### PR TITLE
test: Adds tests and storybook to RefreshLabel

### DIFF
--- a/superset-frontend/src/components/DatabaseSelector.tsx
+++ b/superset-frontend/src/components/DatabaseSelector.tsx
@@ -21,9 +21,8 @@ import { styled, SupersetClient, t } from '@superset-ui/core';
 import rison from 'rison';
 import { Select } from 'src/components/Select';
 import Label from 'src/components/Label';
-
+import RefreshLabel from 'src/components/RefreshLabel';
 import SupersetAsyncSelect from './AsyncSelect';
-import RefreshLabel from './RefreshLabel';
 
 const FieldTitle = styled.p`
   color: ${({ theme }) => theme.colors.secondary.light2};
@@ -41,6 +40,7 @@ const DatabaseSelectorWrapper = styled.div`
     display: flex;
     align-items: center;
     width: 30px;
+    margin-left: ${({ theme }) => theme.gridUnit}px;
   }
 
   .section {

--- a/superset-frontend/src/components/Icon/index.tsx
+++ b/superset-frontend/src/components/Icon/index.tsx
@@ -405,7 +405,7 @@ export const iconsRegistry: Record<
   warning: WarningIcon,
 };
 
-interface IconProps extends SVGProps<SVGSVGElement> {
+export interface IconProps extends SVGProps<SVGSVGElement> {
   name: IconName;
 }
 

--- a/superset-frontend/src/components/RefreshLabel/RefreshLabel.stories.tsx
+++ b/superset-frontend/src/components/RefreshLabel/RefreshLabel.stories.tsx
@@ -16,12 +16,29 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import '../../stylesheets/less/variables.less';
+import React from 'react';
+import RefreshLabel, { RefreshLabelProps } from '.';
 
-.RefreshLabel {
-  color: @bs-gray-light;
+export default {
+  title: 'RefreshLabel',
+};
 
-  &:hover {
-    color: @brand-primary;
-  }
-}
+export const InteractiveRefreshLabel = (args: RefreshLabelProps) => (
+  <RefreshLabel {...args} />
+);
+
+InteractiveRefreshLabel.args = {
+  tooltipContent: 'Tooltip',
+};
+
+InteractiveRefreshLabel.argTypes = {
+  onClick: { action: 'onClick' },
+};
+
+InteractiveRefreshLabel.story = {
+  parameters: {
+    knobs: {
+      disable: true,
+    },
+  },
+};

--- a/superset-frontend/src/components/RefreshLabel/RefreshLabel.test.tsx
+++ b/superset-frontend/src/components/RefreshLabel/RefreshLabel.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { render, screen } from 'spec/helpers/testing-library';
+import userEvent from '@testing-library/user-event';
+import RefreshLabel from 'src/components/RefreshLabel';
+
+test('renders with default props', () => {
+  render(<RefreshLabel tooltipContent="Tooltip" onClick={jest.fn()} />);
+  const refresh = screen.getByRole('button');
+  expect(refresh).toBeInTheDocument();
+  userEvent.hover(refresh);
+});
+
+test('renders tooltip on hover', async () => {
+  const tooltipText = 'Tooltip';
+  render(<RefreshLabel tooltipContent={tooltipText} onClick={jest.fn()} />);
+  const refresh = screen.getByRole('button');
+  userEvent.hover(refresh);
+  const tooltip = await screen.findByRole('tooltip');
+  expect(tooltip).toBeInTheDocument();
+  expect(tooltip).toHaveTextContent(tooltipText);
+});
+
+test('triggers on click event', () => {
+  const onClick = jest.fn();
+  render(<RefreshLabel tooltipContent="Tooltip" onClick={onClick} />);
+  const refresh = screen.getByRole('button');
+  userEvent.click(refresh);
+  expect(onClick).toHaveBeenCalled();
+});

--- a/superset-frontend/src/components/RefreshLabel/index.tsx
+++ b/superset-frontend/src/components/RefreshLabel/index.tsx
@@ -16,32 +16,36 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, { MouseEventHandler } from 'react';
+import { SupersetTheme } from '@superset-ui/core';
 import { Tooltip } from 'src/common/components/Tooltip';
+import Icon, { IconProps } from 'src/components/Icon';
 
-import './RefreshLabel.less';
-
-const propTypes = {
-  onClick: PropTypes.func,
-  tooltipContent: PropTypes.string.isRequired,
-};
-
-class RefreshLabel extends React.PureComponent {
-  render() {
-    return (
-      <Tooltip title={this.props.tooltipContent} id="cache-desc-tooltip">
-        <i
-          aria-label="Icon"
-          role="button"
-          tabIndex={0}
-          className="RefreshLabel fa fa-refresh pointer"
-          onClick={this.props.onClick}
-        />
-      </Tooltip>
-    );
-  }
+export interface RefreshLabelProps {
+  onClick: MouseEventHandler<SVGSVGElement>;
+  tooltipContent: string;
 }
-RefreshLabel.propTypes = propTypes;
+
+const RefreshLabel = ({ onClick, tooltipContent }: RefreshLabelProps) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const IconWithoutRef = React.forwardRef((props: IconProps, ref: any) => (
+    <Icon {...props} />
+  ));
+
+  return (
+    <Tooltip title={tooltipContent}>
+      <IconWithoutRef
+        role="button"
+        onClick={onClick}
+        name="refresh"
+        css={(theme: SupersetTheme) => ({
+          cursor: 'pointer',
+          color: theme.colors.grayscale.base,
+          '&:hover': { color: theme.colors.primary.base },
+        })}
+      />
+    </Tooltip>
+  );
+};
 
 export default RefreshLabel;

--- a/superset-frontend/src/components/TableSelector.less
+++ b/superset-frontend/src/components/TableSelector.less
@@ -22,12 +22,6 @@
   padding-left: 9px;
 }
 
-.TableSelector .refresh-col {
-  display: flex;
-  align-items: center;
-  width: 30px;
-}
-
 .TableSelector .section {
   padding-bottom: 5px;
   display: flex;

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -47,6 +47,7 @@ const TableSelectorWrapper = styled.div`
     display: flex;
     align-items: center;
     width: 30px;
+    margin-left: ${({ theme }) => theme.gridUnit}px;
   }
 
   .section {


### PR DESCRIPTION
### SUMMARY
- Coverts `RefreshLabel` to functional component with typescript
- Adds tests and storybook to `RefreshLabel`
- Changes `RefreshLabel` to use the new `Icon` component
- Removes `less` files

### TEST PLAN
1 - Execute `RefreshLabel` tests
2 - All tests should pass

@rusackas 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
