### PR TITLE
fix: accept null groupby in form data for timeseries table viz

### DIFF
--- a/superset-frontend/src/visualizations/TimeTable/transformProps.js
+++ b/superset-frontend/src/visualizations/TimeTable/transformProps.js
@@ -20,7 +20,7 @@ export default function transformProps(chartProps) {
   const { height, datasource, formData, queriesData } = chartProps;
   const { columnCollection = [], groupby, metrics, url } = formData;
   const { records, columns } = queriesData[0].data;
-  const isGroupBy = groupby.length > 0;
+  const isGroupBy = groupby?.length > 0;
 
   // When there is a "group by",
   // each row in the table is a database column

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -803,8 +803,7 @@ class TimeTableViz(BaseViz):
         return dict(
             records=pt.to_dict(orient="index"),
             columns=list(pt.columns),
-            # "groupby" may not exist in fd or it may exist and be None
-            is_group_by=len(fd.get("groupby") or []) > 0,
+            is_group_by=True if fd.get("groupby") else False,
         )
 
 

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -803,7 +803,8 @@ class TimeTableViz(BaseViz):
         return dict(
             records=pt.to_dict(orient="index"),
             columns=list(pt.columns),
-            is_group_by=len(fd.get("groupby", [])) > 0,
+            # "groupby" may not exist in fd or it may exist and be None
+            is_group_by=len(fd.get("groupby") or []) > 0,
         )
 
 


### PR DESCRIPTION
### SUMMARY
In existing (previously created) timeseries table viz charts the groupby can be null if there are multiple metrics selected and no groupby. In newly created charts in this situation groupby is `[]`. I'm making this change to avoid the error on old charts if groupby is null in the form data.

### TEST PLAN
Tested existing saved charts with multiple metrics and no groupby

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #12750 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

@john-bodley @ktmud @etr2460 