### PR TITLE
fix: date picker support date unit with singular and plural

### DIFF
--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -210,11 +210,11 @@ def get_since_until(
                 lambda unit: f"DATEADD(DATETIME('{_relative_start}'), -1, {unit})",
             ),
             (
-                r"^last\s+([0-9]+)\s+(second|minute|hour|day|week|month|year)s$",
+                r"^last\s+([0-9]+)\s+(second|minute|hour|day|week|month|year)s?$",
                 lambda delta, unit: f"DATEADD(DATETIME('{_relative_start}'), -{int(delta)}, {unit})",  # pylint: disable=line-too-long
             ),
             (
-                r"^next\s+([0-9]+)\s+(second|minute|hour|day|week|month|year)s$",
+                r"^next\s+([0-9]+)\s+(second|minute|hour|day|week|month|year)s?$",
                 lambda delta, unit: f"DATEADD(DATETIME('{_relative_end}'), {int(delta)}, {unit})",  # pylint: disable=line-too-long
             ),
             (

--- a/tests/utils/date_parser_tests.py
+++ b/tests/utils/date_parser_tests.py
@@ -88,16 +88,16 @@ class TestDateParser(SupersetTestCase):
         expected = datetime(2016, 6, 7), datetime(2016, 11, 7)
         self.assertEqual(result, expected)
 
-        result = get_since_until("Last 5 month")
-        expected = datetime(2016, 6, 7), datetime(2016, 11, 7)
+        result = get_since_until("Last 1 month")
+        expected = datetime(2016, 10, 7), datetime(2016, 11, 7)
         self.assertEqual(result, expected)
 
         result = get_since_until("Next 5 months")
         expected = datetime(2016, 11, 7), datetime(2017, 4, 7)
         self.assertEqual(result, expected)
 
-        result = get_since_until("Next 5 month")
-        expected = datetime(2016, 11, 7), datetime(2017, 4, 7)
+        result = get_since_until("Next 1 month")
+        expected = datetime(2016, 11, 7), datetime(2016, 12, 7)
         self.assertEqual(result, expected)
 
         result = get_since_until(since="5 days")

--- a/tests/utils/date_parser_tests.py
+++ b/tests/utils/date_parser_tests.py
@@ -88,7 +88,15 @@ class TestDateParser(SupersetTestCase):
         expected = datetime(2016, 6, 7), datetime(2016, 11, 7)
         self.assertEqual(result, expected)
 
+        result = get_since_until("Last 5 month")
+        expected = datetime(2016, 6, 7), datetime(2016, 11, 7)
+        self.assertEqual(result, expected)
+
         result = get_since_until("Next 5 months")
+        expected = datetime(2016, 11, 7), datetime(2017, 4, 7)
+        self.assertEqual(result, expected)
+
+        result = get_since_until("Next 5 month")
         expected = datetime(2016, 11, 7), datetime(2017, 4, 7)
         self.assertEqual(result, expected)
 


### PR DESCRIPTION
### SUMMARY
fix date picker does not support singular data unit

closed: #13264 

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Added UT for this case

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #13264 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
