### PR TITLE
fix: add alert report timeout limits

### DIFF
--- a/superset-frontend/spec/javascripts/views/CRUD/alert/AlertReportModal_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/alert/AlertReportModal_spec.jsx
@@ -240,4 +240,37 @@ describe('AlertReportModal', () => {
     expect(addWrapper.find('input[name="grace_period"]')).toExist();
     expect(wrapper.find('input[name="grace_period"]')).toHaveLength(0);
   });
+
+  it('only allows grace period values > 1', async () => {
+    const props = {
+      ...mockedProps,
+      isReport: false,
+    };
+
+    const addWrapper = await mountAndWait(props);
+
+    const input = addWrapper.find('input[name="grace_period"]');
+
+    input.simulate('change', { target: { name: 'grace_period', value: 7 } });
+    expect(input.instance().value).toEqual("7");
+
+    input.simulate('change', { target: { name: 'grace_period', value: 0 } });
+    expect(input.instance().value).toEqual("");
+
+    input.simulate('change', { target: { name: 'grace_period', value: -1 } });
+    expect(input.instance().value).toEqual("1");
+  });
+
+  it('only allows working timeout values > 1', () => {
+    const input = wrapper.find('input[name="working_timeout"]');
+
+    input.simulate('change', { target: { name: 'working_timeout', value: 7 } });
+    expect(input.instance().value).toEqual("7");
+
+    input.simulate('change', { target: { name: 'working_timeout', value: 0 } });
+    expect(input.instance().value).toEqual("");
+
+    input.simulate('change', { target: { name: 'working_timeout', value: -1 } });
+    expect(input.instance().value).toEqual("1");
+  });
 });

--- a/superset-frontend/spec/javascripts/views/CRUD/alert/AlertReportModal_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/alert/AlertReportModal_spec.jsx
@@ -252,25 +252,27 @@ describe('AlertReportModal', () => {
     const input = addWrapper.find('input[name="grace_period"]');
 
     input.simulate('change', { target: { name: 'grace_period', value: 7 } });
-    expect(input.instance().value).toEqual("7");
+    expect(input.instance().value).toEqual('7');
 
     input.simulate('change', { target: { name: 'grace_period', value: 0 } });
-    expect(input.instance().value).toEqual("");
+    expect(input.instance().value).toEqual('');
 
     input.simulate('change', { target: { name: 'grace_period', value: -1 } });
-    expect(input.instance().value).toEqual("1");
+    expect(input.instance().value).toEqual('1');
   });
 
   it('only allows working timeout values > 1', () => {
     const input = wrapper.find('input[name="working_timeout"]');
 
     input.simulate('change', { target: { name: 'working_timeout', value: 7 } });
-    expect(input.instance().value).toEqual("7");
+    expect(input.instance().value).toEqual('7');
 
     input.simulate('change', { target: { name: 'working_timeout', value: 0 } });
-    expect(input.instance().value).toEqual("");
+    expect(input.instance().value).toEqual('');
 
-    input.simulate('change', { target: { name: 'working_timeout', value: -1 } });
-    expect(input.instance().value).toEqual("1");
+    input.simulate('change', {
+      target: { name: 'working_timeout', value: -1 },
+    });
+    expect(input.instance().value).toEqual('1');
   });
 });

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -1270,6 +1270,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
               <div className="input-container">
                 <input
                   type="number"
+                  min="0"
                   name="working_timeout"
                   value={currentAlert ? currentAlert.working_timeout : ''}
                   placeholder={t('Time in seconds')}
@@ -1284,6 +1285,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                 <div className="input-container">
                   <input
                     type="number"
+                    min="0"
                     name="grace_period"
                     value={currentAlert?.grace_period || ''}
                     placeholder={t('Time in seconds')}

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -34,6 +34,7 @@ import { AlertReportCronScheduler } from './components/AlertReportCronScheduler'
 import { AlertObject, Operator, Recipient, MetaObject } from './types';
 
 const SELECT_PAGE_SIZE = 2000; // temporary fix for paginated query
+const TIMEOUT_MIN = 1;
 
 type SelectValue = {
   value: string;
@@ -829,6 +830,19 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
     updateAlertState(target.name, target.value);
   };
 
+  const onTimeoutVerifyChange = (
+    event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
+  ) => {
+    const { target } = event;
+    const value = +target.value;
+
+    // Need to make sure grace period is not lower than TIMEOUT_MIN
+    updateAlertState(
+      target.name,
+      value ? Math.max(value, TIMEOUT_MIN) : value,
+    );
+  };
+
   const onSQLChange = (value: string) => {
     updateAlertState('sql', value || '');
   };
@@ -1270,11 +1284,11 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
               <div className="input-container">
                 <input
                   type="number"
-                  min="0"
+                  min="1"
                   name="working_timeout"
                   value={currentAlert ? currentAlert.working_timeout : ''}
                   placeholder={t('Time in seconds')}
-                  onChange={onTextChange}
+                  onChange={onTimeoutVerifyChange}
                 />
                 <span className="input-label">seconds</span>
               </div>
@@ -1285,11 +1299,11 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                 <div className="input-container">
                   <input
                     type="number"
-                    min="0"
+                    min="1"
                     name="grace_period"
                     value={currentAlert?.grace_period || ''}
                     placeholder={t('Time in seconds')}
-                    onChange={onTextChange}
+                    onChange={onTimeoutVerifyChange}
                   />
                   <span className="input-label">seconds</span>
                 </div>

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -837,7 +837,12 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
     const value = +target.value;
 
     // Need to make sure grace period is not lower than TIMEOUT_MIN
-    updateAlertState(target.name, value ? Math.max(value, TIMEOUT_MIN) : value);
+    if ( value === 0 ) {
+      updateAlertState(target.name, null);
+    }
+    else {
+      updateAlertState(target.name, value ? Math.max(value, TIMEOUT_MIN) : value);
+    }
   };
 
   const onSQLChange = (value: string) => {
@@ -1283,7 +1288,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                   type="number"
                   min="1"
                   name="working_timeout"
-                  value={currentAlert ? currentAlert.working_timeout : ''}
+                  value={currentAlert?.working_timeout || ''}
                   placeholder={t('Time in seconds')}
                   onChange={onTimeoutVerifyChange}
                 />

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -837,10 +837,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
     const value = +target.value;
 
     // Need to make sure grace period is not lower than TIMEOUT_MIN
-    updateAlertState(
-      target.name,
-      value ? Math.max(value, TIMEOUT_MIN) : value,
-    );
+    updateAlertState(target.name, value ? Math.max(value, TIMEOUT_MIN) : value);
   };
 
   const onSQLChange = (value: string) => {

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -837,11 +837,13 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
     const value = +target.value;
 
     // Need to make sure grace period is not lower than TIMEOUT_MIN
-    if ( value === 0 ) {
+    if (value === 0) {
       updateAlertState(target.name, null);
-    }
-    else {
-      updateAlertState(target.name, value ? Math.max(value, TIMEOUT_MIN) : value);
+    } else {
+      updateAlertState(
+        target.name,
+        value ? Math.max(value, TIMEOUT_MIN) : value,
+      );
     }
   };
 

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -159,7 +159,11 @@ class ReportSchedulePostSchema(Schema):
         ),
     )
     validator_config_json = fields.Nested(ValidatorConfigJSONSchema)
-    log_retention = fields.Integer(description=log_retention_description, example=90)
+    log_retention = fields.Integer(
+        description=log_retention_description,
+        example=90,
+        validate=[Range(min=1, error=_("Value must be greater than 0"))],
+    )
     grace_period = fields.Integer(
         description=grace_period_description,
         example=60 * 60 * 4,
@@ -170,6 +174,7 @@ class ReportSchedulePostSchema(Schema):
         description=working_timeout_description,
         example=60 * 60 * 1,
         default=60 * 60 * 1,
+        validate=[Range(min=1, error=_("Value must be greater than 0"))],
     )
 
     recipients = fields.List(fields.Nested(ReportRecipientSchema))
@@ -229,15 +234,22 @@ class ReportSchedulePutSchema(Schema):
     )
     validator_config_json = fields.Nested(ValidatorConfigJSONSchema, required=False)
     log_retention = fields.Integer(
-        description=log_retention_description, example=90, required=False
+        description=log_retention_description,
+        example=90,
+        required=False,
+        validate=[Range(min=1, error=_("Value must be greater than 0"))],
     )
     grace_period = fields.Integer(
-        description=grace_period_description, example=60 * 60 * 4, required=False
+        description=grace_period_description,
+        example=60 * 60 * 4,
+        required=False,
+        validate=[Range(min=1, error=_("Value must be greater than 0"))],
     )
     working_timeout = fields.Integer(
         description=working_timeout_description,
         example=60 * 60 * 1,
         allow_none=True,
         required=False,
+        validate=[Range(min=1, error=_("Value must be greater than 0"))],
     )
     recipients = fields.List(fields.Nested(ReportRecipientSchema), required=False)

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -161,8 +161,10 @@ class ReportSchedulePostSchema(Schema):
     validator_config_json = fields.Nested(ValidatorConfigJSONSchema)
     log_retention = fields.Integer(description=log_retention_description, example=90)
     grace_period = fields.Integer(
-        description=grace_period_description, example=60 * 60 * 4, default=60 * 60 * 4,
-        validate=[Range(min=1, error=_("Value must be greater than 0"))]
+        description=grace_period_description,
+        example=60 * 60 * 4,
+        default=60 * 60 * 4,
+        validate=[Range(min=1, error=_("Value must be greater than 0"))],
     )
     working_timeout = fields.Integer(
         description=working_timeout_description,

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -16,9 +16,10 @@
 # under the License.
 from typing import Any, Dict, Union
 
+from flask_babel import gettext as _
 from croniter import croniter
 from marshmallow import fields, Schema, validate, validates_schema
-from marshmallow.validate import Length, ValidationError
+from marshmallow.validate import Length, Range, ValidationError
 
 from superset.models.reports import (
     ReportRecipientType,
@@ -160,7 +161,8 @@ class ReportSchedulePostSchema(Schema):
     validator_config_json = fields.Nested(ValidatorConfigJSONSchema)
     log_retention = fields.Integer(description=log_retention_description, example=90)
     grace_period = fields.Integer(
-        description=grace_period_description, example=60 * 60 * 4, default=60 * 60 * 4
+        description=grace_period_description, example=60 * 60 * 4, default=60 * 60 * 4,
+        validate=[Range(min=1, error=_("Value must be greater than 0"))]
     )
     working_timeout = fields.Integer(
         description=working_timeout_description,

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -16,8 +16,8 @@
 # under the License.
 from typing import Any, Dict, Union
 
-from flask_babel import gettext as _
 from croniter import croniter
+from flask_babel import gettext as _
 from marshmallow import fields, Schema, validate, validates_schema
 from marshmallow.validate import Length, Range, ValidationError
 

--- a/tests/reports/api_tests.py
+++ b/tests/reports/api_tests.py
@@ -512,6 +512,30 @@ class TestReportSchedulesApi(SupersetTestCase):
         rv = self.client.post(uri, json=report_schedule_data)
         assert rv.status_code == 400
 
+        # Test that report can be created with null grace period
+        report_schedule_data = {
+            "type": ReportScheduleType.ALERT,
+            "name": "new3",
+            "description": "description",
+            "crontab": "0 9 * * *",
+            "recipients": [
+                {
+                    "type": ReportRecipientType.EMAIL,
+                    "recipient_config_json": {"target": "target@superset.org"},
+                },
+                {
+                    "type": ReportRecipientType.SLACK,
+                    "recipient_config_json": {"target": "channel"},
+                },
+            ],
+            "working_timeout": 3600,
+            "chart": chart.id,
+            "database": example_db.id,
+        }
+        uri = "api/v1/report/"
+        rv = self.client.post(uri, json=report_schedule_data)
+        assert rv.status_code == 201
+
         # Test that grace period and working timeout cannot be < 1
         report_schedule_data = {
             "type": ReportScheduleType.ALERT,

--- a/tests/reports/api_tests.py
+++ b/tests/reports/api_tests.py
@@ -427,6 +427,8 @@ class TestReportSchedulesApi(SupersetTestCase):
                     "recipient_config_json": {"target": "channel"},
                 },
             ],
+            "grace_period": 14400,
+            "working_timeout": 3600,
             "chart": chart.id,
             "database": example_db.id,
         }
@@ -437,6 +439,8 @@ class TestReportSchedulesApi(SupersetTestCase):
         created_model = db.session.query(ReportSchedule).get(data.get("id"))
         assert created_model is not None
         assert created_model.name == report_schedule_data["name"]
+        assert created_model.grace_period == report_schedule_data["grace_period"]
+        assert created_model.working_timeout == report_schedule_data["working_timeout"]
         assert created_model.description == report_schedule_data["description"]
         assert created_model.crontab == report_schedule_data["crontab"]
         assert created_model.chart.id == report_schedule_data["chart"]
@@ -501,6 +505,54 @@ class TestReportSchedulesApi(SupersetTestCase):
             "name": "name3",
             "description": "description",
             "crontab": "0 9 * * *",
+            "chart": chart.id,
+            "database": example_db.id,
+        }
+        uri = "api/v1/report/"
+        rv = self.client.post(uri, json=report_schedule_data)
+        assert rv.status_code == 400
+
+        # Test that grace period and working timeout cannot be < 1
+        report_schedule_data = {
+            "type": ReportScheduleType.ALERT,
+            "name": "new3",
+            "description": "description",
+            "crontab": "0 9 * * *",
+            "recipients": [
+                {
+                    "type": ReportRecipientType.EMAIL,
+                    "recipient_config_json": {"target": "target@superset.org"},
+                },
+                {
+                    "type": ReportRecipientType.SLACK,
+                    "recipient_config_json": {"target": "channel"},
+                },
+            ],
+            "working_timeout": -10,
+            "chart": chart.id,
+            "database": example_db.id,
+        }
+        uri = "api/v1/report/"
+        rv = self.client.post(uri, json=report_schedule_data)
+        assert rv.status_code == 400
+
+        report_schedule_data = {
+            "type": ReportScheduleType.ALERT,
+            "name": "new3",
+            "description": "description",
+            "crontab": "0 9 * * *",
+            "recipients": [
+                {
+                    "type": ReportRecipientType.EMAIL,
+                    "recipient_config_json": {"target": "target@superset.org"},
+                },
+                {
+                    "type": ReportRecipientType.SLACK,
+                    "recipient_config_json": {"target": "channel"},
+                },
+            ],
+            "grace_period": -10,
+            "working_timeout": 3600,
             "chart": chart.id,
             "database": example_db.id,
         }


### PR DESCRIPTION
### SUMMARY
- [x] Working Timeout and Grace Period fields should not be negative
- [x] Adds min value to modal input fields to prevent user from setting negative values

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TEST PLAN
Manual Test:
1. Open alert/report modal
2. Enter values for Working Timeout/Grace Period (where applicable)
3. Confirm that value cannot be set below 0

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
