### PR TITLE
feat: clear search on dataset change

### DIFF
--- a/superset-frontend/src/explore/components/DatasourcePanel.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel.tsx
@@ -104,6 +104,7 @@ export default function DataSourcePanel({
   actions,
 }: Props) {
   const { columns, metrics } = datasource;
+  const [inputValue, setInputValue] = useState('');
   const [lists, setList] = useState({
     columns,
     metrics,
@@ -168,6 +169,7 @@ export default function DataSourcePanel({
       columns,
       metrics,
     });
+    setInputValue('');
   }, [columns, datasource, metrics]);
 
   const metricSlice = lists.metrics.slice(0, 50);
@@ -178,8 +180,10 @@ export default function DataSourcePanel({
       <input
         type="text"
         onChange={evt => {
+          setInputValue(evt.target.value);
           search(evt.target.value);
         }}
+        value={inputValue}
         className="form-control input-md"
         placeholder={t('Search Metrics & Columns')}
       />


### PR DESCRIPTION
### SUMMARY
resets metrics search input to empty state on dataset change.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/17326228/106697785-5759cc00-6594-11eb-8c09-343a7b074755.mov


### TEST PLAN
In datasource panel change datasource and check if input field is clear from prev state. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
