### PR TITLE
fix: `IS NULL` filter operator for numeric columns

### DIFF
--- a/superset-frontend/src/explore/exploreUtils.js
+++ b/superset-frontend/src/explore/exploreUtils.js
@@ -22,6 +22,7 @@ import { useCallback, useEffect } from 'react';
 import URI from 'urijs';
 import {
   buildQueryContext,
+  ensureIsArray,
   getChartBuildQueryRegistry,
   getChartMetadataRegistry,
 } from '@superset-ui/core';
@@ -319,20 +320,14 @@ export const getSimpleSQLExpression = (subject, operator, comparator) => {
     expression += ` ${operator}`;
     const firstValue =
       isMulti && Array.isArray(comparator) ? comparator[0] : comparator;
-    let comparatorArray;
-    if (comparator === undefined || comparator === null) {
-      comparatorArray = [];
-    } else if (Array.isArray(comparator)) {
-      comparatorArray = comparator;
-    } else {
-      comparatorArray = [comparator];
-    }
+    const comparatorArray = ensureIsArray(comparator);
     const isString =
       firstValue !== undefined && Number.isNaN(Number(firstValue));
     const quote = isString ? "'" : '';
     const [prefix, suffix] = isMulti ? ['(', ')'] : ['', ''];
     const formattedComparators = comparatorArray.map(
-      val => `${quote}${isString ? val.replace("'", "''") : val}${quote}`,
+      val =>
+        `${quote}${isString ? String(val).replace("'", "''") : val}${quote}`,
     );
     if (comparatorArray.length > 0) {
       expression += ` ${prefix}${formattedComparators.join(', ')}${suffix}`;

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -359,10 +359,7 @@ class BaseDatasource(
         if is_list_target and not isinstance(values, (tuple, list)):
             values = [values]  # type: ignore
         elif not is_list_target and isinstance(values, (tuple, list)):
-            if values:
-                values = values[0]
-            else:
-                values = None
+            values = values[0] if values else None
         return values
 
     def external_metadata(self) -> List[Dict[str, str]]:

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1066,6 +1066,7 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
                     is_list_target=is_list_target,
                 )
                 if is_list_target:
+                    assert isinstance(eq, (tuple, list))
                     if len(eq) == 0:
                         raise QueryObjectValidationError(
                             _("Filter value list cannot be empty")

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -53,7 +53,6 @@ from sqlalchemy.types import TypeEngine
 
 from superset import app, db, is_feature_enabled, security_manager
 from superset.connectors.base.models import BaseColumn, BaseDatasource, BaseMetric
-from superset.constants import NULL_STRING
 from superset.db_engine_specs.base import TimestampExpression
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import QueryObjectValidationError, SupersetSecurityException
@@ -1091,7 +1090,8 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
                     if eq is None:
                         raise QueryObjectValidationError(
                             _(
-                                "Must specify a value for filters with comparison operators"
+                                "Must specify a value for filters "
+                                "with comparison operators"
                             )
                         )
                     if op == utils.FilterOperator.EQUALS.value:

--- a/tests/charts/api_tests.py
+++ b/tests/charts/api_tests.py
@@ -1046,7 +1046,12 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         data = json.loads(rv.data.decode("utf-8"))
         self.assertEqual(
             data["result"][0]["applied_filters"],
-            [{"column": "gender"}, {"column": "__time_range"},],
+            [
+                {"column": "gender"},
+                {"column": "num"},
+                {"column": "name"},
+                {"column": "__time_range"},
+            ],
         )
         self.assertEqual(
             data["result"][0]["rejected_filters"],

--- a/tests/fixtures/query_context.py
+++ b/tests/fixtures/query_context.py
@@ -41,7 +41,7 @@ query_birth_names = {
     "filters": [
         {"col": "gender", "op": "==", "val": "boy"},
         {"col": "num", "op": "IS NOT NULL"},
-        {"col": "name", "op": "NOT IN", "val": "<NULL>;abc"},
+        {"col": "name", "op": "NOT IN", "val": ["<NULL>", "\"abc\""]},
     ],
     "having": "",
     "having_filters": [],

--- a/tests/fixtures/query_context.py
+++ b/tests/fixtures/query_context.py
@@ -38,7 +38,11 @@ query_birth_names = {
     "time_range": "100 years ago : now",
     "timeseries_limit": 0,
     "timeseries_limit_metric": None,
-    "filters": [{"col": "gender", "op": "==", "val": "boy"}],
+    "filters": [
+        {"col": "gender", "op": "==", "val": "boy"},
+        {"col": "num", "op": "IS NOT NULL"},
+        {"col": "name", "op": "NOT IN", "val": "<NULL>;abc"},
+    ],
     "having": "",
     "having_filters": [],
     "where": "",

--- a/tests/fixtures/query_context.py
+++ b/tests/fixtures/query_context.py
@@ -41,7 +41,7 @@ query_birth_names = {
     "filters": [
         {"col": "gender", "op": "==", "val": "boy"},
         {"col": "num", "op": "IS NOT NULL"},
-        {"col": "name", "op": "NOT IN", "val": ["<NULL>", "\"abc\""]},
+        {"col": "name", "op": "NOT IN", "val": ["<NULL>", '"abc"']},
     ],
     "having": "",
     "having_filters": [],

--- a/tests/query_context_tests.py
+++ b/tests/query_context_tests.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import re
+
 import pytest
 
 from superset import db
@@ -308,9 +310,10 @@ class TestQueryContext(SupersetTestCase):
         sql_text = response["query"]
         assert response["language"] == "sql"
         assert "SELECT" in sql_text
-        assert "num IS NOT NULL" in sql_text
-        assert "NOT (name IS NULL" in sql_text
-        assert "OR name IN ('abc'))" in sql_text
+        assert re.search(r'"?num"? IS NOT NULL', sql_text)
+        assert re.search(
+            r"""NOT \("?name"? IS NULL[\s\n]* OR "?name"? IN \('abc'\)\)""", sql_text
+        )
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_fetch_values_predicate_in_query(self):

--- a/tests/query_context_tests.py
+++ b/tests/query_context_tests.py
@@ -310,9 +310,11 @@ class TestQueryContext(SupersetTestCase):
         sql_text = response["query"]
         assert response["language"] == "sql"
         assert "SELECT" in sql_text
-        assert re.search(r'"?num"? IS NOT NULL', sql_text)
+        assert re.search(r'[`"\[]?num[`"\]]? IS NOT NULL', sql_text)
         assert re.search(
-            r"""NOT \("?name"? IS NULL[\s\n]* OR "?name"? IN \('abc'\)\)""", sql_text
+            r"""NOT \([`"\[]?name[`"\]]? IS NULL[\s\n]* """
+            r"""OR [`"\[]?name[`"\]]? IN \('abc'\)\)""",
+            sql_text,
         )
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")

--- a/tests/query_context_tests.py
+++ b/tests/query_context_tests.py
@@ -305,8 +305,12 @@ class TestQueryContext(SupersetTestCase):
         assert len(responses) == 1
         response = responses["queries"][0]
         assert len(response) == 2
+        sql_text = response["query"]
         assert response["language"] == "sql"
-        assert "SELECT" in response["query"]
+        assert "SELECT" in sql_text
+        assert "num IS NOT NULL" in sql_text
+        assert "NOT (name IS NULL" in sql_text
+        assert "OR name IN ('abc'))" in sql_text
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_fetch_values_predicate_in_query(self):


### PR DESCRIPTION
### SUMMARY

Fixes #13229  where filters for numeric columns could not use `IS NULL` and `IS NOT NULL` operators in SIMPLE mode.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

![Snip20210305_30](https://user-images.githubusercontent.com/335541/110221000-64612800-7e7e-11eb-8195-8dfa122d63f1.png)

#### After

![filter-is-null-after](https://user-images.githubusercontent.com/335541/110221021-822e8d00-7e7e-11eb-8244-91004125ada6.png)

### TEST PLAN

Manual testing

- Will add more unit tests once SQL query generator was refactored and split into smaller testable functions

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
