### PR TITLE
fix: allow option to generate new query

### DIFF
--- a/superset-frontend/spec/javascripts/sqllab/ResultSet_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/ResultSet_spec.jsx
@@ -45,10 +45,12 @@ const store = mockStore(initialState);
 describe('ResultSet', () => {
   const clearQuerySpy = sinon.spy();
   const fetchQuerySpy = sinon.spy();
+  const reRunQuerySpy = sinon.spy();
   const mockedProps = {
     actions: {
       clearQueryResults: clearQuerySpy,
       fetchQueryResults: fetchQuerySpy,
+      reRunQuery: reRunQuerySpy,
     },
     cache: true,
     query: queries[0],
@@ -82,6 +84,29 @@ describe('ResultSet', () => {
   it('renders a Table', () => {
     const wrapper = shallow(<ResultSet {...mockedProps} />);
     expect(wrapper.find(FilterableTable)).toExist();
+  });
+  describe('componentDidMount', () => {
+    const propsWithError = {
+      ...mockedProps,
+      query: { ...queries[0], errorMessage: 'Your session timed out' },
+    };
+    let spy;
+    beforeEach(() => {
+      reRunQuerySpy.resetHistory();
+      spy = sinon.spy(ResultSet.prototype, 'componentDidMount');
+    });
+    afterEach(() => {
+      spy.restore();
+    });
+    it('should call reRunQuery if timed out', () => {
+      shallow(<ResultSet {...propsWithError} />);
+      expect(reRunQuerySpy.callCount).toBe(1);
+    });
+
+    it('should not call reRunQuery if no error', () => {
+      shallow(<ResultSet {...mockedProps} />);
+      expect(reRunQuerySpy.callCount).toBe(0);
+    });
   });
   describe('UNSAFE_componentWillReceiveProps', () => {
     const wrapper = shallow(<ResultSet {...mockedProps} />);

--- a/superset-frontend/spec/javascripts/sqllab/actions/sqlLab_spec.js
+++ b/superset-frontend/spec/javascripts/sqllab/actions/sqlLab_spec.js
@@ -173,7 +173,7 @@ describe('async actions', () => {
 
       fetchMock.get(
         fetchQueryEndpoint,
-        { throws: { error: 'error text' } },
+        { throws: { message: 'error text' } },
         { overwriteRoutes: true },
       );
 
@@ -238,7 +238,7 @@ describe('async actions', () => {
 
       fetchMock.post(
         runQueryEndpoint,
-        { throws: { error: 'error text' } },
+        { throws: { message: 'error text' } },
         { overwriteRoutes: true },
       );
 
@@ -249,6 +249,29 @@ describe('async actions', () => {
           expectedActionTypes,
         );
       });
+    });
+  });
+
+  describe('reRunQuery', () => {
+    let stub;
+    beforeEach(() => {
+      stub = sinon.stub(shortid, 'generate').returns('abcd');
+    });
+    afterEach(() => {
+      stub.restore();
+    });
+
+    it('creates new query with a new id', () => {
+      const id = 'id';
+      const state = {
+        sqlLab: {
+          tabHistory: [id],
+          queryEditors: [{ id, title: 'Dummy query editor' }],
+        },
+      };
+      const store = mockStore(state);
+      store.dispatch(actions.reRunQuery(query));
+      expect(store.getActions()[0].query.id).toEqual('abcd');
     });
   });
 

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -351,6 +351,13 @@ export function runQuery(query) {
   };
 }
 
+export function reRunQuery(query) {
+  // run Query with a new id
+  return function (dispatch) {
+    dispatch(runQuery({ ...query, id: shortid.generate() }));
+  };
+}
+
 export function validateQuery(query) {
   return function (dispatch) {
     dispatch(startQueryValidation(query));

--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -404,7 +404,7 @@ export default class ResultSet extends React.PureComponent<
       query.errorMessage &&
       query.errorMessage.indexOf('session timed out') > 0
     ) {
-      this.props.actions.runQuery(query, true);
+      this.props.actions.reRunQuery(query);
     }
   }
 


### PR DESCRIPTION
### SUMMARY
We are seeing some errors of runQuery being instantiated with a query that has already been created server-side, resulting in a duplicate client_id error. The second api call happens exactly one minute from the first. I haven't been able to recreate the cause, but I looked for instances where we were possibly dispatching `runQuery` with an existing query. I created a new action called `reRunQuery` that removes the id and generates a new one, and then dispatches `runQuery`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
no visual changes

### TEST PLAN
more unit tests, but plan to look at logs after we push this live and see if the problem is fixed. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
