### PR TITLE
fix: add required * indicator to message content/notif method in alert/report modal

### DIFF
--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -177,8 +177,19 @@ const StyledSectionContainer = styled.div`
 `;
 
 const StyledSectionTitle = styled.div`
+  display: flex;
+  align-items: center;
   margin: ${({ theme }) => theme.gridUnit * 2}px auto
     ${({ theme }) => theme.gridUnit * 4}px auto;
+
+  h4 {
+    margin: 0;
+  }
+
+  .required {
+    margin-left: ${({ theme }) => theme.gridUnit}px;
+    color: ${({ theme }) => theme.colors.error.base};
+  }
 `;
 
 const StyledSwitchContainer = styled.div`
@@ -1213,6 +1224,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                   ? t('Report schedule')
                   : t('Alert condition schedule')}
               </h4>
+              <span className="required">*</span>
             </StyledSectionTitle>
             <AlertReportCronScheduler
               value={
@@ -1282,6 +1294,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
           <div className="column message">
             <StyledSectionTitle>
               <h4>{t('Message content')}</h4>
+              <span className="required">*</span>
             </StyledSectionTitle>
             <div className="inline-container add-margin">
               <Radio.Group onChange={onContentTypeChange} value={contentType}>
@@ -1331,6 +1344,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
             />
             <StyledSectionTitle>
               <h4>{t('Notification method')}</h4>
+              <span className="required">*</span>
             </StyledSectionTitle>
             <NotificationMethod
               setting={notificationSettings[0]}


### PR DESCRIPTION
### SUMMARY
- [x] Adds a `*` to Alert condition schedule, message content and notification method headers in to better communicate that it is a required field for submitting an alert/report

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1305" alt="Screen Shot 2021-02-03 at 2 26 20 PM" src="https://user-images.githubusercontent.com/8216382/106817593-ea921080-662b-11eb-8875-b8d93fb0efdf.png">

### TEST PLAN

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
