### PR TITLE
test: speedup celery tests

### DIFF
--- a/tests/celery_tests.py
+++ b/tests/celery_tests.py
@@ -210,7 +210,6 @@ def test_run_sync_query_cta_config(setup_sqllab, ctas_method):
     )
 
     assert query.select_sql == get_select_star(tmp_table_name, schema=CTAS_SCHEMA_NAME)
-    time.sleep(CELERY_SLEEP_TIME)
     results = run_sql(query.select_sql)
     assert QueryStatus.SUCCESS == results["status"], result
 
@@ -231,9 +230,12 @@ def test_run_async_query_cta_config(setup_sqllab, ctas_method):
         QUERY, cta=True, ctas_method=ctas_method, async_=True, tmp_table=tmp_table_name,
     )
 
-    time.sleep(CELERY_SLEEP_TIME)
+    for _ in range(CELERY_SLEEP_TIME * 2):
+        time.sleep(0.5)
+        query = get_query_by_id(result["query"]["serverId"])
+        if QueryStatus.SUCCESS == query.status:
+            break
 
-    query = get_query_by_id(result["query"]["serverId"])
     assert QueryStatus.SUCCESS == query.status
     assert get_select_star(tmp_table_name, schema=CTAS_SCHEMA_NAME) == query.select_sql
     assert (
@@ -252,9 +254,12 @@ def test_run_async_cta_query(setup_sqllab, ctas_method):
         QUERY, cta=True, ctas_method=ctas_method, async_=True, tmp_table=table_name
     )
 
-    time.sleep(CELERY_SLEEP_TIME)
+    for _ in range(CELERY_SLEEP_TIME * 2):
+        time.sleep(0.5)
+        query = get_query_by_id(result["query"]["serverId"])
+        if QueryStatus.SUCCESS == query.status:
+            break
 
-    query = get_query_by_id(result["query"]["serverId"])
     assert QueryStatus.SUCCESS == query.status
     assert get_select_star(table_name) in query.select_sql
 
@@ -274,9 +279,12 @@ def test_run_async_cta_query_with_lower_limit(setup_sqllab, ctas_method):
     result = run_sql(
         QUERY, cta=True, ctas_method=ctas_method, async_=True, tmp_table=tmp_table
     )
-    time.sleep(CELERY_SLEEP_TIME)
+    for _ in range(CELERY_SLEEP_TIME * 2):
+        time.sleep(0.5)
+        query = get_query_by_id(result["query"]["serverId"])
+        if QueryStatus.SUCCESS == query.status:
+            break
 
-    query = get_query_by_id(result["query"]["serverId"])
     assert QueryStatus.SUCCESS == query.status
 
     assert get_select_star(tmp_table) == query.select_sql


### PR DESCRIPTION
### SUMMARY
Speedup async celery tests by querying db in 0.5 s intervals instead of waiting 6s. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
