### PR TITLE
fix: SQL Lab editor height in Safari

### DIFF
--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -46,6 +46,11 @@ body {
   height: 100%;
 }
 
+.ant-tabs-content-holder {
+  /* This is needed for Safari */
+  height: 100%;
+}
+
 .ant-tabs-content {
   height: 100%;
   position: relative;


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Currently SQL Lab is broken in Safari because the height of the `div.SqlEditor`, set to 100%, is computed as 20px (0 height + 10px vertical padding on each margin). This happens because the parent `<div>` has no height declaration, receiving a height of 0. Updating the parent `<div>` to have height 100% fixes the problem.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

<img width="1436" alt="Screen Shot 2021-02-05 at 11 58 03 AM" src="https://user-images.githubusercontent.com/1534870/107082701-70879600-67a9-11eb-85ad-b8ef65920850.png">

After:

<img width="1436" alt="Screen Shot 2021-02-05 at 11 55 53 AM" src="https://user-images.githubusercontent.com/1534870/107082636-53eb5e00-67a9-11eb-861f-74ea75c53042.png">

This fixes https://github.com/apache/superset/issues/12565.

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: https://github.com/apache/superset/issues/12565
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
