### PR TITLE
fix(sqllab): Table name and schema are encoded twice during fetching table metadata on SQL Lab page.

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -980,10 +980,7 @@ export function mergeTable(table, query) {
 function getTableMetadata(table, query, dispatch) {
   return SupersetClient.get({
     endpoint: encodeURI(
-      `/api/v1/database/${query.dbId}/table/` +
-        `${encodeURIComponent(table.name)}/${encodeURIComponent(
-          table.schema,
-        )}/`,
+      `/api/v1/database/${query.dbId}/table/${table.name}/${table.schema}/`,
     ),
   })
     .then(({ json }) => {


### PR DESCRIPTION
### SUMMARY
Table name and schema are encoded twice during fetching table metadata on SQL Lab page.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![Screenshot from 2021-03-15 23-55-58](https://user-images.githubusercontent.com/6191109/111227342-16b98d80-85eb-11eb-8cae-589fdd9f106e.png)

### TEST PLAN
Tested locally. 

closes https://github.com/apache/superset/issues/13317
### ADDITIONAL INFORMATION
- [x] Has associated 
- [x] Changes UI
