### PR TITLE
fix(menu): links that result in 404s

### DIFF
--- a/superset/app.py
+++ b/superset/app.py
@@ -369,7 +369,7 @@ class SupersetAppInitializer:
             appbuilder.add_link(
                 "Upload a CSV",
                 label=__("Upload a CSV"),
-                href="/csvtodatabaseview/form/",
+                href="/csvtodatabaseview/form",
                 icon="fa-upload",
                 category="Data",
                 category_label=__("Data"),
@@ -384,7 +384,7 @@ class SupersetAppInitializer:
                 appbuilder.add_link(
                     "Upload Excel",
                     label=__("Upload Excel"),
-                    href="/exceltodatabaseview/form/",
+                    href="/exceltodatabaseview/form",
                     icon="fa-upload",
                     category="Data",
                     category_label=__("Data"),

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -620,7 +620,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
     @has_access
     @event_logger.log_this
-    @expose("/import_dashboards", methods=["GET", "POST"])
+    @expose("/import_dashboards/", methods=["GET", "POST"])
     def import_dashboards(self) -> FlaskResponse:
         """Overrides the dashboards using json instances from the file."""
         import_file = request.files.get("file")


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Followup from https://github.com/apache/superset/pull/13246

https://github.com/apache/superset/pull/13087 made some change to the menu links, trying to standardize routes to always end in an `/`, which should make matching between frontend routes and backend routes easier. When a route is `@expose`d, and ends in a `/`, flask automatically redirects urls that do not end in a `/` to the correct endpoint. This behavior does not happen when the route is `@expose`d without the trailing `/`. It looks like FAB `@expose`s most endpoints to end in a `/`, except for the `/form` route, which has resulted in some 404s for the menu links. This PR addresses the issue by changing the `@expose`d routes to end in a `/`, except for the case of the FAB `form` route, where this is not possible, the trailing `/` is removed from the menu links.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- Menu link for `/csvtodatabaseview/form` does not 404
- Menu link for `/exceltodatabaseview/form` does not 404
- Menu link for `/superset/import_dashboards/` does not 404

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
