### PR TITLE
fix(explore): pass partitionColumn when creating new adhoc filter

### DIFF
--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl.jsx
@@ -96,6 +96,7 @@ class AdhocFilterControl extends React.Component {
         onRemoveFilter={() => this.onRemoveFilter(index)}
         onMoveLabel={this.moveLabel}
         onDropLabel={() => this.props.onChange(this.state.values)}
+        partitionColumn={this.state.partitionColumn}
       />
     );
     this.state = {
@@ -130,17 +131,6 @@ class AdhocFilterControl extends React.Component {
                 Object.keys(partitions.cols).length === 1
               ) {
                 this.setState({ partitionColumn: partitions.cols[0] });
-                this.valueRenderer = (adhocFilter, index) => (
-                  <AdhocFilterOption
-                    adhocFilter={adhocFilter}
-                    onFilterEdit={this.onFilterEdit}
-                    options={this.state.options}
-                    datasource={this.props.datasource}
-                    partitionColumn={this.state.partitionColumn}
-                    onRemoveFilter={() => this.onRemoveFilter(index)}
-                    key={index}
-                  />
-                );
               }
             }
           })

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl.jsx
@@ -128,14 +128,14 @@ class AdhocFilterControl extends React.Component {
                 partitions.cols &&
                 Object.keys(partitions.cols).length === 1
               ) {
-                const partitionColumn = partitions.cols[0];
+                this.setState({ partitionColumn: partitions.cols[0] });
                 this.valueRenderer = (adhocFilter, index) => (
                   <AdhocFilterOption
                     adhocFilter={adhocFilter}
                     onFilterEdit={this.onFilterEdit}
                     options={this.state.options}
                     datasource={this.props.datasource}
-                    partitionColumn={partitionColumn}
+                    partitionColumn={this.state.partitionColumn}
                     onRemoveFilter={() => this.onRemoveFilter(index)}
                     key={index}
                   />
@@ -323,6 +323,7 @@ class AdhocFilterControl extends React.Component {
         datasource={this.props.datasource}
         options={this.state.options}
         onFilterEdit={this.onNewFilter}
+        partitionColumn={this.state.partitionColumn}
         createNew
       >
         {trigger}

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl.jsx
@@ -101,6 +101,7 @@ class AdhocFilterControl extends React.Component {
     this.state = {
       values: filters,
       options: this.optionsForSelect(this.props),
+      partitionColumn: null,
     };
   }
 

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx
@@ -304,7 +304,11 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
     }
 
     const operatorSelectProps = {
-      placeholder: t('%s operators(s)', OPERATORS_OPTIONS.length),
+      placeholder: t(
+        '%s operator(s)',
+        OPERATORS_OPTIONS.filter(op => this.isOperatorRelevant(op, subject))
+          .length,
+      ),
       // like AGGREGTES_OPTIONS, operator options are string
       value: operator,
       onChange: this.onOperatorChange,

--- a/superset/translations/de/LC_MESSAGES/messages.json
+++ b/superset/translations/de/LC_MESSAGES/messages.json
@@ -1706,7 +1706,7 @@
       "%s column(s) and metric(s)": [""],
       "%s column(s)": ["Spalten auflisten"],
       "To filter on a metric, use Custom SQL tab.": [""],
-      "%s operators(s)": [""],
+      "%s operator(s)": [""],
       "Type a value here": [""],
       "Filter value (case sensitive)": [""],
       "choose WHERE or HAVING...": [""],

--- a/superset/translations/de/LC_MESSAGES/messages.po
+++ b/superset/translations/de/LC_MESSAGES/messages.po
@@ -6082,7 +6082,7 @@ msgstr ""
 
 #: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx:307
 #, python-format
-msgid "%s operators(s)"
+msgid "%s operator(s)"
 msgstr ""
 
 #: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx:326

--- a/superset/translations/en/LC_MESSAGES/messages.json
+++ b/superset/translations/en/LC_MESSAGES/messages.json
@@ -1616,7 +1616,7 @@
       "%s column(s) and metric(s)": [""],
       "%s column(s)": [""],
       "To filter on a metric, use Custom SQL tab.": [""],
-      "%s operators(s)": [""],
+      "%s operator(s)": [""],
       "Type a value here": [""],
       "Filter value (case sensitive)": [""],
       "choose WHERE or HAVING...": [""],

--- a/superset/translations/en/LC_MESSAGES/messages.po
+++ b/superset/translations/en/LC_MESSAGES/messages.po
@@ -6081,7 +6081,7 @@ msgstr ""
 
 #: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx:307
 #, python-format
-msgid "%s operators(s)"
+msgid "%s operator(s)"
 msgstr ""
 
 #: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx:326

--- a/superset/translations/es/LC_MESSAGES/messages.json
+++ b/superset/translations/es/LC_MESSAGES/messages.json
@@ -1835,7 +1835,7 @@
       "%s column(s) and metric(s)": [""],
       "%s column(s)": [""],
       "To filter on a metric, use Custom SQL tab.": [""],
-      "%s operators(s)": [""],
+      "%s operator(s)": [""],
       "Type a value here": [""],
       "Filter value (case sensitive)": [""],
       "choose WHERE or HAVING...": [""],

--- a/superset/translations/es/LC_MESSAGES/messages.po
+++ b/superset/translations/es/LC_MESSAGES/messages.po
@@ -6154,7 +6154,7 @@ msgstr ""
 
 #: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx:307
 #, python-format
-msgid "%s operators(s)"
+msgid "%s operator(s)"
 msgstr ""
 
 #: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx:326

--- a/superset/translations/fr/LC_MESSAGES/messages.json
+++ b/superset/translations/fr/LC_MESSAGES/messages.json
@@ -1955,7 +1955,7 @@
       "To filter on a metric, use Custom SQL tab.": [
         "À filtrer sur une métrique, utiliser l'onglet Custom SQL."
       ],
-      "%s operators(s)": ["%s opérateur(s)"],
+      "%s operator(s)": ["%s opérateur(s)"],
       "Type a value here": ["Saisir une valeur ici"],
       "Filter value (case sensitive)": [""],
       "choose WHERE or HAVING...": ["Choisir WHERE or HAVING..."],

--- a/superset/translations/fr/LC_MESSAGES/messages.po
+++ b/superset/translations/fr/LC_MESSAGES/messages.po
@@ -6228,7 +6228,7 @@ msgstr "À filtrer sur une métrique, utiliser l'onglet Custom SQL."
 
 #: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx:307
 #, python-format
-msgid "%s operators(s)"
+msgid "%s operator(s)"
 msgstr "%s opérateur(s)"
 
 #: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx:326

--- a/superset/translations/it/LC_MESSAGES/messages.json
+++ b/superset/translations/it/LC_MESSAGES/messages.json
@@ -1727,7 +1727,7 @@
       "%s column(s) and metric(s)": [""],
       "%s column(s)": ["Visualizza colonne"],
       "To filter on a metric, use Custom SQL tab.": [""],
-      "%s operators(s)": ["Seleziona operatore"],
+      "%s operator(s)": ["Seleziona operatore"],
       "Type a value here": [""],
       "Filter value (case sensitive)": [""],
       "choose WHERE or HAVING...": [""],

--- a/superset/translations/it/LC_MESSAGES/messages.po
+++ b/superset/translations/it/LC_MESSAGES/messages.po
@@ -6126,7 +6126,7 @@ msgstr ""
 
 #: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx:307
 #, python-format
-msgid "%s operators(s)"
+msgid "%s operator(s)"
 msgstr "Seleziona operatore"
 
 #: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx:326

--- a/superset/translations/ja/LC_MESSAGES/messages.json
+++ b/superset/translations/ja/LC_MESSAGES/messages.json
@@ -1643,7 +1643,7 @@
       "%s column(s) and metric(s)": [""],
       "%s column(s)": [""],
       "To filter on a metric, use Custom SQL tab.": [""],
-      "%s operators(s)": ["オペレータを選択"],
+      "%s operator(s)": ["オペレータを選択"],
       "Type a value here": [""],
       "Filter value (case sensitive)": [""],
       "choose WHERE or HAVING...": [""],

--- a/superset/translations/ja/LC_MESSAGES/messages.po
+++ b/superset/translations/ja/LC_MESSAGES/messages.po
@@ -6072,7 +6072,7 @@ msgstr ""
 
 #: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx:307
 #, python-format
-msgid "%s operators(s)"
+msgid "%s operator(s)"
 msgstr "オペレータを選択"
 
 #: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx:326

--- a/superset/translations/ko/LC_MESSAGES/messages.json
+++ b/superset/translations/ko/LC_MESSAGES/messages.json
@@ -1617,7 +1617,7 @@
       "%s column(s) and metric(s)": [""],
       "%s column(s)": [""],
       "To filter on a metric, use Custom SQL tab.": [""],
-      "%s operators(s)": [""],
+      "%s operator(s)": [""],
       "Type a value here": [""],
       "Filter value (case sensitive)": [""],
       "choose WHERE or HAVING...": [""],

--- a/superset/translations/ko/LC_MESSAGES/messages.po
+++ b/superset/translations/ko/LC_MESSAGES/messages.po
@@ -6072,7 +6072,7 @@ msgstr ""
 
 #: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx:307
 #, python-format
-msgid "%s operators(s)"
+msgid "%s operator(s)"
 msgstr ""
 
 #: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx:326

--- a/superset/translations/messages.pot
+++ b/superset/translations/messages.pot
@@ -6081,7 +6081,7 @@ msgstr ""
 
 #: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx:307
 #, python-format
-msgid "%s operators(s)"
+msgid "%s operator(s)"
 msgstr ""
 
 #: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx:326

--- a/superset/translations/pt/LC_MESSAGES/message.json
+++ b/superset/translations/pt/LC_MESSAGES/message.json
@@ -1724,7 +1724,7 @@
       "%s column(s) and metric(s)": [""],
       "%s column(s)": ["Lista de Colunas"],
       "To filter on a metric, use Custom SQL tab.": [""],
-      "%s operators(s)": ["Selecione operador"],
+      "%s operator(s)": ["Selecione operador"],
       "type a value here": [""],
       "Filter value (case sensitive)": [""],
       "choose WHERE or HAVING...": [""],

--- a/superset/translations/pt/LC_MESSAGES/message.po
+++ b/superset/translations/pt/LC_MESSAGES/message.po
@@ -5723,7 +5723,7 @@ msgstr ""
 
 #: superset-frontend/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx:307
 #, python-format
-msgid "%s operators(s)"
+msgid "%s operator(s)"
 msgstr "Selecione operador"
 
 #: superset-frontend/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx:326

--- a/superset/translations/pt_BR/LC_MESSAGES/messages.json
+++ b/superset/translations/pt_BR/LC_MESSAGES/messages.json
@@ -2244,7 +2244,7 @@
       "To filter on a metric, use Custom SQL tab.": [
         "Para filtrar uma métrica, use a aba SQL personalizado."
       ],
-      "%s operators(s)": ["%s operador(es)"],
+      "%s operator(s)": ["%s operador(es)"],
       "Type a value here": ["digite um valor aqui"],
       "Filter value (case sensitive)": [
         "Filtrar valor (sensível a maiúscula/minúscula)"

--- a/superset/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/superset/translations/pt_BR/LC_MESSAGES/messages.po
@@ -6489,7 +6489,7 @@ msgstr "Para filtrar uma métrica, use a aba SQL personalizado."
 
 #: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx:307
 #, python-format
-msgid "%s operators(s)"
+msgid "%s operator(s)"
 msgstr "%s operador(es)"
 
 #: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx:326

--- a/superset/translations/ru/LC_MESSAGES/messages.json
+++ b/superset/translations/ru/LC_MESSAGES/messages.json
@@ -1839,7 +1839,7 @@
       "%s column(s) and metric(s)": [""],
       "%s column(s)": ["Список столбцов"],
       "To filter on a metric, use Custom SQL tab.": [""],
-      "%s operators(s)": ["%s параметр(ы)"],
+      "%s operator(s)": ["%s параметр(ы)"],
       "Type a value here": [""],
       "Filter value (case sensitive)": [""],
       "choose WHERE or HAVING...": [""],

--- a/superset/translations/ru/LC_MESSAGES/messages.po
+++ b/superset/translations/ru/LC_MESSAGES/messages.po
@@ -6170,7 +6170,7 @@ msgstr ""
 
 #: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx:307
 #, python-format
-msgid "%s operators(s)"
+msgid "%s operator(s)"
 msgstr "%s параметр(ы)"
 
 #: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx:326

--- a/superset/translations/zh/LC_MESSAGES/messages.json
+++ b/superset/translations/zh/LC_MESSAGES/messages.json
@@ -1731,7 +1731,7 @@
       "To filter on a metric, use Custom SQL tab.": [
         "若要在计量值上筛选，请使用自定义SQL选项卡。"
       ],
-      "%s operators(s)": ["%s 运算符"],
+      "%s operator(s)": ["%s 运算符"],
       "Type a value here": ["在这里键入一个值"],
       "Filter value (case sensitive)": [""],
       "choose WHERE or HAVING...": ["选择WHERE或HAVING子句..."],

--- a/superset/translations/zh/LC_MESSAGES/messages.po
+++ b/superset/translations/zh/LC_MESSAGES/messages.po
@@ -6134,7 +6134,7 @@ msgstr "若要在计量值上筛选，请使用自定义SQL选项卡。"
 
 #: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx:307
 #, python-format
-msgid "%s operators(s)"
+msgid "%s operator(s)"
 msgstr "%s 运算符"
 
 #: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx:326


### PR DESCRIPTION
### SUMMARY
The prop `partitionColumn` was not being passed  to `AdhocFilterPopoverTrigger` in `addNewFilterPopoverTrigger` of `AdhocFilterControl`, causing the latest partition operator to be missing for datasources that support it. The override of `valueRender` seemed to be a leftover from some old time, so it was removed and `partitionColumn` added to the original `valueRenderer` that's created in the constructor. In addition, the operator dropdown showed irrelevant operators, causing the operator count to be inflated. Also fixed a typo ("operators(s)" to "operator(s)") along with relevant translations.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: Partition operator is missing from dropdown. Also notice how the dropdown shows 13 operators, despite only 11 being visible:
![before](https://user-images.githubusercontent.com/33317356/105968706-15aabc00-6090-11eb-9323-6ee1cb8d1d6c.gif)

After
Partition operator pops up if column supports it. The placeholder is also updated to reflect the new operator count after the column has been selected:
![after](https://user-images.githubusercontent.com/33317356/105968841-41c63d00-6090-11eb-8497-2e0930e8a905.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #12752
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
