### PR TITLE
fix: default when adding tab_state.hide_left_bar

### DIFF
--- a/superset/migrations/versions/67da9ef1ef9c_add_hide_left_bar_to_tabstate.py
+++ b/superset/migrations/versions/67da9ef1ef9c_add_hide_left_bar_to_tabstate.py
@@ -29,12 +29,18 @@ down_revision = "1412ec1e5a7b"
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import mysql
+from sqlalchemy.sql import expression
 
 
 def upgrade():
     with op.batch_alter_table("tab_state") as batch_op:
         batch_op.add_column(
-            sa.Column("hide_left_bar", sa.Boolean(), nullable=False, default=False)
+            sa.Column(
+                "hide_left_bar",
+                sa.Boolean(),
+                nullable=False,
+                server_default=expression.false(),
+            )
         )
 
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fix the creation of `tab_state.hide_left_bar` so that the default value is set in the DDL.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

N/A

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
