### PR TITLE
feat: add unit test for LimitMethod.FETCH_MANY

### DIFF
--- a/tests/db_engine_specs/base_engine_spec_tests.py
+++ b/tests/db_engine_specs/base_engine_spec_tests.py
@@ -20,7 +20,11 @@ from unittest import mock
 import pytest
 
 from superset.db_engine_specs import engines
-from superset.db_engine_specs.base import BaseEngineSpec, builtin_time_grains
+from superset.db_engine_specs.base import (
+    BaseEngineSpec,
+    builtin_time_grains,
+    LimitMethod,
+)
 from superset.db_engine_specs.sqlite import SqliteEngineSpec
 from superset.sql_parse import ParsedQuery
 from superset.utils.core import get_example_database
@@ -152,6 +156,14 @@ class TestDbEngineSpecs(TestDbEngineSpec):
     def test_limit_with_non_token_limit(self):
         self.sql_limit_regex(
             """SELECT 'LIMIT 777'""", """SELECT 'LIMIT 777'\nLIMIT 1000"""
+        )
+
+    def test_limit_with_fetch_many(self):
+        class DummyEngineSpec(BaseEngineSpec):
+            limit_method = LimitMethod.FETCH_MANY
+
+        self.sql_limit_regex(
+            "SELECT * FROM table", "SELECT * FROM table", DummyEngineSpec
         )
 
     def test_time_grain_denylist(self):


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add a unit test covering `LimitMethod.FETCH_MANY` when adding limit to a query. The Firebird engine spec (https://github.com/apache/superset/pull/13353) is the first one using the method, and uncovered a 3-year old bug that is captured by test.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

That's it. The PR is the test. :)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
