### PR TITLE
ci: always execute tests on non-PRs

### DIFF
--- a/scripts/ci_check_no_file_changes.sh
+++ b/scripts/ci_check_no_file_changes.sh
@@ -22,6 +22,10 @@
 # to check for python changes, run with CHECKS=python
 # To check for frontend changes, run with CHECKS=frontend
 # To check for python and frontend changes, run with CHECKS="python frontend"
+if [[ -z ${PR_NUMBER} ]]; then
+  echo "Not a PR; Exiting with FAILURE code"
+  exit 1
+fi
 
 URL="https://api.github.com/repos/${GITHUB_REPO}/pulls/${PR_NUMBER}/files"
 FILES=$(curl -s -X GET -G "${URL}" | jq -r '.[] | .filename')


### PR DESCRIPTION
### SUMMARY
When working on a branch before opening a PR I noticed that the conditional test skipping doesn't work properly when `PR_NUMBER` isn't available (=not a PR). This changes tests to always execute when it isn't a PR, for example after merging or when just working on a branch.

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/108635311-78bd2200-7487-11eb-812e-66de883f7f7b.png)

### AFTER
![image](https://user-images.githubusercontent.com/33317356/108635290-617e3480-7487-11eb-9042-ed30ee60b72b.png)

### TEST PLAN
Local testing + ShellCheck:
![image](https://user-images.githubusercontent.com/33317356/108635570-b8383e00-7488-11eb-81fd-3430bd5dd960.png)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
