### PR TITLE
feat: Make initial user configurable in helm chart

### DIFF
--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -128,6 +128,12 @@ init:
     - ". {{ .Values.configMountPath }}/superset_bootstrap.sh; . {{ .Values.configMountPath }}/superset_init.sh"
   enabled: true
   loadExamples: false
+  user:
+    username: admin
+    firstname: Superset
+    lastname: Admin
+    email: admin@superset.com
+    password: admin
   initContainers:
     - name: wait-for-postgres
       image: busybox:latest
@@ -144,11 +150,12 @@ init:
     superset init
     echo "Creating admin user..."
     superset fab create-admin \
-                    --username admin \
-                      --firstname Superset \
-                      --lastname Admin \
-                      --email admin@superset.com \
-                      --password admin || true
+                    --username {{ .Values.init.user.username }} \
+                    --firstname {{ .Values.init.user.firstname }} \
+                    --lastname {{ .Values.init.user.lastname }} \
+                    --email {{ .Values.init.user.email }} \
+                    --password {{ .Values.init.user.password }} \
+                    || true
     {{ if .Values.init.loadExamples }}
     echo "Loading examples..."
     superset load_examples

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -150,11 +150,11 @@ init:
     superset init
     echo "Creating admin user..."
     superset fab create-admin \
-                    --username {{ .Values.init.user.username }} \
-                    --firstname {{ .Values.init.user.firstname }} \
-                    --lastname {{ .Values.init.user.lastname }} \
-                    --email {{ .Values.init.user.email }} \
-                    --password {{ .Values.init.user.password }} \
+                    --username {{ .Values.init.adminUser.username }} \
+                    --firstname {{ .Values.init.adminUser.firstname }} \
+                    --lastname {{ .Values.init.adminUser.lastname }} \
+                    --email {{ .Values.init.adminUser.email }} \
+                    --password {{ .Values.init.adminUser.password }} \
                     || true
     {{ if .Values.init.loadExamples }}
     echo "Loading examples..."

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -128,7 +128,7 @@ init:
     - ". {{ .Values.configMountPath }}/superset_bootstrap.sh; . {{ .Values.configMountPath }}/superset_init.sh"
   enabled: true
   loadExamples: false
-  user:
+  adminUser:
     username: admin
     firstname: Superset
     lastname: Admin


### PR DESCRIPTION
### SUMMARY
This PR updates the helm chart to allow easy configuration of the initial user via helm properties. At the moment, to not use the default admin/admin user, you have to download and modify the chart or to set a the complete init script. With these changes, username/password and the other user details can be set via normal helm properties. 

The default behavior does not change. 


### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
