### PR TITLE
fix: Fix switching viz type to and from Filter box

### DIFF
--- a/superset-frontend/src/explore/actions/exploreActions.ts
+++ b/superset-frontend/src/explore/actions/exploreActions.ts
@@ -61,11 +61,6 @@ export function fetchDatasourcesSucceeded() {
   return { type: FETCH_DATASOURCES_SUCCEEDED };
 }
 
-export const RESET_FIELDS = 'RESET_FIELDS';
-export function resetControls() {
-  return { type: RESET_FIELDS };
-}
-
 export const TOGGLE_FAVE_STAR = 'TOGGLE_FAVE_STAR';
 export function toggleFaveStar(isStarred: boolean) {
   return { type: TOGGLE_FAVE_STAR, isStarred };
@@ -154,7 +149,6 @@ export const exploreActions = {
   setDatasources,
   fetchDatasourcesStarted,
   fetchDatasourcesSucceeded,
-  resetControls,
   toggleFaveStar,
   fetchFaveStar,
   saveFaveStar,

--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -211,12 +211,8 @@ const ExploreChartPanel = props => {
   }, [calcSectionHeight, chartWidth, props, splitSizes]);
 
   const panelBody = useMemo(
-    () => (
-      <div className="panel-body" ref={chartRef}>
-        {renderChart()}
-      </div>
-    ),
-    [chartRef, renderChart],
+    () => <div className="panel-body">{renderChart()}</div>,
+    [renderChart],
   );
 
   const standaloneChartBody = useMemo(
@@ -256,7 +252,7 @@ const ExploreChartPanel = props => {
   });
 
   return (
-    <Styles className="panel panel-default chart-container">
+    <Styles className="panel panel-default chart-container" ref={chartRef}>
       <div className="panel-heading" ref={headerRef}>
         {header}
       </div>

--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -352,6 +352,10 @@ function ExploreViewContainer(props) {
     return false;
   }, [previousControls, props.controls]);
 
+  if (chartIsStale) {
+    props.actions.logEvent(LOG_ACTIONS_CHANGE_EXPLORE_CONTROLS);
+  }
+
   function renderErrorMessage() {
     // Returns an error message as a node if any errors are in the store
     const errors = Object.entries(props.controls)

--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 /* eslint camelcase: 0 */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
@@ -165,7 +165,6 @@ function ExploreViewContainer(props) {
   const windowSize = useWindowSize();
 
   const [showingModal, setShowingModal] = useState(false);
-  const [chartIsStale, setChartIsStale] = useState(false);
   const [isCollapsed, setIsCollapsed] = useState(false);
 
   const width = `${windowSize.width}px`;
@@ -226,7 +225,6 @@ function ExploreViewContainer(props) {
     props.actions.removeControlPanelAlert();
     props.actions.triggerQuery(true, props.chart.id);
 
-    setChartIsStale(false);
     addHistory();
   }
 
@@ -301,9 +299,6 @@ function ExploreViewContainer(props) {
   // effect to run when controls change
   useEffect(() => {
     if (previousControls) {
-      if (props.controls.viz_type.value !== previousControls.viz_type.value) {
-        props.actions.resetControls();
-      }
       if (
         props.controls.datasource &&
         (previousControls.datasource == null ||
@@ -334,19 +329,28 @@ function ExploreViewContainer(props) {
         props.actions.renderTriggered(new Date().getTime(), props.chart.id);
         addHistory();
       }
+    }
+  }, [props.controls]);
 
-      // this should be handled inside actions too
-      const hasQueryControlChanged = changedControlKeys.some(
+  const chartIsStale = useMemo(() => {
+    if (previousControls) {
+      const changedControlKeys = Object.keys(props.controls).filter(
+        key =>
+          typeof previousControls[key] !== 'undefined' &&
+          !areObjectsEqual(
+            props.controls[key].value,
+            previousControls[key].value,
+          ),
+      );
+
+      return changedControlKeys.some(
         key =>
           !props.controls[key].renderTrigger &&
           !props.controls[key].dontRefreshOnChange,
       );
-      if (hasQueryControlChanged) {
-        props.actions.logEvent(LOG_ACTIONS_CHANGE_EXPLORE_CONTROLS);
-        setChartIsStale(true);
-      }
     }
-  }, [props.controls]);
+    return false;
+  }, [previousControls, props.controls]);
 
   function renderErrorMessage() {
     // Returns an error message as a node if any errors are in the store

--- a/superset-frontend/src/explore/reducers/exploreReducer.js
+++ b/superset-frontend/src/explore/reducers/exploreReducer.js
@@ -121,35 +121,30 @@ export default function exploreReducer(state = {}, action) {
       });
       const hasErrors = errors && errors.length > 0;
 
-      const controls =
+      const currentControlsState =
         action.controlName === 'viz_type' &&
         action.value !== state.controls.viz_type.value
-          ? {
-              ...getControlsState(
-                state,
-                getFormDataFromControls({
-                  ...state.controls,
-                  viz_type: control,
-                }),
-              ),
-              [action.controlName]: {
-                ...control,
-                validationErrors: errors,
-              },
-            }
-          : {
-              ...state.controls,
-              [action.controlName]: {
-                ...control,
-                validationErrors: errors,
-              },
-            };
+          ? // rebuild the full control state if switching viz type
+            getControlsState(
+              state,
+              getFormDataFromControls({
+                ...state.controls,
+                viz_type: control,
+              }),
+            )
+          : state.controls;
 
       return {
         ...state,
         form_data: new_form_data,
         triggerRender: control.renderTrigger && !hasErrors,
-        controls,
+        controls: {
+          ...currentControlsState,
+          [action.controlName]: {
+            ...control,
+            validationErrors: errors,
+          },
+        },
       };
     },
     [actions.SET_EXPLORE_CONTROLS]() {

--- a/superset-frontend/src/explore/reducers/exploreReducer.js
+++ b/superset-frontend/src/explore/reducers/exploreReducer.js
@@ -164,15 +164,6 @@ export default function exploreReducer(state = {}, action) {
         sliceName: action.sliceName,
       };
     },
-    [actions.RESET_FIELDS]() {
-      return {
-        ...state,
-        controls: getControlsState(
-          state,
-          getFormDataFromControls(state.controls),
-        ),
-      };
-    },
     [actions.CREATE_NEW_SLICE]() {
       return {
         ...state,

--- a/superset-frontend/src/explore/reducers/exploreReducer.js
+++ b/superset-frontend/src/explore/reducers/exploreReducer.js
@@ -121,17 +121,35 @@ export default function exploreReducer(state = {}, action) {
       });
       const hasErrors = errors && errors.length > 0;
 
+      const controls =
+        action.controlName === 'viz_type' &&
+        action.value !== state.controls.viz_type.value
+          ? {
+              ...getControlsState(
+                state,
+                getFormDataFromControls({
+                  ...state.controls,
+                  viz_type: control,
+                }),
+              ),
+              [action.controlName]: {
+                ...control,
+                validationErrors: errors,
+              },
+            }
+          : {
+              ...state.controls,
+              [action.controlName]: {
+                ...control,
+                validationErrors: errors,
+              },
+            };
+
       return {
         ...state,
         form_data: new_form_data,
         triggerRender: control.renderTrigger && !hasErrors,
-        controls: {
-          ...state.controls,
-          [action.controlName]: {
-            ...control,
-            validationErrors: errors,
-          },
-        },
+        controls,
       };
     },
     [actions.SET_EXPLORE_CONTROLS]() {


### PR DESCRIPTION
### SUMMARY
Switching viz type between a chart type and filter was broken due to a different type of data payload (array for charts and object for filter) and additional rerender caused by dispatching `RESET_FIELDS` after render caused by switching viz type. I moved the logic of resetting control fields to `SET_FIELD_VALUE` reducer, thus removing 1 rerender.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see https://github.com/apache/superset/issues/12624

After:
https://user-images.githubusercontent.com/15073128/107769388-32095280-6d38-11eb-9b1b-f083dba1b1d9.mov

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes https://github.com/apache/superset/issues/12624
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc @villebro @nikolagigic @rusackas 