### PR TITLE
feat: add option to load big/wide tables

### DIFF
--- a/superset/cli.py
+++ b/superset/cli.py
@@ -109,8 +109,8 @@ def version(verbose: bool) -> None:
 
 
 def load_examples_run(
-    load_test_data: bool,
-    load_big_data: bool,
+    load_test_data: bool = False,
+    load_big_data: bool = False,
     only_metadata: bool = False,
     force: bool = False,
 ) -> None:
@@ -171,6 +171,7 @@ def load_examples_run(
         examples.load_deck_dash()
 
     if load_big_data:
+        print("Loading big synthetic data for tests")
         examples.load_big_data()
 
     # load examples that are stored as YAML config files

--- a/superset/cli.py
+++ b/superset/cli.py
@@ -20,6 +20,7 @@ import logging
 import sys
 from datetime import datetime, timedelta
 from subprocess import Popen
+from types import ModuleType
 from typing import Any, Dict, List, Optional, Type, Union
 from zipfile import ZipFile
 
@@ -108,18 +109,11 @@ def version(verbose: bool) -> None:
     print(Style.RESET_ALL)
 
 
-def load_examples_run(
-    load_test_data: bool, only_metadata: bool = False, force: bool = False
+def load_test_data(
+    examples: ModuleType,
+    only_metadata: bool = False,
+    force: bool = False,
 ) -> None:
-    if only_metadata:
-        print("Loading examples metadata")
-    else:
-        examples_db = utils.get_example_database()
-        print(f"Loading examples metadata and related data into {examples_db}")
-
-    from superset import examples
-
-    examples.load_css_templates()
 
     print("Loading energy related dataset")
     examples.load_energy(only_metadata, force)
@@ -133,47 +127,54 @@ def load_examples_run(
     print("Loading [Tabbed dashboard]")
     examples.load_tabbed_dashboard(only_metadata)
 
-    if not load_test_data:
-        print("Loading [Random time series data]")
-        examples.load_random_time_series_data(only_metadata, force)
+    print("Loading additional examples")
+    examples.load_from_configs(force, load_test_data=True)
 
-        print("Loading [Random long/lat data]")
-        examples.load_long_lat_data(only_metadata, force)
 
-        print("Loading [Country Map data]")
-        examples.load_country_map_data(only_metadata, force)
+def load_examples(
+    examples: ModuleType, only_metadata: bool = False, force: bool = False
+) -> None:
+    print("Loading [Random time series data]")
+    examples.load_random_time_series_data(only_metadata, force)
 
-        print("Loading [Multiformat time series]")
-        examples.load_multiformat_time_series(only_metadata, force)
+    print("Loading [Random long/lat data]")
+    examples.load_long_lat_data(only_metadata, force)
 
-        print("Loading [Paris GeoJson]")
-        examples.load_paris_iris_geojson(only_metadata, force)
+    print("Loading [Country Map data]")
+    examples.load_country_map_data(only_metadata, force)
 
-        print("Loading [San Francisco population polygons]")
-        examples.load_sf_population_polygons(only_metadata, force)
+    print("Loading [Multiformat time series]")
+    examples.load_multiformat_time_series(only_metadata, force)
 
-        print("Loading [Flights data]")
-        examples.load_flights(only_metadata, force)
+    print("Loading [Paris GeoJson]")
+    examples.load_paris_iris_geojson(only_metadata, force)
 
-        print("Loading [BART lines]")
-        examples.load_bart_lines(only_metadata, force)
+    print("Loading [San Francisco population polygons]")
+    examples.load_sf_population_polygons(only_metadata, force)
 
-        print("Loading [Multi Line]")
-        examples.load_multi_line(only_metadata)
+    print("Loading [Flights data]")
+    examples.load_flights(only_metadata, force)
 
-        print("Loading [Misc Charts] dashboard")
-        examples.load_misc_dashboard()
+    print("Loading [BART lines]")
+    examples.load_bart_lines(only_metadata, force)
 
-        print("Loading DECK.gl demo")
-        examples.load_deck_dash()
+    print("Loading [Multi Line]")
+    examples.load_multi_line(only_metadata)
 
-    # load examples that are stored as YAML config files
-    examples.load_from_configs(force, load_test_data)
+    print("Loading [Misc Charts] dashboard")
+    examples.load_misc_dashboard()
+
+    print("Loading DECK.gl demo")
+    examples.load_deck_dash()
+
+    print("Loading additional examples")
+    examples.load_from_configs(force, load_test_data=False)
 
 
 @with_appcontext
 @superset.command()
 @click.option("--load-test-data", "-t", is_flag=True, help="Load additional test data")
+@click.option("--load-big-test-data", "-b", is_flag=True, help="Load big test data")
 @click.option(
     "--only-metadata", "-m", is_flag=True, help="Only load metadata, skip actual data"
 )
@@ -184,6 +185,14 @@ def load_examples(
     load_test_data: bool, only_metadata: bool = False, force: bool = False
 ) -> None:
     """Loads a set of Slices and Dashboards and a supporting dataset """
+    if only_metadata:
+        print("Loading examples metadata")
+    else:
+        examples_db = utils.get_example_database()
+        print(f"Loading examples metadata and related data into {examples_db}")
+    from superset import examples
+
+    examples.load_css_templates()
     load_examples_run(load_test_data, only_metadata, force)
 
 
@@ -304,7 +313,9 @@ if feature_flags.get("VERSIONED_EXPORT"):
     @superset.command()
     @with_appcontext
     @click.option(
-        "--path", "-p", help="Path to a single ZIP file",
+        "--path",
+        "-p",
+        help="Path to a single ZIP file",
     )
     @click.option(
         "--username",

--- a/superset/examples/__init__.py
+++ b/superset/examples/__init__.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from .bart_lines import load_bart_lines
+from .big_data import load_big_data
 from .birth_names import load_birth_names
 from .country_map import load_country_map_data
 from .css_templates import load_css_templates

--- a/superset/examples/big_data.py
+++ b/superset/examples/big_data.py
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import List
+
+import sqlalchemy.sql.sqltypes
+
+from superset.utils.data import add_data, ColumnInfo
+
+COLUMN_TYPES = [
+    sqlalchemy.sql.sqltypes.INTEGER(),
+    sqlalchemy.sql.sqltypes.VARCHAR(length=255),
+    sqlalchemy.sql.sqltypes.TEXT(),
+    sqlalchemy.sql.sqltypes.BOOLEAN(),
+    sqlalchemy.sql.sqltypes.FLOAT(),
+    sqlalchemy.sql.sqltypes.DATE(),
+    sqlalchemy.sql.sqltypes.TIME(),
+    sqlalchemy.sql.sqltypes.DATETIME(),
+]
+
+
+def load_big_data() -> None:
+    # create table with 100 columns to test SQL Lab
+    columns: List[ColumnInfo] = []
+    for i in range(100):
+        column: ColumnInfo = {
+            "name": f"col{i}",
+            "type": COLUMN_TYPES[i % len(COLUMN_TYPES)],
+            "nullable": False,
+            "default": None,
+            "autoincrement": "auto",
+            "primary_key": 1 if i == 0 else 0,
+        }
+        columns.append(column)
+
+    add_data(columns=columns, num_rows=1000, table_name="wide_table")

--- a/superset/utils/data.py
+++ b/superset/utils/data.py
@@ -66,6 +66,8 @@ def get_type_generator(sqltype: sqlalchemy.sql.sqltypes) -> Callable[[], Any]:
 
     if isinstance(sqltype, sqlalchemy.sql.sqltypes.TEXT):
         length = random.randrange(65535)
+        # "practicality beats purity"
+        length = max(length, 2048)
         return lambda: "".join(random.choices(string.printable, k=length))
 
     if isinstance(sqltype, sqlalchemy.sql.sqltypes.BOOLEAN):

--- a/superset/utils/data.py
+++ b/superset/utils/data.py
@@ -1,0 +1,143 @@
+import random
+import string
+import sys
+from datetime import date, datetime, time, timedelta
+from typing import Any, Callable, cast, Dict, List, Optional
+
+import sqlalchemy.sql.sqltypes
+from flask_appbuilder import Model
+from sqlalchemy import Column, inspect, MetaData, Table
+from sqlalchemy.sql.visitors import VisitableType
+from typing_extensions import TypedDict
+
+ColumnInfo = TypedDict(
+    "ColumnInfo",
+    {
+        "name": str,
+        "type": VisitableType,
+        "nullable": bool,
+        "default": Optional[Any],
+        "autoincrement": str,
+        "primary_key": int,
+    },
+)
+
+
+example_column = {
+    "name": "id",
+    "type": sqlalchemy.sql.sqltypes.INTEGER(),
+    "nullable": False,
+    "default": None,
+    "autoincrement": "auto",
+    "primary_key": 1,
+}
+
+
+MINIMUM_DATE = date(1900, 1, 1)
+MAXIMUM_DATE = date.today()
+days_range = (MAXIMUM_DATE - MINIMUM_DATE).days
+
+
+def get_type_generator(sqltype: sqlalchemy.sql.sqltypes) -> Callable[[], Any]:
+    if isinstance(sqltype, sqlalchemy.sql.sqltypes.INTEGER):
+        return lambda: random.randrange(2147483647)
+
+    if isinstance(sqltype, sqlalchemy.sql.sqltypes.BIGINT):
+        return lambda: random.randrange(sys.maxsize)
+
+    if isinstance(sqltype, sqlalchemy.sql.sqltypes.VARCHAR):
+        length = random.randrange(sqltype.length or 255)
+        return lambda: "".join(random.choices(string.printable, k=length))
+
+    if isinstance(sqltype, sqlalchemy.sql.sqltypes.TEXT):
+        length = random.randrange(65535)
+        return lambda: "".join(random.choices(string.printable, k=length))
+
+    if isinstance(sqltype, sqlalchemy.sql.sqltypes.BOOLEAN):
+        return lambda: random.choice([True, False])
+
+    if isinstance(
+        sqltype, (sqlalchemy.sql.sqltypes.FLOAT, sqlalchemy.sql.sqltypes.REAL)
+    ):
+        return lambda: random.uniform(-sys.maxsize, sys.maxsize)
+
+    if isinstance(sqltype, sqlalchemy.sql.sqltypes.DATE):
+        return lambda: MINIMUM_DATE + timedelta(days=random.randrange(days_range))
+
+    if isinstance(sqltype, sqlalchemy.sql.sqltypes.TIME):
+        return lambda: time(
+            random.randrange(24), random.randrange(60), random.randrange(60),
+        )
+
+    if isinstance(
+        sqltype, (sqlalchemy.sql.sqltypes.TIMESTAMP, sqlalchemy.sql.sqltypes.DATETIME)
+    ):
+        return lambda: datetime.fromordinal(MINIMUM_DATE.toordinal()) + timedelta(
+            seconds=random.randrange(days_range * 86400)
+        )
+
+    raise Exception(f"Unknown type {sqltype}. Please add it to `get_type_generator`.")
+
+
+def add_data(
+    columns: Optional[List[ColumnInfo]],
+    num_rows: int,
+    table_name: str,
+    append: bool = False,
+) -> None:
+    """
+    Generate synthetic data for testing migrations and features.
+
+    If the table already exists `columns` can be `None`.
+
+    :param Optional[List[ColumnInfo]] columns: list of column names and types to create
+    :param int run_nows: how many rows to generate and insert
+    :param str table_name: name of table, will be created if it doesn't exist
+    :param bool append: if the table already exists, append data or replace?
+    """
+    from superset.utils.core import get_example_database
+
+    database = get_example_database()
+    table_exists = database.has_table_by_name(table_name)
+    engine = database.get_sqla_engine()
+
+    if columns is None:
+        if not table_exists:
+            raise Exception(
+                f"The table {table_name} does not exist. To create it you need to pass a "
+                "list of column names and types."
+            )
+
+        inspector = inspect(engine)
+        columns = inspector.get_columns(table_name)
+
+    # create table if needed
+    column_objects = get_column_objects(columns)
+    metadata = MetaData()
+    table = Table(table_name, metadata, *column_objects)
+    metadata.create_all(engine)
+
+    data = generate_data(columns, num_rows)
+    engine.execute(table.insert(), data)
+
+
+def get_column_objects(columns: List[ColumnInfo]) -> List[Column]:
+    out = []
+    for column in columns:
+        kwargs = cast(Dict[str, Any], column.copy())
+        kwargs["type_"] = kwargs.pop("type")
+        out.append(Column(**kwargs))
+    return out
+
+
+def generate_data(columns: List[ColumnInfo], num_rows: int) -> List[Dict[str, Any]]:
+    keys = [column["name"] for column in columns]
+    return [
+        dict(zip(keys, row))
+        for row in zip(*[generate_column_data(column, num_rows) for column in columns])
+    ]
+
+
+def generate_column_data(column: ColumnInfo, num_rows: int) -> List[Any]:
+    func = get_type_generator(column["type"])
+    return [func() for _ in range(num_rows)]


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR adds a new CLI option to load big/wide tables into Superset. The goal is to create tables with synthetic data that help developers test new features and DB migrations in realistic scenarios.

This first PR just adds a function called `add_data` that generates the data given a schema. When running `superset load-examples -b` it will also create a wide table with 100 columns, to help test SQL Lab (which behaves differently if the table has more than 50 columns).

The next steps include adding more tables, as well as implementing functionality to add more rows to the Superset models, to help benchmark DB migrations.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Ran `superset load-examples -b -t` and verified that the table `wide_table` was created, with 1000 rows and 100 columns.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
