### PR TITLE
fix(explore): Enable selecting an option not included in suggestions

### DIFF
--- a/superset-frontend/src/explore/components/OptionControls.tsx
+++ b/superset-frontend/src/explore/components/OptionControls.tsx
@@ -18,8 +18,11 @@
  */
 import React, { useRef } from 'react';
 import { useDrag, useDrop, DropTargetMonitor } from 'react-dnd';
-import { styled, useTheme } from '@superset-ui/core';
-import { ColumnOption } from '@superset-ui/chart-controls';
+import { styled, t, useTheme } from '@superset-ui/core';
+import {
+  ColumnOption,
+  InfoTooltipWithTrigger,
+} from '@superset-ui/chart-controls';
 import { Tooltip } from 'src/common/components/Tooltip';
 import Icon from 'src/components/Icon';
 import { savedMetricType } from 'src/explore/components/controls/MetricControl/types';
@@ -138,6 +141,7 @@ export const OptionControlLabel = ({
   isFunction,
   type,
   index,
+  isExtra,
   ...props
 }: {
   label: string | React.ReactNode;
@@ -150,6 +154,7 @@ export const OptionControlLabel = ({
   isDraggable?: boolean;
   type: string;
   index: number;
+  isExtra?: boolean;
 }) => {
   const theme = useTheme();
   const ref = useRef<HTMLDivElement>(null);
@@ -236,6 +241,18 @@ export const OptionControlLabel = ({
         {isFunction && <Icon name="function" viewBox="0 0 16 11" />}
         {getLabelContent()}
       </Label>
+      {isExtra && (
+        <InfoTooltipWithTrigger
+          icon="exclamation-triangle"
+          placement="top"
+          className="m-r-5 m-l-5"
+          bsStyle="warning"
+          tooltip={t(`
+                This filter was inherited from the dashboard's context.
+                It won't be saved when saving the chart.
+              `)}
+        />
+      )}
       {isAdhoc && (
         <CaretContainer>
           <Icon name="caret-right" color={theme.colors.grayscale.light1} />

--- a/superset-frontend/src/explore/components/OptionControls.tsx
+++ b/superset-frontend/src/explore/components/OptionControls.tsx
@@ -76,6 +76,10 @@ const CloseContainer = styled.div`
   cursor: pointer;
 `;
 
+const StyledInfoTooltipWithTrigger = styled(InfoTooltipWithTrigger)`
+  margin: 0 ${({ theme }) => theme.gridUnit}px;
+`;
+
 export const HeaderContainer = styled.div`
   display: flex;
   align-items: center;
@@ -242,10 +246,9 @@ export const OptionControlLabel = ({
         {getLabelContent()}
       </Label>
       {isExtra && (
-        <InfoTooltipWithTrigger
+        <StyledInfoTooltipWithTrigger
           icon="exclamation-triangle"
           placement="top"
-          className="m-r-5 m-l-5"
           bsStyle="warning"
           tooltip={t(`
                 This filter was inherited from the dashboard's context.

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx
@@ -95,10 +95,12 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
     this.refreshComparatorSuggestions = this.refreshComparatorSuggestions.bind(
       this,
     );
+    this.clearSuggestionSearch = this.clearSuggestionSearch.bind(this);
 
     this.state = {
       suggestions: [],
       abortActiveRequest: null,
+      currentSuggestionSearch: '',
     };
 
     this.selectProps = {
@@ -272,8 +274,13 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
     return <FilterDefinitionOption option={option} />;
   }
 
+  clearSuggestionSearch() {
+    this.setState({ currentSuggestionSearch: '' });
+  }
+
   render() {
     const { adhocFilter, options, datasource } = this.props;
+    const { currentSuggestionSearch } = this.state;
     let columns = options;
     const { subject, operator, comparator } = adhocFilter;
     const subjectSelectProps = {
@@ -379,12 +386,25 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
               name="filter-value"
               {...comparatorSelectProps}
               getPopupContainer={triggerNode => triggerNode.parentNode}
+              onSearch={val => this.setState({ currentSuggestionSearch: val })}
+              onSelect={this.clearSuggestionSearch}
+              onBlur={this.clearSuggestionSearch}
             >
               {this.state.suggestions.map(suggestion => (
                 <Select.Option value={suggestion} key={suggestion}>
                   {suggestion}
                 </Select.Option>
               ))}
+
+              {/* enable selecting an option not included in suggestions */}
+              {currentSuggestionSearch &&
+                !this.state.suggestions.some(
+                  suggestion => suggestion === currentSuggestionSearch,
+                ) && (
+                  <Select.Option value={currentSuggestionSearch}>
+                    {currentSuggestionSearch}
+                  </Select.Option>
+                )}
             </SelectWithLabel>
           ) : (
             <Input

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterOption.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterOption.jsx
@@ -69,6 +69,7 @@ const AdhocFilterOption = ({
       index={index}
       type={OPTION_TYPES.filter}
       isAdhoc
+      isExtra={adhocFilter.isExtra}
     />
   </AdhocFilterPopoverTrigger>
 );

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterPopoverTrigger.tsx
@@ -17,9 +17,6 @@
  * under the License.
  */
 import React from 'react';
-import { t } from '@superset-ui/core';
-import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
-
 import Popover from 'src/common/components/Popover';
 import columnType from 'src/explore/propTypes/columnType';
 import adhocMetricType from 'src/explore/components/controls/MetricControl/adhocMetricType';
@@ -85,30 +82,17 @@ class AdhocFilterPopoverTrigger extends React.PureComponent<
     );
 
     return (
-      <>
-        {adhocFilter.isExtra && (
-          <InfoTooltipWithTrigger
-            icon="exclamation-triangle"
-            placement="top"
-            className="m-r-5 text-muted"
-            tooltip={t(`
-                This filter was inherited from the dashboard's context.
-                It won't be saved when saving the chart.
-              `)}
-          />
-        )}
-        <Popover
-          placement="right"
-          trigger="click"
-          content={overlayContent}
-          defaultVisible={this.state.popoverVisible}
-          visible={this.state.popoverVisible}
-          onVisibleChange={this.togglePopover}
-          destroyTooltipOnHide={this.props.createNew}
-        >
-          {this.props.children}
-        </Popover>
-      </>
+      <Popover
+        placement="right"
+        trigger="click"
+        content={overlayContent}
+        defaultVisible={this.state.popoverVisible}
+        visible={this.state.popoverVisible}
+        onVisibleChange={this.togglePopover}
+        destroyTooltipOnHide={this.props.createNew}
+      >
+        {this.props.children}
+      </Popover>
     );
   }
 }


### PR DESCRIPTION
### SUMMARY
Filter suggestions endpoint has a 10k limit of returned results. If there are more than 10k possible values and the searched value is at the end of the list, it will not be returned and the user won't be able to select it when using a single value operator. This PR implements a "hack", which creates an additional option based on current search input, thus allowing to select it.

I consider this a temporary solution. Optimally, we should make the `/superset/filter/` endpoint accept a search query param and use it to filter the results. Then we can refactor `src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx` to send a request for suggestions when a user types a query (with some debounce for optimization).

This PR also fixes the issue with warning tooltip mentioned in https://github.com/apache/superset/issues/13017#issuecomment-775607176.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see https://github.com/apache/superset/issues/13017

After:
![image](https://user-images.githubusercontent.com/15073128/107376273-fe38ed80-6ae9-11eb-8066-f07c4302394e.png)
![image](https://user-images.githubusercontent.com/15073128/107376601-5f60c100-6aea-11eb-8ed8-45009baaeef3.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes https://github.com/apache/superset/issues/13017
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
