### PR TITLE
build: fix codecov informational config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,13 +6,13 @@ ignore:
 coverage:
   status:
     project:
-      informational: true
       default:
+        informational: true
         # Commits pushed to master should not make the overall
         # project coverage decrease:
         target: auto
         threshold: 0%
     patch:
-      informational: true
       default:
+        informational: true
         threshold: 0%


### PR DESCRIPTION
### SUMMARY

The [`informational`](https://docs.codecov.io/docs/commit-status#branches) flag added by #13329 was incorrectly added, which means the status checks were not really turned off as expected.

This PR should fix it.

Long-term solution is to use [Carryforward Flags](https://docs.codecov.io/docs/carryforward-flags) as suggested here: https://github.com/apache/superset/issues/9930#issuecomment-785978529

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

1. CI should pass
2. After merge, CI should not be blocked in PRs that do not run all jobs.

Example: https://github.com/apache/superset/pull/13374

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
