### PR TITLE
chore: clean remaining old directed force graph code

### DIFF
--- a/superset-frontend/src/explore/components/controls/VizTypeControl.jsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl.jsx
@@ -85,7 +85,7 @@ const DEFAULT_ORDER = [
   'partition',
   'event_flow',
   'deck_path',
-  'directed_force',
+  'graph_chart',
   'world_map',
   'paired_ttest',
   'para',

--- a/superset/examples/energy.py
+++ b/superset/examples/energy.py
@@ -94,23 +94,21 @@ def load_energy(
 
     slc = Slice(
         slice_name="Energy Force Layout",
-        viz_type="directed_force",
+        viz_type="graph_chart",
         datasource_type="table",
         datasource_id=tbl.id,
         params=textwrap.dedent(
             """\
         {
-            "charge": "-500",
-            "collapsed_fieldsets": "",
-            "groupby": [
-                "source",
-                "target"
-            ],
-            "link_length": "200",
+            "source": "source",
+            "target": "target",
+            "edgeLength": 400,
+            "repulsion": 1000,
+            "layout": "force",
             "metric": "sum__value",
             "row_limit": "5000",
             "slice_name": "Force",
-            "viz_type": "directed_force"
+            "viz_type": "graph_chart"
         }
         """
         ),

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1898,31 +1898,6 @@ class SankeyViz(BaseViz):
         return recs
 
 
-class DirectedForceViz(BaseViz):
-
-    """An animated directed force layout graph visualization"""
-
-    viz_type = "directed_force"
-    verbose_name = _("Directed Force Layout")
-    credits = 'd3noob @<a href="http://bl.ocks.org/d3noob/5141278">bl.ocks.org</a>'
-    is_timeseries = False
-
-    def query_obj(self) -> QueryObjectDict:
-        qry = super().query_obj()
-        if len(self.form_data["groupby"]) != 2:
-            raise QueryObjectValidationError(_("Pick exactly 2 columns to 'Group By'"))
-        qry["metrics"] = [self.form_data["metric"]]
-        if self.form_data.get("sort_by_metric", False):
-            qry["orderby"] = [(qry["metrics"][0], False)]
-        return qry
-
-    def get_data(self, df: pd.DataFrame) -> VizData:
-        if df.empty:
-            return None
-        df.columns = ["source", "target", "value"]
-        return df.to_dict(orient="records")
-
-
 class ChordViz(BaseViz):
 
     """A Chord diagram"""

--- a/tests/fixtures/energy_dashboard.py
+++ b/tests/fixtures/energy_dashboard.py
@@ -141,16 +141,17 @@ def _get_energy_slices():
         },
         {
             "slice_title": "Energy Force Layout",
-            "viz_type": "directed_force",
+            "viz_type": "graph_chart",
             "params": {
-                "charge": "-500",
-                "collapsed_fieldsets": "",
-                "groupby": ["source", "target"],
-                "link_length": "200",
+                "source": "source",
+                "target": "target",
+                "edgeLength": 400,
+                "repulsion": 1000,
+                "layout": "force",
                 "metric": "sum__value",
                 "row_limit": "5000",
                 "slice_name": "Force",
-                "viz_type": "directed_force",
+                "viz_type": "graph_chart",
             },
         },
         {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This cleans up remaining code used for directed force chart which was recently migrated to Echart's graph chart in this [PR](https://github.com/apache/superset/pull/13111)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
1.Remove all graphs from slices table and run ```superset load_examples``` and ```superset init```.
It should load slices of viz_type graph_chart and not directed_force.
2.Run existing tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
