### PR TITLE
feat: Implement drag and drop for metrics

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
@@ -22,7 +22,7 @@ import { ColumnMeta, Metric } from '@superset-ui/chart-controls';
 import { Tooltip } from 'src/common/components/Tooltip';
 import { OPERATORS } from 'src/explore/constants';
 import { OptionSortType } from 'src/explore/types';
-import { DndFilterSelectProps, FilterOptionValueType } from './types';
+import { DndFilterSelectProps, OptionValueType } from './types';
 import AdhocFilterPopoverTrigger from '../FilterControl/AdhocFilterPopoverTrigger';
 import OptionWrapper from './components/OptionWrapper';
 import DndSelectLabel from './DndSelectLabel';
@@ -37,13 +37,13 @@ import {
 } from '../../DatasourcePanel/types';
 import { DndItemType } from '../../DndItemType';
 
-const isDictionaryForAdhocFilter = (value: FilterOptionValueType) =>
+const isDictionaryForAdhocFilter = (value: OptionValueType) =>
   !(value instanceof AdhocFilter) && value?.expressionType;
 
 export const DndFilterSelect = (props: DndFilterSelectProps) => {
   const propsValues = Array.from(props.value ?? []);
   const [values, setValues] = useState(
-    propsValues.map((filter: FilterOptionValueType) =>
+    propsValues.map((filter: OptionValueType) =>
       isDictionaryForAdhocFilter(filter) ? new AdhocFilter(filter) : filter,
     ),
   );
@@ -144,7 +144,7 @@ export const DndFilterSelect = (props: DndFilterSelectProps) => {
 
   useEffect(() => {
     setValues(
-      (props.value || []).map((filter: FilterOptionValueType) =>
+      (props.value || []).map((filter: OptionValueType) =>
         isDictionaryForAdhocFilter(filter) ? new AdhocFilter(filter) : filter,
       ),
     );
@@ -171,7 +171,7 @@ export const DndFilterSelect = (props: DndFilterSelectProps) => {
       (savedMetric: Metric) => savedMetric.metric_name === savedMetricName,
     )?.expression;
 
-  const mapOption = (option: FilterOptionValueType) => {
+  const mapOption = (option: OptionValueType) => {
     // already a AdhocFilter, skip
     if (option instanceof AdhocFilter) {
       return option;
@@ -299,7 +299,7 @@ export const DndFilterSelect = (props: DndFilterSelectProps) => {
 
   return (
     <>
-      <DndSelectLabel<FilterOptionValueType, FilterOptionValueType[]>
+      <DndSelectLabel<OptionValueType, OptionValueType[]>
         values={values}
         onDrop={(item: DatasourcePanelDndItem) => {
           setDroppedItem(item.value);

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useEffect, useMemo, useState } from 'react';
-import { logging, SupersetClient } from '@superset-ui/core';
+import { logging, SupersetClient, t } from '@superset-ui/core';
 import { ColumnMeta, Metric } from '@superset-ui/chart-controls';
 import { Tooltip } from 'src/common/components/Tooltip';
 import { OPERATORS } from 'src/explore/constants';
@@ -313,6 +313,7 @@ export const DndFilterSelect = (props: DndFilterSelectProps) => {
           DndItemType.MetricOption,
           DndItemType.AdhocMetricOption,
         ]}
+        placeholderText={t('Drop columns or metrics')}
         {...props}
       />
       <AdhocFilterPopoverTrigger

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -1,0 +1,297 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with work for additional information
+ * regarding copyright ownership.  The ASF licenses file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { ensureIsArray, t, useTheme } from '@superset-ui/core';
+import { isEqual } from 'lodash';
+import Icon from 'src/components/Icon';
+import AdhocMetric from '../MetricControl/AdhocMetric';
+import AdhocMetricPopoverTrigger from '../MetricControl/AdhocMetricPopoverTrigger';
+import ControlHeader from '../../ControlHeader';
+import {
+  AddControlLabel,
+  AddIconButton,
+  HeaderContainer,
+  LabelsContainer,
+} from '../../OptionControls';
+import MetricDefinitionValue from '../MetricControl/MetricDefinitionValue';
+import { usePrevious } from '../../../../common/hooks/usePrevious';
+
+const isDictionaryForAdhocMetric = (value: any) =>
+  value && !(value instanceof AdhocMetric) && value.expressionType;
+
+const coerceAdhocMetrics = (value: any) => {
+  if (!value) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    if (isDictionaryForAdhocMetric(value)) {
+      return [new AdhocMetric(value)];
+    }
+    return [value];
+  }
+  return value.map(val => {
+    if (isDictionaryForAdhocMetric(val)) {
+      return new AdhocMetric(val);
+    }
+    return val;
+  });
+};
+
+const getOptionsForSavedMetrics = (
+  savedMetrics,
+  currentMetricValues,
+  currentMetric,
+) =>
+  savedMetrics?.filter(savedMetric =>
+    Array.isArray(currentMetricValues)
+      ? !currentMetricValues.includes(savedMetric.metric_name) ||
+        savedMetric.metric_name === currentMetric
+      : savedMetric,
+  ) ?? [];
+
+const columnsContainAllMetrics = (value, columns, savedMetrics) => {
+  const columnNames = new Set(
+    [...(columns || []), ...(savedMetrics || [])]
+      // eslint-disable-next-line camelcase
+      .map(({ column_name, metric_name }) => column_name || metric_name),
+  );
+
+  return (
+    (Array.isArray(value) ? value : [value])
+      .filter(metric => metric)
+      // find column names
+      .map(metric =>
+        metric.column
+          ? metric.column.column_name
+          : metric.column_name || metric,
+      )
+      .filter(name => name && typeof name === 'string')
+      .every(name => columnNames.has(name))
+  );
+};
+
+const areMetricsEqual = (metric1, metric2) => {
+  if (typeof metric1 !== typeof metric2) {
+    return false;
+  }
+  if (typeof metric1 === 'string') {
+    return metric1 === metric2;
+  }
+  if (typeof metric1 === 'object' && metric1 instanceof AdhocMetric) {
+    return metric1.equals(metric2);
+  }
+  return isEqual(metric1, metric2);
+};
+
+const areMetricsArraysEqual = (metrics1, metrics2) => {
+  const metricsArr1 = ensureIsArray(metrics1);
+  const metricsArr2 = ensureIsArray(metrics2);
+  return (
+    metricsArr1.length === metricsArr2.length &&
+    metricsArr1.every((el: any, index: number) =>
+      areMetricsEqual(metricsArr1[index], metricsArr2[index]),
+    )
+  );
+};
+
+export const DndMetricSelect = props => {
+  const { onChange, multi, columns, savedMetrics } = props;
+
+  const handleChange = useCallback(
+    opts => {
+      // if clear out options
+      if (opts === null) {
+        onChange(null);
+        return;
+      }
+
+      let transformedOpts;
+      if (Array.isArray(opts)) {
+        transformedOpts = opts;
+      } else {
+        transformedOpts = opts ? [opts] : [];
+      }
+      const optionValues = transformedOpts
+        .map(option => {
+          // pre-defined metric
+          if (option.metric_name) {
+            return option.metric_name;
+          }
+          return option;
+        })
+        .filter(option => option);
+      onChange(multi ? optionValues : optionValues[0]);
+    },
+    [multi, onChange],
+  );
+
+  const theme = useTheme();
+  const [value, setValue] = useState(coerceAdhocMetrics(props.value));
+  const prevColumns = usePrevious(columns);
+  const prevSavedMetrics = usePrevious(savedMetrics);
+  const prevValue = usePrevious(props.value);
+
+  useEffect(() => {
+    handleChange(value);
+  }, [handleChange, value]);
+
+  useEffect(() => {
+    if (
+      !isEqual(prevColumns, columns) ||
+      !isEqual(prevSavedMetrics, savedMetrics)
+    ) {
+      // Remove all metrics if selected value no longer a valid column
+      // in the dataset. Must use `nextProps` here because Redux reducers may
+      // have already updated the value for this control.
+      if (!columnsContainAllMetrics(props.value, columns, savedMetrics)) {
+        onChange([]);
+      }
+    }
+    if (!areMetricsArraysEqual(prevValue, props.value)) {
+      setValue(coerceAdhocMetrics(props.value));
+    }
+  }, [
+    prevColumns,
+    columns,
+    prevSavedMetrics,
+    savedMetrics,
+    prevValue,
+    props.value,
+    onChange,
+  ]);
+
+  const isAddNewMetricDisabled = () => !props.multi && value.length > 0;
+
+  const onNewMetric = newMetric => {
+    setValue(prevValue => [...prevValue, newMetric]);
+  };
+
+  const onMetricEdit = (changedMetric, oldMetric) => {
+    setValue(prevValue =>
+      prevValue.map(value => {
+        if (
+          // compare saved metrics
+          value === oldMetric.metric_name ||
+          // compare adhoc metrics
+          typeof value.optionName !== 'undefined'
+            ? value.optionName === oldMetric.optionName
+            : false
+        ) {
+          return changedMetric;
+        }
+        return value;
+      }),
+    );
+  };
+
+  const onRemoveMetric = (index: number) => {
+    if (!Array.isArray(value)) {
+      return;
+    }
+    const valuesCopy = [...value];
+    valuesCopy.splice(index, 1);
+    setValue(valuesCopy);
+  };
+
+  const addNewMetricPopoverTrigger = trigger => {
+    if (isAddNewMetricDisabled()) {
+      return trigger;
+    }
+    return (
+      <AdhocMetricPopoverTrigger
+        adhocMetric={new AdhocMetric({ isNew: true })}
+        onMetricEdit={onNewMetric}
+        columns={props.columns}
+        savedMetricsOptions={getOptionsForSavedMetrics(
+          props.savedMetrics,
+          props.value,
+          null,
+        )}
+        datasource={props.datasource}
+        savedMetric={{}}
+        datasourceType={props.datasourceType}
+        createNew
+      >
+        {trigger}
+      </AdhocMetricPopoverTrigger>
+    );
+  };
+
+  const moveLabel = (dragIndex, hoverIndex) => {
+    const newValues = [...value];
+    [newValues[hoverIndex], newValues[dragIndex]] = [
+      newValues[dragIndex],
+      newValues[hoverIndex],
+    ];
+    setValue(newValues);
+  };
+
+  const valueRenderer = (option, index) => (
+    <MetricDefinitionValue
+      key={index}
+      index={index}
+      option={option}
+      onMetricEdit={onMetricEdit}
+      onRemoveMetric={() => onRemoveMetric(index)}
+      columns={props.columns}
+      datasource={props.datasource}
+      savedMetrics={props.savedMetrics}
+      savedMetricsOptions={getOptionsForSavedMetrics(
+        props.savedMetrics,
+        props.value,
+        props.value?.[index],
+      )}
+      datasourceType={props.datasourceType}
+      onMoveLabel={moveLabel}
+      onDropLabel={() => onChange(value)}
+    />
+  );
+
+  return (
+    <div className="metrics-select">
+      <HeaderContainer>
+        <ControlHeader {...props} />
+        {addNewMetricPopoverTrigger(
+          <AddIconButton
+            disabled={isAddNewMetricDisabled()}
+            data-test="add-metric-button"
+          >
+            <Icon
+              name="plus-large"
+              width={theme.gridUnit * 3}
+              height={theme.gridUnit * 3}
+              color={theme.colors.grayscale.light5}
+            />
+          </AddIconButton>,
+        )}
+      </HeaderContainer>
+      <LabelsContainer>
+        {value.length > 0
+          ? value.map((value, index) => valueRenderer(value, index))
+          : addNewMetricPopoverTrigger(
+              <AddControlLabel>
+                <Icon name="plus-small" color={theme.colors.grayscale.light1} />
+                {t('Add metric')}
+              </AddControlLabel>,
+            )}
+      </LabelsContainer>
+    </div>
+  );
+};

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -18,7 +18,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { ensureIsArray, Metric } from '@superset-ui/core';
+import { ensureIsArray, Metric, t } from '@superset-ui/core';
 import { ColumnMeta } from '@superset-ui/chart-controls';
 import { isEqual } from 'lodash';
 import { usePrevious } from 'src/common/hooks/usePrevious';
@@ -275,6 +275,7 @@ export const DndMetricSelect = (props: any) => {
         canDrop={canDrop}
         valuesRenderer={valuesRenderer}
         accept={[DndItemType.Column, DndItemType.Metric]}
+        placeholderText={t('Drop columns or metrics')}
         {...props}
       />
       <AdhocMetricPopoverTrigger

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
@@ -55,7 +55,7 @@ export default function DndSelectLabel<T, O>(
     return (
       <AddControlLabel cancelHover>
         <Icon name="plus-small" color={theme.colors.grayscale.light1} />
-        {t('Drop Columns')}
+        {t(props.placeholderText || 'Drop columns')}
       </AddControlLabel>
     );
   }

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/index.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/index.ts
@@ -19,3 +19,4 @@
 export { default } from './DndSelectLabel';
 export * from './DndColumnSelect';
 export * from './DndFilterSelect';
+export * from './DndMetricSelect';

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
@@ -50,6 +50,7 @@ export interface DndColumnSelectProps<
   canDrop: (item: DatasourcePanelDndItem) => boolean;
   valuesRenderer: () => ReactNode;
   accept: DndItemType | DndItemType[];
+  placeholderText?: string;
 }
 
 export type OptionValueType = Record<string, any>;

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 import { ReactNode } from 'react';
-import { AdhocFilter } from '@superset-ui/core';
 import { ColumnMeta, Metric } from '@superset-ui/chart-controls';
 import { DatasourcePanelDndItem } from '../../DatasourcePanel/types';
 import { DndItemType } from '../../DndItemType';
@@ -53,14 +52,14 @@ export interface DndColumnSelectProps<
   accept: DndItemType | DndItemType[];
 }
 
-export type FilterOptionValueType = Record<string, any> | AdhocFilter;
+export type OptionValueType = Record<string, any>;
 export interface DndFilterSelectProps {
   name: string;
-  value: FilterOptionValueType[];
+  value: OptionValueType[];
   columns: ColumnMeta[];
   datasource: Record<string, any>;
   formData: Record<string, any>;
   savedMetrics: Metric[];
-  onChange: (filters: FilterOptionValueType[]) => void;
+  onChange: (filters: OptionValueType[]) => void;
   options: { string: ColumnMeta };
 }

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
@@ -35,6 +35,10 @@ export type AdhocMetricPopoverTriggerProps = {
   datasourceType: string;
   children: ReactNode;
   createNew?: boolean;
+  isControlledComponent?: boolean;
+  visible?: boolean;
+  togglePopover?: (visible: boolean) => void;
+  closePopover?: () => void;
 };
 
 export type AdhocMetricPopoverTriggerState = {
@@ -139,7 +143,14 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
   }
 
   render() {
-    const { adhocMetric, savedMetric } = this.props;
+    const {
+      adhocMetric,
+      savedMetric,
+      columns,
+      savedMetricsOptions,
+      datasourceType,
+      isControlledComponent,
+    } = this.props;
     const { verbose_name, metric_name } = savedMetric;
     const { hasCustomLabel, label } = adhocMetric;
     const adhocMetricLabel = hasCustomLabel
@@ -152,16 +163,28 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
           hasCustomLabel,
         };
 
+    const { visible, togglePopover, closePopover } = isControlledComponent
+      ? {
+          visible: this.props.visible,
+          togglePopover: this.props.togglePopover,
+          closePopover: this.props.closePopover,
+        }
+      : {
+          visible: this.state.popoverVisible,
+          togglePopover: this.togglePopover,
+          closePopover: this.closePopover,
+        };
+
     const overlayContent = (
       <AdhocMetricEditPopover
         adhocMetric={adhocMetric}
         title={title}
-        columns={this.props.columns}
-        savedMetricsOptions={this.props.savedMetricsOptions}
-        savedMetric={this.props.savedMetric}
-        datasourceType={this.props.datasourceType}
+        columns={columns}
+        savedMetricsOptions={savedMetricsOptions}
+        savedMetric={savedMetric}
+        datasourceType={datasourceType}
         onResize={this.onPopoverResize}
-        onClose={this.closePopover}
+        onClose={closePopover}
         onChange={this.onChange}
         getCurrentTab={this.getCurrentTab}
         getCurrentLabel={this.getCurrentLabel}
@@ -181,9 +204,9 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
         placement="right"
         trigger="click"
         content={overlayContent}
-        defaultVisible={this.state.popoverVisible}
-        visible={this.state.popoverVisible}
-        onVisibleChange={this.togglePopover}
+        defaultVisible={visible}
+        visible={visible}
+        onVisibleChange={togglePopover}
         title={popoverTitle}
         destroyTooltipOnHide={this.props.createNew}
       >

--- a/superset-frontend/src/explore/components/controls/MetricControl/MetricDefinitionValue.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/MetricDefinitionValue.jsx
@@ -18,16 +18,20 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Metric } from '@superset-ui/chart-controls/lib/types';
 import columnType from 'src/explore/propTypes/columnType';
-import { OptionControlLabel } from 'src/explore/components/OptionControls';
 import AdhocMetricOption from './AdhocMetricOption';
 import AdhocMetric from './AdhocMetric';
 import savedMetricType from './savedMetricType';
 import adhocMetricType from './adhocMetricType';
-import { DndItemType } from '../../DndItemType';
 
 const propTypes = {
-  option: PropTypes.oneOfType([savedMetricType, adhocMetricType]).isRequired,
+  option: PropTypes.oneOfType([
+    savedMetricType,
+    adhocMetricType,
+    Metric,
+    PropTypes.string,
+  ]).isRequired,
   index: PropTypes.number.isRequired,
   onMetricEdit: PropTypes.func,
   onRemoveMetric: PropTypes.func,
@@ -80,19 +84,6 @@ export default function MetricDefinitionValue({
     };
 
     return <AdhocMetricOption {...metricOptionProps} />;
-  }
-  if (typeof option === 'string') {
-    return (
-      <OptionControlLabel
-        label={option}
-        onRemove={onRemoveMetric}
-        onMoveLabel={onMoveLabel}
-        onDropLabel={onDropLabel}
-        type={DndItemType.FilterOption}
-        index={index}
-        isFunction
-      />
-    );
   }
   return null;
 }

--- a/superset-frontend/src/explore/components/controls/MetricControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/MetricControl/types.ts
@@ -18,6 +18,6 @@
  */
 export type savedMetricType = {
   metric_name: string;
-  verbose_name: string;
+  verbose_name?: string;
   expression: string;
 };

--- a/superset-frontend/src/explore/components/controls/index.js
+++ b/superset-frontend/src/explore/components/controls/index.js
@@ -42,6 +42,7 @@ import FilterBoxItemControl from './FilterBoxItemControl';
 import DndColumnSelectControl, {
   DndColumnSelect,
   DndFilterSelect,
+  DndMetricSelect,
 } from './DndColumnSelectControl';
 
 const controlMap = {
@@ -57,6 +58,7 @@ const controlMap = {
   DndColumnSelectControl,
   DndColumnSelect,
   DndFilterSelect,
+  DndMetricSelect,
   FixedOrMetricControl,
   HiddenControl,
   SelectAsyncControl,


### PR DESCRIPTION
### SUMMARY
This PR implements creating adhoc metrics by dragging columns and saved metrics from datasource panel to metrics control. 
When user drops a column or saved metric, a popover opens pre-filled with values - if a metric was dropped, a "Saved metrics" tab is open by default with a proper metric selected, otherwise "Simple" tab is open with a column selected.
The old functionality of creating a metric by clicking a "plus" button has ben removed.
To use the feature, enable `ENABLE_EXPLORE_DRAG_AND_DROP` feature flag and use changes from https://github.com/apache-superset/superset-ui/pull/1004.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/15073128/110795291-f7330580-8276-11eb-95bc-5255d7f50c83.mov

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @villebro @junlincc @zhaoyongjie 