### PR TITLE
chore(dashboard_rbac): test no access to charts when no access to dashboard

### DIFF
--- a/tests/dashboards/base_case.py
+++ b/tests/dashboards/base_case.py
@@ -50,6 +50,10 @@ class DashboardTestCase(SupersetTestCase):
         save_dash_url = SAVE_DASHBOARD_URL_FORMAT.format(dashboard_id)
         return self.get_resp(save_dash_url, data=dict(data=json.dumps(dashboard_data)))
 
+    def get_dashboard_charts_api_response(self, id_or_slug: str) -> Response:
+        uri = f"api/v1/dashboard/{id_or_slug}/charts"
+        return self.client.get(uri)
+
     def save_dashboard(
         self, dashboard_id: Union[str, int], dashboard_data: Dict[str, Any]
     ) -> Response:

--- a/tests/dashboards/security/security_rbac_tests.py
+++ b/tests/dashboards/security/security_rbac_tests.py
@@ -373,7 +373,6 @@ class TestDashboardRoleBasedSecurity(BaseTestDashboardSecurity):
         # assert
         self.assertEqual(response.status_code, 404)
 
-
     def test_get_dashboards_api__user_get_only_published_permitted_dashboards(self):
         (
             new_role,

--- a/tests/dashboards/security/security_rbac_tests.py
+++ b/tests/dashboards/security/security_rbac_tests.py
@@ -359,6 +359,21 @@ class TestDashboardRoleBasedSecurity(BaseTestDashboardSecurity):
         # assert
         self.assert_dashboards_api_response(response, 0)
 
+    def test_get_charts_api__user_without_any_permissions_get_403(self):
+        username = random_str()
+        new_role = f"role_{random_str()}"
+        self.create_user_with_roles(username, [new_role], should_create_roles=True)
+        dashboard = create_dashboard_to_db(published=True)
+        self.login(username)
+
+        # act
+        uri = f"api/v1/dashboard/{dashboard.id}/charts"
+        response = self.get_dashboard_charts_api_response(uri)
+
+        # assert
+        self.assertEqual(response.status_code, 404)
+
+
     def test_get_dashboards_api__user_get_only_published_permitted_dashboards(self):
         (
             new_role,


### PR DESCRIPTION
### SUMMARY
follow PR that introduced get charts of a dashboard: https://github.com/apache/superset/pull/12978
introducing an explicit security access test for get_charts endpoint 
this is making sure that that use-case will never break in the future



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
