### PR TITLE
fix: TimeTable average with nulls calculations

### DIFF
--- a/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
+++ b/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
@@ -211,7 +211,7 @@ const TimeTable = ({
         // Average over the last {timeLag}
         v = null;
         if (reversedEntries.length >0) {
-            var stats = reversedEntries
+            let stats = reversedEntries
                 .slice(undefined, column.timeLag)
                 .reduce(function ({count, sum}, entry) {
                 return ( entry[valueField] != null )

--- a/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
+++ b/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
@@ -209,10 +209,20 @@ const TimeTable = ({
             .reduce((a, b) => a + b);
       } else if (column.colType === 'avg') {
         // Average over the last {timeLag}
-        v =
-          reversedEntries
-            .map((k, i) => (i < column.timeLag ? k[valueField] : 0))
-            .reduce((a, b) => a + b) / column.timeLag;
+        v = null;
+        if (reversedEntries.length >0) {
+            var stats = reversedEntries
+                .slice(undefined, column.timeLag)
+                .reduce(function ({count, sum}, entry) {
+                return ( entry[valueField] != null )
+                    ? {count: count+1, sum: sum + entry[valueField]}
+                    : {count, sum};
+                    }, {count:0, sum: 0})
+            if (stats.count>0) {
+                v = stats.sum / stats.count;
+            }
+        }
+
       }
 
       const color = colorFromBounds(v, column.bounds);

--- a/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
+++ b/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
@@ -214,12 +214,12 @@ const TimeTable = ({
             let stats = reversedEntries
                 .slice(undefined, column.timeLag)
                 .reduce(function ({count, sum}, entry) {
-                return ( entry[valueField] != null )
-                    ? {count: count+1, sum: sum + entry[valueField]}
-                    : {count, sum};
-                    }, {count:0, sum: 0})
+                  return ( entry[valueField] != null )
+                      ? {count: count+1, sum: sum + entry[valueField]}
+                      : {count, sum};
+                }, {count:0, sum: 0})
             if (stats.count>0) {
-                v = stats.sum / stats.count;
+              v = stats.sum / stats.count;
             }
         }
 


### PR DESCRIPTION
### SUMMARY

fix #12962, average calculation 


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![изображение](https://user-images.githubusercontent.com/55258742/107886746-0bebda00-6f13-11eb-885a-2a3474e3c87c.png)




### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: #12962 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
