### PR TITLE
fix: Add SASL dependency module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,7 @@ RUN useradd --user-group --no-create-home --no-log-init --shell /bin/bash supers
         && apt-get install -y --no-install-recommends \
             build-essential \
             default-libmysqlclient-dev \
+            libsasl2-modules-gssapi-mit \
             libpq-dev \
         && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
### SUMMARY
Adds required OS dependencies for PyHive/Impyla(Impala) to work with user/password authentication.

Only adds 500KB to final container size.
```
docker inspect -f "{{ .Size }}" superset:latest
1450281124
docker inspect -f "{{ .Size }}" superset:fix-sasl-module
1450709446
```

Motivation: Allows connecting to Ascend.io using Superset over TLS with username and password.
`impala://<service_account_username>:<service_account_password>@<ascendEnvironment>.sql.ascend.io:10000/<dataService>?auth_mechanism=PLAIN&use_ssl=true`


### TEST PLAN

1. Build existing superset master:
    `sudo docker build -t superset:latest https://github.com/apache/superset.git#master`
1. Build this PR branch
    `sudo docker build -t superset:fix-sasl-module https://github.com/danielewood/superset.git#fix-sasl-module`
1. With current superset:master, attempt to use authentication_method=PLAIN with Impala or auth=CUSTOM with PyHive
    `sudo docker run --rm -it -u 0 --entrypoint bash superset:latest`
1. See error from both PyHive and Impyla:
    `thrift.transport.TTransport.TTransportException: Could not start SASL: b'Error in sasl_client_start (-4) SASL(-4): no mechanism available: No worthy mechs found'`
1. With this PR patch, attempt to use authentication_method=PLAIN with Impala or auth=CUSTOM with PyHive
    `sudo docker run --rm -it -u 0 --entrypoint bash superset:fix-sasl-module`
1. See authentication error if you dont have a hive cluster to test against and use ascend with invalid credentials, otherwise see no errors because the connection worked.

Example:
```python
sudo docker build -t superset:fix-sasl-module https://github.com/danielewood/superset.git#fix-sasl-module
sudo docker run --rm -it -u 0 --entrypoint bash superset:fix-sasl-module

# If you dont have a hive instance to test against, install socat to tunnel TLS to Ascend.io
# replace hive2.example.local with localhost
# apt update \
#    && apt install -y socat \
#    && socat TCP-LISTEN:10000,fork,reuseaddr openssl:trial.sql.ascend.io:10000,verify=1 &

python3 - <<-"EOF"
from sqlalchemy import create_engine
create_engine("hive://username:password@hive2.example.local:10000/database?auth=CUSTOM",echo=True,echo_pool='debug').connect()
EOF

####

# If you dont have a hive instance to test against, 
#  replace hive2.example.local with trial.sql.ascend.io, 
#  and add ";use_ssl=true" to the end of the connection string

pip install impyla
python3 - <<-"EOF"
from sqlalchemy import create_engine
create_engine("impala://username:password@hive2.example.local:10000/database?auth_mechanism=PLAIN",echo=True,echo_pool='debug').connect()
EOF

```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Brings desired results from abandonded PR #7015
- [x] Fixes #2174
- [x] Fixes #2632