### PR TITLE
fix(release): pin pyjwt to version <2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,7 @@ setup(
         "python-geohash",
         "pyarrow>=1.0.1, <1.1",
         "pyyaml>=5.1",
+        "PyJWT>=1.7.1, <2",
         "redis",
         "retry>=0.9.2",
         "selenium>=3.141.0",


### PR DESCRIPTION
### SUMMARY
Currently `pip install apache-superset` pulls in an incompatible version of `PyJWT` due to it being restricted on one of the dependencies. See https://stackoverflow.com/questions/60303682/why-is-pip-installing-an-incompatible-package-version for more info. Note: this is just a quick fix; we should preferably do some more work in this area to have more robust dependency resolution and achieving proper locking e.g. via [poetry](https://python-poetry.org/).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
