### PR TITLE
feat(alerts): apply SQL limit to all alerts

### DIFF
--- a/superset/reports/commands/alert.py
+++ b/superset/reports/commands/alert.py
@@ -36,6 +36,9 @@ from superset.reports.commands.exceptions import (
 logger = logging.getLogger(__name__)
 
 
+ALERT_SQL_LIMIT = 2
+# All sql statements have an applied LIMIT,
+# to avoid heavy loads done by a user mistake
 OPERATOR_FUNCTIONS = {">=": ge, ">": gt, "<=": le, "<": lt, "==": eq, "!=": ne}
 
 
@@ -118,7 +121,7 @@ class AlertCommand(BaseCommand):
         rendered_sql = sql_template.process_template(self._report_schedule.sql)
         try:
             limited_rendered_sql = self._report_schedule.database.apply_limit_to_sql(
-                rendered_sql, 1
+                rendered_sql, ALERT_SQL_LIMIT
             )
             df = self._report_schedule.database.get_df(limited_rendered_sql)
         except Exception as ex:

--- a/superset/reports/commands/alert.py
+++ b/superset/reports/commands/alert.py
@@ -117,7 +117,10 @@ class AlertCommand(BaseCommand):
         )
         rendered_sql = sql_template.process_template(self._report_schedule.sql)
         try:
-            df = self._report_schedule.database.get_df(rendered_sql)
+            limited_rendered_sql = self._report_schedule.database.apply_limit_to_sql(
+                rendered_sql, 1
+            )
+            df = self._report_schedule.database.get_df(limited_rendered_sql)
         except Exception as ex:
             raise AlertQueryError(message=str(ex))
 

--- a/tests/reports/commands_tests.py
+++ b/tests/reports/commands_tests.py
@@ -643,12 +643,13 @@ def test_alert_limit_is_applied(screenshot_mock, email_mock, create_alert_email_
     """
     ExecuteReport Command: Test that all alerts apply a SQL limit to stmts
     """
-    execute_mock = create_alert_email_chart.database.db_engine_spec.execute = Mock()
-
-    AsyncExecuteReportScheduleCommand(
-        create_alert_email_chart.id, datetime.utcnow()
-    ).run()
-    assert "LIMIT 2" in execute_mock.call_args[0][1]
+    with patch.object(
+        create_alert_email_chart.database.db_engine_spec, "execute", return_value=None
+    ) as execute_mock:
+        AsyncExecuteReportScheduleCommand(
+            create_alert_email_chart.id, datetime.utcnow()
+        ).run()
+        assert "LIMIT 2" in execute_mock.call_args[0][1]
 
 
 @pytest.mark.usefixtures("create_report_email_dashboard")

--- a/tests/reports/commands_tests.py
+++ b/tests/reports/commands_tests.py
@@ -643,15 +643,18 @@ def test_alert_limit_is_applied(screenshot_mock, email_mock, create_alert_email_
     """
     ExecuteReport Command: Test that all alerts apply a SQL limit to stmts
     """
+
     with patch.object(
         create_alert_email_chart.database.db_engine_spec, "execute", return_value=None
     ) as execute_mock:
         with patch.object(
-            create_alert_email_chart.database.db_engine_spec, "fetch_data", return_value=None
+            create_alert_email_chart.database.db_engine_spec,
+            "fetch_data",
+            return_value=None,
         ) as fetch_data_mock:
             AsyncExecuteReportScheduleCommand(
-                    create_alert_email_chart.id, datetime.utcnow()
-                ).run()
+                create_alert_email_chart.id, datetime.utcnow()
+            ).run()
             assert "LIMIT 2" in execute_mock.call_args[0][1]
 
 

--- a/tests/reports/commands_tests.py
+++ b/tests/reports/commands_tests.py
@@ -646,10 +646,13 @@ def test_alert_limit_is_applied(screenshot_mock, email_mock, create_alert_email_
     with patch.object(
         create_alert_email_chart.database.db_engine_spec, "execute", return_value=None
     ) as execute_mock:
-        AsyncExecuteReportScheduleCommand(
-            create_alert_email_chart.id, datetime.utcnow()
-        ).run()
-        assert "LIMIT 2" in execute_mock.call_args[0][1]
+        with patch.object(
+            create_alert_email_chart.database.db_engine_spec, "fetch_data", return_value=None
+        ) as fetch_data_mock:
+            AsyncExecuteReportScheduleCommand(
+                    create_alert_email_chart.id, datetime.utcnow()
+                ).run()
+            assert "LIMIT 2" in execute_mock.call_args[0][1]
 
 
 @pytest.mark.usefixtures("create_report_email_dashboard")


### PR DESCRIPTION
### SUMMARY
Applies a limit of 2 to all alerts. Running huge queries on the DB by mistake may cause performance impact.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
