### PR TITLE
feat: helm chart oauth configuration

### DIFF
--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
   - name: Chuan-Yen Chiang
     email: cychiang0823@gmail.com
     url: https://github.com/cychiang
-version: 0.1.0
+version: 0.2.0

--- a/helm/superset/templates/_helpers.tpl
+++ b/helm/superset/templates/_helpers.tpl
@@ -56,6 +56,24 @@ pip install {{ range .Values.additionalRequirements }}{{ . }} {{ end }}
 
 {{ end -}}
 
+{{- define "superset-common-oauthconfig" }}
+
+from flask_appbuilder.security.manager import AUTH_OAUTH
+AUTH_TYPE = AUTH_OAUTH
+AUTH_USER_REGISTRATION = {{- if .Values.supersetNode.oauth.registration_enabled }} True{{- else }} False{{- end }}
+AUTH_USER_REGISTRATION_ROLE = "{{ .Values.supersetNode.oauth.userRegistrationRole | default "Public" }}"
+
+{{ end -}}
+
+
+{{- define "superset-oauthconfig" }}
+import json
+OAUTH_PROVIDERS = [
+    json.loads('{{ .Values.supersetNode.oauth.config | toJson }}')
+]
+
+{{- end }}
+
 {{- define "superset-config" }}
 import os
 from cachelib.redis import RedisCache
@@ -97,4 +115,10 @@ RESULTS_BACKEND = RedisCache(
       port=env('REDIS_PORT'),
       key_prefix='superset_results'
 )
+
+{{ if .Values.supersetNode.oauth.enabled }}
+{{ include "superset-common-oauthconfig" .  }}
+{{ include "superset-oauthconfig" .  }}
+{{- end }}
+
 {{- end }}

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -101,6 +101,24 @@ supersetNode:
         - secretRef:
             name: '{{ tpl .Values.envFromSecret . }}'
       command: [ "/bin/sh", "-c", "until nc -zv $DB_HOST $DB_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
+  oauth:
+    enabled: false
+    registration_enabled: true
+    userRegistrationRole: Public
+    config:
+      name: google
+      whitelist: []
+      icon: fa-google
+      token_key: access_token
+      remote_app:
+        api_base_url: https://www.googleapis.com/oauth2/v2/
+        client_kwargs:
+          scope: email profile
+        request_token_url: null
+        access_token_url: https://accounts.google.com/o/oauth2/token
+        authorize_url: https://accounts.google.com/o/oauth2/auth
+        # client_id: xx
+        # client_secret: xx
 
 ##
 ## Superset worker configuration


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Ability to configure Oauth for Helm

this is a revival of #10190 

usage as follows in `values.yaml`

```
supersetNode:
  oauth:
    enabled: true
    registration_enabled: true
    userRegistrationRole: Public
    config:
      name: google
      whitelist:
        - '@email_domain.com'
      icon: fa-google
      token_key: access_token
      remote_app:
        api_base_url: https://www.googleapis.com/oauth2/v2/
        client_kwargs:
          scope: email profile
        request_token_url: null
        access_token_url: https://accounts.google.com/o/oauth2/token
        authorize_url: https://accounts.google.com/o/oauth2/auth
        client_id: bladibla_key
        client_secret: bladibla_secret
```


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes #10189 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
