### PR TITLE
feat(dashboard_rbac): single dashboard api

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -322,7 +322,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     # designs introduced in https://github.com/apache/superset/issues/8976
     # (SIP-34). This is a work in progress so not all features available in FAB have
     # been implemented.
-    "ENABLE_REACT_CRUD_VIEWS": False,
+    "ENABLE_REACT_CRUD_VIEWS": True,
     # When True, this flag allows display of HTML tags in Markdown components
     "DISPLAY_MARKDOWN_HTML": True,
     # When True, this escapes HTML (rather than rendering it) in Markdown components
@@ -342,7 +342,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     "ALERT_REPORTS": False,
     # Enable experimental feature to search for other dashboards
     "OMNIBAR": False,
-    "DASHBOARD_RBAC": True,
+    "DASHBOARD_RBAC": False,
 }
 
 # Set the default view to card/grid view if thumbnail support is enabled.

--- a/superset/config.py
+++ b/superset/config.py
@@ -322,7 +322,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     # designs introduced in https://github.com/apache/superset/issues/8976
     # (SIP-34). This is a work in progress so not all features available in FAB have
     # been implemented.
-    "ENABLE_REACT_CRUD_VIEWS": True,
+    "ENABLE_REACT_CRUD_VIEWS": False,
     # When True, this flag allows display of HTML tags in Markdown components
     "DISPLAY_MARKDOWN_HTML": True,
     # When True, this escapes HTML (rather than rendering it) in Markdown components
@@ -342,7 +342,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     "ALERT_REPORTS": False,
     # Enable experimental feature to search for other dashboards
     "OMNIBAR": False,
-    "DASHBOARD_RBAC": False,
+    "DASHBOARD_RBAC": True,
 }
 
 # Set the default view to card/grid view if thumbnail support is enabled.

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -488,7 +488,84 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             utils.error_msg_from_exception(ex), status=403
         ),
     )
+    @merge_response_func(ModelRestApi.merge_show_label_columns, API_LABEL_COLUMNS_RIS_KEY)
+    @merge_response_func(ModelRestApi.merge_show_columns, API_SHOW_COLUMNS_RIS_KEY)
+    @merge_response_func(ModelRestApi.merge_description_columns, API_DESCRIPTION_COLUMNS_RIS_KEY)
+    @merge_response_func(ModelRestApi.merge_show_title, API_SHOW_TITLE_RIS_KEY)
     def get(self, pk, **kwargs):
+        """Get Dashboard from Model
+        ---
+        get:
+          description: >-
+            Get an dashboard model
+          parameters:
+          - in: path
+            schema:
+              type: integer
+            name: pk
+          - in: query
+            name: q
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/get_item_schema'
+          responses:
+            200:
+              description: Item from Model
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      label_columns:
+                        type: object
+                        properties:
+                          column_name:
+                            description: >-
+                              The label for the column name.
+                              Will be translated by babel
+                            example: A Nice label for the column
+                            type: string
+                      show_columns:
+                        description: >-
+                          A list of columns
+                        type: array
+                        items:
+                          type: string
+                      description_columns:
+                        type: object
+                        properties:
+                          column_name:
+                            description: >-
+                              The description for the column name.
+                              Will be translated by babel
+                            example: A Nice description for the column
+                            type: string
+                      show_title:
+                        description: >-
+                          A title to render.
+                          Will be translated by babel
+                        example: Show Item Details
+                        type: string
+                      id:
+                        description: The item id
+                        type: string
+                      result:
+                        $ref: '#/components/schemas/{{self.__class__.__name__}}.get'
+            400:
+              $ref: '#/components/responses/400'
+            401:
+              $ref: '#/components/responses/401'
+            403:
+              $ref: '#/components/responses/403'
+            404:
+              $ref: '#/components/responses/404'
+            422:
+              $ref: '#/components/responses/422'
+            500:
+              $ref: '#/components/responses/500'
+        """
+
         return super(DashboardRestApi, self).get(pk, **kwargs)
 
     @expose("/export/", methods=["GET"])

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -23,13 +23,7 @@ from zipfile import ZipFile
 
 from flask import g, make_response, redirect, request, Response, send_file, url_for
 from flask_appbuilder import permission_name
-from flask_appbuilder.api import (
-    expose,
-    get_item_schema,
-    protect,
-    rison,
-    safe,
-)
+from flask_appbuilder.api import expose, get_item_schema, protect, rison, safe
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_babel import ngettext
 from marshmallow import ValidationError

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -488,9 +488,13 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             utils.error_msg_from_exception(ex), status=403
         ),
     )
-    @merge_response_func(ModelRestApi.merge_show_label_columns, API_LABEL_COLUMNS_RIS_KEY)
+    @merge_response_func(
+        ModelRestApi.merge_show_label_columns, API_LABEL_COLUMNS_RIS_KEY
+    )
     @merge_response_func(ModelRestApi.merge_show_columns, API_SHOW_COLUMNS_RIS_KEY)
-    @merge_response_func(ModelRestApi.merge_description_columns, API_DESCRIPTION_COLUMNS_RIS_KEY)
+    @merge_response_func(
+        ModelRestApi.merge_description_columns, API_DESCRIPTION_COLUMNS_RIS_KEY
+    )
     @merge_response_func(ModelRestApi.merge_show_title, API_SHOW_TITLE_RIS_KEY)
     def get(self, pk, **kwargs):
         """Get Dashboard from Model

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -507,55 +507,9 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             schema:
               type: integer
             name: pk
-          - in: query
-            name: q
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/get_item_schema'
           responses:
             200:
-              description: Item from Model
-              content:
-                application/json:
-                  schema:
-                    type: object
-                    properties:
-                      label_columns:
-                        type: object
-                        properties:
-                          column_name:
-                            description: >-
-                              The label for the column name.
-                              Will be translated by babel
-                            example: A Nice label for the column
-                            type: string
-                      show_columns:
-                        description: >-
-                          A list of columns
-                        type: array
-                        items:
-                          type: string
-                      description_columns:
-                        type: object
-                        properties:
-                          column_name:
-                            description: >-
-                              The description for the column name.
-                              Will be translated by babel
-                            example: A Nice description for the column
-                            type: string
-                      show_title:
-                        description: >-
-                          A title to render.
-                          Will be translated by babel
-                        example: Show Item Details
-                        type: string
-                      id:
-                        description: The item id
-                        type: string
-                      result:
-                        $ref: '#/components/schemas/{{self.__class__.__name__}}.get'
+              $ref: '#/components/responses/200'
             400:
               $ref: '#/components/responses/400'
             401:

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -507,9 +507,55 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             schema:
               type: integer
             name: pk
+          - in: query
+            name: q
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/get_item_schema'
           responses:
             200:
-              $ref: '#/components/responses/200'
+              description: Item from Model
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      label_columns:
+                        type: object
+                        properties:
+                          column_name:
+                            description: >-
+                              The label for the column name.
+                              Will be translated by babel
+                            example: A Nice label for the column
+                            type: string
+                      show_columns:
+                        description: >-
+                          A list of columns
+                        type: array
+                        items:
+                          type: string
+                      description_columns:
+                        type: object
+                        properties:
+                          column_name:
+                            description: >-
+                              The description for the column name.
+                              Will be translated by babel
+                            example: A Nice description for the column
+                            type: string
+                      show_title:
+                        description: >-
+                          A title to render.
+                          Will be translated by babel
+                        example: Show Item Details
+                        type: string
+                      id:
+                        description: The item id
+                        type: string
+                      result:
+                        $ref: '#/components/schemas/{{self.__class__.__name__}}.get'
             400:
               $ref: '#/components/responses/400'
             401:

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -26,17 +26,9 @@ from flask_appbuilder import permission_name
 from flask_appbuilder.api import (
     expose,
     get_item_schema,
-    merge_response_func,
-    ModelRestApi,
     protect,
     rison,
     safe,
-)
-from flask_appbuilder.const import (
-    API_DESCRIPTION_COLUMNS_RIS_KEY,
-    API_LABEL_COLUMNS_RIS_KEY,
-    API_SHOW_COLUMNS_RIS_KEY,
-    API_SHOW_TITLE_RIS_KEY,
 )
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_babel import ngettext

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -488,74 +488,24 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             utils.error_msg_from_exception(ex), status=403
         ),
     )
-    @merge_response_func(
-        ModelRestApi.merge_show_label_columns, API_LABEL_COLUMNS_RIS_KEY
-    )
-    @merge_response_func(ModelRestApi.merge_show_columns, API_SHOW_COLUMNS_RIS_KEY)
-    @merge_response_func(
-        ModelRestApi.merge_description_columns, API_DESCRIPTION_COLUMNS_RIS_KEY
-    )
-    @merge_response_func(ModelRestApi.merge_show_title, API_SHOW_TITLE_RIS_KEY)
     def get(self, pk: int, **kwargs: Dict[str, Any]) -> Response:
-        """Get Dashboard from Model
+        """Get item from Model
         ---
         get:
           description: >-
-            Get an dashboard model
+            Get an item model
           parameters:
           - in: path
             schema:
               type: integer
             name: pk
-          - in: query
-            name: q
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/get_item_schema'
           responses:
             200:
               description: Item from Model
               content:
                 application/json:
                   schema:
-                    type: object
-                    properties:
-                      label_columns:
-                        type: object
-                        properties:
-                          column_name:
-                            description: >-
-                              The label for the column name.
-                              Will be translated by babel
-                            example: A Nice label for the column
-                            type: string
-                      show_columns:
-                        description: >-
-                          A list of columns
-                        type: array
-                        items:
-                          type: string
-                      description_columns:
-                        type: object
-                        properties:
-                          column_name:
-                            description: >-
-                              The description for the column name.
-                              Will be translated by babel
-                            example: A Nice description for the column
-                            type: string
-                      show_title:
-                        description: >-
-                          A title to render.
-                          Will be translated by babel
-                        example: Show Item Details
-                        type: string
-                      id:
-                        description: The item id
-                        type: string
-                      result:
-                        $ref: '#/components/schemas/{{self.__class__.__name__}}.get'
+                    $ref: '#/components/schemas/get_item_schema'
             400:
               $ref: '#/components/responses/400'
             401:

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -496,7 +496,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         ModelRestApi.merge_description_columns, API_DESCRIPTION_COLUMNS_RIS_KEY
     )
     @merge_response_func(ModelRestApi.merge_show_title, API_SHOW_TITLE_RIS_KEY)
-    def get(self, pk, **kwargs):
+    def get(self, pk: int, **kwargs: Dict[str, Any]) -> Response:
         """Get Dashboard from Model
         ---
         get:

--- a/superset/utils/decorators.py
+++ b/superset/utils/decorators.py
@@ -82,6 +82,7 @@ def on_security_exception(self: Any, ex: Exception) -> Response:
 
 # noinspection PyPackageRequirements
 def check_dashboard_access(
+    dashboard_key: str,
     on_error: Callable[..., Any] = on_security_exception
 ) -> Callable[..., Any]:
     def decorator(f: Callable[..., Any]) -> Callable[..., Any]:
@@ -92,7 +93,7 @@ def check_dashboard_access(
                 raise_for_dashboard_access,
             )
 
-            dashboard = Dashboard.get(str(kwargs["dashboard_id_or_slug"]))
+            dashboard = Dashboard.get(str(kwargs[dashboard_key]))
             if is_feature_enabled("DASHBOARD_RBAC"):
                 try:
                     raise_for_dashboard_access(dashboard)

--- a/superset/utils/decorators.py
+++ b/superset/utils/decorators.py
@@ -82,8 +82,7 @@ def on_security_exception(self: Any, ex: Exception) -> Response:
 
 # noinspection PyPackageRequirements
 def check_dashboard_access(
-    dashboard_key: str,
-    on_error: Callable[..., Any] = on_security_exception
+    dashboard_key: str, on_error: Callable[..., Any] = on_security_exception
 ) -> Callable[..., Any]:
     def decorator(f: Callable[..., Any]) -> Callable[..., Any]:
         @wraps(f)
@@ -94,7 +93,7 @@ def check_dashboard_access(
             )
 
             dashboard = Dashboard.get(str(kwargs[dashboard_key]))
-            if is_feature_enabled("DASHBOARD_RBAC"):
+            if dashboard and is_feature_enabled("DASHBOARD_RBAC"):
                 try:
                     raise_for_dashboard_access(dashboard)
                 except DashboardAccessDeniedError as ex:

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1787,10 +1787,10 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @expose("/dashboard/<dashboard_id_or_slug>/")
     @event_logger.log_this_with_extra_payload
     @check_dashboard_access(
-        dashboard_key='dashboard_id_or_slug',
+        dashboard_key="dashboard_id_or_slug",
         on_error=lambda self, ex: Response(
             utils.error_msg_from_exception(ex), status=403
-        )
+        ),
     )
     def dashboard(  # pylint: disable=too-many-locals
         self,  # pylint: disable=no-self-use

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1787,6 +1787,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @expose("/dashboard/<dashboard_id_or_slug>/")
     @event_logger.log_this_with_extra_payload
     @check_dashboard_access(
+        dashboard_key='dashboard_id_or_slug',
         on_error=lambda self, ex: Response(
             utils.error_msg_from_exception(ex), status=403
         )


### PR DESCRIPTION
### SUMMARY
enforce access for a single dashboard on api.py endpoint
the before state was returning 404 (Not found) as the dashboardFilter filtered out the dashboards
and after state is returning 403 as forbidden


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
