### PR TITLE
fix(alerts): void query with numeric comparison

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -339,7 +339,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     # tables that users do not have access to.
     "ROW_LEVEL_SECURITY": False,
     # Enables Alerts and reports new implementation
-    "ALERT_REPORTS": False,
+    "ALERT_REPORTS": True,
     # Enable experimental feature to search for other dashboards
     "OMNIBAR": False,
     "DASHBOARD_RBAC": False,
@@ -1122,3 +1122,5 @@ elif importlib.util.find_spec("superset_config") and not is_test():
     except Exception:
         logger.exception("Found but failed to import local superset_config")
         raise
+
+SQLALCHEMY_DATABASE_URI = "postgresql://superset:superset@localhost:5432/superset"

--- a/superset/config.py
+++ b/superset/config.py
@@ -339,7 +339,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     # tables that users do not have access to.
     "ROW_LEVEL_SECURITY": False,
     # Enables Alerts and reports new implementation
-    "ALERT_REPORTS": True,
+    "ALERT_REPORTS": False,
     # Enable experimental feature to search for other dashboards
     "OMNIBAR": False,
     "DASHBOARD_RBAC": False,
@@ -1122,5 +1122,3 @@ elif importlib.util.find_spec("superset_config") and not is_test():
     except Exception:
         logger.exception("Found but failed to import local superset_config")
         raise
-
-SQLALCHEMY_DATABASE_URI = "postgresql://superset:superset@localhost:5432/superset"

--- a/superset/reports/commands/alert.py
+++ b/superset/reports/commands/alert.py
@@ -111,8 +111,10 @@ class AlertCommand(BaseCommand):
 
         if df.empty and ReportScheduleValidatorType.NOT_NULL:
             self._result = None
+            return
         if df.empty and ReportScheduleValidatorType.OPERATOR:
             self._result = 0.0
+            return
         rows = df.to_records()
         if self._report_schedule.validator_type == ReportScheduleValidatorType.NOT_NULL:
             self._validate_not_null(rows)

--- a/superset/reports/commands/alert.py
+++ b/superset/reports/commands/alert.py
@@ -49,13 +49,16 @@ class AlertCommand(BaseCommand):
 
         if self._report_schedule.validator_type == ReportScheduleValidatorType.NOT_NULL:
             self._report_schedule.last_value_row_json = str(self._result)
-            return self._result not in (0, None, np.nan)
+            return self._result not in (0, 0.0, None, np.nan)
+        if self._result in (0, 0.0, None, np.nan):
+            self._result = 0.0
         self._report_schedule.last_value = self._result
         try:
             operator = json.loads(self._report_schedule.validator_config_json)["op"]
             threshold = json.loads(self._report_schedule.validator_config_json)[
                 "threshold"
             ]
+
             return OPERATOR_FUNCTIONS[operator](self._result, threshold)
         except (KeyError, json.JSONDecodeError):
             raise AlertValidatorConfigError()

--- a/tests/reports/commands_tests.py
+++ b/tests/reports/commands_tests.py
@@ -233,7 +233,7 @@ def create_alert_slack_chart_grace():
 
 
 @pytest.yield_fixture(
-    params=["alert1", "alert2", "alert3", "alert4", "alert5", "alert6", "alert7",]
+    params=["alert1", "alert2", "alert3", "alert4", "alert5", "alert6", "alert7"]
 )
 def create_alert_email_chart(request):
     param_config = {

--- a/tests/reports/commands_tests.py
+++ b/tests/reports/commands_tests.py
@@ -233,7 +233,16 @@ def create_alert_slack_chart_grace():
 
 
 @pytest.yield_fixture(
-    params=["alert1", "alert2", "alert3", "alert4", "alert5", "alert6", "alert7"]
+    params=[
+        "alert1",
+        "alert2",
+        "alert3",
+        "alert4",
+        "alert5",
+        "alert6",
+        "alert7",
+        "alert8",
+    ]
 )
 def create_alert_email_chart(request):
     param_config = {
@@ -272,6 +281,11 @@ def create_alert_email_chart(request):
             "validator_type": ReportScheduleValidatorType.OPERATOR,
             "validator_config_json": '{"op": "!=", "threshold": 11}',
         },
+        "alert8": {
+            "sql": "SELECT first from test_table where first=0",
+            "validator_type": ReportScheduleValidatorType.OPERATOR,
+            "validator_config_json": '{"op": "==", "threshold": 0}',
+        },
     }
     with app.app_context():
         chart = db.session.query(Slice).first()
@@ -308,7 +322,7 @@ def create_test_table_context(database: Database):
 
 
 @pytest.yield_fixture(
-    params=["alert1", "alert2", "alert3", "alert4", "alert5", "alert6"]
+    params=["alert1", "alert2", "alert3", "alert4", "alert5", "alert6", "alert7"]
 )
 def create_no_alert_email_chart(request):
     param_config = {
@@ -341,6 +355,11 @@ def create_no_alert_email_chart(request):
             "sql": "SELECT first from test_table where first=0",
             "validator_type": ReportScheduleValidatorType.NOT_NULL,
             "validator_config_json": "{}",
+        },
+        "alert7": {
+            "sql": "SELECT first from test_table where first=0",
+            "validator_type": ReportScheduleValidatorType.OPERATOR,
+            "validator_config_json": '{"op": ">", "threshold": 0}',
         },
     }
     with app.app_context():

--- a/tests/reports/commands_tests.py
+++ b/tests/reports/commands_tests.py
@@ -338,12 +338,12 @@ def create_no_alert_email_chart(request):
             "validator_config_json": '{"op": "!=", "threshold": 10}',
         },
         "alert6": {
-            "sql": "SELECT first from test_table where first=0",
+            "sql": "SELECT first from test_table where 1=0",
             "validator_type": ReportScheduleValidatorType.NOT_NULL,
             "validator_config_json": "{}",
         },
         "alert7": {
-            "sql": "SELECT first from test_table where first=0",
+            "sql": "SELECT first from test_table where 1=0",
             "validator_type": ReportScheduleValidatorType.OPERATOR,
             "validator_config_json": '{"op": ">", "threshold": 0}',
         },

--- a/tests/reports/commands_tests.py
+++ b/tests/reports/commands_tests.py
@@ -233,16 +233,7 @@ def create_alert_slack_chart_grace():
 
 
 @pytest.yield_fixture(
-    params=[
-        "alert1",
-        "alert2",
-        "alert3",
-        "alert4",
-        "alert5",
-        "alert6",
-        "alert7",
-        "alert8",
-    ]
+    params=["alert1", "alert2", "alert3", "alert4", "alert5", "alert6", "alert7",]
 )
 def create_alert_email_chart(request):
     param_config = {
@@ -280,11 +271,6 @@ def create_alert_email_chart(request):
             "sql": "SELECT {{ 5 + 5 }} as metric",
             "validator_type": ReportScheduleValidatorType.OPERATOR,
             "validator_config_json": '{"op": "!=", "threshold": 11}',
-        },
-        "alert8": {
-            "sql": "SELECT first from test_table where first=0",
-            "validator_type": ReportScheduleValidatorType.OPERATOR,
-            "validator_config_json": '{"op": "==", "threshold": 0}',
         },
     }
     with app.app_context():


### PR DESCRIPTION
### SUMMARY
Fix for Alerts & Reports:

If an alert query returns no rows and the validation is a comparison, this fix assumes that no rows is zero and applies the configured comparison to that  

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
