### PR TITLE
feat(dashboard): dashboard/id/datasets endpoint

### DIFF
--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -237,6 +237,7 @@ class BaseDatasource(
         return {
             # simple fields
             "id": self.id,
+            "uid": self.uid,
             "column_formats": self.column_formats,
             "description": self.description,
             "database": self.database.data,  # pylint: disable=no-member

--- a/superset/constants.py
+++ b/superset/constants.py
@@ -115,4 +115,5 @@ MODEL_API_RW_METHOD_PERMISSION_MAP = {
     "data": "read",
     "data_from_cache": "read",
     "get_charts": "read",
+    "get_datasets": "read",
 }

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -93,6 +93,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         "bulk_delete",  # not using RouteMethod since locally defined
         "favorite_status",
         "get_charts",
+        "get_datasets",
     }
     resource_name = "dashboard"
     allow_browser_login = True
@@ -249,6 +250,54 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             dash = DashboardDAO.get_by_id_or_slug(id_or_slug)
             result = self.dashboard_get_response_schema.dump(dash)
             return self.response(200, result=result)
+        except DashboardNotFoundError:
+            return self.response_404()
+
+    @expose("/<id_or_slug>/datasets", methods=["GET"])
+    @protect()
+    @safe
+    @statsd_metrics
+    @event_logger.log_this_with_context(
+        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.get_datasets",
+        log_to_statsd=False,
+    )
+    def get_datasets(self, id_or_slug: str) -> Response:
+        """Gets a dashboard's datasets
+                ---
+                get:
+                  description: >-
+                    Returns a map of a dashboard's datasets, keyed by dataset Uid.
+                    Each dataset includes only the information necessary to render
+                    the dashboard's charts.
+                  parameters:
+                  - in: path
+                    schema:
+                      type: string
+                    name: id_or_slug
+                    description: Either the id of the dashboard, or its slug
+                  responses:
+                    200:
+                      description: Dashboard dataset definitions
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            properties:
+                              result:
+                                type: object
+                    302:
+                      description: Redirects to the current digest
+                    400:
+                      $ref: '#/components/responses/400'
+                    401:
+                      $ref: '#/components/responses/401'
+                    404:
+                      $ref: '#/components/responses/404'
+                """
+        try:
+            dash = DashboardDAO.get_datasets_for_dashboard(id_or_slug)
+            # result = self.datasets_response_schema.dump(dash)
+            return self.response(200, result=dash)
         except DashboardNotFoundError:
             return self.response_404()
 

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -192,6 +192,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     openapi_spec_component_schemas = (
         ChartEntityResponseSchema,
         DashboardGetResponseSchema,
+        DashboardDatasetSchema,
         GetFavStarIdsSchema,
     )
     apispec_parameter_schemas = {

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -268,9 +268,8 @@ class DashboardRestApi(BaseSupersetModelRestApi):
                 ---
                 get:
                   description: >-
-                    Returns a map of a dashboard's datasets, keyed by dataset Uid.
-                    Each dataset includes only the information necessary to render
-                    the dashboard's charts.
+                    Returns a list of a dashboard's datasets. Each dataset includes only
+                    the information necessary to render the dashboard's charts.
                   parameters:
                   - in: path
                     schema:

--- a/superset/dashboards/dao.py
+++ b/superset/dashboards/dao.py
@@ -29,6 +29,7 @@ from superset.extensions import db
 from superset.models.core import FavStar, FavStarClassName
 from superset.models.dashboard import Dashboard, id_or_slug_filter
 from superset.models.slice import Slice
+from superset.utils import core
 from superset.utils.dashboard_filter_scopes_converter import copy_filter_scopes
 
 logger = logging.getLogger(__name__)
@@ -56,6 +57,29 @@ class DashboardDAO(BaseDAO):
         if not dashboard:
             raise DashboardNotFoundError()
         return dashboard
+
+    @staticmethod
+    def get_datasets_for_dashboard(id_or_slug: str) -> Dict[str, Any]:
+        query = (
+            db.session.query(Dashboard)
+            .filter(id_or_slug_filter(id_or_slug))
+            .outerjoin(Slice, Dashboard.slices)
+            .outerjoin(Slice.table)
+        )
+        # Apply dashboard base filters
+        query = DashboardFilter("id", SQLAInterface(Dashboard, db.session)).apply(
+            query, None
+        )
+        dashboard = query.one_or_none()
+        if not dashboard:
+            raise DashboardNotFoundError()
+        datasource_slices = core.indexed(dashboard.slices, "datasource")
+        data = {
+            datasource.uid: datasource.data_for_slices(slices)
+            for datasource, slices in datasource_slices.items()
+            if datasource
+        }
+        return data
 
     @staticmethod
     def get_charts_for_dashboard(dashboard_id: int) -> List[Slice]:

--- a/superset/dashboards/dao.py
+++ b/superset/dashboards/dao.py
@@ -59,7 +59,7 @@ class DashboardDAO(BaseDAO):
         return dashboard
 
     @staticmethod
-    def get_datasets_for_dashboard(id_or_slug: str) -> Dict[str, Any]:
+    def get_datasets_for_dashboard(id_or_slug: str) -> List[Any]:
         query = (
             db.session.query(Dashboard)
             .filter(id_or_slug_filter(id_or_slug))
@@ -74,11 +74,11 @@ class DashboardDAO(BaseDAO):
         if not dashboard:
             raise DashboardNotFoundError()
         datasource_slices = core.indexed(dashboard.slices, "datasource")
-        data = {
-            datasource.uid: datasource.data_for_slices(slices)
+        data = [
+            datasource.data_for_slices(slices)
             for datasource, slices in datasource_slices.items()
             if datasource
-        }
+        ]
         return data
 
     @staticmethod

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -158,6 +158,38 @@ class DashboardGetResponseSchema(Schema):
     table_names = fields.String()  # legacy nonsense
 
 
+class DatabaseSchema(Schema):
+    id = fields.Int()
+    name = fields.String()
+    backend = fields.String()
+    allow_multi_schema_metadata_fetch = fields.Bool()
+    allows_subquery = fields.Bool()
+    allows_cost_estimate = fields.Bool()
+    allows_virtual_table_explore = fields.Bool()
+    explore_database_id = fields.Int()
+
+
+class DashboardDatasetSchema(Schema):
+    id = fields.Int()
+    uid = fields.Str()
+    column_formats = fields.Dict()
+    database = fields.Nested(DatabaseSchema)
+    default_endpoint = fields.String()
+    filter_select = fields.Bool()
+    filter_select_enabled = fields.Bool()
+    name = fields.Str()
+    datasource_name = fields.Str()
+    table_name = fields.Str()
+    type = fields.Str()
+    schema = fields.Str()
+    offset = fields.Int()
+    cache_timeout = fields.Int()
+    params = fields.Str()
+    perm = fields.Str()
+    edit_url = fields.Str()
+    sql = fields.Str()
+
+
 class BaseDashboardSchema(Schema):
     # pylint: disable=no-self-use,unused-argument
     @post_load

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -162,7 +162,7 @@ class DatabaseSchema(Schema):
     id = fields.Int()
     name = fields.String()
     backend = fields.String()
-    allow_multi_schema_metadata_fetch = fields.Bool()
+    allow_multi_schema_metadata_fetch = fields.Bool()  # pylint: disable=invalid-name
     allows_subquery = fields.Bool()
     allows_cost_estimate = fields.Bool()
     allows_virtual_table_explore = fields.Bool()

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -177,6 +177,7 @@ class DashboardDatasetSchema(Schema):
     default_endpoint = fields.String()
     filter_select = fields.Bool()
     filter_select_enabled = fields.Bool()
+    is_sqllab_view = fields.Bool()
     name = fields.Str()
     datasource_name = fields.Str()
     table_name = fields.Str()
@@ -188,6 +189,18 @@ class DashboardDatasetSchema(Schema):
     perm = fields.Str()
     edit_url = fields.Str()
     sql = fields.Str()
+    select_star = fields.Str()
+    main_dttm_col = fields.Str()
+    health_check_message = fields.Str()
+    fetch_values_predicate = fields.Str()
+    template_params = fields.Str()
+    owners = fields.List(fields.Int())
+    columns = fields.List(fields.Dict())
+    metrics = fields.List(fields.Dict())
+    order_by_choices = fields.List(fields.List(fields.Str()))
+    verbose_map = fields.Dict(fields.Str(), fields.Str())
+    time_grain_sqla = fields.List(fields.List(fields.Str()))
+    granularity_sqla = fields.List(fields.List(fields.Str()))
 
 
 class BaseDashboardSchema(Schema):

--- a/tests/dashboards/api_tests.py
+++ b/tests/dashboards/api_tests.py
@@ -170,6 +170,31 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
             db.session.delete(dashboard)
             db.session.commit()
 
+    @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
+    def test_get_dashboard_datasets(self):
+        self.login(username="admin")
+        uri = "api/v1/dashboard/world_health/datasets"
+        response = self.get_assert_metric(uri, "get_datasets")
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data.decode("utf-8"))
+        dashboard = Dashboard.get("world_health")
+        dataset_ids = set([s.datasource_id for s in dashboard.slices])
+        self.assertEqual(len(data["result"]), len(dataset_ids))
+
+    @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
+    def test_get_dashboard_datasets_not_found(self):
+        self.login(username="alpha")
+        uri = "api/v1/dashboard/not_found/datasets"
+        response = self.get_assert_metric(uri, "get_datasets")
+        self.assertEqual(response.status_code, 404)
+
+    @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
+    def test_get_dashboard_datasets_not_allowed(self):
+        self.login(username="gamma")
+        uri = "api/v1/dashboard/world_health/datasets"
+        response = self.get_assert_metric(uri, "get_datasets")
+        self.assertEqual(response.status_code, 404)
+
     @pytest.mark.usefixtures("create_dashboards")
     def get_dashboard_by_slug(self):
         self.login(username="admin")

--- a/tests/dashboards/api_tests.py
+++ b/tests/dashboards/api_tests.py
@@ -178,8 +178,9 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode("utf-8"))
         dashboard = Dashboard.get("world_health")
-        dataset_ids = set([s.datasource_id for s in dashboard.slices])
-        self.assertEqual(len(data["result"]), len(dataset_ids))
+        expected_dataset_ids = set([s.datasource_id for s in dashboard.slices])
+        actual_dataset_ids = set([dataset["id"] for dataset in data["result"]])
+        self.assertEqual(actual_dataset_ids, expected_dataset_ids)
 
     @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
     def test_get_dashboard_datasets_not_found(self):


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Adding a new endpoint that gets the dataset metadata for a dashboard.

This is intended to replace the template-loaded bootstrap data on the dashboard page. In keeping with the precedent set by the existing bootstrap data, I have opted to return data in the same shape (a map of datasets) rather than a list, and to copy the bootstrap data's "trimming" behavior where any data unnecessary for rendering the dashboard is stripped out of the result. I don't believe these design decisions make for the ideal endpoint, but they do reduce potential regressions in the Single Page App project.

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Wrote unit tests, tested manually

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
