### PR TITLE
feat: add ErrorBoundary to chart controls

### DIFF
--- a/superset-frontend/src/explore/components/Control.tsx
+++ b/superset-frontend/src/explore/components/Control.tsx
@@ -19,6 +19,7 @@
 import React, { ReactNode } from 'react';
 import { ControlType } from '@superset-ui/chart-controls';
 import { JsonValue, QueryFormData } from '@superset-ui/core';
+import ErrorBoundary from 'src/components/ErrorBoundary';
 import { ExploreActions } from 'src/explore/actions/exploreActions';
 import controlMap from './controls';
 
@@ -78,11 +79,13 @@ export default class Control extends React.PureComponent<
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
       >
-        <ControlComponent
-          onChange={this.onChange}
-          hovered={this.state.hovered}
-          {...this.props}
-        />
+        <ErrorBoundary>
+          <ControlComponent
+            onChange={this.onChange}
+            hovered={this.state.hovered}
+            {...this.props}
+          />
+        </ErrorBoundary>
       </div>
     );
   }

--- a/superset-frontend/src/explore/components/controls/index.js
+++ b/superset-frontend/src/explore/components/controls/index.js
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { sharedControlComponents } from '@superset-ui/chart-controls';
 import AnnotationLayerControl from './AnnotationLayerControl';
 import BoundsControl from './BoundsControl';
 import CheckboxControl from './CheckboxControl';
@@ -71,5 +72,6 @@ const controlMap = {
   MetricsControl,
   AdhocFilterControl,
   FilterBoxItemControl,
+  ...sharedControlComponents,
 };
 export default controlMap;


### PR DESCRIPTION
### SUMMARY

Two small changes to:

1. Add ErrorBoundary to control items, so a JS error in a single chart control does not crash the whole page. Error may happen more often with the addition of more and more custom controls.
2. Allow `CollectionControl` to load control components from `@superset-ui/chart-controls`' `sharedControlComponents`. The plan is to move all control components to `chart-controls` so they have better isolation and less dependencies. Currently new DnD controls are still added to `superset-frontend`, that's fine, too. We'll consolidate both once [the monorepo merge](https://github.com/apache/superset/issues/13013) is completed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

A JS error may cause the whole page to crash.

#### After

<img width="401" alt="wrap-control-error" src="https://user-images.githubusercontent.com/335541/110876396-446da200-828c-11eb-8821-4e131f01a6f8.png">


### TEST PLAN

Tested manually

1. Add JS error to one of the chart control, e.g. reference an undefined variable in `render`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
