### PR TITLE
feat(presto): add support for user impersonation

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -924,7 +924,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         return {}
 
     @classmethod
-    def get_connect_args_for_impersonation(
+    def connect_arg_for_impersonation(
         cls, uri: str, impersonate_user: bool, username: Optional[str]
     ) -> Dict[str, str]:
         """

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -909,24 +909,9 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
             url.username = username
 
     @classmethod
-    def get_configuration_for_impersonation(  # pylint: disable=invalid-name
+    def update_connect_args_for_impersonation(
         cls, uri: str, impersonate_user: bool, username: Optional[str]
-    ) -> Dict[str, str]:
-        """
-        Return a configuration dictionary that can be merged with other configs
-        that can set the correct properties for impersonating users
-
-        :param uri: URI
-        :param impersonate_user: Flag indicating if impersonation is enabled
-        :param username: Effective username
-        :return: Configs required for impersonation
-        """
-        return {}
-
-    @classmethod
-    def connect_arg_for_impersonation(
-        cls, uri: str, impersonate_user: bool, username: Optional[str]
-    ) -> Dict[str, str]:
+    ) -> Dict[str, Any]:
         """
         Return a configuration dictionary that can be merged with other configs
         that can set the correct properties for impersonating users

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -910,18 +910,17 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
 
     @classmethod
     def update_connect_args_for_impersonation(
-        cls, uri: str, impersonate_user: bool, username: Optional[str]
-    ) -> Dict[str, Any]:
+        cls, connect_args : Dict[Any, Any], uri: str, impersonate_user: bool, username: Optional[str]
+    ) -> None:
         """
-        Return a configuration dictionary that can be merged with other configs
-        that can set the correct properties for impersonating users
+        Update a configuration dictionary that can set the correct properties for impersonating users
 
+        :param connect_args: config to be updated
         :param uri: URI
         :param impersonate_user: Flag indicating if impersonation is enabled
         :param username: Effective username
-        :return: Configs required for impersonation
+        :return: None
         """
-        return {}
 
     @classmethod
     def execute(cls, cursor: Any, query: str, **kwargs: Any) -> None:

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -911,9 +911,8 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     @classmethod
     def update_connect_args_for_impersonation(
         cls,
-        connect_args: Dict[Any, Any],
+        connect_args: Dict[str, Any],
         uri: str,
-        impersonate_user: bool,
         username: Optional[str],
     ) -> None:
         """

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -924,6 +924,21 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         return {}
 
     @classmethod
+    def get_connect_args_for_impersonation(
+        cls, uri: str, impersonate_user: bool, username: Optional[str]
+    ) -> Dict[str, str]:
+        """
+        Return a configuration dictionary that can be merged with other configs
+        that can set the correct properties for impersonating users
+
+        :param uri: URI
+        :param impersonate_user: Flag indicating if impersonation is enabled
+        :param username: Effective username
+        :return: Configs required for impersonation
+        """
+        return {}
+
+    @classmethod
     def execute(cls, cursor: Any, query: str, **kwargs: Any) -> None:
         """
         Execute a SQL query

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -910,10 +910,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
 
     @classmethod
     def update_impersonation_config(
-        cls,
-        connect_args: Dict[str, Any],
-        uri: str,
-        username: Optional[str],
+        cls, connect_args: Dict[str, Any], uri: str, username: Optional[str],
     ) -> None:
         """
         Update a configuration dictionary

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -916,7 +916,8 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         username: Optional[str],
     ) -> None:
         """
-        Update a configuration dictionary that can set the correct properties for impersonating users
+        Update a configuration dictionary
+        that can set the correct properties for impersonating users
 
         :param connect_args: config to be updated
         :param uri: URI

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -909,7 +909,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
             url.username = username
 
     @classmethod
-    def update_connect_args_for_impersonation(
+    def update_impersonation_config(
         cls,
         connect_args: Dict[str, Any],
         uri: str,

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -910,7 +910,11 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
 
     @classmethod
     def update_connect_args_for_impersonation(
-        cls, connect_args : Dict[Any, Any], uri: str, impersonate_user: bool, username: Optional[str]
+        cls,
+        connect_args: Dict[Any, Any],
+        uri: str,
+        impersonate_user: bool,
+        username: Optional[str],
     ) -> None:
         """
         Update a configuration dictionary that can set the correct properties for impersonating users

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -488,7 +488,11 @@ class HiveEngineSpec(PrestoEngineSpec):
 
     @classmethod
     def update_connect_args_for_impersonation(
-        cls, connect_args : Dict[Any, Any], uri: str, impersonate_user: bool, username: Optional[str]
+        cls,
+        connect_args: Dict[Any, Any],
+        uri: str,
+        impersonate_user: bool,
+        username: Optional[str],
     ) -> None:
         """
         Update a configuration dictionary that can set the correct properties for impersonating users

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -487,9 +487,9 @@ class HiveEngineSpec(PrestoEngineSpec):
         # the configuraiton dictionary. See get_configuration_for_impersonation
 
     @classmethod
-    def get_configuration_for_impersonation(
+    def update_connect_args_for_impersonation(
         cls, uri: str, impersonate_user: bool, username: Optional[str]
-    ) -> Dict[str, str]:
+    ) -> Dict[str, Any]:
         """
         Return a configuration dictionary that can be merged with other configs
         that can set the correct properties for impersonating users
@@ -498,15 +498,16 @@ class HiveEngineSpec(PrestoEngineSpec):
         :param username: Effective username
         :return: Configs required for impersonation
         """
-        configuration = {}
         url = make_url(uri)
         backend_name = url.get_backend_name()
 
         # Must be Hive connection, enable impersonation, and set optional param
         # auth=LDAP|KERBEROS
         if backend_name == "hive" and impersonate_user and username is not None:
-            configuration["hive.server2.proxy.user"] = username
-        return configuration
+            connect_args = {"configuration": {}}  # type: Dict[str, Any]
+            connect_args["configuration"]["hive.server2.proxy.user"] = username
+            return connect_args
+        return {}
 
     @staticmethod
     def execute(  # type: ignore

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -488,10 +488,7 @@ class HiveEngineSpec(PrestoEngineSpec):
 
     @classmethod
     def update_impersonation_config(
-        cls,
-        connect_args: Dict[str, Any],
-        uri: str,
-        username: Optional[str],
+        cls, connect_args: Dict[str, Any], uri: str, username: Optional[str],
     ) -> None:
         """
         Update a configuration dictionary

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -487,7 +487,7 @@ class HiveEngineSpec(PrestoEngineSpec):
         # the configuraiton dictionary. See get_configuration_for_impersonation
 
     @classmethod
-    def update_connect_args_for_impersonation(
+    def update_impersonation_config(
         cls,
         connect_args: Dict[str, Any],
         uri: str,

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -494,7 +494,8 @@ class HiveEngineSpec(PrestoEngineSpec):
         username: Optional[str],
     ) -> None:
         """
-        Update a configuration dictionary that can set the correct properties for impersonating users
+        Update a configuration dictionary
+        that can set the correct properties for impersonating users
         :param connect_args:
         :param uri: URI string
         :param impersonate_user: Flag indicating if impersonation is enabled

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -489,9 +489,8 @@ class HiveEngineSpec(PrestoEngineSpec):
     @classmethod
     def update_connect_args_for_impersonation(
         cls,
-        connect_args: Dict[Any, Any],
+        connect_args: Dict[str, Any],
         uri: str,
-        impersonate_user: bool,
         username: Optional[str],
     ) -> None:
         """
@@ -507,7 +506,8 @@ class HiveEngineSpec(PrestoEngineSpec):
 
         # Must be Hive connection, enable impersonation, and set optional param
         # auth=LDAP|KERBEROS
-        if backend_name == "hive" and impersonate_user and username is not None:
+        # this will set hive.server2.proxy.user=$effective_username on connect_args['configuration']
+        if backend_name == "hive" and username is not None:
             configuration = connect_args.get("configuration", {})
             configuration["hive.server2.proxy.user"] = username
             connect_args["configuration"] = configuration

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -488,15 +488,15 @@ class HiveEngineSpec(PrestoEngineSpec):
 
     @classmethod
     def update_connect_args_for_impersonation(
-        cls, uri: str, impersonate_user: bool, username: Optional[str]
-    ) -> Dict[str, Any]:
+        cls, connect_args : Dict[Any, Any], uri: str, impersonate_user: bool, username: Optional[str]
+    ) -> None:
         """
-        Return a configuration dictionary that can be merged with other configs
-        that can set the correct properties for impersonating users
+        Update a configuration dictionary that can set the correct properties for impersonating users
+        :param connect_args:
         :param uri: URI string
         :param impersonate_user: Flag indicating if impersonation is enabled
         :param username: Effective username
-        :return: Configs required for impersonation
+        :return: None
         """
         url = make_url(uri)
         backend_name = url.get_backend_name()
@@ -504,10 +504,9 @@ class HiveEngineSpec(PrestoEngineSpec):
         # Must be Hive connection, enable impersonation, and set optional param
         # auth=LDAP|KERBEROS
         if backend_name == "hive" and impersonate_user and username is not None:
-            connect_args = {"configuration": {}}  # type: Dict[str, Any]
-            connect_args["configuration"]["hive.server2.proxy.user"] = username
-            return connect_args
-        return {}
+            configuration = connect_args.get("configuration", {})
+            configuration["hive.server2.proxy.user"] = username
+            connect_args["configuration"] = configuration
 
     @staticmethod
     def execute(  # type: ignore

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -137,7 +137,7 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
         return version is not None and StrictVersion(version) >= StrictVersion("0.319")
 
     @classmethod
-    def update_connect_args_for_impersonation(
+    def update_impersonation_config(
         cls,
         connect_args: Dict[str, Any],
         uri: str,

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -138,10 +138,7 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
 
     @classmethod
     def update_impersonation_config(
-        cls,
-        connect_args: Dict[str, Any],
-        uri: str,
-        username: Optional[str],
+        cls, connect_args: Dict[str, Any], uri: str, username: Optional[str],
     ) -> None:
         """
         Update a configuration dictionary

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -138,17 +138,16 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
 
     @classmethod
     def update_connect_args_for_impersonation(
-        cls, uri: str, impersonate_user: bool, username: Optional[str]
-    ) -> Dict[str, Any]:
+        cls, connect_args : Dict[Any, Any], uri: str, impersonate_user: bool, username: Optional[str]
+    ) -> None:
         """
-        Return a configuration dictionary that can be merged with other configs
-        that can set the correct properties for impersonating users
+        Update a configuration dictionary that can set the correct properties for impersonating users
+        :param connect_args: config to be updated
         :param uri: URI string
         :param impersonate_user: Flag indicating if impersonation is enabled
         :param username: Effective username
-        :return: Configs required for impersonation
+        :return: None
         """
-        connect_args = {}
         url = make_url(uri)
         backend_name = url.get_backend_name()
 
@@ -156,7 +155,6 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
         # auth=LDAP|KERBEROS
         if backend_name == "presto" and impersonate_user and username is not None:
             connect_args["principal_username"] = username
-        return connect_args
 
     @classmethod
     def get_table_names(

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -27,7 +27,7 @@ from typing import Any, cast, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 from urllib import parse
 
 import pandas as pd
-import simplejson as json
+import simplejson as jsoget_connect_argsn
 from flask_babel import gettext as __, lazy_gettext as _
 from sqlalchemy import Column, literal_column, types
 from sqlalchemy.engine.base import Engine
@@ -137,7 +137,7 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
         return version is not None and StrictVersion(version) >= StrictVersion("0.319")
 
     @classmethod
-    def get_connect_args_for_impersonation(
+    def connect_arg_for_impersonation(
         cls, uri: str, impersonate_user: bool, username: Optional[str]
     ) -> Dict[str, str]:
         """

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -138,7 +138,11 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
 
     @classmethod
     def update_connect_args_for_impersonation(
-        cls, connect_args : Dict[Any, Any], uri: str, impersonate_user: bool, username: Optional[str]
+        cls,
+        connect_args: Dict[Any, Any],
+        uri: str,
+        impersonate_user: bool,
+        username: Optional[str],
     ) -> None:
         """
         Update a configuration dictionary that can set the correct properties for impersonating users

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -144,7 +144,8 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
         username: Optional[str],
     ) -> None:
         """
-        Update a configuration dictionary that can set the correct properties for impersonating users
+        Update a configuration dictionary
+        that can set the correct properties for impersonating users
         :param connect_args: config to be updated
         :param uri: URI string
         :param impersonate_user: Flag indicating if impersonation is enabled

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -139,9 +139,8 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
     @classmethod
     def update_connect_args_for_impersonation(
         cls,
-        connect_args: Dict[Any, Any],
+        connect_args: Dict[str, Any],
         uri: str,
-        impersonate_user: bool,
         username: Optional[str],
     ) -> None:
         """
@@ -157,7 +156,8 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
 
         # Must be Presto connection, enable impersonation, and set optional param
         # auth=LDAP|KERBEROS
-        if backend_name == "presto" and impersonate_user and username is not None:
+        # Set principal_username=$effective_username
+        if backend_name == "presto" and username is not None:
             connect_args["principal_username"] = username
 
     @classmethod

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -137,9 +137,9 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
         return version is not None and StrictVersion(version) >= StrictVersion("0.319")
 
     @classmethod
-    def connect_arg_for_impersonation(
+    def update_connect_args_for_impersonation(
         cls, uri: str, impersonate_user: bool, username: Optional[str]
-    ) -> Dict[str, str]:
+    ) -> Dict[str, Any]:
         """
         Return a configuration dictionary that can be merged with other configs
         that can set the correct properties for impersonating users
@@ -148,15 +148,15 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
         :param username: Effective username
         :return: Configs required for impersonation
         """
-        configuration = {}
+        connect_args = {}
         url = make_url(uri)
         backend_name = url.get_backend_name()
 
         # Must be Presto connection, enable impersonation, and set optional param
         # auth=LDAP|KERBEROS
         if backend_name == "presto" and impersonate_user and username is not None:
-            configuration["principal_username"] = username
-        return configuration
+            connect_args["principal_username"] = username
+        return connect_args
 
     @classmethod
     def get_table_names(

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -27,7 +27,7 @@ from typing import Any, cast, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 from urllib import parse
 
 import pandas as pd
-import simplejson as jsoget_connect_argsn
+import simplejson as json
 from flask_babel import gettext as __, lazy_gettext as _
 from sqlalchemy import Column, literal_column, types
 from sqlalchemy.engine.base import Engine

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -328,10 +328,8 @@ class Database(
 
         # If using presto, this will set principal_username=$effective_username
         # If using Hive, this will set hive.server2.proxy.user=$effective_username on connect_args['configuration']
-        connect_args.update(
-            self.db_engine_spec.update_connect_args_for_impersonation(
-                str(sqlalchemy_url), self.impersonate_user, effective_username
-            )
+        self.db_engine_spec.update_connect_args_for_impersonation(
+            connect_args, str(sqlalchemy_url), self.impersonate_user, effective_username
         )
 
         if connect_args:

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -325,24 +325,15 @@ class Database(
             params["poolclass"] = NullPool
 
         connect_args = params.get("connect_args", {})
-        configuration = connect_args.get("configuration", {})
-
-        # If using Hive, this will set hive.server2.proxy.user=$effective_username
-        configuration.update(
-            self.db_engine_spec.get_configuration_for_impersonation(
-                str(sqlalchemy_url), self.impersonate_user, effective_username
-            )
-        )
 
         # If using presto, this will set principal_username=$effective_username
+        # If using Hive, this will set hive.server2.proxy.user=$effective_username on connect_args['configuration']
         connect_args.update(
-            self.db_engine_spec.connect_arg_for_impersonation(
+            self.db_engine_spec.update_connect_args_for_impersonation(
                 str(sqlalchemy_url), self.impersonate_user, effective_username
             )
         )
 
-        if configuration:
-            connect_args["configuration"] = configuration
         if connect_args:
             params["connect_args"] = connect_args
 

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -325,12 +325,10 @@ class Database(
             params["poolclass"] = NullPool
 
         connect_args = params.get("connect_args", {})
-
-        # If using presto, this will set principal_username=$effective_username
-        # If using Hive, this will set hive.server2.proxy.user=$effective_username on connect_args['configuration']
-        self.db_engine_spec.update_connect_args_for_impersonation(
-            connect_args, str(sqlalchemy_url), self.impersonate_user, effective_username
-        )
+        if self.impersonate_user:
+            self.db_engine_spec.update_connect_args_for_impersonation(
+                connect_args, str(sqlalchemy_url), effective_username
+            )
 
         if connect_args:
             params["connect_args"] = connect_args

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -336,7 +336,7 @@ class Database(
 
         # If using presto, this will set principal_username=$effective_username
         connect_args.update(
-            self.db_engine_spec.get_connect_args_for_impersonation(
+            self.db_engine_spec.connect_arg_for_impersonation(
                 str(sqlalchemy_url), self.impersonate_user, effective_username
             )
         )

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -326,7 +326,7 @@ class Database(
 
         connect_args = params.get("connect_args", {})
         if self.impersonate_user:
-            self.db_engine_spec.update_connect_args_for_impersonation(
+            self.db_engine_spec.update_impersonation_config(
                 connect_args, str(sqlalchemy_url), effective_username
             )
 

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -333,6 +333,14 @@ class Database(
                 str(sqlalchemy_url), self.impersonate_user, effective_username
             )
         )
+
+        # If using presto, this will set principal_username=$effective_username
+        connect_args.update(
+            self.db_engine_spec.get_connect_args_for_impersonation(
+                str(sqlalchemy_url), self.impersonate_user, effective_username
+            )
+        )
+
         if configuration:
             connect_args["configuration"] = configuration
         if connect_args:

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -17,6 +17,7 @@
 # isort:skip_file
 import textwrap
 import unittest
+from unittest import mock
 from tests.fixtures.birth_names_dashboard import load_birth_names_dashboard_with_slices
 
 import pandas
@@ -109,6 +110,52 @@ class TestDatabaseModel(SupersetTestCase):
         model.impersonate_user = False
         user_name = make_url(model.get_sqla_engine(user_name=example_user).url).username
         self.assertNotEqual(example_user, user_name)
+
+    @mock.patch("superset.models.core.create_engine")
+    def test_impersonate_user_presto(self, mocked_create_engine):
+        uri = "presto://localhost"
+        principal_user = "logged_in_user"
+        extra = """
+                {
+                    "metadata_params": {},
+                    "engine_params": {
+                               "connect_args":{
+                                  "protocol": "https",
+                                  "username":"original_user",
+                                  "password":"original_user_password"
+                               }
+                    },
+                    "metadata_cache_timeout": {},
+                    "schemas_allowed_for_csv_upload": []
+                }
+                """
+
+        model = Database(database_name="test_database", sqlalchemy_uri=uri, extra=extra)
+
+        model.impersonate_user = True
+        model.get_sqla_engine(user_name=principal_user)
+        call_args = mocked_create_engine.call_args
+
+        assert str(call_args[0][0]) == "presto://logged_in_user@localhost"
+
+        assert call_args[1]["connect_args"] == {
+            "protocol": "https",
+            "username": "original_user",
+            "password": "original_user_password",
+            "principal_username": "logged_in_user",
+        }
+
+        model.impersonate_user = False
+        model.get_sqla_engine(user_name=principal_user)
+        call_args = mocked_create_engine.call_args
+
+        assert str(call_args[0][0]) == "presto://localhost"
+
+        assert call_args[1]["connect_args"] == {
+            "protocol": "https",
+            "username": "original_user",
+            "password": "original_user_password",
+        }
 
     @pytest.mark.usefixtures("load_energy_table_with_slice")
     def test_select_star(self):

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -157,6 +157,52 @@ class TestDatabaseModel(SupersetTestCase):
             "password": "original_user_password",
         }
 
+    @mock.patch("superset.models.core.create_engine")
+    def test_impersonate_user_hive(self, mocked_create_engine):
+        uri = "hive://localhost"
+        principal_user = "logged_in_user"
+        extra = """
+                {
+                    "metadata_params": {},
+                    "engine_params": {
+                               "connect_args":{
+                                  "protocol": "https",
+                                  "username":"original_user",
+                                  "password":"original_user_password"
+                               }
+                    },
+                    "metadata_cache_timeout": {},
+                    "schemas_allowed_for_csv_upload": []
+                }
+                """
+
+        model = Database(database_name="test_database", sqlalchemy_uri=uri, extra=extra)
+
+        model.impersonate_user = True
+        model.get_sqla_engine(user_name=principal_user)
+        call_args = mocked_create_engine.call_args
+
+        assert str(call_args[0][0]) == "hive://localhost"
+
+        assert call_args[1]["connect_args"] == {
+            "protocol": "https",
+            "username": "original_user",
+            "password": "original_user_password",
+            "configuration": {"hive.server2.proxy.user": "logged_in_user"},
+        }
+
+        model.impersonate_user = False
+        model.get_sqla_engine(user_name=principal_user)
+        call_args = mocked_create_engine.call_args
+
+        assert str(call_args[0][0]) == "hive://localhost"
+
+        assert call_args[1]["connect_args"] == {
+            "protocol": "https",
+            "username": "original_user",
+            "password": "original_user_password",
+        }
+
     @pytest.mark.usefixtures("load_energy_table_with_slice")
     def test_select_star(self):
         db = get_example_database()


### PR DESCRIPTION
### SUMMARY
Fix for issue https://github.com/apache/superset/issues/11359, https://github.com/apache/superset/issues/9406

When using LDAP authentication with presto/trino, the current behavior is just to modify the URL to replace the username which will result in an unauthorized exception. This PR will fix this by updating the connection argument with the effective user. 


### TEST PLAN
Step 1: Setup database connection to presto without credentials in URL.
Step 2: Provide admin(who can impersonate as any other user in presto) credentials in connection properties via extras  
```
"engine_params": {
           "connect_args":{
              "protocol": "https",
              "username":"<admin>",
              "password":"<admin_password>"
           }
}
```

Step 3: Enable impersonation for the database connection. 
Step 4: Log in with a different user and run the query via SQL lab and you will see the **principal user** as admin and **user** as the logged-in user in presto UI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API