### PR TITLE
other: Don't expose the superset_db and superset_cache to the host machine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,6 @@ services:
     image: redis:3.2
     container_name: superset_cache
     restart: unless-stopped
-    ports:
-      - "127.0.0.1:6379:6379"
     volumes:
       - redis:/data
 
@@ -42,8 +40,6 @@ services:
     image: postgres:10
     container_name: superset_db
     restart: unless-stopped
-    ports:
-      - "127.0.0.1:5432:5432"
     volumes:
       - db_home:/var/lib/postgresql/data
 


### PR DESCRIPTION
### SUMMARY
Don't expose the superset_db and superset_cache to host machine as it is not necessary.

### TEST PLAN
Run `docker-compose up` and still functions as expected.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
