### PR TITLE
build(deps): Bump jinja2 to 2.11.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -53,7 +53,7 @@ idna==2.10                # via email-validator, yarl
 importlib-metadata==2.1.1  # via -r requirements/base.in, jsonschema, kombu, markdown
 isodate==0.6.0            # via apache-superset
 itsdangerous==1.1.0       # via flask, flask-wtf
-jinja2==2.11.2            # via flask, flask-babel
+jinja2==2.11.3            # via flask, flask-babel
 jsonschema==3.2.0         # via flask-appbuilder
 kombu==4.6.11             # via celery
 korean-lunar-calendar==0.2.1  # via holidays


### PR DESCRIPTION
### SUMMARY
Bump `jinja2` to latest version due to recent patches.

### TEST PLAN
Test Jinja templating functionality in queries.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
