### PR TITLE
fix(explore): missing select when groupby without metrics

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -967,7 +967,7 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
         columns = columns or []
         columns = [col for col in columns if col != utils.DTTM_ALIAS]
 
-        if (is_sip_38 and metrics and columns) or (not is_sip_38 and metrics):
+        if metrics or groupby:
             # dedup columns while preserving order
             columns = columns if is_sip_38 else (groupby or columns)
             select_exprs = []


### PR DESCRIPTION
### SUMMARY
When a query has a `groupby` without a metric, the `groupby` columns don't show up in the query. Regression caused by #10270 (verified that it worked on the previous commit and broke after).

### AFTER
![image](https://user-images.githubusercontent.com/33317356/106613906-654b2500-6573-11eb-8732-24ce511b6dbe.png)

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/106613832-506e9180-6573-11eb-8b3c-3ced0561b075.png)


### TEST PLAN
Local testing of all examples dashboards + CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #12892
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
