### PR TITLE
fix: TimeTable average with nulls calculations

### DIFF
--- a/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
+++ b/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
@@ -209,10 +209,21 @@ const TimeTable = ({
             .reduce((a, b) => a + b);
       } else if (column.colType === 'avg') {
         // Average over the last {timeLag}
-        v =
-          reversedEntries
-            .map((k, i) => (i < column.timeLag ? k[valueField] : 0))
-            .reduce((a, b) => a + b) / column.timeLag;
+        v = null;
+        if (reversedEntries.length > 0) {
+          const stats = reversedEntries.slice(undefined, column.timeLag).reduce(
+            function ({ count, sum }, entry) {
+              return entry[valueField] !== undefined &&
+                entry[valueField] !== null
+                ? { count: count + 1, sum: sum + entry[valueField] }
+                : { count, sum };
+            },
+            { count: 0, sum: 0 },
+          );
+          if (stats.count > 0) {
+            v = stats.sum / stats.count;
+          }
+        }
       }
 
       const color = colorFromBounds(v, column.bounds);


### PR DESCRIPTION
### SUMMARY
Fix for issue #12962

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![изображение](https://user-images.githubusercontent.com/55258742/107911746-328b2e80-6f6e-11eb-84d8-5875f20eaf04.png)


### ADDITIONAL INFORMATION
- [X] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
