### PR TITLE
docs: Fix typo in pyathena connection string

### DIFF
--- a/docs/src/pages/docs/Connecting to Databases/athena.mdx
+++ b/docs/src/pages/docs/Connecting to Databases/athena.mdx
@@ -31,5 +31,5 @@ You can also use [PyAthena library](https://pypi.org/project/PyAthena/) (no Java
 following connection string:
 
 ```
-awsathena+rest://{aws_access_key_id}:{aws_secret_access_key}@athena.{region_name}.amazonaws.com/{
+awsathena+rest://{aws_access_key_id}:{aws_secret_access_key}@athena.{region_name}.amazonaws.com/{schema_name}?s3_staging_dir={s3_staging_dir}&...
 ```


### PR DESCRIPTION
### SUMMARY
The pyathena connection string is missing the schema name and the s3 staging dir parameter.
