### PR TITLE
chore: Moves TableSelector tests to component's folder

### DIFF
--- a/superset-frontend/src/components/TableSelector/TableSelector.test.jsx
+++ b/superset-frontend/src/components/TableSelector/TableSelector.test.jsx
@@ -29,7 +29,7 @@ import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
 
 import DatabaseSelector from 'src/components/DatabaseSelector';
 import TableSelector from 'src/components/TableSelector';
-import { initialState, tables } from '../sqllab/fixtures';
+import { initialState, tables } from 'spec/javascripts/sqllab/fixtures';
 
 const mockStore = configureStore([thunk]);
 const store = mockStore(initialState);

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -27,9 +27,9 @@ import { AsyncSelect, CreatableSelect, Select } from 'src/components/Select';
 
 import FormLabel from 'src/components/FormLabel';
 
-import DatabaseSelector from './DatabaseSelector';
-import RefreshLabel from './RefreshLabel';
-import CertifiedIconWithTooltip from './CertifiedIconWithTooltip';
+import DatabaseSelector from 'src/components/DatabaseSelector';
+import RefreshLabel from 'src/components/RefreshLabel';
+import CertifiedIconWithTooltip from 'src/components/CertifiedIconWithTooltip';
 
 const FieldTitle = styled.p`
   color: ${({ theme }) => theme.colors.secondary.light2};


### PR DESCRIPTION
### SUMMARY
Moves `TableSelector` tests to component's folder.

@rusackas 

### TEST PLAN
1 - Execute `TableSelector` tests
2 - All tests should pass

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
