### PR TITLE
fix(database): ensure pk_constraint is JSON serializable

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -632,7 +632,10 @@ class Database(
     def get_pk_constraint(
         self, table_name: str, schema: Optional[str] = None
     ) -> Dict[str, Any]:
-        return self.inspector.get_pk_constraint(table_name, schema)
+        pk_constraint = self.inspector.get_pk_constraint(table_name, schema) or {}
+        return {
+            key: utils.base_json_conv(value) for key, value in pk_constraint.items()
+        }
 
     def get_foreign_keys(
         self, table_name: str, schema: Optional[str] = None


### PR DESCRIPTION
### SUMMARY
Some databases return sets in the dict payload (they should be lists according to the [docs](https://docs.sqlalchemy.org/en/13/core/reflection.html#sqlalchemy.engine.reflection.Inspector.get_pk_constraint)) when calling `inspector.get_pk_constraint` which doesn't serialize to JSON. In addition, an empty set evaluates to truthy vs lists that evaluate to falsy, causing trouble downstream. By normalizing to JSON serializable datatypes we ensure that the response for the external metadata endpoint will return a valid response.

### TEST PLAN
Local testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
