### PR TITLE
feat: Custom superset_config.py + secret envs

### DIFF
--- a/helm/superset/templates/_helpers.tpl
+++ b/helm/superset/templates/_helpers.tpl
@@ -97,4 +97,13 @@ RESULTS_BACKEND = RedisCache(
       port=env('REDIS_PORT'),
       key_prefix='superset_results'
 )
+
+{{ if .Values.configOverrides }}
+# Overrides
+{{- range $key, $value := .Values.configOverrides }}
+# {{ $key }}
+{{ $value }}
+{{- end }}
+{{- end }}
+
 {{- end }}

--- a/helm/superset/templates/secret-env.yaml
+++ b/helm/superset/templates/secret-env.yaml
@@ -32,3 +32,8 @@ data:
     DB_USER: {{ .Values.supersetNode.connections.db_user | b64enc | quote }}
     DB_PASS: {{ .Values.supersetNode.connections.db_pass | b64enc | quote }}
     DB_NAME: {{ .Values.supersetNode.connections.db_name | b64enc | quote }}
+    {{- if .Values.extraSecretEnv }}
+    {{- range $key, $value := .Values.extraSecretEnv }}
+    {{ $key }}: {{ $value | b64enc | quote }}
+    {{- end }}
+    {{- end }}

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -41,6 +41,13 @@ envFromSecret: '{{ template "superset.fullname" . }}-env'
 ##
 extraEnv: {}
 
+## Extra environment variables to pass as secrets
+##
+extraSecretEnv: {}
+  # MAPBOX_API_KEY: ...
+  # GOOGLE_KEY: ...
+  # GOOGLE_SECRET: ...
+
 extraConfigs: {}
   # datasources-init.yaml: |
   #     databases:
@@ -53,6 +60,30 @@ extraConfigs: {}
   #         }"
   #       sqlalchemy_uri: example://example-db.local
   #       tables: []
+
+# A dictionary of overrides to append at the end of superset_config.py - the name does not matter
+# WARNING: the order is not guaranteed
+configOverrides: {}
+  # enable_oauth: |
+  #   from flask_appbuilder.security.manager import AUTH_DB
+  #   AUTH_TYPE = AUTH_OAUTH
+
+  #   OAUTH_PROVIDERS = [
+  #       {
+  #           "name": "google",
+  #           "icon": "fa-google",
+  #           "token_key": "access_token",
+  #           "remote_app": {
+  #               "client_id": os.environ.get("GOOGLE_KEY"),
+  #               "client_secret": os.environ.get("GOOGLE_SECRET"),
+  #               "api_base_url": "https://www.googleapis.com/oauth2/v2/",
+  #               "client_kwargs": {"scope": "email profile"},
+  #               "request_token_url": None,
+  #               "access_token_url": "https://accounts.google.com/o/oauth2/token",
+  #               "authorize_url": "https://accounts.google.com/o/oauth2/auth",
+  #           },
+  #       }
+  #   ]
 
 configMountPath: "/app/pythonpath"
 


### PR DESCRIPTION
### SUMMARY

This update to the Helm chart provides support for:
* Specifying custom variables to be passed to the pods as secrets
* Specifying extra conf snippets to append to `superset_config.py`

### TEST PLAN

* Deploy updated chart passing custom values for:
  * `extraSecretEnv`
  * `configOverrides`

```
helm upgrade --install --values my-values.yaml superset helm/superset
```

Sample `values.yaml`:

```
additionalRequirements:
  - Authlib

extraSecretEnv:
  MAPBOX_API_KEY: ...
  GOOGLE_KEY: ...
  GOOGLE_SECRET: ...

configOverrides:
  # requires Authlib
  enable_oauth: |
    from flask_appbuilder.security.manager import AUTH_OAUTH
    AUTH_TYPE = AUTH_OAUTH

    OAUTH_PROVIDERS = [
        {
            "name": "google",
            "icon": "fa-google",
            "token_key": "access_token",
            "remote_app": {
                "client_id": os.environ.get("GOOGLE_KEY"),
                "client_secret": os.environ.get("GOOGLE_SECRET"),
                "api_base_url": "https://www.googleapis.com/oauth2/v2/",
                "client_kwargs": {"scope": "email profile"},
                "request_token_url": None,
                "access_token_url": "https://accounts.google.com/o/oauth2/token",
                "authorize_url": "https://accounts.google.com/o/oauth2/auth",
            },
        }
    ]

    # Will allow user self registration, allowing to create Flask users from Authorized User
    AUTH_USER_REGISTRATION = True

    # The default user self registration role
    AUTH_USER_REGISTRATION_ROLE = "Public"

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
