### PR TITLE
fix(dashboard|chart): use correct url for favorite_status and change …

### DIFF
--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -484,15 +484,15 @@ type FavoriteStatusResponse = {
 };
 
 const favoriteApis = {
-  chart: makeApi<string, FavoriteStatusResponse>({
-    requestType: 'search',
+  chart: makeApi<Array<string | number>, FavoriteStatusResponse>({
+    requestType: 'rison',
     method: 'GET',
-    endpoint: '/api/v1/chart/favorite_status',
+    endpoint: '/api/v1/chart/favorite_status/',
   }),
-  dashboard: makeApi<string, FavoriteStatusResponse>({
-    requestType: 'search',
+  dashboard: makeApi<Array<string | number>, FavoriteStatusResponse>({
+    requestType: 'rison',
     method: 'GET',
-    endpoint: '/api/v1/dashboard/favorite_status',
+    endpoint: '/api/v1/dashboard/favorite_status/',
   }),
 };
 
@@ -510,7 +510,7 @@ export function useFavoriteStatus(
     if (!ids.length) {
       return;
     }
-    favoriteApis[type](`q=${rison.encode(ids)}`).then(
+    favoriteApis[type](ids).then(
       ({ result }) => {
         const update = result.reduce((acc, element) => {
           acc[element.id] = element.value;
@@ -524,7 +524,7 @@ export function useFavoriteStatus(
         ),
       ),
     );
-  }, [ids]);
+  }, [ids, type, handleErrorMsg]);
 
   const saveFaveStar = useCallback(
     (id: number, isStarred: boolean) => {


### PR DESCRIPTION
…request type to rison

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The url for favorite status does not match the actual server url, so `.../favorite_status` was getting redirected by flask to `.../favorite_status/`, since flask doesn't know about SSL config (when it's done at the load balancer/proxy level) flask returns a 308 using the http protocol. This PR updates the endpoint to match the one on the server, as well as converts the request type to `rison` which should make the request query params more readable. 
 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A
### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Manual testing (local): 
- confirm favorite status is fetched without errors
- confirm that the response is not 308
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes #13327 fixes #13072 fixes #12592
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
