### PR TITLE
refactor: speed up conversion from dataframe to list of records

### DIFF
--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -24,11 +24,24 @@ from superset.utils.core import JS_MAX_INTEGER
 
 
 def _convert_big_integers(dframe: pd.DataFrame) -> pd.DataFrame:
+    """
+    Cast all integers larger than ``JS_MAX_INTEGER`` in a DataFrame to strings.
+
+    :param dframe: the DataFrame to process
+    :returns: the same DataFrame, with all integer values over
+        ``JS_MAX_INTEGER`` recast as strings
+    """
     return dframe.applymap(
         lambda v: str(v) if isinstance(v, int) and abs(v) > JS_MAX_INTEGER else v
     )
 
 
 def df_to_records(dframe: pd.DataFrame) -> List[Dict[str, Any]]:
+    """
+    Convert a DataFrame to a set of records.
+
+    :param dframe: the DataFrame to convert
+    :returns: a list of dictionaries reflecting each single row of the DataFrame
+    """
     data: List[Dict[str, Any]] = _convert_big_integers(dframe).to_dict(orient="records")
     return data

--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -31,7 +31,7 @@ def _convert_big_integers(val: Any) -> Any:
     :returns: the same value but recast as a string if it was an integer over
         ``JS_MAX_INTEGER``
     """
-    return str(val) if isinstance(val, int) and val > JS_MAX_INTEGER else val
+    return str(val) if isinstance(val, int) and abs(val) > JS_MAX_INTEGER else val
 
 
 def df_to_records(dframe: pd.DataFrame) -> List[Dict[str, Any]]:

--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -43,7 +43,7 @@ def df_to_records(dframe: pd.DataFrame) -> List[Dict[str, Any]]:
     """
     data: List[Dict[str, Any]] = list(
         dict(zip(dframe.columns, map(_convert_big_integers, row)))
-        for row in dframe.itertuples(index=False, name=None)
+        for row in zip(*[dframe[col] for col in dframe.columns])
     )
 
     return data

--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -23,15 +23,15 @@ import pandas as pd
 from superset.utils.core import JS_MAX_INTEGER
 
 
-def _convert_big_integers(row: List[Any]) -> List[Any]:
+def _convert_big_integers(val: Any) -> Any:
     """
-    Cast all integers larger than ``JS_MAX_INTEGER`` in a row to strings.
+    Cast integers larger than ``JS_MAX_INTEGER`` to strings.
 
-    :param row: the DataFrame row to process
-    :returns: the same DataFrame row, with all integer values over
-        ``JS_MAX_INTEGER`` recast as strings
+    :param val: the value to process
+    :returns: the same value but recast as a string if it was an integer over
+        ``JS_MAX_INTEGER`` 
     """
-    return [str(v) if isinstance(v, int) and v > JS_MAX_INTEGER else v for v in row]
+    return str(val) if isinstance(val, int) and val > JS_MAX_INTEGER else val
 
 
 def df_to_records(dframe: pd.DataFrame) -> List[Dict[str, Any]]:
@@ -42,7 +42,7 @@ def df_to_records(dframe: pd.DataFrame) -> List[Dict[str, Any]]:
     :returns: a list of dictionaries reflecting each single row of the DataFrame
     """
     data: List[Dict[str, Any]] = list(
-        dict(zip(dframe.columns, _convert_big_integers(row)))
+        dict(zip(dframe.columns, map(_convert_big_integers, row)))
         for row in dframe.itertuples(index=False, name=None)
     )
 

--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -16,6 +16,7 @@
 # under the License.
 """ Superset utilities for pandas.DataFrame.
 """
+import warnings
 from typing import Any, Dict, List
 
 import pandas as pd
@@ -41,6 +42,13 @@ def df_to_records(dframe: pd.DataFrame) -> List[Dict[str, Any]]:
     :param dframe: the DataFrame to convert
     :returns: a list of dictionaries reflecting each single row of the DataFrame
     """
+    if not dframe.columns.is_unique:
+        warnings.warn(
+            "DataFrame columns are not unique, some columns will be omitted.",
+            UserWarning,
+            stacklevel=2,
+        )
+
     return list(
         dict(zip(dframe.columns, map(_convert_big_integers, row)))
         for row in zip(*[dframe[col] for col in dframe.columns])

--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -48,8 +48,8 @@ def df_to_records(dframe: pd.DataFrame) -> List[Dict[str, Any]]:
             UserWarning,
             stacklevel=2,
         )
-
+    columns = dframe.columns
     return list(
-        dict(zip(dframe.columns, map(_convert_big_integers, row)))
-        for row in zip(*[dframe[col] for col in dframe.columns])
+        dict(zip(columns, map(_convert_big_integers, row)))
+        for row in zip(*[dframe[col] for col in columns])
     )

--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -23,13 +23,12 @@ import pandas as pd
 from superset.utils.core import JS_MAX_INTEGER
 
 
+def _convert_big_integers(dframe: pd.DataFrame) -> pd.DataFrame:
+    return dframe.applymap(
+        lambda v: str(v) if isinstance(v, int) and abs(v) > JS_MAX_INTEGER else v
+    )
+
+
 def df_to_records(dframe: pd.DataFrame) -> List[Dict[str, Any]]:
-    data: List[Dict[str, Any]] = dframe.to_dict(orient="records")
-    # TODO: refactor this
-    for row in data:
-        for key, value in list(row.items()):
-            # if an int is too big for JavaScript to handle
-            # convert it to a string
-            if isinstance(value, int) and abs(value) > JS_MAX_INTEGER:
-                row[key] = str(value)
+    data: List[Dict[str, Any]] = _convert_big_integers(dframe).to_dict(orient="records")
     return data

--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -41,9 +41,7 @@ def df_to_records(dframe: pd.DataFrame) -> List[Dict[str, Any]]:
     :param dframe: the DataFrame to convert
     :returns: a list of dictionaries reflecting each single row of the DataFrame
     """
-    data: List[Dict[str, Any]] = list(
+    return list(
         dict(zip(dframe.columns, map(_convert_big_integers, row)))
         for row in zip(*[dframe[col] for col in dframe.columns])
     )
-
-    return data

--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -27,12 +27,22 @@ def _convert_big_integers(dframe: pd.DataFrame) -> pd.DataFrame:
     """
     Cast all integers larger than ``JS_MAX_INTEGER`` in a DataFrame to strings.
 
+    Despite the additional code complexity, this dict comprehension approach is
+    faster than using pandas ``DataFrame.applymap()``.
+
     :param dframe: the DataFrame to process
     :returns: the same DataFrame, with all integer values over
         ``JS_MAX_INTEGER`` recast as strings
     """
-    return dframe.applymap(
-        lambda v: str(v) if isinstance(v, int) and abs(v) > JS_MAX_INTEGER else v
+    return pd.DataFrame(
+        {
+            column: dframe[column].map(
+                lambda v: str(v)
+                if isinstance(v, int) and abs(v) > JS_MAX_INTEGER
+                else v
+            )
+            for column in dframe.columns
+        }
     )
 
 

--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -29,7 +29,7 @@ def _convert_big_integers(val: Any) -> Any:
 
     :param val: the value to process
     :returns: the same value but recast as a string if it was an integer over
-        ``JS_MAX_INTEGER`` 
+        ``JS_MAX_INTEGER``
     """
     return str(val) if isinstance(val, int) and val > JS_MAX_INTEGER else val
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Converting big integers to strings was previously done manually by looping over every single value in the DataFrame, after first calling pandas `DataFrame.to_dict()`, which uses `DataFrame.itertuples()` under the hood.

New version drops pandas `to_dict()` in favour of grabbing the data directly and inserting the big integer conversion within that single loop over the full dataset.

This speeds up the overall record collection by a factor of ~2 (primarily because we're only looping through the data once).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Functionality covered by existing unit tests in `dataframe_test.py`

Benchmarking notebook available [here](https://colab.research.google.com/drive/1_b2KKFrscNsbzceocxNpoNHGTS-IHbSL?usp=sharing)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
