### PR TITLE
fix: use semver for badge sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Superset
 =========
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/apache/superset)
+![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/apache/superset?sort=semver)
 [![Build Status](https://github.com/apache/superset/workflows/Python/badge.svg)](https://github.com/apache/superset/actions)
 [![PyPI version](https://badge.fury.io/py/apache-superset.svg)](https://badge.fury.io/py/apache-superset)
 [![Coverage Status](https://codecov.io/github/apache/superset/coverage.svg?branch=master)](https://codecov.io/github/apache/superset)


### PR DESCRIPTION
### SUMMARY
We want to show the latest release badge based on semver. Currently the badge shows v38.0.1 on the readme

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

after:
<img width="128" alt="Screenshot_3_2_21__1_55_PM" src="https://user-images.githubusercontent.com/5186919/109720548-176c1180-7b5f-11eb-825f-2fb593eb118e.png">



### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
