### PR TITLE
fix: timeout context manager on Windows

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -46,7 +46,6 @@ from typing import (
     Any,
     Callable,
     cast,
-    ContextManager,
     Dict,
     Iterable,
     Iterator,
@@ -84,7 +83,7 @@ from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.sql.type_api import Variant
 from sqlalchemy.types import TEXT, TypeDecorator
 
-import _thread
+import _thread  # pylint: disable=C0411
 from superset.errors import ErrorLevel, SupersetErrorType
 from superset.exceptions import (
     CertificateException,

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -23,6 +23,7 @@ import hashlib
 import json
 import logging
 import os
+import platform
 import re
 import signal
 import smtplib
@@ -45,6 +46,7 @@ from typing import (
     Any,
     Callable,
     cast,
+    ContextManager,
     Dict,
     Iterable,
     Iterator,
@@ -82,6 +84,7 @@ from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.sql.type_api import Variant
 from sqlalchemy.types import TEXT, TypeDecorator
 
+import _thread
 from superset.errors import ErrorLevel, SupersetErrorType
 from superset.exceptions import (
     CertificateException,
@@ -710,7 +713,7 @@ def validate_json(obj: Union[bytes, bytearray, str]) -> None:
             raise SupersetException("JSON is not valid")
 
 
-class timeout:  # pylint: disable=invalid-name
+class SigalrmTimeout:
     """
     To be used in a ``with`` block and timeout its content.
     """
@@ -747,6 +750,34 @@ class timeout:  # pylint: disable=invalid-name
         except ValueError as ex:
             logger.warning("timeout can't be used in the current context")
             logger.exception(ex)
+
+
+class TimerTimeout:
+    def __init__(self, seconds: int = 1, error_message: str = "Timeout") -> None:
+        self.seconds = seconds
+        self.error_message = error_message
+        self.timer = threading.Timer(seconds, _thread.interrupt_main)
+
+    def __enter__(self) -> None:
+        self.timer.start()
+
+    def __exit__(  # pylint: disable=redefined-outer-name,unused-variable,redefined-builtin
+        self, type: Any, value: Any, traceback: TracebackType
+    ) -> None:
+        self.timer.cancel()
+        if type is KeyboardInterrupt:  # raised by _thread.interrupt_main
+            raise SupersetTimeoutException(
+                error_type=SupersetErrorType.BACKEND_TIMEOUT_ERROR,
+                message=self.error_message,
+                level=ErrorLevel.ERROR,
+                extra={"timeout": self.seconds},
+            )
+
+
+# Windows has no support for SIGALRM, so we use the timer based timeout
+timeout: Union[Type[TimerTimeout], Type[SigalrmTimeout]] = (
+    TimerTimeout if platform.system() == "Windows" else SigalrmTimeout
+)
 
 
 def pessimistic_connection_handling(some_engine: Engine) -> None:


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

We currently use a context manager to timeout queries that run in SQL Lab, eg:

```python
with utils.timeout(seconds=timeout, error_message=timeout_msg):
    data = sql_lab.get_sql_results(...)
```

The context manager uses `SIGALRM`, which is not available in Windows, resulting in an error (see https://github.com/apache/superset/issues/12824).

Even though Windows is not technically supported by Superset, this is a simple fix. I introduced a new timeout context manager based on a timer.  This PR changes Superset to use that context manager only when running on Windows. In theory we could replace the old one, but I thought it would be safer to introduce the new one in parallel first.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

I installed Python under a Windows VPS and tested the context manager with this script:

```python
# test.py
import _thread
import threading


class Timeout:
    def __init__(self, seconds: int = 1, error_message: str = "Timeout") -> None:
        self.seconds = seconds
        self.error_message = error_message
        self.timer = threading.Timer(self.seconds, _thread.interrupt_main)

    def __enter__(self) -> None:
        self.timer.start()

    def __exit__(self, type, value, traceback) -> None:
        self.timer.cancel()
        if type is KeyboardInterrupt:
            raise Exception(self.error_message)


with Timeout():
    for i in range(int(1e15)):
        pass
```

(I didn't use `sleep()` because the `_thread.interrupt_main` doesn't interrupt it.)

Then running it causes the main thread to be aborted after 1 second:

```
C:\Users\Administrator\Documents>powershell -Command "Measure-Command {python test.py}"
Traceback (most recent call last):
  File "C:\Users\Administrator\Documents\test.py", line 21, in <module>
    pass
KeyboardInterrupt

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\Administrator\Documents\test.py", line 21, in <module>
    pass
  File "C:\Users\Administrator\Documents\test.py", line 16, in __exit__
    raise Exception(self.error_message)
Exception: Timeout


Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 1
Milliseconds      : 463
Ticks             : 14631515
TotalDays         : 1.69346238425926E-05
TotalHours        : 0.000406430972222222
TotalMinutes      : 0.0243858583333333
TotalSeconds      : 1.4631515
TotalMilliseconds : 1463.1515




C:\Users\Administrator\Documents>
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/12824
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
