### PR TITLE
docs: deprecate old alerts and dash/charts reports

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -26,6 +26,13 @@ assists people when migrating to a new version.
 ### Breaking Changes
 ### Potential Downtime
 ### Deprecations
+- [11509](https://github.com/apache/superset/pull/12491): Dashboard/Charts reports and old Alerts is deprecated. The following config keys are deprecated:
+    - ENABLE_ALERTS
+    - SCHEDULED_EMAIL_DEBUG_MODE
+    - EMAIL_REPORTS_CRON_RESOLUTION
+    - EMAIL_ASYNC_TIME_LIMIT_SEC
+    - EMAIL_REPORT_BCC_ADDRESS
+    - EMAIL_REPORTS_USER
 ### Other
 
 [shillelagh](https://github.com/betodealmeida/shillelagh/) is now the recommended module to connect Superset to Google Spreadsheets, since it's more robust and has extensive test coverage. You should uninstall the `gsheetsdb` module and install the `shillelagh` module in its place. Shillelagh is a drop-in replacement, so no modifications are needed to be done on existing queries, datasets or charts.

--- a/docs/src/pages/docs/installation/alerts_reports.mdx
+++ b/docs/src/pages/docs/installation/alerts_reports.mdx
@@ -343,7 +343,7 @@ are not accessible to unauthorized requests, that is why the worker needs to tak
 of an existing user to take a snapshot.
 
 ```python
-EMAIL_REPORTS_USER = 'username_with_permission_to_access_dashboards'
+THUMBNAIL_SELENIUM_USER = 'username_with_permission_to_access_dashboards'
 ```
 
 **Important notes**

--- a/superset/app.py
+++ b/superset/app.py
@@ -412,6 +412,10 @@ class SupersetAppInitializer:
         # Conditionally setup email views
         #
         if self.config["ENABLE_SCHEDULED_EMAIL_REPORTS"]:
+            logging.warning(
+                "ENABLE_SCHEDULED_EMAIL_REPORTS "
+                "is deprecated and will be removed in version 2.0.0"
+            )
             appbuilder.add_separator("Manage")
             appbuilder.add_view(
                 DashboardEmailScheduleView,
@@ -431,6 +435,9 @@ class SupersetAppInitializer:
             )
 
         if self.config["ENABLE_ALERTS"]:
+            logging.warning(
+                "ENABLE_ALERTS is deprecated and will be removed in version 2.0.0"
+            )
             appbuilder.add_view(
                 AlertModelView,
                 "Alerts",

--- a/superset/config.py
+++ b/superset/config.py
@@ -424,6 +424,7 @@ EXTRA_SEQUENTIAL_COLOR_SCHEMES: List[Dict[str, Any]] = []
 
 # ---------------------------------------------------
 # Thumbnail config (behind feature flag)
+# Also used by Alerts & Reports
 # ---------------------------------------------------
 THUMBNAIL_SELENIUM_USER = "admin"
 THUMBNAIL_CACHE_CONFIG: CacheConfig = {
@@ -614,18 +615,8 @@ class CeleryConfig:  # pylint: disable=too-few-public-methods
     CELERY_ACKS_LATE = False
     CELERY_ANNOTATIONS = {
         "sql_lab.get_sql_results": {"rate_limit": "100/s"},
-        "email_reports.send": {
-            "rate_limit": "1/s",
-            "time_limit": 120,
-            "soft_time_limit": 150,
-            "ignore_result": True,
-        },
     }
     CELERYBEAT_SCHEDULE = {
-        "email_reports.schedule_hourly": {
-            "task": "email_reports.schedule_hourly",
-            "schedule": crontab(minute=1, hour="*"),
-        },
         "reports.scheduler": {
             "task": "reports.scheduler",
             "schedule": crontab(minute="*", hour="*"),
@@ -891,24 +882,35 @@ DB_CONNECTION_MUTATOR = None
 SQL_QUERY_MUTATOR = None
 
 # Enable / disable scheduled email reports
+#
+# Warning: This config key is deprecated and will be removed in version 2.0.0"
 ENABLE_SCHEDULED_EMAIL_REPORTS = False
 
 # Enable / disable Alerts, where users can define custom SQL that
 # will send emails with screenshots of charts or dashboards periodically
 # if it meets the criteria
+#
+# Warning: This config key is deprecated and will be removed in version 2.0.0"
 ENABLE_ALERTS = False
 
+# ---------------------------------------------------
+# Alerts & Reports
+# ---------------------------------------------------
 # Used for Alerts/Reports (Feature flask ALERT_REPORTS) to set the size for the
 # sliding cron window size, should be synced with the celery beat config minus 1 second
 ALERT_REPORTS_CRON_WINDOW_SIZE = 59
+# A custom prefix to use on all Alerts & Reports emails
+EMAIL_REPORTS_SUBJECT_PREFIX = "[Report] "
 
 # Slack API token for the superset reports
 SLACK_API_TOKEN = None
 SLACK_PROXY = None
 
-# If enabled, certail features are run in debug mode
+# If enabled, certain features are run in debug mode
 # Current list:
 # * Emails are sent using dry-run mode (logging only)
+#
+# Warning: This config key is deprecated and will be removed in version 2.0.0"
 SCHEDULED_EMAIL_DEBUG_MODE = False
 
 # This auth provider is used by background (offline) tasks that need to access
@@ -917,26 +919,29 @@ SCHEDULED_EMAIL_DEBUG_MODE = False
 MACHINE_AUTH_PROVIDER_CLASS = "superset.utils.machine_auth.MachineAuthProvider"
 
 # Email reports - minimum time resolution (in minutes) for the crontab
+#
+# Warning: This config key is deprecated and will be removed in version 2.0.0"
 EMAIL_REPORTS_CRON_RESOLUTION = 15
 
 # The MAX duration (in seconds) a email schedule can run for before being killed
 # by celery.
+#
+# Warning: This config key is deprecated and will be removed in version 2.0.0"
 EMAIL_ASYNC_TIME_LIMIT_SEC = 300
-
-# Email report configuration
-# From address in emails
-EMAIL_REPORT_FROM_ADDRESS = "reports@superset.org"
 
 # Send bcc of all reports to this address. Set to None to disable.
 # This is useful for maintaining an audit trail of all email deliveries.
+#
+# Warning: This config key is deprecated and will be removed in version 2.0.0"
 EMAIL_REPORT_BCC_ADDRESS = None
 
 # User credentials to use for generating reports
 # This user should have permissions to browse all the dashboards and
 # slices.
 # TODO: In the future, login as the owner of the item to generate reports
+#
+# Warning: This config key is deprecated and will be removed in version 2.0.0"
 EMAIL_REPORTS_USER = "admin"
-EMAIL_REPORTS_SUBJECT_PREFIX = "[Report] "
 
 # The webdriver to use for generating reports. Use one of the following
 # firefox

--- a/superset/config.py
+++ b/superset/config.py
@@ -615,8 +615,18 @@ class CeleryConfig:  # pylint: disable=too-few-public-methods
     CELERY_ACKS_LATE = False
     CELERY_ANNOTATIONS = {
         "sql_lab.get_sql_results": {"rate_limit": "100/s"},
+        "email_reports.send": {
+            "rate_limit": "1/s",
+            "time_limit": 120,
+            "soft_time_limit": 150,
+            "ignore_result": True,
+        },
     }
     CELERYBEAT_SCHEDULE = {
+        "email_reports.schedule_hourly": {
+            "task": "email_reports.schedule_hourly",
+            "schedule": crontab(minute=1, hour="*"),
+        },
         "reports.scheduler": {
             "task": "reports.scheduler",
             "schedule": crontab(minute="*", hour="*"),

--- a/superset/tasks/slack_util.py
+++ b/superset/tasks/slack_util.py
@@ -14,6 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""
+DEPRECATION NOTICE: this module is deprecated and will be removed on 2.0.
+"""
 import logging
 from io import IOBase
 from typing import cast, Optional, Union

--- a/superset/views/alerts.py
+++ b/superset/views/alerts.py
@@ -14,8 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""
+DEPRECATION NOTICE: this module is deprecated and will be removed on 2.0.
+"""
+
 from croniter import croniter
-from flask import abort
+from flask import abort, flash, Markup
 from flask_appbuilder import CompactCRUDMixin, permission_name
 from flask_appbuilder.api import expose
 from flask_appbuilder.models.sqla.interface import SQLAInterface
@@ -81,7 +85,6 @@ class BaseAlertReportView(BaseSupersetView):
             and is_feature_enabled("ALERT_REPORTS")
         ):
             return abort(404)
-
         return super().render_app_template()
 
     @expose("/<pk>/log/", methods=["GET"])
@@ -208,6 +211,22 @@ class AlertModelView(SupersetModelView):  # pylint: disable=too-many-ancestors
         AlertObservationModelView,
         AlertLogModelView,
     ]
+
+    @expose("/list/")
+    @has_access
+    def list(self) -> FlaskResponse:
+        flash(
+            Markup(
+                _(
+                    "This feature is deprecated and will be removed on 2.0. "
+                    "Take a look at the replacement feature "
+                    "<a href='https://superset.apache.org/docs/installation/alerts-reports'>"
+                    "Alerts & Reports documentation</a>"
+                )
+            ),
+            "warning",
+        )
+        return super().list()
 
     def pre_add(self, item: "AlertModelView") -> None:
         item.recipients = get_email_address_str(item.recipients)

--- a/superset/views/alerts.py
+++ b/superset/views/alerts.py
@@ -220,7 +220,8 @@ class AlertModelView(SupersetModelView):  # pylint: disable=too-many-ancestors
                 _(
                     "This feature is deprecated and will be removed on 2.0. "
                     "Take a look at the replacement feature "
-                    "<a href='https://superset.apache.org/docs/installation/alerts-reports'>"
+                    "<a href="
+                    "'https://superset.apache.org/docs/installation/alerts-reports'>"
                     "Alerts & Reports documentation</a>"
                 )
             ),

--- a/superset/views/schedules.py
+++ b/superset/views/schedules.py
@@ -14,12 +14,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""
+DEPRECATION NOTICE: this module is deprecated and will be removed on 2.0.
+"""
+
 import enum
 from typing import Type, Union
 
 import simplejson as json
 from croniter import croniter
-from flask import flash, g
+from flask import flash, g, Markup
 from flask_appbuilder import expose
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.security.decorators import has_access
@@ -232,6 +236,22 @@ class DashboardEmailScheduleView(
         "delivery_type": _("Delivery Type"),
     }
 
+    @expose("/list/")
+    @has_access
+    def list(self) -> FlaskResponse:
+        flash(
+            Markup(
+                _(
+                    "This feature is deprecated and will be removed on 2.0. "
+                    "Take a look at the replacement feature "
+                    "<a href='https://superset.apache.org/docs/installation/alerts-reports'>"
+                    "Alerts & Reports documentation</a>"
+                )
+            ),
+            "warning",
+        )
+        return super().list()
+
     def pre_add(self, item: "DashboardEmailScheduleView") -> None:
         if item.dashboard is None:
             raise SupersetException("Dashboard is mandatory")
@@ -295,6 +315,22 @@ class SliceEmailScheduleView(EmailScheduleView):  # pylint: disable=too-many-anc
         "delivery_type": _("Delivery Type"),
         "email_format": _("Email Format"),
     }
+
+    @expose("/list/")
+    @has_access
+    def list(self) -> FlaskResponse:
+        flash(
+            Markup(
+                _(
+                    "This feature is deprecated and will be removed on 2.0. "
+                    "Take a look at the replacement feature "
+                    "<a href='https://superset.apache.org/docs/installation/alerts-reports'>"
+                    "Alerts & Reports documentation</a>"
+                )
+            ),
+            "warning",
+        )
+        return super().list()
 
     def pre_add(self, item: "SliceEmailScheduleView") -> None:
         if item.slice is None:

--- a/superset/views/schedules.py
+++ b/superset/views/schedules.py
@@ -244,7 +244,8 @@ class DashboardEmailScheduleView(
                 _(
                     "This feature is deprecated and will be removed on 2.0. "
                     "Take a look at the replacement feature "
-                    "<a href='https://superset.apache.org/docs/installation/alerts-reports'>"
+                    "<a href="
+                    "'https://superset.apache.org/docs/installation/alerts-reports'>"
                     "Alerts & Reports documentation</a>"
                 )
             ),
@@ -324,7 +325,8 @@ class SliceEmailScheduleView(EmailScheduleView):  # pylint: disable=too-many-anc
                 _(
                     "This feature is deprecated and will be removed on 2.0. "
                     "Take a look at the replacement feature "
-                    "<a href='https://superset.apache.org/docs/installation/alerts-reports'>"
+                    "<a href="
+                    "'https://superset.apache.org/docs/installation/alerts-reports'>"
                     "Alerts & Reports documentation</a>"
                 )
             ),


### PR DESCRIPTION
### SUMMARY
Deprecates the old alerts and reports feature

- Adds deprecation comments to the config keys
- Adds deprecation comments on the code modules
- Adds deprecation log warnings when the feature is enabled
- Adds a flash message on the MVC list for all the 3 views
 
<img width="1181" alt="Screenshot 2021-03-03 at 16 38 14" src="https://user-images.githubusercontent.com/4025227/109839349-eebb4900-7c3e-11eb-8cba-c7be2ab56460.png">


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
