### PR TITLE
feat: add more big data for testing

### DIFF
--- a/superset/examples/big_data.py
+++ b/superset/examples/big_data.py
@@ -33,7 +33,7 @@ COLUMN_TYPES = [
 
 
 def load_big_data() -> None:
-    # create table with 100 columns to test SQL Lab
+    print("Creating table `wide_table` with 100 columns")
     columns: List[ColumnInfo] = []
     for i in range(100):
         column: ColumnInfo = {
@@ -45,5 +45,26 @@ def load_big_data() -> None:
             "primary_key": 1 if i == 0 else 0,
         }
         columns.append(column)
-
     add_data(columns=columns, num_rows=1000, table_name="wide_table")
+
+    print("Creating 1000 small tables")
+    columns = [
+        {
+            "name": "id",
+            "type": sqlalchemy.sql.sqltypes.INTEGER(),
+            "nullable": False,
+            "default": None,
+            "autoincrement": "auto",
+            "primary_key": 1,
+        },
+        {
+            "name": "value",
+            "type": sqlalchemy.sql.sqltypes.VARCHAR(length=255),
+            "nullable": False,
+            "default": None,
+            "autoincrement": "auto",
+            "primary_key": 0,
+        },
+    ]
+    for i in range(1000):
+        add_data(columns=columns, num_rows=10, table_name=f"small_table_{i}")


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

https://github.com/apache/superset/pull/13448 added a new option `-b` to `superset load-examples`, that when enabled will create synthetic "big data" to test features and migrations on a realistic environment.

This PR adds 1000 small tables, to test loading tables in SQL Lab.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Ran `superset load-examples -b -t` and verified that tables are created.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
