### PR TITLE
fix: API tests, make them possible to run independently again

### DIFF
--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -1,5 +1,5 @@
-# Python MySQL unit tests
-name: Python MySQL
+# Python unit tests
+name: Python
 
 on:
   push:

--- a/tests/dashboards/api_tests.py
+++ b/tests/dashboards/api_tests.py
@@ -22,7 +22,6 @@ from io import BytesIO
 from typing import List, Optional
 from unittest.mock import patch
 from zipfile import is_zipfile, ZipFile
-from tests.fixtures.birth_names_dashboard import load_birth_names_dashboard_with_slices
 
 import pytest
 import prison
@@ -49,6 +48,7 @@ from tests.fixtures.importexport import (
     dataset_metadata_config,
 )
 from tests.utils.get_dashboards import get_dashboards_ids
+from tests.fixtures.birth_names_dashboard import load_birth_names_dashboard_with_slices
 from tests.fixtures.world_bank_dashboard import load_world_bank_dashboard_with_slices
 
 DASHBOARDS_FIXTURE_COUNT = 10
@@ -223,6 +223,7 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin):
         assert "can_write" in data["permissions"]
         assert len(data["permissions"]) == 2
 
+    @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
     def test_get_dashboard_not_found(self):
         """
         Dashboard API: Test get dashboard not found

--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -1119,6 +1119,7 @@ class TestDatasetApi(SupersetTestCase):
         {"VERSIONED_EXPORT": True},
         clear=True,
     )
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_export_dataset_bundle(self):
         """
         Dataset API: Test export dataset

--- a/tests/reports/api_tests.py
+++ b/tests/reports/api_tests.py
@@ -23,7 +23,6 @@ import pytest
 import prison
 from sqlalchemy.sql import func
 
-import tests.test_app
 from superset import db
 from superset.models.core import Database
 from superset.models.slice import Slice
@@ -36,8 +35,9 @@ from superset.models.reports import (
     ReportRecipientType,
     ReportState,
 )
-
+import tests.test_app
 from tests.base_tests import SupersetTestCase
+from tests.fixtures.birth_names_dashboard import load_birth_names_dashboard_with_slices
 from tests.reports.utils import insert_report_schedule
 from superset.utils.core import get_example_database
 
@@ -403,7 +403,7 @@ class TestReportSchedulesApi(SupersetTestCase):
             rv = self.client.get(uri)
             assert rv.status_code == 200
 
-    @pytest.mark.usefixtures("create_report_schedules")
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_create_report_schedule(self):
         """
         ReportSchedule Api: Test create report schedule
@@ -508,7 +508,7 @@ class TestReportSchedulesApi(SupersetTestCase):
         rv = self.client.post(uri, json=report_schedule_data)
         assert rv.status_code == 400
 
-    @pytest.mark.usefixtures("create_report_schedules")
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_create_report_schedule_chart_dash_validation(self):
         """
         ReportSchedule Api: Test create report schedule chart and dashboard validation
@@ -556,7 +556,7 @@ class TestReportSchedulesApi(SupersetTestCase):
         data = json.loads(rv.data.decode("utf-8"))
         assert data == {"message": {"database": "Database is required for alerts"}}
 
-    @pytest.mark.usefixtures("create_report_schedules")
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_create_report_schedule_relations_exist(self):
         """
         ReportSchedule Api: Test create report schedule
@@ -700,7 +700,9 @@ class TestReportSchedulesApi(SupersetTestCase):
         rv = self.client.put(uri, json=report_schedule_data)
         assert rv.status_code == 404
 
-    @pytest.mark.usefixtures("create_report_schedules")
+    @pytest.mark.usefixtures(
+        "load_birth_names_dashboard_with_slices", "create_report_schedules"
+    )
     def test_update_report_schedule_chart_dash_validation(self):
         """
         ReportSchedule Api: Test update report schedule chart and dashboard validation
@@ -727,7 +729,9 @@ class TestReportSchedulesApi(SupersetTestCase):
         data = json.loads(rv.data.decode("utf-8"))
         assert data == {"message": {"chart": "Choose a chart or dashboard not both"}}
 
-    @pytest.mark.usefixtures("create_report_schedules")
+    @pytest.mark.usefixtures(
+        "load_birth_names_dashboard_with_slices", "create_report_schedules"
+    )
     def test_update_report_schedule_relations_exist(self):
         """
         ReportSchedule Api: Test update report schedule relations exist


### PR DESCRIPTION
### SUMMARY
Quick fix to make it possible again to run API tests independently

Tested with:

`./scripts/tests/run.sh --module tests/annotation_layers/api_tests.py`

`./scripts/tests/run.sh --module tests/charts/api_tests.py`

`./scripts/tests/run.sh --module tests/css_templates/api_tests.py`

`./scripts/tests/run.sh --module tests/dashboards/api_tests.py`

`./scripts/tests/run.sh --module tests/databases/api_tests.py`

`./scripts/tests/run.sh --module tests/reports/api_tests.py`

Unfortunately datasets tests still depend on uncleaned data from other tests (difficult to pin), I'll address this problem on a separate PR

### TEST PLAN
Run API tests independently

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
