### PR TITLE
feat: add 'extra' column to saved_queries GET

### DIFF
--- a/superset/queries/saved_queries/api.py
+++ b/superset/queries/saved_queries/api.py
@@ -98,6 +98,7 @@ class SavedQueryRestApi(BaseSupersetModelRestApi):
         "sql_tables",
         "rows",
         "last_run_delta_humanized",
+        "extra",
     ]
     add_columns = ["db_id", "description", "label", "schema", "sql"]
     edit_columns = add_columns


### PR DESCRIPTION
### SUMMARY
This column contains schedule information when the feature flag
`SCHEDULED_QUERIES` is enabled. Adding it here makes it available
through the REST API.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="563" alt="Screen Shot 2021-03-16 at 9 30 04 PM" src="https://user-images.githubusercontent.com/487433/111416414-1b407d80-86a1-11eb-95b3-fa9e36827d34.png">


### TEST PLAN
manual