### PR TITLE
fix(explore): hide time section for datasets with no time column

### DIFF
--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -38,10 +38,10 @@ default-setup-command() {
 }
 
 apt-get-install() {
-    say "::group::apt-get install dependencies"
-    sudo apt-get update && sudo apt-get install --yes \
-      libsasl2-dev
-    say "::endgroup::"
+  say "::group::apt-get install dependencies"
+  sudo apt-get update && sudo apt-get install --yes \
+    libsasl2-dev
+  say "::endgroup::"
 }
 
 pip-upgrade() {
@@ -167,7 +167,8 @@ cypress-run() {
   if [[ -z $CYPRESS_KEY ]]; then
     $cypress --spec "cypress/integration/$page" --browser "$browser"
   else
-    export CYPRESS_RECORD_KEY=`echo $CYPRESS_KEY | base64 --decode`
+    CYPRESS_RECORD_KEY=$(echo "$CYPRESS_KEY" | base64 --decode)
+    export CYPRESS_RECORD_KEY
     # additional flags for Cypress dashboard recording
     $cypress --spec "cypress/integration/$page" --browser "$browser" \
       --record --group "$group" --tag "${GITHUB_REPOSITORY},${GITHUB_EVENT_NAME}" \

--- a/superset-frontend/cypress-base/cypress/integration/explore/chart.test.js
+++ b/superset-frontend/cypress-base/cypress/integration/explore/chart.test.js
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { FORM_DATA_DEFAULTS, NUM_METRIC } from './visualizations/shared.helper';
+import { FORM_DATA_DEFAULTS, NUM_METRIC } from './visualizations/constants';
 
 describe('No Results', () => {
   beforeEach(() => {

--- a/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
@@ -20,7 +20,6 @@
 // Tests for setting controls in the UI
 // ***********************************************
 import { interceptChart } from 'cypress/utils';
-import { FORM_DATA_DEFAULTS, NUM_METRIC } from './visualizations/shared.helper';
 
 describe('Datasource control', () => {
   const newMetricName = `abc${Date.now()}`;
@@ -119,119 +118,6 @@ describe('VizType control', () => {
       waitAlias: '@lineChartData',
       chartSelector: 'svg',
     });
-  });
-});
-
-describe('Time range filter', () => {
-  beforeEach(() => {
-    cy.login();
-    interceptChart({ legacy: true }).as('chartData');
-  });
-
-  it('Advanced time_range params', () => {
-    const formData = {
-      ...FORM_DATA_DEFAULTS,
-      viz_type: 'line',
-      time_range: '100 years ago : now',
-      metrics: [NUM_METRIC],
-    };
-
-    cy.visitChartByParams(JSON.stringify(formData));
-    cy.verifySliceSuccess({ waitAlias: '@chartData' });
-
-    cy.get('[data-test=time-range-trigger]')
-      .click()
-      .then(() => {
-        cy.get('.footer').find('button').its('length').should('eq', 2);
-        cy.get('.ant-popover-content').within(() => {
-          cy.get('input[value="100 years ago"]');
-          cy.get('input[value="now"]');
-        });
-        cy.get('[data-test=cancel-button]').click();
-        cy.get('.ant-popover').should('not.be.visible');
-      });
-  });
-
-  it('Common time_range params', () => {
-    const formData = {
-      ...FORM_DATA_DEFAULTS,
-      viz_type: 'line',
-      metrics: [NUM_METRIC],
-      time_range: 'Last year',
-    };
-
-    cy.visitChartByParams(JSON.stringify(formData));
-    cy.verifySliceSuccess({ waitAlias: '@chartData' });
-
-    cy.get('[data-test=time-range-trigger]')
-      .click()
-      .then(() => {
-        cy.get('.ant-radio-group').children().its('length').should('eq', 5);
-        cy.get('.ant-radio-checked + span').contains('last year');
-        cy.get('[data-test=cancel-button]').click();
-      });
-  });
-
-  it('Previous time_range params', () => {
-    const formData = {
-      ...FORM_DATA_DEFAULTS,
-      viz_type: 'line',
-      metrics: [NUM_METRIC],
-      time_range: 'previous calendar month',
-    };
-
-    cy.visitChartByParams(JSON.stringify(formData));
-    cy.verifySliceSuccess({ waitAlias: '@chartData' });
-
-    cy.get('[data-test=time-range-trigger]')
-      .click()
-      .then(() => {
-        cy.get('.ant-radio-group').children().its('length').should('eq', 3);
-        cy.get('.ant-radio-checked + span').contains('previous calendar month');
-        cy.get('[data-test=cancel-button]').click();
-      });
-  });
-
-  it('Custom time_range params', () => {
-    const formData = {
-      ...FORM_DATA_DEFAULTS,
-      viz_type: 'line',
-      metrics: [NUM_METRIC],
-      time_range: 'DATEADD(DATETIME("today"), -7, day) : today',
-    };
-
-    cy.visitChartByParams(JSON.stringify(formData));
-    cy.verifySliceSuccess({ waitAlias: '@chartData' });
-
-    cy.get('[data-test=time-range-trigger]')
-      .click()
-      .then(() => {
-        cy.get('[data-test=custom-frame]').then(() => {
-          cy.get('.ant-input-number-input-wrap > input')
-            .invoke('attr', 'value')
-            .should('eq', '7');
-        });
-        cy.get('[data-test=cancel-button]').click();
-      });
-  });
-
-  it('No filter time_range params', () => {
-    const formData = {
-      ...FORM_DATA_DEFAULTS,
-      viz_type: 'line',
-      metrics: [NUM_METRIC],
-      time_range: 'No filter',
-    };
-
-    cy.visitChartByParams(JSON.stringify(formData));
-    cy.verifySliceSuccess({ waitAlias: '@chartData' });
-
-    cy.get('[data-test=time-range-trigger]')
-      .click()
-      .then(() => {
-        cy.get('[data-test=no-filter]');
-      });
-    cy.get('[data-test=cancel-button]').click();
   });
 });
 

--- a/superset-frontend/cypress-base/cypress/integration/explore/controls/time.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/controls/time.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { interceptChart } from 'cypress/utils';
+import { FORM_DATA_DEFAULTS, NUM_METRIC } from '../visualizations/constants';
+
+function changeDatasetTo(target: string) {
+  // change to a non-timeseries dataset
+  cy.get('[data-test=datasource-menu-trigger]').click();
+  cy.get('[role=menu] li').contains('Change dataset').click();
+  cy.get('[data-test=datasource-link]').contains(target).click({ force: true });
+  cy.get('button').contains('Proceed').click();
+}
+
+describe('Time column and time granularity', () => {
+  beforeEach(() => {
+    cy.login();
+    interceptChart({ legacy: false }).as('chartData');
+    interceptChart({ legacy: true }).as('legacyChartData');
+  });
+
+  it('Show time section for Table and FilterBox chart', () => {
+    const formData = {
+      ...FORM_DATA_DEFAULTS,
+      metrics: [NUM_METRIC],
+    };
+    cy.visitChartByParams(JSON.stringify(formData));
+    cy.verifySliceSuccess({ waitAlias: '@chartData' });
+
+    cy.get('.control-panel-section').should('contain', 'Time');
+    cy.get('[data-test=granularity_sqla]').contains('Time Column');
+
+    // change to FilterBox
+    cy.get('[data-test=visualization-type]').click();
+    cy.get('.viztype-selector-container ').contains('Filter box').click();
+    // time sections should still be visible, check Filter configuration section
+    // exists first to make sure viz type switch was successful
+    cy.get('.control-panel-section').contains('Filters configuration');
+    cy.get('[data-test=granularity_sqla]').contains('Time Column');
+
+    changeDatasetTo('energy_usage');
+    cy.get('[data-test=granularity_sqla]').should('not.exist');
+    cy.get('.control-panel-section').should('not.contain', 'Time');
+
+    // change back to a timeseries dataset should add back time section
+    changeDatasetTo('birth_names');
+    cy.get('[data-test=granularity_sqla]').should('exist');
+    cy.get('.control-panel-section').should('contain', 'Time');
+  });
+});

--- a/superset-frontend/cypress-base/cypress/integration/explore/controls/time_range.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/controls/time_range.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { interceptChart } from 'cypress/utils';
+import { FORM_DATA_DEFAULTS, NUM_METRIC } from '../visualizations/constants';
+
+describe('Time range filter', () => {
+  beforeEach(() => {
+    cy.login();
+    interceptChart({ legacy: true }).as('chartData');
+  });
+
+  it('Advanced time_range params', () => {
+    const formData = {
+      ...FORM_DATA_DEFAULTS,
+      viz_type: 'line',
+      time_range: '100 years ago : now',
+      metrics: [NUM_METRIC],
+    };
+
+    cy.visitChartByParams(JSON.stringify(formData));
+    cy.verifySliceSuccess({ waitAlias: '@chartData' });
+
+    cy.get('[data-test=time-range-trigger]')
+      .click()
+      .then(() => {
+        cy.get('.footer').find('button').its('length').should('eq', 2);
+        cy.get('.ant-popover-content').within(() => {
+          cy.get('input[value="100 years ago"]');
+          cy.get('input[value="now"]');
+        });
+        cy.get('[data-test=cancel-button]').click();
+        cy.get('.ant-popover').should('not.be.visible');
+      });
+  });
+
+  it('Common time_range params', () => {
+    const formData = {
+      ...FORM_DATA_DEFAULTS,
+      viz_type: 'line',
+      metrics: [NUM_METRIC],
+      time_range: 'Last year',
+    };
+
+    cy.visitChartByParams(JSON.stringify(formData));
+    cy.verifySliceSuccess({ waitAlias: '@chartData' });
+
+    cy.get('[data-test=time-range-trigger]')
+      .click()
+      .then(() => {
+        cy.get('.ant-radio-group').children().its('length').should('eq', 5);
+        cy.get('.ant-radio-checked + span').contains('last year');
+        cy.get('[data-test=cancel-button]').click();
+      });
+  });
+
+  it('Previous time_range params', () => {
+    const formData = {
+      ...FORM_DATA_DEFAULTS,
+      viz_type: 'line',
+      metrics: [NUM_METRIC],
+      time_range: 'previous calendar month',
+    };
+
+    cy.visitChartByParams(JSON.stringify(formData));
+    cy.verifySliceSuccess({ waitAlias: '@chartData' });
+
+    cy.get('[data-test=time-range-trigger]')
+      .click()
+      .then(() => {
+        cy.get('.ant-radio-group').children().its('length').should('eq', 3);
+        cy.get('.ant-radio-checked + span').contains('previous calendar month');
+        cy.get('[data-test=cancel-button]').click();
+      });
+  });
+
+  it('Custom time_range params', () => {
+    const formData = {
+      ...FORM_DATA_DEFAULTS,
+      viz_type: 'line',
+      metrics: [NUM_METRIC],
+      time_range: 'DATEADD(DATETIME("today"), -7, day) : today',
+    };
+
+    cy.visitChartByParams(JSON.stringify(formData));
+    cy.verifySliceSuccess({ waitAlias: '@chartData' });
+
+    cy.get('[data-test=time-range-trigger]')
+      .click()
+      .then(() => {
+        cy.get('[data-test=custom-frame]').then(() => {
+          cy.get('.ant-input-number-input-wrap > input')
+            .invoke('attr', 'value')
+            .should('eq', '7');
+        });
+        cy.get('[data-test=cancel-button]').click();
+      });
+  });
+
+  it('No filter time_range params', () => {
+    const formData = {
+      ...FORM_DATA_DEFAULTS,
+      viz_type: 'line',
+      metrics: [NUM_METRIC],
+      time_range: 'No filter',
+    };
+
+    cy.visitChartByParams(JSON.stringify(formData));
+    cy.verifySliceSuccess({ waitAlias: '@chartData' });
+
+    cy.get('[data-test=time-range-trigger]')
+      .click()
+      .then(() => {
+        cy.get('[data-test=no-filter]');
+      });
+    cy.get('[data-test=cancel-button]').click();
+  });
+});

--- a/superset-frontend/cypress-base/cypress/integration/explore/filter_box.test.js
+++ b/superset-frontend/cypress-base/cypress/integration/explore/filter_box.test.js
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { FORM_DATA_DEFAULTS } from './visualizations/shared.helper';
+import { FORM_DATA_DEFAULTS } from './visualizations/constants';
 
 describe('Edit FilterBox Chart', () => {
   const VIZ_DEFAULTS = { ...FORM_DATA_DEFAULTS, viz_type: 'filter_box' };

--- a/superset-frontend/cypress-base/cypress/integration/explore/link.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/link.test.ts
@@ -23,7 +23,7 @@
 import rison from 'rison';
 import shortid from 'shortid';
 import { interceptChart } from 'cypress/utils';
-import { HEALTH_POP_FORM_DATA_DEFAULTS } from './visualizations/shared.helper';
+import { HEALTH_POP_FORM_DATA_DEFAULTS } from './visualizations/constants';
 
 const apiURL = (endpoint: string, queryObject: Record<string, unknown>) =>
   `${endpoint}?q=${rison.encode(queryObject)}`;

--- a/superset-frontend/cypress-base/cypress/integration/explore/visualizations/big_number_total.test.js
+++ b/superset-frontend/cypress-base/cypress/integration/explore/visualizations/big_number_total.test.js
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { FORM_DATA_DEFAULTS, NUM_METRIC } from './shared.helper';
+import { FORM_DATA_DEFAULTS, NUM_METRIC } from './constants';
 
 describe('Visualization > Big Number Total', () => {
   const BIG_NUMBER_DEFAULTS = {

--- a/superset-frontend/cypress-base/cypress/integration/explore/visualizations/constants.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/visualizations/constants.ts
@@ -20,8 +20,14 @@
 // Constants for visualization tests
 // ***********************************************
 
+export enum DatasourceId {
+  engergy_use = '1__table',
+  world_population = '2__table',
+  birth_names = '3__table',
+}
+
 export const FORM_DATA_DEFAULTS = {
-  datasource: '3__table',
+  datasource: DatasourceId.birth_names,
   granularity_sqla: 'ds',
   time_grain_sqla: null,
   time_range: '100+years+ago+:+now',
@@ -34,7 +40,7 @@ export const FORM_DATA_DEFAULTS = {
 };
 
 export const HEALTH_POP_FORM_DATA_DEFAULTS = {
-  datasource: '2__table',
+  datasource: DatasourceId.world_population,
   granularity_sqla: 'ds',
   time_grain_sqla: 'P1D',
   time_range: '1960-01-01+:+2014-01-02',

--- a/superset-frontend/cypress-base/cypress/integration/explore/visualizations/dist_bar.test.js
+++ b/superset-frontend/cypress-base/cypress/integration/explore/visualizations/dist_bar.test.js
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { FORM_DATA_DEFAULTS, NUM_METRIC } from './shared.helper';
+import { FORM_DATA_DEFAULTS, NUM_METRIC } from './constants';
 
 describe('Visualization > Distribution bar chart', () => {
   const VIZ_DEFAULTS = { ...FORM_DATA_DEFAULTS, viz_type: 'dist_bar' };

--- a/superset-frontend/cypress-base/cypress/integration/explore/visualizations/line.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/visualizations/line.test.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { FORM_DATA_DEFAULTS, NUM_METRIC, SIMPLE_FILTER } from './shared.helper';
+import { FORM_DATA_DEFAULTS, NUM_METRIC, SIMPLE_FILTER } from './constants';
 
 describe('Visualization > Line', () => {
   const LINE_CHART_DEFAULTS = { ...FORM_DATA_DEFAULTS, viz_type: 'line' };

--- a/superset-frontend/cypress-base/cypress/integration/explore/visualizations/table.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/visualizations/table.test.ts
@@ -23,7 +23,7 @@ import {
   MAX_DS,
   MAX_STATE,
   SIMPLE_FILTER,
-} from './shared.helper';
+} from './constants';
 
 // Table
 describe('Visualization > Table', () => {

--- a/superset-frontend/cypress-base/cypress/integration/explore/visualizations/time_table.js
+++ b/superset-frontend/cypress-base/cypress/integration/explore/visualizations/time_table.js
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { FORM_DATA_DEFAULTS, NUM_METRIC } from './shared.helper';
+import { FORM_DATA_DEFAULTS, NUM_METRIC } from './constants';
 
 describe('Visualization > Time TableViz', () => {
   const VIZ_DEFAULTS = { ...FORM_DATA_DEFAULTS, viz_type: 'time_table' };


### PR DESCRIPTION
### SUMMARY

This could be a somewhat controversial feature, but it doesn't seem to make much sense to display the Time section when the datasource has no time columns available. Shall we hide it for these datasources?

One downside of this is that the granularity and time range will reset to default when users change to a non-timeseries dataset then change it back to a timeseries dataset. The benefit is cleaner UI and less clutters for non-timeseries datasets.

#### Before

<img width="1101" alt="energy-use-yes-time" src="https://user-images.githubusercontent.com/335541/106671932-14800000-6564-11eb-83da-c0a21b33f150.png">


#### After

<img width="1107" alt="energy-use-no-time" src="https://user-images.githubusercontent.com/335541/106671846-f1ede700-6563-11eb-9810-ab15024bc13b.png">


### TEST PLAN

Manual verification:

1. Open "Explore" in datasets with and without a time column
2. Make sure both cases work

I also added some Cypress tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: 
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
