### PR TITLE
feat: add option inject external scripts

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -404,6 +404,16 @@ EXTRA_CATEGORICAL_COLOR_SCHEMES: List[Dict[str, Any]] = []
 
 THEME_OVERRIDES: Dict[str, Any] = {}
 
+# EXTRA_SCRIPTS: Dict[str, str] = {}
+EXTRA_SCRIPTS: Dict[str, str] = {
+    "position" : 'head',
+    "code": """
+        fetch('https://jsonplaceholder.typicode.com/posts/42', {
+            method: 'GET',
+        }).then(response => response.json()).then(result => console.log("Result from remote server: ", result));
+    """
+}
+
 # EXTRA_SEQUENTIAL_COLOR_SCHEMES is used for adding custom sequential color schemes
 # EXTRA_SEQUENTIAL_COLOR_SCHEMES =  [
 #     {

--- a/superset/config.py
+++ b/superset/config.py
@@ -404,15 +404,21 @@ EXTRA_CATEGORICAL_COLOR_SCHEMES: List[Dict[str, Any]] = []
 
 THEME_OVERRIDES: Dict[str, Any] = {}
 
-# EXTRA_SCRIPTS: Dict[str, str] = {}
-EXTRA_SCRIPTS: Dict[str, str] = {
-    "position" : 'head',
-    "code": """
-        fetch('https://jsonplaceholder.typicode.com/posts/42', {
-            method: 'GET',
-        }).then(response => response.json()).then(result => console.log("Result from remote server: ", result));
-    """
-}
+# EXTRA_SCRIPTS gives opportunity to inject custom scripts to head/body tags in html page
+# Parameters:
+# - position: 'head' / 'body' - specify position of injected script (in the end of <head/> or <body/> tag)
+# - code: valid js snippet code that will be called when page loaded
+#
+# Example:
+# EXTRA_SCRIPTS: Dict[str, str] = {
+#     "position" : 'head',
+#     "code": """
+#         fetch('https://jsonplaceholder.typicode.com/posts/42', {
+#             method: 'GET',
+#         }).then(response => response.json()).then(result => console.log("Result from remote server: ", result));
+#     """
+# }
+EXTRA_SCRIPTS: Dict[str, str] = {}
 
 # EXTRA_SEQUENTIAL_COLOR_SCHEMES is used for adding custom sequential color schemes
 # EXTRA_SEQUENTIAL_COLOR_SCHEMES =  [

--- a/superset/templates/superset/basic.html
+++ b/superset/templates/superset/basic.html
@@ -70,13 +70,17 @@
         {% include 'appbuilder/navbar.html' %}
       {% endif %}
     {% endblock %}
-
     {% block body %}
       <div id="app" data-bootstrap="{{ bootstrap_data }}">
         <img src="/static/assets/images/loading.gif" style="width: 50px; position: absolute; top: 50%; left: 50%; transform: translate(-50%,-50%)">
       </div>
     {% endblock %}
 
+    {% if extra_scripts and extra_scripts.position == 'head' %}
+      <script>
+        {{ extra_scripts.code | safe }}
+      </script>
+    {% endif %}
     <!-- Modal for misc messages / alerts  -->
     <div class="misc-modal modal fade" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
       <div class="modal-dialog" role="document">
@@ -105,5 +109,11 @@
       {% endif %}
       {% include "tail_js_custom_extra.html" %}
     {% endblock %}
+
+    {% if extra_scripts and extra_scripts.position == 'body' %}
+      <script>
+        {{ extra_scripts.code | safe }}
+      </script>
+    {% endif %}
   </body>
 </html>

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -824,6 +824,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             bootstrap_data=json.dumps(
                 bootstrap_data, default=utils.pessimistic_json_iso_dttm_ser
             ),
+            extra_scripts=conf.get("EXTRA_SCRIPTS"),
             entry="explore",
             title=title,
             standalone_mode=standalone,
@@ -1884,6 +1885,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         return self.render_template(
             "superset/dashboard.html",
             entry="dashboard",
+            extra_scripts=conf.get("EXTRA_SCRIPTS"),
             standalone_mode=standalone_mode,
             title=dash.dashboard_title,
             custom_css=dash.css,
@@ -2820,6 +2822,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             "superset/basic.html",
             title=_("%(user)s's profile", user=username),
             entry="profile",
+            extra_scripts=conf.get("EXTRA_SCRIPTS"),
             bootstrap_data=json.dumps(
                 payload, default=utils.pessimistic_json_iso_dttm_ser
             ),
@@ -2894,7 +2897,10 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         )
 
         return self.render_template(
-            "superset/basic.html", entry="sqllab", bootstrap_data=bootstrap_data
+            "superset/basic.html",
+            extra_scripts=conf.get("EXTRA_SCRIPTS"),
+            entry="sqllab",
+            bootstrap_data=bootstrap_data,
         )
 
     @has_access


### PR DESCRIPTION
### SUMMARY
This feature gives opportunity to inject external custom scripts.
Main goal of this feature to add analytics scripts like (Goggle Analytics, etc...), but can be used also for injecting other scripts required by customer needs.

Attached code description:
```
# EXTRA_SCRIPTS gives opportunity to inject custom scripts to head/body tags in html page
# Parameters:
# - position: 'head' / 'body' - specify position of injected script (in the end of <head/> or <body/> tag)
# - code: valid js snippet code that will be called when page loaded
#
# Example:
# EXTRA_SCRIPTS: Dict[str, str] = {
#     "position" : 'head',
#     "code": """
#         fetch('https://jsonplaceholder.typicode.com/posts/42', {
#             method: 'GET',
#         }).then(response => response.json()).then(result => console.log("Result from remote server: ", result));
#     """
# }
```
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

https://user-images.githubusercontent.com/56388545/106898497-ef72c500-66fc-11eb-93cd-3e4aacf4fdea.mov

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
