### PR TITLE
fix: chart keys in MultiLineViz

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1453,10 +1453,14 @@ class MultiLineViz(NVD3Viz):
                 x_values = [value["x"] for value in series["values"]]
                 min_x = min(x_values + ([min_x] if min_x is not None else []))
                 max_x = max(x_values + ([max_x] if max_x is not None else []))
-
+                series_key = (
+                    series["key"]
+                    if isinstance(series["key"], (list, tuple))
+                    else [series["key"]]
+                )
                 data.append(
                     {
-                        "key": prefix + ", ".join(series["key"]),
+                        "key": prefix + ", ".join(series_key),
                         "type": "line",
                         "values": series["values"],
                         "yAxis": y_axis,


### PR DESCRIPTION
### SUMMARY
fixing multi-line viz issue of incorrectly formatted text for chart key when single line chart is used as a data

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before**
<img width="1017" alt="BeforeMultiLinVizFix" src="https://user-images.githubusercontent.com/20442310/106868364-4d1ef700-6694-11eb-8be1-f3d12764fadd.png">

**After**
<img width="1012" alt="AfterMultiLineVizFix" src="https://user-images.githubusercontent.com/20442310/106868365-4db78d80-6694-11eb-8abb-3b64a55764cc.png">


### TEST PLAN
Observe correctly formatted key for data in API call for both multi-line charts and single-line charts as a chart source

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #12935 
- [x] Fixes #12935 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
