### PR TITLE
fix(explore): Fix downloading as image charts which use Mapbox

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -35,7 +35,7 @@
         "@superset-ui/legacy-plugin-chart-treemap": "^0.17.9",
         "@superset-ui/legacy-plugin-chart-world-map": "^0.17.9",
         "@superset-ui/legacy-preset-chart-big-number": "^0.17.9",
-        "@superset-ui/legacy-preset-chart-deckgl": "^0.4.1",
+        "@superset-ui/legacy-preset-chart-deckgl": "^0.4.2",
         "@superset-ui/legacy-preset-chart-nvd3": "^0.17.9",
         "@superset-ui/plugin-chart-echarts": "^0.17.9",
         "@superset-ui/plugin-chart-table": "^0.17.9",
@@ -14579,9 +14579,9 @@
       }
     },
     "node_modules/@superset-ui/legacy-preset-chart-deckgl": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-deckgl/-/legacy-preset-chart-deckgl-0.4.1.tgz",
-      "integrity": "sha512-3THN+WM8HUU1NlV3VNXRVS1j2jH33CmVAdyPNB35RqtwkY+udgFGOxm0lXumcUElht/3ROGMPvcwo1SXijVuLA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-deckgl/-/legacy-preset-chart-deckgl-0.4.2.tgz",
+      "integrity": "sha512-lr9K0KihVgaCjE72Zu/nd3YoU/q2EDX7qd73y95vzoXBgIA2cMfIkAmEnOe2Komb51ed9hzz0MnudfZHZk1cfw==",
       "dependencies": {
         "@math.gl/web-mercator": "^3.2.2",
         "@types/d3-array": "^2.0.0",
@@ -14601,6 +14601,11 @@
         "underscore": "^1.8.3",
         "urijs": "^1.18.10",
         "xss": "^1.0.6"
+      },
+      "peerDependencies": {
+        "@superset-ui/chart-controls": "^0.16.3",
+        "@superset-ui/core": "^0.16.3",
+        "react": "^15 || ^16"
       }
     },
     "node_modules/@superset-ui/legacy-preset-chart-nvd3": {
@@ -68831,9 +68836,9 @@
       }
     },
     "@superset-ui/legacy-preset-chart-deckgl": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-deckgl/-/legacy-preset-chart-deckgl-0.4.1.tgz",
-      "integrity": "sha512-3THN+WM8HUU1NlV3VNXRVS1j2jH33CmVAdyPNB35RqtwkY+udgFGOxm0lXumcUElht/3ROGMPvcwo1SXijVuLA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-deckgl/-/legacy-preset-chart-deckgl-0.4.2.tgz",
+      "integrity": "sha512-lr9K0KihVgaCjE72Zu/nd3YoU/q2EDX7qd73y95vzoXBgIA2cMfIkAmEnOe2Komb51ed9hzz0MnudfZHZk1cfw==",
       "requires": {
         "@math.gl/web-mercator": "^3.2.2",
         "@types/d3-array": "^2.0.0",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -87,7 +87,7 @@
     "@superset-ui/legacy-plugin-chart-treemap": "^0.17.9",
     "@superset-ui/legacy-plugin-chart-world-map": "^0.17.9",
     "@superset-ui/legacy-preset-chart-big-number": "^0.17.9",
-    "@superset-ui/legacy-preset-chart-deckgl": "^0.4.1",
+    "@superset-ui/legacy-preset-chart-deckgl": "^0.4.2",
     "@superset-ui/legacy-preset-chart-nvd3": "^0.17.9",
     "@superset-ui/plugin-chart-echarts": "^0.17.9",
     "@superset-ui/plugin-chart-table": "^0.17.9",

--- a/superset-frontend/src/explore/components/DisplayQueryButton.jsx
+++ b/superset-frontend/src/explore/components/DisplayQueryButton.jsx
@@ -110,12 +110,11 @@ export const DisplayQueryButton = props => {
         break;
       case MENU_KEYS.DOWNLOAD_AS_IMAGE:
         downloadAsImage(
-          '.chart-container',
+          '.panel-body > .chart-container',
           // eslint-disable-next-line camelcase
           slice?.slice_name ?? t('New chart'),
-          {
-            height: parseInt(chartHeight, 10),
-          },
+          {},
+          true,
         )(domEvent);
         break;
       default:

--- a/superset-frontend/src/explore/components/DisplayQueryButton.jsx
+++ b/superset-frontend/src/explore/components/DisplayQueryButton.jsx
@@ -47,7 +47,6 @@ const propTypes = {
   onOpenPropertiesModal: PropTypes.func,
   onOpenInEditor: PropTypes.func,
   chartStatus: PropTypes.string,
-  chartHeight: PropTypes.string.isRequired,
   latestQueryFormData: PropTypes.object.isRequired,
   slice: PropTypes.object,
 };
@@ -100,7 +99,7 @@ export const DisplayQueryButton = props => {
   };
 
   const handleMenuClick = ({ key, domEvent }) => {
-    const { chartHeight, slice, onOpenInEditor, latestQueryFormData } = props;
+    const { slice, onOpenInEditor, latestQueryFormData } = props;
     switch (key) {
       case MENU_KEYS.EDIT_PROPERTIES:
         props.onOpenPropertiesModal();

--- a/superset-frontend/src/explore/components/ExploreActionButtons.tsx
+++ b/superset-frontend/src/explore/components/ExploreActionButtons.tsx
@@ -41,7 +41,6 @@ type ActionButtonProps = {
 type ExploreActionButtonsProps = {
   actions: { redirectSQLLab: Function; openPropertiesModal: Function };
   canDownload: boolean;
-  chartHeight: number;
   chartStatus: string;
   latestQueryFormData: {};
   queriesResponse: {};
@@ -85,7 +84,6 @@ const ExploreActionButtons = (props: ExploreActionButtonsProps) => {
   const {
     actions,
     canDownload,
-    chartHeight,
     chartStatus,
     latestQueryFormData,
     queriesResponse,
@@ -189,7 +187,6 @@ const ExploreActionButtons = (props: ExploreActionButtonsProps) => {
         </>
       )}
       <ConnectedDisplayQueryButton
-        chartHeight={chartHeight}
         queryResponse={queriesResponse?.[0]}
         latestQueryFormData={latestQueryFormData}
         chartStatus={chartStatus}

--- a/superset-frontend/src/explore/components/ExploreChartHeader.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader.jsx
@@ -44,7 +44,6 @@ const propTypes = {
   addHistory: PropTypes.func,
   can_overwrite: PropTypes.bool.isRequired,
   can_download: PropTypes.bool.isRequired,
-  chartHeight: PropTypes.string.isRequired,
   isStarred: PropTypes.bool.isRequired,
   slice: PropTypes.object,
   sliceName: PropTypes.string,
@@ -210,7 +209,6 @@ export class ExploreChartHeader extends React.PureComponent {
             slice={this.props.slice}
             canDownload={this.props.can_download}
             chartStatus={chartStatus}
-            chartHeight={this.props.chartHeight}
             latestQueryFormData={latestQueryFormData}
             queryResponse={queryResponse}
           />

--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -241,7 +241,6 @@ const ExploreChartPanel = props => {
       addHistory={props.addHistory}
       can_overwrite={props.can_overwrite}
       can_download={props.can_download}
-      chartHeight={props.height}
       isStarred={props.isStarred}
       slice={props.slice}
       sliceName={props.sliceName}


### PR DESCRIPTION
### SUMMARY
Due to Mapbox controls being loaded from different origin, it was impossible to convert Mapbox canvas to base64 encoded image due to CORS policy of `HTMLCanvasElement.toDataURL` method (https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL#exceptions). This PR fixes it by filtering out div that contains control elements (such as Mapbox logo).
This PR needs https://github.com/apache-superset/superset-ui-plugins-deckgl/pull/25 and https://github.com/apache-superset/superset-ui/pull/965 to be merged and respective packages to be bumped to work properly. Mapbox and DeckGL components need to have `preserveDrawingBuffer` prop set to true - otherwise only a gray background is getting captured. This change may affect performance of MapBox and DeckGL charts - I'd appreciate some stress tests and verifying if performance is acceptable when compared to current version

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see https://github.com/apache/superset/issues/12745
After:
![country-of-citizenship-2021-02-17T17-01-42 411Z](https://user-images.githubusercontent.com/15073128/108241334-ff9e9180-714b-11eb-9bf4-ef82cbd199fe.jpg)
![country-of-citizenship-2021-02-17T17-02-26 826Z](https://user-images.githubusercontent.com/15073128/108241340-03321880-714c-11eb-9664-d77a1e7deb2c.jpg)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes https://github.com/apache/superset/issues/12745
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @villebro @junlincc @altef 