### PR TITLE
chore: change test environment to jsdom

### DIFF
--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
     '^src/(.*)$': '<rootDir>/src/$1',
     '^spec/(.*)$': '<rootDir>/spec/$1',
   },
-  testEnvironment: 'enzyme',
+  testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/spec/helpers/setup.ts'],
   testURL: 'http://localhost',
   collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}'],


### PR DESCRIPTION
### SUMMARY
Change test environment to `jsdom` (default when installed) so we can use react-testing-library functions that listen for DOM mutations like findBy.

Test environment with `enzyme` option was causing TypeError: MutationObserver is not a constructor

@ktmud @rusackas @geido  

Add to #13079

### TEST PLAN
1 - Execute all jest tests
2 - All tests should pass

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
