### PR TITLE
fix: Let superset configure the correct time display according to locale

### DIFF
--- a/superset-frontend/src/preamble.ts
+++ b/superset-frontend/src/preamble.ts
@@ -40,7 +40,7 @@ if (typeof window !== 'undefined') {
   if (bootstrapData.common && bootstrapData.common.language_pack) {
     const languagePack = bootstrapData.common.language_pack;
     configure({ languagePack });
-    moment.locale(bootstrapData.common.locale);
+    moment.locale(bootstrapData.common.moment_locale);
   } else {
     configure();
   }

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -425,7 +425,19 @@ class AuditMixinNullable(AuditMixin):
 
     @property
     def changed_on_humanized(self) -> str:
-        return humanize.naturaltime(datetime.now() - self.changed_on)
+        try:
+            from superset import conf
+            from flask_babel import get_locale
+            langs = conf.get("LANGUAGES", None)
+            locale = str(get_locale())
+
+            if "_" in locale:
+                humanize.i18n.activate(locale)
+            elif langs is not None:
+                humanize.i18n.activate("{}_{}".format(locale,
+                                                      langs[locale]["flag"].upper()))
+        finally:
+            return humanize.naturaltime(datetime.now() - self.changed_on)
 
     @renders("changed_on")
     def modified(self) -> Markup:

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -313,11 +313,13 @@ def common_bootstrap_payload() -> Dict[str, Any]:
     """Common data always sent to the client"""
     messages = get_flashed_messages(with_categories=True)
     locale = str(get_locale())
+    moment_locale = get_moment_locale(locale)
 
     return {
         "flash_messages": messages,
         "conf": {k: conf.get(k) for k in FRONTEND_CONF_KEYS},
         "locale": locale,
+        "moment_locale": moment_locale,
         "language_pack": get_language_pack(locale),
         "feature_flags": get_feature_flags(),
         "extra_sequential_color_schemes": conf["EXTRA_SEQUENTIAL_COLOR_SCHEMES"],
@@ -325,6 +327,17 @@ def common_bootstrap_payload() -> Dict[str, Any]:
         "theme_overrides": conf["THEME_OVERRIDES"],
         "menu_data": menu_data(),
     }
+
+
+def get_moment_locale(locale):
+    moment_locale = locale
+    if "_" in moment_locale:
+        moment_locale = moment_locale.split("_")[0]
+
+    flag = conf.get("LANGUAGES").get(locale).get("flag")
+    if flag != locale:
+        moment_locale = locale + "-" + flag
+    return moment_locale
 
 
 @superset_app.context_processor


### PR DESCRIPTION
### SUMMARY
Let superset configure the correct time display according to locale. Now superset can't display the correct time format according to locale

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![chartlist](https://user-images.githubusercontent.com/12069428/107328128-32f87500-6ae9-11eb-9d6f-ee3e3448642f.jpg)


### TEST PLAN
Can view the results in a browser

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
