### PR TITLE
build: check potential db migration conflict for open PRs

### DIFF
--- a/.github/workflows/check_db_migration_confict.yml
+++ b/.github/workflows/check_db_migration_confict.yml
@@ -11,37 +11,39 @@ jobs:
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
-        with:
-          persist-credentials: false
-          submodules: recursive
       - name: Check and notify
         uses: actions/github-script@v3
         with:
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             // API reference: https://octokit.github.io/rest.js
+            const currentBranch = context.ref.replace('ref/heads', '');
 
             // Find all pull requests to current branch
             const opts = github.pulls.list.endpoint.merge({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              base: contect.ref,
+              base: currentBranch,
               state: 'open',
               sort: 'updated',
               per_page: 100,
             });
             const pulls = await github.paginate(opts);
+            if (pulls.length > 0) {
+              console.log(`Found ${pulls.length} open PRs for base branch "${currentBranch}"`)
+            }
 
             for (const pull in pulls) {
               const listFilesOpts = await github.pulls.listFiles.endpoint.merge({
                 owner: context.repo.owner,
-                repo: contet.repo.repo,
+                repo: context.repo.repo,
                 pull_number: pull.number,
               });
               const files = await github.paginate(listFilesOpts);
               if (
                 files.some(x => x.contents_url.includes('/contents/superset/migrations'))
               ) {
+                console.log(`Found open PR #${pull.number} that has also added db migration`)
                 await github.issues.createComment({
                   issue_number: context.issue.number,
                   owner: context.repo.owner,
@@ -53,6 +55,5 @@ jobs:
                     '\n' +
                     '**Please consider rebasing your branch.**',
                 });
-                break;
               }
             }

--- a/.github/workflows/check_db_migration_confict.yml
+++ b/.github/workflows/check_db_migration_confict.yml
@@ -1,0 +1,58 @@
+name: Check DB migration conflict
+on:
+  push:
+    paths:
+      - "superset/migrations/**"
+
+jobs:
+  check_db_migration_conflict:
+    name: Check potential DB migration conflict
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - name: Check and notify
+        uses: actions/github-script@v3
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // API reference: https://octokit.github.io/rest.js
+
+            // Find all pull requests to current branch
+            const opts = github.pulls.list.endpoint.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              base: contect.ref,
+              state: 'open',
+              sort: 'updated',
+              per_page: 100,
+            });
+            const pulls = await github.paginate(opts);
+
+            for (const pull in pulls) {
+              const listFilesOpts = await github.pulls.listFiles.endpoint.merge({
+                owner: context.repo.owner,
+                repo: contet.repo.repo,
+                pull_number: pull.number,
+              });
+              const files = await github.paginate(listFilesOpts);
+              if (
+                files.some(x => x.contents_url.includes('/contents/superset/migrations'))
+              ) {
+                await github.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pull.number,
+                  body:
+                    `@${pull.user.login} Your base branch just also updated \`superset/migrations\`.` +
+                    'It may cause db migration conflicts with your current changes.' +
+                    '\n' +
+                    '**Please consider rebasing your branch.**',
+                });
+                break;
+              }
+            }

--- a/.github/workflows/check_db_migration_confict.yml
+++ b/.github/workflows/check_db_migration_confict.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check_db_migration_conflict:
-    name: Check potential DB migration conflict
+    name: Check DB migration conflict
     runs-on: ubuntu-20.04
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
@@ -17,13 +17,13 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             // API reference: https://octokit.github.io/rest.js
-            const currentBranch = context.ref.replace('ref/heads', '');
+            const currentBranch = context.ref.replace('refs/heads/', '');
 
             // Find all pull requests to current branch
             const opts = github.pulls.list.endpoint.merge({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              base: currentBranch,
+              base: context.ref,
               state: 'open',
               sort: 'updated',
               per_page: 100,
@@ -34,6 +34,7 @@ jobs:
             }
 
             for (const pull in pulls) {
+              console.log(pull);
               const listFilesOpts = await github.pulls.listFiles.endpoint.merge({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -43,7 +44,7 @@ jobs:
               if (
                 files.some(x => x.contents_url.includes('/contents/superset/migrations'))
               ) {
-                console.log(`Found open PR #${pull.number} that has also added db migration`)
+                console.log(`PR #${pull.number} "${pull.title}" also added db migration`)
                 await github.issues.createComment({
                   issue_number: context.issue.number,
                   owner: context.repo.owner,

--- a/.github/workflows/check_db_migration_confict.yml
+++ b/.github/workflows/check_db_migration_confict.yml
@@ -33,8 +33,7 @@ jobs:
               console.log(`Found ${pulls.length} open PRs for base branch "${currentBranch}"`)
             }
 
-            for (const pull in pulls) {
-              console.log(pull);
+            for (const pull of pulls) {
               const listFilesOpts = await github.pulls.listFiles.endpoint.merge({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/check_db_migration_confict.yml
+++ b/.github/workflows/check_db_migration_confict.yml
@@ -50,10 +50,11 @@ jobs:
                   repo: context.repo.repo,
                   issue_number: pull.number,
                   body:
-                    `@${pull.user.login} Your base branch just also updated \`superset/migrations\`.` +
-                    'It may cause db migration conflicts with your current changes.' +
+                    `⚠️ @${pull.user.login} Your base branch just also updated \`superset/migrations\`.\n` +
                     '\n' +
-                    '**Please consider rebasing your branch.**',
+                    'It may cause db migration conflicts with your current changes.\n' +
+                    '\n' +
+                    '**❗ Please consider rebasing your branch.**',
                 });
               }
             }

--- a/.github/workflows/check_db_migration_confict.yml
+++ b/.github/workflows/check_db_migration_confict.yml
@@ -50,11 +50,10 @@ jobs:
                   repo: context.repo.repo,
                   issue_number: pull.number,
                   body:
-                    `⚠️ @${pull.user.login} Your base branch just also updated \`superset/migrations\`.\n` +
+                    `⚠️ @${pull.user.login} Your base branch \`${currentBranch}\` has just ` +
+                    'also updated `superset/migrations`.\n' +
                     '\n' +
-                    'It may cause db migration conflicts with your current changes.\n' +
-                    '\n' +
-                    '**❗ Please consider rebasing your branch.**',
+                    '❗ **Please consider rebasing your branch to avoid db migration conflicts.**',
                 });
               }
             }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1001,7 +1001,7 @@ Submissions will be considered for submission (or removal) on a case-by-case bas
 
 When two DB migrations collide, you'll get an error message like this one:
 
-```
+```text
 alembic.util.exc.CommandError: Multiple head revisions are present for
 given argument 'head'; please specify a specific target
 revision, '<branchname>@head' to narrow to a specific head,
@@ -1016,15 +1016,46 @@ To fix it:
    superset db heads
    ```
 
-   This should list two or more migration hashes.
+   This should list two or more migration hashes. E.g.
 
-1. Create a new merge migration
+   ```bash
+   1412ec1e5a7b (head)
+   67da9ef1ef9c (head)
+   ```
+
+2. Pick one of them as the parent revision, open the script for the other revision
+   and update `Revises` and `down_revision` to the new parent revision. E.g.:
+
+   ```diff
+   --- a/67da9ef1ef9c_add_hide_left_bar_to_tabstate.py
+   +++ b/67da9ef1ef9c_add_hide_left_bar_to_tabstate.py
+   @@ -17,14 +17,14 @@
+   """add hide_left_bar to tabstate
+
+   Revision ID: 67da9ef1ef9c
+   -Revises: c501b7c653a3
+   +Revises: 1412ec1e5a7b
+   Create Date: 2021-02-22 11:22:10.156942
+
+   """
+
+   # revision identifiers, used by Alembic.
+   revision = "67da9ef1ef9c"
+   -down_revision = "c501b7c653a3"
+   +down_revision = "1412ec1e5a7b"
+
+   import sqlalchemy as sa
+   from alembic import op
+   ```
+
+   Alternatively you may also run `superset db merge` to create a migration script
+   just for merging the heads.
 
    ```bash
    superset db merge {HASH1} {HASH2}
    ```
 
-1. Upgrade the DB to the new checkpoint
+3. Upgrade the DB to the new checkpoint
 
    ```bash
    superset db upgrade


### PR DESCRIPTION
### SUMMARY

Today `master` was broken for a couple of hours because a merge conflict of db migrations. This can happen when two PRs with db migrations that point to the same revision merge separately right after one another---since we don't rerun CI after merges, it's hard to catch this before merging.

This PR adds a new workflow that checks and notifies the PR author of potential db migration conflicts. It runs when an update of the db migration scripts is pushed to any branch, scans all open PRs that are using said branch as the base branch, and checks whether they also update the migration scripts. If yes, then a comment is sent to remind the PR author to rebase the branch. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<img src="https://user-images.githubusercontent.com/335541/110190583-daab4f00-7dd8-11eb-950b-6eee32d9cdad.png" width="800">


### TEST PLAN

Tested on my personal fork: https://github.com/ktmud/superset/pull/303

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
