### PR TITLE
fix(query-object): extra time-range-endpoints

### DIFF
--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -30,6 +30,7 @@ from superset.utils.core import (
     FilterOperator,
     PostProcessingBoxplotWhiskerType,
     PostProcessingContributionOrientation,
+    TimeRangeEndpoint,
 )
 
 #
@@ -769,13 +770,7 @@ class ChartDataFilterSchema(Schema):
 
 class ChartDataExtrasSchema(Schema):
 
-    time_range_endpoints = fields.List(
-        fields.String(
-            validate=validate.OneOf(choices=("unknown", "inclusive", "exclusive")),
-            description="A list with two values, stating if start/end should be "
-            "inclusive/exclusive.",
-        )
-    )
+    time_range_endpoints = fields.List(EnumField(TimeRangeEndpoint, by_value=True))
     relative_start = fields.String(
         description="Start time for relative time deltas. "
         'Default: `config["DEFAULT_RELATIVE_START_TIME"]`',

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -181,8 +181,10 @@ class QueryObject:
         self.order_desc = order_desc
         self.extras = extras
 
-        if config["SIP_15_ENABLED"] and "time_range_endpoints" not in self.extras:
-            self.extras["time_range_endpoints"] = get_time_range_endpoints(form_data={})
+        if config["SIP_15_ENABLED"]:
+            self.extras["time_range_endpoints"] = get_time_range_endpoints(
+                form_data=self.extras
+            )
 
         self.columns = columns
         self.groupby = groupby or []

--- a/tests/fixtures/query_context.py
+++ b/tests/fixtures/query_context.py
@@ -17,13 +17,16 @@
 import copy
 from typing import Any, Dict, List
 
-from superset.utils.core import AnnotationType, DTTM_ALIAS
+from superset.utils.core import AnnotationType, DTTM_ALIAS, TimeRangeEndpoint
 from tests.base_tests import get_table_by_name
 
 query_birth_names = {
     "extras": {
         "where": "",
-        "time_range_endpoints": ["inclusive", "exclusive"],
+        "time_range_endpoints": (
+            TimeRangeEndpoint.INCLUSIVE,
+            TimeRangeEndpoint.EXCLUSIVE,
+        ),
         "time_grain_sqla": "P1D",
     },
     "groupby": ["name"],


### PR DESCRIPTION
### SUMMARY

I'm really perplexed why this issue has recently surfaced and/or been reported and why it only applies to certain visualization types (is there any chance [this](https://github.com/apache-superset/superset-ui/blob/master/packages/superset-ui-core/src/query/extractExtras.ts) is overridden by various chart types), but it seems like the Python date format wasn't being adhered to due to poorly formed extra time-range-endpoints.

More specifically for the QueryObject the `extra` fields are coming from `superset-ui` where, if defined, the `time_range_endpoints` is a tuple of strings which are never converted to a tuple of `TimeRangeEndpoint` enums and thus [this](https://github.com/apache/superset/blob/0a00153375fb69891c2a9f0115a33cdf5551b2d6/superset/connectors/sqla/models.py#L309) check is false meaning the default date format is never adhered to.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
