### PR TITLE
feat: Force pod restart on config changes

### DIFF
--- a/helm/superset/templates/deployment.yaml
+++ b/helm/superset/templates/deployment.yaml
@@ -31,11 +31,17 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
-      {{ if .Values.supersetNode.forceReload }}
       annotations:
-        # Optionally force the thing to reload
+        # Force reload on config changes
+        checksum/superset_config.py: {{ include "superset-config" . | sha256sum }}
+        checksum/superset_init.sh: {{ tpl .Values.init.initscript . | sha256sum }}
+        checksum/superset_bootstrap.sh: {{ include "superset-bootstrap" . | sha256sum }}
+        checksum/connections: {{ .Values.supersetNode.connections | toYaml | sha256sum }}
+        checksum/extraConfigs: {{ .Values.extraConfigs | toYaml | sha256sum }}
+        {{- if .Values.supersetNode.forceReload }}
+        # Optionally force the thing to reload unconditionally
         force-reload: {{ randAlphaNum 5 | quote }}
-      {{ end }}
+       {{- end }}
       labels:
         app: {{ template "superset.name" . }}
         release: {{ .Release.Name }}


### PR DESCRIPTION
### SUMMARY

Added some checksum annotations in the chart template to trigger a pod restart if any dependent configuration has changed (therefore not needing the `forceReload` flag)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TEST PLAN

* Deploy an existing release with the updated chart (`helm upgrade --install --values my-values.yaml superset  helm/superset`)
* Change some config value in `my-values.yaml` (e.g. adding an `additionalRequirements`)
* Upgrade the release with the same command
* Check that a new Deployment/ReplicaSet/Pod have been spawned

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
