### PR TITLE
fix(explore): make sure sort by metric is not duplicated

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -719,7 +719,7 @@ class TableViz(BaseViz):
             sort_by = fd.get("timeseries_limit_metric")
             if sort_by:
                 sort_by_label = utils.get_metric_name(sort_by)
-                if sort_by_label not in d["metrics"]:
+                if sort_by_label not in utils.get_metric_names(d["metrics"]):
                     d["metrics"].append(sort_by)
                 d["orderby"] = [(sort_by, not fd.get("order_desc", True))]
             elif d["metrics"]:
@@ -847,7 +847,7 @@ class PivotTableViz(BaseViz):
         sort_by = self.form_data.get("timeseries_limit_metric")
         if sort_by:
             sort_by_label = utils.get_metric_name(sort_by)
-            if sort_by_label not in d["metrics"]:
+            if sort_by_label not in utils.get_metric_names(d["metrics"]):
                 d["metrics"].append(sort_by)
             if self.form_data.get("order_desc"):
                 d["orderby"] = [(sort_by, not self.form_data.get("order_desc", True))]
@@ -951,11 +951,10 @@ class TreemapViz(BaseViz):
 
     def query_obj(self) -> QueryObjectDict:
         d = super().query_obj()
-        metrics = self.form_data.get("metrics")
         sort_by = self.form_data.get("timeseries_limit_metric")
         if sort_by:
             sort_by_label = utils.get_metric_name(sort_by)
-            if sort_by_label not in d["metrics"]:
+            if sort_by_label not in utils.get_metric_names(d["metrics"]):
                 d["metrics"].append(sort_by)
             if self.form_data.get("order_desc"):
                 d["orderby"] = [(sort_by, not self.form_data.get("order_desc", True))]
@@ -1637,11 +1636,10 @@ class NVD3TimeSeriesStackedViz(NVD3TimeSeriesViz):
 
     def query_obj(self) -> QueryObjectDict:
         d = super().query_obj()
-        metrics = self.form_data.get("metrics")
         sort_by = self.form_data.get("timeseries_limit_metric")
         if sort_by:
             sort_by_label = utils.get_metric_name(sort_by)
-            if sort_by_label not in d["metrics"]:
+            if sort_by_label not in utils.get_metric_names(d["metrics"]):
                 d["metrics"].append(sort_by)
             if self.form_data.get("order_desc"):
                 d["orderby"] = [(sort_by, not self.form_data.get("order_desc", True))]
@@ -1729,7 +1727,7 @@ class DistributionBarViz(BaseViz):
         sort_by = fd.get("timeseries_limit_metric")
         if sort_by:
             sort_by_label = utils.get_metric_name(sort_by)
-            if sort_by_label not in d["metrics"]:
+            if sort_by_label not in utils.get_metric_names(d["metrics"]):
                 d["metrics"].append(sort_by)
             d["orderby"] = [(sort_by, not fd.get("order_desc", True))]
         elif d["metrics"]:
@@ -2103,7 +2101,7 @@ class ParallelCoordinatesViz(BaseViz):
         sort_by = self.form_data.get("timeseries_limit_metric")
         if sort_by:
             sort_by_label = utils.get_metric_name(sort_by)
-            if sort_by_label not in d["metrics"]:
+            if sort_by_label not in utils.get_metric_names(d["metrics"]):
                 d["metrics"].append(sort_by)
             if self.form_data.get("order_desc"):
                 d["orderby"] = [(sort_by, not self.form_data.get("order_desc", True))]
@@ -2190,7 +2188,7 @@ class HorizonViz(NVD3TimeSeriesViz):
         sort_by = self.form_data.get("timeseries_limit_metric")
         if sort_by:
             sort_by_label = utils.get_metric_name(sort_by)
-            if sort_by_label not in d["metrics"]:
+            if sort_by_label not in utils.get_metric_names(d["metrics"]):
                 d["metrics"].append(sort_by)
             if self.form_data.get("order_desc"):
                 d["orderby"] = [(sort_by, not self.form_data.get("order_desc", True))]
@@ -2818,7 +2816,7 @@ class PairedTTestViz(BaseViz):
         sort_by = self.form_data.get("timeseries_limit_metric")
         if sort_by:
             sort_by_label = utils.get_metric_name(sort_by)
-            if sort_by_label not in d["metrics"]:
+            if sort_by_label not in utils.get_metric_names(d["metrics"]):
                 d["metrics"].append(sort_by)
             if self.form_data.get("order_desc"):
                 d["orderby"] = [(sort_by, not self.form_data.get("order_desc", True))]
@@ -2881,11 +2879,10 @@ class RoseViz(NVD3TimeSeriesViz):
 
     def query_obj(self) -> QueryObjectDict:
         d = super().query_obj()
-        metrics = self.form_data.get("metrics")
         sort_by = self.form_data.get("timeseries_limit_metric")
         if sort_by:
             sort_by_label = utils.get_metric_name(sort_by)
-            if sort_by_label not in d["metrics"]:
+            if sort_by_label not in utils.get_metric_names(d["metrics"]):
                 d["metrics"].append(sort_by)
             if self.form_data.get("order_desc"):
                 d["orderby"] = [(sort_by, not self.form_data.get("order_desc", True))]
@@ -2932,7 +2929,7 @@ class PartitionViz(NVD3TimeSeriesViz):
         sort_by = self.form_data.get("timeseries_limit_metric")
         if sort_by:
             sort_by_label = utils.get_metric_name(sort_by)
-            if sort_by_label not in query_obj["metrics"]:
+            if sort_by_label not in utils.get_metric_names(query_obj["metrics"]):
                 query_obj["metrics"].append(sort_by)
             query_obj["orderby"] = [
                 (sort_by, not self.form_data.get("order_desc", True))


### PR DESCRIPTION
### SUMMARY

Closes #13423

#13057 Added sortby metrics for some multi-series charts but it causes duplicate metrics and wrong queries. 

This is a bandaid PR to quickly fix the issue from the surface. I'm making the handling of sort by metrics more robust in #13434 .

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

![Snip20210304_25](https://user-images.githubusercontent.com/335541/110076240-04149e00-7d39-11eb-9c68-2abe10b388de.png)
![Snip20210304_26](https://user-images.githubusercontent.com/335541/110076251-0971e880-7d39-11eb-8bbc-13b224066b2e.png)


#### After

![Snip20210304_28](https://user-images.githubusercontent.com/335541/110076322-23133000-7d39-11eb-837c-07d7b113c9a4.png)

![Snip20210304_27](https://user-images.githubusercontent.com/335541/110076293-1989c800-7d39-11eb-9c22-f40aaec902e6.png)


### TEST PLAN

1. Go to a Area chart
2. Add a metric and a sort by metric of the same name

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
