### PR TITLE
fix(ci): multiline regex in change detection

### DIFF
--- a/scripts/ci_check_no_file_changes.sh
+++ b/scripts/ci_check_no_file_changes.sh
@@ -39,7 +39,7 @@ do
     echo "Invalid check: \"${CHECK}\". Falling back to exiting with FAILURE code"
     exit 1
   fi
-  REGEXES=(${REGEXES[@]} ${REGEX})
+  REGEXES=("${REGEXES[@]}" "${REGEX}")
 done
 echo
 
@@ -51,10 +51,11 @@ EOF
 
 for FILE in ${FILES}
 do
-  for REGEX in ${REGEXES[@]}
+  for REGEX in "${REGEXES[@]}"
   do
     if [[ "${FILE}" =~ ${REGEX} ]]; then
-      echo "Detected changes in following file: ${FILE}... Exiting with FAILURE code"
+      echo "Detected changes in following file: ${FILE}"
+      echo "Exiting with FAILURE code"
       exit 1
     fi
   done

--- a/scripts/ci_check_no_file_changes.sh
+++ b/scripts/ci_check_no_file_changes.sh
@@ -26,12 +26,7 @@
 URL="https://api.github.com/repos/${GITHUB_REPO}/pulls/${PR_NUMBER}/files"
 FILES=$(curl -s -X GET -G "${URL}" | jq -r '.[] | .filename')
 
-cat<<EOF
-CHANGED FILES:
-$FILES
-
-EOF
-
+REGEXES=()
 for CHECK in "$@"
 do
   if [[ ${CHECK} == "python" ]]; then
@@ -44,11 +39,25 @@ do
     echo "Invalid check: \"${CHECK}\". Falling back to exiting with FAILURE code"
     exit 1
   fi
+  REGEXES=(${REGEXES[@]} ${REGEX})
+done
+echo
 
-  if [[ "${FILES}" =~ ${REGEX} ]]; then
-    echo "Detected changes... Exiting with FAILURE code"
-    exit 1
-  fi
+cat<<EOF
+CHANGED FILES:
+$FILES
+
+EOF
+
+for FILE in ${FILES}
+do
+  for REGEX in ${REGEXES[@]}
+  do
+    if [[ "${FILE}" =~ ${REGEX} ]]; then
+      echo "Detected changes in following file: ${FILE}... Exiting with FAILURE code"
+      exit 1
+    fi
+  done
 done
 echo "No changes detected... Exiting with SUCCESS code"
 exit 0


### PR DESCRIPTION
### SUMMARY
Currently the CI test skipping logic applies a regex on a variable containing all modified files. As these checks are checking for start of line (`^`) and the regular `=~` doesn't support multiline matching, the script has been changed to loop through each row in the changed files variable, and flag the first row where changes were detected.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
Tested with a PR where changes weren't being picked up correctly:
```
$ GITHUB_REPO=apache/superset PR_NUMBER=13051 ./ci_check_no_file_changes.sh python
Searching for changes in python files

CHANGED FILES:
.github/workflows/docker_build_push.sh
superset/config.py
superset/connectors/sqla/views.py
superset/views/core.py
superset/views/datasource.py

Detected changes in following file: superset/config.py
Exiting with FAILURE code
```

Checking this PR:
```
$ GITHUB_REPO=apache/superset PR_NUMBER=13075 ./ci_check_no_file_changes.sh python frontend
Searching for changes in python files
Searching for changes in frontend files

CHANGED FILES:
scripts/ci_check_no_file_changes.sh

No changes detected... Exiting with SUCCESS code
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
