### PR TITLE
fix(listview): preserve bulk selections when view mode is changed

### DIFF
--- a/superset-frontend/src/components/ListView/utils.ts
+++ b/superset-frontend/src/components/ListView/utils.ts
@@ -324,7 +324,7 @@ export function useListViewState({
     setQuery(queryParams, method);
 
     fetchData({ pageIndex, pageSize, sortBy, filters });
-  }, [fetchData, pageIndex, pageSize, sortBy, filters, viewMode]);
+  }, [fetchData, pageIndex, pageSize, sortBy, filters]);
 
   useEffect(() => {
     if (!isEqual(initialState.pageIndex, pageIndex)) {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Quickfix for: https://github.com/apache/superset/pull/13245#issuecomment-782521554

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A 

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Manual test:
- bulk selected rows are preserved when the view mode is toggled from list to card and vice versa.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
