### PR TITLE
fix(native-filters): fix initial filter loading

### DIFF
--- a/superset-frontend/src/dashboard/containers/Chart.jsx
+++ b/superset-frontend/src/dashboard/containers/Chart.jsx
@@ -66,7 +66,7 @@ function mapStateToProps(
     colorScheme,
     colorNamespace,
     sliceId: id,
-    nativeFilters: nativeFilters.filters,
+    nativeFilters,
     dataMask,
   });
 


### PR DESCRIPTION
### SUMMARY
This PR fix bug that default values on first loading applied to all charts out of scope

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
