### PR TITLE
fix: added parser to parse request referer url for url_param (issue_id : 13315)

### DIFF
--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -209,7 +209,6 @@ class ExtraCache:
         form_data, _ = get_form_data()
         url_params = form_data.get("url_params") or {}
 
-        ##Parsing Referer to get query params
         if request.headers.get("Referer", None):
             referer_query_param = dict(
                 parse.parse_qsl(parse.urlsplit(request.headers["Referer"]).query)

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -239,10 +239,7 @@ def safe_proxy(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
             return_value = json.loads(json.dumps(return_value))
         except TypeError:
             raise SupersetTemplateException(
-                _(
-                    "Unsupported return value for method %(name)s",
-                    name=func.__name__,
-                )
+                _("Unsupported return value for method %(name)s", name=func.__name__,)
             )
 
     return return_value

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -212,7 +212,8 @@ class ExtraCache:
         ##Parsing Referer to get query params
         if request.headers.get("Referer", None):
             referer_query_param = dict(
-                parse.parse_qsl(parse.urlsplit(request.headers["Referer"]).query))
+                parse.parse_qsl(parse.urlsplit(request.headers["Referer"]).query)
+            )
             if len(referer_query_param):
                 url_params.update(referer_query_param)
 
@@ -239,7 +240,10 @@ def safe_proxy(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
             return_value = json.loads(json.dumps(return_value))
         except TypeError:
             raise SupersetTemplateException(
-                _("Unsupported return value for method %(name)s", name=func.__name__,)
+                _(
+                    "Unsupported return value for method %(name)s",
+                    name=func.__name__,
+                )
             )
 
     return return_value

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -202,14 +202,12 @@ class ExtraCache:
         :param add_to_cache_keys: Whether the value should be included in the cache key
         :returns: The URL parameters
         """
-
         from superset.views.utils import get_form_data
 
         if request.args.get(param):
             return request.args.get(param, default)
         form_data, _ = get_form_data()
         url_params = form_data.get("url_params") or {}
-        result = url_params.get(param, default)
 
         ##Parsing Referer to get query params
         if request.headers.get("Referer", None):
@@ -217,6 +215,8 @@ class ExtraCache:
                 parse.parse_qsl(parse.urlsplit(request.headers["Referer"]).query))
             if len(referer_query_param):
                 url_params.update(referer_query_param)
+
+        result = url_params.get(param, default)
 
         if add_to_cache_keys:
             self.cache_key_wrapper(result)

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -19,6 +19,7 @@ import json
 import re
 from functools import partial
 from typing import Any, Callable, cast, Dict, List, Optional, Tuple, TYPE_CHECKING
+from urllib import parse
 
 from flask import current_app, g, request
 from flask_babel import gettext as _
@@ -209,6 +210,14 @@ class ExtraCache:
         form_data, _ = get_form_data()
         url_params = form_data.get("url_params") or {}
         result = url_params.get(param, default)
+
+        ## Parsing Referer to get query params
+        if request.headers.get("Referer", None):
+            referer_query_param = dict(
+                parse.parse_qsl(parse.urlsplit(request.headers["Referer"]).query))
+            if len(referer_query_param):
+                url_params.update(referer_query_param)
+
         if add_to_cache_keys:
             self.cache_key_wrapper(result)
         return result

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -211,7 +211,7 @@ class ExtraCache:
         url_params = form_data.get("url_params") or {}
         result = url_params.get(param, default)
 
-        ## Parsing Referer to get query params
+        ##Parsing Referer to get query params
         if request.headers.get("Referer", None):
             referer_query_param = dict(
                 parse.parse_qsl(parse.urlsplit(request.headers["Referer"]).query))

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -213,8 +213,7 @@ class ExtraCache:
             referer_query_param = dict(
                 parse.parse_qsl(parse.urlsplit(request.headers["Referer"]).query)
             )
-            if len(referer_query_param):
-                url_params.update(referer_query_param)
+            url_params.update(referer_query_param)
 
         result = url_params.get(param, default)
 

--- a/tests/jinja_context_tests.py
+++ b/tests/jinja_context_tests.py
@@ -111,7 +111,9 @@ class TestJinja2Context(SupersetTestCase):
             self.assertEqual(ExtraCache().url_param("foo"), "bar")
 
     def test_referer_url_param_query(self) -> None:
-        with app.test_request_context(environ_base={'HTTP_REFERER': "http://test.com?foo=bar"}):
+        with app.test_request_context(
+            environ_base={"HTTP_REFERER": "http://test.com?foo=bar"}
+        ):
             self.assertEqual(ExtraCache().url_param("foo"), "bar")
 
     def test_safe_proxy_primitive(self) -> None:

--- a/tests/jinja_context_tests.py
+++ b/tests/jinja_context_tests.py
@@ -110,6 +110,10 @@ class TestJinja2Context(SupersetTestCase):
         ):
             self.assertEqual(ExtraCache().url_param("foo"), "bar")
 
+    def test_referer_url_param_query(self) -> None:
+        with app.test_request_context(environ_base={'HTTP_REFERER': "http://test.com?foo=bar"}):
+            self.assertEqual(ExtraCache().url_param("foo"), "bar")
+
     def test_safe_proxy_primitive(self) -> None:
         def func(input: Any) -> Any:
             return input


### PR DESCRIPTION
### SUMMARY
I have added code to parse request's referer url to get query params for `url_param` function used is sql editor.
[Link to issue](https://github.com/apache/superset/issues/13315)

closes #13315 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Added test case for change

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
