### PR TITLE
fix: Slack dashboard has stale charts

### DIFF
--- a/superset/examples/configs/charts/Messages_per_Channel.yaml
+++ b/superset/examples/configs/charts/Messages_per_Channel.yaml
@@ -87,7 +87,7 @@ params:
   slice_id: 2395
   stacked_style: stream
   time_grain_sqla: P1D
-  time_range: Last quarter
+  time_range: No filter
   time_range_endpoints:
   - inclusive
   - exclusive

--- a/superset/examples/configs/charts/Weekly_Messages.yaml
+++ b/superset/examples/configs/charts/Weekly_Messages.yaml
@@ -37,7 +37,7 @@ params:
   start_y_axis_at_zero: true
   subheader_font_size: 0.15
   time_grain_sqla: P1W
-  time_range: Last quarter
+  time_range: No filter
   time_range_endpoints:
   - inclusive
   - exclusive


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The Slack dashboard in the examples has 2 charts that show no data, since the time range ("last quarter") is now pointing to stale data. I fixed it by setting "no filter" in these charts.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

![Screenshot_2021-03-16 Slack Dashboard](https://user-images.githubusercontent.com/1534870/111373184-d7c22100-8658-11eb-9356-8ff965bbd441.png)

After:

![Screenshot_2021-03-16 Slack Dashboard(1)](https://user-images.githubusercontent.com/1534870/111373327-fe805780-8658-11eb-88fb-d242aa358da3.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Ran `superset load-examples` and verified the dashboard works (see screenshot above).

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
