### PR TITLE
fix: bump FAB to 3.2.1, SQLAlchemy fix

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -66,7 +66,7 @@ dnspython==2.0.0
 # via email-validator
 email-validator==1.1.1
 # via flask-appbuilder
-flask-appbuilder==3.1.1
+flask-appbuilder==3.2.1
 # via apache-superset
 flask-babel==1.0.0
 # via flask-appbuilder

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         "cron-descriptor",
         "cryptography>=3.2.1",
         "flask>=1.1.0, <2.0.0",
-        "flask-appbuilder>=3.1.1, <4.0.0",
+        "flask-appbuilder>=3.2.1, <4.0.0",
         "flask-caching",
         "flask-compress",
         "flask-talisman",


### PR DESCRIPTION
### SUMMARY
Bumps FAB to 3.2.1, includes latest patch release with a pinned SQLAlchemy bellow 1.4.0 

Issues:
pallets/flask-sqlalchemy#910
apache/superset#13631

From 3.1.1 to 3.2.1 Includes the following changes:

```
Improvements and Bug fixes on 3.2.1
-----------------------------------

- docs: improve contributing run single test (#1579) [Daniel Vaz Gaspar]
- fix: sqlalchemy 1.4.0 breaking changes (#1586) [Daniel Vaz Gaspar]

Improvements and Bug fixes on 3.2.0
-----------------------------------

- fix: issue 1469 error in filters (#1541) [Duy Nguyen Hoang]
- fix: showing excluded routes in server log (#1565) [runoutnow]
- refactor: AUTH_LDAP/AUTH_OAUTH + implement role mapping (#1374) [Mathew Wicks]
- fix(api): OpenAPI spec of nested components without auto generated names (#1547) [Daniel Vaz Gaspar]
- fix(mvc): action confirmation on single show view (#1539) [Daniel Vaz Gaspar]
- docs: improve docs around LDAP auth (#1526) [Daniel Vaz Gaspar]
- ci: tests for python 3.8 and 3.9 (#1525) [Daniel Vaz Gaspar]
- docs: fix, swagger path in readme (#1518) [Felix Rilling]
- fix: oauth #1511 (#1522) [Daniel Vaz Gaspar]
- fix: github actions (#1523) [Daniel Vaz Gaspar]
- fix: changelog (#1507) [Daniel Vaz Gaspar]
``` 

### ADDITIONAL INFORMATION
- [ ] Has associated issue: #13631 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
