### PR TITLE
fix(alerts): Handle None on results

### DIFF
--- a/superset/reports/commands/alert.py
+++ b/superset/reports/commands/alert.py
@@ -52,7 +52,7 @@ class AlertCommand(BaseCommand):
 
         if self._is_validator_not_null:
             self._report_schedule.last_value_row_json = str(self._result)
-            return self._result is not None
+            return self._result not in (0, None, np.nan)
         self._report_schedule.last_value = self._result
         try:
             operator = json.loads(self._report_schedule.validator_config_json)["op"]
@@ -90,7 +90,8 @@ class AlertCommand(BaseCommand):
 
     def _validate_operator(self, rows: np.recarray) -> None:
         self._validate_result(rows)
-        if rows[0][1] is None:
+        if rows[0][1] in (0, None, np.nan):
+            self._result = 0.0
             return
         try:
             # Check if it's float or if we can convert it

--- a/tests/reports/commands_tests.py
+++ b/tests/reports/commands_tests.py
@@ -318,7 +318,17 @@ def create_alert_email_chart(request):
 
 
 @pytest.yield_fixture(
-    params=["alert1", "alert2", "alert3", "alert4", "alert5", "alert6", "alert7"]
+    params=[
+        "alert1",
+        "alert2",
+        "alert3",
+        "alert4",
+        "alert5",
+        "alert6",
+        "alert7",
+        "alert8",
+        "alert9",
+    ]
 )
 def create_no_alert_email_chart(request):
     param_config = {
@@ -354,6 +364,16 @@ def create_no_alert_email_chart(request):
         },
         "alert7": {
             "sql": "SELECT first from test_table where 1=0",
+            "validator_type": ReportScheduleValidatorType.OPERATOR,
+            "validator_config_json": '{"op": ">", "threshold": 0}',
+        },
+        "alert8": {
+            "sql": "SELECT Null as metric",
+            "validator_type": ReportScheduleValidatorType.NOT_NULL,
+            "validator_config_json": "{}",
+        },
+        "alert9": {
+            "sql": "SELECT Null as metric",
             "validator_type": ReportScheduleValidatorType.OPERATOR,
             "validator_config_json": '{"op": ">", "threshold": 0}',
         },


### PR DESCRIPTION
### SUMMARY
When an alert produces a result with `None`, the alert command raises an unexpected exception that keep the alert on a working state.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
