### PR TITLE
refactor: TemplateParamsEditor.jsx converted from class to functional component

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -62,7 +62,7 @@ import {
   validateQuery,
 } from '../actions/sqlLab';
 
-import TemplateParamsEditorRename from './TemplateParamsEditor';
+import TemplateParamsEditor from './TemplateParamsEditor';
 import ConnectedSouthPane from './SouthPane';
 import SaveQuery from './SaveQuery';
 import ScheduleQueryButton from './ScheduleQueryButton';
@@ -514,7 +514,7 @@ class SqlEditor extends React.PureComponent {
         </Menu.Item>
         {isFeatureEnabled(FeatureFlag.ENABLE_TEMPLATE_PROCESSING) && (
           <Menu.Item>
-            <TemplateParamsEditorRename
+            <TemplateParamsEditor
               language="json"
               onChange={params => {
                 this.props.actions.queryEditorSetTemplateParams(qe, params);

--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -62,7 +62,7 @@ import {
   validateQuery,
 } from '../actions/sqlLab';
 
-import TemplateParamsEditor from './TemplateParamsEditor';
+import TemplateParamsEditorRename from './TemplateParamsEditor';
 import ConnectedSouthPane from './SouthPane';
 import SaveQuery from './SaveQuery';
 import ScheduleQueryButton from './ScheduleQueryButton';
@@ -514,7 +514,7 @@ class SqlEditor extends React.PureComponent {
         </Menu.Item>
         {isFeatureEnabled(FeatureFlag.ENABLE_TEMPLATE_PROCESSING) && (
           <Menu.Item>
-            <TemplateParamsEditor
+            <TemplateParamsEditorRename
               language="json"
               onChange={params => {
                 this.props.actions.queryEditorSetTemplateParams(qe, params);

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
@@ -42,7 +42,7 @@ const StyledConfigEditor = styled(ConfigEditor)`
   }
 `;
 
-export const TemplateParamsEditor = props => {
+function TemplateParamsEditor(props) {
   const codeText = props.code || '{}';
   const [state, setState] = useState({
     codeText,
@@ -132,7 +132,7 @@ export const TemplateParamsEditor = props => {
       modalBody={renderModalBody}
     />
   );
-};
+}
 
 TemplateParamsEditor.propTypes = propTypes;
 TemplateParamsEditor.defaultProps = defaultProps;

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
@@ -74,13 +74,13 @@ function TemplateParamsEditor({ code, language }) {
   const modalBody = (
     <div>
       <p>
-        {t('Assign a set of parameters as')}
+        'Assign a set of parameters as'
         <code>JSON</code>
-        {t('below (example:')}
+        'below (example:'
         <code>{'{"my_table": "foo"}'}</code>
-        {t('), and they become available in your SQL (example:')}
+        '), and they become available in your SQL (example:'
         <code>SELECT * FROM {'{{ my_table }}'} </code>
-        {t(') by using')}&nbsp;
+        ') by using'&nbsp;
         <a
           href="https://superset.apache.org/sqllab.html#templating-with-jinja"
           target="_blank"

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Badge from 'src/common/components/Badge';
 import { t, styled } from '@superset-ui/core';
@@ -42,29 +42,18 @@ const StyledConfigEditor = styled(ConfigEditor)`
   }
 `;
 
-function TemplateParamsEditor({ code = '{}', language, onChange }) {
-  const [codeText, setCodeText] = useState(code);
-  const [parsedJSON, setParsedJSON] = useState(null);
+function TemplateParamsEditor({ code, language, onChange }) {
+  const [parsedJSON, setParsedJSON] = useState();
   const [isValid, setIsValid] = useState(true);
 
-  const onChangefunc = value => {
-    const codeText = value;
-    let isValid;
-    let parsedJSON = {};
+  useEffect(() => {
     try {
-      parsedJSON = JSON.parse(value);
-      isValid = true;
-    } catch (e) {
-      isValid = false;
+      setParsedJSON(JSON.parse(code));
+      setIsValid(true);
+    } catch {
+      setIsValid(false);
     }
-    setCodeText(codeText);
-    setIsValid(isValid);
-    setParsedJSON(parsedJSON);
-    const newValue = isValid ? codeText : '{}';
-    if (newValue !== code) {
-      onChange(newValue);
-    }
-  };
+  }, [code]);
 
   const modalBody = (
     <div>
@@ -89,11 +78,11 @@ function TemplateParamsEditor({ code = '{}', language, onChange }) {
         mode={language}
         minLines={25}
         maxLines={50}
-        onChange={onChangefunc}
+        onChange={onChange}
         width="100%"
         editorProps={{ $blockScrolling: true }}
         enableLiveAutocompletion
-        value={codeText}
+        value={code}
       />
     </div>
   );

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Badge from 'src/common/components/Badge';
 import { t, styled } from '@superset-ui/core';
@@ -42,13 +42,10 @@ const StyledConfigEditor = styled(ConfigEditor)`
   }
 `;
 
-function TemplateParamsEditor({ code, language, onChange }) {
-  const codeText = code || '{}';
-  const [state, setState] = useState({
-    codeText,
-    parsedJSON: null,
-    isValid: true,
-  });
+function TemplateParamsEditor({ code = '{}', language, onChange }) {
+  const [codeText, setCodeText] = useState(code);
+  const [parsedJSON, setParsedJSON] = useState(null);
+  const [isValid, setIsValid] = useState(true);
 
   const onChangefunc = value => {
     const codeText = value;
@@ -60,7 +57,9 @@ function TemplateParamsEditor({ code, language, onChange }) {
     } catch (e) {
       isValid = false;
     }
-    setState({ parsedJSON, isValid, codeText });
+    setCodeText(codeText);
+    setIsValid(isValid);
+    setParsedJSON(parsedJSON);
     const newValue = isValid ? codeText : '{}';
     if (newValue !== code) {
       onChange(newValue);
@@ -94,14 +93,12 @@ function TemplateParamsEditor({ code, language, onChange }) {
         width="100%"
         editorProps={{ $blockScrolling: true }}
         enableLiveAutocompletion
-        value={state.codeText}
+        value={codeText}
       />
     </div>
   );
 
-  const paramCount = state.parsedJSON
-    ? Object.keys(state.parsedJSON).length
-    : 0;
+  const paramCount = parsedJSON ? Object.keys(parsedJSON).length : 0;
 
   return (
     <ModalTrigger
@@ -110,7 +107,7 @@ function TemplateParamsEditor({ code, language, onChange }) {
         <div tooltip={t('Edit template parameters')} buttonSize="small">
           {`${t('Parameters')} `}
           <Badge count={paramCount} />
-          {!state.isValid && (
+          {!isValid && (
             <InfoTooltipWithTrigger
               icon="exclamation-triangle"
               bsStyle="danger"

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
@@ -42,8 +42,8 @@ const StyledConfigEditor = styled(ConfigEditor)`
   }
 `;
 
-function TemplateParamsEditor(props) {
-  const codeText = props.code || '{}';
+function TemplateParamsEditor({ code, language }) {
+  const codeText = code || '{}';
   const [state, setState] = useState({
     codeText,
     parsedJSON: null,
@@ -62,8 +62,8 @@ function TemplateParamsEditor(props) {
     }
     setState({ parsedJSON, isValid, codeText });
     const newValue = isValid ? codeText : '{}';
-    if (newValue !== props.code) {
-      props.onChange(newValue);
+    if (newValue !== code) {
+      onChange(newValue);
     }
   };
 
@@ -96,7 +96,7 @@ function TemplateParamsEditor(props) {
       {renderDoc}
       <StyledConfigEditor
         keywords={[]}
-        mode={props.language}
+        mode={language}
         minLines={25}
         maxLines={50}
         onChange={onChange}

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
@@ -71,29 +71,25 @@ function TemplateParamsEditor({ code, language }) {
     onChange(codeText);
   }, [codeText]);
 
-  const renderDoc = (
-    <p>
-      {t('Assign a set of parameters as')}
-      <code>JSON</code>
-      {t('below (example:')}
-      <code>{'{"my_table": "foo"}'}</code>
-      {t('), and they become available in your SQL (example:')}
-      <code>SELECT * FROM {'{{ my_table }}'} </code>
-      {t(') by using')}&nbsp;
-      <a
-        href="https://superset.apache.org/sqllab.html#templating-with-jinja"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Jinja templating
-      </a>{' '}
-      syntax.
-    </p>
-  );
-
-  const renderModalBody = (
+  const modalBody = (
     <div>
-      {renderDoc}
+      <p>
+        {t('Assign a set of parameters as')}
+        <code>JSON</code>
+        {t('below (example:')}
+        <code>{'{"my_table": "foo"}'}</code>
+        {t('), and they become available in your SQL (example:')}
+        <code>SELECT * FROM {'{{ my_table }}'} </code>
+        {t(') by using')}&nbsp;
+        <a
+          href="https://superset.apache.org/sqllab.html#templating-with-jinja"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Jinja templating
+        </a>{' '}
+        syntax.
+      </p>
       <StyledConfigEditor
         keywords={[]}
         mode={language}
@@ -129,7 +125,7 @@ function TemplateParamsEditor({ code, language }) {
           )}
         </div>
       }
-      modalBody={renderModalBody}
+      modalBody={modalBody}
     />
   );
 }

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
@@ -21,6 +21,7 @@ import PropTypes from 'prop-types';
 import Badge from 'src/common/components/Badge';
 import { t, styled } from '@superset-ui/core';
 import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
+import { throttle } from 'lodash';
 
 import ModalTrigger from 'src/components/ModalTrigger';
 import { ConfigEditor } from 'src/components/AsyncAceEditor';
@@ -79,7 +80,7 @@ function TemplateParamsEditor({ code, language, onChange }) {
         mode={language}
         minLines={25}
         maxLines={50}
-        onChange={onChange}
+        onChange={throttle(onChange, 200)}
         width="100%"
         editorProps={{ $blockScrolling: true }}
         enableLiveAutocompletion

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
@@ -51,6 +51,7 @@ function TemplateParamsEditor({ code, language, onChange }) {
       setParsedJSON(JSON.parse(code));
       setIsValid(true);
     } catch {
+      setParsedJSON({});
       setIsValid(false);
     }
   }, [code]);

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Badge from 'src/common/components/Badge';
 import { t, styled } from '@superset-ui/core';
@@ -42,23 +42,15 @@ const StyledConfigEditor = styled(ConfigEditor)`
   }
 `;
 
-export default class TemplateParamsEditor extends React.Component {
-  constructor(props) {
-    super(props);
-    const codeText = props.code || '{}';
-    this.state = {
-      codeText,
-      parsedJSON: null,
-      isValid: true,
-    };
-    this.onChange = this.onChange.bind(this);
-  }
+export const TemplateParamsEditor = props => {
+  const codeText = props.code || '{}';
+  const [state, setState] = useState({
+    codeText,
+    parsedJSON: null,
+    isValid: true,
+  });
 
-  componentDidMount() {
-    this.onChange(this.state.codeText);
-  }
-
-  onChange(value) {
+  const onChange = value => {
     const codeText = value;
     let isValid;
     let parsedJSON = {};
@@ -68,15 +60,19 @@ export default class TemplateParamsEditor extends React.Component {
     } catch (e) {
       isValid = false;
     }
-    this.setState({ parsedJSON, isValid, codeText });
+    setState({ parsedJSON, isValid, codeText });
     const newValue = isValid ? codeText : '{}';
-    if (newValue !== this.props.code) {
-      this.props.onChange(newValue);
+    if (newValue !== props.code) {
+      props.onChange(newValue);
     }
-  }
+  };
 
-  renderDoc() {
-    return (
+  useEffect(() => {
+    onChange(codeText);
+  }, [codeText]);
+
+  const renderDoc = () => {
+    const renderDocContent = (
       <p>
         {t('Assign a set of parameters as')}
         <code>JSON</code>
@@ -95,53 +91,56 @@ export default class TemplateParamsEditor extends React.Component {
         syntax.
       </p>
     );
-  }
+    return renderDocContent;
+  };
 
-  renderModalBody() {
-    return (
+  const renderModalBody = () => {
+    const renderModalBodyContent = (
       <div>
-        {this.renderDoc()}
+        {renderDoc()}
         <StyledConfigEditor
           keywords={[]}
-          mode={this.props.language}
+          mode={props.language}
           minLines={25}
           maxLines={50}
-          onChange={this.onChange}
+          onChange={onChange}
           width="100%"
           editorProps={{ $blockScrolling: true }}
           enableLiveAutocompletion
-          value={this.state.codeText}
+          value={setState(state.codeText)}
         />
       </div>
     );
-  }
+    return renderModalBodyContent;
+  };
 
-  render() {
-    const paramCount = this.state.parsedJSON
-      ? Object.keys(this.state.parsedJSON).length
-      : 0;
-    return (
-      <ModalTrigger
-        modalTitle={t('Template parameters')}
-        triggerNode={
-          <div tooltip={t('Edit template parameters')} buttonSize="small">
-            {`${t('Parameters')} `}
-            <Badge count={paramCount} />
-            {!this.state.isValid && (
-              <InfoTooltipWithTrigger
-                icon="exclamation-triangle"
-                bsStyle="danger"
-                tooltip={t('Invalid JSON')}
-                label="invalid-json"
-              />
-            )}
-          </div>
-        }
-        modalBody={this.renderModalBody(true)}
-      />
-    );
-  }
-}
+  const paramCount = state.parsedJSON
+    ? Object.keys(state.parsedJSON).length
+    : 0;
+
+  return (
+    <ModalTrigger
+      modalTitle={t('Template parameters')}
+      triggerNode={
+        <div tooltip={t('Edit template parameters')} buttonSize="small">
+          {`${t('Parameters')} `}
+          <Badge count={paramCount} />
+          {!state.isValid && (
+            <InfoTooltipWithTrigger
+              icon="exclamation-triangle"
+              bsStyle="danger"
+              tooltip={t('Invalid JSON')}
+              label="invalid-json"
+            />
+          )}
+        </div>
+      }
+      modalBody={renderModalBody(true)}
+    />
+  );
+};
 
 TemplateParamsEditor.propTypes = propTypes;
 TemplateParamsEditor.defaultProps = defaultProps;
+
+export default TemplateParamsEditor;

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
@@ -21,7 +21,7 @@ import PropTypes from 'prop-types';
 import Badge from 'src/common/components/Badge';
 import { t, styled } from '@superset-ui/core';
 import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
-import { throttle } from 'lodash';
+import { debounce } from 'lodash';
 
 import ModalTrigger from 'src/components/ModalTrigger';
 import { ConfigEditor } from 'src/components/AsyncAceEditor';
@@ -80,7 +80,7 @@ function TemplateParamsEditor({ code, language, onChange }) {
         mode={language}
         minLines={25}
         maxLines={50}
-        onChange={throttle(onChange, 200)}
+        onChange={debounce(onChange, 200)}
         width="100%"
         editorProps={{ $blockScrolling: true }}
         enableLiveAutocompletion

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
@@ -71,33 +71,30 @@ export const TemplateParamsEditor = props => {
     onChange(codeText);
   }, [codeText]);
 
-  const renderDoc = () => {
-    const renderDocContent = (
-      <p>
-        {t('Assign a set of parameters as')}
-        <code>JSON</code>
-        {t('below (example:')}
-        <code>{'{"my_table": "foo"}'}</code>
-        {t('), and they become available in your SQL (example:')}
-        <code>SELECT * FROM {'{{ my_table }}'} </code>
-        {t(') by using')}&nbsp;
-        <a
-          href="https://superset.apache.org/sqllab.html#templating-with-jinja"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Jinja templating
-        </a>{' '}
-        syntax.
-      </p>
-    );
-    return renderDocContent;
-  };
+  const renderDoc = (
+    <p>
+      {t('Assign a set of parameters as')}
+      <code>JSON</code>
+      {t('below (example:')}
+      <code>{'{"my_table": "foo"}'}</code>
+      {t('), and they become available in your SQL (example:')}
+      <code>SELECT * FROM {'{{ my_table }}'} </code>
+      {t(') by using')}&nbsp;
+      <a
+        href="https://superset.apache.org/sqllab.html#templating-with-jinja"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Jinja templating
+      </a>{' '}
+      syntax.
+    </p>
+  );
 
   const renderModalBody = () => {
     const renderModalBodyContent = (
       <div>
-        {renderDoc()}
+        {renderDoc}
         <StyledConfigEditor
           keywords={[]}
           mode={props.language}

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
@@ -91,25 +91,22 @@ export const TemplateParamsEditor = props => {
     </p>
   );
 
-  const renderModalBody = () => {
-    const renderModalBodyContent = (
-      <div>
-        {renderDoc}
-        <StyledConfigEditor
-          keywords={[]}
-          mode={props.language}
-          minLines={25}
-          maxLines={50}
-          onChange={onChange}
-          width="100%"
-          editorProps={{ $blockScrolling: true }}
-          enableLiveAutocompletion
-          value={setState(state.codeText)}
-        />
-      </div>
-    );
-    return renderModalBodyContent;
-  };
+  const renderModalBody = (
+    <div>
+      {renderDoc}
+      <StyledConfigEditor
+        keywords={[]}
+        mode={props.language}
+        minLines={25}
+        maxLines={50}
+        onChange={onChange}
+        width="100%"
+        editorProps={{ $blockScrolling: true }}
+        enableLiveAutocompletion
+        value={state.codeText}
+      />
+    </div>
+  );
 
   const paramCount = state.parsedJSON
     ? Object.keys(state.parsedJSON).length
@@ -132,7 +129,7 @@ export const TemplateParamsEditor = props => {
           )}
         </div>
       }
-      modalBody={renderModalBody(true)}
+      modalBody={renderModalBody}
     />
   );
 };

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
@@ -74,13 +74,12 @@ function TemplateParamsEditor({ code, language }) {
   const modalBody = (
     <div>
       <p>
-        'Assign a set of parameters as'
+        Assign a set of parameters as
         <code>JSON</code>
-        'below (example:'
+        below (example:
         <code>{'{"my_table": "foo"}'}</code>
-        '), and they become available in your SQL (example:'
-        <code>SELECT * FROM {'{{ my_table }}'} </code>
-        ') by using'&nbsp;
+        ), and they become available in your SQL (example:
+        <code>SELECT * FROM {'{{ my_table }}'} </code>) by using&nbsp;
         <a
           href="https://superset.apache.org/sqllab.html#templating-with-jinja"
           target="_blank"

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
@@ -42,7 +42,7 @@ const StyledConfigEditor = styled(ConfigEditor)`
   }
 `;
 
-function TemplateParamsEditor({ code, language }) {
+function TemplateParamsEditor({ code, language, onChange }) {
   const codeText = code || '{}';
   const [state, setState] = useState({
     codeText,
@@ -50,7 +50,7 @@ function TemplateParamsEditor({ code, language }) {
     isValid: true,
   });
 
-  const onChange = value => {
+  const onChangefunc = value => {
     const codeText = value;
     let isValid;
     let parsedJSON = {};
@@ -66,10 +66,6 @@ function TemplateParamsEditor({ code, language }) {
       onChange(newValue);
     }
   };
-
-  useEffect(() => {
-    onChange(codeText);
-  }, [codeText]);
 
   const modalBody = (
     <div>
@@ -94,7 +90,7 @@ function TemplateParamsEditor({ code, language }) {
         mode={language}
         minLines={25}
         maxLines={50}
-        onChange={onChange}
+        onChange={onChangefunc}
         width="100%"
         editorProps={{ $blockScrolling: true }}
         enableLiveAutocompletion


### PR DESCRIPTION
### SUMMARY
TemplateParamsEditor.jsx converted from class to functional component.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
I have manually tested changes, see screenshots:
- Dropdown (no set parameters)
<img width="278" alt="Screen Shot 2021-02-01 at 4 35 23 PM" src="https://user-images.githubusercontent.com/55605634/106527218-898ffe80-64ac-11eb-8490-19855b67faef.png">

- Dropdown (1 set parameter)
<img width="226" alt="Screen Shot 2021-02-01 at 4 39 48 PM" src="https://user-images.githubusercontent.com/55605634/106527258-96145700-64ac-11eb-828f-9dcf61bcecfb.png">

- Modal (no set parameters)
<img width="712" alt="Screen Shot 2021-02-01 at 4 36 02 PM" src="https://user-images.githubusercontent.com/55605634/106527452-edb2c280-64ac-11eb-8b42-2c13a0fdf1c3.png">

- Modal (1 set parameter)
<img width="639" alt="Screen Shot 2021-02-01 at 5 10 10 PM" src="https://user-images.githubusercontent.com/55605634/106529721-97e01980-64b0-11eb-8ba1-243cb6b922ae.png">

- Successful query with template parameter
<img width="1035" alt="Screen Shot 2021-02-01 at 5 09 49 PM" src="https://user-images.githubusercontent.com/55605634/106529770-ae867080-64b0-11eb-9c3a-ae0ea27fb466.png">
<img width="1010" alt="Screen Shot 2021-02-01 at 5 10 31 PM" src="https://user-images.githubusercontent.com/55605634/106529782-b0e8ca80-64b0-11eb-8e3a-d050ea65827f.png">
<img width="642" alt="Screen Shot 2021-02-01 at 5 10 45 PM" src="https://user-images.githubusercontent.com/55605634/106529785-b34b2480-64b0-11eb-9658-b3e645f619fc.png">


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
