### PR TITLE
fix(home): missing key and invalid dates in Recents cards

### DIFF
--- a/superset-frontend/src/types/Chart.ts
+++ b/superset-frontend/src/types/Chart.ts
@@ -23,17 +23,18 @@
 
 import Owner from './Owner';
 
-export default interface Chart {
+export interface Chart {
   id: number;
   url: string;
   viz_type: string;
   slice_name: string;
   creator: string;
   changed_on: string;
+  changed_on_delta_humanized?: string;
+  changed_on_utc?: string;
   description: string | null;
   cache_timeout: number | null;
   thumbnail_url?: string;
-  changed_on_delta_humanized?: string;
   owners?: Owner[];
   datasource_name_text?: string;
 }
@@ -44,4 +45,7 @@ export type Slice = {
   slice_name: string;
   description: string | null;
   cache_timeout: number | null;
+  url?: string;
 };
+
+export default Chart;

--- a/superset-frontend/src/views/CRUD/types.ts
+++ b/superset-frontend/src/views/CRUD/types.ts
@@ -34,7 +34,8 @@ export interface DashboardTableProps {
 export interface Dashboard {
   changed_by_name: string;
   changed_by_url: string;
-  changed_on_delta_humanized: string;
+  changed_on_delta_humanized?: string;
+  changed_on_utc?: string;
   changed_by: string;
   dashboard_title: string;
   slice_name?: string;
@@ -47,13 +48,15 @@ export interface Dashboard {
 }
 
 export type SavedQueryObject = {
+  id: number;
+  changed_on: string;
+  changed_on_delta_humanized: string;
   database: {
     database_name: string;
     id: number;
   };
   db_id: number;
   description?: string;
-  id: number;
   label: string;
   schema: string;
   sql: string | null;

--- a/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
@@ -99,20 +99,17 @@ const ActivityContainer = styled.div`
 
 const UNTITLED = t('[Untitled]');
 const UNKNOWN_TIME = t('Unknown');
-// translation keys for last action on
-const TRANS_LAST_VIEWED = `Last viewed %s`;
-const TRANS_LAST_MODIFIED = `Last modified %s`;
 
-const getEntityTitle = (e: ActivityObject) => {
-  if ('dashboard_title' in e) return e.dashboard_title || UNTITLED;
-  if ('slice_name' in e) return e.slice_name || UNTITLED;
-  if ('label' in e) return e.label || UNTITLED;
-  return e.item_title || UNTITLED;
+const getEntityTitle = (entity: ActivityObject) => {
+  if ('dashboard_title' in entity) return entity.dashboard_title || UNTITLED;
+  if ('slice_name' in entity) return entity.slice_name || UNTITLED;
+  if ('label' in entity) return entity.label || UNTITLED;
+  return entity.item_title || UNTITLED;
 };
 
-const getEntityIconName = (e: ActivityObject) => {
-  if ('sql' in e) return 'sql';
-  const url = 'item_url' in e ? e.item_url : e.url;
+const getEntityIconName = (entity: ActivityObject) => {
+  if ('sql' in entity) return 'sql';
+  const url = 'item_url' in entity ? entity.item_url : entity.url;
   if (url?.includes('dashboard')) {
     return 'nav-dashboard';
   }
@@ -122,30 +119,35 @@ const getEntityIconName = (e: ActivityObject) => {
   return '';
 };
 
-const getEntityUrl = (e: ActivityObject) => {
-  if ('sql' in e) return `/superset/sqllab?savedQueryId=${e.id}`;
-  if ('url' in e) return e.url;
-  return e.item_url;
+const getEntityUrl = (entity: ActivityObject) => {
+  if ('sql' in entity) return `/superset/sqllab?savedQueryId=${entity.id}`;
+  if ('url' in entity) return entity.url;
+  return entity.item_url;
 };
 
-const getEntityLastActionOn = (e: ActivityObject) => {
-  if ('time_delta_humanized' in e) {
-    return t(TRANS_LAST_VIEWED, e.time_delta_humanized);
+const getEntityLastActionOn = (entity: ActivityObject) => {
+  // translation keys for last action on
+  const LAST_VIEWED = `Last viewed %s`;
+  const LAST_MODIFIED = `Last modified %s`;
+
+  // for Recent viewed items
+  if ('time_delta_humanized' in entity) {
+    return t(LAST_VIEWED, entity.time_delta_humanized);
   }
 
-  if ('changed_on_delta_humanized' in e) {
-    return t(TRANS_LAST_MODIFIED, e.changed_on_delta_humanized);
+  if ('changed_on_delta_humanized' in entity) {
+    return t(LAST_MODIFIED, entity.changed_on_delta_humanized);
   }
 
   let time: number | string | undefined | null;
-  let translationKey = TRANS_LAST_MODIFIED;
-  if ('time' in e) {
+  let translationKey = LAST_MODIFIED;
+  if ('time' in entity) {
     // eslint-disable-next-line prefer-destructuring
-    time = e.time;
-    translationKey = TRANS_LAST_VIEWED;
+    time = entity.time;
+    translationKey = LAST_VIEWED;
   }
-  if ('changed_on' in e) time = e.changed_on;
-  if ('changed_on_utc' in e) time = e.changed_on_utc;
+  if ('changed_on' in entity) time = entity.changed_on;
+  if ('changed_on_utc' in entity) time = entity.changed_on_utc;
 
   return t(
     translationKey,
@@ -195,9 +197,9 @@ export default function ActivityTable({
   }
 
   const renderActivity = () =>
-    activityData[activeChild].map((e: ActivityObject) => {
-      const url = getEntityUrl(e);
-      const lastActionOn = getEntityLastActionOn(e);
+    activityData[activeChild].map((entity: ActivityObject) => {
+      const url = getEntityUrl(entity);
+      const lastActionOn = getEntityLastActionOn(entity);
       return (
         <CardStyles
           onClick={() => {
@@ -209,9 +211,9 @@ export default function ActivityTable({
             loading={loading}
             cover={<></>}
             url={url}
-            title={getEntityTitle(e)}
+            title={getEntityTitle(entity)}
             description={lastActionOn}
-            avatar={getEntityIconName(e)}
+            avatar={getEntityIconName(entity)}
             actions={null}
           />
         </CardStyles>

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -23,6 +23,7 @@ from typing import Any, Callable, cast, Dict, List, Optional, Union
 from urllib import parse
 
 import backoff
+import humanize
 import pandas as pd
 import simplejson as json
 from flask import abort, flash, g, Markup, redirect, render_template, request, Response
@@ -1395,6 +1396,9 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
                     "item_url": item_url,
                     "item_title": item_title,
                     "time": log.dttm,
+                    "time_delta_humanized": humanize.naturaltime(
+                        datetime.now() - log.dttm
+                    ),
                 }
             )
         return json_success(json.dumps(payload, default=utils.json_int_dttm_ser))


### PR DESCRIPTION
### SUMMARY

- Cleaning up tech debt in Welcome recents cards and add proper typing.
- Fixes missing React children key and invalid dates bug (PR #12227 seems to have brought back Bug #12893 )
- Make `Last modified xxx` format consistent. Let Recent activity cards use backend humanized relative dates, too.
- Change the copy from "Last modified" to "Last viewed" for `Viewed` cards because that's what they are.

Alternative solution to #13225 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

![image](https://user-images.githubusercontent.com/335541/108788757-993fb780-752d-11eb-9d2b-2c7ae3213e84.png)

#### After

![Snip20210222_34](https://user-images.githubusercontent.com/335541/108788880-d441eb00-752d-11eb-9a30-41074fcd1819.png)


### TEST PLAN

Manual verification on the home page

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
