### PR TITLE
fix: samples should not be timeseries

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -247,6 +247,7 @@ class BaseViz:
         query_obj = self.query_obj()
         query_obj.update(
             {
+                "is_timeseries": False,
                 "groupby": [],
                 "metrics": [],
                 "orderby": [],


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When we fetch samples for a given viz we need to ensure the `is_timeseries` attribute is false, otherwise Superset will add a group by on the temporal column, resuilting in an invalid column:

```sql
SELECT ts AS ts,
       name AS name,
       text AS text,
       DATE(ts) AS __timestamp  -- HERE
FROM
  (SELECT m.ts,
          c.name,
          m.text
   FROM messages m
   JOIN channels c ON m.channel_id = c.id) AS expr_qry
WHERE ts >= STR_TO_DATE('2020-10-27 00:00:00.000000', '%Y-%m-%d %H:%i:%s.%f')
  AND ts < STR_TO_DATE('2021-01-27 00:00:00.000000', '%Y-%m-%d %H:%i:%s.%f')
  AND name != 'github-notifications'
GROUP BY DATE(ts)  -- HERE
LIMIT 1000
```

The query above is invalid because the `GROUP BY` should contain all non-aggregation expressions from the `SELECT`.

Because of this, some charts fail to load their samples.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

![Screenshot_2021-01-27 Messages per Channel(1)](https://user-images.githubusercontent.com/1534870/106039351-e2ffc400-608d-11eb-900a-35027bcb0857.png)

After:

![Screenshot_2021-01-27 Messages per Channel](https://user-images.githubusercontent.com/1534870/106038992-708ee400-608d-11eb-938c-a6b459f2c4e5.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Open chart and navigated to "DATA" -> "VIEW SAMPLES", now it works as expected.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: https://github.com/apache/superset/issues/12504
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
