### PR TITLE
style: fix typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Superset provides:
     authentication backends (database, OpenID, LDAP, OAuth, REMOTE_USER, etc)
 * The ability to add custom visualization plugins
 * An API for programmatic customization
-* A cloud-native archiecture designed from the ground up for scale
+* A cloud-native architecture designed from the ground up for scale
 
 ## Supported Databases
 

--- a/docs/src/pages/docs/introduction.mdx
+++ b/docs/src/pages/docs/introduction.mdx
@@ -33,7 +33,7 @@ Superset provides:
 - Integration with major authentication backends (database, OpenID, LDAP, OAuth, REMOTE_USER, etc)
 - The ability to add custom visualization plugins
 - An API for programmatic customization
-- A cloud-native archiecture designed from the ground up for scale
+- A cloud-native architecture designed from the ground up for scale
 
 Superset is cloud-native and designed to be highly available. It was designed to scale out to large,
 distributed environments and works very well inside containers. While you can easily test drive


### PR DESCRIPTION
### SUMMARY
`archiecture` -> `architecture` in README.md and docs/introduction.mdx
