### PR TITLE
chore: disable drag metrics and columns in datasourcePanel

### DIFF
--- a/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanel.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanel.tsx
@@ -28,10 +28,11 @@ import {
 import { debounce } from 'lodash';
 import { matchSorter, rankings } from 'match-sorter';
 import { FAST_DEBOUNCE } from 'src/constants';
+import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 import { ExploreActions } from 'src/explore/actions/exploreActions';
-import Control from './Control';
-import DatasourcePanelDragWrapper from './DatasourcePanel/DatasourcePanelDragWrapper';
-import { DatasourcePanelDndType } from './DatasourcePanel/types';
+import Control from 'src/explore/components/Control';
+import DatasourcePanelDragWrapper from './DatasourcePanelDragWrapper';
+import { DatasourcePanelDndType } from './types';
 
 interface DatasourceControl extends ControlConfig {
   datasource?: DatasourceMeta;
@@ -100,6 +101,10 @@ const LabelContainer = styled.div`
     }
   }
 `;
+
+const enableExploreDnd = isFeatureEnabled(
+  FeatureFlag.ENABLE_EXPLORE_DRAG_AND_DROP,
+);
 
 export default function DataSourcePanel({
   datasource,
@@ -206,12 +211,16 @@ export default function DataSourcePanel({
             </div>
             {metricSlice.map(m => (
               <LabelContainer key={m.metric_name} className="column">
-                <DatasourcePanelDragWrapper
-                  metricOrColumnName={m.metric_name}
-                  type={DatasourcePanelDndType.METRIC}
-                >
+                {enableExploreDnd ? (
+                  <DatasourcePanelDragWrapper
+                    metricOrColumnName={m.metric_name}
+                    type={DatasourcePanelDndType.METRIC}
+                  >
+                    <MetricOption metric={m} showType />
+                  </DatasourcePanelDragWrapper>
+                ) : (
                   <MetricOption metric={m} showType />
-                </DatasourcePanelDragWrapper>
+                )}
               </LabelContainer>
             ))}
           </Collapse.Panel>
@@ -224,12 +233,16 @@ export default function DataSourcePanel({
             </div>
             {columnSlice.map(col => (
               <LabelContainer key={col.column_name} className="column">
-                <DatasourcePanelDragWrapper
-                  metricOrColumnName={col.column_name}
-                  type={DatasourcePanelDndType.COLUMN}
-                >
+                {enableExploreDnd ? (
+                  <DatasourcePanelDragWrapper
+                    metricOrColumnName={col.column_name}
+                    type={DatasourcePanelDndType.COLUMN}
+                  >
+                    <ColumnOption column={col} showType />
+                  </DatasourcePanelDragWrapper>
+                ) : (
                   <ColumnOption column={col} showType />
-                </DatasourcePanelDragWrapper>
+                )}
               </LabelContainer>
             ))}
           </Collapse.Panel>

--- a/superset-frontend/src/explore/components/DatasourcePanel/index.ts
+++ b/superset-frontend/src/explore/components/DatasourcePanel/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+export { default } from './DatasourcePanel';


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Disable drag metrics and columns in DatasourcePanel when DnD FF is false.
- restructure DatasourcePanel

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
tested in my local environment

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
