### PR TITLE
chore(homepage): separate out api calls to make homepage load more dynamically

### DIFF
--- a/superset-frontend/spec/javascripts/views/CRUD/welcome/ActivityTable_spec.tsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/welcome/ActivityTable_spec.tsx
@@ -18,6 +18,10 @@
  */
 import React from 'react';
 import { styledMount as mount } from 'spec/helpers/theming';
+import { act } from 'react-dom/test-utils';
+import { ReactWrapper } from 'enzyme';
+import { Provider } from 'react-redux';
+import fetchMock from 'fetch-mock';
 import thunk from 'redux-thunk';
 import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
 import configureStore from 'redux-mock-store';
@@ -25,6 +29,9 @@ import ActivityTable from 'src/views/CRUD/welcome/ActivityTable';
 
 const mockStore = configureStore([thunk]);
 const store = mockStore({});
+
+const chartsEndpoint = 'glob:*/api/v1/chart/?*';
+const dashboardsEndpoint = 'glob:*/api/v1/dashboard/?*';
 
 const mockData = {
   Viewed: [
@@ -34,14 +41,6 @@ const mockData = {
       url: '/fakeUrl/explore',
       id: '4',
       table: {},
-    },
-  ],
-  Edited: [
-    {
-      dashboard_title: 'Dashboard_Test',
-      changed_on_utc: '24 Feb 2014 10:13:14',
-      url: '/fakeUrl/dashboard',
-      id: '3',
     },
   ],
   Created: [
@@ -54,20 +53,48 @@ const mockData = {
   ],
 };
 
+fetchMock.get(chartsEndpoint, {
+  result: [
+    {
+      slice_name: 'ChartyChart',
+      changed_on_utc: '24 Feb 2014 10:13:14',
+      url: '/fakeUrl/explore',
+      id: '4',
+      table: {},
+    },
+  ],
+});
+
+fetchMock.get(dashboardsEndpoint, {
+  result: [
+    {
+      dashboard_title: 'Dashboard_Test',
+      changed_on_utc: '24 Feb 2014 10:13:14',
+      url: '/fakeUrl/dashboard',
+      id: '3',
+    },
+  ],
+});
+
 describe('ActivityTable', () => {
   const activityProps = {
-    activeChild: 'Edited',
+    activeChild: 'Created',
     activityData: mockData,
     setActiveChild: jest.fn(),
     user: { userId: '1' },
     loading: false,
   };
-  const wrapper = mount(<ActivityTable {...activityProps} />, {
-    context: { store },
-  });
+
+  let wrapper: ReactWrapper;
 
   beforeAll(async () => {
-    await waitForComponentToPaint(wrapper);
+    await act(async () => {
+      wrapper = mount(
+        <Provider store={store}>
+          <ActivityTable {...activityProps} />
+        </Provider>,
+      );
+    });
   });
 
   it('the component renders', () => {
@@ -78,5 +105,33 @@ describe('ActivityTable', () => {
   });
   it('renders ActivityCards', async () => {
     expect(wrapper.find('ListViewCard')).toExist();
+  });
+  it('calls the getEdited batch call when edited tab is clicked', async () => {
+    act(() => {
+      const handler = wrapper.find('li.no-router a').at(1).prop('onClick');
+      if (handler) {
+        handler({} as any);
+      }
+    });
+    await waitForComponentToPaint(wrapper);
+    const dashboardCall = fetchMock.calls(/dashboard\/\?q/);
+    const chartCall = fetchMock.calls(/chart\/\?q/);
+    expect(chartCall).toHaveLength(1);
+    expect(dashboardCall).toHaveLength(1);
+  });
+  it('show empty state if there is data', () => {
+    const activityProps = {
+      activeChild: 'Created',
+      activityData: {},
+      setActiveChild: jest.fn(),
+      user: { userId: '1' },
+      loading: false,
+    };
+    const wrapper = mount(
+      <Provider store={store}>
+        <ActivityTable {...activityProps} />
+      </Provider>,
+    );
+    expect(wrapper.find('EmptyState')).toExist();
   });
 });

--- a/superset-frontend/spec/javascripts/views/CRUD/welcome/Welcome_spec.tsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/welcome/Welcome_spec.tsx
@@ -67,7 +67,10 @@ fetchMock.get(savedQueryEndpoint, {
   result: [],
 });
 
-fetchMock.get(recentActivityEndpoint, {});
+fetchMock.get(recentActivityEndpoint, {
+  Created: [],
+  Viewed: [],
+});
 
 fetchMock.get(chartInfoEndpoint, {
   permissions: [],
@@ -122,10 +125,14 @@ describe('Welcome', () => {
     expect(wrapper.find('CollapsePanel')).toHaveLength(8);
   });
 
-  it('calls batch method on page load', () => {
+  it('calls api methods in parallel on page load', () => {
     const chartCall = fetchMock.calls(/chart\/\?q/);
+    const savedQueryCall = fetchMock.calls(/saved_query\/\?q/);
+    const recentCall = fetchMock.calls(/superset\/recent_activity\/*/);
     const dashboardCall = fetchMock.calls(/dashboard\/\?q/);
-    expect(chartCall).toHaveLength(2);
-    expect(dashboardCall).toHaveLength(2);
+    expect(chartCall).toHaveLength(1);
+    expect(recentCall).toHaveLength(1);
+    expect(savedQueryCall).toHaveLength(1);
+    expect(dashboardCall).toHaveLength(1);
   });
 });

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -36,7 +36,6 @@ interface ListViewResourceState<D extends object = any> {
   lastFetchDataConfig: FetchDataConfig | null;
   bulkSelectEnabled: boolean;
   lastFetched?: string;
-  defualtLoading?: boolean;
 }
 
 export function useListViewResource<D extends object = any>(
@@ -46,12 +45,12 @@ export function useListViewResource<D extends object = any>(
   infoEnable = true,
   defaultCollectionValue: D[] = [],
   baseFilters?: FilterValue[], // must be memoized
-  defaultLoading = true,
+  initialLoadingState = true,
 ) {
   const [state, setState] = useState<ListViewResourceState<D>>({
     count: 0,
     collection: defaultCollectionValue,
-    loading: defaultLoading,
+    loading: initialLoadingState,
     lastFetchDataConfig: null,
     permissions: [],
     bulkSelectEnabled: false,

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -36,6 +36,7 @@ interface ListViewResourceState<D extends object = any> {
   lastFetchDataConfig: FetchDataConfig | null;
   bulkSelectEnabled: boolean;
   lastFetched?: string;
+  defualtLoading?: boolean;
 }
 
 export function useListViewResource<D extends object = any>(
@@ -45,11 +46,12 @@ export function useListViewResource<D extends object = any>(
   infoEnable = true,
   defaultCollectionValue: D[] = [],
   baseFilters?: FilterValue[], // must be memoized
+  defaultLoading = true,
 ) {
   const [state, setState] = useState<ListViewResourceState<D>>({
     count: 0,
     collection: defaultCollectionValue,
-    loading: true,
+    loading: defaultLoading,
     lastFetchDataConfig: null,
     permissions: [],
     bulkSelectEnabled: false,

--- a/superset-frontend/src/views/CRUD/types.ts
+++ b/superset-frontend/src/views/CRUD/types.ts
@@ -23,6 +23,12 @@ export type FavoriteStatus = {
   [id: number]: boolean;
 };
 
+export type Filters = {
+  col: string;
+  opr: string;
+  value: string;
+};
+
 export interface DashboardTableProps {
   addDangerToast: (message: string) => void;
   addSuccessToast: (message: string) => void;

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -91,14 +91,15 @@ export const getEditedObjs = (userId: string | number) => {
       endpoint: `/api/v1/chart/?q=${getParams(filters.edited)}`,
     }),
   ];
-  return Promise.all(batch).then(([editedCharts, editedDashboards]) => {
-    const res = {
-      editedDash: editedDashboards.json?.result.slice(0, 3),
-      editedChart: editedCharts.json?.result.slice(0, 3),
-    };
-    console.log('res', res);
-    return res;
-  });
+  return Promise.all(batch)
+    .then(([editedCharts, editedDashboards]) => {
+      const res = {
+        editedDash: editedDashboards.json?.result.slice(0, 3),
+        editedChart: editedCharts.json?.result.slice(0, 3),
+      };
+      return res;
+    })
+    .catch(err => err);
 };
 
 export const getMineObjs = (userId: string | number, resource: string) => {
@@ -113,30 +114,15 @@ export const getMineObjs = (userId: string | number, resource: string) => {
   };
   return SupersetClient.get({
     endpoint: `/api/v1/${resource}/?q=${getParams(filters.created)}`,
-  }).then(res => {
-    console.log('res', res);
-    return res.json?.result;
-  });
+  }).then(res => res.json?.result);
 };
 
 export const getRecentAcitivtyObjs = (
   userId: string | number,
   recent: string,
   addDangerToast: (arg1: string, arg2: any) => any,
-) => {
-  const filters = {
-    // chart and dashbaord uses same filters
-    // for edited and created
-    edited: [
-      {
-        col: 'changed_by',
-        opr: 'rel_o_m',
-        value: `${userId}`,
-      },
-    ],
-  };
-  const baseBatch = [];
-  return SupersetClient.get({ endpoint: recent }).then(recentsRes => {
+) =>
+  SupersetClient.get({ endpoint: recent }).then(recentsRes => {
     const res: any = {};
     if (recentsRes.json.length === 0) {
       const newBatch = [
@@ -160,7 +146,6 @@ export const getRecentAcitivtyObjs = (
     res.viewed = recentsRes.json;
     return res;
   });
-};
 
 export const createFetchRelated = createFetchResourceMethod('related');
 export const createFetchDistinct = createFetchResourceMethod('distinct');

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -29,6 +29,12 @@ import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 import { FetchDataConfig } from 'src/components/ListView';
 import { Dashboard } from './types';
 
+interface Filters {
+  col: string;
+  opr: string;
+  value: string;
+}
+
 const createFetchResourceMethod = (method: string) => (
   resource: string,
   relation: string,
@@ -61,7 +67,7 @@ const createFetchResourceMethod = (method: string) => (
   return [];
 };
 
-const getParams = (filters?: Array<any>) => {
+const getParams = (filters?: Array<Filters>) => {
   const params = {
     order_column: 'changed_on_delta_humanized',
     order_direction: 'desc',

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -27,13 +27,7 @@ import Chart from 'src/types/Chart';
 import rison from 'rison';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 import { FetchDataConfig } from 'src/components/ListView';
-import { Dashboard } from './types';
-
-interface Filters {
-  col: string;
-  opr: string;
-  value: string;
-}
+import { Dashboard, Filters } from './types';
 
 const createFetchResourceMethod = (method: string) => (
   resource: string,
@@ -79,7 +73,7 @@ const getParams = (filters?: Array<Filters>) => {
   return rison.encode(params);
 };
 
-export const getEditedObjs = (userId: string | number) => {
+export const getEditedObjects = (userId: string | number) => {
   const filters = {
     edited: [
       {
@@ -108,7 +102,10 @@ export const getEditedObjs = (userId: string | number) => {
     .catch(err => err);
 };
 
-export const getMineObjs = (userId: string | number, resource: string) => {
+export const getUserOwnedObjects = (
+  userId: string | number,
+  resource: string,
+) => {
   const filters = {
     created: [
       {

--- a/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
@@ -25,12 +25,7 @@ import ListViewCard from 'src/components/ListViewCard';
 import SubMenu from 'src/components/Menu/SubMenu';
 import { Chart } from 'src/types/Chart';
 import { Dashboard, SavedQueryObject } from 'src/views/CRUD/types';
-import {
-  mq,
-  CardStyles,
-  getEditedObjs,
-  getMineObjs,
-} from 'src/views/CRUD/utils';
+import { mq, CardStyles, getEditedObjs } from 'src/views/CRUD/utils';
 
 import { ActivityData } from './Welcome';
 import EmptyState from './EmptyState';
@@ -167,14 +162,12 @@ export default function ActivityTable({
   activityData,
   user,
 }: ActivityProps) {
-  console.log('loading acitivty', loading);
   const [editedObjs, setEditedObjs] = useState<any>();
   const [loadingState, setLoadingState] = useState(false);
 
   const getEditedCards = () => {
     setLoadingState(true);
     getEditedObjs(user.userId).then(r => {
-      console.log('editobjs', r);
       setEditedObjs([...r.editedChart, ...r.editedDash]);
       setLoadingState(false);
     });
@@ -215,39 +208,34 @@ export default function ActivityTable({
     });
   }
 
-  const renderActivity = () => {
-    console.log('editedObjs', editedObjs);
-    return (activeChild !== 'Edited'
-      ? activityData[activeChild]
-      : editedObjs
-    ).map((entity: ActivityObject) => {
-      console.log('entity', entity);
-      const url = getEntityUrl(entity);
-      const lastActionOn = getEntityLastActionOn(entity);
-      return (
-        <CardStyles
-          onClick={() => {
-            window.location.href = url;
-          }}
-          key={url}
-        >
-          <ListViewCard
-            loading={loading}
-            cover={<></>}
-            url={url}
-            title={getEntityTitle(entity)}
-            description={lastActionOn}
-            avatar={getEntityIconName(entity)}
-            actions={null}
-          />
-        </CardStyles>
-      );
-    });
-  };
+  const renderActivity = () =>
+    (activeChild !== 'Edited' ? activityData[activeChild] : editedObjs).map(
+      (entity: ActivityObject) => {
+        const url = getEntityUrl(entity);
+        const lastActionOn = getEntityLastActionOn(entity);
+        return (
+          <CardStyles
+            onClick={() => {
+              window.location.href = url;
+            }}
+            key={url}
+          >
+            <ListViewCard
+              loading={loading}
+              cover={<></>}
+              url={url}
+              title={getEntityTitle(entity)}
+              description={lastActionOn}
+              avatar={getEntityIconName(entity)}
+              actions={null}
+            />
+          </CardStyles>
+        );
+      },
+    );
   if (loading || (loadingState && !editedObjs)) {
     return <Loading position="inline" />;
   }
-  console.log('activityData *&*&*&*&', editedObjs);
   return (
     <>
       <SubMenu

--- a/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
@@ -162,7 +162,7 @@ export default function ActivityTable({
   activityData,
   user,
 }: ActivityProps) {
-  const [editedObjs, setEditedObjs] = useState<any>();
+  const [editedObjs, setEditedObjs] = useState<Array<ActivityData>>();
   const [loadingState, setLoadingState] = useState(false);
 
   const getEditedCards = () => {
@@ -245,7 +245,7 @@ export default function ActivityTable({
       />
       <>
         {activityData[activeChild]?.length > 0 ||
-        (activeChild === 'Edited' && editedObjs) ? (
+        (activeChild === 'Edited' && editedObjs && editedObjs.length > 0) ? (
           <ActivityContainer>{renderActivity()}</ActivityContainer>
         ) : (
           <EmptyState tableName="RECENTS" tab={activeChild} />

--- a/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
@@ -25,7 +25,7 @@ import ListViewCard from 'src/components/ListViewCard';
 import SubMenu from 'src/components/Menu/SubMenu';
 import { Chart } from 'src/types/Chart';
 import { Dashboard, SavedQueryObject } from 'src/views/CRUD/types';
-import { mq, CardStyles, getEditedObjs } from 'src/views/CRUD/utils';
+import { mq, CardStyles, getEditedObjects } from 'src/views/CRUD/utils';
 
 import { ActivityData } from './Welcome';
 import EmptyState from './EmptyState';
@@ -167,7 +167,7 @@ export default function ActivityTable({
 
   const getEditedCards = () => {
     setLoadingState(true);
-    getEditedObjs(user.userId).then(r => {
+    getEditedObjects(user.userId).then(r => {
       setEditedObjs([...r.editedChart, ...r.editedDash]);
       setLoadingState(false);
     });

--- a/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
@@ -66,7 +66,6 @@ interface ActivityProps {
   };
   activeChild: string;
   setActiveChild: (arg0: string) => void;
-  loading: boolean;
   activityData: ActivityData;
 }
 
@@ -156,7 +155,6 @@ const getEntityLastActionOn = (entity: ActivityObject) => {
 };
 
 export default function ActivityTable({
-  loading,
   activeChild,
   setActiveChild,
   activityData,
@@ -164,7 +162,6 @@ export default function ActivityTable({
 }: ActivityProps) {
   const [editedObjs, setEditedObjs] = useState<Array<ActivityData>>();
   const [loadingState, setLoadingState] = useState(false);
-
   const getEditedCards = () => {
     setLoadingState(true);
     getEditedObjects(user.userId).then(r => {
@@ -221,7 +218,6 @@ export default function ActivityTable({
             key={url}
           >
             <ListViewCard
-              loading={loading}
               cover={<></>}
               url={url}
               title={getEntityTitle(entity)}
@@ -233,7 +229,7 @@ export default function ActivityTable({
         );
       },
     );
-  if (loading || (loadingState && !editedObjs)) {
+  if (loadingState && !editedObjs) {
     return <Loading position="inline" />;
   }
   return (

--- a/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
@@ -65,6 +65,7 @@ function ChartTable({
     true,
     mine,
   );
+
   const chartIds = useMemo(() => charts.map(c => c.id), [charts]);
   const [saveFavoriteStatus, favoriteStatus] = useFavoriteStatus(
     'chart',

--- a/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
@@ -29,6 +29,7 @@ import PropertiesModal from 'src/explore/components/PropertiesModal';
 import { User } from 'src/types/bootstrapTypes';
 import ChartCard from 'src/views/CRUD/chart/ChartCard';
 import Chart from 'src/types/Chart';
+import Loading from 'src/components/Loading';
 import ErrorBoundary from 'src/components/ErrorBoundary';
 import SubMenu from 'src/components/Menu/SubMenu';
 import EmptyState from './EmptyState';
@@ -53,7 +54,7 @@ function ChartTable({
 }: ChartTableProps) {
   const history = useHistory();
   const {
-    state: { resourceCollection: charts, bulkSelectEnabled },
+    state: { loading, resourceCollection: charts, bulkSelectEnabled },
     setResourceCollection: setCharts,
     hasPerm,
     refreshData,
@@ -64,6 +65,8 @@ function ChartTable({
     addDangerToast,
     true,
     mine,
+    [],
+    false,
   );
 
   const chartIds = useMemo(() => charts.map(c => c.id), [charts]);
@@ -113,6 +116,7 @@ function ChartTable({
       filters: getFilters(filter),
     });
 
+  if (loading) return <Loading position="inline" />;
   return (
     <ErrorBoundary>
       {sliceCurrentlyEditing && (

--- a/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useState, useMemo, useEffect } from 'react';
+import React, { useState, useMemo } from 'react';
 import { SupersetClient, t } from '@superset-ui/core';
 import { useListViewResource, useFavoriteStatus } from 'src/views/CRUD/hooks';
 import { Dashboard, DashboardTableProps } from 'src/views/CRUD/types';
@@ -56,8 +56,9 @@ function DashboardTable({
     addDangerToast,
     true,
     mine,
+    [],
+    false,
   );
-  console.log('dashboard', dashboards)
   const dashboardIds = useMemo(() => dashboards.map(c => c.id), [dashboards]);
   const [saveFavoriteStatus, favoriteStatus] = useFavoriteStatus(
     'dashboard',
@@ -127,7 +128,7 @@ function DashboardTable({
       filters: getFilters(filter),
     });
 
-  // if (loading) return <Loading position="inline" />;
+  if (loading) return <Loading position="inline" />;
   return (
     <>
       <SubMenu

--- a/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
@@ -16,12 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { SupersetClient, t } from '@superset-ui/core';
 import { useListViewResource, useFavoriteStatus } from 'src/views/CRUD/hooks';
 import { Dashboard, DashboardTableProps } from 'src/views/CRUD/types';
 import { useHistory } from 'react-router-dom';
 import withToasts from 'src/messageToasts/enhancers/withToasts';
+import Loading from 'src/components/Loading';
 import PropertiesModal from 'src/dashboard/components/PropertiesModal';
 import DashboardCard from 'src/views/CRUD/dashboard/DashboardCard';
 import SubMenu from 'src/components/Menu/SubMenu';
@@ -56,6 +57,7 @@ function DashboardTable({
     true,
     mine,
   );
+  console.log('dashboard', dashboards)
   const dashboardIds = useMemo(() => dashboards.map(c => c.id), [dashboards]);
   const [saveFavoriteStatus, favoriteStatus] = useFavoriteStatus(
     'dashboard',
@@ -125,6 +127,7 @@ function DashboardTable({
       filters: getFilters(filter),
     });
 
+  // if (loading) return <Loading position="inline" />;
   return (
     <>
       <SubMenu

--- a/superset-frontend/src/views/CRUD/welcome/SavedQueries.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/SavedQueries.tsx
@@ -22,6 +22,7 @@ import SyntaxHighlighter from 'react-syntax-highlighter/dist/cjs/light';
 import sql from 'react-syntax-highlighter/dist/cjs/languages/hljs/sql';
 import github from 'react-syntax-highlighter/dist/cjs/styles/hljs/github';
 import withToasts from 'src/messageToasts/enhancers/withToasts';
+import Loading from 'src/components/Loading';
 import { Dropdown, Menu } from 'src/common/components';
 import { useListViewResource, copyQueryLink } from 'src/views/CRUD/hooks';
 import ListViewCard from 'src/components/ListViewCard';
@@ -111,7 +112,7 @@ const SavedQueries = ({
   mine,
 }: SavedQueriesProps) => {
   const {
-    state: { resourceCollection: queries },
+    state: { loading, resourceCollection: queries },
     hasPerm,
     fetchData,
     refreshData,
@@ -121,6 +122,8 @@ const SavedQueries = ({
     addDangerToast,
     true,
     mine,
+    [],
+    false,
   );
   const [queryFilter, setQueryFilter] = useState('Mine');
   const [queryDeleteModal, setQueryDeleteModal] = useState(false);
@@ -227,6 +230,8 @@ const SavedQueries = ({
       )}
     </Menu>
   );
+
+  if (loading) return <Loading position="inline" />;
   return (
     <>
       {queryDeleteModal && (

--- a/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
@@ -89,13 +89,15 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
   const [activityData, setActivityData] = useState<ActivityData>({});
   const [chartData, setChartData] = useState<Array<object> | null>(null);
   const [queryData, setQueryData] = useState<Array<object> | null>(null);
-  const [dashboardData, setDashboardData] = useState<Array<object> | null>(null);
+  const [dashboardData, setDashboardData] = useState<Array<object> | null>(
+    null,
+  );
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     getRecentAcitivtyObjs(user.userId, recent, addDangerToast)
       .then(res => {
-        const data: any = {};
+        const data: ActivityData | null = {};
         if (res.viewed) {
           const filtered = reject(res.viewed, ['item_url', null]).map(r => r);
           data.Viewed = filtered;

--- a/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
@@ -27,7 +27,7 @@ import {
   createErrorHandler,
   getRecentAcitivtyObjs,
   mq,
-  getMineObjs,
+  getUserOwnedObjects,
 } from 'src/views/CRUD/utils';
 
 import ActivityTable from './ActivityTable';
@@ -120,7 +120,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
 
     // Sets other activity data in parallel with recents api call
     const id = user.userId;
-    getMineObjs(id, 'dashboard')
+    getUserOwnedObjects(id, 'dashboard')
       .then(r => {
         setDashboardData(r);
       })
@@ -130,7 +130,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
           t('There was an issues fetching your dashboards: %s', err),
         );
       });
-    getMineObjs(id, 'chart')
+    getUserOwnedObjects(id, 'chart')
       .then(r => {
         setChartData(r);
       })
@@ -138,7 +138,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
         setChartData([]);
         addDangerToast(t('There was an issues fetching your chart: %s', err));
       });
-    getMineObjs(id, 'saved_query')
+    getUserOwnedObjects(id, 'saved_query')
       .then(r => {
         setQueryData(r);
       })

--- a/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
@@ -45,9 +45,6 @@ export interface ActivityData {
   Edited?: Array<object>;
   Viewed?: Array<object>;
   Examples?: Array<object>;
-  myChart?: Array<object>;
-  myDash?: Array<object>;
-  myQuery?: Array<object>;
 }
 
 const WelcomeContainer = styled.div`

--- a/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
@@ -86,13 +86,12 @@ const WelcomeContainer = styled.div`
 function Welcome({ user, addDangerToast }: WelcomeProps) {
   const recent = `/superset/recent_activity/${user.userId}/?limit=6`;
   const [activeChild, setActiveChild] = useState('Viewed');
-  const [activityData, setActivityData] = useState<ActivityData>({});
+  const [activityData, setActivityData] = useState<ActivityData | null >(null);
   const [chartData, setChartData] = useState<Array<object> | null>(null);
   const [queryData, setQueryData] = useState<Array<object> | null>(null);
   const [dashboardData, setDashboardData] = useState<Array<object> | null>(
     null,
   );
-  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     getRecentAcitivtyObjs(user.userId, recent, addDangerToast)
@@ -106,12 +105,11 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
           data.Examples = res.examples;
           setActiveChild('Examples');
         }
-        setActivityData(data);
-        setLoading(false);
+        setActivityData(activityData => ({ ...activityData, ...data}));
       })
       .catch(
         createErrorHandler((errMsg: unknown) => {
-          setLoading(false);
+          setActivityData(activityData => ({ ...activityData, Viewed: [] }));
           addDangerToast(
             t('There was an issue fetching your recent activity: %s', errMsg),
           );
@@ -165,13 +163,16 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
     <WelcomeContainer>
       <Collapse defaultActiveKey={['1', '2', '3', '4']} ghost bigger>
         <Collapse.Panel header={t('Recents')} key="1">
-          <ActivityTable
-            user={user}
-            activeChild={activeChild}
-            setActiveChild={setActiveChild}
-            loading={loading && !chartData && !queryData && !dashboardData}
-            activityData={activityData}
-          />
+          {activityData && (activityData.Viewed || activityData.Examples)  ?
+            <ActivityTable
+              user={user}
+              activeChild={activeChild}
+              setActiveChild={setActiveChild}
+              activityData={activityData}
+            />
+            :
+            <Loading position="inline" />
+          }
         </Collapse.Panel>
         <Collapse.Panel header={t('Dashboards')} key="2">
           {!dashboardData ? (

--- a/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
@@ -86,7 +86,7 @@ const WelcomeContainer = styled.div`
 function Welcome({ user, addDangerToast }: WelcomeProps) {
   const recent = `/superset/recent_activity/${user.userId}/?limit=6`;
   const [activeChild, setActiveChild] = useState('Viewed');
-  const [activityData, setActivityData] = useState<ActivityData | null >(null);
+  const [activityData, setActivityData] = useState<ActivityData | null>(null);
   const [chartData, setChartData] = useState<Array<object> | null>(null);
   const [queryData, setQueryData] = useState<Array<object> | null>(null);
   const [dashboardData, setDashboardData] = useState<Array<object> | null>(
@@ -105,7 +105,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
           data.Examples = res.examples;
           setActiveChild('Examples');
         }
-        setActivityData(activityData => ({ ...activityData, ...data}));
+        setActivityData(activityData => ({ ...activityData, ...data }));
       })
       .catch(
         createErrorHandler((errMsg: unknown) => {
@@ -163,16 +163,16 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
     <WelcomeContainer>
       <Collapse defaultActiveKey={['1', '2', '3', '4']} ghost bigger>
         <Collapse.Panel header={t('Recents')} key="1">
-          {activityData && (activityData.Viewed || activityData.Examples)  ?
+          {activityData && (activityData.Viewed || activityData.Examples) ? (
             <ActivityTable
               user={user}
               activeChild={activeChild}
               setActiveChild={setActiveChild}
               activityData={activityData}
             />
-            :
+          ) : (
             <Loading position="inline" />
-          }
+          )}
         </Collapse.Panel>
         <Collapse.Panel header={t('Dashboards')} key="2">
           {!dashboardData ? (


### PR DESCRIPTION
### SUMMARY
This pr is based off feedback from users with slow loading home page from api calls. The initial setup for page load was to batch call for all data on page load. This pr separates out api calls for recent activity and run mine's api calls in parallel on page load. This should allow some data to show faster on homepage without depending on long api requests.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
Unit test will be updated as change are made.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
