### PR TITLE
fix: API to allow importing old exports (JSON/YAML)

### DIFF
--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -993,11 +993,14 @@ class ChartRestApi(BaseSupersetModelRestApi):
                   type: object
                   properties:
                     formData:
+                      description: upload file (ZIP)
                       type: string
                       format: binary
                     passwords:
+                      description: JSON map of passwords for each file
                       type: string
                     overwrite:
+                      description: overwrite existing databases?
                       type: bool
           responses:
             200:

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -19,7 +19,7 @@ import logging
 from datetime import datetime
 from io import BytesIO
 from typing import Any, Dict
-from zipfile import ZipFile
+from zipfile import is_zipfile, ZipFile
 
 from flask import g, make_response, redirect, request, Response, send_file, url_for
 from flask_appbuilder.api import expose, protect, rison, safe
@@ -787,8 +787,12 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         upload = request.files.get("formData")
         if not upload:
             return self.response_400()
-        with ZipFile(upload) as bundle:
-            contents = get_contents_from_bundle(bundle)
+        if is_zipfile(upload):
+            with ZipFile(upload) as bundle:
+                contents = get_contents_from_bundle(bundle)
+        else:
+            upload.seek(0)
+            contents = {upload.filename: upload.read()}
 
         passwords = (
             json.loads(request.form["passwords"])

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -759,11 +759,14 @@ class DashboardRestApi(BaseSupersetModelRestApi):
                   type: object
                   properties:
                     formData:
+                      description: upload file (ZIP or JSON)
                       type: string
                       format: binary
                     passwords:
+                      description: JSON map of passwords for each file
                       type: string
                     overwrite:
+                      description: overwrite existing databases?
                       type: bool
           responses:
             200:

--- a/superset/dashboards/commands/importers/v0.py
+++ b/superset/dashboards/commands/importers/v0.py
@@ -317,7 +317,9 @@ class ImportDashboardsCommand(BaseCommand):
     in Superset.
     """
 
-    def __init__(self, contents: Dict[str, str], database_id: Optional[int] = None):
+    def __init__(
+        self, contents: Dict[str, str], database_id: Optional[int] = None, **kwargs: Any
+    ):
         self.contents = contents
         self.database_id = database_id
 

--- a/superset/dashboards/commands/importers/v0.py
+++ b/superset/dashboards/commands/importers/v0.py
@@ -317,6 +317,7 @@ class ImportDashboardsCommand(BaseCommand):
     in Superset.
     """
 
+    # pylint: disable=unused-argument
     def __init__(
         self, contents: Dict[str, str], database_id: Optional[int] = None, **kwargs: Any
     ):

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -751,11 +751,14 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
                   type: object
                   properties:
                     formData:
+                      description: upload file (ZIP)
                       type: string
                       format: binary
                     passwords:
+                      description: JSON map of passwords for each file
                       type: string
                     overwrite:
+                      description: overwrite existing databases?
                       type: bool
           responses:
             200:

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -20,7 +20,7 @@ from datetime import datetime
 from distutils.util import strtobool
 from io import BytesIO
 from typing import Any
-from zipfile import ZipFile
+from zipfile import is_zipfile, ZipFile
 
 import yaml
 from flask import g, request, Response, send_file
@@ -687,8 +687,12 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         upload = request.files.get("formData")
         if not upload:
             return self.response_400()
-        with ZipFile(upload) as bundle:
-            contents = get_contents_from_bundle(bundle)
+        if is_zipfile(upload):
+            with ZipFile(upload) as bundle:
+                contents = get_contents_from_bundle(bundle)
+        else:
+            upload.seek(0)
+            contents = {upload.filename: upload.read()}
 
         passwords = (
             json.loads(request.form["passwords"])

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -659,11 +659,14 @@ class DatasetRestApi(BaseSupersetModelRestApi):
                   type: object
                   properties:
                     formData:
+                      description: upload file (ZIP or YAML)
                       type: string
                       format: binary
                     passwords:
+                      description: JSON map of passwords for each file
                       type: string
                     overwrite:
+                      description: overwrite existing databases?
                       type: bool
           responses:
             200:

--- a/tests/dashboards/api_tests.py
+++ b/tests/dashboards/api_tests.py
@@ -1341,12 +1341,10 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
         )
         chart = dashboard.slices[0]
         dataset = chart.table
-        database = dataset.database
 
         db.session.delete(dashboard)
         db.session.delete(chart)
         db.session.delete(dataset)
-        db.session.delete(database)
         db.session.commit()
 
     def test_import_dashboard_overwrite(self):

--- a/tests/dashboards/api_tests.py
+++ b/tests/dashboards/api_tests.py
@@ -45,6 +45,7 @@ from tests.fixtures.importexport import (
     chart_config,
     database_config,
     dashboard_config,
+    dashboard_export,
     dashboard_metadata_config,
     dataset_config,
     dataset_metadata_config,
@@ -1309,6 +1310,38 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
 
         database = dataset.database
         assert str(database.uuid) == database_config["uuid"]
+
+        db.session.delete(dashboard)
+        db.session.delete(chart)
+        db.session.delete(dataset)
+        db.session.delete(database)
+        db.session.commit()
+
+    def test_import_dashboard_v0_export(self):
+        num_dashboards = db.session.query(Dashboard).count()
+
+        self.login(username="admin")
+        uri = "api/v1/dashboard/import/"
+
+        buf = BytesIO()
+        buf.write(json.dumps(dashboard_export).encode())
+        buf.seek(0)
+        form_data = {
+            "formData": (buf, "20201119_181105.json"),
+        }
+        rv = self.client.post(uri, data=form_data, content_type="multipart/form-data")
+        response = json.loads(rv.data.decode("utf-8"))
+
+        assert rv.status_code == 200
+        assert response == {"message": "OK"}
+        assert db.session.query(Dashboard).count() == num_dashboards + 1
+
+        dashboard = (
+            db.session.query(Dashboard).filter_by(dashboard_title="Births 2").one()
+        )
+        chart = dashboard.slices[0]
+        dataset = chart.table
+        database = dataset.database
 
         db.session.delete(dashboard)
         db.session.delete(chart)

--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -47,6 +47,7 @@ from tests.fixtures.importexport import (
     database_metadata_config,
     dataset_config,
     dataset_metadata_config,
+    dataset_ui_export,
 )
 
 
@@ -1273,6 +1274,31 @@ class TestDatasetApi(SupersetTestCase):
 
         db.session.delete(dataset)
         db.session.delete(database)
+        db.session.commit()
+
+    def test_import_dataset_v0_export(self):
+        num_datasets = db.session.query(SqlaTable).count()
+
+        self.login(username="admin")
+        uri = "api/v1/dataset/import/"
+
+        buf = BytesIO()
+        buf.write(json.dumps(dataset_ui_export).encode())
+        buf.seek(0)
+        form_data = {
+            "formData": (buf, "dataset_export.zip"),
+        }
+        rv = self.client.post(uri, data=form_data, content_type="multipart/form-data")
+        response = json.loads(rv.data.decode("utf-8"))
+
+        assert rv.status_code == 200
+        assert response == {"message": "OK"}
+        assert db.session.query(SqlaTable).count() == num_datasets + 1
+
+        dataset = (
+            db.session.query(SqlaTable).filter_by(table_name="birth_names_2").one()
+        )
+        db.session.delete(dataset)
         db.session.commit()
 
     def test_import_dataset_overwrite(self):


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The new APIs for importing dashboards and datasets only accept ZIP files, even though the logic to import the old format (JSON and YAML, respectively) is in the backend. This PR makes the API accept the old format.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Added tests, and also tested manually.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
