### PR TITLE
fix: always recalc cache key when SQL_QUERY_MUTATOR is defined

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1465,6 +1465,12 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
         for statement in templatable_statements:
             if ExtraCache.regex.search(statement):
                 return True
+
+        # Always recalculate the cache keys since the SQL query mutator can modify the
+        # query in arbitrary ways
+        if config["SQL_QUERY_MUTATOR"]:
+            return True
+
         return False
 
     def get_extra_cache_keys(self, query_obj: QueryObjectDict) -> List[Hashable]:


### PR DESCRIPTION
### SUMMARY
Since the query mutator can change the query in arbitrary ways, I think we should always recalculate the extra cache keys when it exists.

That said, i'm not familiar with this code at all, so would really appreciate other eyes on this

### TEST PLAN
CI: ensure the sql query mutator runs on cached charts

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @betodealmeida @villebro @hughhhh @mistercrunch @john-bodley 