### PR TITLE
fix: Detecting top scroll on Dashboard header

### DIFF
--- a/superset-frontend/src/dashboard/components/dnd/handleScroll.ts
+++ b/superset-frontend/src/dashboard/components/dnd/handleScroll.ts
@@ -16,29 +16,27 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { throttle } from 'lodash';
-import getDropPosition from '../../util/getDropPosition';
-import handleScroll from './handleScroll';
+let scrollTopDashboardInterval: any;
+const SCROLL_STEP = 120;
+const INTERVAL_DELAY = 50;
 
-const HOVER_THROTTLE_MS = 100;
-
-function handleHover(props, monitor, Component) {
-  // this may happen due to throttling
-  if (!Component.mounted) return;
-
-  const dropPosition = getDropPosition(monitor, Component);
-
-  handleScroll(dropPosition);
-
-  if (!dropPosition || dropPosition === 'SCROLL_TOP') {
-    Component.setState(() => ({ dropIndicator: null }));
-    return;
+export default function handleScroll(dropPosition: string) {
+  if (dropPosition === 'SCROLL_TOP') {
+    if (!scrollTopDashboardInterval) {
+      scrollTopDashboardInterval = setInterval(() => {
+        let scrollTop = document.documentElement.scrollTop - SCROLL_STEP;
+        if (scrollTop < 0) {
+          scrollTop = 0;
+        }
+        window.scroll({
+          top: scrollTop,
+          behavior: 'smooth',
+        });
+      }, INTERVAL_DELAY);
+    }
   }
-
-  Component.setState(() => ({
-    dropIndicator: dropPosition,
-  }));
+  if (dropPosition !== 'SCROLL_TOP' && scrollTopDashboardInterval) {
+    clearInterval(scrollTopDashboardInterval);
+    scrollTopDashboardInterval = null;
+  }
 }
-
-// this is called very frequently by react-dnd
-export default throttle(handleHover, HOVER_THROTTLE_MS);

--- a/superset-frontend/src/dashboard/util/getDropPosition.js
+++ b/superset-frontend/src/dashboard/util/getDropPosition.js
@@ -17,12 +17,13 @@
  * under the License.
  */
 import isValidChild from './isValidChild';
-import { TAB_TYPE, TABS_TYPE } from './componentTypes';
+import { DASHBOARD_ROOT_TYPE, TAB_TYPE, TABS_TYPE } from './componentTypes';
 
 export const DROP_TOP = 'DROP_TOP';
 export const DROP_RIGHT = 'DROP_RIGHT';
 export const DROP_BOTTOM = 'DROP_BOTTOM';
 export const DROP_LEFT = 'DROP_LEFT';
+export const SCROLL_TOP = 'SCROLL_TOP';
 
 // this defines how close the mouse must be to the edge of a component to display
 // a sibling type drop indicator
@@ -52,6 +53,10 @@ export default function getDropPosition(monitor, Component) {
   // if dropped self on self, do nothing
   if (!draggingItem || draggingItem.id === component.id) {
     return null;
+  }
+
+  if (component.type === DASHBOARD_ROOT_TYPE) {
+    return SCROLL_TOP;
   }
 
   // TODO need a better solution to prevent nested tabs


### PR DESCRIPTION
### SUMMARY
This is updated [PR](https://github.com/apache/superset/pull/12104) which was closed due to react-dnd upgrade. 
Currently in edit mode in dashboard it's impossible to scroll to top while dragging an element. It is now possible when dragged element is hovering dashboard's header.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/2536609/102547288-47a42800-40b9-11eb-8915-05a7db66226c.gif

### TEST PLAN
1. Go to one of dashboards
2. Go to edit mode
3. Add so many elements that right scroll appears
4. Scroll down
5. Drag element and move it over header

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes: #11907
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
