### PR TITLE
fix: better handle datasource exceptions

### DIFF
--- a/superset/databases/commands/create.py
+++ b/superset/databases/commands/create.py
@@ -56,7 +56,7 @@ class CreateDatabaseCommand(BaseCommand):
                     action=f"db_creation_failed.{ex.__class__.__name__}",
                     engine=database.db_engine_spec.__name__,
                 )
-                raise DatabaseConnectionFailedError(str(ex))
+                raise DatabaseConnectionFailedError()
 
             # adding a new database we always want to force refresh schema list
             schemas = database.get_all_schema_names(cache=False)

--- a/superset/databases/commands/create.py
+++ b/superset/databases/commands/create.py
@@ -56,7 +56,7 @@ class CreateDatabaseCommand(BaseCommand):
                     action=f"db_creation_failed.{ex.__class__.__name__}",
                     engine=database.db_engine_spec.__name__,
                 )
-                raise DatabaseConnectionFailedError()
+                raise DatabaseConnectionFailedError(str(ex))
 
             # adding a new database we always want to force refresh schema list
             schemas = database.get_all_schema_names(cache=False)

--- a/superset/databases/commands/update.py
+++ b/superset/databases/commands/update.py
@@ -56,7 +56,7 @@ class UpdateDatabaseCommand(BaseCommand):
                 schemas = database.get_all_schema_names()
             except Exception as ex:
                 db.session.rollback()
-                raise DatabaseConnectionFailedError(str(ex))
+                raise DatabaseConnectionFailedError()
             for schema in schemas:
                 security_manager.add_permission_view_menu(
                     "schema_access", security_manager.get_schema_perm(database, schema)

--- a/superset/databases/commands/update.py
+++ b/superset/databases/commands/update.py
@@ -54,9 +54,9 @@ class UpdateDatabaseCommand(BaseCommand):
             # TODO Improve this simplistic implementation for catching DB conn fails
             try:
                 schemas = database.get_all_schema_names()
-            except Exception:
+            except Exception as ex:
                 db.session.rollback()
-                raise DatabaseConnectionFailedError()
+                raise DatabaseConnectionFailedError(str(ex))
             for schema in schemas:
                 security_manager.add_permission_view_menu(
                     "schema_access", security_manager.get_schema_perm(database, schema)

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -38,6 +38,7 @@ from sqlalchemy import (
     UniqueConstraint,
 )
 from sqlalchemy.engine.base import Connection
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import relationship, sessionmaker, subqueryload
 from sqlalchemy.orm.mapper import Mapper
 from sqlalchemy.orm.session import object_session
@@ -249,7 +250,7 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
                 for datasource, slices in datasource_slices.items()
                 if datasource
             }
-        except SupersetException:
+        except (SupersetException, SQLAlchemyError):
             datasources = {}
         return {
             # dashboard metadata

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -241,18 +241,22 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
         """Bootstrap data for rendering the dashboard page."""
         slices = self.slices
         datasource_slices = utils.indexed(slices, "datasource")
+        try:
+            datasources = {
+                # Filter out unneeded fields from the datasource payload
+                datasource.uid: datasource.data_for_slices(slices)
+                for datasource, slices in datasource_slices.items()
+                if datasource
+            }
+        except Exception:
+            datasources = {}
         return {
             # dashboard metadata
             "dashboard": self.data,
             # slices metadata
             "slices": [slc.data for slc in slices],
             # datasource metadata
-            "datasources": {
-                # Filter out unneeded fields from the datasource payload
-                datasource.uid: datasource.data_for_slices(slices)
-                for datasource, slices in datasource_slices.items()
-                if datasource
-            },
+            "datasources": datasources,
         }
 
     @property  # type: ignore

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -48,6 +48,7 @@ from superset import app, ConnectorRegistry, db, is_feature_enabled, security_ma
 from superset.connectors.base.models import BaseDatasource
 from superset.connectors.druid.models import DruidColumn, DruidMetric
 from superset.connectors.sqla.models import SqlMetric, TableColumn
+from superset.exceptions import SupersetException
 from superset.extensions import cache_manager
 from superset.models.helpers import AuditMixinNullable, ImportExportMixin
 from superset.models.slice import Slice
@@ -248,7 +249,7 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
                 for datasource, slices in datasource_slices.items()
                 if datasource
             }
-        except Exception:
+        except SupersetException:
             datasources = {}
         return {
             # dashboard metadata

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -793,7 +793,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         }
         try:
             datasource_data = datasource.data if datasource else dummy_datasource_data
-        except SupersetSecurityException:
+        except SupersetException:
             datasource_data = dummy_datasource_data
 
         bootstrap_data = {

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -793,7 +793,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         }
         try:
             datasource_data = datasource.data if datasource else dummy_datasource_data
-        except SupersetException:
+        except (SupersetException, SQLAlchemyError):
             datasource_data = dummy_datasource_data
 
         bootstrap_data = {

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -789,12 +789,18 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             "name": datasource_name,
             "columns": [],
             "metrics": [],
+            "database": {"id": 0, "backend": "",},
         }
+        try:
+            datasource_data = datasource.data if datasource else dummy_datasource_data
+        except SupersetSecurityException:
+            datasource_data = dummy_datasource_data
+
         bootstrap_data = {
             "can_add": slice_add_perm,
             "can_download": slice_download_perm,
             "can_overwrite": slice_overwrite_perm,
-            "datasource": datasource.data if datasource else dummy_datasource_data,
+            "datasource": datasource_data,
             "form_data": form_data,
             "datasource_id": datasource_id,
             "datasource_type": datasource_type,

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -666,7 +666,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @event_logger.log_this
     @expose("/explore/<datasource_type>/<int:datasource_id>/", methods=["GET", "POST"])
     @expose("/explore/", methods=["GET", "POST"])
-    def explore(  # pylint: disable=too-many-locals,too-many-return-statements
+    def explore(  # pylint: disable=too-many-locals,too-many-return-statements,too-many-statements
         self, datasource_type: Optional[str] = None, datasource_id: Optional[int] = None
     ) -> FlaskResponse:
         user_id = g.user.get_id() if g.user else None

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -1490,7 +1490,6 @@ class TestCore(SupersetTestCase):
         self.login()
         data = self.get_resp(url)
         self.assertIn("Error message", data)
-        self.assertIn(slice.slice_name, data)
 
     @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
     @mock.patch("superset.models.core.DB_CONNECTION_MUTATOR")


### PR DESCRIPTION
### SUMMARY
Fixes `explore` and `dashboard` superset API endpoints so that they can more gracefully handle exceptions from the engines. A more special case is by using the `DB_CONNECTION_MUTATOR` and raising from there.

Previously these endpoint would crash with HTTP 500

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
