### PR TITLE
fix(reports): handle exceptions properly in scope

### DIFF
--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -15,11 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
-from dateutil import parser
 from datetime import datetime, timedelta
 from typing import Iterator
 
 import croniter
+from dateutil import parser
 
 from superset import app
 from superset.commands.exceptions import CommandException

--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
+from dateutil import parser
 from datetime import datetime, timedelta
 from typing import Iterator
 
@@ -60,9 +61,10 @@ def scheduler() -> None:
 
 
 @celery_app.task(name="reports.execute")
-def execute(report_schedule_id: int, scheduled_dttm: datetime) -> None:
+def execute(report_schedule_id: int, scheduled_dttm: str) -> None:
     try:
-        AsyncExecuteReportScheduleCommand(report_schedule_id, scheduled_dttm).run()
+        scheduled_dttm_ = parser.parse(scheduled_dttm)
+        AsyncExecuteReportScheduleCommand(report_schedule_id, scheduled_dttm_).run()
     except ReportScheduleUnexpectedError as ex:
         logger.error("An unexpected occurred while executing the report: %s", ex)
     except CommandException as ex:

--- a/superset/utils/celery.py
+++ b/superset/utils/celery.py
@@ -17,9 +17,9 @@
 import logging
 from typing import Iterator
 
+from contextlib2 import contextmanager
 from sqlalchemy import create_engine
 from sqlalchemy.exc import SQLAlchemyError
-from contextlib2 import contextmanager
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import NullPool
 

--- a/superset/utils/celery.py
+++ b/superset/utils/celery.py
@@ -17,7 +17,8 @@
 import logging
 from typing import Iterator
 
-import sqlalchemy as sa
+from sqlalchemy import create_engine
+from sqlalchemy.exc import SQLAlchemyError
 from contextlib2 import contextmanager
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import NullPool
@@ -38,7 +39,7 @@ def session_scope(nullpool: bool) -> Iterator[Session]:
             in a future version of Superset."
         )
     if nullpool:
-        engine = sa.create_engine(database_uri, poolclass=NullPool)
+        engine = create_engine(database_uri, poolclass=NullPool)
         session_class = sessionmaker()
         session_class.configure(bind=engine)
         session = session_class()
@@ -49,7 +50,7 @@ def session_scope(nullpool: bool) -> Iterator[Session]:
     try:
         yield session
         session.commit()
-    except Exception as ex:
+    except SQLAlchemyError as ex:
         session.rollback()
         logger.exception(ex)
         raise

--- a/tests/reports/commands_tests.py
+++ b/tests/reports/commands_tests.py
@@ -62,7 +62,7 @@ def get_target_from_report_schedule(report_schedule) -> List[str]:
 
 
 def assert_log(state: str, error_message: Optional[str] = None):
-    # db.session.commit()
+    db.session.commit()
     logs = db.session.query(ReportExecutionLog).all()
     if state == ReportState.WORKING:
         assert len(logs) == 1
@@ -574,7 +574,7 @@ def test_report_schedule_working_timeout(create_report_slack_chart_working):
             ).run()
 
     # Only needed for MySQL, understand why
-    # db.session.commit()
+    db.session.commit()
     logs = db.session.query(ReportExecutionLog).all()
     assert len(logs) == 1
     assert logs[0].error_message == ReportScheduleWorkingTimeoutError.message
@@ -598,7 +598,7 @@ def test_report_schedule_success_grace(create_alert_slack_chart_success):
             create_alert_slack_chart_success.id, datetime.utcnow()
         ).run()
 
-    # db.session.commit()
+    db.session.commit()
     assert create_alert_slack_chart_success.last_state == ReportState.GRACE
 
 
@@ -617,7 +617,7 @@ def test_report_schedule_success_grace_end(create_alert_slack_chart_grace):
             create_alert_slack_chart_grace.id, datetime.utcnow()
         ).run()
 
-    # db.session.commit()
+    db.session.commit()
     assert create_alert_slack_chart_grace.last_state == ReportState.NOOP
 
 

--- a/tests/reports/commands_tests.py
+++ b/tests/reports/commands_tests.py
@@ -62,7 +62,7 @@ def get_target_from_report_schedule(report_schedule) -> List[str]:
 
 
 def assert_log(state: str, error_message: Optional[str] = None):
-    db.session.commit()
+    # db.session.commit()
     logs = db.session.query(ReportExecutionLog).all()
     if state == ReportState.WORKING:
         assert len(logs) == 1
@@ -574,7 +574,7 @@ def test_report_schedule_working_timeout(create_report_slack_chart_working):
             ).run()
 
     # Only needed for MySQL, understand why
-    db.session.commit()
+    # db.session.commit()
     logs = db.session.query(ReportExecutionLog).all()
     assert len(logs) == 1
     assert logs[0].error_message == ReportScheduleWorkingTimeoutError.message
@@ -598,7 +598,7 @@ def test_report_schedule_success_grace(create_alert_slack_chart_success):
             create_alert_slack_chart_success.id, datetime.utcnow()
         ).run()
 
-    db.session.commit()
+    # db.session.commit()
     assert create_alert_slack_chart_success.last_state == ReportState.GRACE
 
 
@@ -617,7 +617,7 @@ def test_report_schedule_success_grace_end(create_alert_slack_chart_grace):
             create_alert_slack_chart_grace.id, datetime.utcnow()
         ).run()
 
-    db.session.commit()
+    # db.session.commit()
     assert create_alert_slack_chart_grace.last_state == ReportState.NOOP
 
 


### PR DESCRIPTION
### SUMMARY
Fixes badly handled exception flow on reports and worker `session_scope`. This would surface any exceptions raised inside the exception block even if they were handled after

Also includes a fix that surfaces on SQLite but is not correct, since by default celery JSON serialises the datetime type is not preserved

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
