### PR TITLE
fix: Table filter bug

### DIFF
--- a/superset-frontend/src/dashboard/reducers/getInitialState.js
+++ b/superset-frontend/src/dashboard/reducers/getInitialState.js
@@ -170,7 +170,7 @@ export default function getInitialState(bootstrapData) {
     // build DashboardFilters for interactive filter features
     if (
       slice.form_data.viz_type === 'filter_box' ||
-      slice.form_data.viz_type === 'filter_select' || 
+      slice.form_data.viz_type === 'filter_select' ||
       slice.form_data.viz_type === 'table'
     ) {
       const configs = getFilterConfigsFromFormdata(slice.form_data);

--- a/superset-frontend/src/dashboard/reducers/getInitialState.js
+++ b/superset-frontend/src/dashboard/reducers/getInitialState.js
@@ -170,7 +170,8 @@ export default function getInitialState(bootstrapData) {
     // build DashboardFilters for interactive filter features
     if (
       slice.form_data.viz_type === 'filter_box' ||
-      slice.form_data.viz_type === 'filter_select'
+      slice.form_data.viz_type === 'filter_select' || 
+      slice.form_data.viz_type === 'table'
     ) {
       const configs = getFilterConfigsFromFormdata(slice.form_data);
       let { columns } = configs;


### PR DESCRIPTION
Create dashboardFilters initial state for table components

### SUMMARY
Tables can emit filters changes but they throw an error in the dashboardFilter reducer as the state has not been initialized. This restores previous functionality with table filters. 

### TEST PLAN
Install superset following the CONTRIBUTING.md guide and test with Examples. 


### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #8273
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
