### PR TITLE
fix: add config to disable dataset ownership on the old api

### DIFF
--- a/.github/workflows/docker_build_push.sh
+++ b/.github/workflows/docker_build_push.sh
@@ -21,14 +21,14 @@ SHA=$(git rev-parse HEAD)
 REPO_NAME="apache/superset"
 
 if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-  REFSPEC=$(echo "${GITHUB_HEAD_REF}" | sed 's/[^a-zA-Z0-9]/-/' | head -c 40)
+  REFSPEC=$(echo "${GITHUB_HEAD_REF}" | sed 's/[^a-zA-Z0-9]/-/g' | head -c 40)
   PR_NUM=$(echo "${GITHUB_REF}" | sed 's:refs/pull/::' | sed 's:/merge::')
   LATEST_TAG="pr-${PR_NUM}"
 elif [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
   REFSPEC=$(echo "${GITHUB_REF}" | sed 's:refs/tags/::' | head -c 40)
   LATEST_TAG="${REFSPEC}"
 else
-  REFSPEC=$(echo "${GITHUB_REF}" | sed 's:refs/heads/::' | sed 's/[^a-zA-Z0-9]/-/' | head -c 40)
+  REFSPEC=$(echo "${GITHUB_REF}" | sed 's:refs/heads/::' | sed 's/[^a-zA-Z0-9]/-/g' | head -c 40)
   LATEST_TAG="${REFSPEC}"
 fi
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -1057,6 +1057,10 @@ SIP_15_TOAST_MESSAGE = (
     'class="alert-link">here</a>.'
 )
 
+# Turn this key to False to disable ownership check on the old dataset MVC and
+# datasource API /datasource/save.
+OLD_API_CHECK_DATASET_OWNERSHIP = True
+
 # SQLA table mutator, every time we fetch the metadata for a certain table
 # (superset.connectors.sqla.models.SqlaTable), we call this hook
 # to allow mutating the object with this callback.

--- a/superset/config.py
+++ b/superset/config.py
@@ -1059,6 +1059,8 @@ SIP_15_TOAST_MESSAGE = (
 
 # Turn this key to False to disable ownership check on the old dataset MVC and
 # datasource API /datasource/save.
+#
+# Warning: This config key is deprecated and will be removed in version 2.0.0"
 OLD_API_CHECK_DATASET_OWNERSHIP = True
 
 # SQLA table mutator, every time we fetch the metadata for a certain table

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -173,13 +173,25 @@ class TableColumnInlineView(  # pylint: disable=too-many-ancestors
     edit_form_extra_fields = add_form_extra_fields
 
     def pre_add(self, item: "models.SqlMetric") -> None:
-        check_ownership(item.table)
+        logger.warning(
+            "This endpoint is deprecated and will be removed in version 2.0.0"
+        )
+        if app.config["OLD_API_CHECK_DATASET_OWNERSHIP"]:
+            check_ownership(item.table)
 
     def pre_update(self, item: "models.SqlMetric") -> None:
-        check_ownership(item.table)
+        logger.warning(
+            "This endpoint is deprecated and will be removed in version 2.0.0"
+        )
+        if app.config["OLD_API_CHECK_DATASET_OWNERSHIP"]:
+            check_ownership(item.table)
 
     def pre_delete(self, item: "models.SqlMetric") -> None:
-        check_ownership(item.table)
+        logger.warning(
+            "This endpoint is deprecated and will be removed in version 2.0.0"
+        )
+        if app.config["OLD_API_CHECK_DATASET_OWNERSHIP"]:
+            check_ownership(item.table)
 
 
 class SqlMetricInlineView(  # pylint: disable=too-many-ancestors
@@ -256,13 +268,25 @@ class SqlMetricInlineView(  # pylint: disable=too-many-ancestors
     edit_form_extra_fields = add_form_extra_fields
 
     def pre_add(self, item: "models.SqlMetric") -> None:
-        check_ownership(item.table)
+        logger.warning(
+            "This endpoint is deprecated and will be removed in version 2.0.0"
+        )
+        if app.config["OLD_API_CHECK_DATASET_OWNERSHIP"]:
+            check_ownership(item.table)
 
     def pre_update(self, item: "models.SqlMetric") -> None:
-        check_ownership(item.table)
+        logger.warning(
+            "This endpoint is deprecated and will be removed in version 2.0.0"
+        )
+        if app.config["OLD_API_CHECK_DATASET_OWNERSHIP"]:
+            check_ownership(item.table)
 
     def pre_delete(self, item: "models.SqlMetric") -> None:
-        check_ownership(item.table)
+        logger.warning(
+            "This endpoint is deprecated and will be removed in version 2.0.0"
+        )
+        if app.config["OLD_API_CHECK_DATASET_OWNERSHIP"]:
+            check_ownership(item.table)
 
 
 class RowLevelSecurityListWidget(
@@ -476,10 +500,17 @@ class TableModelView(  # pylint: disable=too-many-ancestors
     }
 
     def pre_add(self, item: "TableModelView") -> None:
+        logger.warning(
+            "This endpoint is deprecated and will be removed in version 2.0.0"
+        )
         validate_sqlatable(item)
 
     def pre_update(self, item: "TableModelView") -> None:
-        check_ownership(item)
+        logger.warning(
+            "This endpoint is deprecated and will be removed in version 2.0.0"
+        )
+        if app.config["OLD_API_CHECK_DATASET_OWNERSHIP"]:
+            check_ownership(item)
 
     def post_add(  # pylint: disable=arguments-differ
         self,
@@ -522,6 +553,9 @@ class TableModelView(  # pylint: disable=too-many-ancestors
     def refresh(  # pylint: disable=no-self-use, too-many-branches
         self, tables: Union["TableModelView", List["TableModelView"]]
     ) -> FlaskResponse:
+        logger.warning(
+            "This endpoint is deprecated and will be removed in version 2.0.0"
+        )
         if not isinstance(tables, list):
             tables = [tables]
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -989,7 +989,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         self, db_id: int, force_refresh: str = "false"
     ) -> FlaskResponse:
         logger.warning(
-            "This API endpoint is deprecated and will be removed in version 1.0.0"
+            "This API endpoint is deprecated and will be removed in version 2.0.0"
         )
         db_id = int(db_id)
         database = db.session.query(Database).get(db_id)
@@ -1754,7 +1754,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     ) -> FlaskResponse:
         """Gets and toggles published status on dashboards"""
         logger.warning(
-            "This API endpoint is deprecated and will be removed in version 1.0.0"
+            "This API endpoint is deprecated and will be removed in version 2.0.0"
         )
         session = db.session()
         Role = ab_models.Role
@@ -2071,7 +2071,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     ) -> FlaskResponse:
         logging.warning(
             "%s.select_star "
-            "This API endpoint is deprecated and will be removed in version 1.0.0",
+            "This API endpoint is deprecated and will be removed in version 2.0.0",
             self.__class__.__name__,
         )
         stats_logger.incr(f"{self.__class__.__name__}.select_star.init")

--- a/superset/views/datasource.py
+++ b/superset/views/datasource.py
@@ -53,16 +53,13 @@ class Datasource(BaseSupersetView):
         )
         orm_datasource.database_id = database_id
 
-        if (
-            app.config["OLD_API_CHECK_DATASET_OWNERSHIP"]
-            and "owners" in datasource_dict
-            and orm_datasource.owner_class is not None
-        ):
+        if "owners" in datasource_dict and orm_datasource.owner_class is not None:
             # Check ownership
-            try:
-                check_ownership(orm_datasource)
-            except SupersetSecurityException:
-                raise DatasetForbiddenError()
+            if app.config["OLD_API_CHECK_DATASET_OWNERSHIP"]:
+                try:
+                    check_ownership(orm_datasource)
+                except SupersetSecurityException:
+                    raise DatasetForbiddenError()
 
             datasource_dict["owners"] = (
                 db.session.query(orm_datasource.owner_class)

--- a/superset/views/datasource.py
+++ b/superset/views/datasource.py
@@ -22,7 +22,7 @@ from flask_appbuilder import expose
 from flask_appbuilder.security.decorators import has_access_api
 from flask_babel import _
 
-from superset import db
+from superset import app, db
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.datasets.commands.exceptions import DatasetForbiddenError
 from superset.exceptions import SupersetException, SupersetSecurityException
@@ -53,7 +53,11 @@ class Datasource(BaseSupersetView):
         )
         orm_datasource.database_id = database_id
 
-        if "owners" in datasource_dict and orm_datasource.owner_class is not None:
+        if (
+            app.config["OLD_API_CHECK_DATASET_OWNERSHIP"]
+            and "owners" in datasource_dict
+            and orm_datasource.owner_class is not None
+        ):
             # Check ownership
             try:
                 check_ownership(orm_datasource)


### PR DESCRIPTION
### SUMMARY
A follow up for #12491 that caused problems. The ownership check is inline with the current security logic that only owners can change their object metadata.

This PR adds a new config flag `OLD_API_CHECK_DATASET_OWNERSHIP` that user's can set to `False` to return to the previous behaviour (no ownership checking).

Also added a deprecation warning to the MVC endpoints and `datasource/save`. Note that the new API for datasets will check for ownership and ignore `OLD_API_CHECK_DATASET_OWNERSHIP`. 

Yet, probably the ownership concept is problematic, and a move for using associated roles to objects (dashboards, datasets, charts) is easier to manage. 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
