### PR TITLE
perf: add lazy loading along react-router routes and router links in menu

### DIFF
--- a/superset-frontend/spec/javascripts/components/Menu_spec.jsx
+++ b/superset-frontend/spec/javascripts/components/Menu_spec.jsx
@@ -17,11 +17,12 @@
  * under the License.
  */
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { styledMount as mount } from 'spec/helpers/theming';
+import { shallow } from 'enzyme';
 import { Nav } from 'react-bootstrap';
 import { Menu as DropdownMenu } from 'src/common/components';
 import NavDropdown from 'src/components/NavDropdown';
-import { supersetTheme, ThemeProvider } from '@superset-ui/core';
+import { Link } from 'react-router-dom';
 
 import { Menu } from 'src/components/Menu/Menu';
 import MenuObject from 'src/components/Menu/MenuObject';
@@ -172,10 +173,7 @@ describe('Menu', () => {
       ...overrideProps,
     };
 
-    const versionedWrapper = mount(<Menu {...props} />, {
-      wrappingComponent: ThemeProvider,
-      wrappingComponentProps: { theme: supersetTheme },
-    });
+    const versionedWrapper = mount(<Menu {...props} />);
 
     expect(versionedWrapper.find('.version-info span')).toHaveLength(2);
   });
@@ -186,5 +184,29 @@ describe('Menu', () => {
 
   it('renders MenuItems in NavDropdown (settings)', () => {
     expect(wrapper.find(NavDropdown).find(DropdownMenu.Item)).toHaveLength(3);
+  });
+
+  it('renders a react-router Link if isFrontendRoute', () => {
+    const props = {
+      ...defaultProps,
+      isFrontendRoute: jest.fn(() => true),
+    };
+
+    const wrapper2 = mount(<Menu {...props} />);
+
+    expect(props.isFrontendRoute).toHaveBeenCalled();
+    expect(wrapper2.find(Link)).toExist();
+  });
+
+  it('does not render a react-router Link if not isFrontendRoute', () => {
+    const props = {
+      ...defaultProps,
+      isFrontendRoute: jest.fn(() => false),
+    };
+
+    const wrapper2 = mount(<Menu {...props} />);
+
+    expect(props.isFrontendRoute).toHaveBeenCalled();
+    expect(wrapper2.find(Link).exists()).toBe(false);
   });
 });

--- a/superset-frontend/spec/javascripts/components/Menu_spec.jsx
+++ b/superset-frontend/spec/javascripts/components/Menu_spec.jsx
@@ -44,7 +44,7 @@ const defaultProps = {
             name: 'Datasets',
             icon: 'fa-table',
             label: 'Datasets',
-            url: '/tablemodelview/list/?_flt_1_is_sqllab_view=y',
+            url: '/tablemodelview/list/',
           },
           '-',
           {

--- a/superset-frontend/src/components/Menu/Menu.tsx
+++ b/superset-frontend/src/components/Menu/Menu.tsx
@@ -173,14 +173,23 @@ export function Menu({
           <Navbar.Toggle />
         </Navbar.Header>
         <Nav data-test="navbar-top">
-          {menu.map((item, index) => (
-            <MenuObject
-              {...item}
-              frontEndRoutes={frontEndRoutes}
-              key={item.label}
-              index={index + 1}
-            />
-          ))}
+          {menu.map((item, index) => {
+            const props = {
+              ...item,
+              isFrontendRoute: !!frontEndRoutes?.[item.url || ''],
+              childs: item.childs?.map(c => {
+                if (typeof c === 'string') {
+                  return c;
+                }
+
+                return {
+                  ...c,
+                  isFrontendRoute: !!frontEndRoutes?.[c.url || ''],
+                };
+              }),
+            };
+            return <MenuObject {...props} key={item.label} index={index + 1} />;
+          })}
         </Nav>
         <Nav className="navbar-right">
           {!navbarRight.user_is_anonymous && <NewMenu />}

--- a/superset-frontend/src/components/Menu/Menu.tsx
+++ b/superset-frontend/src/components/Menu/Menu.tsx
@@ -21,6 +21,7 @@ import { t, styled } from '@superset-ui/core';
 import { Nav, Navbar, NavItem } from 'react-bootstrap';
 import NavDropdown from 'src/components/NavDropdown';
 import { Menu as DropdownMenu } from 'src/common/components';
+import { Link } from 'react-router-dom';
 import MenuObject, {
   MenuObjectProps,
   MenuObjectChildProps,
@@ -56,6 +57,9 @@ export interface MenuProps {
     brand: BrandProps;
     navbar_right: NavBarProps;
     settings: MenuObjectProps[];
+  };
+  frontEndRoutes?: {
+    [route: string]: boolean;
   };
 }
 
@@ -99,7 +103,7 @@ const StyledHeader = styled.header`
     padding-left: 12px;
   }
 
-  .navbar-inverse .navbar-nav > li > a {
+  .navbar-inverse .navbar-nav li a {
     color: ${({ theme }) => theme.colors.grayscale.dark1};
     border-bottom: none;
     transition: background-color ${({ theme }) => theme.transitionTiming}s;
@@ -153,6 +157,7 @@ const StyledHeader = styled.header`
 
 export function Menu({
   data: { menu, brand, navbar_right: navbarRight, settings },
+  frontEndRoutes,
 }: MenuProps) {
   const [dropdownOpen, setDropdownOpen] = useState(false);
 
@@ -169,7 +174,12 @@ export function Menu({
         </Navbar.Header>
         <Nav data-test="navbar-top">
           {menu.map((item, index) => (
-            <MenuObject {...item} key={item.label} index={index + 1} />
+            <MenuObject
+              {...item}
+              frontEndRoutes={frontEndRoutes}
+              key={item.label}
+              index={index + 1}
+            />
           ))}
         </Nav>
         <Nav className="navbar-right">
@@ -192,7 +202,11 @@ export function Menu({
                     if (typeof child !== 'string') {
                       return (
                         <DropdownMenu.Item key={`${child.label}`}>
-                          <a href={child.url}>{child.label}</a>
+                          {frontEndRoutes && frontEndRoutes[child.url || ''] ? (
+                            <Link to={child.url || ''}>{child.label}</Link>
+                          ) : (
+                            <a href={child.url}>{child.label}</a>
+                          )}
                         </DropdownMenu.Item>
                       );
                     }
@@ -276,7 +290,7 @@ export function Menu({
 }
 
 // transform the menu data to reorganize components
-export default function MenuWrapper({ data }: MenuProps) {
+export default function MenuWrapper({ data, frontEndRoutes }: MenuProps) {
   const newMenuData = {
     ...data,
   };
@@ -322,5 +336,5 @@ export default function MenuWrapper({ data }: MenuProps) {
   newMenuData.menu = cleanedMenu;
   newMenuData.settings = settings;
 
-  return <Menu data={newMenuData} />;
+  return <Menu data={newMenuData} frontEndRoutes={frontEndRoutes} />;
 }

--- a/superset-frontend/src/components/Menu/Menu.tsx
+++ b/superset-frontend/src/components/Menu/Menu.tsx
@@ -58,9 +58,7 @@ export interface MenuProps {
     navbar_right: NavBarProps;
     settings: MenuObjectProps[];
   };
-  frontEndRoutes?: {
-    [route: string]: boolean;
-  };
+  isFrontendRoute?: (path?: string) => boolean;
 }
 
 const StyledHeader = styled.header`
@@ -157,7 +155,7 @@ const StyledHeader = styled.header`
 
 export function Menu({
   data: { menu, brand, navbar_right: navbarRight, settings },
-  frontEndRoutes,
+  isFrontendRoute = () => false,
 }: MenuProps) {
   const [dropdownOpen, setDropdownOpen] = useState(false);
 
@@ -176,7 +174,7 @@ export function Menu({
           {menu.map((item, index) => {
             const props = {
               ...item,
-              isFrontendRoute: !!frontEndRoutes?.[item.url || ''],
+              isFrontendRoute: isFrontendRoute(item.url),
               childs: item.childs?.map(c => {
                 if (typeof c === 'string') {
                   return c;
@@ -184,7 +182,7 @@ export function Menu({
 
                 return {
                   ...c,
-                  isFrontendRoute: !!frontEndRoutes?.[c.url || ''],
+                  isFrontendRoute: isFrontendRoute(c.url),
                 };
               }),
             };
@@ -211,7 +209,7 @@ export function Menu({
                     if (typeof child !== 'string') {
                       return (
                         <DropdownMenu.Item key={`${child.label}`}>
-                          {frontEndRoutes && frontEndRoutes[child.url || ''] ? (
+                          {isFrontendRoute(child.url) ? (
                             <Link to={child.url || ''}>{child.label}</Link>
                           ) : (
                             <a href={child.url}>{child.label}</a>
@@ -299,7 +297,7 @@ export function Menu({
 }
 
 // transform the menu data to reorganize components
-export default function MenuWrapper({ data, frontEndRoutes }: MenuProps) {
+export default function MenuWrapper({ data, ...rest }: MenuProps) {
   const newMenuData = {
     ...data,
   };
@@ -345,5 +343,5 @@ export default function MenuWrapper({ data, frontEndRoutes }: MenuProps) {
   newMenuData.menu = cleanedMenu;
   newMenuData.settings = settings;
 
-  return <Menu data={newMenuData} frontEndRoutes={frontEndRoutes} />;
+  return <Menu data={newMenuData} {...rest} />;
 }

--- a/superset-frontend/src/components/Menu/MenuObject.tsx
+++ b/superset-frontend/src/components/Menu/MenuObject.tsx
@@ -28,18 +28,12 @@ export interface MenuObjectChildProps {
   icon: string;
   index: number;
   url?: string;
+  isFrontendRoute?: boolean;
 }
 
-export interface MenuObjectProps {
-  label?: string;
-  icon?: string;
-  index: number;
-  url?: string;
+export interface MenuObjectProps extends MenuObjectChildProps {
   childs?: (MenuObjectChildProps | string)[];
   isHeader?: boolean;
-  frontEndRoutes?: {
-    [route: string]: boolean;
-  };
 }
 
 export default function MenuObject({
@@ -47,10 +41,10 @@ export default function MenuObject({
   childs,
   url,
   index,
-  frontEndRoutes,
+  isFrontendRoute,
 }: MenuObjectProps) {
   const [dropdownOpen, setDropdownOpen] = useState(false);
-  if (url && frontEndRoutes && frontEndRoutes[url]) {
+  if (url && isFrontendRoute) {
     return (
       <li role="presentation">
         <Link role="button" to={url}>
@@ -84,10 +78,10 @@ export default function MenuObject({
           if (typeof child !== 'string') {
             return (
               <Menu.Item key={`${child.label}`}>
-                {frontEndRoutes && frontEndRoutes[child.url || ''] ? (
-                  <Link to={child.url || ''}>&nbsp; {child.label}</Link>
+                {child.isFrontendRoute ? (
+                  <Link to={child.url || ''}>{child.label}</Link>
                 ) : (
-                  <a href={child.url}>&nbsp; {child.label}</a>
+                  <a href={child.url}>{child.label}</a>
                 )}
               </Menu.Item>
             );

--- a/superset-frontend/src/components/Menu/MenuObject.tsx
+++ b/superset-frontend/src/components/Menu/MenuObject.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { NavItem } from 'react-bootstrap';
 import { Menu } from 'src/common/components';
 import NavDropdown from '../NavDropdown';
@@ -36,6 +37,9 @@ export interface MenuObjectProps {
   url?: string;
   childs?: (MenuObjectChildProps | string)[];
   isHeader?: boolean;
+  frontEndRoutes?: {
+    [route: string]: boolean;
+  };
 }
 
 export default function MenuObject({
@@ -43,9 +47,18 @@ export default function MenuObject({
   childs,
   url,
   index,
+  frontEndRoutes,
 }: MenuObjectProps) {
   const [dropdownOpen, setDropdownOpen] = useState(false);
-
+  if (url && frontEndRoutes && frontEndRoutes[url]) {
+    return (
+      <li role="presentation">
+        <Link role="button" to={url}>
+          {label}
+        </Link>
+      </li>
+    );
+  }
   if (url) {
     return (
       <NavItem eventKey={index} href={url}>
@@ -71,7 +84,11 @@ export default function MenuObject({
           if (typeof child !== 'string') {
             return (
               <Menu.Item key={`${child.label}`}>
-                <a href={child.url}>&nbsp; {child.label}</a>
+                {frontEndRoutes && frontEndRoutes[child.url || ''] ? (
+                  <Link to={child.url || ''}>&nbsp; {child.label}</Link>
+                ) : (
+                  <a href={child.url}>&nbsp; {child.label}</a>
+                )}
               </Menu.Item>
             );
           }

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { lazy, Suspense } from 'react';
+import React, { Suspense } from 'react';
 import { hot } from 'react-hot-loader/root';
 import thunk from 'redux-thunk';
 import { createStore, applyMiddleware, compose, combineReducers } from 'redux';
@@ -30,80 +30,13 @@ import ErrorBoundary from 'src/components/ErrorBoundary';
 import Loading from 'src/components/Loading';
 import Menu from 'src/components/Menu/Menu';
 import FlashProvider from 'src/components/FlashProvider';
-import Welcome from 'src/views/CRUD/welcome/Welcome';
 import { theme } from 'src/preamble';
 import ToastPresenter from 'src/messageToasts/containers/ToastPresenter';
 import setupPlugins from 'src/setup/setupPlugins';
 import setupApp from 'src/setup/setupApp';
 import messageToastReducer from 'src/messageToasts/reducers';
 import { initEnhancer } from 'src/reduxUtils';
-
-const AnnotationLayersList = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "AnnotationLayersList" */ 'src/views/CRUD/annotationlayers/AnnotationLayersList'
-    ),
-);
-const AlertList = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "AlertList" */ 'src/views/CRUD/alert/AlertList'
-    ),
-);
-const AnnotationList = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "AnnotationList" */ 'src/views/CRUD/annotation/AnnotationList'
-    ),
-);
-const ChartList = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "ChartList" */ 'src/views/CRUD/chart/ChartList'
-    ),
-);
-const CssTemplatesList = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "CssTemplatesList" */ 'src/views/CRUD/csstemplates/CssTemplatesList'
-    ),
-);
-const DashboardList = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "DashboardList" */ 'src/views/CRUD/dashboard/DashboardList'
-    ),
-);
-const DatabaseList = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "DatabaseList" */ 'src/views/CRUD/data/database/DatabaseList'
-    ),
-);
-const DatasetList = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "DatasetList" */ 'src/views/CRUD/data/dataset/DatasetList'
-    ),
-);
-const ExecutionLog = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "ExecutionLog" */ 'src/views/CRUD/alert/ExecutionLog'
-    ),
-);
-const QueryList = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "QueryList" */ 'src/views/CRUD/data/query/QueryList'
-    ),
-);
-const SavedQueryList = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "SavedQueryList" */ 'src/views/CRUD/data/savedquery/SavedQueryList'
-    ),
-);
+import { routes, isFrontendRoute } from 'src/views/routes';
 
 setupApp();
 setupPlugins();
@@ -122,29 +55,7 @@ const store = createStore(
   {},
   compose(applyMiddleware(thunk), initEnhancer(false)),
 );
-const routes = {
-  welcome: '/superset/welcome/',
-  dashboards: '/dashboard/list/',
-  charts: '/chart/list/',
-  datasets: '/tablemodelview/list/',
-  databases: '/databaseview/list/',
-  savedQueries: '/savedqueryview/list/',
-  cssTemplates: '/csstemplatemodelview/list/',
-  annotationLayers: '/annotationlayermodelview/list/',
-  annotations: '/annotationmodelview/:annotationLayerId/annotation/',
-  queries: '/superset/sqllab/history/',
-  alerts: '/alert/list/',
-  reports: '/report/list/',
-  alertLogs: '/alert/:alertId/log/',
-  reportLogs: '/report/:alertId/log/',
-};
-const frontEndRoutes = Object.values(routes).reduce(
-  (acc, curr) => ({
-    ...acc,
-    [curr]: true,
-  }),
-  {},
-);
+
 const App = () => (
   <ReduxProvider store={store}>
     <ThemeProvider theme={theme}>
@@ -155,81 +66,20 @@ const App = () => (
               ReactRouterRoute={Route}
               stringifyOptions={{ encode: false }}
             >
-              <Menu data={menu} frontEndRoutes={frontEndRoutes} />
-              <Suspense fallback={<Loading />}>
-                <Switch>
-                  <Route path={routes.welcome}>
-                    <ErrorBoundary>
-                      <Welcome user={user} />
-                    </ErrorBoundary>
-                  </Route>
-                  <Route path={routes.dashboards}>
-                    <ErrorBoundary>
-                      <DashboardList user={user} />
-                    </ErrorBoundary>
-                  </Route>
-                  <Route path={routes.charts}>
-                    <ErrorBoundary>
-                      <ChartList user={user} />
-                    </ErrorBoundary>
-                  </Route>
-                  <Route path={routes.datasets}>
-                    <ErrorBoundary>
-                      <DatasetList user={user} />
-                    </ErrorBoundary>
-                  </Route>
-                  <Route path={routes.databases}>
-                    <ErrorBoundary>
-                      <DatabaseList user={user} />
-                    </ErrorBoundary>
-                  </Route>
-                  <Route path={routes.savedQueries}>
-                    <ErrorBoundary>
-                      <SavedQueryList user={user} />
-                    </ErrorBoundary>
-                  </Route>
-                  <Route path={routes.cssTemplates}>
-                    <ErrorBoundary>
-                      <CssTemplatesList user={user} />
-                    </ErrorBoundary>
-                  </Route>
-                  <Route path={routes.annotationLayers}>
-                    <ErrorBoundary>
-                      <AnnotationLayersList user={user} />
-                    </ErrorBoundary>
-                  </Route>
-                  <Route path={routes.annotations}>
-                    <ErrorBoundary>
-                      <AnnotationList user={user} />
-                    </ErrorBoundary>
-                  </Route>
-                  <Route path={routes.queries}>
-                    <ErrorBoundary>
-                      <QueryList user={user} />
-                    </ErrorBoundary>
-                  </Route>
-                  <Route path={routes.alerts}>
-                    <ErrorBoundary>
-                      <AlertList user={user} />
-                    </ErrorBoundary>
-                  </Route>
-                  <Route path={routes.reports}>
-                    <ErrorBoundary>
-                      <AlertList user={user} isReportEnabled />
-                    </ErrorBoundary>
-                  </Route>
-                  <Route path={routes.alertLogs}>
-                    <ErrorBoundary>
-                      <ExecutionLog user={user} />
-                    </ErrorBoundary>
-                  </Route>
-                  <Route path={routes.reportLogs}>
-                    <ErrorBoundary>
-                      <ExecutionLog user={user} isReportEnabled />
-                    </ErrorBoundary>
-                  </Route>
-                </Switch>
-              </Suspense>
+              <Menu data={menu} isFrontendRoute={isFrontendRoute} />
+              <Switch>
+                {routes.map(
+                  ({ path, Component, props = {}, Fallback = Loading }) => (
+                    <Route path={path} key={path}>
+                      <Suspense fallback={<Fallback />}>
+                        <ErrorBoundary>
+                          <Component user={user} {...props} />
+                        </ErrorBoundary>
+                      </Suspense>
+                    </Route>
+                  ),
+                )}
+              </Switch>
               <ToastPresenter />
             </QueryParamProvider>
           </DynamicPluginProvider>

--- a/superset-frontend/src/views/menu.tsx
+++ b/superset-frontend/src/views/menu.tsx
@@ -16,6 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
+// Menu App. Used in views that do not already include the Menu component in the layout.
+// eg, backend rendered views
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { ThemeProvider } from '@superset-ui/core';

--- a/superset-frontend/src/views/routes.test.tsx
+++ b/superset-frontend/src/views/routes.test.tsx
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { isFrontendRoute, routes } from './routes';
+
+describe('isFrontendRoute', () => {
+  it('returns true if a route matches', () => {
+    routes.forEach(r => {
+      expect(isFrontendRoute(r.path)).toBe(true);
+    });
+  });
+
+  it('returns false if a route does not match', () => {
+    expect(isFrontendRoute('/non-existent/path/')).toBe(false);
+  });
+});

--- a/superset-frontend/src/views/routes.tsx
+++ b/superset-frontend/src/views/routes.tsx
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 import React, { lazy } from 'react';
 
 // not lazy loaded since this is the home page.

--- a/superset-frontend/src/views/routes.tsx
+++ b/superset-frontend/src/views/routes.tsx
@@ -1,0 +1,161 @@
+import React, { lazy } from 'react';
+
+// not lazy loaded since this is the home page.
+import Welcome from 'src/views/CRUD/welcome/Welcome';
+
+const AnnotationLayersList = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "AnnotationLayersList" */ 'src/views/CRUD/annotationlayers/AnnotationLayersList'
+    ),
+);
+const AlertList = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "AlertList" */ 'src/views/CRUD/alert/AlertList'
+    ),
+);
+const AnnotationList = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "AnnotationList" */ 'src/views/CRUD/annotation/AnnotationList'
+    ),
+);
+const ChartList = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "ChartList" */ 'src/views/CRUD/chart/ChartList'
+    ),
+);
+const CssTemplatesList = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "CssTemplatesList" */ 'src/views/CRUD/csstemplates/CssTemplatesList'
+    ),
+);
+const DashboardList = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "DashboardList" */ 'src/views/CRUD/dashboard/DashboardList'
+    ),
+);
+const DatabaseList = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "DatabaseList" */ 'src/views/CRUD/data/database/DatabaseList'
+    ),
+);
+const DatasetList = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "DatasetList" */ 'src/views/CRUD/data/dataset/DatasetList'
+    ),
+);
+const ExecutionLog = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "ExecutionLog" */ 'src/views/CRUD/alert/ExecutionLog'
+    ),
+);
+const QueryList = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "QueryList" */ 'src/views/CRUD/data/query/QueryList'
+    ),
+);
+const SavedQueryList = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "SavedQueryList" */ 'src/views/CRUD/data/savedquery/SavedQueryList'
+    ),
+);
+
+type Routes = {
+  path: string;
+  Component: React.ComponentType;
+  Fallback?: React.ComponentType;
+  props?: React.ComponentProps<any>;
+}[];
+
+export const routes: Routes = [
+  {
+    path: '/superset/welcome/',
+    Component: Welcome,
+  },
+  {
+    path: '/dashboard/list/',
+    Component: DashboardList,
+  },
+  {
+    path: '/chart/list/',
+    Component: ChartList,
+  },
+  {
+    path: '/tablemodelview/list/',
+    Component: DatasetList,
+  },
+  {
+    path: '/databaseview/list/',
+    Component: DatabaseList,
+  },
+  {
+    path: '/savedqueryview/list/',
+    Component: SavedQueryList,
+  },
+  {
+    path: '/csstemplatemodelview/list/',
+    Component: CssTemplatesList,
+  },
+  {
+    path: '/annotationlayermodelview/list/',
+    Component: AnnotationLayersList,
+  },
+  {
+    path: '/annotationmodelview/:annotationLayerId/annotation/',
+    Component: AnnotationList,
+  },
+  {
+    path: '/superset/sqllab/history/',
+    Component: QueryList,
+  },
+  {
+    path: '/alert/list/',
+    Component: AlertList,
+  },
+  {
+    path: '/report/list/',
+    Component: AlertList,
+    props: {
+      isReportEnabled: true,
+    },
+  },
+  {
+    path: '/alert/:alertId/log/',
+    Component: ExecutionLog,
+  },
+  {
+    path: '/report/:alertId/log/',
+    Component: ExecutionLog,
+    props: {
+      isReportEnabled: true,
+    },
+  },
+];
+
+export const frontEndRoutes = routes
+  .map(r => r.path)
+  .reduce(
+    (acc, curr) => ({
+      ...acc,
+      [curr]: true,
+    }),
+    {},
+  );
+
+export function isFrontendRoute(path?: string) {
+  if (path) {
+    const basePath = path.split(/[?#]/)[0]; // strip out query params and link bookmarks
+    return !!frontEndRoutes[basePath];
+  }
+  return false;
+}

--- a/superset/app.py
+++ b/superset/app.py
@@ -72,7 +72,7 @@ def create_app() -> Flask:
 class SupersetIndexView(IndexView):
     @expose("/")
     def index(self) -> FlaskResponse:
-        return redirect("/superset/welcome")
+        return redirect("/superset/welcome/")
 
 
 class SupersetAppInitializer:
@@ -222,7 +222,7 @@ class SupersetAppInitializer:
         #
         if appbuilder.app.config["LOGO_TARGET_PATH"]:
             appbuilder.add_link(
-                "Home", label=__("Home"), href="/superset/welcome",
+                "Home", label=__("Home"), href="/superset/welcome/",
             )
         appbuilder.add_view(
             AnnotationLayerModelView,
@@ -245,7 +245,7 @@ class SupersetAppInitializer:
         appbuilder.add_link(
             "Datasets",
             label=__("Datasets"),
-            href="/tablemodelview/list/?_flt_1_is_sqllab_view=y",
+            href="/tablemodelview/list/",
             icon="fa-table",
             category="Data",
             category_label=__("Data"),
@@ -333,7 +333,7 @@ class SupersetAppInitializer:
             appbuilder.add_link(
                 "Import Dashboards",
                 label=__("Import Dashboards"),
-                href="/superset/import_dashboards",
+                href="/superset/import_dashboards/",
                 icon="fa-cloud-upload",
                 category="Manage",
                 category_label=__("Manage"),
@@ -342,7 +342,7 @@ class SupersetAppInitializer:
         appbuilder.add_link(
             "SQL Editor",
             label=_("SQL Editor"),
-            href="/superset/sqllab",
+            href="/superset/sqllab/",
             category_icon="fa-flask",
             icon="fa-flask",
             category="SQL Lab",
@@ -350,14 +350,14 @@ class SupersetAppInitializer:
         )
         appbuilder.add_link(
             __("Saved Queries"),
-            href="/sqllab/my_queries/",
+            href="/savedqueryview/list/",
             icon="fa-save",
             category="SQL Lab",
         )
         appbuilder.add_link(
             "Query Search",
             label=_("Query History"),
-            href="/superset/sqllab/history",
+            href="/superset/sqllab/history/",
             icon="fa-search",
             category_icon="fa-flask",
             category="SQL Lab",
@@ -369,7 +369,7 @@ class SupersetAppInitializer:
             appbuilder.add_link(
                 "Upload a CSV",
                 label=__("Upload a CSV"),
-                href="/csvtodatabaseview/form",
+                href="/csvtodatabaseview/form/",
                 icon="fa-upload",
                 category="Data",
                 category_label=__("Data"),
@@ -384,7 +384,7 @@ class SupersetAppInitializer:
                 appbuilder.add_link(
                     "Upload Excel",
                     label=__("Upload Excel"),
-                    href="/exceltodatabaseview/form",
+                    href="/exceltodatabaseview/form/",
                     icon="fa-upload",
                     category="Data",
                     category_label=__("Data"),

--- a/superset/config.py
+++ b/superset/config.py
@@ -198,7 +198,7 @@ APP_ICON = "/static/assets/images/superset-logo-horiz.png"
 APP_ICON_WIDTH = 126
 
 # Uncomment to specify where clicking the logo would take the user
-# e.g. setting it to '/welcome' would take the user to '/superset/welcome'
+# e.g. setting it to '/' would take the user to '/superset/welcome/'
 LOGO_TARGET_PATH = None
 
 # Enables SWAGGER UI for superset openapi spec

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2772,7 +2772,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         )
 
     @event_logger.log_this
-    @expose("/welcome")
+    @expose("/welcome/")
     def welcome(self) -> FlaskResponse:
         """Personalized welcome page"""
         if not g.user or not g.user.get_id():


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Part of the move towards consolidating superset front-end into a single page app, this page includes some performance improvements between page loads. 

- code splitting and lazy loading along react-router routes.
- use react router `<Link/>` component in the navigation menu if react-router route exists
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- All pages in the app load without error
- No visual changes
- Menu navigating between front-end routes (eg, Charts, Dashboards, Databases, Datasets, Alerts & Reports) does not result in a full-page load. Page loads should be much faster.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/12896
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
