### PR TITLE
fix: Remove view in sql lab from druid datasources

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/DatasourceControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/DatasourceControl_spec.jsx
@@ -93,6 +93,28 @@ describe('DatasourceControl', () => {
       </div>,
     );
     expect(menuWrapper.find(Menu.Item)).toHaveLength(2);
+
+    wrapper = setup({
+      datasource: {
+        name: 'birth_names',
+        type: 'druid',
+        uid: '1__druid',
+        id: 1,
+        columns: [],
+        metrics: [],
+        database: {
+          backend: 'druid',
+          name: 'main',
+        },
+      },
+    });
+    expect(wrapper.find('[data-test="datasource-menu"]')).toExist();
+    menuWrapper = shallow(
+      <div>
+        {wrapper.find('[data-test="datasource-menu"]').prop('overlay')}
+      </div>,
+    );
+    expect(menuWrapper.find(Menu.Item)).toHaveLength(2);
   });
 
   it('should render health check message', () => {

--- a/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
@@ -151,7 +151,7 @@ class DatasourceControl extends React.PureComponent {
         datasourceKey: `${datasource.id}__${datasource.type}`,
         sql: datasource.sql,
       };
-      postForm('/superset/sqllab', payload);
+      postForm('/superset/sqllab/', payload);
     }
   }
 
@@ -159,6 +159,9 @@ class DatasourceControl extends React.PureComponent {
     const { showChangeDatasourceModal, showEditDatasourceModal } = this.state;
     const { datasource, onChange } = this.props;
     const isMissingDatasource = datasource.id == null;
+
+    const isSqlSupported = datasource.type === 'table';
+
     const datasourceMenu = (
       <Menu onClick={this.handleMenuItemClick}>
         {this.props.isEditable && (
@@ -167,7 +170,9 @@ class DatasourceControl extends React.PureComponent {
           </Menu.Item>
         )}
         <Menu.Item key={CHANGE_DATASET}>{t('Change dataset')}</Menu.Item>
-        <Menu.Item key={VIEW_IN_SQL_LAB}>{t('View in SQL Lab')}</Menu.Item>
+        {isSqlSupported && (
+          <Menu.Item key={VIEW_IN_SQL_LAB}>{t('View in SQL Lab')}</Menu.Item>
+        )}
       </Menu>
     );
 


### PR DESCRIPTION
### SUMMARY
This bug was reported internally, when you try to view in sql lab from a druid datasource with the native druid connector, it causes a JS error in sql lab. However, I don't think you should be able to open a native druid datasource in sql lab at all, so i'm removing this functionality

### TEST PLAN
CI and new unit test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @graceguo-supercat @ktmud @hughhhh 