### PR TITLE
fix: style tweaks for inconsistent button spacing

### DIFF
--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -372,7 +372,6 @@ div.tablePopover {
 .ResultSetButtons {
   display: grid;
   grid-auto-flow: column;
-  grid-gap: 4px;
   padding-right: 8px;
 }
 

--- a/superset-frontend/src/components/Button/index.tsx
+++ b/superset-frontend/src/components/Button/index.tsx
@@ -159,7 +159,7 @@ export default function Button(props: ButtonProps) {
     <AntdButton
       href={disabled ? undefined : href}
       disabled={disabled}
-      className={cx(className, { cta: !!cta })}
+      className={cx(className, 'superset-button', { cta: !!cta })}
       css={{
         display: 'inline-flex',
         alignItems: 'center',
@@ -199,9 +199,9 @@ export default function Button(props: ButtonProps) {
           backgroundColor: backgroundColorDisabled,
           borderColor: borderColorDisabled,
         },
-        marginLeft: theme.gridUnit * 2,
-        '&:first-of-type': {
-          marginLeft: 0,
+        marginLeft: 0,
+        '& + .superset-button': {
+          marginLeft: theme.gridUnit * 2,
         },
         '& :first-of-type': {
           marginRight: firstChildMargin,

--- a/superset-frontend/src/components/Menu/SubMenu.tsx
+++ b/superset-frontend/src/components/Menu/SubMenu.tsx
@@ -169,14 +169,15 @@ const SubMenu: React.FunctionComponent<SubMenuProps> = props => {
         </Nav>
         <Nav className="navbar-right">
           {props.buttons?.map((btn, i) => (
-            <Button
-              key={`${i}`}
-              buttonStyle={btn.buttonStyle}
-              onClick={btn.onClick}
-              data-test={btn['data-test']}
-            >
-              {btn.name}
-            </Button>
+            <React.Fragment key={`${i}`}>
+              <Button
+                buttonStyle={btn.buttonStyle}
+                onClick={btn.onClick}
+                data-test={btn['data-test']}
+              >
+                {btn.name}
+              </Button>
+            </React.Fragment>
           ))}
         </Nav>
       </Navbar>

--- a/superset-frontend/src/components/Menu/SubMenu.tsx
+++ b/superset-frontend/src/components/Menu/SubMenu.tsx
@@ -169,15 +169,14 @@ const SubMenu: React.FunctionComponent<SubMenuProps> = props => {
         </Nav>
         <Nav className="navbar-right">
           {props.buttons?.map((btn, i) => (
-            <React.Fragment key={`${i}`}>
-              <Button
-                buttonStyle={btn.buttonStyle}
-                onClick={btn.onClick}
-                data-test={btn['data-test']}
-              >
-                {btn.name}
-              </Button>
-            </React.Fragment>
+            <Button
+              key={`${i}`}
+              buttonStyle={btn.buttonStyle}
+              onClick={btn.onClick}
+              data-test={btn['data-test']}
+            >
+              {btn.name}
+            </Button>
           ))}
         </Nav>
       </Navbar>


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `Button` component had some styles to adjust margins of consecutive sibling buttons. This wasn't working in all cases since some were rendered as different element types (`button` or `a`). This PR adds a (library agnostic) class to the `Button` elements, so that they can be spaced more reliably using an Adjascent Sibling Selector (`+`).

I also pulled out the `grid-gap` from `.ResultSetButtons` since the above adjustments take care of the spacing.

~~This also includes a little bycatch of a seemingly unnecessary `React.Fragment`~~

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![image](https://user-images.githubusercontent.com/812905/108586556-1e478880-7304-11eb-9600-0defa0ee37da.png)

After:
![image](https://user-images.githubusercontent.com/812905/108586542-06700480-7304-11eb-92a8-020217e8b8c3.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Screenshots look right
Storybook looks good
Other buttons elsewhere in the UI show no fallout.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

reviews welcome from @eschutho @AAfghahi @michael-s-molina  (or anyone else, of course)