### PR TITLE
fix(explore): add current savedMetric to dropdown

### DIFF
--- a/superset-frontend/src/explore/components/controls/MetricControl/MetricsControl.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/MetricsControl.jsx
@@ -63,11 +63,16 @@ const defaultProps = {
   columns: [],
 };
 
-function getOptionsForSavedMetrics(savedMetrics, currentMetricValues) {
+function getOptionsForSavedMetrics(
+  savedMetrics,
+  currentMetricValues,
+  currentMetric,
+) {
   return (
     savedMetrics?.filter(savedMetric =>
       Array.isArray(currentMetricValues)
-        ? !currentMetricValues.includes(savedMetric.metric_name)
+        ? !currentMetricValues.includes(savedMetric.metric_name) ||
+          savedMetric.metric_name === currentMetric
         : savedMetric,
     ) ?? []
   );
@@ -143,6 +148,7 @@ class MetricsControl extends React.PureComponent {
         savedMetricsOptions={getOptionsForSavedMetrics(
           this.props.savedMetrics,
           this.props.value,
+          this.props.value?.[index],
         )}
         datasourceType={this.props.datasourceType}
         onMoveLabel={this.moveLabel}
@@ -284,6 +290,7 @@ class MetricsControl extends React.PureComponent {
         savedMetricsOptions={getOptionsForSavedMetrics(
           this.props.savedMetrics,
           this.props.value,
+          null,
         )}
         savedMetric={{}}
         datasourceType={this.props.datasourceType}


### PR DESCRIPTION
### SUMMARY
When a saved metric is edited in the metric control, the currently selected metric value is missing from the dropdown. This adds the saved value to the dropdown.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #12825
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
