### PR TITLE
fix(helm): Add missing extraConfigs template volume mapping and fix type error on template.

### DIFF
--- a/helm/superset/templates/configmap-superset.yaml
+++ b/helm/superset/templates/configmap-superset.yaml
@@ -27,6 +27,6 @@ metadata:
 data:
 {{- range $path, $config := .Values.extraConfigs }}
   {{ $path }}: |
-{{ tpl $config . | indent 4 -}}
+{{- tpl $config $ | nindent 4 -}}
 {{- end -}}
 {{- end -}}

--- a/helm/superset/templates/deployment.yaml
+++ b/helm/superset/templates/deployment.yaml
@@ -75,6 +75,11 @@ spec:
             - name: superset-config
               mountPath: {{ .Values.configMountPath | quote }}
               readOnly: true
+          {{- if .Values.extraConfigs }}
+            - name: superset-extra-config
+              mountPath: {{ .Values.extraConfigMountPath | quote }}
+              readOnly: true
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
@@ -97,3 +102,8 @@ spec:
         - name: superset-config
           secret:
             secretName: {{ tpl .Values.configFromSecret . }}
+        {{- if .Values.extraConfigs }}
+        - name: superset-extra-config
+          configMap:
+            name: {{ template "superset.fullname" . }}-extra-config
+        {{- end }}


### PR DESCRIPTION
### SUMMARY
Two parts:
1. superset-extra-config configMap was not attached to the deployment container
2. You cannot use "." inside a range with tpl. Instead "$" for global context can be used.
    - Reference https://github.com/helm/helm/issues/5979

I also cleaned up the template slightly to result in the desired formatting no matter the input whitespace, thanks to @Yann-J for the feedback.

### TEST PLAN
1. Attempt to use extraConfigs:
```bash
test_config=$(cat<<'EOF'
extraConfigs:
  test.yaml: |
    test data
EOF
)
helm template deploytest superset -f - <<<"${test_config}"
```
2. See error:
```
Error: template: superset/templates/configmap-superset.yaml:30:16: executing "superset/templates/configmap-superset.yaml" at <.>: wrong type for value; expected chartutil.Values; got string
```
3. Apply this PR.
4. Attempt to use extraConfigs
5. Template builds configs, including volume maps

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
