### PR TITLE
docs: Fix typo in footer

### DIFF
--- a/docs/src/components/footer.tsx
+++ b/docs/src/components/footer.tsx
@@ -105,7 +105,7 @@ const LayoutFooter = () => (
       {new Date().getFullYear()}
       ,
       <a href="http://www.apache.org/" target="_blank" rel="noreferrer">
-        &nbsp;The Apache Software Fountation
+        &nbsp;The Apache Software Foundation
       </a>
       , &nbsp;Licensed under the Apache
       <a


### PR DESCRIPTION
### SUMMARY
The correct spelling is _Foundation_. It is already correct in all other places of the footer.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
Check the footer of the generated docs.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
