### PR TITLE
chore: bump pyyaml to latest

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -229,7 +229,7 @@ pytz==2020.4
 #   convertdate
 #   flask-babel
 #   pandas
-pyyaml==5.3.1
+pyyaml==5.4.1
 # via
 #   apache-superset
 #   apispec

--- a/requirements/integration.txt
+++ b/requirements/integration.txt
@@ -20,7 +20,7 @@ pluggy==0.13.1            # via tox
 pre-commit==2.8.2         # via -r requirements/integration.in
 py==1.9.0                 # via tox
 pyparsing==2.4.7          # via packaging
-pyyaml==5.3.1             # via pre-commit
+pyyaml==5.4.1             # via pre-commit
 six==1.15.0               # via packaging, pip-tools, tox, virtualenv
 toml==0.10.2              # via pre-commit, tox
 toposort==1.5             # via pip-compile-multi

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
         "python-dotenv",
         "python-geohash",
         "pyarrow>=3.0.0, <3.1",
-        "pyyaml>=5.1",
+        "pyyaml>=5.4",
         "PyJWT>=1.7.1, <2",
         "redis",
         "retry>=0.9.2",


### PR DESCRIPTION
### SUMMARY
Bumps `pyyaml` dependency to latest version [[1](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-14343)].

Note that this dependency was updated manually as the `pip-compile-multi` upgrade workflow resulted in several errors, including:

```
ERROR! requirements/base.txt was not regenerated after changes in requirements/base.in.
Expecting: # SHA1:9eeea842b4dffc85a3611351dcb33aca43fbb9e9
Found:     # SHA1:af5d6b34d3fc7fa4f5ad7fac81ce3161da042c2c
```

### TEST PLAN
Sanity check in test environment.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
