### PR TITLE
fix: Fixing pinot query generation for date format conversion from python datetime format to java simple date format

### DIFF
--- a/superset/db_engine_specs/pinot.py
+++ b/superset/db_engine_specs/pinot.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import datetime
 from typing import Dict, List, Optional
 
 from sqlalchemy.sql.expression import ColumnClause, ColumnElement
@@ -79,11 +78,6 @@ class PinotEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method
         tf = ""
         java_date_format = ""
         if not is_epoch:
-            try:
-                today = datetime.datetime.today()
-                today.strftime(str(pdf))
-            except ValueError:
-                raise ValueError(f"Invalid column datetime format:{str(pdf)}")
             java_date_format = pdf
             for (
                 python_pattern,

--- a/superset/db_engine_specs/pinot.py
+++ b/superset/db_engine_specs/pinot.py
@@ -69,24 +69,29 @@ class PinotEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method
         time_grain: Optional[str],
         type_: Optional[str] = None,
     ) -> TimestampExpression:
+        if not pdf:
+            raise NotImplementedError(f"Empty date format for '{col}'")
         is_epoch = pdf in ("epoch_s", "epoch_ms")
 
         # The DATETIMECONVERT pinot udf is documented at
         # Per https://github.com/apache/incubator-pinot/wiki/dateTimeConvert-UDF
         # We are not really converting any time units, just bucketing them.
         tf = ""
+        java_date_format = ""
         if not is_epoch:
             try:
                 today = datetime.datetime.today()
                 today.strftime(str(pdf))
             except ValueError:
                 raise ValueError(f"Invalid column datetime format:{str(pdf)}")
-            java_date_format = str(pdf)
+            java_date_format = pdf
             for (
                 python_pattern,
                 java_pattern,
             ) in cls._python_to_java_time_patterns.items():
-                java_date_format.replace(python_pattern, java_pattern)
+                java_date_format = java_date_format.replace(
+                    python_pattern, java_pattern
+                )
             tf = f"1:SECONDS:SIMPLE_DATE_FORMAT:{java_date_format}"
         else:
             seconds_or_ms = "MILLISECONDS" if pdf == "epoch_ms" else "SECONDS"
@@ -94,13 +99,20 @@ class PinotEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method
         if time_grain:
             granularity = cls.get_time_grain_expressions().get(time_grain)
             if not granularity:
-                raise NotImplementedError("No pinot grain spec for " + str(time_grain))
+                raise NotImplementedError(f"No pinot grain spec for '{time_grain}'")
         else:
             return TimestampExpression("{{col}}", col)
 
         # In pinot the output is a string since there is no timestamp column like pg
         if cls._use_date_trunc_function.get(time_grain):
-            time_expr = f"DATETRUNC('{granularity}', {{col}}, '{seconds_or_ms}')"
+            if is_epoch:
+                time_expr = f"DATETRUNC('{granularity}', {{col}}, '{seconds_or_ms}')"
+            else:
+                time_expr = (
+                    f"ToDateTime(DATETRUNC('{granularity}', "
+                    + f"FromDateTime({{col}}, '{java_date_format}'), "
+                    + f"'MILLISECONDS'), '{java_date_format}')"
+                )
         else:
             time_expr = f"DATETIMECONVERT({{col}}, '{tf}', '{tf}', '{granularity}')"
 

--- a/tests/db_engine_specs/pinot_tests.py
+++ b/tests/db_engine_specs/pinot_tests.py
@@ -30,7 +30,7 @@ class TestPinotDbEngineSpec(TestDbEngineSpec):
         self.assertEqual(
             result,
             "DATETIMECONVERT(tstamp, '1:SECONDS:EPOCH', '1:SECONDS:EPOCH', '1:DAYS')",
-        )  # noqa
+        )
 
     def test_pinot_time_expression_simple_date_format_1d_grain(self):
         col = column("tstamp")
@@ -43,7 +43,7 @@ class TestPinotDbEngineSpec(TestDbEngineSpec):
                 + "'1:SECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss', "
                 + "'1:SECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss', '1:DAYS')"
             ),
-        )  # noqa
+        )
 
     def test_pinot_time_expression_simple_date_format_1w_grain(self):
         col = column("tstamp")
@@ -55,7 +55,7 @@ class TestPinotDbEngineSpec(TestDbEngineSpec):
                 "ToDateTime(DATETRUNC('week', FromDateTime(tstamp, "
                 + "'yyyy-MM-dd HH:mm:ss'), 'MILLISECONDS'), 'yyyy-MM-dd HH:mm:ss')"
             ),
-        )  # noqa
+        )
 
     def test_pinot_time_expression_sec_one_1m_grain(self):
         col = column("tstamp")
@@ -63,17 +63,13 @@ class TestPinotDbEngineSpec(TestDbEngineSpec):
         result = str(expr.compile())
         self.assertEqual(
             result, "DATETRUNC('month', tstamp, 'SECONDS')",
-        )  # noqa
+        )
 
     def test_invalid_get_time_expression_arguments(self):
-        with self.assertRaises(NotImplementedError) as context:
+        with self.assertRaises(NotImplementedError):
             PinotEngineSpec.get_timestamp_expr(column("tstamp"), None, "P1M")
-        self.assertEqual("Empty date format for 'tstamp'", str(context.exception))
 
-        with self.assertRaises(NotImplementedError) as context:
+        with self.assertRaises(NotImplementedError):
             PinotEngineSpec.get_timestamp_expr(
                 column("tstamp"), "epoch_s", "invalid_grain"
             )
-        self.assertEqual(
-            "No pinot grain spec for 'invalid_grain'", str(context.exception)
-        )

--- a/tests/db_engine_specs/pinot_tests.py
+++ b/tests/db_engine_specs/pinot_tests.py
@@ -32,6 +32,31 @@ class TestPinotDbEngineSpec(TestDbEngineSpec):
             "DATETIMECONVERT(tstamp, '1:SECONDS:EPOCH', '1:SECONDS:EPOCH', '1:DAYS')",
         )  # noqa
 
+    def test_pinot_time_expression_simple_date_format_1d_grain(self):
+        col = column("tstamp")
+        expr = PinotEngineSpec.get_timestamp_expr(col, "%Y-%m-%d %H:%M:%S", "P1D")
+        result = str(expr.compile())
+        self.assertEqual(
+            result,
+            (
+                "DATETIMECONVERT(tstamp, "
+                + "'1:SECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss', "
+                + "'1:SECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss', '1:DAYS')"
+            ),
+        )  # noqa
+
+    def test_pinot_time_expression_simple_date_format_1w_grain(self):
+        col = column("tstamp")
+        expr = PinotEngineSpec.get_timestamp_expr(col, "%Y-%m-%d %H:%M:%S", "P1W")
+        result = str(expr.compile())
+        self.assertEqual(
+            result,
+            (
+                "ToDateTime(DATETRUNC('week', FromDateTime(tstamp, "
+                + "'yyyy-MM-dd HH:mm:ss'), 'MILLISECONDS'), 'yyyy-MM-dd HH:mm:ss')"
+            ),
+        )  # noqa
+
     def test_pinot_time_expression_sec_one_1m_grain(self):
         col = column("tstamp")
         expr = PinotEngineSpec.get_timestamp_expr(col, "epoch_s", "P1M")

--- a/tests/db_engine_specs/pinot_tests.py
+++ b/tests/db_engine_specs/pinot_tests.py
@@ -64,3 +64,16 @@ class TestPinotDbEngineSpec(TestDbEngineSpec):
         self.assertEqual(
             result, "DATETRUNC('month', tstamp, 'SECONDS')",
         )  # noqa
+
+    def test_invalid_get_time_expression_arguments(self):
+        with self.assertRaises(NotImplementedError) as context:
+            PinotEngineSpec.get_timestamp_expr(column("tstamp"), None, "P1M")
+        self.assertEqual("Empty date format for 'tstamp'", str(context.exception))
+
+        with self.assertRaises(NotImplementedError) as context:
+            PinotEngineSpec.get_timestamp_expr(
+                column("tstamp"), "epoch_s", "invalid_grain"
+            )
+        self.assertEqual(
+            "No pinot grain spec for 'invalid_grain'", str(context.exception)
+        )


### PR DESCRIPTION
### SUMMARY
Fixing Pinot query generation converting DateTime format from python DateTime format to Java SimpleDate Format.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After：
Generated query and chart:
```
SELECT DATETIMECONVERT(FlightDate, '1:SECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd', '1:SECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd', '1:DAYS'),
       COUNT(*)
FROM "airlineStats"."airlineStats"
GROUP BY DATETIMECONVERT(FlightDate, '1:SECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd', '1:SECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd', '1:DAYS')
LIMIT 10000;
```
![image](https://user-images.githubusercontent.com/1202120/108172497-c74a7500-70b1-11eb-9f47-d01e3b80381a.png)

### TEST PLAN
Adding unit test for query generation.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
