### PR TITLE
chore: rename duplicate build jobs

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -61,6 +61,8 @@ github:
         # contexts are the names of checks that must pass
         contexts:
           - check
+          - lint
+          - test-mysql
 
       required_pull_request_reviews:
         dismiss_stale_reviews: false

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -61,8 +61,6 @@ github:
         # contexts are the names of checks that must pass
         contexts:
           - check
-          - lint
-          - test-mysql
 
       required_pull_request_reviews:
         dismiss_stale_reviews: false

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -4,8 +4,8 @@ on:
   release:
     types: [published]
 jobs:
-  build:
-    name: build
+  docker-release:
+    name: docker-release
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"

--- a/.github/workflows/superset-docs.yml
+++ b/.github/workflows/superset-docs.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   docs:
-    name: build
+    name: docs
     runs-on: ubuntu-20.04
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"

--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -9,7 +9,7 @@ on:
     types: [synchronize, opened, reopened, ready_for_review]
 
 jobs:
-  build:
+  frontend-build:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
### SUMMARY
On https://github.com/apache/superset/pull/12694 we started moving some required checks to the new .asf.yaml config that Apache provides. We started by testing just one job so that we could verify that it worked and we didn't inadvertently block any jobs by using the wrong job name. We have tested that the file is working, but there are some checks with duplicate names. This pr renames the duplicate jobs. In a subsequent PR(s), I will add the rest of the checks with the new job names. 


### TEST PLAN
Verify that master requires the new jobs when this merges. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
