### PR TITLE
fix: data column in SQL lab left panel open by default 

### DIFF
--- a/superset-frontend/spec/javascripts/sqllab/fixtures.ts
+++ b/superset-frontend/spec/javascripts/sqllab/fixtures.ts
@@ -172,6 +172,7 @@ export const table = {
   ],
   expanded: true,
 };
+
 export const defaultQueryEditor = {
   id: 'dfsadfs',
   autorun: false,

--- a/superset-frontend/spec/javascripts/sqllab/reducers/sqlLab_spec.js
+++ b/superset-frontend/spec/javascripts/sqllab/reducers/sqlLab_spec.js
@@ -153,6 +153,7 @@ describe('sqlLabReducer', () => {
     it('should add a table', () => {
       // Testing that beforeEach actually added the table
       expect(newState.tables).toHaveLength(1);
+      expect(newState.tables[0].expanded).toBe(true);
     });
     it('should merge the table attributes', () => {
       // Merging the extra attribute

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -1064,7 +1064,7 @@ export function addTable(query, tableName, schemaName) {
         ...table,
         isMetadataLoading: true,
         isExtraMetadataLoading: true,
-        expanded: false,
+        expanded: true,
       }),
     );
 

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar.jsx
@@ -147,8 +147,9 @@ export default class SqlEditorLeftBar extends React.PureComponent {
         <StyledScrollbarContainer>
           <StyledScrollbarContent contentHeight={tableMetaDataHeight}>
             <Collapse
-              ghost
-              expandIconPosition="right"
+              activeKey={this.props.tables
+                .filter(({ expanded }) => expanded)
+                .map(({ id }) => id)}
               css={theme => css`
                 .ant-collapse-item {
                   margin-bottom: ${theme.gridUnit * 3}px;
@@ -169,6 +170,8 @@ export default class SqlEditorLeftBar extends React.PureComponent {
                   }
                 }
               `}
+              expandIconPosition="right"
+              ghost
             >
               {this.props.tables.map(table => (
                 <TableElement

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar.jsx
@@ -178,6 +178,7 @@ export default class SqlEditorLeftBar extends React.PureComponent {
                   table={table}
                   key={table.id}
                   actions={this.props.actions}
+                  onClick={this.toggleTable}
                 />
               ))}
             </Collapse>

--- a/superset-frontend/src/SqlLab/components/TableElement.jsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.jsx
@@ -283,6 +283,7 @@ class TableElement extends React.PureComponent {
         {...this.props}
         header={this.renderHeader()}
         className="TableElement"
+        forceRender="true"
       >
         {this.renderBody()}
       </Collapse.Panel>


### PR DESCRIPTION
### SUMMARY
Fix to Left Panel tables being auto-expanded when added. This was a feature they had previous to the switch to antd Collapse. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/48933336/111169955-d2da7000-8579-11eb-856f-0c3b391d2430.mov

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: https://github.com/apache/superset/issues/13366
