### PR TITLE
fix(sqllab): menu link results in 404

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2873,7 +2873,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
     @has_access
     @event_logger.log_this
-    @expose("/sqllab", methods=["GET", "POST"])
+    @expose("/sqllab/", methods=["GET", "POST"])
     def sqllab(self) -> FlaskResponse:
         """SQL Editor"""
         payload = {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Reported in https://github.com/apache/superset/pull/13087#issuecomment-780497250. An update was made to all menu links in order to standardize superset urls (always ending in a `/`) to facilitate matching against frontend routes. SQL Lab was exposed as `/sqllab` which was causing a 404. This PR standardizes the SQL Lab url. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- manual test, opening SQL Lab -> SQL Editor does not result in 404 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
