### PR TITLE
fix: vertical scroll in query history

### DIFF
--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -55,6 +55,7 @@ body {
   height: 100%;
   position: relative;
   background-color: @lightest;
+  overflow: auto;
 
   > .ant-tabs-tabpane {
     position: absolute;


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Vertical scrolling in the query history in SQL Editor is currently broken. This PR fixes https://github.com/apache/superset/issues/12922.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Scrolling now works:

![output_optimized](https://user-images.githubusercontent.com/1534870/107457489-fdfb1b00-6b06-11eb-9ce9-6b02bf4ba9ae.gif)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

I tested other tabs (preview, results) and everything works as expected.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/12922
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
