### PR TITLE
fix: refresh dashboard list after bulk delete

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/chart_list/list_view.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/chart_list/list_view.test.ts
@@ -47,4 +47,15 @@ describe('chart list view', () => {
       .find('[data-test="cell-text"]')
       .contains('Location of Current Developers');
   });
+
+  it('should bulk delete correctly', () => {
+    cy.get('[data-test="listview-table"]').should('be.visible');
+    cy.get('[data-test="bulk-select"]').eq(0).click();
+    cy.get('[data-test="checkbox-off"]').eq(1).click();
+    cy.get('[data-test="checkbox-off"]').eq(2).click();
+    cy.get('[data-test="bulk-select-action"]').eq(0).click();
+    cy.get('[data-test="delete-modal-input"]').eq(0).type('DELETE');
+    cy.get('[data-test="modal-confirm-button"]').eq(0).click();
+    cy.get('[data-test="checkbox-on"]').should('not.exist');
+  });
 });

--- a/superset-frontend/cypress-base/cypress/integration/dashboard_list/list_view.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard_list/list_view.test.ts
@@ -47,4 +47,15 @@ describe('dashboard list view', () => {
       .find('[data-test="cell-text"]')
       .contains("World Bank's Data");
   });
+
+  it('should bulk delete correctly', () => {
+    cy.get('[data-test="listview-table"]').should('be.visible');
+    cy.get('[data-test="bulk-select"]').eq(0).click();
+    cy.get('[data-test="checkbox-off"]').eq(1).click();
+    cy.get('[data-test="checkbox-off"]').eq(2).click();
+    cy.get('[data-test="bulk-select-action"]').eq(0).click();
+    cy.get('[data-test="delete-modal-input"]').eq(0).type('DELETE');
+    cy.get('[data-test="modal-confirm-button"]').eq(0).click();
+    cy.get('[data-test="checkbox-on"]').should('not.exist');
+  });
 });

--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -516,6 +516,7 @@ function ChartList(props: ChartListProps) {
     subMenuButtons.push({
       name: t('Bulk select'),
       buttonStyle: 'secondary',
+      'data-test': 'bulk-select',
       onClick: toggleBulkSelect,
     });
   }

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
@@ -169,6 +169,7 @@ function DashboardList(props: DashboardListProps) {
       )}`,
     }).then(
       ({ json = {} }) => {
+        refreshData();
         addSuccessToast(json.message);
       },
       createErrorHandler(errMsg =>
@@ -471,6 +472,7 @@ function DashboardList(props: DashboardListProps) {
     subMenuButtons.push({
       name: t('Bulk select'),
       buttonStyle: 'secondary',
+      'data-test': 'bulk-select',
       onClick: toggleBulkSelect,
     });
   }


### PR DESCRIPTION
### SUMMARY
Refresh dashboard list after bulk delete.

@junlincc 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![before](https://user-images.githubusercontent.com/70410625/106901214-3b5e4380-66d6-11eb-852a-8302de5f1d8f.gif)

![after](https://user-images.githubusercontent.com/70410625/106900878-d276cb80-66d5-11eb-8ae4-8eb380918bff.gif)


### TEST PLAN
1 - Go to dashboad list
2 - Delete an item using bulk delete
3 - The item should be deleted and the list refreshed

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
