### PR TITLE
build: Use redis:latest in docker-compose workflow

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ x-superset-volumes: &superset-volumes
 version: "3.7"
 services:
   redis:
-    image: redis:3.2
+    image: redis:latest
     container_name: superset_cache
     restart: unless-stopped
     ports:


### PR DESCRIPTION
### SUMMARY
Redis 5.0+ is required for Global Async Query support.

### TEST PLAN
Ensure `docker-compose` functions normally in a local dev environment.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
