### PR TITLE
refactor: dbapi exception mapping for dbapi's

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -181,8 +181,8 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     @classmethod
     def get_dbapi_exception_mapping(cls) -> Dict[Type[Exception], Type[Exception]]:
         """
-        Each engine can implement and converge it's own specific exceptions into
-        SQLAlchemy DBAPI exceptions
+        Each engine can implement and converge its own specific exceptions into
+        Superset DBAPI exceptions
 
         Note: On python 3.9 this method can be changed to a classmethod property
         without the need of implementing a metaclass type

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -32,6 +32,7 @@ from typing import (
     Optional,
     Pattern,
     Tuple,
+    Type,
     TYPE_CHECKING,
     Union,
 )
@@ -178,6 +179,35 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     }
 
     @classmethod
+    def get_dbapi_exception_mapping(cls) -> Dict[Type[Exception], Type[Exception]]:
+        """
+        Each engine can implement and converge it's own specific exceptions into
+        SQLAlchemy DBAPI exceptions
+
+        Note: On python 3.9 this method can be changed to a classmethod property
+        without the need of implementing a metaclass type
+
+        :return: A map of driver specific exception to superset custom exceptions
+        """
+        return {}
+
+    @classmethod
+    def get_dbapi_mapped_exception(cls, exception: Exception) -> Exception:
+        """
+        Get a superset custom DBAPI exception from the driver specific exception.
+
+        Override if the engine needs to perform extra changes to the exception, for
+        example change the exception message or implement custom more complex logic
+
+        :param exception: The driver specific exception
+        :return: Superset custom DBAPI exception
+        """
+        new_exception = cls.get_dbapi_exception_mapping().get(type(exception))
+        if not new_exception:
+            return exception
+        return new_exception(str(exception))
+
+    @classmethod
     def is_db_column_type_match(
         cls, db_column_type: Optional[str], target_column_type: utils.GenericDataType
     ) -> bool:
@@ -314,9 +344,12 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         """
         if cls.arraysize:
             cursor.arraysize = cls.arraysize
-        if cls.limit_method == LimitMethod.FETCH_MANY and limit:
-            return cursor.fetchmany(limit)
-        return cursor.fetchall()
+        try:
+            if cls.limit_method == LimitMethod.FETCH_MANY and limit:
+                return cursor.fetchmany(limit)
+            return cursor.fetchall()
+        except Exception as ex:
+            raise cls.get_dbapi_mapped_exception(ex)
 
     @classmethod
     def expand_data(
@@ -902,7 +935,10 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         """
         if cls.arraysize:
             cursor.arraysize = cls.arraysize
-        cursor.execute(query)
+        try:
+            cursor.execute(query)
+        except Exception as ex:
+            raise cls.get_dbapi_mapped_exception(ex)
 
     @classmethod
     def make_label_compatible(cls, label: str) -> Union[str, quoted_name]:

--- a/superset/db_engine_specs/elasticsearch.py
+++ b/superset/db_engine_specs/elasticsearch.py
@@ -15,9 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 from datetime import datetime
-from typing import Dict, Optional
+from typing import Dict, Optional, Type
 
 from superset.db_engine_specs.base import BaseEngineSpec
+from superset.db_engine_specs.exceptions import (
+    SupersetDBAPIDatabaseError,
+    SupersetDBAPIOperationalError,
+    SupersetDBAPIProgrammingError,
+)
 from superset.utils import core as utils
 
 
@@ -40,6 +45,16 @@ class ElasticSearchEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-metho
     }
 
     type_code_map: Dict[int, str] = {}  # loaded from get_datatype only if needed
+
+    @classmethod
+    def get_dbapi_exception_mapping(cls) -> Dict[Type[Exception], Type[Exception]]:
+        import es.exceptions as es_exceptions
+
+        return {
+            es_exceptions.DatabaseError: SupersetDBAPIDatabaseError,
+            es_exceptions.OperationalError: SupersetDBAPIOperationalError,
+            es_exceptions.ProgrammingError: SupersetDBAPIProgrammingError,
+        }
 
     @classmethod
     def convert_dttm(cls, target_type: str, dttm: datetime) -> Optional[str]:

--- a/superset/db_engine_specs/elasticsearch.py
+++ b/superset/db_engine_specs/elasticsearch.py
@@ -48,7 +48,7 @@ class ElasticSearchEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-metho
 
     @classmethod
     def get_dbapi_exception_mapping(cls) -> Dict[Type[Exception], Type[Exception]]:
-        import es.exceptions as es_exceptions
+        import es.exceptions as es_exceptions  # pylint: disable=import-error
 
         return {
             es_exceptions.DatabaseError: SupersetDBAPIDatabaseError,

--- a/superset/db_engine_specs/exceptions.py
+++ b/superset/db_engine_specs/exceptions.py
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from superset.exceptions import SupersetException
+
+
+class SupersetDBAPIError(SupersetException):
+    pass
+
+
+class SupersetDBAPIDataError(SupersetDBAPIError):
+    pass
+
+
+class SupersetDBAPIDatabaseError(SupersetDBAPIError):
+    pass
+
+
+class SupersetDBAPIDisconnectionError(SupersetDBAPIError):
+    pass
+
+
+class SupersetDBAPIOperationalError(SupersetDBAPIError):
+    pass
+
+
+class SupersetDBAPIProgrammingError(SupersetDBAPIError):
+    pass

--- a/tests/db_engine_specs/clickhouse_tests.py
+++ b/tests/db_engine_specs/clickhouse_tests.py
@@ -45,4 +45,3 @@ class TestClickHouseDbEngineSpec(TestDbEngineSpec):
         )
         with pytest.raises(SupersetDBAPIDatabaseError) as ex:
             ClickHouseEngineSpec.execute(cursor, "SELECT col1 from table1")
-            assert str(ex) == "xpyo"

--- a/tests/db_engine_specs/clickhouse_tests.py
+++ b/tests/db_engine_specs/clickhouse_tests.py
@@ -14,7 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from unittest import mock
+
+import pytest
+
 from superset.db_engine_specs.clickhouse import ClickHouseEngineSpec
+from superset.db_engine_specs.exceptions import SupersetDBAPIDatabaseError
 from tests.db_engine_specs.base_tests import TestDbEngineSpec
 
 
@@ -30,3 +35,14 @@ class TestClickHouseDbEngineSpec(TestDbEngineSpec):
             ClickHouseEngineSpec.convert_dttm("DATETIME", dttm),
             "toDateTime('2019-01-02 03:04:05')",
         )
+
+    def test_execute_connection_error(self):
+        from urllib3.exceptions import NewConnectionError
+
+        cursor = mock.Mock()
+        cursor.execute.side_effect = NewConnectionError(
+            "Dummypool", message="Exception with sensitive data"
+        )
+        with pytest.raises(SupersetDBAPIDatabaseError) as ex:
+            ClickHouseEngineSpec.execute(cursor, "SELECT col1 from table1")
+            assert str(ex) == "xpyo"


### PR DESCRIPTION
### SUMMARY
Lays the foundation for implementing superset's custom DBAPI exceptions from driver exceptions (following a @villebro idea/proposal). 

DBAPI drivers raise custom exceptions or straight unexpected exceptions, this causes several problems e.g.: UI messages with sensitive text, use of broad exceptions, not possible to use more fine grain actions when an error occurs at the DBAPI.

Fixes: #11822

### ADDITIONAL INFORMATION
- [ ] Has associated issue: #11822
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
