### PR TITLE
fix(api): apply dashboard filter to get dash charts API

### DIFF
--- a/superset/dashboards/dao.py
+++ b/superset/dashboards/dao.py
@@ -18,6 +18,7 @@ import json
 import logging
 from typing import Any, Dict, List, Optional
 
+from flask_appbuilder.models.sqla.interface import SQLAInterface
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import contains_eager
 
@@ -46,6 +47,9 @@ class DashboardDAO(BaseDAO):
             .filter(Dashboard.id == dashboard_id)
             .options(contains_eager(Dashboard.slices))
         )
+        # Apply dashboard base filters
+        query = DashboardFilter("id", SQLAInterface(Dashboard, db.session)).apply(query, None)
+
         dashboard = query.one_or_none()
         if not dashboard:
             raise DashboardNotFoundError()

--- a/superset/dashboards/dao.py
+++ b/superset/dashboards/dao.py
@@ -48,7 +48,9 @@ class DashboardDAO(BaseDAO):
             .options(contains_eager(Dashboard.slices))
         )
         # Apply dashboard base filters
-        query = DashboardFilter("id", SQLAInterface(Dashboard, db.session)).apply(query, None)
+        query = DashboardFilter("id", SQLAInterface(Dashboard, db.session)).apply(
+            query, None
+        )
 
         dashboard = query.one_or_none()
         if not dashboard:

--- a/tests/dashboards/api_tests.py
+++ b/tests/dashboards/api_tests.py
@@ -174,6 +174,7 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
         """
         Dashboard API: Test getting charts belonging to a dashboard
         """
+        self.login(username="admin")
         dashboard = self.dashboards[0]
         uri = f"api/v1/dashboard/{dashboard.id}/charts"
         response = self.get_assert_metric(uri, "get_charts")
@@ -192,6 +193,17 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
         self.login(username="admin")
         bad_id = self.get_nonexistent_numeric_id(Dashboard)
         uri = f"api/v1/dashboard/{bad_id}/charts"
+        response = self.get_assert_metric(uri, "get_charts")
+        self.assertEqual(response.status_code, 404)
+
+    @pytest.mark.usefixtures("create_dashboards")
+    def test_get_dashboard_charts_not_allowed(self):
+        """
+        Dashboard API: Test getting charts on a dashboard a user does not have access to
+        """
+        self.login(username="gamma")
+        dashboard = self.dashboards[0]
+        uri = f"api/v1/dashboard/{dashboard.id}/charts"
         response = self.get_assert_metric(uri, "get_charts")
         self.assertEqual(response.status_code, 404)
 


### PR DESCRIPTION
### SUMMARY
Applies dashboard filters to the get dashboard chart API endpoint.
Dashboard filters contains logic around datasource access and dashboard RBAC

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
