### PR TITLE
fix(ci): remove signature requirements for commits to master

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -77,4 +77,4 @@ github:
         require_code_owner_reviews: true
         required_approving_review_count: 1
 
-      required_signatures: true
+      required_signatures: false


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- I misunderstood how this asf.yaml setting works when I suggested enabling it in https://github.com/apache/superset/pull/12970. I thought by committing via github the signing requirements would be met, however it appears this setting requires all commits on a branch to be signed before the branch is mergeable. 

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- PRs with unsigned commits will be mergeable after this PR merges

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
