### PR TITLE
fix(viz): bump table viz to fix ordering bug

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -19077,9 +19077,9 @@
       }
     },
     "@superset-ui/plugin-chart-table": {
-      "version": "0.17.3",
-      "resolved": "https://registry.npmjs.org/@superset-ui/plugin-chart-table/-/plugin-chart-table-0.17.3.tgz",
-      "integrity": "sha512-mfVrm/P0vdiwDvsSwjc/h9KaYaOtV/Kr+IgQZ8FDrcovuKokkyXSvnkPBB/FFogBGuhXn1EEymrqgF7yQZqiMA==",
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@superset-ui/plugin-chart-table/-/plugin-chart-table-0.17.4.tgz",
+      "integrity": "sha512-lP8lA85ycTczYmEK33X56INQopAd+5lsORAfN0rglgGexIOGmHpIsNsMQDlDmr0QYGOyUcU+uk27Nxn3zfg05Q==",
       "requires": {
         "@emotion/core": "^10.0.28",
         "@superset-ui/chart-controls": "0.17.2",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -90,7 +90,7 @@
     "@superset-ui/legacy-preset-chart-deckgl": "^0.4.1",
     "@superset-ui/legacy-preset-chart-nvd3": "^0.17.2",
     "@superset-ui/plugin-chart-echarts": "^0.17.2",
-    "@superset-ui/plugin-chart-table": "^0.17.3",
+    "@superset-ui/plugin-chart-table": "^0.17.4",
     "@superset-ui/plugin-chart-word-cloud": "^0.17.2",
     "@superset-ui/preset-chart-xy": "^0.17.2",
     "@vx/responsive": "^0.0.195",


### PR DESCRIPTION
### SUMMARY
During a recent refactor the default behavior of table chart changed which requires explicitly stating the ordering of rows. This PR updates the table chart viz plugin to the newest version which sorts the data based on the first metric unless an order is set. See https://github.com/apache-superset/superset-ui/pull/930 for screenshots and more details.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
