### PR TITLE
refactor: Bootstrap to AntD - DropdownButton

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/link.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/link.test.ts
@@ -38,7 +38,7 @@ describe('Test explore links', () => {
     cy.visitChartByName('Growth Rate');
     cy.verifySliceSuccess({ waitAlias: '@chartData' });
 
-    cy.get('button#query').click();
+    cy.get('div#query').click();
     cy.get('span').contains('View query').parent().click();
     cy.wait('@chartData').then(() => {
       cy.get('code');

--- a/superset-frontend/spec/javascripts/explore/components/DisplayQueryButton_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/DisplayQueryButton_spec.jsx
@@ -17,10 +17,9 @@
  * under the License.
  */
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { supersetTheme, ThemeProvider } from '@superset-ui/core';
-import { Menu } from 'src/common/components';
-import ModalTrigger from 'src/components/ModalTrigger';
+import { Dropdown, Menu } from 'src/common/components';
 import { DisplayQueryButton } from 'src/explore/components/DisplayQueryButton';
 
 describe('DisplayQueryButton', () => {
@@ -43,14 +42,16 @@ describe('DisplayQueryButton', () => {
       true,
     );
   });
-  it('renders a dropdown', () => {
+  it('renders a dropdown with 3 itens', () => {
     const wrapper = mount(<DisplayQueryButton {...defaultProps} />, {
       wrappingComponent: ThemeProvider,
       wrappingComponentProps: {
         theme: supersetTheme,
       },
     });
-    expect(wrapper.find(ModalTrigger)).toHaveLength(1);
-    expect(wrapper.find(Menu.Item)).toHaveLength(3);
+    const dropdown = wrapper.find(Dropdown);
+    const menu = shallow(<div>{dropdown.prop('overlay')}</div>);
+    const menuItems = menu.find(Menu.Item);
+    expect(menuItems).toHaveLength(3);
   });
 });

--- a/superset-frontend/src/dashboard/components/menu/PopoverDropdown.jsx
+++ b/superset-frontend/src/dashboard/components/menu/PopoverDropdown.jsx
@@ -19,9 +19,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { styled } from '@superset-ui/core';
-import { DropdownButton } from 'react-bootstrap';
-import { Menu } from 'src/common/components';
+import { styled, withTheme } from '@superset-ui/core';
+import { Dropdown, Menu } from 'src/common/components';
+import Icon from 'src/components/Icon';
 
 const propTypes = {
   id: PropTypes.string.isRequired,
@@ -78,6 +78,7 @@ const MenuItem = styled(Menu.Item)`
 class PopoverDropdown extends React.PureComponent {
   constructor(props) {
     super(props);
+
     this.handleSelect = this.handleSelect.bind(this);
   }
 
@@ -86,28 +87,41 @@ class PopoverDropdown extends React.PureComponent {
   }
 
   render() {
-    const { id, value, options, renderButton, renderOption } = this.props;
+    const {
+      id,
+      value,
+      options,
+      renderButton,
+      renderOption,
+      theme,
+    } = this.props;
     const selected = options.find(opt => opt.value === value);
     return (
-      <DropdownButton
+      <Dropdown
         id={id}
-        bsSize="small"
-        title={renderButton(selected)}
-        className="popover-dropdown"
+        trigger="click"
+        overlayStyle={{ zIndex: theme.zIndex.max }}
+        overlay={
+          <Menu onClick={this.handleSelect}>
+            {options.map(option => (
+              <MenuItem
+                id="menu-item"
+                key={option.value}
+                className={cx('dropdown-item', {
+                  active: option.value === value,
+                })}
+              >
+                {renderOption(option)}
+              </MenuItem>
+            ))}
+          </Menu>
+        }
       >
-        <Menu onClick={this.handleSelect}>
-          {options.map(option => (
-            <MenuItem
-              key={option.value}
-              className={cx('dropdown-item', {
-                active: option.value === value,
-              })}
-            >
-              {renderOption(option)}
-            </MenuItem>
-          ))}
-        </Menu>
-      </DropdownButton>
+        <div role="button" css={{ display: 'flex', alignItems: 'center' }}>
+          {renderButton(selected)}
+          <Icon name="caret-down" css={{ marginTop: 4 }} />
+        </div>
+      </Dropdown>
     );
   }
 }
@@ -115,4 +129,4 @@ class PopoverDropdown extends React.PureComponent {
 PopoverDropdown.propTypes = propTypes;
 PopoverDropdown.defaultProps = defaultProps;
 
-export default PopoverDropdown;
+export default withTheme(PopoverDropdown);

--- a/superset-frontend/src/dashboard/components/menu/WithPopoverMenu.jsx
+++ b/superset-frontend/src/dashboard/components/menu/WithPopoverMenu.jsx
@@ -38,7 +38,9 @@ const defaultProps = {
   menuItems: [],
   isFocused: false,
   shouldFocus: (event, container) =>
-    container && container.contains(event.target),
+    container?.contains(event.target) ||
+    event.target.id === 'menu-item' ||
+    event.target.parentNode?.id === 'menu-item',
   style: null,
 };
 

--- a/superset-frontend/src/dashboard/stylesheets/components/header.less
+++ b/superset-frontend/src/dashboard/stylesheets/components/header.less
@@ -48,11 +48,11 @@
   .dragdroppable-row .dashboard-component-header {
     cursor: move;
   }
+}
 
-  .header-style-option {
-    font-weight: @font-weight-bold;
-    color: @almost-black;
-  }
+.header-style-option {
+  font-weight: @font-weight-bold;
+  color: @almost-black;
 }
 
 .dashboard-header .dashboard-component-header {

--- a/superset-frontend/src/dashboard/stylesheets/popover-menu.less
+++ b/superset-frontend/src/dashboard/stylesheets/popover-menu.less
@@ -66,13 +66,6 @@
     background: @gray-light;
     margin: 0 16px;
   }
-
-  .popover-dropdown.btn {
-    border: none;
-    padding: 0;
-    font-size: inherit;
-    color: @almost-black;
-  }
 }
 
 /* the focus menu doesn't account for parent padding */
@@ -88,7 +81,6 @@
   left: -7px;
 }
 
-.popover-menu .popover-dropdown.btn,
 .hover-dropdown .btn {
   &:hover,
   &:active,
@@ -111,12 +103,6 @@
       color: @almost-black;
     }
   }
-}
-
-.popover-dropdown .caret {
-  /* without this the caret doesn't take up full width / is clipped */
-  width: auto;
-  border-top-color: transparent;
 }
 
 /* background style menu */

--- a/superset-frontend/src/explore/components/DisplayQueryButton.jsx
+++ b/superset-frontend/src/explore/components/DisplayQueryButton.jsx
@@ -26,10 +26,9 @@ import markdownSyntax from 'react-syntax-highlighter/dist/cjs/languages/hljs/mar
 import sqlSyntax from 'react-syntax-highlighter/dist/cjs/languages/hljs/sql';
 import jsonSyntax from 'react-syntax-highlighter/dist/cjs/languages/hljs/json';
 import github from 'react-syntax-highlighter/dist/cjs/styles/hljs/github';
-import { DropdownButton } from 'react-bootstrap';
 import { styled, t } from '@superset-ui/core';
 
-import { Menu } from 'src/common/components';
+import { Dropdown, Menu } from 'src/common/components';
 import { getClientErrorObject } from '../../utils/getClientErrorObject';
 import CopyToClipboard from '../../components/CopyToClipboard';
 import { getChartDataRequest } from '../../chart/chartAction';
@@ -75,7 +74,6 @@ export const DisplayQueryButton = props => {
   const [sqlSupported] = useState(
     datasource && datasource.split('__')[1] === 'table',
   );
-  const [menuVisible, setMenuVisible] = useState(false);
 
   const beforeOpen = resultType => {
     setIsLoading(true);
@@ -103,7 +101,6 @@ export const DisplayQueryButton = props => {
 
   const handleMenuClick = ({ key, domEvent }) => {
     const { chartHeight, slice, onOpenInEditor, latestQueryFormData } = props;
-    setMenuVisible(false);
     switch (key) {
       case MENU_KEYS.EDIT_PROPERTIES:
         props.onOpenPropertiesModal();
@@ -156,48 +153,47 @@ export const DisplayQueryButton = props => {
 
   const { slice } = props;
   return (
-    <DropdownButton
-      open={menuVisible}
-      noCaret
+    <Dropdown
+      trigger="click"
       data-test="query-dropdown"
-      title={
-        <span>
-          <i className="fa fa-bars" />
-          &nbsp;
-        </span>
+      overlay={
+        <Menu onClick={handleMenuClick} selectable={false}>
+          {slice && (
+            <Menu.Item key={MENU_KEYS.EDIT_PROPERTIES}>
+              {t('Edit properties')}
+            </Menu.Item>
+          )}
+          <Menu.Item>
+            <ModalTrigger
+              triggerNode={
+                <span data-test="view-query-menu-item">{t('View query')}</span>
+              }
+              modalTitle={t('View query')}
+              beforeOpen={() => beforeOpen('query')}
+              modalBody={renderQueryModalBody()}
+              responsive
+            />
+          </Menu.Item>
+          {sqlSupported && (
+            <Menu.Item key={MENU_KEYS.RUN_IN_SQL_LAB}>
+              {t('Run in SQL Lab')}
+            </Menu.Item>
+          )}
+          <Menu.Item key={MENU_KEYS.DOWNLOAD_AS_IMAGE}>
+            {t('Download as image')}
+          </Menu.Item>
+        </Menu>
       }
-      bsSize="sm"
-      pullRight
-      id="query"
-      onToggle={setMenuVisible}
     >
-      <Menu onClick={handleMenuClick} selectable={false}>
-        {slice && (
-          <Menu.Item key={MENU_KEYS.EDIT_PROPERTIES}>
-            {t('Edit properties')}
-          </Menu.Item>
-        )}
-        <Menu.Item>
-          <ModalTrigger
-            triggerNode={
-              <span data-test="view-query-menu-item">{t('View query')}</span>
-            }
-            modalTitle={t('View query')}
-            beforeOpen={() => beforeOpen('query')}
-            modalBody={renderQueryModalBody()}
-            responsive
-          />
-        </Menu.Item>
-        {sqlSupported && (
-          <Menu.Item key={MENU_KEYS.RUN_IN_SQL_LAB}>
-            {t('Run in SQL Lab')}
-          </Menu.Item>
-        )}
-        <Menu.Item key={MENU_KEYS.DOWNLOAD_AS_IMAGE}>
-          {t('Download as image')}
-        </Menu.Item>
-      </Menu>
-    </DropdownButton>
+      <div
+        role="button"
+        id="query"
+        tabIndex={0}
+        className="btn btn-default btn-sm"
+      >
+        <i className="fa fa-bars" />
+      </div>
+    </Dropdown>
   );
 };
 

--- a/superset-frontend/stylesheets/less/cosmo/bootswatch.less
+++ b/superset-frontend/stylesheets/less/cosmo/bootswatch.less
@@ -62,6 +62,11 @@
   text-transform: uppercase;
 }
 
+.btn:focus,
+.btn:active:focus {
+  outline: none;
+}
+
 .nav-tabs {
   .dropdown-toggle.btn,
   .btn-group.open .dropdown-toggle.btn {


### PR DESCRIPTION
### SUMMARY
- Migrates Collapse component from Bootstrap to AntD.
- Aligns dropdown caret with text

See: #10254

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="525" alt="Screen Shot 2021-02-05 at 2 50 34 PM" src="https://user-images.githubusercontent.com/70410625/107237531-97da9f00-6a05-11eb-8cef-8b1c5d2b51da.png">
<img width="525" alt="Screen Shot 2021-02-05 at 2 50 34 PM" src="https://user-images.githubusercontent.com/70410625/107237548-9e691680-6a05-11eb-9d1d-07869d53fe13.png">
<img width="384" alt="Screen Shot 2021-02-05 at 2 51 08 PM" src="https://user-images.githubusercontent.com/70410625/107237668-bb9de500-6a05-11eb-9233-19f121b0b1b1.png">
<img width="508" alt="Screen Shot 2021-02-08 at 10 22 04 AM" src="https://user-images.githubusercontent.com/70410625/107237681-c2c4f300-6a05-11eb-9521-c06df242434f.png">
<img width="770" alt="Screen Shot 2021-02-08 at 10 20 29 AM" src="https://user-images.githubusercontent.com/70410625/107237720-cd7f8800-6a05-11eb-9f4c-47faa77f777f.png">
<img width="759" alt="Screen Shot 2021-02-08 at 10 21 16 AM" src="https://user-images.githubusercontent.com/70410625/107237736-d3756900-6a05-11eb-9b00-79544fc0d367.png">
<img width="274" alt="Screen Shot 2021-02-08 at 10 52 39 AM" src="https://user-images.githubusercontent.com/70410625/107237756-d96b4a00-6a05-11eb-912f-57e304ceeac5.png">
<img width="264" alt="Screen Shot 2021-02-08 at 10 53 11 AM" src="https://user-images.githubusercontent.com/70410625/107237781-dec89480-6a05-11eb-9eb0-a587b9146e19.png">

@rusackas @junlincc

### TEST PLAN
1 - Open any screen that contains a `DropdownButton` (explore, dashboard -> edit, etc.)
2 - All `DropdownButton` components should have the same theme and behavior

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
