### PR TITLE
chore(explore): Metric/Column and Filter popover unexpectedly closes on scroll

### DIFF
--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx
@@ -337,6 +337,7 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
             {...this.selectProps}
             {...subjectSelectProps}
             name="filter-column"
+            getPopupContainer={triggerNode => triggerNode.parentNode}
           >
             {columns.map(column => (
               <Select.Option
@@ -355,6 +356,7 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
           <Select
             {...this.selectProps}
             {...operatorSelectProps}
+            getPopupContainer={triggerNode => triggerNode.parentNode}
             name="filter-operator"
           >
             {OPERATORS_OPTIONS.filter(op =>
@@ -369,7 +371,11 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
         <FormGroup data-test="adhoc-filter-simple-value">
           {MULTI_OPERATORS.has(operator) ||
           this.state.suggestions.length > 0 ? (
-            <SelectWithLabel name="filter-value" {...comparatorSelectProps}>
+            <SelectWithLabel
+              name="filter-value"
+              {...comparatorSelectProps}
+              getPopupContainer={triggerNode => triggerNode.parentNode}
+            >
               {this.state.suggestions.map(suggestion => (
                 <Select.Option value={suggestion} key={suggestion}>
                   {suggestion}

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSqlTabContent.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSqlTabContent.jsx
@@ -116,6 +116,7 @@ export default class AdhocFilterEditPopoverSqlTabContent extends React.Component
             {...this.selectProps}
             {...clauseSelectProps}
             className="filter-edit-clause-dropdown"
+            getPopupContainer={triggerNode => triggerNode.parentNode}
           >
             {Object.keys(CLAUSES).map(clause => (
               <Select.Option value={clause} key={clause}>

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover.jsx
@@ -348,7 +348,11 @@ export default class AdhocMetricEditPopover extends React.Component {
               <FormLabel>
                 <strong>{t('Saved metric')}</strong>
               </FormLabel>
-              <Select name="select-saved" {...savedSelectProps}>
+              <Select
+                {...savedSelectProps}
+                name="select-saved"
+                getPopupContainer={triggerNode => triggerNode.parentNode}
+              >
                 {Array.isArray(savedMetricsOptions) &&
                   savedMetricsOptions.map(savedMetric => (
                     <Select.Option
@@ -369,7 +373,11 @@ export default class AdhocMetricEditPopover extends React.Component {
               <FormLabel>
                 <strong>{t('column')}</strong>
               </FormLabel>
-              <Select name="select-column" {...columnSelectProps}>
+              <Select
+                {...columnSelectProps}
+                name="select-column"
+                getPopupContainer={triggerNode => triggerNode.parentNode}
+              >
                 {columns.map(column => (
                   <Select.Option
                     value={column.id}
@@ -385,7 +393,11 @@ export default class AdhocMetricEditPopover extends React.Component {
               <FormLabel>
                 <strong>{t('aggregate')}</strong>
               </FormLabel>
-              <Select name="select-aggregate" {...aggregateSelectProps}>
+              <Select
+                {...aggregateSelectProps}
+                name="select-aggregate"
+                getPopupContainer={triggerNode => triggerNode.parentNode}
+              >
                 {AGGREGATES_OPTIONS.map(option => (
                   <Select.Option value={option} key={option}>
                     {option}


### PR DESCRIPTION
### SUMMARY
Metrics/Columns and Filter **Select** component makes the **AdHoc components** to close unexpectedly on scroll.
https://github.com/apache/superset/issues/12641

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/26679866/106284154-1e8fbf00-6243-11eb-8aff-4b5c7fe91e27.mp4

### TEST PLAN
1. Go to any chart with atleast 10 metrics/column or filter options
2. Try to scroll through metrics/columns in the **AdHoc Component**

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
