### PR TITLE
fix(graph): graph page error

### DIFF
--- a/superset-frontend/src/explore/components/Control.tsx
+++ b/superset-frontend/src/explore/components/Control.tsx
@@ -40,6 +40,7 @@ export type ControlProps = {
   validationErrors?: any[];
   hidden?: boolean;
   renderTrigger?: boolean;
+  options?: any;
 };
 
 export default class Control extends React.PureComponent<
@@ -70,6 +71,12 @@ export default class Control extends React.PureComponent<
     const { type, hidden } = this.props;
     if (!type) return null;
     const ControlComponent = typeof type === 'string' ? controlMap[type] : type;
+
+    let { options } = this.props;
+    if (type === 'SelectControl' && !!options && !Array.isArray(options)) {
+      options = Object.values(options);
+    }
+
     return (
       <div
         className="Control"
@@ -82,6 +89,7 @@ export default class Control extends React.PureComponent<
           onChange={this.onChange}
           hovered={this.state.hovered}
           {...this.props}
+          options={options}
         />
       </div>
     );


### PR DESCRIPTION
### SUMMARY
When creating a Graph Chart with the feature flag `ENABLE_EXPLORE_DRAG_AND_DROP ` activated, the application freezes on a white screen.

#### Scope
The purpose of this PR is to resolve the bug with as little impact as possible on the application

#### Debuging
When a chart (Graph) is created several error messages are displayed on the console. One of the messages is
```
Warning: Failed prop type: Invalid prop `options` of type `object` supplied to `SelectControl`, expected `array`.
```
<img width="1042" alt="Captura de Tela 2021-03-04 às 3 37 44 PM" src="https://user-images.githubusercontent.com/1014611/110012733-9b5cff80-7cff-11eb-82cd-e5252fb423d0.png">

#### Proposed solution
As the interface is not very clear, and for some reason the contract was changed, the idea of the solution is to change this `prop` **only in the case where the error occurred** and not impact any other part of the application that may be using this data.

For this, only the `src/explore/components/Control.tsx` component was changed, transforming the `options` props into an array only for the use of `SelectControl`.

### AFTER 
<img width="1676" alt="Captura de Tela 2021-03-04 às 4 22 03 PM" src="https://user-images.githubusercontent.com/1014611/110018220-d5c99b00-7d05-11eb-99f2-7e32d0413d3f.png">

### TEST PLAN
No behavior has been changed, so the application should work normally. In addition, all tests already implemented should pass correctly.

To test if this fix is working correctly, it is necessary to activate the feature flag:`ENABLE_EXPLORE_DRAG_AND_DROP` 
(The activation is not in this PR because it is not intended to change any application's behavior.)

### ADDITIONAL INFORMATION

The bug was reported in this comment: https://github.com/apache/superset/pull/13210#issuecomment-788097589

@junlincc @ktmud 
