### PR TITLE
chore: lock down npm to v6

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -57,7 +57,7 @@
   ],
   "engines": {
     "node": ">= 12.18.3 < 13",
-    "npm": ">= 6.14.8"
+    "npm": ">= 6.14.8 < 7"
   },
   "homepage": "https://superset.apache.org/",
   "dependencies": {


### PR DESCRIPTION
### SUMMARY

Lock down npm requirement to  npm 6 so developers at least get a warning if they try to run `npm install` with npm 7.

<img src="https://user-images.githubusercontent.com/335541/107595203-d66c8700-6bc8-11eb-98f7-28021455d2fe.png" width="550">


npm 7 has some breaking changes that needs additional work to care for, which requires coordination between the `superset-ui` and `superset` repo. Since we have some open PRs right now, let's lockdown the npm version for now.

See. https://github.com/apache/superset/issues/13067


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
