### PR TITLE
fix: ParsedQuery subselect edge case

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -21,7 +21,14 @@ from typing import List, Optional, Set
 from urllib import parse
 
 import sqlparse
-from sqlparse.sql import Identifier, IdentifierList, remove_quotes, Token, TokenList
+from sqlparse.sql import (
+    Identifier,
+    IdentifierList,
+    Parenthesis,
+    remove_quotes,
+    Token,
+    TokenList,
+)
 from sqlparse.tokens import Keyword, Name, Punctuation, String, Whitespace
 from sqlparse.utils import imt
 
@@ -278,7 +285,9 @@ class ParsedQuery:
         table_name_preceding_token = False
 
         for item in token.tokens:
-            if item.is_group and not self._is_identifier(item):
+            if item.is_group and (
+                not self._is_identifier(item) or isinstance(item.tokens[0], Parenthesis)
+            ):
                 self._extract_from_token(item)
 
             if item.ttype in Keyword and (
@@ -291,7 +300,6 @@ class ParsedQuery:
             if item.ttype in Keyword:
                 table_name_preceding_token = False
                 continue
-
             if table_name_preceding_token:
                 if isinstance(item, Identifier):
                     self._process_tokenlist(item)

--- a/tests/sql_parse_tests.py
+++ b/tests/sql_parse_tests.py
@@ -158,6 +158,13 @@ class TestSupersetSqlParse(unittest.TestCase):
         query = "SELECT f1, (SELECT count(1) FROM t2) FROM t1"
         self.assertEqual({Table("t1"), Table("t2")}, self.extract_tables(query))
 
+        query = "SELECT f1, (SELECT count(1) FROM t2) as f2 FROM t1"
+        self.assertEqual({Table("t1"), Table("t2")}, self.extract_tables(query))
+
+    def test_parentheses(self):
+        query = "SELECT f1, (x + y) AS f2 FROM t1"
+        self.assertEqual({Table("t1")}, self.extract_tables(query))
+
     def test_union(self):
         query = "SELECT * FROM t1 UNION SELECT * FROM t2"
         self.assertEqual({Table("t1"), Table("t2")}, self.extract_tables(query))


### PR DESCRIPTION
### SUMMARY
I found that aliased subselects would break the logic to extract table names from a query. When using sqlparse, it seemed like the query got expanded more than expected when the alias was added:
```
>>> import sqlparse
>>> sqlparse.parse("SELECT f1, (SELECT count(1) FROM t2) FROM t1")[0]._pprint_tree()
|- 0 DML 'SELECT'
|- 1 Whitespace ' '
|- 2 Identifier 'f1'
|  `- 0 Name 'f1'
|- 3 Punctuation ','
|- 4 Whitespace ' '
|- 5 Parenthesis '(SELEC...'
|  |- 0 Punctuation '('
|  |- 1 DML 'SELECT'
|  |- 2 Whitespace ' '
|  |- 3 Function 'count(...'
|  |  |- 0 Identifier 'count'
|  |  |  `- 0 Name 'count'
|  |  `- 1 Parenthesis '(1)'
|  |     |- 0 Punctuation '('
|  |     |- 1 Integer '1'
|  |     `- 2 Punctuation ')'
|  |- 4 Whitespace ' '
|  |- 5 Keyword 'FROM'
|  |- 6 Whitespace ' '
|  |- 7 Identifier 't2'
|  |  `- 0 Name 't2'
|  `- 8 Punctuation ')'
|- 6 Whitespace ' '
|- 7 Keyword 'FROM'
|- 8 Whitespace ' '
`- 9 Identifier 't1'
   `- 0 Name 't1'
>>> sqlparse.parse("SELECT f1, (SELECT count(1) FROM t2) as f2 FROM t1")[0]._pprint_tree()
|- 0 DML 'SELECT'
|- 1 Whitespace ' '
|- 2 IdentifierList 'f1, (S...'
|  |- 0 Identifier 'f1'
|  |  `- 0 Name 'f1'
|  |- 1 Punctuation ','
|  |- 2 Whitespace ' '
|  `- 3 Identifier '(SELEC...'
|     |- 0 Parenthesis '(SELEC...'
|     |  |- 0 Punctuation '('
|     |  |- 1 DML 'SELECT'
|     |  |- 2 Whitespace ' '
|     |  |- 3 Function 'count(...'
|     |  |  |- 0 Identifier 'count'
|     |  |  |  `- 0 Name 'count'
|     |  |  `- 1 Parenthesis '(1)'
|     |  |     |- 0 Punctuation '('
|     |  |     |- 1 Integer '1'
|     |  |     `- 2 Punctuation ')'
|     |  |- 4 Whitespace ' '
|     |  |- 5 Keyword 'FROM'
|     |  |- 6 Whitespace ' '
|     |  |- 7 Identifier 't2'
|     |  |  `- 0 Name 't2'
|     |  `- 8 Punctuation ')'
|     |- 1 Whitespace ' '
|     |- 2 Keyword 'as'
|     |- 3 Whitespace ' '
|     `- 4 Identifier 'f2'
|        `- 0 Name 'f2'
|- 3 Whitespace ' '
|- 4 Keyword 'FROM'
|- 5 Whitespace ' '
`- 6 Identifier 't1'
   `- 0 Name 't1'
```

This adds logic to recursively explore sections wrapped in parens, which seems safe and didn't break any of the existing tests while allowing mine to pass. That said, would love any thoughts on a better way to do this too

### TEST PLAN
CI

to: @villebro @lilykuang @serenajiang @bkyryliuk @michellethomas 