### PR TITLE
fix(explore): Reset values in TextControl only when datasource changes

### DIFF
--- a/superset-frontend/src/explore/components/controls/SelectControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.jsx
@@ -247,6 +247,7 @@ export default class SelectControl extends React.PureComponent {
       isMulti &&
       optionsRemaining &&
       Array.isArray(this.state.value) &&
+      Array.isArray(value) &&
       !!value.length
     ) {
       assistiveText = optionRemaingText;

--- a/superset-frontend/src/explore/components/controls/TextControl.tsx
+++ b/superset-frontend/src/explore/components/controls/TextControl.tsx
@@ -37,6 +37,7 @@ interface TextControlProps {
 
 interface TextControlState {
   controlId: string;
+  currentDatasource?: string;
   value?: string | number;
 }
 
@@ -55,8 +56,14 @@ export default class TextControl extends React.Component<
     props: TextControlProps,
     state: TextControlState,
   ) {
-    if (props.value !== state.value) {
-      return { value: props.value };
+    // reset value when datasource changes
+    // props.datasource and props.value don't update in the same re-render,
+    // so we need to synchronize them to update the state with correct values
+    if (
+      props.value !== state.value &&
+      props.datasource !== state.currentDatasource
+    ) {
+      return { value: props.value, currentDatasource: props.datasource };
     }
     return null;
   }
@@ -69,12 +76,9 @@ export default class TextControl extends React.Component<
     this.state = {
       controlId: generateControlId(props.controlId),
       value: props.value,
+      currentDatasource: props.datasource,
     };
   }
-
-  defaultInput = () => {
-    this.setState({ value: '' });
-  };
 
   onChange = (inputValue: string) => {
     let parsedValue: string | number = inputValue;


### PR DESCRIPTION
### SUMMARY
Due to recent changes in #12782 regarding resetting control values when datasource changes, debounce in TextControl component stopped working properly. This was caused by comparing `props.value` with `state.value` and setting `state.value` to `props.value` if they were not equal. Because of using 0.5s debounce, props and state values were always unequal when user typed a new value. This PR fixes the issue by adding a comparison of props and state datasource and updating value only when datasources are not equal.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see https://github.com/apache/superset/issues/13191
After:
https://user-images.githubusercontent.com/15073128/108376726-8ebab080-7203-11eb-8ef2-f3ef73aab2f3.mov

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes https://github.com/apache/superset/issues/13191
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @villebro @junlincc 
@nikolagigic @mayurnewase please help review this PR, thanks! (from junlin)