### PR TITLE
fix: Grab datasets initially onMount

### DIFF
--- a/superset-frontend/spec/javascripts/datasource/ChangeDatasourceModal_spec.jsx
+++ b/superset-frontend/spec/javascripts/datasource/ChangeDatasourceModal_spec.jsx
@@ -84,7 +84,7 @@ describe('ChangeDatasourceModal', () => {
   });
 
   it('fetches datasources', async () => {
-    expect(fetchMock.calls(/api\/v1\/dataset/)).toHaveLength(4);
+    expect(fetchMock.calls(/api\/v1\/dataset/)).toHaveLength(3);
   });
 
   it('renders confirmation message', async () => {

--- a/superset-frontend/spec/javascripts/datasource/ChangeDatasourceModal_spec.jsx
+++ b/superset-frontend/spec/javascripts/datasource/ChangeDatasourceModal_spec.jsx
@@ -84,7 +84,7 @@ describe('ChangeDatasourceModal', () => {
   });
 
   it('fetches datasources', async () => {
-    expect(fetchMock.calls(/api\/v1\/dataset/)).toHaveLength(3);
+    expect(fetchMock.calls(/api\/v1\/dataset/)).toHaveLength(4);
   });
 
   it('renders confirmation message', async () => {

--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -163,7 +163,7 @@ export default class ResultSet extends React.PureComponent<
   async componentDidMount() {
     // only do this the first time the component is rendered/mounted
     this.reRunQueryIfSessionTimeoutErrorOnMount();
-    const userDatasetsOwned = await this.getUserDatasets('');
+    const userDatasetsOwned = await this.getUserDatasets();
     this.setState({ userDatasetOptions: userDatasetsOwned });
   }
 
@@ -299,7 +299,7 @@ export default class ResultSet extends React.PureComponent<
     });
   };
 
-  getUserDatasets = async (searchText: string) => {
+  getUserDatasets = async (searchText: string = '') => {
     // Making sure that autocomplete input has a value before rendering the dropdown
     // Transforming the userDatasetsOwned data for SaveModalComponent)
     const appContainer = document.getElementById('app');

--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -329,8 +329,6 @@ export default class ResultSet extends React.PureComponent<
         endpoint: '/api/v1/dataset',
       })(`q=${queryParams}`);
 
-      console.log(response)
-
       return response.result.map((r: { table_name: string; id: number }) => ({
         value: r.table_name,
         datasetId: r.id,
@@ -341,43 +339,6 @@ export default class ResultSet extends React.PureComponent<
   };
 
   handleSaveDatasetModalSearch = async (searchText: string) => {
-    // // Making sure that autocomplete input has a value before rendering the dropdown
-    // // Transforming the userDatasetsOwned data for SaveModalComponent)
-    // const appContainer = document.getElementById('app');
-    // const bootstrapData = JSON.parse(
-    //   appContainer?.getAttribute('data-bootstrap') || '{}',
-    // );
-
-    // if (bootstrapData.user && bootstrapData.user.userId) {
-    //   const queryParams = rison.encode({
-    //     filters: [
-    //       {
-    //         col: 'table_name',
-    //         opr: 'ct',
-    //         value: searchText,
-    //       },
-    //       {
-    //         col: 'owners',
-    //         opr: 'rel_m_m',
-    //         value: bootstrapData.user.userId,
-    //       },
-    //     ],
-    //     order_column: 'changed_on_delta_humanized',
-    //     order_direction: 'desc',
-    //   });
-
-    //   const response = await makeApi({
-    //     method: 'GET',
-    //     endpoint: '/api/v1/dataset',
-    //   })(`q=${queryParams}`);
-
-    //   const userDatasetsOwned = response.result.map(
-    //     (r: { table_name: string; id: number }) => ({
-    //       value: r.table_name,
-    //       datasetId: r.id,
-    //     }),
-    //   );
-
     const userDatasetsOwned = await this.getUserDatasets(searchText);
     this.setState({ userDatasetOptions: userDatasetsOwned });
   };

--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -298,7 +298,7 @@ export default class ResultSet extends React.PureComponent<
     });
   };
 
-  getUserDatasets = async (searchText: string = '') => {
+  getUserDatasets = async (searchText = '') => {
     // Making sure that autocomplete input has a value before rendering the dropdown
     // Transforming the userDatasetsOwned data for SaveModalComponent)
     const appContainer = document.getElementById('app');

--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -159,9 +159,23 @@ export default class ResultSet extends React.PureComponent<
     this.handleExploreBtnClick = this.handleExploreBtnClick.bind(this);
   }
 
-  componentDidMount() {
+  async componentDidMount() {
     // only do this the first time the component is rendered/mounted
     this.reRunQueryIfSessionTimeoutErrorOnMount();
+
+    const response = await makeApi({
+      method: 'GET',
+      endpoint: '/api/v1/dataset',
+    })(``);
+
+    const userDatasetsOwned = response.result.map(
+      (r: { table_name: string; id: number }) => ({
+        value: r.table_name,
+        datasetId: r.id,
+      }),
+    );
+
+    this.setState({ userDatasetOptions: userDatasetsOwned });
   }
 
   UNSAFE_componentWillReceiveProps(nextProps: ResultSetProps) {

--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -42,6 +42,7 @@ import { prepareCopyToClipboardTabularData } from '../../utils/common';
 import { exploreChart } from '../../explore/exploreUtils';
 import { CtasEnum } from '../actions/sqlLab';
 import { Query } from '../types';
+import { null } from 'mathjs';
 
 const SEARCH_HEIGHT = 46;
 
@@ -162,19 +163,7 @@ export default class ResultSet extends React.PureComponent<
   async componentDidMount() {
     // only do this the first time the component is rendered/mounted
     this.reRunQueryIfSessionTimeoutErrorOnMount();
-
-    const response = await makeApi({
-      method: 'GET',
-      endpoint: '/api/v1/dataset',
-    })(``);
-
-    const userDatasetsOwned = response.result.map(
-      (r: { table_name: string; id: number }) => ({
-        value: r.table_name,
-        datasetId: r.id,
-      }),
-    );
-
+    const userDatasetsOwned = await this.getUserDatasets('');
     this.setState({ userDatasetOptions: userDatasetsOwned });
   }
 
@@ -310,7 +299,7 @@ export default class ResultSet extends React.PureComponent<
     });
   };
 
-  handleSaveDatasetModalSearch = async (searchText: string) => {
+  getUserDatasets = async (searchText: string) => {
     // Making sure that autocomplete input has a value before rendering the dropdown
     // Transforming the userDatasetsOwned data for SaveModalComponent)
     const appContainer = document.getElementById('app');
@@ -341,15 +330,57 @@ export default class ResultSet extends React.PureComponent<
         endpoint: '/api/v1/dataset',
       })(`q=${queryParams}`);
 
-      const userDatasetsOwned = response.result.map(
-        (r: { table_name: string; id: number }) => ({
-          value: r.table_name,
-          datasetId: r.id,
-        }),
-      );
+      console.log(response)
 
-      this.setState({ userDatasetOptions: userDatasetsOwned });
+      return response.result.map((r: { table_name: string; id: number }) => ({
+        value: r.table_name,
+        datasetId: r.id,
+      }));
     }
+
+    return null;
+  };
+
+  handleSaveDatasetModalSearch = async (searchText: string) => {
+    // // Making sure that autocomplete input has a value before rendering the dropdown
+    // // Transforming the userDatasetsOwned data for SaveModalComponent)
+    // const appContainer = document.getElementById('app');
+    // const bootstrapData = JSON.parse(
+    //   appContainer?.getAttribute('data-bootstrap') || '{}',
+    // );
+
+    // if (bootstrapData.user && bootstrapData.user.userId) {
+    //   const queryParams = rison.encode({
+    //     filters: [
+    //       {
+    //         col: 'table_name',
+    //         opr: 'ct',
+    //         value: searchText,
+    //       },
+    //       {
+    //         col: 'owners',
+    //         opr: 'rel_m_m',
+    //         value: bootstrapData.user.userId,
+    //       },
+    //     ],
+    //     order_column: 'changed_on_delta_humanized',
+    //     order_direction: 'desc',
+    //   });
+
+    //   const response = await makeApi({
+    //     method: 'GET',
+    //     endpoint: '/api/v1/dataset',
+    //   })(`q=${queryParams}`);
+
+    //   const userDatasetsOwned = response.result.map(
+    //     (r: { table_name: string; id: number }) => ({
+    //       value: r.table_name,
+    //       datasetId: r.id,
+    //     }),
+    //   );
+
+    const userDatasetsOwned = await this.getUserDatasets(searchText);
+    this.setState({ userDatasetOptions: userDatasetsOwned });
   };
 
   handleFilterAutocompleteOption = (

--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -42,7 +42,6 @@ import { prepareCopyToClipboardTabularData } from '../../utils/common';
 import { exploreChart } from '../../explore/exploreUtils';
 import { CtasEnum } from '../actions/sqlLab';
 import { Query } from '../types';
-import { null } from 'mathjs';
 
 const SEARCH_HEIGHT = 46;
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
User now will be able to see the top 20 datasets, without having to type in the `SaveDataModal.autocomplete`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![dataset_onload](https://user-images.githubusercontent.com/27827808/108115590-59c62680-7068-11eb-8c7f-49cbbca493d4.gif)

Closes #12822

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
1. Goto sql lab
2. Run a query
3. Click Explore
4. Click on `Overwrite Dataset`
5. See dropdown show dataset available

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
