### PR TITLE
test(coverage): ignore database migrations on coverage reports

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,5 @@
+ignore:
+  - "superset/migrations/versions/*.py"
 coverage:
   status:
     project:


### PR DESCRIPTION
### SUMMARY
Currently test coverage metrics in Superset do not enforce a minimum level of test coverage for the project. They are also not particularly accurate, as the metric percentages include files that do not normally receive test coverage, such as migrations. While I would love to add test coverage for database migrations in the future, for now I believe we should exclude them as well as any other files that are not currently intended to receive tests from coverage reports. This will give us a stable coverage metric that we can begin to enforce (after appropriate discussion in the community, of course).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
