### PR TITLE
build: add more files to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,9 @@
 # limitations under the License.
 #
 **/__pycache__/
+**/.git
+**/.apache_superset.egg-info
+**/.github
 **/.mypy_cache
 **/.pytest_cache
 **/.tox
@@ -30,11 +33,14 @@
 **/*.pyc
 **/*.sqllite
 **/*.swp
+**/.terser-plugin-cache/
+**/.storybook/
+**/node_modules/
 
 tests/
 docs/
 install/
-superset-frontend/node_modules/
-superset-frontend/cypress/
+superset-frontend/cypress-base/
 superset-frontend/coverage/
+superset/static/assets/
 venv


### PR DESCRIPTION
### SUMMARY

Add cache and built assets from `npm run build` to `.dockerignore` to speed up `docker build` for local environment.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

Make sure docker build still works.

1. Run `cd superset-frontend && npm run build`
2. Run `docker build .`
3. With this PR, the initial step of copying files for Docker build context should be significantly faster

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
