### PR TITLE
chore: remove example token to avoid confusion

### DIFF
--- a/scripts/cancel_github_workflows.py
+++ b/scripts/cancel_github_workflows.py
@@ -20,7 +20,7 @@ Manually cancel previous GitHub Action workflow runs in queue.
 
 Example:
   # Set up
-  export GITHUB_TOKEN=394ba3b48494ab8f930fbc93
+  export GITHUB_TOKEN={{ your personal github access token }}
   export GITHUB_REPOSITORY=apache/superset
 
   # cancel previous jobs for a PR, will even cancel the running ones


### PR DESCRIPTION
### SUMMARY

Some may think the example GitHub token added in [#12625](https://github.com/apache/superset/pull/12625#discussion_r566027843) is real.

Let's just remove it to avoid future confusion.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

Not needed

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
