### PR TITLE
feat: add separate endpoint to fetch function names for autocomplete

### DIFF
--- a/superset-frontend/spec/javascripts/sqllab/SqlEditor_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/SqlEditor_spec.jsx
@@ -33,7 +33,10 @@ import ConnectedSouthPane from 'src/SqlLab/components/SouthPane';
 import SqlEditor from 'src/SqlLab/components/SqlEditor';
 import SqlEditorLeftBar from 'src/SqlLab/components/SqlEditorLeftBar';
 import { Dropdown } from 'src/common/components';
-import { queryEditorSetSelectedText } from 'src/SqlLab/actions/sqlLab';
+import {
+  queryEditorSetFunctionNames,
+  queryEditorSetSelectedText,
+} from 'src/SqlLab/actions/sqlLab';
 
 import { initialState, queries, table } from './fixtures';
 
@@ -45,7 +48,7 @@ const store = mockStore(initialState);
 
 describe('SqlEditor', () => {
   const mockedProps = {
-    actions: { queryEditorSetSelectedText },
+    actions: { queryEditorSetFunctionNames, queryEditorSetSelectedText },
     database: {},
     queryEditorId: initialState.sqlLab.queryEditors[0].id,
     latestQuery: queries[0],

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -57,6 +57,8 @@ export const QUERY_EDITOR_SET_QUERY_LIMIT = 'QUERY_EDITOR_SET_QUERY_LIMIT';
 export const QUERY_EDITOR_SET_TEMPLATE_PARAMS =
   'QUERY_EDITOR_SET_TEMPLATE_PARAMS';
 export const QUERY_EDITOR_SET_SELECTED_TEXT = 'QUERY_EDITOR_SET_SELECTED_TEXT';
+export const QUERY_EDITOR_SET_FUNCTION_NAMES =
+  'QUERY_EDITOR_SET_FUNCTION_NAMES';
 export const QUERY_EDITOR_PERSIST_HEIGHT = 'QUERY_EDITOR_PERSIST_HEIGHT';
 export const MIGRATE_QUERY_EDITOR = 'MIGRATE_QUERY_EDITOR';
 export const MIGRATE_TAB_HISTORY = 'MIGRATE_TAB_HISTORY';
@@ -1298,5 +1300,25 @@ export function createCtasDatasource(vizOptions) {
         dispatch(createDatasourceFailed(errorMsg));
         return Promise.reject(new Error(errorMsg));
       });
+  };
+}
+
+export function queryEditorSetFunctionNames(queryEditor, dbId) {
+  return function (dispatch) {
+    return SupersetClient.get({
+      endpoint: encodeURI(`/api/v1/database/${dbId}/function_names/`),
+    })
+      .then(({ json }) =>
+        dispatch({
+          type: QUERY_EDITOR_SET_FUNCTION_NAMES,
+          queryEditor,
+          functionNames: json.function_names,
+        }),
+      )
+      .catch(() =>
+        dispatch(
+          addDangerToast(t('An error occurred while fetching function names')),
+        ),
+      );
   };
 }

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -1317,7 +1317,7 @@ export function queryEditorSetFunctionNames(queryEditor, dbId) {
       )
       .catch(() =>
         dispatch(
-          addDangerToast(t('An error occurred while fetching function names')),
+          addDangerToast(t('An error occurred while fetching function names.')),
         ),
       );
   };

--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper.tsx
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper.tsx
@@ -41,6 +41,7 @@ type HotKey = {
 interface Props {
   actions: {
     queryEditorSetSelectedText: (edit: any, text: null | string) => void;
+    queryEditorSetFunctionNames: (queryEditor: object, dbId: number) => void;
     addTable: (queryEditor: any, value: any, schema: any) => void;
   };
   autocomplete: boolean;
@@ -85,6 +86,10 @@ class AceEditorWrapper extends React.PureComponent<Props, State> {
   componentDidMount() {
     // Making sure no text is selected from previous mount
     this.props.actions.queryEditorSetSelectedText(this.props.queryEditor, null);
+    this.props.actions.queryEditorSetFunctionNames(
+      this.props.queryEditor,
+      this.props.queryEditor.dbId,
+    );
     this.setAutoCompleter(this.props);
   }
 

--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -471,9 +471,7 @@ class SqlEditor extends React.PureComponent {
             sql={this.props.queryEditor.sql}
             schemas={this.props.queryEditor.schemaOptions}
             tables={this.props.queryEditor.tableOptions}
-            functionNames={
-              this.props.database ? this.props.database.function_names : []
-            }
+            functionNames={this.props.queryEditor.functionNames}
             extendedTables={this.props.tables}
             height={`${aceEditorHeight}px`}
             hotkeys={hotkeys}

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar.jsx
@@ -80,6 +80,10 @@ export default class SqlEditorLeftBar extends React.PureComponent {
 
   onDbChange(db) {
     this.props.actions.queryEditorSetDb(this.props.queryEditor, db.id);
+    this.props.actions.queryEditorSetFunctionNames(
+      this.props.queryEditor,
+      db.id,
+    );
   }
 
   onTableChange(tableName, schemaName) {

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.js
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.js
@@ -48,6 +48,7 @@ export default function getInitialState({
     autorun: false,
     templateParams: null,
     dbId: defaultDbId,
+    functionNames: [],
     queryLimit: common.conf.DEFAULT_SQLLAB_LIMIT,
     validationResult: {
       id: null,
@@ -80,6 +81,7 @@ export default function getInitialState({
         autorun: activeTab.autorun,
         templateParams: activeTab.template_params,
         dbId: activeTab.database_id,
+        functionNames: [],
         schema: activeTab.schema,
         queryLimit: activeTab.query_limit,
         validationResult: {

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -434,6 +434,11 @@ export default function sqlLabReducer(state = {}, action) {
         dbId: action.dbId,
       });
     },
+    [actions.QUERY_EDITOR_SET_FUNCTION_NAMES]() {
+      return alterInArr(state, 'queryEditors', action.queryEditor, {
+        functionNames: action.functionNames,
+      });
+    },
     [actions.QUERY_EDITOR_SET_SCHEMA]() {
       return alterInArr(state, 'queryEditors', action.queryEditor, {
         schema: action.schema,

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -53,6 +53,7 @@ from superset.databases.decorators import check_datasource_access
 from superset.databases.filters import DatabaseFilter
 from superset.databases.schemas import (
     database_schemas_query_schema,
+    DatabaseFunctionNamesResponse,
     DatabasePostSchema,
     DatabasePutSchema,
     DatabaseRelatedObjectsResponse,
@@ -83,6 +84,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         "schemas",
         "test_connection",
         "related_objects",
+        "function_names",
     }
     resource_name = "database"
     class_permission_name = "Database"
@@ -126,7 +128,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         "explore_database_id",
         "expose_in_sqllab",
         "force_ctas_schema",
-        "function_names",
         "id",
     ]
     add_columns = [
@@ -642,8 +643,8 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-        dataset = DatabaseDAO.find_by_id(pk)
-        if not dataset:
+        database = DatabaseDAO.find_by_id(pk)
+        if not database:
             return self.response_404()
         data = DatabaseDAO.get_related_objects(pk)
         charts = [
@@ -799,3 +800,43 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         except DatabaseImportError as exc:
             logger.exception("Import database failed")
             return self.response_500(message=str(exc))
+
+    @expose("/<int:pk>/function_names/", methods=["GET"])
+    @protect()
+    @safe
+    @statsd_metrics
+    @event_logger.log_this_with_context(
+        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
+        f".function_names",
+        log_to_statsd=False,
+    )
+    def function_names(self, pk: int) -> Response:
+        """Get function names supported by a database
+        ---
+        get:
+          description:
+            Get function names supported by a database
+          parameters:
+          - in: path
+            name: pk
+            schema:
+              type: integer
+          responses:
+            200:
+            200:
+              description: Query result
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/DatabaseFunctionNamesResponse"
+            401:
+              $ref: '#/components/responses/401'
+            404:
+              $ref: '#/components/responses/404'
+            500:
+              $ref: '#/components/responses/500'
+        """
+        database = DatabaseDAO.find_by_id(pk)
+        if not database:
+            return self.response_404()
+        return self.response(200, function_names=database.function_names,)

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -171,6 +171,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     }
     openapi_spec_tag = "Database"
     openapi_spec_component_schemas = (
+        DatabaseFunctionNamesResponse,
         DatabaseRelatedObjectsResponse,
         DatabaseTestConnectionSchema,
         TableMetadataResponseSchema,

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -413,11 +413,15 @@ class DatabaseRelatedObjectsResponse(Schema):
     dashboards = fields.Nested(DatabaseRelatedDashboards)
 
 
+class DatabaseFunctionNamesResponse(Schema):
+    function_names = fields.List(fields.String())
+
+
 class ImportV1DatabaseExtraSchema(Schema):
     metadata_params = fields.Dict(keys=fields.Str(), values=fields.Raw())
     engine_params = fields.Dict(keys=fields.Str(), values=fields.Raw())
     metadata_cache_timeout = fields.Dict(keys=fields.Str(), values=fields.Integer())
-    schemas_allowed_for_csv_upload = fields.List(fields.String)
+    schemas_allowed_for_csv_upload = fields.List(fields.String())
     cost_estimate_enabled = fields.Boolean()
 
 

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1019,7 +1019,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         :param database: The database to get functions for
         :return: A list of function names useable in the database
         """
-        return ["foo", "bar", "baz"]
+        return []
 
     @staticmethod
     def pyodbc_rows_to_tuples(data: List[Any]) -> List[Tuple[Any, ...]]:

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1019,7 +1019,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         :param database: The database to get functions for
         :return: A list of function names useable in the database
         """
-        return []
+        return ["foo", "bar", "baz"]
 
     @staticmethod
     def pyodbc_rows_to_tuples(data: List[Any]) -> List[Tuple[Any, ...]]:

--- a/tests/databases/api_tests.py
+++ b/tests/databases/api_tests.py
@@ -137,7 +137,6 @@ class TestDatabaseApi(SupersetTestCase):
             "explore_database_id",
             "expose_in_sqllab",
             "force_ctas_schema",
-            "function_names",
             "id",
         ]
         self.assertGreater(response["count"], 0)

--- a/tests/databases/api_tests.py
+++ b/tests/databases/api_tests.py
@@ -1128,6 +1128,10 @@ class TestDatabaseApi(SupersetTestCase):
 
     @mock.patch("superset.db_engine_specs.base.BaseEngineSpec.get_function_names",)
     def test_function_names(self, mock_get_function_names):
+        example_db = get_example_database()
+        if example_db.backend in {"hive", "presto"}:
+            return
+
         mock_get_function_names.return_value = ["AVG", "MAX", "SUM"]
 
         self.login(username="admin")

--- a/tests/databases/api_tests.py
+++ b/tests/databases/api_tests.py
@@ -1125,3 +1125,16 @@ class TestDatabaseApi(SupersetTestCase):
 
         db.session.delete(database)
         db.session.commit()
+
+    @mock.patch("superset.db_engine_specs.base.BaseEngineSpec.get_function_names",)
+    def test_function_names(self, mock_get_function_names):
+        mock_get_function_names.return_value = ["AVG", "MAX", "SUM"]
+
+        self.login(username="admin")
+        uri = "api/v1/database/1/function_names/"
+
+        rv = self.client.get(uri)
+        response = json.loads(rv.data.decode("utf-8"))
+
+        assert rv.status_code == 200
+        assert response == {"function_names": ["AVG", "MAX", "SUM"]}

--- a/tests/databases/api_tests.py
+++ b/tests/databases/api_tests.py
@@ -588,7 +588,8 @@ class TestDatabaseApi(SupersetTestCase):
         assert rv.status_code == 200
         assert "can_read" in data["permissions"]
         assert "can_write" in data["permissions"]
-        assert len(data["permissions"]) == 2
+        assert "can_function_names" in data["permissions"]
+        assert len(data["permissions"]) == 3
 
     def test_get_invalid_database_table_metadata(self):
         """


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Currently some of the `/api/v1/database/` API responses include the list of functions supported by the DB. This is currently only implemented in Presto and Hive, and both implementations need to query the 3rd party DB in order to get that list. If the DB is down or overloaded, this might time out or take too long to complete, affecting users who are trying to see the list of databases or using SQL Lab.

Ideally we want to separate API calls that need to talk to 3rd party DBs (like Hive or Presto), from the calls that talk only to the main Superset DB. This PR changes the database response to **not include** the list of function names. This has been moved to a separate endpoint that is called asynchronously wherever needed (AFAIK only for autocomplete in SQL Lab).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

I changed `superset.db_engine_specs.base.BaseEngineSpec.get_function_names` to return some fake data. Loaded SQL Lab and verified that they show up in the autocomplete, both when loading an existing tab as well as when creating a new one.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
