### PR TITLE
fix: typo to apache/superset

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -563,7 +563,7 @@ pip3 install -r requirements/integration.txt
 pre-commit install
 ```
 
-Alternatively it possible to run pre-commit via tox:
+Alternatively it is possible to run pre-commit via tox:
 
 ```bash
 tox -e pre-commit


### PR DESCRIPTION
### SUMMARY
Changed typo on line 566 of Contributing Doc. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![image](https://user-images.githubusercontent.com/48933336/107071899-67032b80-67b3-11eb-9722-5421f8d684b7.png)


