### PR TITLE
feat(explore): Drag and drop UX improvements

### DIFF
--- a/superset-frontend/src/explore/components/OptionControls.tsx
+++ b/superset-frontend/src/explore/components/OptionControls.tsx
@@ -99,7 +99,7 @@ export const DndLabelsContainer = styled.div<{
 }>`
   padding: ${({ theme }) => theme.gridUnit}px;
   border: ${({ canDrop, isOver, theme }) => {
-    if (isOver && canDrop) {
+    if (canDrop) {
       return `dashed 1px ${theme.colors.info.dark1}`;
     }
     if (isOver && !canDrop) {

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
@@ -72,7 +72,6 @@ export const DndColumnSelect = (props: LabelProps) => {
 
   return (
     <DndSelectLabel<string | string[], ColumnMeta[]>
-      values={values}
       onDrop={onDrop}
       canDrop={canDrop}
       valuesRenderer={valuesRenderer}

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
@@ -300,7 +300,6 @@ export const DndFilterSelect = (props: DndFilterSelectProps) => {
   return (
     <>
       <DndSelectLabel<OptionValueType, OptionValueType[]>
-        values={values}
         onDrop={(item: DatasourcePanelDndItem) => {
           setDroppedItem(item.value);
           togglePopover(true);

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
@@ -312,7 +312,7 @@ export const DndFilterSelect = (props: DndFilterSelectProps) => {
           DndItemType.MetricOption,
           DndItemType.AdhocMetricOption,
         ]}
-        placeholderText={t('Drop columns or metrics')}
+        ghostButtonText={t('Drop columns or metrics')}
         {...props}
       />
       <AdhocFilterPopoverTrigger

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
@@ -17,8 +17,8 @@
  * under the License.
  */
 import React, { useEffect, useMemo, useState } from 'react';
-import { logging, SupersetClient, t } from '@superset-ui/core';
-import { ColumnMeta, Metric } from '@superset-ui/chart-controls';
+import { logging, SupersetClient, t, Metric } from '@superset-ui/core';
+import { ColumnMeta } from '@superset-ui/chart-controls';
 import { Tooltip } from 'src/common/components/Tooltip';
 import { OPERATORS } from 'src/explore/constants';
 import { OptionSortType } from 'src/explore/types';

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -268,7 +268,7 @@ export const DndMetricSelect = (props: any) => {
         canDrop={canDrop}
         valuesRenderer={valuesRenderer}
         accept={[DndItemType.Column, DndItemType.Metric]}
-        placeholderText={t('Drop columns or metrics')}
+        ghostButtonText={t('Drop columns or metrics')}
         displayGhostButton={multi || value.length === 0}
         {...props}
       />

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -264,12 +264,12 @@ export const DndMetricSelect = (props: any) => {
   return (
     <div className="metrics-select">
       <DndSelectLabel<OptionValueType, OptionValueType[]>
-        values={value}
         onDrop={handleDrop}
         canDrop={canDrop}
         valuesRenderer={valuesRenderer}
         accept={[DndItemType.Column, DndItemType.Metric]}
         placeholderText={t('Drop columns or metrics')}
+        displayGhostButton={multi || value.length === 0}
         {...props}
       />
       <AdhocMetricPopoverTrigger

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -241,37 +241,31 @@ export const DndMetricSelect = (props: any) => {
     togglePopover(false);
   };
 
-  const { savedMetric, adhocMetric } = useMemo(() => {
-    if (droppedItem?.type === 'column') {
+  const handleDrop = (item: DatasourcePanelDndItem) => {
+    if (item.type === DndItemType.Metric) {
+      onNewMetric(item.value as Metric);
+    }
+    if (item.type === DndItemType.Column) {
+      setDroppedItem(item);
+      togglePopover(true);
+    }
+  };
+
+  const adhocMetric = useMemo(() => {
+    if (droppedItem?.type === DndItemType.Column) {
       const itemValue = droppedItem?.value as ColumnMeta;
-      return {
-        savedMetric: {} as savedMetricType,
-        adhocMetric: new AdhocMetric({
-          column: { column_name: itemValue?.column_name },
-        }),
-      };
+      return new AdhocMetric({
+        column: { column_name: itemValue?.column_name },
+      });
     }
-    if (droppedItem?.type === 'metric') {
-      const itemValue = droppedItem?.value as savedMetricType;
-      return {
-        savedMetric: itemValue,
-        adhocMetric: new AdhocMetric({ isNew: true }),
-      };
-    }
-    return {
-      savedMetric: {} as savedMetricType,
-      adhocMetric: new AdhocMetric({ isNew: true }),
-    };
+    return new AdhocMetric({ isNew: true });
   }, [droppedItem?.type, droppedItem?.value]);
 
   return (
     <div className="metrics-select">
       <DndSelectLabel<OptionValueType, OptionValueType[]>
         values={value}
-        onDrop={(item: DatasourcePanelDndItem) => {
-          setDroppedItem(item);
-          togglePopover(true);
-        }}
+        onDrop={handleDrop}
         canDrop={canDrop}
         valuesRenderer={valuesRenderer}
         accept={[DndItemType.Column, DndItemType.Metric]}
@@ -286,7 +280,7 @@ export const DndMetricSelect = (props: any) => {
           props.savedMetrics,
           props.value,
         )}
-        savedMetric={savedMetric}
+        savedMetric={{} as savedMetricType}
         datasourceType={props.datasourceType}
         isControlledComponent
         visible={newMetricPopoverVisible}

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
@@ -51,11 +51,11 @@ export default function DndSelectLabel<T, O>({
     }),
   });
 
-  function renderPlaceHolder() {
+  function renderGhostButton() {
     return (
       <AddControlLabel cancelHover>
         <Icon name="plus-small" color={theme.colors.grayscale.light1} />
-        {t(props.placeholderText || 'Drop columns')}
+        {t(props.ghostButtonText || 'Drop columns')}
       </AddControlLabel>
     );
   }
@@ -67,7 +67,7 @@ export default function DndSelectLabel<T, O>({
       </HeaderContainer>
       <DndLabelsContainer canDrop={canDrop} isOver={isOver}>
         {props.valuesRenderer()}
-        {displayGhostButton && renderPlaceHolder()}
+        {displayGhostButton && renderGhostButton()}
       </DndLabelsContainer>
     </div>
   );

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
@@ -18,7 +18,6 @@
  */
 import React from 'react';
 import { useDrop } from 'react-dnd';
-import { isEmpty } from 'lodash';
 import { t, useTheme } from '@superset-ui/core';
 import ControlHeader from 'src/explore/components/ControlHeader';
 import {
@@ -30,9 +29,10 @@ import { DatasourcePanelDndItem } from 'src/explore/components/DatasourcePanel/t
 import Icon from 'src/components/Icon';
 import { DndColumnSelectProps } from './types';
 
-export default function DndSelectLabel<T, O>(
-  props: DndColumnSelectProps<T, O>,
-) {
+export default function DndSelectLabel<T, O>({
+  displayGhostButton = true,
+  ...props
+}: DndColumnSelectProps<T, O>) {
   const theme = useTheme();
 
   const [{ isOver, canDrop }, datasourcePanelDrop] = useDrop({
@@ -66,7 +66,8 @@ export default function DndSelectLabel<T, O>(
         <ControlHeader {...props} />
       </HeaderContainer>
       <DndLabelsContainer canDrop={canDrop} isOver={isOver}>
-        {isEmpty(props.values) ? renderPlaceHolder() : props.valuesRenderer()}
+        {props.valuesRenderer()}
+        {displayGhostButton && renderPlaceHolder()}
       </DndLabelsContainer>
     </div>
   );

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
@@ -50,7 +50,7 @@ export interface DndColumnSelectProps<
   canDrop: (item: DatasourcePanelDndItem) => boolean;
   valuesRenderer: () => ReactNode;
   accept: DndItemType | DndItemType[];
-  placeholderText?: string;
+  ghostButtonText?: string;
   displayGhostButton?: boolean;
 }
 

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
@@ -46,12 +46,12 @@ export interface DndColumnSelectProps<
   T = string[] | string,
   O = string[] | string
 > extends LabelProps<T> {
-  values?: O;
   onDrop: (item: DatasourcePanelDndItem) => void;
   canDrop: (item: DatasourcePanelDndItem) => boolean;
   valuesRenderer: () => ReactNode;
   accept: DndItemType | DndItemType[];
   placeholderText?: string;
+  displayGhostButton?: boolean;
 }
 
 export type OptionValueType = Record<string, any>;

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
@@ -17,7 +17,8 @@
  * under the License.
  */
 import { ReactNode } from 'react';
-import { ColumnMeta, Metric } from '@superset-ui/chart-controls';
+import { Metric } from '@superset-ui/core';
+import { ColumnMeta } from '@superset-ui/chart-controls';
 import { DatasourcePanelDndItem } from '../../DatasourcePanel/types';
 import { DndItemType } from '../../DndItemType';
 


### PR DESCRIPTION
### SUMMARY
This PR adds a few UX improvements to dnd feature implemented in https://github.com/apache/superset/pull/13575:

1. Display a ghost button in all DnD components to indicate that user can drop a metric or column in that component.
2. When user starts dragging a column or a metric, display dashed border around control boxes in which the dragged element can be dropped (before - the border was displayed only when user was hovering over a control box)
3. When user drops a saved metric in metrics control box, instead of opening a popover, the metric is created immediately.

In order to test the changes, make sure that `ENABLE_EXPLORE_DRAG_AND_DROP` feature flag is enabled

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/15073128/110958401-f53b7600-834c-11eb-8e21-b2d710eaf7d7.mov

https://user-images.githubusercontent.com/15073128/110958599-26b44180-834d-11eb-971b-4ca4b2a6b4dc.mov

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @villebro @junlincc @zhaoyongjie @ktmud 