### PR TITLE
refactor: Share sql lab query

### DIFF
--- a/superset-frontend/spec/javascripts/sqllab/ShareSqlLabQuery_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/ShareSqlLabQuery_spec.jsx
@@ -21,24 +21,35 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import fetchMock from 'fetch-mock';
 import * as featureFlags from 'src/featureFlags';
-import { shallow } from 'enzyme';
-
+import { Provider } from 'react-redux';
+import { supersetTheme, ThemeProvider } from '@superset-ui/core';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import userEvent from '@testing-library/user-event';
 import * as utils from 'src/utils/common';
 import ShareSqlLabQuery from 'src/SqlLab/components/ShareSqlLabQuery';
-import CopyToClipboard from 'src/components/CopyToClipboard';
-import { Tooltip } from 'src/common/components/Tooltip';
 
 const mockStore = configureStore([thunk]);
-const store = mockStore();
+const store = mockStore({});
 let isFeatureEnabledMock;
 
-const clipboardSpy = jest.fn();
+const defaultProps = {
+  queryEditor: {
+    dbId: 0,
+    title: 'query title',
+    schema: 'query_schema',
+    autorun: false,
+    sql: 'SELECT * FROM ...',
+    remoteId: 999,
+  },
+  addDangerToast: jest.fn(),
+};
 
 describe('ShareSqlLabQuery', () => {
   const storeQueryUrl = 'glob:*/kv/store/';
   const storeQueryMockId = '123';
 
-  beforeEach(() => {
+  beforeEach(async () => {
     fetchMock.post(storeQueryUrl, () => ({ id: storeQueryMockId }), {
       overwriteRoutes: true,
     });
@@ -47,33 +58,6 @@ describe('ShareSqlLabQuery', () => {
   });
 
   afterAll(fetchMock.reset);
-
-  const defaultProps = {
-    queryEditor: {
-      dbId: 0,
-      title: 'query title',
-      schema: 'query_schema',
-      autorun: false,
-      sql: 'SELECT * FROM ...',
-      remoteId: 999,
-    },
-  };
-
-  const storedQueryAttributes = {
-    dbId: 0,
-    title: 'query title',
-    schema: 'query_schema',
-    autorun: false,
-    sql: 'SELECT * FROM ...',
-  };
-
-  function setup(overrideProps) {
-    const wrapper = shallow(
-      <ShareSqlLabQuery store={store} {...defaultProps} {...overrideProps} />,
-    ).dive(); // wrapped in withToasts HOC
-
-    return wrapper;
-  }
 
   describe('via /kv/store', () => {
     beforeAll(() => {
@@ -86,54 +70,24 @@ describe('ShareSqlLabQuery', () => {
       isFeatureEnabledMock.restore();
     });
 
-    it('calls storeQuery() with the query when getCopyUrl() is called', () => {
-      expect.assertions(4);
-      const storeQuerySpy = jest.spyOn(utils, 'storeQuery');
-
-      const wrapper = setup();
-      const instance = wrapper.instance();
-
-      return instance.getCopyUrl(clipboardSpy).then(() => {
-        expect(storeQuerySpy.mock.calls).toHaveLength(1);
-        expect(fetchMock.calls(storeQueryUrl)).toHaveLength(1);
-        expect(storeQuerySpy.mock.calls[0][0]).toMatchObject(
-          storedQueryAttributes,
+    it('calls storeQuery() with the query when getCopyUrl() is called', async () => {
+      await act(async () => {
+        render(
+          <ThemeProvider theme={supersetTheme}>
+            <Provider store={store}>
+              <ShareSqlLabQuery {...defaultProps} />
+            </Provider>
+          </ThemeProvider>,
         );
-        expect(clipboardSpy).toHaveBeenCalledWith(
-          expect.stringContaining('?id='),
-        );
-
-        storeQuerySpy.mockRestore();
-
-        return Promise.resolve();
       });
-    });
-
-    it('dispatches an error toast upon fetching failure', () => {
-      expect.assertions(3);
-      const error = 'There was an error with your request';
-      const addDangerToastSpy = jest.fn();
-      fetchMock.post(
-        storeQueryUrl,
-        { throws: error },
-        { overwriteRoutes: true },
-      );
-      const wrapper = setup();
-      wrapper.setProps({ addDangerToast: addDangerToastSpy });
-
-      return wrapper
-        .instance()
-        .getCopyUrl(clipboardSpy)
-        .then(() => {
-          // Fails then retries thrice
-          expect(fetchMock.calls(storeQueryUrl)).toHaveLength(4);
-          expect(addDangerToastSpy.mock.calls).toHaveLength(1);
-          expect(addDangerToastSpy.mock.calls[0][0]).toBe(error);
-
-          return Promise.resolve();
-        });
+      const button = screen.getByRole('button');
+      const storeQuerySpy = jest.spyOn(utils, 'storeQuery');
+      userEvent.click(button);
+      expect(storeQuerySpy.mock.calls).toHaveLength(1);
+      storeQuerySpy.mockRestore();
     });
   });
+
   describe('via saved query', () => {
     beforeAll(() => {
       isFeatureEnabledMock = jest
@@ -145,37 +99,42 @@ describe('ShareSqlLabQuery', () => {
       isFeatureEnabledMock.restore();
     });
 
-    it('does not call storeQuery() with the query when getCopyUrl() is called', () => {
+    it('does not call storeQuery() with the query when getCopyUrl() is called and feature is not enabled', async () => {
+      await act(async () => {
+        render(
+          <ThemeProvider theme={supersetTheme}>
+            <Provider store={store}>
+              <ShareSqlLabQuery {...defaultProps} />
+            </Provider>
+          </ThemeProvider>,
+        );
+      });
       const storeQuerySpy = jest.spyOn(utils, 'storeQuery');
-
-      const wrapper = setup();
-      const instance = wrapper.instance();
-
-      instance.getCopyUrl(clipboardSpy);
-
+      const button = screen.getByRole('button');
+      userEvent.click(button);
       expect(storeQuerySpy.mock.calls).toHaveLength(0);
-      expect(fetchMock.calls(storeQueryUrl)).toHaveLength(0);
-      expect(clipboardSpy).toHaveBeenCalledWith(
-        expect.stringContaining('savedQueryId'),
-      );
-
       storeQuerySpy.mockRestore();
     });
 
-    it('shows a request to save the query when the query is not yet saved', () => {
-      const wrapper = setup({
+    it('button is disabled and there is a request to save the query', async () => {
+      const updatedProps = {
         queryEditor: {
           ...defaultProps.queryEditor,
           remoteId: undefined,
         },
+      };
+      await act(async () => {
+        render(
+          <ThemeProvider theme={supersetTheme}>
+            <Provider store={store}>
+              <ShareSqlLabQuery {...updatedProps} />
+            </Provider>
+          </ThemeProvider>,
+        );
       });
-
-      expect(wrapper.find(CopyToClipboard)).toHaveLength(0);
-      expect(wrapper.find('.btn-disabled')).toHaveLength(1);
-      expect(wrapper.find(Tooltip)).toHaveProp(
-        'title',
-        expect.stringContaining('Save the query'),
-      );
+      const button = screen.getByRole('button', { name: /copy link/i });
+      const style = window.getComputedStyle(button);
+      expect(style.color).toBe('rgb(102, 102, 102)');
     });
   });
 });

--- a/superset-frontend/spec/javascripts/sqllab/ShareSqlLabQuery_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/ShareSqlLabQuery_spec.jsx
@@ -33,6 +33,12 @@ const mockStore = configureStore([thunk]);
 const store = mockStore({});
 let isFeatureEnabledMock;
 
+const standardProvider = ({ children }) => (
+  <ThemeProvider theme={supersetTheme}>
+    <Provider store={store}>{children}</Provider>
+  </ThemeProvider>
+);
+
 const defaultProps = {
   queryEditor: {
     dbId: 0,
@@ -72,13 +78,9 @@ describe('ShareSqlLabQuery', () => {
 
     it('calls storeQuery() with the query when getCopyUrl() is called', async () => {
       await act(async () => {
-        render(
-          <ThemeProvider theme={supersetTheme}>
-            <Provider store={store}>
-              <ShareSqlLabQuery {...defaultProps} />
-            </Provider>
-          </ThemeProvider>,
-        );
+        render(<ShareSqlLabQuery {...defaultProps} />, {
+          wrapper: standardProvider,
+        });
       });
       const button = screen.getByRole('button');
       const storeQuerySpy = jest.spyOn(utils, 'storeQuery');
@@ -101,13 +103,9 @@ describe('ShareSqlLabQuery', () => {
 
     it('does not call storeQuery() with the query when getCopyUrl() is called and feature is not enabled', async () => {
       await act(async () => {
-        render(
-          <ThemeProvider theme={supersetTheme}>
-            <Provider store={store}>
-              <ShareSqlLabQuery {...defaultProps} />
-            </Provider>
-          </ThemeProvider>,
-        );
+        render(<ShareSqlLabQuery {...defaultProps} />, {
+          wrapper: standardProvider,
+        });
       });
       const storeQuerySpy = jest.spyOn(utils, 'storeQuery');
       const button = screen.getByRole('button');
@@ -124,13 +122,9 @@ describe('ShareSqlLabQuery', () => {
         },
       };
       await act(async () => {
-        render(
-          <ThemeProvider theme={supersetTheme}>
-            <Provider store={store}>
-              <ShareSqlLabQuery {...updatedProps} />
-            </Provider>
-          </ThemeProvider>,
-        );
+        render(<ShareSqlLabQuery {...updatedProps} />, {
+          wrapper: standardProvider,
+        });
       });
       const button = screen.getByRole('button', { name: /copy link/i });
       const style = window.getComputedStyle(button);

--- a/superset-frontend/src/SqlLab/components/ShareSqlLabQuery.tsx
+++ b/superset-frontend/src/SqlLab/components/ShareSqlLabQuery.tsx
@@ -36,7 +36,7 @@ interface ShareSqlLabQueryPropTypes {
     schema: string;
     autorun: boolean;
     sql: string;
-    remoteId: number;
+    remoteId: number | null;
   };
   addDangerToast: (msg: string) => void;
 }
@@ -133,7 +133,7 @@ function ShareSqlLabQuery({
     >
       {canShare ? (
         <CopyToClipboard
-          getText={(callback: any) => getCopyUrl(callback)}
+          getText={getCopyUrl}
           wrapped={false}
           copyNode={buildButton()}
         />

--- a/superset-frontend/src/SqlLab/components/ShareSqlLabQuery.tsx
+++ b/superset-frontend/src/SqlLab/components/ShareSqlLabQuery.tsx
@@ -125,10 +125,15 @@ function ShareSqlLabQuery({
     <Tooltip
       id="copy_link"
       placement="top"
+      overlayStyle={{
+        fontSize: supersetTheme.typography.sizes.s,
+        lineHeight: '1.6',
+        maxWidth: '125px',
+      }}
       title={
         canShare
           ? t('Copy query link to your clipboard')
-          : t('Save the query to copy the link')
+          : t('Save the query to enable this feature')
       }
     >
       {canShare ? (

--- a/superset-frontend/src/SqlLab/components/ShareSqlLabQuery.tsx
+++ b/superset-frontend/src/SqlLab/components/ShareSqlLabQuery.tsx
@@ -29,10 +29,10 @@ import { storeQuery } from 'src/utils/common';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 import { FeatureFlag, isFeatureEnabled } from '../../featureFlags';
 
-interface propTypes {
+interface ShareSqlLabQueryPropTypes {
   queryEditor: {
-    dbId: number;
-    title: string;
+    dbId?: number;
+    title?: string;
     schema: string;
     autorun: boolean;
     sql: string;
@@ -55,8 +55,11 @@ const Styles = styled.div`
   }
 `;
 
-function ShareSqlLabQuery({ queryEditor, addDangerToast }: propTypes) {
-  const getCopyUrlForKvStore = (callback: any) => {
+function ShareSqlLabQuery({
+  queryEditor,
+  addDangerToast,
+}: ShareSqlLabQueryPropTypes) {
+  const getCopyUrlForKvStore = (callback: Function) => {
     const { dbId, title, schema, autorun, sql } = queryEditor;
     const sharedQuery = { dbId, title, schema, autorun, sql };
 
@@ -71,7 +74,7 @@ function ShareSqlLabQuery({ queryEditor, addDangerToast }: propTypes) {
       });
   };
 
-  const getCopyUrlForSavedQuery = (callback: any) => {
+  const getCopyUrlForSavedQuery = (callback: Function) => {
     let savedQueryToastContent;
 
     if (queryEditor.remoteId) {
@@ -84,7 +87,7 @@ function ShareSqlLabQuery({ queryEditor, addDangerToast }: propTypes) {
       callback(savedQueryToastContent);
     }
   };
-  const getCopyUrl = (callback: any) => {
+  const getCopyUrl = (callback: Function) => {
     if (isFeatureEnabled(FeatureFlag.SHARE_QUERIES_VIA_KV_STORE)) {
       return getCopyUrlForKvStore(callback);
     }


### PR DESCRIPTION
### SUMMARY
Changed the share SQL Lab Query button into a TypeScript file using react hooks. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
When Query is not saved:
![Screen Shot 2021-02-25 at 5 45 38 PM](https://user-images.githubusercontent.com/48933336/109229471-567e1980-7791-11eb-8b36-88d78134c26e.png)
When Query is saved: 
![Screen Shot 2021-02-25 at 5 45 49 PM](https://user-images.githubusercontent.com/48933336/109229478-5aaa3700-7791-11eb-93d0-6734a10ab831.png)
### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
