### PR TITLE
chore(native-filters): Connect indicator magnifier with Filter Bar

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder.jsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder.jsx
@@ -222,6 +222,7 @@ class DashboardBuilder extends React.Component {
       showBuilderPane,
       setColorSchemeAndUnsavedChanges,
       colorScheme,
+      directPathToChild,
     } = this.props;
     const { tabIndex } = this.state;
     const dashboardRoot = dashboardLayout[DASHBOARD_ROOT_ID];
@@ -297,6 +298,7 @@ class DashboardBuilder extends React.Component {
                 <FilterBar
                   filtersOpen={this.state.dashboardFiltersOpen}
                   toggleFiltersBar={this.toggleDashboardFiltersOpen}
+                  directPathToChild={directPathToChild}
                 />
               </ErrorBoundary>
             </StickyVerticalBar>

--- a/superset-frontend/src/dashboard/components/nativeFilters/CascadePopover.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/CascadePopover.tsx
@@ -27,6 +27,7 @@ import { Filter, CascadeFilter } from './types';
 interface CascadePopoverProps {
   filter: CascadeFilter;
   visible: boolean;
+  directPathToChild: string[];
   onVisibleChange: (visible: boolean) => void;
   onExtraFormDataChange: (filter: Filter, extraFormData: ExtraFormData) => void;
 }
@@ -73,6 +74,7 @@ const CascadePopover: React.FC<CascadePopoverProps> = ({
   visible,
   onVisibleChange,
   onExtraFormDataChange,
+  directPathToChild,
 }) => {
   const getActiveChildren = useCallback((filter: CascadeFilter):
     | CascadeFilter[]
@@ -99,6 +101,7 @@ const CascadePopover: React.FC<CascadePopoverProps> = ({
     return (
       <FilterControl
         filter={filter}
+        directPathToChild={directPathToChild}
         onExtraFormDataChange={onExtraFormDataChange}
       />
     );
@@ -152,6 +155,7 @@ const CascadePopover: React.FC<CascadePopoverProps> = ({
             key={activeFilter.id}
             filter={activeFilter}
             onExtraFormDataChange={onExtraFormDataChange}
+            directPathToChild={directPathToChild}
             icon={
               <>
                 {filter.cascadeChildren.length !== 0 && (

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -23,7 +23,13 @@ import {
   t,
   ExtraFormData,
 } from '@superset-ui/core';
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useMemo,
+  useCallback,
+  useRef,
+} from 'react';
 import { useSelector } from 'react-redux';
 import cx from 'classnames';
 import { Form } from 'src/common/components';
@@ -194,16 +200,19 @@ const StyledLoadingBox = styled.div`
 interface FilterProps {
   filter: Filter;
   icon?: React.ReactElement;
+  directPathToChild?: string[];
   onExtraFormDataChange: (filter: Filter, extraFormData: ExtraFormData) => void;
 }
 
 interface FiltersBarProps {
   filtersOpen: boolean;
   toggleFiltersBar: any;
+  directPathToChild: string[];
 }
 
 const FilterValue: React.FC<FilterProps> = ({
   filter,
+  directPathToChild,
   onExtraFormDataChange,
 }) => {
   const {
@@ -219,6 +228,7 @@ const FilterValue: React.FC<FilterProps> = ({
   const [state, setState] = useState([]);
   const [error, setError] = useState<boolean>(false);
   const [formData, setFormData] = useState<Partial<QueryFormData>>({});
+  const inputRef = useRef<HTMLInputElement>(null);
   const [target] = targets;
   const { datasetId = 18, column } = target;
   const { name: groupby } = column;
@@ -240,6 +250,7 @@ const FilterValue: React.FC<FilterProps> = ({
     url_params: {},
     viz_type: 'filter_select',
     defaultValues: currentValue || defaultValue || [],
+    inputRef,
   });
 
   useEffect(() => {
@@ -262,6 +273,14 @@ const FilterValue: React.FC<FilterProps> = ({
         });
     }
   }, [cascadingFilters, datasetId, groupby]);
+
+  const isFocused = directPathToChild?.[0] === filter.id;
+
+  useEffect(() => {
+    if (isFocused) {
+      inputRef?.current?.focus();
+    }
+  }, [inputRef, isFocused]);
 
   const setExtraFormData = (extraFormData: ExtraFormData) =>
     onExtraFormDataChange(filter, extraFormData);
@@ -308,8 +327,10 @@ export const FilterControl: React.FC<FilterProps> = ({
   filter,
   icon,
   onExtraFormDataChange,
+  directPathToChild,
 }) => {
   const { name = '<undefined>' } = filter;
+
   return (
     <StyledFilterControlContainer>
       <StyledFilterControlTitleBox>
@@ -318,6 +339,7 @@ export const FilterControl: React.FC<FilterProps> = ({
       </StyledFilterControlTitleBox>
       <FilterValue
         filter={filter}
+        directPathToChild={directPathToChild}
         onExtraFormDataChange={onExtraFormDataChange}
       />
     </StyledFilterControlContainer>
@@ -358,6 +380,7 @@ export const CascadeFilterControl: React.FC<CascadeFilterControlProps> = ({
 const FilterBar: React.FC<FiltersBarProps> = ({
   filtersOpen,
   toggleFiltersBar,
+  directPathToChild,
 }) => {
   const [filterData, setFilterData] = useState<{ [id: string]: ExtraFormData }>(
     {},
@@ -493,6 +516,7 @@ const FilterBar: React.FC<FiltersBarProps> = ({
               }
               filter={filter}
               onExtraFormDataChange={handleExtraFormDataChange}
+              directPathToChild={directPathToChild}
             />
           ))}
         </FilterControls>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -207,7 +207,7 @@ interface FilterProps {
 interface FiltersBarProps {
   filtersOpen: boolean;
   toggleFiltersBar: any;
-  directPathToChild: string[];
+  directPathToChild?: string[];
 }
 
 const FilterValue: React.FC<FilterProps> = ({
@@ -274,13 +274,16 @@ const FilterValue: React.FC<FilterProps> = ({
     }
   }, [cascadingFilters, datasetId, groupby]);
 
-  const isFocused = directPathToChild?.[0] === filter.id;
-
   useEffect(() => {
-    if (isFocused) {
-      inputRef?.current?.focus();
+    if (directPathToChild?.[0] === filter.id) {
+      // wait for Cascade Popover to open
+      const timeout = setTimeout(() => {
+        inputRef?.current?.focus();
+      }, 200);
+      return () => clearTimeout(timeout);
     }
-  }, [inputRef, isFocused]);
+    return undefined;
+  }, [inputRef, directPathToChild, filter.id]);
 
   const setExtraFormData = (extraFormData: ExtraFormData) =>
     onExtraFormDataChange(filter, extraFormData);
@@ -348,11 +351,13 @@ export const FilterControl: React.FC<FilterProps> = ({
 
 interface CascadeFilterControlProps {
   filter: CascadeFilter;
+  directPathToChild?: string[];
   onExtraFormDataChange: (filter: Filter, extraFormData: ExtraFormData) => void;
 }
 
 export const CascadeFilterControl: React.FC<CascadeFilterControlProps> = ({
   filter,
+  directPathToChild,
   onExtraFormDataChange,
 }) => (
   <>
@@ -360,6 +365,7 @@ export const CascadeFilterControl: React.FC<CascadeFilterControlProps> = ({
       <StyledCaretIcon name="caret-down" />
       <FilterControl
         filter={filter}
+        directPathToChild={directPathToChild}
         onExtraFormDataChange={onExtraFormDataChange}
       />
     </StyledFilterControlBox>
@@ -369,6 +375,7 @@ export const CascadeFilterControl: React.FC<CascadeFilterControlProps> = ({
         <li key={childFilter.id}>
           <CascadeFilterControl
             filter={childFilter}
+            directPathToChild={directPathToChild}
             onExtraFormDataChange={onExtraFormDataChange}
           />
         </li>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -333,7 +333,6 @@ export const FilterControl: React.FC<FilterProps> = ({
   directPathToChild,
 }) => {
   const { name = '<undefined>' } = filter;
-
   return (
     <StyledFilterControlContainer>
       <StyledFilterControlTitleBox>

--- a/superset-frontend/src/filters/components/Range/AntdRangeFilter.tsx
+++ b/superset-frontend/src/filters/components/Range/AntdRangeFilter.tsx
@@ -29,7 +29,7 @@ const Styles = styled.div<AntdPluginFilterStylesProps>`
 `;
 
 export default function AntdRangeFilter(props: AntdPluginFilterRangeProps) {
-  const { data, formData, height, width, setExtraFormData } = props;
+  const { data, formData, height, width, setExtraFormData, inputRef } = props;
   const [row] = data;
   // @ts-ignore
   const { min, max }: { min: number; max: number } = row;

--- a/superset-frontend/src/filters/components/Range/AntdRangeFilter.tsx
+++ b/superset-frontend/src/filters/components/Range/AntdRangeFilter.tsx
@@ -50,6 +50,7 @@ export default function AntdRangeFilter(props: AntdPluginFilterRangeProps) {
         max={max}
         defaultValue={[min, max]}
         onChange={handleChange}
+        ref={inputRef}
       />
     </Styles>
   );

--- a/superset-frontend/src/filters/components/Range/types.ts
+++ b/superset-frontend/src/filters/components/Range/types.ts
@@ -21,6 +21,7 @@ import {
   QueryFormData,
   SetExtraFormDataHook,
 } from '@superset-ui/core';
+import { RefObject } from 'react';
 import { AntdPluginFilterStylesProps } from '../types';
 
 interface AntdPluginFilterSelectCustomizeProps {
@@ -36,4 +37,5 @@ export type AntdPluginFilterRangeProps = AntdPluginFilterStylesProps & {
   data: DataRecord[];
   formData: PluginFilterRangeQueryFormData;
   setExtraFormData: SetExtraFormDataHook;
+  inputRef: RefObject<any>;
 };

--- a/superset-frontend/src/filters/components/Select/AntdSelectFilter.tsx
+++ b/superset-frontend/src/filters/components/Select/AntdSelectFilter.tsx
@@ -41,6 +41,7 @@ export default function AntdPluginFilterSelect(
     multiSelect,
     showSearch,
     inverseSelection,
+    inputRef,
   } = {
     ...DEFAULT_FORM_DATA,
     ...formData,
@@ -79,6 +80,7 @@ export default function AntdPluginFilterSelect(
         placeholder={placeholderText}
         // @ts-ignore
         onChange={handleChange}
+        ref={inputRef}
       >
         {(data || []).map(row => {
           const option = `${groupby.map(col => row[col])[0]}`;

--- a/superset-frontend/src/filters/components/Select/types.ts
+++ b/superset-frontend/src/filters/components/Select/types.ts
@@ -21,6 +21,7 @@ import {
   DataRecord,
   SetExtraFormDataHook,
 } from '@superset-ui/core';
+import { RefSelectProps } from 'antd/lib/select';
 import { AntdPluginFilterStylesProps } from '../types';
 
 interface AntdPluginFilterSelectCustomizeProps {
@@ -30,6 +31,7 @@ interface AntdPluginFilterSelectCustomizeProps {
   inverseSelection: boolean;
   multiSelect: boolean;
   showSearch: boolean;
+  inputRef?: RefSelectProps;
 }
 
 export type AntdPluginFilterSelectQueryFormData = QueryFormData &

--- a/superset-frontend/src/filters/components/Select/types.ts
+++ b/superset-frontend/src/filters/components/Select/types.ts
@@ -21,7 +21,7 @@ import {
   DataRecord,
   SetExtraFormDataHook,
 } from '@superset-ui/core';
-import { RefSelectProps } from 'antd/lib/select';
+import { RefObject } from 'react';
 import { AntdPluginFilterStylesProps } from '../types';
 
 interface AntdPluginFilterSelectCustomizeProps {
@@ -31,7 +31,7 @@ interface AntdPluginFilterSelectCustomizeProps {
   inverseSelection: boolean;
   multiSelect: boolean;
   showSearch: boolean;
-  inputRef?: RefSelectProps;
+  inputRef?: RefObject<HTMLInputElement>;
 }
 
 export type AntdPluginFilterSelectQueryFormData = QueryFormData &


### PR DESCRIPTION
### SUMMARY
The aim of this PR was to standarize clicking magnifier action between dashboard filters and native filters. The implementation was created based on how it works for dashboard filers, so using `directPathToChild`.

When users click filter indicator, the list of native filters and dashboard filters are presented. When users click magnifier next to a given dashboard filter, the component gets blue outline. The same should happen with native filters - when magnifier next to native filter is clicked, the given native filter input is focused.

This implementation fully supports 'Select inputs', as for now in Filter Bar there is `viz_type: 'filter_select' `. I have added a small support for range filters (by giving `inputRef` prop), but focusing that type of inputs should be investigated once again when they are widely used. (cc @villebro)

Connected with Issue #12703
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before 
![focus_before](https://user-images.githubusercontent.com/47450693/106148634-909bd180-6179-11eb-89f2-a60c7d09fd0c.gif)

After:
**simple native filter:**
![focus_no_children_after](https://user-images.githubusercontent.com/47450693/106148417-516d8080-6179-11eb-91bb-bd6e0b336d85.gif)

**with cascading popover:**
![focus_with_children_after](https://user-images.githubusercontent.com/47450693/106148382-49154580-6179-11eb-8cad-32ff9026cf78.gif)

### TEST PLAN
Verify manually. Go to config.py and set "DASHBOARD_NATIVE_FILTERS": True
Go to a dashboard and create Native Filter.
Click an indicator presented on the charts (dark gray pill with a number). Click magnifier and check how native filter input behaves.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #12703
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

@adam-stasiak could you test it?
@junlincc @rusackas @suddjian 