### PR TITLE
fix: Change default upload folder to DATA_DIR

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -441,11 +441,11 @@ SCREENSHOT_LOAD_WAIT = 60
 # Image and file configuration
 # ---------------------------------------------------
 # The file upload folder, when using models with files
-UPLOAD_FOLDER = BASE_DIR + "/app/static/uploads/"
+UPLOAD_FOLDER = DATA_DIR + "/app/static/uploads/"
 UPLOAD_CHUNK_SIZE = 4096
 
 # The image upload folder, when using models with images
-IMG_UPLOAD_FOLDER = BASE_DIR + "/app/static/uploads/"
+IMG_UPLOAD_FOLDER = DATA_DIR + "/app/static/uploads/"
 
 # The image upload url, when using models with images
 IMG_UPLOAD_URL = "/static/uploads/"


### PR DESCRIPTION
Signed-off-by: Đặng Minh Dũng <dungdm93@live.com>

### SUMMARY
Currently, `UPLOAD_FOLDER` and `IMG_UPLOAD_FOLDER` is based on `BASE_DIR` which will lead to `FileNotFoundError` when install superset as root, but run as normal user (e.g in **container** environment)
![image](https://user-images.githubusercontent.com/6848311/109134944-292d6d80-7789-11eb-9d40-4c5f70362952.png)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
