### PR TITLE
fix(native-filters): set currentValue null when empty

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CascadePopover.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CascadePopover.tsx
@@ -108,7 +108,7 @@ const CascadePopover: React.FC<CascadePopoverProps> = ({
         return activeChildren;
       }
 
-      if (currentValue) {
+      if (currentValue !== undefined && currentValue !== null) {
         return [filter];
       }
 

--- a/superset-frontend/src/filters/components/Select/AntdSelectFilter.tsx
+++ b/superset-frontend/src/filters/components/Select/AntdSelectFilter.tsx
@@ -76,7 +76,10 @@ export default function AntdPluginFilterSelect(
       ),
       // @ts-ignore (add to superset-ui/core)
       currentState: {
-        value: resultValue,
+        value:
+          Array.isArray(resultValue) && resultValue.length === 0
+            ? null
+            : resultValue,
       },
     });
   };

--- a/superset-frontend/src/filters/components/Select/AntdSelectFilter.tsx
+++ b/superset-frontend/src/filters/components/Select/AntdSelectFilter.tsx
@@ -76,10 +76,7 @@ export default function AntdPluginFilterSelect(
       ),
       // @ts-ignore (add to superset-ui/core)
       currentState: {
-        value:
-          Array.isArray(resultValue) && resultValue.length === 0
-            ? null
-            : resultValue,
+        value: resultValue.length ? resultValue : null,
       },
     });
   };


### PR DESCRIPTION
### SUMMARY
Currently cascading filters evaluate truthiness of the parent filter when determining if the child filter should be rendered in place of the parent. Since the native Select filter returns an empty array for an empty selection, the parent filter is determined to be set, even though it isn't.

Here we change the cascading logic so that only `undefined` and `null` are assumed to be unset. This is done because there may be other filters that have falsy values which in fact mean that the filter is set, for instance a lower range being set to `0`.

### SCREENSHOTS
In the example, I've constructed a cascading filter with "region" as the parent and "country" as the child. As can be seen, the "country" filter show up on the filter tab, despite the selection being empty on the "region" filter:
![image](https://user-images.githubusercontent.com/33317356/107234702-9a042400-6a2c-11eb-9dbc-5a3201d1fa70.png)

After the change, an empty selection is set as `null`, making the parent filter display in the filter tab:
![image](https://user-images.githubusercontent.com/33317356/107233815-a6d44800-6a2b-11eb-90c7-a2efb06987fc.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
