### PR TITLE
refactor: run python tests in a separate database

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1222,10 +1222,6 @@ def get_main_database() -> "Database":
     return get_or_create_db("main", db_uri)
 
 
-def backend() -> str:
-    return get_example_database().backend
-
-
 def is_adhoc_metric(metric: Metric) -> bool:
     return isinstance(metric, dict)
 

--- a/tests/alerts_tests.py
+++ b/tests/alerts_tests.py
@@ -40,9 +40,9 @@ from superset.tasks.schedules import (
     evaluate_alert,
     validate_observations,
 )
-from superset.utils import core as utils
 from tests.test_app import app
 from tests.utils import read_fixture
+from tests.fixtures.utils import get_test_database
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 @pytest.yield_fixture(scope="module")
 def setup_database():
     with app.app_context():
-        example_database = utils.get_example_database()
+        example_database = get_test_database()
         example_database.get_sqla_engine().execute(
             "CREATE TABLE test_table AS SELECT 1 as first, 2 as second"
         )
@@ -83,7 +83,7 @@ def create_alert(
         recipients="recipient1@superset.com",
         slack_channel="#test_channel",
         sql=sql,
-        database_id=utils.get_example_database().id,
+        database_id=get_test_database().id,
         validator_type=validator_type,
         validator_config=validator_config,
     )

--- a/tests/alerts_tests.py
+++ b/tests/alerts_tests.py
@@ -40,9 +40,9 @@ from superset.tasks.schedules import (
     evaluate_alert,
     validate_observations,
 )
+from tests.fixtures.utils import get_test_database
 from tests.test_app import app
 from tests.utils import read_fixture
-from tests.fixtures.utils import get_test_database
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -18,7 +18,6 @@
 """Unit tests for Superset"""
 import imp
 import json
-from tests.fixtures.utils import TEST_DATABSE_NAME, get_test_database
 from typing import Any, Dict, Union, List, Optional
 from unittest.mock import Mock, patch
 
@@ -30,7 +29,6 @@ from flask_testing import TestCase
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import func
 
-from tests.test_app import app
 from superset.sql_parse import CtasMethod
 from superset import db, security_manager
 from superset.connectors.base.models import BaseDatasource
@@ -41,8 +39,10 @@ from superset.models.slice import Slice
 from superset.models.core import Database
 from superset.models.dashboard import Dashboard
 from superset.models.datasource_access_request import DatasourceAccessRequest
-from superset.utils.core import get_example_database
 from superset.views.base_api import BaseSupersetModelRestApi
+
+from tests.test_app import app
+from tests.fixtures.utils import get_test_database
 
 FAKE_DB_NAME = "fake_db_100"
 test_client = app.test_client()
@@ -127,15 +127,6 @@ class SupersetTestCase(TestCase):
     @staticmethod
     def get_nonexistent_numeric_id(model):
         return (db.session.query(func.max(model.id)).scalar() or 0) + 1
-
-    @staticmethod
-    def get_birth_names_dataset():
-        example_db = get_example_database()
-        return (
-            db.session.query(SqlaTable)
-            .filter_by(database=example_db, table_name="birth_names")
-            .one()
-        )
 
     @staticmethod
     def create_user_with_roles(

--- a/tests/cachekeys/api_tests.py
+++ b/tests/cachekeys/api_tests.py
@@ -22,12 +22,8 @@ from tests.test_app import app  # noqa
 
 from superset.extensions import cache_manager, db
 from superset.models.cache import CacheKey
-from tests.base_tests import (
-    SupersetTestCase,
-    post_assert_metric,
-    test_client,
-    logged_in_admin,
-)  # noqa
+from tests.base_tests import post_assert_metric, test_client
+from tests.fixtures.birth_names_dashboard import get_birth_names_dataset
 
 
 def invalidate(params: Dict[str, Any]):
@@ -93,7 +89,7 @@ def test_invalidate_cache_bad_request(logged_in_admin):
 
 
 def test_invalidate_existing_caches(logged_in_admin):
-    bn = SupersetTestCase.get_birth_names_dataset()
+    bn = get_birth_names_dataset()
 
     db.session.add(CacheKey(cache_key="cache_key1", datasource_uid="3__druid"))
     db.session.add(CacheKey(cache_key="cache_key2", datasource_uid="3__druid"))

--- a/tests/charts/api_tests.py
+++ b/tests/charts/api_tests.py
@@ -44,11 +44,10 @@ from superset.models.dashboard import Dashboard
 from superset.models.reports import ReportSchedule, ReportScheduleType
 from superset.models.slice import Slice
 from superset.utils import core as utils
-from superset.utils.core import AnnotationType, get_example_database, get_main_database
+from superset.utils.core import AnnotationType, get_main_database
 
 from tests.base_api_tests import ApiOwnersTestCaseMixin
 from tests.base_tests import SupersetTestCase, post_assert_metric, test_client
-
 from tests.fixtures.importexport import (
     chart_config,
     chart_metadata_config,
@@ -61,6 +60,8 @@ from tests.fixtures.query_context import get_query_context, ANNOTATION_LAYERS
 from tests.fixtures.unicode_dashboard import load_unicode_dashboard_with_slice
 from tests.annotation_layers.fixtures import create_annotation_layers
 from tests.utils.get_dashboards import get_dashboards_ids
+from tests.fixtures.utils import get_test_database
+
 
 CHART_DATA_URI = "api/v1/chart/data"
 CHARTS_FIXTURE_COUNT = 10
@@ -1076,7 +1077,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         self.assertEqual(result["rowcount"], 5)
 
         # TODO: fix offset for presto DB
-        if get_example_database().backend == "presto":
+        if get_test_database().backend == "presto":
             return
 
         # ensure that offset works properly
@@ -1322,7 +1323,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         response_payload = json.loads(rv.data.decode("utf-8"))
         result = response_payload["result"][0]["query"]
-        if get_example_database().backend != "presto":
+        if get_test_database().backend != "presto":
             assert "('boy' = 'boy')" in result
 
     @mock.patch.dict(
@@ -1699,7 +1700,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
 
     def quote_name(self, name: str):
         if get_main_database().backend in {"presto", "hive"}:
-            return get_example_database().inspector.engine.dialect.identifier_preparer.quote_identifier(
+            return get_test_database().inspector.engine.dialect.identifier_preparer.quote_identifier(
                 name
             )
         return name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ from sqlalchemy.engine import Engine
 from tests.test_app import app
 
 from superset import db
-from superset.utils.core import get_example_database
+from tests.fixtures.utils import get_test_database
 
 
 CTAS_SCHEMA_NAME = "sqllab_test_db"
@@ -46,7 +46,7 @@ def setup_sample_data() -> Any:
     yield
 
     with app.app_context():
-        engine = get_example_database().get_sqla_engine()
+        engine = get_test_database().get_sqla_engine()
 
         # drop sqlachemy tables
 
@@ -77,12 +77,12 @@ def setup_presto_if_needed():
         # decrease poll interval for tests
         presto_poll_interval = app.config["PRESTO_POLL_INTERVAL"]
         extra = f'{{"engine_params": {{"connect_args": {{"poll_interval": {presto_poll_interval}}}}}}}'
-        database = get_example_database()
+        database = get_test_database()
         database.extra = extra
         db.session.commit()
 
     if backend in {"presto", "hive"}:
-        database = get_example_database()
+        database = get_test_database()
         engine = database.get_sqla_engine()
         drop_from_schema(engine, CTAS_SCHEMA_NAME)
         engine.execute(f"DROP SCHEMA IF EXISTS {CTAS_SCHEMA_NAME}")

--- a/tests/css_templates/api_tests.py
+++ b/tests/css_templates/api_tests.py
@@ -24,7 +24,7 @@ from sqlalchemy.sql import func
 import tests.test_app
 from superset import db
 from superset.models.core import CssTemplate
-from superset.utils.core import get_example_database
+from tests.fixtures.utils import get_test_database
 
 from tests.base_tests import SupersetTestCase
 

--- a/tests/dashboard_utils.py
+++ b/tests/dashboard_utils.py
@@ -17,49 +17,12 @@
 """Utils to provide dashboards for tests"""
 
 import json
-from typing import Any, Dict, List, Optional
+from typing import Dict, List
 
-from pandas import DataFrame
-
-from superset import ConnectorRegistry, db
+from superset import db
 from superset.connectors.sqla.models import SqlaTable
-from superset.models.core import Database
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
-
-
-def create_table_for_dashboard(
-    df: DataFrame,
-    table_name: str,
-    database: Database,
-    dtype: Dict[str, Any],
-    table_description: str = "",
-    fetch_values_predicate: Optional[str] = None,
-) -> SqlaTable:
-    df.to_sql(
-        table_name,
-        database.get_sqla_engine(),
-        if_exists="replace",
-        chunksize=500,
-        dtype=dtype,
-        index=False,
-        method="multi",
-    )
-
-    table_source = ConnectorRegistry.sources["table"]
-    table = (
-        db.session.query(table_source).filter_by(table_name=table_name).one_or_none()
-    )
-    if not table:
-        table = table_source(table_name=table_name)
-    if fetch_values_predicate:
-        table.fetch_values_predicate = fetch_values_predicate
-    table.database = database
-    table.description = table_description
-    db.session.merge(table)
-    db.session.commit()
-
-    return table
 
 
 def create_slice(

--- a/tests/databases/api_tests.py
+++ b/tests/databases/api_tests.py
@@ -32,7 +32,6 @@ from superset import db, security_manager
 from superset.connectors.sqla.models import SqlaTable
 from superset.models.core import Database
 from superset.models.reports import ReportSchedule, ReportScheduleType
-from superset.utils.core import get_example_database, get_main_database
 from tests.base_tests import SupersetTestCase
 from tests.fixtures.birth_names_dashboard import load_birth_names_dashboard_with_slices
 from tests.fixtures.certificates import ssl_certificate
@@ -45,6 +44,7 @@ from tests.fixtures.importexport import (
     dataset_metadata_config,
 )
 from tests.fixtures.unicode_dashboard import load_unicode_dashboard_with_position
+from tests.fixtures.utils import get_test_database, get_main_database
 from tests.test_app import app
 
 
@@ -73,7 +73,7 @@ class TestDatabaseApi(SupersetTestCase):
     @pytest.fixture()
     def create_database_with_report(self):
         with self.create_app().app_context():
-            example_db = get_example_database()
+            example_db = get_test_database()
             database = self.insert_database(
                 "database_with_report",
                 example_db.sqlalchemy_uri_decrypted,
@@ -97,7 +97,7 @@ class TestDatabaseApi(SupersetTestCase):
     @pytest.fixture()
     def create_database_with_dataset(self):
         with self.create_app().app_context():
-            example_db = get_example_database()
+            example_db = get_test_database()
             self._database = self.insert_database(
                 "database_with_dataset",
                 example_db.sqlalchemy_uri_decrypted,
@@ -168,7 +168,7 @@ class TestDatabaseApi(SupersetTestCase):
         """
         Database API: Test get items with filter
         """
-        example_db = get_example_database()
+        example_db = get_test_database()
         test_database = self.insert_database(
             "test-database", example_db.sqlalchemy_uri_decrypted, expose_in_sqllab=True
         )
@@ -216,7 +216,7 @@ class TestDatabaseApi(SupersetTestCase):
         }
 
         self.login(username="admin")
-        example_db = get_example_database()
+        example_db = get_test_database()
         if example_db.backend == "sqlite":
             return
         database_data = {
@@ -239,7 +239,7 @@ class TestDatabaseApi(SupersetTestCase):
         """
         Database API: Test create server cert validation
         """
-        example_db = get_example_database()
+        example_db = get_test_database()
         if example_db.backend == "sqlite":
             return
 
@@ -261,7 +261,7 @@ class TestDatabaseApi(SupersetTestCase):
         """
         Database API: Test create encrypted extra and extra validation
         """
-        example_db = get_example_database()
+        example_db = get_test_database()
         if example_db.backend == "sqlite":
             return
 
@@ -295,7 +295,7 @@ class TestDatabaseApi(SupersetTestCase):
         """
         Database API: Test create extra metadata_params validation
         """
-        example_db = get_example_database()
+        example_db = get_test_database()
         if example_db.backend == "sqlite":
             return
 
@@ -330,7 +330,7 @@ class TestDatabaseApi(SupersetTestCase):
         """
         Database API: Test create database_name already exists
         """
-        example_db = get_example_database()
+        example_db = get_test_database()
         if example_db.backend == "sqlite":
             return
 
@@ -399,7 +399,7 @@ class TestDatabaseApi(SupersetTestCase):
         """
         Database API: Test create fails connection
         """
-        example_db = get_example_database()
+        example_db = get_test_database()
         if example_db.backend in ("sqlite", "hive", "presto"):
             return
         example_db.password = "wrong_password"
@@ -422,7 +422,7 @@ class TestDatabaseApi(SupersetTestCase):
         """
         Database API: Test update
         """
-        example_db = get_example_database()
+        example_db = get_test_database()
         test_database = self.insert_database(
             "test-database", example_db.sqlalchemy_uri_decrypted
         )
@@ -440,7 +440,7 @@ class TestDatabaseApi(SupersetTestCase):
         """
         Database API: Test update fails connection
         """
-        example_db = get_example_database()
+        example_db = get_test_database()
         if example_db.backend in ("sqlite", "hive", "presto"):
             return
 
@@ -470,7 +470,7 @@ class TestDatabaseApi(SupersetTestCase):
         """
         Database API: Test update uniqueness
         """
-        example_db = get_example_database()
+        example_db = get_test_database()
         test_database1 = self.insert_database(
             "test-database1", example_db.sqlalchemy_uri_decrypted
         )
@@ -507,7 +507,7 @@ class TestDatabaseApi(SupersetTestCase):
         """
         Database API: Test update sqlalchemy_uri validate
         """
-        example_db = get_example_database()
+        example_db = get_test_database()
         test_database = self.insert_database(
             "test-database", example_db.sqlalchemy_uri_decrypted
         )
@@ -585,7 +585,7 @@ class TestDatabaseApi(SupersetTestCase):
         """
         Database API: Test get table metadata info
         """
-        example_db = get_example_database()
+        example_db = get_test_database()
         self.login(username="admin")
         uri = f"api/v1/database/{example_db.id}/table/birth_names/null/"
         rv = self.client.get(uri)
@@ -629,7 +629,7 @@ class TestDatabaseApi(SupersetTestCase):
         """
         Database API: Test get invalid table from table metadata
         """
-        example_db = get_example_database()
+        example_db = get_test_database()
         uri = f"api/v1/database/{example_db.id}/wrong_table/null/"
         self.login(username="admin")
         rv = self.client.get(uri)
@@ -640,7 +640,7 @@ class TestDatabaseApi(SupersetTestCase):
         Database API: Test get table metadata from not permitted db
         """
         self.login(username="gamma")
-        example_db = get_example_database()
+        example_db = get_test_database()
         uri = f"api/v1/database/{example_db.id}/birth_names/null/"
         rv = self.client.get(uri)
         self.assertEqual(rv.status_code, 404)
@@ -651,7 +651,7 @@ class TestDatabaseApi(SupersetTestCase):
         Database API: Test get select star
         """
         self.login(username="admin")
-        example_db = get_example_database()
+        example_db = get_test_database()
         uri = f"api/v1/database/{example_db.id}/select_star/birth_names/"
         rv = self.client.get(uri)
         self.assertEqual(rv.status_code, 200)
@@ -663,7 +663,7 @@ class TestDatabaseApi(SupersetTestCase):
         Database API: Test get select star not allowed
         """
         self.login(username="gamma")
-        example_db = get_example_database()
+        example_db = get_test_database()
         uri = f"api/v1/database/{example_db.id}/select_star/birth_names/"
         rv = self.client.get(uri)
         self.assertEqual(rv.status_code, 404)
@@ -712,7 +712,7 @@ class TestDatabaseApi(SupersetTestCase):
         Database API: Test get select star not found database
         """
         self.login(username="admin")
-        example_db = get_example_database()
+        example_db = get_test_database()
         # sqllite will not raise a NoSuchTableError
         if example_db.backend == "sqlite":
             return
@@ -745,7 +745,7 @@ class TestDatabaseApi(SupersetTestCase):
         """
         self.logout()
         self.login(username="gamma")
-        example_db = get_example_database()
+        example_db = get_test_database()
         uri = f"api/v1/database/{example_db.id}/schemas/"
         rv = self.client.get(uri)
         self.assertEqual(rv.status_code, 404)
@@ -774,7 +774,7 @@ class TestDatabaseApi(SupersetTestCase):
         # need to temporarily allow sqlite dbs, teardown will undo this
         app.config["PREVENT_UNSAFE_DB_CONNECTIONS"] = False
         self.login("admin")
-        example_db = get_example_database()
+        example_db = get_test_database()
         # validate that the endpoint works with the password-masked sqlalchemy uri
         data = {
             "database_name": "examples",
@@ -878,7 +878,7 @@ class TestDatabaseApi(SupersetTestCase):
         :return:
         """
         self.login(username="admin")
-        database = get_example_database()
+        database = get_test_database()
         uri = f"api/v1/database/{database.id}/related_objects/"
         rv = self.get_assert_metric(uri, "related_objects")
         self.assertEqual(rv.status_code, 200)
@@ -899,7 +899,7 @@ class TestDatabaseApi(SupersetTestCase):
         self.assertEqual(rv.status_code, 404)
         self.logout()
         self.login(username="gamma")
-        database = get_example_database()
+        database = get_test_database()
         uri = f"api/v1/database/{database.id}/related_objects/"
         rv = self.get_assert_metric(uri, "related_objects")
         self.assertEqual(rv.status_code, 404)
@@ -909,7 +909,7 @@ class TestDatabaseApi(SupersetTestCase):
         Database API: Test export database
         """
         self.login(username="admin")
-        database = get_example_database()
+        database = get_test_database()
         argument = [database.id]
         uri = f"api/v1/database/export/?q={prison.dumps(argument)}"
         rv = self.get_assert_metric(uri, "export")
@@ -923,7 +923,7 @@ class TestDatabaseApi(SupersetTestCase):
         Database API: Test export database not allowed
         """
         self.login(username="gamma")
-        database = get_example_database()
+        database = get_test_database()
         argument = [database.id]
         uri = f"api/v1/database/export/?q={prison.dumps(argument)}"
         rv = self.client.get(uri)
@@ -1148,7 +1148,7 @@ class TestDatabaseApi(SupersetTestCase):
 
     @mock.patch("superset.db_engine_specs.base.BaseEngineSpec.get_function_names",)
     def test_function_names(self, mock_get_function_names):
-        example_db = get_example_database()
+        example_db = get_test_database()
         if example_db.backend in {"hive", "presto"}:
             return
 

--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -36,11 +36,14 @@ from superset.dao.exceptions import (
 )
 from superset.extensions import db, security_manager
 from superset.models.core import Database
-from superset.utils.core import backend, get_example_database, get_main_database
+from superset.utils.core import get_main_database
 from superset.utils.dict_import_export import export_to_dict
 from tests.base_tests import SupersetTestCase
 from tests.conftest import CTAS_SCHEMA_NAME
-from tests.fixtures.birth_names_dashboard import load_birth_names_dashboard_with_slices
+from tests.fixtures.birth_names_dashboard import (
+    get_birth_names_dataset,
+    load_birth_names_dashboard_with_slices,
+)
 from tests.fixtures.energy_dashboard import load_energy_table_with_slice
 from tests.fixtures.importexport import (
     database_config,
@@ -49,6 +52,7 @@ from tests.fixtures.importexport import (
     dataset_metadata_config,
     dataset_ui_export,
 )
+from tests.fixtures.utils import get_test_database
 
 
 class TestDatasetApi(SupersetTestCase):
@@ -134,7 +138,7 @@ class TestDatasetApi(SupersetTestCase):
 
     @staticmethod
     def get_energy_usage_dataset():
-        example_db = get_example_database()
+        example_db = get_test_database()
         return (
             db.session.query(SqlaTable)
             .filter_by(database=example_db, table_name="energy_usage")
@@ -161,7 +165,7 @@ class TestDatasetApi(SupersetTestCase):
         """
         Dataset API: Test get dataset list
         """
-        example_db = get_example_database()
+        example_db = get_test_database()
         self.login(username="admin")
         arguments = {
             "filters": [
@@ -262,7 +266,7 @@ class TestDatasetApi(SupersetTestCase):
             assert rv.status_code == 200
             assert response == expected_response
 
-        example_db = get_example_database()
+        example_db = get_test_database()
         datasets = []
         if example_db.backend == "postgresql":
             datasets.append(
@@ -484,11 +488,11 @@ class TestDatasetApi(SupersetTestCase):
         }
 
     def test_create_dataset_same_name_different_schema(self):
-        if backend() == "sqlite":
+        if superset_db_backend() == "sqlite":
             # sqlite doesn't support schemas
             return
 
-        example_db = get_example_database()
+        example_db = get_test_database()
         example_db.get_sqla_engine().execute(
             f"CREATE TABLE {CTAS_SCHEMA_NAME}.birth_names AS SELECT 2 as two"
         )
@@ -529,7 +533,7 @@ class TestDatasetApi(SupersetTestCase):
         """
         Dataset API: Test create dataset validate table exists
         """
-        example_db = get_example_database()
+        example_db = get_test_database()
         self.login(username="admin")
         table_data = {
             "database": example_db.id,
@@ -687,7 +691,7 @@ class TestDatasetApi(SupersetTestCase):
         assert columns[0].column_name == "id"
         assert columns[1].column_name, "name"
         # TODO(bkyryliuk): find the reason why update is failing for the presto database
-        if get_example_database().backend != "presto":
+        if get_test_database().backend != "presto":
             assert columns[0].groupby is False
             assert columns[0].filterable is False
 
@@ -1062,7 +1066,7 @@ class TestDatasetApi(SupersetTestCase):
         """
         Dataset API: Test export dataset
         """
-        birth_names_dataset = self.get_birth_names_dataset()
+        birth_names_dataset = get_birth_names_dataset()
         # TODO: fix test for presto
         # debug with dump: https://github.com/apache/superset/runs/1092546855
         if birth_names_dataset.database.backend in {"presto", "hive"}:
@@ -1106,7 +1110,7 @@ class TestDatasetApi(SupersetTestCase):
         """
         Dataset API: Test export dataset has gamma
         """
-        birth_names_dataset = self.get_birth_names_dataset()
+        birth_names_dataset = get_birth_names_dataset()
 
         argument = [birth_names_dataset.id]
         uri = f"api/v1/dataset/export/?q={prison.dumps(argument)}"
@@ -1125,7 +1129,7 @@ class TestDatasetApi(SupersetTestCase):
         """
         Dataset API: Test export dataset
         """
-        birth_names_dataset = self.get_birth_names_dataset()
+        birth_names_dataset = get_birth_names_dataset()
         # TODO: fix test for presto
         # debug with dump: https://github.com/apache/superset/runs/1092546855
         if birth_names_dataset.database.backend in {"presto", "hive"}:
@@ -1168,7 +1172,7 @@ class TestDatasetApi(SupersetTestCase):
         """
         Dataset API: Test export dataset has gamma
         """
-        birth_names_dataset = self.get_birth_names_dataset()
+        birth_names_dataset = get_birth_names_dataset()
 
         argument = [birth_names_dataset.id]
         uri = f"api/v1/dataset/export/?q={prison.dumps(argument)}"
@@ -1185,7 +1189,7 @@ class TestDatasetApi(SupersetTestCase):
         :return:
         """
         self.login(username="admin")
-        table = self.get_birth_names_dataset()
+        table = get_birth_names_dataset()
         uri = f"api/v1/dataset/{table.id}/related_objects"
         rv = self.get_assert_metric(uri, "related_objects")
         response = json.loads(rv.data.decode("utf-8"))
@@ -1206,7 +1210,7 @@ class TestDatasetApi(SupersetTestCase):
         assert rv.status_code == 404
         self.logout()
         self.login(username="gamma")
-        table = self.get_birth_names_dataset()
+        table = get_birth_names_dataset()
         uri = f"api/v1/dataset/{table.id}/related_objects"
         rv = self.client.get(uri)
         assert rv.status_code == 404

--- a/tests/datasets/commands_tests.py
+++ b/tests/datasets/commands_tests.py
@@ -32,7 +32,6 @@ from superset.datasets.commands.exceptions import DatasetNotFoundError
 from superset.datasets.commands.export import ExportDatasetsCommand
 from superset.datasets.commands.importers import v0, v1
 from superset.models.core import Database
-from superset.utils.core import get_example_database
 from tests.base_tests import SupersetTestCase
 from tests.fixtures.energy_dashboard import load_energy_table_with_slice
 from tests.fixtures.importexport import (
@@ -43,6 +42,7 @@ from tests.fixtures.importexport import (
     dataset_metadata_config,
     dataset_ui_export,
 )
+from tests.fixtures.utils import get_test_database
 from tests.fixtures.world_bank_dashboard import load_world_bank_dashboard_with_slices
 
 
@@ -52,7 +52,7 @@ class TestExportDatasetsCommand(SupersetTestCase):
     def test_export_dataset_command(self, mock_g):
         mock_g.user = security_manager.find_user("admin")
 
-        example_db = get_example_database()
+        example_db = get_test_database()
         example_dataset = _get_table_from_list_by_name(
             "energy_usage", example_db.tables
         )
@@ -160,7 +160,7 @@ class TestExportDatasetsCommand(SupersetTestCase):
         """Test that users can't export datasets they don't have access to"""
         mock_g.user = security_manager.find_user("gamma")
 
-        example_db = get_example_database()
+        example_db = get_test_database()
         example_dataset = example_db.tables[0]
         command = ExportDatasetsCommand([example_dataset.id])
         contents = command.run()
@@ -182,7 +182,7 @@ class TestExportDatasetsCommand(SupersetTestCase):
         """Test that they keys in the YAML have the same order as export_fields"""
         mock_g.user = security_manager.find_user("admin")
 
-        example_db = get_example_database()
+        example_db = get_test_database()
         example_dataset = _get_table_from_list_by_name(
             "energy_usage", example_db.tables
         )

--- a/tests/datasource_tests.py
+++ b/tests/datasource_tests.py
@@ -23,11 +23,10 @@ import pytest
 from superset import app, ConnectorRegistry, db
 from superset.connectors.sqla.models import SqlaTable
 from superset.datasets.commands.exceptions import DatasetNotFoundError
-from superset.utils.core import get_example_database
+from tests.base_tests import SupersetTestCase
 from tests.fixtures.birth_names_dashboard import load_birth_names_dashboard_with_slices
-
-from tests.fixtures.utils import db_insert_temp_object, SupersetTestCase
 from tests.fixtures.datasource import datasource_post
+from tests.fixtures.utils import db_insert_temp_object, get_test_database
 
 
 class TestDatasource(SupersetTestCase):
@@ -58,7 +57,7 @@ class TestDatasource(SupersetTestCase):
         session = db.session
         table = SqlaTable(
             table_name="dummy_sql_table",
-            database=get_example_database(),
+            database=get_test_database(),
             sql="select 123 as intcol, 'abc' as strcol",
         )
         session.add(table)
@@ -75,7 +74,7 @@ class TestDatasource(SupersetTestCase):
         self.login(username="admin")
         table = SqlaTable(
             table_name="malicious_sql_table",
-            database=get_example_database(),
+            database=get_test_database(),
             sql="delete table birth_names",
         )
         with db_insert_temp_object(table):
@@ -87,7 +86,7 @@ class TestDatasource(SupersetTestCase):
         self.login(username="admin")
         table = SqlaTable(
             table_name="multistatement_sql_table",
-            database=get_example_database(),
+            database=get_test_database(),
             sql="select 123 as intcol, 'abc' as strcol;"
             "select 123 as intcol, 'abc' as strcol",
         )

--- a/tests/datasource_tests.py
+++ b/tests/datasource_tests.py
@@ -26,8 +26,8 @@ from superset.datasets.commands.exceptions import DatasetNotFoundError
 from superset.utils.core import get_example_database
 from tests.fixtures.birth_names_dashboard import load_birth_names_dashboard_with_slices
 
-from .base_tests import db_insert_temp_object, SupersetTestCase
-from .fixtures.datasource import datasource_post
+from tests.fixtures.utils import db_insert_temp_object, SupersetTestCase
+from tests.fixtures.datasource import datasource_post
 
 
 class TestDatasource(SupersetTestCase):

--- a/tests/db_engine_specs/base_engine_spec_tests.py
+++ b/tests/db_engine_specs/base_engine_spec_tests.py
@@ -27,8 +27,8 @@ from superset.db_engine_specs.base import (
 )
 from superset.db_engine_specs.sqlite import SqliteEngineSpec
 from superset.sql_parse import ParsedQuery
-from superset.utils.core import get_example_database
 from tests.db_engine_specs.base_tests import TestDbEngineSpec
+from tests.fixtures.utils import get_test_database
 from tests.test_app import app
 
 from ..fixtures.energy_dashboard import load_energy_table_with_slice
@@ -212,7 +212,7 @@ class TestDbEngineSpecs(TestDbEngineSpec):
 
     @pytest.mark.usefixtures("load_energy_table_with_slice")
     def test_column_datatype_to_string(self):
-        example_db = get_example_database()
+        example_db = get_test_database()
         sqla_table = example_db.get_table("energy_usage")
         dialect = example_db.get_dialect()
 

--- a/tests/dict_import_export_tests.py
+++ b/tests/dict_import_export_tests.py
@@ -31,7 +31,7 @@ from superset.connectors.druid.models import (
     DruidCluster,
 )
 from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
-from superset.utils.core import get_example_database
+from tests.fixtures.utils import get_test_database
 from superset.utils.dict_import_export import export_to_dict
 
 from .base_tests import SupersetTestCase
@@ -76,7 +76,7 @@ class TestDictImportExport(SupersetTestCase):
             cols_uuids = [None] * len(cols_names)
 
         dict_rep = {
-            "database_id": get_example_database().id,
+            "database_id": get_test_database().id,
             "table_name": name,
             "schema": schema,
             "id": id,

--- a/tests/fixtures/birth_names_dashboard.py
+++ b/tests/fixtures/birth_names_dashboard.py
@@ -213,3 +213,11 @@ us_states = [
     "WY",
     "other",
 ]
+
+
+def get_birth_names_dataset():
+    return (
+        db.session.query(SqlaTable)
+        .filter_by(database=get_test_database(), table_name="birth_names")
+        .one()
+    )

--- a/tests/fixtures/energy_dashboard.py
+++ b/tests/fixtures/energy_dashboard.py
@@ -25,9 +25,8 @@ from sqlalchemy import column, Float, String
 from superset import db
 from superset.connectors.sqla.models import SqlaTable, SqlMetric
 from superset.models.slice import Slice
-from superset.utils.core import get_example_database
 from tests.dashboard_utils import create_slice
-from tests.fixtures.utils import create_table_from_df
+from tests.fixtures.utils import create_table_from_df, get_test_database
 from tests.test_app import app
 
 misc_dash_slices: Set[str] = set()
@@ -49,7 +48,7 @@ def _get_dataframe():
 
 
 def _create_energy_table(df: DataFrame, table_name: str):
-    database = get_example_database()
+    database = get_test_database()
 
     table_description = "Energy consumption"
     schema = {"source": String(255), "target": String(255), "value": Float()}
@@ -96,7 +95,7 @@ def _create_and_commit_energy_slice(
 
 
 def _cleanup() -> None:
-    engine = get_example_database().get_sqla_engine()
+    engine = get_test_database().get_sqla_engine()
     engine.execute("DROP TABLE IF EXISTS energy_usage")
     for slice_data in _get_energy_slices():
         slice = (

--- a/tests/fixtures/energy_dashboard.py
+++ b/tests/fixtures/energy_dashboard.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 import random
-import textwrap
 from typing import Dict, Set
 
 import pandas as pd
@@ -25,10 +24,10 @@ from sqlalchemy import column, Float, String
 
 from superset import db
 from superset.connectors.sqla.models import SqlaTable, SqlMetric
-from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.utils.core import get_example_database
-from tests.dashboard_utils import create_slice, create_table_for_dashboard
+from tests.dashboard_utils import create_slice
+from tests.fixtures.utils import create_table_from_df
 from tests.test_app import app
 
 misc_dash_slices: Set[str] = set()
@@ -54,8 +53,12 @@ def _create_energy_table(df: DataFrame, table_name: str):
 
     table_description = "Energy consumption"
     schema = {"source": String(255), "target": String(255), "value": Float()}
-    table = create_table_for_dashboard(
-        df, table_name, database, schema, table_description
+    table = create_table_from_df(
+        df,
+        table_name,
+        database=database,
+        dtype=schema,
+        table_description=table_description,
     )
     table.fetch_metadata()
 

--- a/tests/fixtures/unicode_dashboard.py
+++ b/tests/fixtures/unicode_dashboard.py
@@ -24,11 +24,8 @@ from superset.connectors.sqla.models import SqlaTable
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.utils.core import get_example_database
-from tests.dashboard_utils import (
-    create_dashboard,
-    create_slice,
-    create_table_for_dashboard,
-)
+from tests.dashboard_utils import create_dashboard, create_slice
+from tests.fixtures.utils import create_table_from_df
 from tests.test_app import app
 
 
@@ -81,7 +78,7 @@ def _create_unicode_dashboard(
     dtype = {
         "phrase": String(500),
     }
-    table = create_table_for_dashboard(df, table_name, database, dtype)
+    table = create_table_from_df(df, table_name, database, dtype)
     table.fetch_metadata()
 
     if slice_title:

--- a/tests/fixtures/unicode_dashboard.py
+++ b/tests/fixtures/unicode_dashboard.py
@@ -23,9 +23,8 @@ from superset import db
 from superset.connectors.sqla.models import SqlaTable
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
-from superset.utils.core import get_example_database
 from tests.dashboard_utils import create_dashboard, create_slice
-from tests.fixtures.utils import create_table_from_df
+from tests.fixtures.utils import create_table_from_df, get_test_database
 from tests.test_app import app
 
 
@@ -74,11 +73,7 @@ def _get_unicode_data():
 def _create_unicode_dashboard(
     df: DataFrame, table_name: str, slice_title: str, position: str
 ) -> Dashboard:
-    database = get_example_database()
-    dtype = {
-        "phrase": String(500),
-    }
-    table = create_table_from_df(df, table_name, database, dtype)
+    table = create_table_from_df(df, table_name, dtype={"phrase": String(500),})
     table.fetch_metadata()
 
     if slice_title:
@@ -98,7 +93,7 @@ def _create_and_commit_unicode_slice(table: SqlaTable, title: str):
 
 
 def _cleanup(dash: Dashboard, slice_name: str) -> None:
-    engine = get_example_database().get_sqla_engine()
+    engine = get_test_database().get_sqla_engine()
     engine.execute("DROP TABLE IF EXISTS unicode_test")
     db.session.delete(dash)
     if slice_name:

--- a/tests/fixtures/utils.py
+++ b/tests/fixtures/utils.py
@@ -23,9 +23,11 @@ from sqlalchemy.ext.declarative.api import DeclarativeMeta
 from superset import ConnectorRegistry, db
 from superset.connectors.sqla.models import SqlaTable
 from superset.models.core import Database
-from superset.utils.core import get_or_create_db
+from superset.utils.core import get_main_database, get_or_create_db
 
 TEST_DATABSE_NAME = "tests"
+
+get_main_database = get_main_database
 
 
 def get_test_database() -> "Database":
@@ -33,6 +35,10 @@ def get_test_database() -> "Database":
 
     db_uri = conf.get("SQLALCHEMY_EXAMPLES_URI") or conf.get("SQLALCHEMY_DATABASE_URI")
     return get_or_create_db(TEST_DATABSE_NAME, db_uri)
+
+
+def superset_db_backend() -> str:
+    return get_test_database().backend
 
 
 def create_table_from_df(

--- a/tests/fixtures/utils.py
+++ b/tests/fixtures/utils.py
@@ -1,0 +1,80 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from contextlib import contextmanager
+from typing import Any, Dict, Optional
+
+from pandas import DataFrame
+from sqlalchemy.ext.declarative.api import DeclarativeMeta
+
+from superset import ConnectorRegistry, db
+from superset.connectors.sqla.models import SqlaTable
+from superset.models.core import Database
+from superset.utils.core import get_or_create_db
+
+TEST_DATABSE_NAME = "tests"
+
+
+def get_test_database() -> "Database":
+    from superset import conf
+
+    db_uri = conf.get("SQLALCHEMY_EXAMPLES_URI") or conf.get("SQLALCHEMY_DATABASE_URI")
+    return get_or_create_db(TEST_DATABSE_NAME, db_uri)
+
+
+def create_table_from_df(
+    df: DataFrame,
+    table_name: str,
+    dtype: Dict[str, Any],
+    table_description: str = "",
+    fetch_values_predicate: Optional[str] = None,
+    if_exists: str = "replace",
+    database: Optional[Database] = None,
+) -> SqlaTable:
+    database = database or get_test_database()
+    df.to_sql(
+        table_name,
+        database.get_sqla_engine(),
+        if_exists=if_exists,
+        chunksize=500,
+        dtype=dtype,
+        index=False,
+        method="multi",
+    )
+    Table = ConnectorRegistry.sources["table"]
+    table = db.session.query(Table).filter_by(table_name=table_name).one_or_none()
+    if not table:
+        table = Table(table_name=table_name)
+    if fetch_values_predicate:
+        table.fetch_values_predicate = fetch_values_predicate
+    table.database = database
+    table.description = table_description
+    db.session.merge(table)
+    db.session.commit()
+    return table
+
+
+@contextmanager
+def db_insert_temp_object(obj: DeclarativeMeta):
+    """Insert a temporary object in database; delete when done."""
+    session = db.session
+    try:
+        session.add(obj)
+        session.commit()
+        yield obj
+    finally:
+        session.delete(obj)
+        session.commit()

--- a/tests/fixtures/world_bank_dashboard.py
+++ b/tests/fixtures/world_bank_dashboard.py
@@ -30,7 +30,8 @@ from superset.models.core import Database
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.utils.core import get_example_database
-from tests.dashboard_utils import create_dashboard, create_table_for_dashboard
+from tests.dashboard_utils import create_dashboard
+from tests.fixtures.utils import create_table_from_df
 from tests.test_app import app
 
 
@@ -62,7 +63,7 @@ def _load_data():
             "country_name": String(255),
             "region": String(255),
         }
-        table = create_table_for_dashboard(df, table_name, database, dtype)
+        table = create_table_from_df(df, table_name, database, dtype)
         slices = _create_world_bank_slices(table)
         dash = _create_world_bank_dashboard(table, slices)
         slices_ids_to_delete = [slice.id for slice in slices]

--- a/tests/fixtures/world_bank_dashboard.py
+++ b/tests/fixtures/world_bank_dashboard.py
@@ -29,9 +29,8 @@ from superset.connectors.sqla.models import SqlaTable
 from superset.models.core import Database
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
-from superset.utils.core import get_example_database
 from tests.dashboard_utils import create_dashboard
-from tests.fixtures.utils import create_table_from_df
+from tests.fixtures.utils import create_table_from_df, get_test_database
 from tests.test_app import app
 
 
@@ -55,7 +54,7 @@ def _load_data():
     table_name = "wb_health_population"
 
     with app.app_context():
-        database = get_example_database()
+        database = get_test_database()
         df = _get_dataframe(database)
         dtype = {
             "year": DateTime if database.backend != "presto" else String(255),
@@ -107,7 +106,7 @@ def _create_world_bank_dashboard(table: SqlaTable, slices: List[Slice]) -> Dashb
 
 
 def _cleanup(dash_id: int, slices_ids: List[int]) -> None:
-    engine = get_example_database().get_sqla_engine()
+    engine = get_test_database().get_sqla_engine()
     engine.execute("DROP TABLE IF EXISTS wb_health_population")
     dash = db.session.query(Dashboard).filter_by(id=dash_id).first()
     db.session.delete(dash)

--- a/tests/fixtures/world_bank_dashboard.py
+++ b/tests/fixtures/world_bank_dashboard.py
@@ -62,7 +62,7 @@ def _load_data():
             "country_name": String(255),
             "region": String(255),
         }
-        table = create_table_from_df(df, table_name, database, dtype)
+        table = create_table_from_df(df, table_name, dtype=dtype, database=database)
         slices = _create_world_bank_slices(table)
         dash = _create_world_bank_dashboard(table, slices)
         slices_ids_to_delete = [slice.id for slice in slices]

--- a/tests/import_export_tests.py
+++ b/tests/import_export_tests.py
@@ -39,7 +39,7 @@ from superset.dashboards.commands.importers.v0 import import_chart, import_dashb
 from superset.datasets.commands.importers.v0 import import_dataset
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
-from superset.utils.core import get_example_database
+from tests.fixtures.utils import get_test_database
 
 from tests.fixtures.world_bank_dashboard import load_world_bank_dashboard_with_slices
 from .base_tests import SupersetTestCase
@@ -580,7 +580,7 @@ class TestImportExport(SupersetTestCase):
         return dash_with_1_slice
 
     def test_import_table_no_metadata(self):
-        db_id = get_example_database().id
+        db_id = get_test_database().id
         table = self.create_table("pure_table", id=10001)
         imported_id = import_dataset(table, db_id, import_time=1989)
         imported = self.get_table_by_id(imported_id)
@@ -590,7 +590,7 @@ class TestImportExport(SupersetTestCase):
         table = self.create_table(
             "table_1_col_1_met", id=10002, cols_names=["col1"], metric_names=["metric1"]
         )
-        db_id = get_example_database().id
+        db_id = get_test_database().id
         imported_id = import_dataset(table, db_id, import_time=1990)
         imported = self.get_table_by_id(imported_id)
         self.assert_table_equals(table, imported)
@@ -606,7 +606,7 @@ class TestImportExport(SupersetTestCase):
             cols_names=["c1", "c2"],
             metric_names=["m1", "m2"],
         )
-        db_id = get_example_database().id
+        db_id = get_test_database().id
         imported_id = import_dataset(table, db_id, import_time=1991)
 
         imported = self.get_table_by_id(imported_id)
@@ -616,7 +616,7 @@ class TestImportExport(SupersetTestCase):
         table = self.create_table(
             "table_override", id=10003, cols_names=["col1"], metric_names=["m1"]
         )
-        db_id = get_example_database().id
+        db_id = get_test_database().id
         imported_id = import_dataset(table, db_id, import_time=1991)
 
         table_over = self.create_table(
@@ -644,7 +644,7 @@ class TestImportExport(SupersetTestCase):
             cols_names=["new_col1", "col2", "col3"],
             metric_names=["new_metric1"],
         )
-        db_id = get_example_database().id
+        db_id = get_test_database().id
         imported_id = import_dataset(table, db_id, import_time=1993)
 
         copy_table = self.create_table(

--- a/tests/importexport/commands_tests.py
+++ b/tests/importexport/commands_tests.py
@@ -22,8 +22,8 @@ from freezegun import freeze_time
 
 from superset import security_manager
 from superset.databases.commands.export import ExportDatabasesCommand
-from superset.utils.core import get_example_database
 from tests.base_tests import SupersetTestCase
+from tests.fixtures.utils import get_test_database
 
 
 class TestExportModelsCommand(SupersetTestCase):
@@ -32,7 +32,7 @@ class TestExportModelsCommand(SupersetTestCase):
         """Make sure metadata.yaml has the correct content."""
         mock_g.user = security_manager.find_user("admin")
 
-        example_db = get_example_database()
+        example_db = get_test_database()
 
         with freeze_time("2020-01-01T00:00:00Z"):
             command = ExportDatabasesCommand([example_db.id])

--- a/tests/jinja_context_tests.py
+++ b/tests/jinja_context_tests.py
@@ -21,7 +21,6 @@ from unittest import mock
 
 import pytest
 
-import tests.test_app
 from superset import app
 from superset.exceptions import SupersetTemplateException
 from superset.jinja_context import (
@@ -30,8 +29,8 @@ from superset.jinja_context import (
     get_template_processor,
     safe_proxy,
 )
-from superset.utils import core as utils
 from tests.base_tests import SupersetTestCase
+from tests.fixtures.utils import get_test_database
 
 
 class TestJinja2Context(SupersetTestCase):
@@ -139,77 +138,77 @@ class TestJinja2Context(SupersetTestCase):
             safe_proxy(func, {"foo": lambda: "bar"})
 
     def test_process_template(self) -> None:
-        maindb = utils.get_example_database()
+        maindb = get_test_database()
         sql = "SELECT '{{ 1+1 }}'"
         tp = get_template_processor(database=maindb)
         rendered = tp.process_template(sql)
         self.assertEqual("SELECT '2'", rendered)
 
     def test_get_template_kwarg(self) -> None:
-        maindb = utils.get_example_database()
+        maindb = get_test_database()
         s = "{{ foo }}"
         tp = get_template_processor(database=maindb, foo="bar")
         rendered = tp.process_template(s)
         self.assertEqual("bar", rendered)
 
     def test_template_kwarg(self) -> None:
-        maindb = utils.get_example_database()
+        maindb = get_test_database()
         s = "{{ foo }}"
         tp = get_template_processor(database=maindb)
         rendered = tp.process_template(s, foo="bar")
         self.assertEqual("bar", rendered)
 
     def test_get_template_kwarg_dict(self) -> None:
-        maindb = utils.get_example_database()
+        maindb = get_test_database()
         s = "{{ foo.bar }}"
         tp = get_template_processor(database=maindb, foo={"bar": "baz"})
         rendered = tp.process_template(s)
         self.assertEqual("baz", rendered)
 
     def test_template_kwarg_dict(self) -> None:
-        maindb = utils.get_example_database()
+        maindb = get_test_database()
         s = "{{ foo.bar }}"
         tp = get_template_processor(database=maindb)
         rendered = tp.process_template(s, foo={"bar": "baz"})
         self.assertEqual("baz", rendered)
 
     def test_get_template_kwarg_lambda(self) -> None:
-        maindb = utils.get_example_database()
+        maindb = get_test_database()
         s = "{{ foo() }}"
         tp = get_template_processor(database=maindb, foo=lambda: "bar")
         with pytest.raises(SupersetTemplateException):
             tp.process_template(s)
 
     def test_template_kwarg_lambda(self) -> None:
-        maindb = utils.get_example_database()
+        maindb = get_test_database()
         s = "{{ foo() }}"
         tp = get_template_processor(database=maindb)
         with pytest.raises(SupersetTemplateException):
             tp.process_template(s, foo=lambda: "bar")
 
     def test_get_template_kwarg_module(self) -> None:
-        maindb = utils.get_example_database()
+        maindb = get_test_database()
         s = "{{ dt(2017, 1, 1).isoformat() }}"
         tp = get_template_processor(database=maindb, dt=datetime)
         with pytest.raises(SupersetTemplateException):
             tp.process_template(s)
 
     def test_template_kwarg_module(self) -> None:
-        maindb = utils.get_example_database()
+        maindb = get_test_database()
         s = "{{ dt(2017, 1, 1).isoformat() }}"
         tp = get_template_processor(database=maindb)
         with pytest.raises(SupersetTemplateException):
             tp.process_template(s, dt=datetime)
 
     def test_get_template_kwarg_nested_module(self) -> None:
-        maindb = utils.get_example_database()
+        maindb = get_test_database()
         s = "{{ foo.dt }}"
         tp = get_template_processor(database=maindb, foo={"dt": datetime})
         with pytest.raises(SupersetTemplateException):
             tp.process_template(s)
 
     def test_template_kwarg_nested_module(self) -> None:
-        maindb = utils.get_example_database()
+        maindb = get_test_database()
         s = "{{ foo.dt }}"
         tp = get_template_processor(database=maindb)
         with pytest.raises(SupersetTemplateException):
@@ -228,7 +227,7 @@ class TestJinja2Context(SupersetTestCase):
     @mock.patch("superset.jinja_context.context_addons")
     def test_template_context_addons(self, addons_mock) -> None:
         addons_mock.return_value = {"datetime": datetime}
-        maindb = utils.get_example_database()
+        maindb = get_test_database()
         s = "SELECT '{{ datetime(2017, 1, 1).isoformat() }}'"
         tp = get_template_processor(database=maindb)
         rendered = tp.process_template(s)
@@ -287,7 +286,7 @@ class TestJinja2Context(SupersetTestCase):
     def test_custom_template_processors_ignored(self) -> None:
         """Test custom template processor is ignored for a difference backend
         database."""
-        maindb = utils.get_example_database()
+        maindb = get_test_database()
         sql = "SELECT '$DATE()'"
         tp = get_template_processor(database=maindb)
         rendered = tp.process_template(sql)

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -18,20 +18,19 @@
 import textwrap
 import unittest
 from unittest import mock
-from tests.fixtures.birth_names_dashboard import load_birth_names_dashboard_with_slices
 
-import pandas
 import pytest
 from sqlalchemy.engine.url import make_url
 
-import tests.test_app
 from superset import app, db as metadata_db
 from superset.models.core import Database
 from superset.models.slice import Slice
-from superset.utils.core import get_example_database, QueryStatus
+from superset.utils.core import QueryStatus
 
-from .base_tests import SupersetTestCase
-from .fixtures.energy_dashboard import load_energy_table_with_slice
+from tests.base_tests import SupersetTestCase
+from tests.fixtures.energy_dashboard import load_energy_table_with_slice
+from tests.fixtures.birth_names_dashboard import load_birth_names_dashboard_with_slices
+from tests.fixtures.utils import get_test_database
 
 
 class TestDatabaseModel(SupersetTestCase):
@@ -205,7 +204,7 @@ class TestDatabaseModel(SupersetTestCase):
 
     @pytest.mark.usefixtures("load_energy_table_with_slice")
     def test_select_star(self):
-        db = get_example_database()
+        db = get_test_database()
         table_name = "energy_usage"
         sql = db.select_star(table_name, show_cols=False, latest_partition=False)
         quote = db.inspector.engine.dialect.identifier_preparer.quote_identifier
@@ -265,7 +264,7 @@ class TestDatabaseModel(SupersetTestCase):
             )
 
     def test_select_star_fully_qualified_names(self):
-        db = get_example_database()
+        db = get_test_database()
         schema = "schema.name"
         table_name = "table/name"
         sql = db.select_star(
@@ -287,7 +286,7 @@ class TestDatabaseModel(SupersetTestCase):
             assert sql.startswith(expected)
 
     def test_single_statement(self):
-        main_db = get_example_database()
+        main_db = get_test_database()
 
         if main_db.backend == "mysql":
             df = main_db.get_df("SELECT 1", None)
@@ -297,7 +296,7 @@ class TestDatabaseModel(SupersetTestCase):
             self.assertEqual(df.iat[0, 0], 1)
 
     def test_multi_statement(self):
-        main_db = get_example_database()
+        main_db = get_test_database()
 
         if main_db.backend == "mysql":
             df = main_db.get_df("USE superset; SELECT 1", None)
@@ -395,7 +394,7 @@ class TestSqlaTableModel(SupersetTestCase):
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_query_with_expr_groupby_timeseries(self):
-        if get_example_database().backend == "presto":
+        if get_test_database().backend == "presto":
             # TODO(bkyryliuk): make it work for presto.
             return
 

--- a/tests/queries/api_tests.py
+++ b/tests/queries/api_tests.py
@@ -16,21 +16,21 @@
 # under the License.
 # isort:skip_file
 """Unit tests for Superset"""
-from datetime import datetime, timedelta
 import json
 import random
 import string
-
 import pytest
 import prison
+
+from datetime import datetime
 from sqlalchemy.sql import func
 
-import tests.test_app
 from superset import db, security_manager
 from superset.models.core import Database
-from superset.utils.core import get_example_database, get_main_database, QueryStatus
 from superset.models.sql_lab import Query
+from superset.utils.core import get_main_database, QueryStatus
 
+from tests.fixtures.utils import get_test_database
 from tests.base_tests import SupersetTestCase
 
 QUERIES_FIXTURE_COUNT = 10
@@ -77,7 +77,7 @@ class TestQueryApi(SupersetTestCase):
             queries = []
             admin_id = self.get_user("admin").id
             alpha_id = self.get_user("alpha").id
-            example_database_id = get_example_database().id
+            example_database_id = get_test_database().id
             main_database_id = get_main_database().id
             for cx in range(QUERIES_FIXTURE_COUNT - 1):
                 queries.append(
@@ -121,7 +121,7 @@ class TestQueryApi(SupersetTestCase):
         """
         admin = self.get_user("admin")
         client_id = self.get_random_string()
-        example_db = get_example_database()
+        example_db = get_test_database()
         query = self.insert_query(
             example_db.id,
             admin.id,
@@ -179,7 +179,7 @@ class TestQueryApi(SupersetTestCase):
         """
         admin = self.get_user("admin")
         client_id = self.get_random_string()
-        query = self.insert_query(get_example_database().id, admin.id, client_id)
+        query = self.insert_query(get_test_database().id, admin.id, client_id)
         max_id = db.session.query(func.max(Query.id)).scalar()
         self.login(username="admin")
         uri = f"api/v1/query/{max_id + 1}"
@@ -203,10 +203,10 @@ class TestQueryApi(SupersetTestCase):
         gamma1_client_id = self.get_random_string()
         gamma2_client_id = self.get_random_string()
         query_gamma1 = self.insert_query(
-            get_example_database().id, gamma1.id, gamma1_client_id
+            get_test_database().id, gamma1.id, gamma1_client_id
         )
         query_gamma2 = self.insert_query(
-            get_example_database().id, gamma2.id, gamma2_client_id
+            get_test_database().id, gamma2.id, gamma2_client_id
         )
 
         # Gamma1 user, only sees his own queries
@@ -374,7 +374,7 @@ class TestQueryApi(SupersetTestCase):
         admin = self.get_user("admin")
         client_id = self.get_random_string()
         query = self.insert_query(
-            get_example_database().id,
+            get_test_database().id,
             admin.id,
             client_id,
             sql="SELECT col1, col2 from table1",

--- a/tests/queries/saved_queries/api_tests.py
+++ b/tests/queries/saved_queries/api_tests.py
@@ -30,7 +30,7 @@ from superset import db
 from superset.models.core import Database
 from superset.models.core import FavStar
 from superset.models.sql_lab import SavedQuery
-from superset.utils.core import get_example_database
+from tests.fixtures.utils import get_test_database
 
 from tests.base_tests import SupersetTestCase
 
@@ -67,7 +67,7 @@ class TestSavedQueryApi(SupersetTestCase):
         self, label: str = "saved1", schema: str = "schema1", username: str = "admin"
     ) -> SavedQuery:
         admin = self.get_user(username)
-        example_db = get_example_database()
+        example_db = get_test_database()
         return self.insert_saved_query(
             label,
             "SELECT col1, col2 from table1",
@@ -223,7 +223,7 @@ class TestSavedQueryApi(SupersetTestCase):
         """
         Saved Query API: Test get list and database saved query
         """
-        example_db = get_example_database()
+        example_db = get_test_database()
         admin_user = self.get_user("admin")
 
         all_db_queries = (
@@ -542,7 +542,7 @@ class TestSavedQueryApi(SupersetTestCase):
         Saved Query API: Test create
         """
         admin = self.get_user("admin")
-        example_db = get_example_database()
+        example_db = get_test_database()
 
         post_data = {
             "schema": "schema1",

--- a/tests/queries/saved_queries/commands_tests.py
+++ b/tests/queries/saved_queries/commands_tests.py
@@ -23,13 +23,13 @@ from superset import db, security_manager
 from superset.models.sql_lab import SavedQuery
 from superset.queries.saved_queries.commands.exceptions import SavedQueryNotFoundError
 from superset.queries.saved_queries.commands.export import ExportSavedQueriesCommand
-from superset.utils.core import get_example_database
 from tests.base_tests import SupersetTestCase
+from tests.fixtures.utils import get_test_database
 
 
 class TestExportSavedQueriesCommand(SupersetTestCase):
     def setUp(self):
-        self.example_database = get_example_database()
+        self.example_database = get_test_database()
         self.example_query = SavedQuery(
             database=self.example_database,
             created_by=self.get_user("admin"),

--- a/tests/reports/api_tests.py
+++ b/tests/reports/api_tests.py
@@ -39,7 +39,7 @@ import tests.test_app
 from tests.base_tests import SupersetTestCase
 from tests.fixtures.birth_names_dashboard import load_birth_names_dashboard_with_slices
 from tests.reports.utils import insert_report_schedule
-from superset.utils.core import get_example_database
+from tests.fixtures.utils import get_test_database
 
 
 REPORTS_COUNT = 10
@@ -53,7 +53,7 @@ class TestReportSchedulesApi(SupersetTestCase):
             admin_user = self.get_user("admin")
             alpha_user = self.get_user("alpha")
             chart = db.session.query(Slice).first()
-            example_db = get_example_database()
+            example_db = get_test_database()
 
             report_schedule = insert_report_schedule(
                 type=ReportScheduleType.ALERT,
@@ -79,7 +79,7 @@ class TestReportSchedulesApi(SupersetTestCase):
             admin_user = self.get_user("admin")
             alpha_user = self.get_user("alpha")
             chart = db.session.query(Slice).first()
-            example_db = get_example_database()
+            example_db = get_test_database()
             for cx in range(REPORTS_COUNT):
                 recipients = []
                 logs = []
@@ -417,7 +417,7 @@ class TestReportSchedulesApi(SupersetTestCase):
         self.login(username="admin")
 
         chart = db.session.query(Slice).first()
-        example_db = get_example_database()
+        example_db = get_test_database()
         report_schedule_data = {
             "type": ReportScheduleType.ALERT,
             "name": "new3",
@@ -463,7 +463,7 @@ class TestReportSchedulesApi(SupersetTestCase):
         self.login(username="admin")
 
         chart = db.session.query(Slice).first()
-        example_db = get_example_database()
+        example_db = get_test_database()
         report_schedule_data = {
             "type": ReportScheduleType.ALERT,
             "name": "name3",
@@ -503,7 +503,7 @@ class TestReportSchedulesApi(SupersetTestCase):
         """
         self.login(username="admin")
         chart = db.session.query(Slice).first()
-        example_db = get_example_database()
+        example_db = get_test_database()
 
         # Check that a report does not have a database reference
         report_schedule_data = {
@@ -600,7 +600,7 @@ class TestReportSchedulesApi(SupersetTestCase):
         # Test we can submit a chart or a dashboard not both
         chart = db.session.query(Slice).first()
         dashboard = db.session.query(Dashboard).first()
-        example_db = get_example_database()
+        example_db = get_test_database()
         report_schedule_data = {
             "type": ReportScheduleType.ALERT,
             "name": "new3",
@@ -649,7 +649,7 @@ class TestReportSchedulesApi(SupersetTestCase):
         # Test chart and database do not exist
         chart_max_id = db.session.query(func.max(Slice.id)).scalar()
         database_max_id = db.session.query(func.max(Database.id)).scalar()
-        examples_db = get_example_database()
+        examples_db = get_test_database()
         report_schedule_data = {
             "type": ReportScheduleType.ALERT,
             "name": "new3",
@@ -698,7 +698,7 @@ class TestReportSchedulesApi(SupersetTestCase):
 
         self.login(username="admin")
         chart = db.session.query(Slice).first()
-        example_db = get_example_database()
+        example_db = get_test_database()
         report_schedule_data = {
             "type": ReportScheduleType.ALERT,
             "name": "changed",
@@ -799,7 +799,7 @@ class TestReportSchedulesApi(SupersetTestCase):
         # Test we can submit a chart or a dashboard not both
         chart = db.session.query(Slice).first()
         dashboard = db.session.query(Dashboard).first()
-        example_db = get_example_database()
+        example_db = get_test_database()
         report_schedule_data = {
             "chart": chart.id,
             "dashboard": dashboard.id,
@@ -830,7 +830,7 @@ class TestReportSchedulesApi(SupersetTestCase):
         # Test chart and database do not exist
         chart_max_id = db.session.query(func.max(Slice.id)).scalar()
         database_max_id = db.session.query(func.max(Database.id)).scalar()
-        examples_db = get_example_database()
+        examples_db = get_test_database()
         report_schedule_data = {
             "type": ReportScheduleType.ALERT,
             "name": "new3",

--- a/tests/reports/commands_tests.py
+++ b/tests/reports/commands_tests.py
@@ -51,8 +51,8 @@ from superset.reports.commands.exceptions import (
     ReportScheduleWorkingTimeoutError,
 )
 from superset.reports.commands.execute import AsyncExecuteReportScheduleCommand
-from superset.utils.core import get_example_database
 from tests.fixtures.birth_names_dashboard import load_birth_names_dashboard_with_slices
+from tests.fixtures.utils import get_test_database
 from tests.fixtures.world_bank_dashboard import (
     load_world_bank_dashboard_with_slices_module_scope,
 )
@@ -329,7 +329,7 @@ def create_alert_email_chart(request):
     }
     with app.app_context():
         chart = db.session.query(Slice).first()
-        example_database = get_example_database()
+        example_database = get_test_database()
         with create_test_table_context(example_database):
 
             report_schedule = create_report_notification(
@@ -411,7 +411,7 @@ def create_no_alert_email_chart(request):
     }
     with app.app_context():
         chart = db.session.query(Slice).first()
-        example_database = get_example_database()
+        example_database = get_test_database()
         with create_test_table_context(example_database):
 
             report_schedule = create_report_notification(
@@ -446,7 +446,7 @@ def create_mul_alert_email_chart(request):
     }
     with app.app_context():
         chart = db.session.query(Slice).first()
-        example_database = get_example_database()
+        example_database = get_test_database()
         with create_test_table_context(example_database):
 
             report_schedule = create_report_notification(
@@ -481,7 +481,7 @@ def create_invalid_sql_alert_email_chart(request):
     }
     with app.app_context():
         chart = db.session.query(Slice).first()
-        example_database = get_example_database()
+        example_database = get_test_database()
         with create_test_table_context(example_database):
 
             report_schedule = create_report_notification(

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -41,12 +41,7 @@ from superset.models.slice import Slice
 from superset.sql_parse import Table
 from superset.utils.core import get_example_database
 
-from .base_tests import SupersetTestCase
-from .dashboard_utils import (
-    create_table_for_dashboard,
-    create_slice,
-    create_dashboard,
-)
+from tests.base_tests import SupersetTestCase
 from tests.fixtures.birth_names_dashboard import load_birth_names_dashboard_with_slices
 from tests.fixtures.energy_dashboard import load_energy_table_with_slice
 from tests.fixtures.public_role import (

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -39,7 +39,7 @@ from superset.exceptions import SupersetSecurityException
 from superset.models.core import Database
 from superset.models.slice import Slice
 from superset.sql_parse import Table
-from superset.utils.core import get_example_database
+from tests.fixtures.utils import get_test_database
 
 from tests.base_tests import SupersetTestCase
 from tests.fixtures.birth_names_dashboard import load_birth_names_dashboard_with_slices
@@ -149,7 +149,7 @@ class TestRolePermission(SupersetTestCase):
         table = SqlaTable(
             schema="tmp_schema",
             table_name="tmp_perm_table",
-            database=get_example_database(),
+            database=get_test_database(),
         )
         session.add(table)
         session.commit()
@@ -489,7 +489,7 @@ class TestRolePermission(SupersetTestCase):
     def test_schemas_accessible_by_user_admin(self, mock_g):
         mock_g.user = security_manager.find_user("admin")
         with self.client.application.test_request_context():
-            database = get_example_database()
+            database = get_test_database()
             schemas = security_manager.get_schemas_accessible_by_user(
                 database, ["1", "2", "3"]
             )
@@ -501,7 +501,7 @@ class TestRolePermission(SupersetTestCase):
         create_schema_perm("[examples].[1]")
         mock_g.user = security_manager.find_user("gamma")
         with self.client.application.test_request_context():
-            database = get_example_database()
+            database = get_test_database()
             schemas = security_manager.get_schemas_accessible_by_user(
                 database, ["1", "2", "3"]
             )
@@ -514,7 +514,7 @@ class TestRolePermission(SupersetTestCase):
         # User has schema access to the datasource temp_schema.wb_health_population in examples DB.
         mock_g.user = security_manager.find_user("gamma")
         with self.client.application.test_request_context():
-            database = get_example_database()
+            database = get_test_database()
             schemas = security_manager.get_schemas_accessible_by_user(
                 database, ["temp_schema", "2", "3"]
             )
@@ -526,7 +526,7 @@ class TestRolePermission(SupersetTestCase):
         create_schema_perm("[examples].[2]")
         mock_g.user = security_manager.find_user("gamma")
         with self.client.application.test_request_context():
-            database = get_example_database()
+            database = get_test_database()
             schemas = security_manager.get_schemas_accessible_by_user(
                 database, ["temp_schema", "2", "3"]
             )
@@ -938,7 +938,7 @@ class TestSecurityManager(SupersetTestCase):
 
     @patch("superset.security.SupersetSecurityManager.raise_for_access")
     def test_can_access_table(self, mock_raise_for_access):
-        database = get_example_database()
+        database = get_test_database()
         table = Table("bar", "foo")
 
         mock_raise_for_access.return_value = None
@@ -971,7 +971,7 @@ class TestSecurityManager(SupersetTestCase):
     @patch("superset.security.SupersetSecurityManager.can_access")
     def test_raise_for_access_query(self, mock_can_access):
         query = Mock(
-            database=get_example_database(), schema="bar", sql="SELECT * FROM foo"
+            database=get_test_database(), schema="bar", sql="SELECT * FROM foo"
         )
 
         mock_can_access.return_value = True
@@ -1000,7 +1000,7 @@ class TestSecurityManager(SupersetTestCase):
 
     @patch("superset.security.SupersetSecurityManager.can_access")
     def test_raise_for_access_table(self, mock_can_access):
-        database = get_example_database()
+        database = get_test_database()
         table = Table("bar", "foo")
 
         mock_can_access.return_value = True

--- a/tests/sql_validator_tests.py
+++ b/tests/sql_validator_tests.py
@@ -31,7 +31,7 @@ from superset.sql_validators.presto_db import (
     PrestoDBSQLValidator,
     PrestoSQLValidationError,
 )
-from superset.utils.core import get_example_database
+from tests.fixtures.utils import get_test_database
 
 from .base_tests import SupersetTestCase
 
@@ -73,7 +73,7 @@ class TestSqlValidatorEndpoint(SupersetTestCase):
     def test_validate_sql_endpoint_mocked(self, get_validator_by_name):
         """Assert that, with a mocked validator, annotations make it back out
         from the validate_sql_json endpoint as a list of json dictionaries"""
-        if get_example_database().backend == "hive":
+        if get_test_database().backend == "hive":
             pytest.skip("Hive validator is not implemented")
         self.login("admin")
 
@@ -116,7 +116,7 @@ class TestSqlValidatorEndpoint(SupersetTestCase):
             "SELECT * FROM birth_names", client_id="1", raise_on_error=False
         )
         # TODO(bkyryliuk): properly handle hive error
-        if get_example_database().backend == "hive":
+        if get_test_database().backend == "hive":
             assert resp["error"] == "no SQL validator is configured for hive"
         else:
             self.assertIn("error", resp)
@@ -214,7 +214,7 @@ class TestPrestoValidator(SupersetTestCase):
 
 class TestPostgreSQLValidator(SupersetTestCase):
     def test_valid_syntax(self):
-        if get_example_database().backend != "postgresql":
+        if get_test_database().backend != "postgresql":
             return
 
         mock_database = MagicMock()
@@ -224,7 +224,7 @@ class TestPostgreSQLValidator(SupersetTestCase):
         assert annotations == []
 
     def test_invalid_syntax(self):
-        if get_example_database().backend != "postgresql":
+        if get_test_database().backend != "postgresql":
             return
 
         mock_database = MagicMock()

--- a/tests/sqla_models_tests.py
+++ b/tests/sqla_models_tests.py
@@ -25,10 +25,11 @@ from superset.connectors.sqla.models import SqlaTable, TableColumn
 from superset.db_engine_specs.druid import DruidEngineSpec
 from superset.exceptions import QueryObjectValidationError
 from superset.models.core import Database
-from superset.utils.core import GenericDataType, get_example_database, FilterOperator
-from tests.fixtures.birth_names_dashboard import load_birth_names_dashboard_with_slices
+from superset.utils.core import GenericDataType, FilterOperator
 
-from .base_tests import SupersetTestCase
+from tests.base_tests import SupersetTestCase
+from tests.fixtures.birth_names_dashboard import load_birth_names_dashboard_with_slices
+from tests.fixtures.utils import get_test_database
 
 
 VIRTUAL_TABLE_INT_TYPES: Dict[str, Pattern[str]] = {
@@ -65,7 +66,7 @@ class TestDatabaseModel(SupersetTestCase):
     def test_temporal_varchar(self):
         """Ensure a column with is_dttm set to true evaluates to is_temporal == True"""
 
-        database = get_example_database()
+        database = get_test_database()
         tbl = SqlaTable(table_name="test_tbl", database=database)
         col = TableColumn(column_name="ds", type="VARCHAR", table=tbl)
         # by default, VARCHAR should not be assumed to be temporal
@@ -96,7 +97,7 @@ class TestDatabaseModel(SupersetTestCase):
             "TIMESTAMP": GenericDataType.TEMPORAL,
         }
 
-        tbl = SqlaTable(table_name="col_type_test_tbl", database=get_example_database())
+        tbl = SqlaTable(table_name="col_type_test_tbl", database=get_test_database())
         for str_type, db_col_type in test_cases.items():
             col = TableColumn(column_name="foo", type=str_type, table=tbl)
             self.assertEqual(col.is_temporal, db_col_type == GenericDataType.TEMPORAL)
@@ -120,7 +121,7 @@ class TestDatabaseModel(SupersetTestCase):
         table1 = SqlaTable(
             table_name="test_has_extra_cache_keys_table",
             sql="SELECT '{{ current_username() }}' as user",
-            database=get_example_database(),
+            database=get_test_database(),
         )
 
         query_obj = dict(**base_query_obj, extras={})
@@ -132,7 +133,7 @@ class TestDatabaseModel(SupersetTestCase):
         table2 = SqlaTable(
             table_name="test_has_extra_cache_keys_disabled_table",
             sql="SELECT '{{ current_username(False) }}' as user",
-            database=get_example_database(),
+            database=get_test_database(),
         )
         query_obj = dict(**base_query_obj, extras={})
         extra_cache_keys = table2.get_extra_cache_keys(query_obj)
@@ -144,7 +145,7 @@ class TestDatabaseModel(SupersetTestCase):
         table3 = SqlaTable(
             table_name="test_has_no_extra_cache_keys_table",
             sql=query,
-            database=get_example_database(),
+            database=get_test_database(),
         )
 
         query_obj = dict(**base_query_obj, extras={"where": "(user != 'abc')"})
@@ -218,10 +219,10 @@ class TestDatabaseModel(SupersetTestCase):
         table = SqlaTable(
             table_name="test_table",
             sql="SELECT '{{ abcd xyz + 1 ASDF }}' as user",
-            database=get_example_database(),
+            database=get_test_database(),
         )
         # TODO(villebro): make it work with presto
-        if get_example_database().backend != "presto":
+        if get_test_database().backend != "presto":
             with pytest.raises(QueryObjectValidationError):
                 table.get_sqla_query(**query_obj)
 
@@ -239,7 +240,7 @@ class TestDatabaseModel(SupersetTestCase):
         table = SqlaTable(
             table_name="test_has_extra_cache_keys_table",
             sql="SELECT 'foo' as grp, 1 as num; SELECT 'bar' as grp, 2 as num",
-            database=get_example_database(),
+            database=get_test_database(),
         )
 
         query_obj = dict(**base_query_obj, extras={})
@@ -260,7 +261,7 @@ class TestDatabaseModel(SupersetTestCase):
         table = SqlaTable(
             table_name="test_has_extra_cache_keys_table",
             sql="DELETE FROM foo",
-            database=get_example_database(),
+            database=get_test_database(),
         )
 
         query_obj = dict(**base_query_obj, extras={})
@@ -270,7 +271,7 @@ class TestDatabaseModel(SupersetTestCase):
     def test_fetch_metadata_for_updated_virtual_table(self):
         table = SqlaTable(
             table_name="updated_sql_table",
-            database=get_example_database(),
+            database=get_test_database(),
             sql="select 123 as intcol, 'abc' as strcol, 'abc' as mycase",
         )
         TableColumn(column_name="intcol", type="FLOAT", table=table)
@@ -301,7 +302,7 @@ class TestDatabaseModel(SupersetTestCase):
         }
         cols: Dict[str, TableColumn] = {col.column_name: col for col in table.columns}
         # assert that the type for intcol has been updated (asserting CI types)
-        backend = get_example_database().backend
+        backend = get_test_database().backend
         assert VIRTUAL_TABLE_INT_TYPES[backend].match(cols["intcol"].type)
         # assert that the expression has been replaced with the new physical column
         assert cols["mycase"].expression == ""

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -139,7 +139,6 @@ class TestSqlLab(SupersetTestCase):
             self.run_sql(
                 "SELECT * FROM birth_names",
                 "1",
-                database_name="examples",
                 tmp_table_name=tmp_table_name,
                 select_as_cta=True,
                 ctas_method=ctas_method,

--- a/tests/strategy_tests.py
+++ b/tests/strategy_tests.py
@@ -27,7 +27,7 @@ import pytest
 import pandas as pd
 
 from superset.models.slice import Slice
-from superset.utils.core import get_example_database
+from tests.fixtures.utils import get_test_database
 
 from superset import db
 

--- a/tests/strategy_tests.py
+++ b/tests/strategy_tests.py
@@ -39,9 +39,8 @@ from superset.tasks.cache import (
     TopNDashboardsStrategy,
 )
 
-from .base_tests import SupersetTestCase
-from .dashboard_utils import create_dashboard, create_slice, create_table_for_dashboard
-from .fixtures.unicode_dashboard import load_unicode_dashboard_with_slice
+from tests.base_tests import SupersetTestCase
+from tests.fixtures.unicode_dashboard import load_unicode_dashboard_with_slice
 
 URL_PREFIX = "http://0.0.0.0:8081"
 


### PR DESCRIPTION
### SUMMARY

It's annoying sometimes when I run [a unit test using the `birth_names` fixture](https://github.com/apache/superset/blob/b9884fb55bdf40cc7f073d2b758f43a5b6265d6c/tests/query_context_tests.py#L320), it will drop the whole `birth_names` table in the example database once the test is finished. I can't remember how many times I had to run `superset load_examples` to add the data back.

This PR adds a `test` database just for running tests and makes sure all applicable Python unit tests (those using ad-hoc fixtures instead of actual examples data) are run on the test database instead of examples.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

No functional changes. CI should pass. Running a single unit test with `load_birth_names_dashboard_with_slices` fixture should not drop the `birth_names` table.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
