### PR TITLE
chore: create better links for latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Superset
 =========
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/apache/superset?sort=semver)
+[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/apache/superset?sort=semver)](https://github.com/apache/superset/tree/latest)
 [![Build Status](https://github.com/apache/superset/workflows/Python/badge.svg)](https://github.com/apache/superset/actions)
 [![PyPI version](https://badge.fury.io/py/apache-superset.svg)](https://badge.fury.io/py/apache-superset)
 [![Coverage Status](https://codecov.io/github/apache/superset/coverage.svg?branch=master)](https://codecov.io/github/apache/superset)
@@ -52,27 +52,27 @@ A modern, enterprise-ready business intelligence web application.
 
 **Gallery**
 
-<kbd><a href="https://superset.apache.org/gallery"><img title="Gallery" src="superset-frontend/images/screenshots/gallery.jpg"></a></kbd><br/>
+<kbd><a href="https://superset.apache.org/gallery"><img title="Gallery" src="superset-frontend/images/screenshots/gallery.jpg"/></a></kbd><br/>
 
 **View Dashboards**
 
-<kbd><img title="View Dashboards" src="superset-frontend/images/screenshots/slack_dash.jpg"></kbd><br/>
+<kbd><img title="View Dashboards" src="superset-frontend/images/screenshots/slack_dash.jpg"/></kbd><br/>
 
 **Slice & dice your data**
 
-<kbd><img title="Slice & dice your data" src="superset-frontend/images/screenshots/explore.jpg"></kbd><br/>
+<kbd><img title="Slice & dice your data" src="superset-frontend/images/screenshots/explore.jpg"/></kbd><br/>
 
 **Query and visualize your data with SQL Lab**
 
-<kbd><img title="SQL Lab" src="superset-frontend/images/screenshots/sql_lab.jpg"></kbd><br/>
+<kbd><img title="SQL Lab" src="superset-frontend/images/screenshots/sql_lab.jpg"/></kbd><br/>
 
 **Visualize geospatial data with deck.gl**
 
-<kbd><img title="Geospatial" src="superset-frontend/images/screenshots/geospatial_dash.jpg"></kbd><br/>
+<kbd><img title="Geospatial" src="superset-frontend/images/screenshots/geospatial_dash.jpg"/></kbd><br/>
 
 **Choose from a wide array of visualizations**
 
-<kbd><img title="Visualizations" src="superset-frontend/images/screenshots/explore_visualizations.jpg"></kbd><br/>
+<kbd><img title="Visualizations" src="superset-frontend/images/screenshots/explore_visualizations.jpg"/></kbd><br/>
 
 
 ## Why Superset?

--- a/docs/src/pages/docs/introduction.mdx
+++ b/docs/src/pages/docs/introduction.mdx
@@ -17,8 +17,8 @@ Here are a **few different ways you can get started with Superset**:
 - Setup Superset locally with one command
 using [Docker Compose](docs/installation/installing-superset-using-docker-compose)
 - Download the [Docker image](https://hub.docker.com/r/apache/superset) from Dockerhub
-- Install bleeding-edge master version of Superset
-[from Github](https://github.com/apache/superset/tree/master/superset)
+- Install the latest version of Superset
+[from Github](https://github.com/apache/superset/tree/latest)
 
 Superset provides:
 


### PR DESCRIPTION
### SUMMARY
The badge was linking to the image. This updates it to link to https://github.com/apache/superset/tree/latest
I also updated the docs to point to the latest release rather than bleeding edge

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
no visual changes
<img width="883" alt="README_md_—_preset__Workspace_" src="https://user-images.githubusercontent.com/5186919/110884364-de881700-8299-11eb-8e16-509289db778a.png">


### TEST PLAN
tested locally by manually rendering readme

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
