### PR TITLE
fix: Adding v0 import/export fields to dashboard metadata schema

### DIFF
--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -119,6 +119,9 @@ class DashboardJSONMetadataSchema(Schema):
     stagger_time = fields.Integer()
     color_scheme = fields.Str(allow_none=True)
     label_colors = fields.Dict()
+    # used for v0 import/export
+    import_time = fields.Integer()
+    remote_id = fields.Integer()
 
 
 class BaseDashboardSchema(Schema):


### PR DESCRIPTION
### SUMMARY
We see errors editing the metadata for dashboards that were imported using the v0 import/export feature. I'm adding those fields to the DashboardJSONMetadataSchema so we don't see those errors on validation. I'm adding these fields to the schema instead of removing them because the v0 import/export feature [uses](https://github.com/apache/superset/blob/45738ffc1dfe94deb6578b6e5b0d6687558969e9/superset/dashboards/commands/importers/v0.py#L49-L50) them. 

I tested this change by editing a chart with these fields, let me know if there's anything else to test with this change.

### TEST PLAN
I tested editing a chart that had these fields in the dashboard `json_metadata`.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #10742
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

@betodealmeida @dpgaspar @serenajiang 