### PR TITLE
fix: add the untranslated text content of Chart page, Sql Editor page and some dashboard label in messages.pot

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -503,7 +503,7 @@ class SqlEditor extends React.PureComponent {
       <Menu onClick={this.handleMenuClick} style={{ width: 176 }}>
         <Menu.Item style={{ display: 'flex', justifyContent: 'space-between' }}>
           {' '}
-          <span>Autocomplete</span>{' '}
+          <span>{t('Autocomplete')}</span>{' '}
           <Switch
             checked={this.state.autocompleteEnabled}
             onChange={this.handleToggleAutocompleteEnabled}

--- a/superset-frontend/src/dashboard/components/Header.jsx
+++ b/superset-frontend/src/dashboard/components/Header.jsx
@@ -482,7 +482,7 @@ class Header extends React.PureComponent {
             <>
               <span
                 role="button"
-                title={t('Edit Dashboard')}
+                title={t('Edit dashboard')}
                 tabIndex={0}
                 className="action-button"
                 onClick={this.toggleEditMode}

--- a/superset-frontend/src/dashboard/components/Header.jsx
+++ b/superset-frontend/src/dashboard/components/Header.jsx
@@ -482,7 +482,7 @@ class Header extends React.PureComponent {
             <>
               <span
                 role="button"
-                title="Edit dashboard"
+                title={t('Edit Dashboard')}
                 tabIndex={0}
                 className="action-button"
                 onClick={this.toggleEditMode}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal/FiltersList.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal/FiltersList.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { styled } from '@superset-ui/core';
+import { styled, t } from '@superset-ui/core';
 import { Button } from 'src/common/components';
 import Icon from 'src/components/Icon';
 import { useFilterConfiguration } from '../state';
@@ -53,7 +53,7 @@ const FiltersList = ({ setEditFilter, setDataset }: FiltersListProps) => {
         </Button>
         <span
           role="button"
-          title="Edit dashboard"
+          title={t('Edit Dashboard')}
           tabIndex={0}
           className="action-button"
         >

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal/FiltersList.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal/FiltersList.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { styled, t } from '@superset-ui/core';
+import { styled } from '@superset-ui/core';
 import { Button } from 'src/common/components';
 import Icon from 'src/components/Icon';
 import { useFilterConfiguration } from '../state';
@@ -53,7 +53,7 @@ const FiltersList = ({ setEditFilter, setDataset }: FiltersListProps) => {
         </Button>
         <span
           role="button"
-          title={t('Edit dashboard')}
+          title="Edit dashboard"
           tabIndex={0}
           className="action-button"
         >

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal/FiltersList.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal/FiltersList.tsx
@@ -53,7 +53,7 @@ const FiltersList = ({ setEditFilter, setDataset }: FiltersListProps) => {
         </Button>
         <span
           role="button"
-          title={t('Edit Dashboard')}
+          title={t('Edit dashboard')}
           tabIndex={0}
           className="action-button"
         >

--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -375,7 +375,7 @@ function ChartList(props: ChartListProps) {
       id: 'owners',
       input: 'select',
       operator: FilterOperators.relationManyMany,
-      unfilteredLabel: 'All',
+      unfilteredLabel: t('All'),
       fetchSelects: createFetchRelated(
         'chart',
         'owners',
@@ -396,7 +396,7 @@ function ChartList(props: ChartListProps) {
       id: 'created_by',
       input: 'select',
       operator: FilterOperators.relationOneMany,
-      unfilteredLabel: 'All',
+      unfilteredLabel: t('All'),
       fetchSelects: createFetchRelated(
         'chart',
         'created_by',
@@ -417,7 +417,7 @@ function ChartList(props: ChartListProps) {
       id: 'viz_type',
       input: 'select',
       operator: FilterOperators.equals,
-      unfilteredLabel: 'All',
+      unfilteredLabel: t('All'),
       selects: registry
         .keys()
         .map(k => ({ label: registry.get(k)?.name || k, value: k }))
@@ -441,7 +441,7 @@ function ChartList(props: ChartListProps) {
       id: 'datasource_id',
       input: 'select',
       operator: FilterOperators.equals,
-      unfilteredLabel: 'All',
+      unfilteredLabel: t('All'),
       fetchSelects: createFetchDatasets(
         createErrorHandler(errMsg =>
           addDangerToast(
@@ -460,7 +460,7 @@ function ChartList(props: ChartListProps) {
       urlDisplay: 'favorite',
       input: 'select',
       operator: FilterOperators.chartIsFav,
-      unfilteredLabel: 'Any',
+      unfilteredLabel: t('Any'),
       selects: [
         { label: t('Yes'), value: true },
         { label: t('No'), value: false },
@@ -478,19 +478,19 @@ function ChartList(props: ChartListProps) {
     {
       desc: false,
       id: 'slice_name',
-      label: 'Alphabetical',
+      label: t('Alphabetical'),
       value: 'alphabetical',
     },
     {
       desc: true,
       id: 'changed_on_delta_humanized',
-      label: 'Recently modified',
+      label: t('Recently modified'),
       value: 'recently_modified',
     },
     {
       desc: false,
       id: 'changed_on_delta_humanized',
-      label: 'Least recently modified',
+      label: t('Least recently modified'),
       value: 'least_recently_modified',
     },
   ];

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardCard.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardCard.tsx
@@ -135,7 +135,7 @@ function DashboardCard({
         loading={dashboard.loading || false}
         title={dashboard.dashboard_title}
         titleRight={
-          <Label>{dashboard.published ? 'published' : 'draft'}</Label>
+          <Label>{dashboard.published ? t('published') : t('draft')}</Label>
         }
         url={bulkSelectEnabled ? undefined : dashboard.url}
         imgURL={dashboard.thumbnail_url}

--- a/superset/translations/messages.pot
+++ b/superset/translations/messages.pot
@@ -7793,5 +7793,3 @@ msgstr ""
 #: superset-frontend/src/SqlLab/components/SqlEditor.jsx:506
 msgid "Autocomplete"
 msgstr ""
-
-

--- a/superset/translations/messages.pot
+++ b/superset/translations/messages.pot
@@ -2707,9 +2707,12 @@ msgid "Add Dashboard"
 msgstr ""
 
 #: superset/views/dashboard/mixin.py:28
+msgid "Edit Dashboard"
+msgstr ""
+
 #: superset-frontend/src/dashboard/components/Header.jsx:485
 #: superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal/FiltersList.tsx:56
-msgid "Edit Dashboard"
+msgid "Edit dashboard"
 msgstr ""
 
 #: superset/views/dashboard/mixin.py:46
@@ -7790,3 +7793,5 @@ msgstr ""
 #: superset-frontend/src/SqlLab/components/SqlEditor.jsx:506
 msgid "Autocomplete"
 msgstr ""
+
+

--- a/superset/translations/messages.pot
+++ b/superset/translations/messages.pot
@@ -2707,6 +2707,8 @@ msgid "Add Dashboard"
 msgstr ""
 
 #: superset/views/dashboard/mixin.py:28
+#: superset-frontend/src/dashboard/components/Header.jsx:485
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal/FiltersList.tsx:56
 msgid "Edit Dashboard"
 msgstr ""
 
@@ -7745,26 +7747,46 @@ msgstr ""
 
 #: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:385
 #: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:364
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:378
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:399
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:420
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:444
 msgid "All"
 msgstr ""
 
 #: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:406
 #: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:418
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:463
 msgid "Any"
 msgstr ""
 
 #: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:436
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:481
 msgid "Alphabetical"
 msgstr ""
 
 #: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:442
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:487
 msgid "Recently modified"
 msgstr ""
 
 #: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:448
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:493
 msgid "Least recently modified"
 msgstr ""
 
 #: superset-frontend/src/components/ListView/ListView.tsx:393
 msgid "No Data"
+msgstr ""
+
+#: superset-frontend/src/views/CRUD/dashboard/DashboardCard.tsx:138
+msgid "published"
+msgstr ""
+
+#: superset-frontend/src/views/CRUD/dashboard/DashboardCard.tsx:138
+msgid "draft"
+msgstr ""
+
+#: superset-frontend/src/SqlLab/components/SqlEditor.jsx:506
+msgid "Autocomplete"
 msgstr ""


### PR DESCRIPTION
### SUMMARY
Add the untranslated text content in Chart page, Sql Editor page and some dashboard label in messages.pot

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
It can be viewed in the browser
![chartlist2](https://user-images.githubusercontent.com/12069428/107913462-6d578b80-6f9b-11eb-9044-89c151de4589.jpg)
![auto_complete](https://user-images.githubusercontent.com/12069428/107913535-8c561d80-6f9b-11eb-954b-0892380e1d43.jpg)


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
