### PR TITLE
fix: time filter db migration optimization

### DIFF
--- a/superset/charts/commands/exceptions.py
+++ b/superset/charts/commands/exceptions.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from flask_babel import lazy_gettext as _
+from flask_babel import _
 from marshmallow.validate import ValidationError
 
 from superset.commands.exceptions import (
@@ -28,13 +28,41 @@ from superset.commands.exceptions import (
 )
 
 
+class TimeRangeUnclearError(ValidationError):
+    """
+    Time range is in valid error.
+    """
+
+    def __init__(self, human_readable: str) -> None:
+        super().__init__(
+            _(
+                "Time string is unclear."
+                " Please specify [%(human_readable)s ago]"
+                " or [%(human_readable)s later].",
+                human_readable=human_readable,
+            ),
+            field_name="time_range",
+        )
+
+
+class TimeRangeParseFailError(ValidationError):
+    def __init__(self, human_readable: str) -> None:
+        super().__init__(
+            _(
+                "Cannot parse time string [%(human_readable)s]",
+                human_readable=human_readable,
+            ),
+            field_name="time_range",
+        )
+
+
 class DatabaseNotFoundValidationError(ValidationError):
     """
     Marshmallow validation error for database does not exist
     """
 
     def __init__(self) -> None:
-        super().__init__(_("Database does not exist"), field_names=["database"])
+        super().__init__(_("Database does not exist"), field_name="database")
 
 
 class DashboardsNotFoundValidationError(ValidationError):
@@ -43,7 +71,7 @@ class DashboardsNotFoundValidationError(ValidationError):
     """
 
     def __init__(self) -> None:
-        super().__init__(_("Dashboards do not exist"), field_names=["dashboards"])
+        super().__init__(_("Dashboards do not exist"), field_name="dashboards")
 
 
 class DatasourceTypeUpdateRequiredValidationError(ValidationError):

--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -39,7 +39,11 @@ from pyparsing import (
     Suppress,
 )
 
-from .core import memoized
+from superset.charts.commands.exceptions import (
+    TimeRangeParseFailError,
+    TimeRangeUnclearError,
+)
+from superset.utils.core import memoized
 
 ParserElement.enablePackrat()
 
@@ -73,15 +77,7 @@ def parse_human_datetime(human_readable: str) -> datetime:
     """
     x_periods = r"^\s*([0-9]+)\s+(second|minute|hour|day|week|month|quarter|year)s?\s*$"
     if re.search(x_periods, human_readable, re.IGNORECASE):
-        raise ValueError(
-            _(
-                "Date string is unclear."
-                " Please specify [%(human_readable)s ago]"
-                " or [%(human_readable)s later]",
-                human_readable=human_readable,
-            )
-        )
-
+        raise TimeRangeUnclearError(human_readable)
     try:
         dttm = parse(human_readable)
     except (ValueError, OverflowError) as ex:
@@ -90,12 +86,7 @@ def parse_human_datetime(human_readable: str) -> datetime:
         # 0 == not parsed at all
         if parsed_flags == 0:
             logger.exception(ex)
-            raise ValueError(
-                _(
-                    "Couldn't parse date string [%(human_readable)s]",
-                    human_readable=human_readable,
-                )
-            )
+            raise TimeRangeParseFailError(human_readable)
         # when time is not extracted, we 'reset to midnight'
         if parsed_flags & 2 == 0:
             parsed_dttm = parsed_dttm.replace(hour=0, minute=0, second=0)
@@ -492,9 +483,9 @@ def datetime_eval(datetime_expression: Optional[str] = None) -> Optional[datetim
 
 class DateRangeMigration:  # pylint: disable=too-few-public-methods
     x_dateunit_in_since = (
-        r'"time_range":\s"\s*[0-9]+\s(day|week|month|quarter|year)s?\s*\s:\s'
+        r'"time_range":\s*"\s*[0-9]+\s(day|week|month|quarter|year)s?\s*\s:\s'
     )
     x_dateunit_in_until = (
-        r'"time_range":\s".*\s:\s\s*[0-9]+\s(day|week|month|quarter|year)s?\s*"'
+        r'"time_range":\s*".*\s:\s*[0-9]+\s(day|week|month|quarter|year)s?\s*"'
     )
     x_dateunit = r"\s*[0-9]+\s(day|week|month|quarter|year)s?\s*"

--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -483,9 +483,9 @@ def datetime_eval(datetime_expression: Optional[str] = None) -> Optional[datetim
 
 class DateRangeMigration:  # pylint: disable=too-few-public-methods
     x_dateunit_in_since = (
-        r'"time_range":\s*"\s*[0-9]+\s(day|week|month|quarter|year)s?\s*\s:\s'
+        r'"time_range":\s*"\s*[0-9]+\s+(day|week|month|quarter|year)s?\s*\s:\s'
     )
     x_dateunit_in_until = (
-        r'"time_range":\s*".*\s:\s*[0-9]+\s(day|week|month|quarter|year)s?\s*"'
+        r'"time_range":\s*".*\s:\s*[0-9]+\s+(day|week|month|quarter|year)s?\s*"'
     )
-    x_dateunit = r"\s*[0-9]+\s(day|week|month|quarter|year)s?\s*"
+    x_dateunit = r"^\s*[0-9]+\s+(day|week|month|quarter|year)s?\s*$"

--- a/tests/utils/date_parser_tests.py
+++ b/tests/utils/date_parser_tests.py
@@ -298,3 +298,6 @@ class TestDateParser(SupersetTestCase):
 
         field = "last week"
         self.assertNotRegex(field, DateRangeMigration.x_dateunit)
+
+        field = "10 years ago"
+        self.assertNotRegex(field, DateRangeMigration.x_dateunit)

--- a/tests/utils/date_parser_tests.py
+++ b/tests/utils/date_parser_tests.py
@@ -17,6 +17,10 @@
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
+from superset.charts.commands.exceptions import (
+    TimeRangeParseFailError,
+    TimeRangeUnclearError,
+)
 from superset.utils.date_parser import (
     DateRangeMigration,
     datetime_eval,
@@ -265,13 +269,13 @@ class TestDateParser(SupersetTestCase):
         self.assertEqual(parse_past_timedelta("1 month"), timedelta(31))
 
     def test_parse_human_datetime(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TimeRangeUnclearError):
             parse_human_datetime("  2 days  ")
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TimeRangeUnclearError):
             parse_human_datetime("2 day")
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TimeRangeParseFailError):
             parse_human_datetime("xxxxxxx")
 
     def test_DateRangeMigration(self):

--- a/tests/utils/date_parser_tests.py
+++ b/tests/utils/date_parser_tests.py
@@ -291,3 +291,6 @@ class TestDateParser(SupersetTestCase):
 
         field = "   8 days   "
         self.assertRegex(field, DateRangeMigration.x_dateunit)
+
+        field = "last week"
+        self.assertNotRegex(field, DateRangeMigration.x_dateunit)


### PR DESCRIPTION
### SUMMARY

Optimizes free-text time range filter db migration added by #12505 

1. Update the validation Exception so it can be exposed to the frontend (when migration hasn't applied).
2. Update the migration script so it handle cases like `100 years : 30 years ago`.  Previously it will incorrectly change it to `100 years ago : 30 years later` when it should be `100 years ago : 30 years ago`.

These are edge cases nonetheless.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

When opening a chart with "100 years" (i.e. periods without "ago" or "before/after"), it shows "Fatal error":

<img width="848" alt="request-is-incorret" src="https://user-images.githubusercontent.com/335541/107283248-fbb69500-6a10-11eb-806e-90e337ee2461.png">

#### After

The error is more actionable:

<img width="848" alt="request-is-incorret" src="https://user-images.githubusercontent.com/335541/107283231-f35e5a00-6a10-11eb-9779-207b4adc251e.png">

(Still need some optimization here in order to render the backend validation error more properly but let's do it in another PR for other fields as well. Ideally the backend validation errors should come back to each control based on field name.)

### TEST PLAN

#12552 is for fixing legacy charts. You will not be able to add bad data anymore because of the backend validation. You'd need to either find a legacy bad chart, or manually add one. A quick way to do it is this:

1. Connect to your Superset db using any database manager

For example I use `psql`:

```
psql "postgresql://superset:superset@127.0.0.1:5432/superset_test"
```

2. Run following SQL command:

```sql
INSERT INTO
  slices (
    created_on,
    changed_on,
    slice_name,
    datasource_type,
    datasource_name,
    viz_type,
    params,
    perm,
    datasource_id
  )
VALUES
  (
    '2021-01-25T13:21:40.763807',
    '2021-01-25T13:21:40.763807',
    'Test time period',
    'table',
    null,
    'table',
    '{ "compare_lag": "10", "compare_suffix": "o10Y", "country_fieldtype": "cca3", "entity": "country_code", "granularity_sqla": "year", "groupby": [ "country_name" ], "limit": "25", "markup_type": "markdown", "metrics": [ "sum__SP_POP_TOTL" ], "row_limit": 50000, "show_bubbles": true, "time_range": "100 years : 30 years ago", "time_range_endpoints": [ "inclusive", "exclusive" ], "viz_type": "table" }',
    '[examples].[wb_health_population](id:2)',
    2
  );
```

Note we set the time range to be `"100 years : 30 years ago"`

4. Find the ID of the chart you just inserted:

```sql
SELECT *
FROM slices
WHERE slice_name like 'Test time period'
```

3. Go to `/superset/slice/{slice_id}`


Before migration, you should see the "Unexpected error" when you open the chart.

After migration, you should see the chart render correctly. 

Note: if you have already upgraded superset db, you need to downgrade it first:

```
superset db downgrade c878781977c6 
superset db upgrade
```

When in current master, after migration, you will also see the filter being updated to "100 years ago : 30 years later":

<img src="https://user-images.githubusercontent.com/335541/107286526-8e593300-6a15-11eb-820c-b14113e1c3e7.png" width="300">

With this PR, after migration, you should see the filter being updated to "100 years ago : 30 years ago":

<img src="https://user-images.githubusercontent.com/335541/107287959-91552300-6a17-11eb-8bea-9da72bbe92b3.png" width="300">


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [x] Requires DB Migration.
- [x] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
