### PR TITLE
test: optimize codecov config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,13 +1,18 @@
+codecov:
+    notify:
+        after_n_builds: 4
 ignore:
   - "superset/migrations/versions/*.py"
 coverage:
   status:
     project:
+      informational: true
       default:
         # Commits pushed to master should not make the overall
         # project coverage decrease:
         target: auto
         threshold: 0%
     patch:
+      informational: true
       default:
         threshold: 0%

--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -191,11 +191,6 @@ cypress-run-all() {
 
   cypress-run "*/**/*"
 
-  # Upload code coverage separately so each page can have separate flags
-  # -c will clean existing coverage reports, -F means add flags
-  # || true to prevent CI failure on codecov upload
-  codecov -cF "cypress" || true
-
   # After job is done, print out Flask log for debugging
   say "::group::Flask log for default run"
   cat "$flasklog"
@@ -211,8 +206,10 @@ cypress-run-all() {
 
   cypress-run "sqllab/*" "Backend persist"
 
+  # Upload code coverage separately so each page can have separate flags
+  # -c will clean existing coverage reports, -F means add flags
   # || true to prevent CI failure on codecov upload
-  codecov -cF "cypress" || true
+  codecov -c -F "cypress" || true
 
   say "::group::Flask log for backend persist"
   cat "$flasklog"

--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -45,4 +45,4 @@ jobs:
         if: steps.check.outcome == 'failure'
         working-directory: ./superset-frontend
         run: |
-          bash <(curl -s https://codecov.io/bash) -cF javascript
+          bash <(curl -s https://codecov.io/bash) -c -F javascript

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Upload code coverage
         if: steps.check.outcome == 'failure'
         run: |
-          bash <(curl -s https://codecov.io/bash) -cF python
+          bash <(curl -s https://codecov.io/bash) -c -F python -F presto
 
   test-postgres-hive:
     if: github.event.pull_request.draft == false
@@ -158,4 +158,4 @@ jobs:
       - name: Upload code coverage
         if: steps.check.outcome == 'failure'
         run: |
-          bash <(curl -s https://codecov.io/bash) -cF python
+          bash <(curl -s https://codecov.io/bash) -c -F python -F hive

--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Upload code coverage
         if: steps.check.outcome == 'failure'
         run: |
-          bash <(curl -s https://codecov.io/bash) -cF python
+          bash <(curl -s https://codecov.io/bash) -c -F python -F mysql
 
   test-postgres:
     if: github.event.pull_request.draft == false
@@ -134,7 +134,7 @@ jobs:
       - name: Upload code coverage
         if: steps.check.outcome == 'failure'
         run: |
-          bash <(curl -s https://codecov.io/bash) -cF python
+          bash <(curl -s https://codecov.io/bash) -c -F python -F postgres
 
   test-sqlite:
     if: github.event.pull_request.draft == false
@@ -190,4 +190,4 @@ jobs:
       - name: Upload code coverage
         if: steps.check.outcome == 'failure'
         run: |
-          bash <(curl -s https://codecov.io/bash) -cF python
+          bash <(curl -s https://codecov.io/bash) -c -F python -F sqlite

--- a/scripts/ci_check_no_file_changes.sh
+++ b/scripts/ci_check_no_file_changes.sh
@@ -34,10 +34,10 @@ REGEXES=()
 for CHECK in "$@"
 do
   if [[ ${CHECK} == "python" ]]; then
-    REGEX="(^tests\/|^superset\/|^setup\.py|^requirements\/.+\.txt)"
+    REGEX="(^\.github\/workflows\/.*python|^tests\/|^superset\/|^setup\.py|^requirements\/.+\.txt)"
     echo "Searching for changes in python files"
   elif [[ ${CHECK} == "frontend" ]]; then
-    REGEX="(^superset-frontend\/)"
+    REGEX="(^\.github\/workflows\/.*(frontend|e2e)|^superset-frontend\/)"
     echo "Searching for changes in frontend files"
   else
     echo "Invalid check: \"${CHECK}\". Falling back to exiting with FAILURE code"


### PR DESCRIPTION
### SUMMARY

Optimize CodeCov config to

1. Always let GitHub CodeCov checks pass because we don't always report all test coverage (because of [conditional CI jobs](https://github.com/apache/superset/pull/12583))
2. Add more detailed flags for coverage [uploads](https://codecov.io/gh/apache/superset/commit/a700205d75abf8ad628e063c3bbf12c8625330fc/build)
3. Run tests also on workflow file changes

It seems the CodeCov App has recently been enabled in this repo (#9930), which is good, but it starts to block some PRs on status check due to false alarms of decreased test coverage.

<img width="947" alt="blocked" src="https://user-images.githubusercontent.com/335541/109105158-2fb4da00-76e2-11eb-8955-8cff809f415d.png">


This is because:

1. The target coverage setting is set to "auto", which will report any decrease in test coverage
2. We conditionally skip Python tests for pure frontend changes (and vice versa), hence certain PRs will never have the full test coverage reported.
3. Sometimes frontend and backend workflows are delayed in queue and run in very different time. After wait for a while, CodeCov may come to believe the full CI has finished, therefore reporting only partial coverage from the already finished jobs.

The [`after_n_builds`](https://docs.codecov.io/docs/notifications) config is designed to address this issue, but since we don't know which jobs will run for each PR, we can't really set a meaningful value for this config.

I'm setting it to 4 because for Python tests there are 5 uploads (mysql, postgres, sqlite, hive, presto),  and for frontend, there are 4 ([unit tests](https://github.com/apache/superset/blob/59d4e8759a0490e6b5bca8cfa87cbf1191b486d2/.github/workflows/superset-frontend.yml#L48) + Cypress * 3).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

- CI Passes and flags correctly marked on CodeCov
   <img width="1166" alt="commit-flags" src="https://user-images.githubusercontent.com/335541/109105029-f9775a80-76e1-11eb-8147-7859b9f0cba7.png">
- GH checks are not blocked by CodeCov

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
