### PR TITLE
fix: AntD select dropdown scroll issue

### DIFF
--- a/superset-frontend/src/common/components/CronPicker/CronPicker.tsx
+++ b/superset-frontend/src/common/components/CronPicker/CronPicker.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import React from 'react';
+import { ConfigProvider } from 'antd';
 import { styled, t } from '@superset-ui/core';
 import ReactCronPicker, { Locale, CronProps } from 'react-js-cron';
 
@@ -103,7 +104,11 @@ export const LOCALE: Locale = {
 };
 
 export const CronPicker = styled((props: CronProps) => (
-  <ReactCronPicker locale={LOCALE} {...props} />
+  <ConfigProvider
+    getPopupContainer={trigger => trigger.parentElement as HTMLElement}
+  >
+    <ReactCronPicker locale={LOCALE} {...props} />
+  </ConfigProvider>
 ))`
   .react-js-cron-select:not(.react-js-cron-custom-select) > div:first-of-type,
   .react-js-cron-custom-select {

--- a/superset-frontend/src/common/components/Select.tsx
+++ b/superset-frontend/src/common/components/Select.tsx
@@ -16,10 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import React from 'react';
 import { styled } from '@superset-ui/core';
-import { Select as BaseSelect } from 'src/common/components';
+import { Select as BaseSelect, SelectProps } from 'src/common/components';
 
-const StyledSelect = styled(BaseSelect)`
+const StyledSelect = styled((props: SelectProps<any>) => (
+  <BaseSelect
+    getPopupContainer={(trigger: any) => trigger.parentNode}
+    {...props}
+  />
+))`
   display: block;
 `;
 

--- a/superset-frontend/src/common/components/index.tsx
+++ b/superset-frontend/src/common/components/index.tsx
@@ -44,7 +44,6 @@ export {
   Slider,
   Row,
   Space,
-  Select,
   Skeleton,
   Switch,
   Tag,
@@ -52,10 +51,11 @@ export {
   Tooltip,
   Input as AntdInput,
 } from 'antd';
-export { default as Alert, AlertProps } from 'antd/lib/alert';
-export { TreeProps } from 'antd/lib/tree';
 export { FormInstance } from 'antd/lib/form';
 export { RadioChangeEvent } from 'antd/lib/radio';
+export { TreeProps } from 'antd/lib/tree';
+export { default as Alert, AlertProps } from 'antd/lib/alert';
+export { default as Select, SelectProps } from 'antd/lib/select';
 
 export { default as Collapse } from './Collapse';
 export { default as Progress } from './ProgressBar';


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There is an issue with AntD select https://github.com/ant-design/ant-design/issues/3438.  The select popover doesn't move with scrolling.

AntD has provided a [fix](https://ant.design/docs/react/faq) with `getPopupContainer`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
BEFORE:
https://www.loom.com/share/fe9f3933852840859620d92a84a44926
AFTER:
https://www.loom.com/share/47aeef38b3bc44d7a1343e368558a411

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
