### PR TITLE
fix: strip leading # from hash in URL shortener call

### DIFF
--- a/superset-frontend/src/dashboard/components/HeaderActionsDropdown.jsx
+++ b/superset-frontend/src/dashboard/components/HeaderActionsDropdown.jsx
@@ -33,6 +33,7 @@ import URLShortLinkModal from '../../components/URLShortLinkModal';
 import FilterScopeModal from './filterscope/FilterScopeModal';
 import downloadAsImage from '../../utils/downloadAsImage';
 import getDashboardUrl from '../util/getDashboardUrl';
+import getLocationHash from '../util/getLocationHash';
 import { getActiveFilters } from '../util/activeDashboardFilters';
 
 const propTypes = {
@@ -168,7 +169,7 @@ class HeaderActionsDropdown extends React.PureComponent {
         const url = getDashboardUrl(
           window.location.pathname,
           getActiveFilters(),
-          window.location.hash,
+          getLocationHash(),
           !hasStandalone,
         );
         window.location.replace(url);
@@ -241,7 +242,7 @@ class HeaderActionsDropdown extends React.PureComponent {
             url={getDashboardUrl(
               window.location.pathname,
               getActiveFilters(),
-              window.location.hash,
+              getLocationHash(),
             )}
             emailSubject={emailSubject}
             emailContent={emailBody}


### PR DESCRIPTION
### SUMMARY

This change strips the leading # off of the URL hash when calling the URL shortening utility function. The function expects this to be removed.

### TEST PLAN

To reproduce the issue before fixing:
- Go to the tabbed dashboard sample
- Create a short link for a tab by clicking on the '%' menu for the tab
- Copy the short URL, and navigate to it in the browser
- Now create a short link from the dashboard's '...' menu > Share dashboard
- Copy the URL
- The URL has double hashes (##) and will fail to load

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
