### PR TITLE
fix(dashboard): Get dashboard by slug

### DIFF
--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -100,29 +100,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     class_permission_name = "Dashboard"
     method_permission_name = MODEL_API_RW_METHOD_PERMISSION_MAP
 
-    show_columns = [
-        "id",
-        "charts",
-        "css",
-        "dashboard_title",
-        "json_metadata",
-        "owners.id",
-        "owners.username",
-        "owners.first_name",
-        "owners.last_name",
-        "roles.id",
-        "roles.name",
-        "changed_by_name",
-        "changed_by_url",
-        "changed_by.username",
-        "changed_on",
-        "position_json",
-        "published",
-        "url",
-        "slug",
-        "table_names",
-        "thumbnail_url",
-    ]
     list_columns = [
         "id",
         "published",

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -244,7 +244,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
               $ref: '#/components/responses/404'
         """
         try:
-            dash = Dashboard.get(id_or_slug)
+            dash = DashboardDAO.get_dashboard(id_or_slug)
             result = self.dashboard_response_schema.dump(dash)
             return self.response(200, result=result)
         except DashboardNotFoundError:

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -58,9 +58,9 @@ from superset.dashboards.filters import (
     FilterRelatedRoles,
 )
 from superset.dashboards.schemas import (
+    DashboardGetResponseSchema,
     DashboardPostSchema,
     DashboardPutSchema,
-    DashboardResponseSchema,
     get_delete_ids_schema,
     get_export_ids_schema,
     get_fav_star_ids_schema,
@@ -168,7 +168,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     add_model_schema = DashboardPostSchema()
     edit_model_schema = DashboardPutSchema()
     chart_entity_response_schema = ChartEntityResponseSchema()
-    dashboard_response_schema = DashboardResponseSchema()
+    dashboard_response_schema = DashboardGetResponseSchema()
 
     base_filters = [["slice", DashboardFilter, lambda: []]]
 
@@ -188,7 +188,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     """ Override the name set for this collection of endpoints """
     openapi_spec_component_schemas = (
         ChartEntityResponseSchema,
-        DashboardResponseSchema,
+        DashboardGetResponseSchema,
         GetFavStarIdsSchema,
     )
     apispec_parameter_schemas = {
@@ -224,6 +224,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             schema:
               type: string
             name: id_or_slug
+            description: Either the id of the dashboard, or its slug
           responses:
             200:
               description: Dashboard
@@ -245,7 +246,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         """
         # pylint: disable=arguments-differ
         try:
-            dash = DashboardDAO.get_dashboard(id_or_slug)
+            dash = DashboardDAO.get_by_id_or_slug(id_or_slug)
             result = self.dashboard_response_schema.dump(dash)
             return self.response(200, result=result)
         except DashboardNotFoundError:

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -243,6 +243,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             404:
               $ref: '#/components/responses/404'
         """
+        # pylint: disable=arguments-differ
         try:
             dash = DashboardDAO.get_dashboard(id_or_slug)
             result = self.dashboard_response_schema.dump(dash)

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -168,7 +168,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     add_model_schema = DashboardPostSchema()
     edit_model_schema = DashboardPutSchema()
     chart_entity_response_schema = ChartEntityResponseSchema()
-    dashboard_response_schema = DashboardGetResponseSchema()
+    dashboard_get_response_schema = DashboardGetResponseSchema()
 
     base_filters = [["slice", DashboardFilter, lambda: []]]
 
@@ -234,7 +234,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
                     type: object
                     properties:
                       result:
-                        $ref: '#/components/schemas/DashboardResponseSchema'
+                        $ref: '#/components/schemas/DashboardGetResponseSchema'
             302:
               description: Redirects to the current digest
             400:
@@ -247,7 +247,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         # pylint: disable=arguments-differ
         try:
             dash = DashboardDAO.get_by_id_or_slug(id_or_slug)
-            result = self.dashboard_response_schema.dump(dash)
+            result = self.dashboard_get_response_schema.dump(dash)
             return self.response(200, result=result)
         except DashboardNotFoundError:
             return self.response_404()

--- a/superset/dashboards/dao.py
+++ b/superset/dashboards/dao.py
@@ -27,7 +27,7 @@ from superset.dashboards.commands.exceptions import DashboardNotFoundError
 from superset.dashboards.filters import DashboardFilter
 from superset.extensions import db
 from superset.models.core import FavStar, FavStarClassName
-from superset.models.dashboard import Dashboard
+from superset.models.dashboard import Dashboard, id_or_slug_filter
 from superset.models.slice import Slice
 from superset.utils.dashboard_filter_scopes_converter import copy_filter_scopes
 
@@ -40,9 +40,7 @@ class DashboardDAO(BaseDAO):
 
     @staticmethod
     def get_dashboard(id_or_slug: str) -> Dashboard:
-        query = db.session.query(Dashboard).filter(
-            Dashboard.id_or_slug_filter(id_or_slug)
-        )
+        query = db.session.query(Dashboard).filter(id_or_slug_filter(id_or_slug))
         # Apply dashboard base filters
         query = DashboardFilter("id", SQLAInterface(Dashboard, db.session)).apply(
             query, None

--- a/superset/dashboards/dao.py
+++ b/superset/dashboards/dao.py
@@ -25,9 +25,9 @@ from sqlalchemy.orm import contains_eager
 from superset.dao.base import BaseDAO
 from superset.dashboards.commands.exceptions import DashboardNotFoundError
 from superset.dashboards.filters import DashboardFilter
-from superset.extensions import db, security_manager
+from superset.extensions import db
 from superset.models.core import FavStar, FavStarClassName
-from superset.models.dashboard import Dashboard, dashboard_user
+from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.utils.dashboard_filter_scopes_converter import copy_filter_scopes
 

--- a/superset/dashboards/dao.py
+++ b/superset/dashboards/dao.py
@@ -39,8 +39,15 @@ class DashboardDAO(BaseDAO):
     base_filter = DashboardFilter
 
     @staticmethod
-    def get_dashboard(id_or_slug: str) -> Dashboard:
-        query = db.session.query(Dashboard).filter(id_or_slug_filter(id_or_slug))
+    def get_by_id_or_slug(id_or_slug: str) -> Dashboard:
+        query = (
+            db.session.query(Dashboard)
+            .filter(id_or_slug_filter(id_or_slug))
+            .outerjoin(Slice, Dashboard.slices)
+            .outerjoin(Slice.table)
+            .outerjoin(Dashboard.owners)
+            .outerjoin(Dashboard.roles)
+        )
         # Apply dashboard base filters
         query = DashboardFilter("id", SQLAInterface(Dashboard, db.session)).apply(
             query, None

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -61,7 +61,9 @@ published_description = (
     "Determines whether or not this dashboard is visible in "
     "the list of all dashboards."
 )
-
+charts_description = (
+    "The names of the dashboard's charts. Names are used for legacy reasons."
+)
 
 openapi_spec_methods_override = {
     "get": {"get": {"description": "Get a dashboard detail information."}},
@@ -119,6 +121,45 @@ class DashboardJSONMetadataSchema(Schema):
     stagger_time = fields.Integer()
     color_scheme = fields.Str(allow_none=True)
     label_colors = fields.Dict()
+
+
+class UserSchema(Schema):
+    id = fields.Int()
+    username = fields.String()
+    first_name = fields.String()
+    last_name = fields.String()
+
+
+class RolesSchema(Schema):
+    id = fields.Int()
+    name = fields.String()
+
+
+class DatasourceSchema(Schema):
+    id = fields.Int()
+    name = fields.String()
+    description = fields.String()
+
+
+class DashboardResponseSchema(Schema):
+    id = fields.Int()
+    slug = fields.String()
+    url = fields.String()
+    dashboard_title = fields.String(description=dashboard_title_description)
+    thumbnail_url = fields.String()
+    published = fields.Boolean()
+    css = fields.String(description=css_description)
+    json_metadata = fields.String(description=json_metadata_description)
+    position_json = fields.String(description=position_json_description)
+    changed_by_name = fields.String()
+    changed_by_url = fields.String()
+    changed_by = fields.Nested(UserSchema)
+    changed_on = fields.DateTime()
+    charts = fields.List(fields.String(description=charts_description))
+    owners = fields.List(fields.Nested(UserSchema))
+    roles = fields.List(fields.Nested(RolesSchema))
+    datasources = fields.List(fields.Nested(DatasourceSchema))
+    table_names = fields.String()  # legacy nonsense
 
 
 class BaseDashboardSchema(Schema):

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -135,13 +135,7 @@ class RolesSchema(Schema):
     name = fields.String()
 
 
-class DatasourceSchema(Schema):
-    id = fields.Int()
-    name = fields.String()
-    description = fields.String()
-
-
-class DashboardResponseSchema(Schema):
+class DashboardGetResponseSchema(Schema):
     id = fields.Int()
     slug = fields.String()
     url = fields.String()
@@ -158,7 +152,6 @@ class DashboardResponseSchema(Schema):
     charts = fields.List(fields.String(description=charts_description))
     owners = fields.List(fields.Nested(UserSchema))
     roles = fields.List(fields.Nested(RolesSchema))
-    datasources = fields.List(fields.Nested(DatasourceSchema))
     table_names = fields.String()  # legacy nonsense
 
 

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -58,6 +58,8 @@ from superset.utils import core as utils
 from superset.utils.decorators import debounce
 from superset.utils.urls import get_url_path
 
+# pylint: disable=too-many-public-methods
+
 metadata = Model.metadata  # pylint: disable=no-member
 config = app.config
 logger = logging.getLogger(__name__)
@@ -153,8 +155,6 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
         "css",
         "slug",
     ]
-
-    # pylint: disable=too-many-public-methods
 
     def __repr__(self) -> str:
         return f"Dashboard<{self.id or self.slug}>"
@@ -362,16 +362,16 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
         )
 
     @classmethod
-    def id_or_slug_filter(cls, id_or_slug: str) -> BinaryExpression:
-        if id_or_slug.isdigit():
-            return Dashboard.id == int(id_or_slug)
-        return Dashboard.slug == id_or_slug
-
-    @classmethod
     def get(cls, id_or_slug: str) -> Dashboard:
         session = db.session()
-        qry = session.query(Dashboard).filter(Dashboard.id_or_slug_filter(id_or_slug))
+        qry = session.query(Dashboard).filter(id_or_slug_filter(id_or_slug))
         return qry.one_or_none()
+
+
+def id_or_slug_filter(id_or_slug: str) -> BinaryExpression:
+    if id_or_slug.isdigit():
+        return Dashboard.id == int(id_or_slug)
+    return Dashboard.slug == id_or_slug
 
 
 OnDashboardChange = Callable[[Mapper, Connection, Dashboard], Any]

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -42,6 +42,7 @@ from sqlalchemy.orm import relationship, sessionmaker, subqueryload
 from sqlalchemy.orm.mapper import Mapper
 from sqlalchemy.orm.session import object_session
 from sqlalchemy.sql import join, select
+from sqlalchemy.sql.elements import BinaryExpression
 
 from superset import app, ConnectorRegistry, db, is_feature_enabled, security_manager
 from superset.connectors.base.models import BaseDatasource
@@ -359,14 +360,16 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
         )
 
     @classmethod
+    def id_or_slug_filter(cls, id_or_slug: str) -> BinaryExpression:
+        if id_or_slug.isdigit():
+            return Dashboard.id == int(id_or_slug)
+        else:
+            return Dashboard.slug == id_or_slug
+
+    @classmethod
     def get(cls, id_or_slug: str) -> Dashboard:
         session = db.session()
-        qry = session.query(Dashboard)
-        if id_or_slug.isdigit():
-            qry = qry.filter_by(id=int(id_or_slug))
-        else:
-            qry = qry.filter_by(slug=id_or_slug)
-
+        qry = session.query(Dashboard).filter(Dashboard.id_or_slug_filter(id_or_slug))
         return qry.one_or_none()
 
 

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -154,6 +154,8 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
         "slug",
     ]
 
+    # pylint: disable=too-many-public-methods
+
     def __repr__(self) -> str:
         return f"Dashboard<{self.id or self.slug}>"
 
@@ -363,8 +365,7 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
     def id_or_slug_filter(cls, id_or_slug: str) -> BinaryExpression:
         if id_or_slug.isdigit():
             return Dashboard.id == int(id_or_slug)
-        else:
-            return Dashboard.slug == id_or_slug
+        return Dashboard.slug == id_or_slug
 
     @classmethod
     def get(cls, id_or_slug: str) -> Dashboard:

--- a/tests/dashboards/api_tests.py
+++ b/tests/dashboards/api_tests.py
@@ -170,6 +170,32 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
             db.session.commit()
 
     @pytest.mark.usefixtures("create_dashboards")
+    def get_dashboard_by_slug(self):
+        self.login(username="admin")
+        dashboard = self.dashboards[0]
+        uri = f"api/v1/dashboard/{dashboard.slug}"
+        response = self.get_assert_metric(uri, "get")
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data.decode("utf-8"))
+        self.assertEqual(data["id"], dashboard.id)
+
+    @pytest.mark.usefixtures("create_dashboards")
+    def get_dashboard_by_bad_slug(self):
+        self.login(username="admin")
+        dashboard = self.dashboards[0]
+        uri = f"api/v1/dashboard/{dashboard.slug}-bad-slug"
+        response = self.get_assert_metric(uri, "get")
+        self.assertEqual(response.status_code, 404)
+
+    @pytest.mark.usefixtures("create_dashboards")
+    def get_dashboard_by_slug_not_allowed(self):
+        self.login(username="gamma")
+        dashboard = self.dashboards[0]
+        uri = f"api/v1/dashboard/{dashboard.slug}"
+        response = self.get_assert_metric(uri, "get")
+        self.assertEqual(response.status_code, 404)
+
+    @pytest.mark.usefixtures("create_dashboards")
     def test_get_dashboard_charts(self):
         """
         Dashboard API: Test getting charts belonging to a dashboard
@@ -241,6 +267,7 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
             "id": dashboard.id,
             "css": "",
             "dashboard_title": "title",
+            "datasources": [],
             "json_metadata": "",
             "owners": [
                 {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Need get dashboard by slug. Can't get dashboard by slug. Override default FAB endpoint to get dashboard by slug.

Also add field `datasources`, two birds one stone.

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Tests to be written.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
