### PR TITLE
fix(wip): Changes to support presto impersionation with ldap

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -924,21 +924,6 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         return {}
 
     @classmethod
-    def get_connect_args_for_impersonation(
-        cls, uri: str, impersonate_user: bool, username: Optional[str]
-    ) -> Dict[str, str]:
-        """
-        Return a configuration dictionary that can be merged with other configs
-        that can set the correct properties for impersonating users
-
-        :param uri: URI
-        :param impersonate_user: Flag indicating if impersonation is enabled
-        :param username: Effective username
-        :return: Configs required for impersonation
-        """
-        return {}
-
-    @classmethod
     def execute(cls, cursor: Any, query: str, **kwargs: Any) -> None:
         """
         Execute a SQL query

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -924,6 +924,21 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         return {}
 
     @classmethod
+    def get_connect_args_for_impersonation(
+        cls, uri: str, impersonate_user: bool, username: Optional[str]
+    ) -> Dict[str, str]:
+        """
+        Return a configuration dictionary that can be merged with other configs
+        that can set the correct properties for impersonating users
+
+        :param uri: URI
+        :param impersonate_user: Flag indicating if impersonation is enabled
+        :param username: Effective username
+        :return: Configs required for impersonation
+        """
+        return {}
+
+    @classmethod
     def execute(cls, cursor: Any, query: str, **kwargs: Any) -> None:
         """
         Execute a SQL query

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -137,7 +137,7 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
         return version is not None and StrictVersion(version) >= StrictVersion("0.319")
 
     @classmethod
-    def get_connect_args_for_impersonation(
+    def get_configuration_for_impersonation(
         cls, uri: str, impersonate_user: bool, username: Optional[str]
     ) -> Dict[str, str]:
         """

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -336,7 +336,7 @@ class Database(
 
         # If using presto, this will set principal_username=$effective_username
         connect_args.update(
-            self.db_engine_spec.get_configuration_for_impersonation(
+            self.db_engine_spec.get_connect_args_for_impersonation(
                 str(sqlalchemy_url), self.impersonate_user, effective_username
             )
         )

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -336,7 +336,7 @@ class Database(
 
         # If using presto, this will set principal_username=$effective_username
         connect_args.update(
-            self.db_engine_spec.get_connect_args_for_impersonation(
+            self.db_engine_spec.get_configuration_for_impersonation(
                 str(sqlalchemy_url), self.impersonate_user, effective_username
             )
         )

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -333,6 +333,14 @@ class Database(
                 str(sqlalchemy_url), self.impersonate_user, effective_username
             )
         )
+
+        # If using presto, this will set principal_username=$effective_username
+        connect_args.update(
+            self.db_engine_spec.get_connect_args_for_impersonation(
+                str(sqlalchemy_url), self.impersonate_user, effective_username
+            )
+        )
+
         if configuration:
             connect_args["configuration"] = configuration
         if connect_args:


### PR DESCRIPTION
### SUMMARY
Fix for issue https://github.com/apache/superset/issues/11359, https://github.com/apache/superset/issues/9406

When using LDAP authentication with presto/trino, the current behavior is just to modify the URL to replace the username which will result in an unauthorized exception. This PR will fix this by updating the connection argument with the effective user. 


### TEST PLAN
Step 1: Setup database connection to presto without credentials in URL.
Step 2: Provide admin(who can impersonate as any other user in presto) credentials in connection properties via extras  
```
"engine_params": {
           "connect_args":{
              "protocol": "https",
              "username":"<admin>",
              "password":"<admin_password>"
           }
}
```

Step 3: Enable impersonation for the database connection. 
Step 4: Log in with a different user and run the query via SQL lab and you will see the **principal user** as admin and **user** as the logged-in user in presto UI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
