### PR TITLE
chore: cleanup no-op Cypress (chrome) job

### DIFF
--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -109,12 +109,3 @@ jobs:
         with:
           name: screenshots
           path: ${{ github.workspace }}/superset-frontend/cypress-base/cypress/screenshots
-  Cypress:
-    if: github.event.pull_request.draft == false && ${{ always() }}
-    name: Cypress (chrome)
-    runs-on: ubuntu-20.04
-    needs: cypress-matrix
-    steps:
-      - name: Check build matrix status
-        if: ${{ needs.cypress-matrix.result != 'success' }}
-        run: exit 1


### PR DESCRIPTION
### SUMMARY

Clean up the no-op "Cypress (chrome)" in `superset-e2e` workflow since we don't need it to pass required checks anymore: https://github.com/apache/superset/pull/12928#issuecomment-773104736

It takes time to schedule and run this job, which sometimes blocks CI checks in yellow state when it should be green.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

Make sure `Cypress (chrome)` is gone and not shown up in required checks.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
