### PR TITLE
feat(helm): Evaluate configOverrides as templates

### DIFF
--- a/helm/superset/templates/_helpers.tpl
+++ b/helm/superset/templates/_helpers.tpl
@@ -102,7 +102,7 @@ RESULTS_BACKEND = RedisCache(
 # Overrides
 {{- range $key, $value := .Values.configOverrides }}
 # {{ $key }}
-{{ $value }}
+{{ tpl $value $ }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
### SUMMARY

This change will evaluate `configOverrides` as templates. This allows making those overrides dynamic and use input values from `values.yaml` which may not be easy to ingest as env variables. For instance:

```
configOverrides:
   reports: |
    WEBDRIVER_BASEURL = "http://{{ template "superset.fullname" . }}:{{ .Values.service.port }}/"
```

### TEST PLAN

* Update your `values.yaml` with some values based on Helm values - see example above
* `helm upgrade` your chart release

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
