### PR TITLE
feat: Save datapanel state in local storage

### DIFF
--- a/superset-frontend/src/explore/components/DataTablesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane.tsx
@@ -31,6 +31,7 @@ import {
   useFilteredTableData,
   useTableColumns,
 } from './DataTableControl';
+import { getFromLocalStorage, setInLocalStorage } from '../exploreUtils';
 
 const RESULT_TYPES = {
   results: 'results' as const,
@@ -43,6 +44,10 @@ const NULLISH_RESULTS_STATE = {
 };
 
 const DATA_TABLE_PAGE_SIZE = 50;
+
+const STORAGE_KEYS = {
+  isOpen: 'is_datapanel_open',
+};
 
 const TableControlsWrapper = styled.div`
   display: flex;
@@ -98,7 +103,9 @@ export const DataTablesPane = ({
     [RESULT_TYPES.results]?: boolean;
     [RESULT_TYPES.samples]?: boolean;
   }>(NULLISH_RESULTS_STATE);
-  const [panelOpen, setPanelOpen] = useState(false);
+  const [panelOpen, setPanelOpen] = useState(
+    getFromLocalStorage(STORAGE_KEYS.isOpen, false),
+  );
 
   const getData = useCallback(
     (resultType: string) => {
@@ -139,6 +146,10 @@ export const DataTablesPane = ({
     },
     [queryFormData],
   );
+
+  useEffect(() => {
+    setInLocalStorage(STORAGE_KEYS.isOpen, panelOpen);
+  }, [panelOpen]);
 
   useEffect(() => {
     setIsRequestPending(prevState => ({
@@ -244,6 +255,7 @@ export const DataTablesPane = ({
         <Collapse
           accordion
           bordered={false}
+          defaultActiveKey={panelOpen ? 'data' : undefined}
           onChange={handleCollapseChange}
           bold
           ghost

--- a/superset-frontend/src/explore/components/DataTablesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane.tsx
@@ -49,6 +49,8 @@ const STORAGE_KEYS = {
   isOpen: 'is_datapanel_open',
 };
 
+const DATAPANEL_KEY = 'data';
+
 const TableControlsWrapper = styled.div`
   display: flex;
   align-items: center;
@@ -255,12 +257,12 @@ export const DataTablesPane = ({
         <Collapse
           accordion
           bordered={false}
-          defaultActiveKey={panelOpen ? 'data' : undefined}
+          defaultActiveKey={panelOpen ? DATAPANEL_KEY : undefined}
           onChange={handleCollapseChange}
           bold
           ghost
         >
-          <Collapse.Panel header={t('Data')} key="data">
+          <Collapse.Panel header={t('Data')} key={DATAPANEL_KEY}>
             <Tabs
               fullWidth={false}
               tabBarExtraContent={TableControls}

--- a/superset-frontend/src/explore/components/DataTablesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane.tsx
@@ -25,13 +25,16 @@ import TableView, { EmptyWrapperType } from 'src/components/TableView';
 import { getChartDataRequest } from 'src/chart/chartAction';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 import {
+  getFromLocalStorage,
+  setInLocalStorage,
+} from 'src/utils/localStorageHelpers';
+import {
   CopyToClipboardButton,
   FilterInput,
   RowCount,
   useFilteredTableData,
   useTableColumns,
 } from './DataTableControl';
-import { getFromLocalStorage, setInLocalStorage } from '../exploreUtils';
 
 const RESULT_TYPES = {
   results: 'results' as const,

--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -25,6 +25,7 @@ import { chartPropShape } from 'src/dashboard/util/propShapes';
 import ChartContainer from 'src/chart/ChartContainer';
 import ConnectedExploreChartHeader from './ExploreChartHeader';
 import { DataTablesPane } from './DataTablesPane';
+import { getFromLocalStorage, setInLocalStorage } from '../exploreUtils';
 
 const propTypes = {
   actions: PropTypes.object.isRequired,
@@ -55,6 +56,10 @@ const GUTTER_SIZE_FACTOR = 1.25;
 
 const CHART_PANEL_PADDING = 30;
 const HEADER_PADDING = 15;
+
+const STORAGE_KEYS = {
+  sizes: 'chart_split_sizes',
+};
 
 const INITIAL_SIZES = [90, 10];
 const MIN_SIZES = [300, 50];
@@ -114,7 +119,9 @@ const ExploreChartPanel = props => {
     refreshMode: 'debounce',
     refreshRate: 300,
   });
-  const [splitSizes, setSplitSizes] = useState(INITIAL_SIZES);
+  const [splitSizes, setSplitSizes] = useState(
+    getFromLocalStorage(STORAGE_KEYS.sizes, INITIAL_SIZES),
+  );
 
   const calcSectionHeight = useCallback(
     percent => {
@@ -148,6 +155,10 @@ const ExploreChartPanel = props => {
   useEffect(() => {
     recalcPanelSizes(splitSizes);
   }, [recalcPanelSizes, splitSizes]);
+
+  useEffect(() => {
+    setInLocalStorage(STORAGE_KEYS.sizes, splitSizes);
+  }, [splitSizes]);
 
   const onDragEnd = sizes => {
     setSplitSizes(sizes);

--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -23,9 +23,12 @@ import { styled, useTheme } from '@superset-ui/core';
 import { useResizeDetector } from 'react-resize-detector';
 import { chartPropShape } from 'src/dashboard/util/propShapes';
 import ChartContainer from 'src/chart/ChartContainer';
+import {
+  getFromLocalStorage,
+  setInLocalStorage,
+} from 'src/utils/localStorageHelpers';
 import ConnectedExploreChartHeader from './ExploreChartHeader';
 import { DataTablesPane } from './DataTablesPane';
-import { getFromLocalStorage, setInLocalStorage } from '../exploreUtils';
 
 const propTypes = {
   actions: PropTypes.object.isRequired,

--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -30,6 +30,10 @@ import { Global } from '@emotion/core';
 import { Tooltip } from 'src/common/components/Tooltip';
 import { usePrevious } from 'src/common/hooks/usePrevious';
 import Icon from 'src/components/Icon';
+import {
+  getFromLocalStorage,
+  setInLocalStorage,
+} from 'src/utils/localStorageHelpers';
 import ExploreChartPanel from './ExploreChartPanel';
 import ConnectedControlPanelsContainer from './ControlPanelsContainer';
 import SaveModal from './SaveModal';
@@ -379,20 +383,12 @@ function ExploreViewContainer(props) {
   }
 
   function getSidebarWidths(key) {
-    try {
-      return localStorage.getItem(key) || defaultSidebarsWidth[key];
-    } catch {
-      return defaultSidebarsWidth[key];
-    }
+    return getFromLocalStorage(key, defaultSidebarsWidth[key]);
   }
 
   function setSidebarWidths(key, dimension) {
-    try {
-      const newDimension = Number(getSidebarWidths(key)) + dimension.width;
-      localStorage.setItem(key, newDimension);
-    } catch {
-      // Catch in case localStorage is unavailable
-    }
+    const newDimension = Number(getSidebarWidths(key)) + dimension.width;
+    setInLocalStorage(key, newDimension);
   }
 
   if (props.standalone) {

--- a/superset-frontend/src/explore/exploreUtils.js
+++ b/superset-frontend/src/explore/exploreUtils.js
@@ -330,3 +330,19 @@ export const getSimpleSQLExpression = (subject, operator, comparator) => {
   }
   return expression;
 };
+
+export const getFromLocalStorage = (key, defaultValue) => {
+  try {
+    return JSON.parse(localStorage.getItem(key)) || defaultValue;
+  } catch {
+    return defaultValue;
+  }
+};
+
+export const setInLocalStorage = (key, value) => {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // Catch in case localStorage is unavailable
+  }
+};

--- a/superset-frontend/src/explore/exploreUtils.js
+++ b/superset-frontend/src/explore/exploreUtils.js
@@ -330,19 +330,3 @@ export const getSimpleSQLExpression = (subject, operator, comparator) => {
   }
   return expression;
 };
-
-export const getFromLocalStorage = (key, defaultValue) => {
-  try {
-    return JSON.parse(localStorage.getItem(key)) || defaultValue;
-  } catch {
-    return defaultValue;
-  }
-};
-
-export const setInLocalStorage = (key, value) => {
-  try {
-    localStorage.setItem(key, JSON.stringify(value));
-  } catch {
-    // Catch in case localStorage is unavailable
-  }
-};

--- a/superset-frontend/src/utils/localStorageHelpers.ts
+++ b/superset-frontend/src/utils/localStorageHelpers.ts
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export const getFromLocalStorage = (key: string, defaultValue: any) => {
+  try {
+    const value = localStorage.getItem(key);
+    return JSON.parse(value || 'null') || defaultValue;
+  } catch {
+    return defaultValue;
+  }
+};
+
+export const setInLocalStorage = (key: string, value: any) => {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // Catch in case localStorage is unavailable
+  }
+};


### PR DESCRIPTION
### SUMMARY
This PR implements persisting datapanel size  and open/close state in local storage. When user opens explore page again, state from local storage will be used; if local storage is empty, default values will be used (data panel closed, split sizes 90%/10%).

CC: @junlincc @villebro

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/15073128/107207795-079a5b00-6a01-11eb-9c0f-f898a122b9e4.mov

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes https://github.com/apache/superset/issues/12852
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
