### PR TITLE
build(test env): Shutdown test environments on PR close

### DIFF
--- a/.github/workflows/ephemeral-env-pr-close.yml
+++ b/.github/workflows/ephemeral-env-pr-close.yml
@@ -1,0 +1,58 @@
+name: Cleanup ephemeral envs (PR close)
+
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  ephemeral-env-cleanup:
+    name: Cleanup ephemeral envs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
+      - name: Describe ECS service
+        id: describe-services
+        run: |
+          echo "::set-output name=active::$(aws ecs describe-services --cluster superset-ci --services pr-${{ github.event.number }}-service | jq '.services[] | select(.status == "ACTIVE") | any')"
+
+      - name: Delete ECS service
+        if: steps.describe-services.outputs.active == 'true'
+        id: delete-service
+        run: |
+          aws ecs delete-service \
+          --cluster superset-ci \
+          --service pr-${{ github.event.number }}-service \
+          --force
+
+      - name: Login to Amazon ECR
+        if: steps.describe-services.outputs.active == 'true'
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Delete ECR image tag
+        if: steps.describe-services.outputs.active == 'true'
+        id: delete-image-tag
+        run: |
+          aws ecr batch-delete-image \
+          --registry-id $(echo "${{ steps.login-ecr.outputs.registry }}" | grep -Eo "^[0-9]+") \
+          --repository-name superset-ci \
+          --image-ids imageTag=pr-${{ github.event.number }}
+
+      - name: Comment (success)
+        if: steps.describe-services.outputs.active == 'true'
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.createComment({
+              issue_number: ${{ github.event.number }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Ephemeral environment shutdown and build artifacts deleted.'
+            })

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,7 @@ little bit helps, and credit will always be given.
     - [Protocol](#protocol)
       - [Authoring](#authoring)
       - [Reviewing](#reviewing)
+      - [Test Environments](#test-environments)
       - [Merging](#merging)
       - [Post-merge Responsibility](#post-merge-responsibility)
   - [Design Guidelines](#design-guidelines)
@@ -247,6 +248,13 @@ Finally, never submit a PR that will put master branch in broken state. If the P
 - If there are changes required, state clearly what needs to be done before the PR can be approved.
 - If you are asked to update your pull request with some changes there's no need to create a new one. Push your changes to the same branch.
 - The committers reserve the right to reject any PR and in some cases may request the author to file an issue.
+
+#### Test Environments
+
+- Members of the Apache GitHub org can launch an ephemeral test environment directly on a pull request by creating a comment containing (only) the command `/testenv up`
+- A comment will be created by the workflow script with the address and login information for the ephemeral environment.
+- Test environments may be created once the Docker build CI workflow for the PR has completed successfully.
+- Running test environments will be shutdown upon closing the pull request.
 
 #### Merging
 


### PR DESCRIPTION
### SUMMARY
- Workflow to shutdown running test environments and delete associated AWS resources on PR close events. Using `pull_request_target` here for access to repository secrets, with no building or execution of untrusted code.
- Documentation on using the ephemeral test environment feature added to CONTRIBUTING.md.

### TEST PLAN
- Create an ephemeral test environment on a PR (see CONTRIBUTING.md).
- Close the PR and verify the test env is no longer accessible.
- This has been tested here: https://github.com/robdiciuccio/incubator-superset/pull/8

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
