### PR TITLE
test: replace data-test-id with data-test

### DIFF
--- a/superset-frontend/spec/helpers/setup.ts
+++ b/superset-frontend/spec/helpers/setup.ts
@@ -21,5 +21,5 @@ import './shim';
 import { configure as configureTestingLibrary } from '@testing-library/react';
 
 configureTestingLibrary({
-  testIdAttribute: 'data-test-id',
+  testIdAttribute: 'data-test',
 });

--- a/superset-frontend/src/components/ModalTrigger/index.jsx
+++ b/superset-frontend/src/components/ModalTrigger/index.jsx
@@ -91,7 +91,7 @@ export default class ModalTrigger extends React.Component {
         <>
           <Button
             className="modal-trigger"
-            data-test-id="btn-modal-trigger"
+            data-test="btn-modal-trigger"
             tooltip={this.props.tooltip}
             onClick={this.open}
           >
@@ -104,11 +104,7 @@ export default class ModalTrigger extends React.Component {
     /* eslint-disable jsx-a11y/interactive-supports-focus */
     return (
       <>
-        <span
-          data-test-id="span-modal-trigger"
-          onClick={this.open}
-          role="button"
-        >
+        <span data-test="span-modal-trigger" onClick={this.open} role="button">
           {this.props.triggerNode}
         </span>
         {this.renderModal()}


### PR DESCRIPTION
### SUMMARY

Replace global default [`testAttributeId`](https://testing-library.com/docs/dom-testing-library/api-configuration/#testidattribute) for React Testing Library to `data-test` as it has been used in many places for Cypress tests already.

See: https://github.com/apache/superset/pull/13286#discussion_r580505220

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

All tests should pass

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
