### PR TITLE
fix: use FeatureFlags in @superset-ui/core

### DIFF
--- a/superset-frontend/src/featureFlags.ts
+++ b/superset-frontend/src/featureFlags.ts
@@ -16,46 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-// We can codegen the enum definition based on a list of supported flags that we
-// check into source control. We're hardcoding the supported flags for now.
-export enum FeatureFlag {
-  ALLOW_DASHBOARD_DOMAIN_SHARDING = 'ALLOW_DASHBOARD_DOMAIN_SHARDING',
-  OMNIBAR = 'OMNIBAR',
-  CLIENT_CACHE = 'CLIENT_CACHE',
-  DYNAMIC_PLUGINS = 'DYNAMIC_PLUGINS',
-  SCHEDULED_QUERIES = 'SCHEDULED_QUERIES',
-  SQL_VALIDATORS_BY_ENGINE = 'SQL_VALIDATORS_BY_ENGINE',
-  ESTIMATE_QUERY_COST = 'ESTIMATE_QUERY_COST',
-  SHARE_QUERIES_VIA_KV_STORE = 'SHARE_QUERIES_VIA_KV_STORE',
-  SQLLAB_BACKEND_PERSISTENCE = 'SQLLAB_BACKEND_PERSISTENCE',
-  THUMBNAILS = 'THUMBNAILS',
-  LISTVIEWS_DEFAULT_CARD_VIEW = 'LISTVIEWS_DEFAULT_CARD_VIEW',
-  ENABLE_REACT_CRUD_VIEWS = 'ENABLE_REACT_CRUD_VIEWS',
-  DISABLE_DATASET_SOURCE_EDIT = 'DISABLE_DATASET_SOURCE_EDIT',
-  DISPLAY_MARKDOWN_HTML = 'DISPLAY_MARKDOWN_HTML',
-  ESCAPE_MARKDOWN_HTML = 'ESCAPE_MARKDOWN_HTML',
-  DASHBOARD_NATIVE_FILTERS = 'DASHBOARD_NATIVE_FILTERS',
-  DASHBOARD_CROSS_FILTERS = 'DASHBOARD_CROSS_FILTERS',
-  DASHBOARD_RBAC = 'DASHBOARD_RBAC',
-  DASHBOARD_NATIVE_FILTERS_SET = 'DASHBOARD_NATIVE_FILTERS_SET',
-  VERSIONED_EXPORT = 'VERSIONED_EXPORT',
-  GLOBAL_ASYNC_QUERIES = 'GLOBAL_ASYNC_QUERIES',
-  ENABLE_TEMPLATE_PROCESSING = 'ENABLE_TEMPLATE_PROCESSING',
-  ENABLE_EXPLORE_DRAG_AND_DROP = 'ENABLE_EXPLORE_DRAG_AND_DROP',
-}
+import { FeatureFlagMap, FeatureFlag } from '@superset-ui/core';
 
-export type FeatureFlagMap = {
-  [key in FeatureFlag]?: boolean;
-};
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-declare global {
-  interface Window {
-    featureFlags: FeatureFlagMap;
-    $: any;
-    jQuery: any;
-  }
-}
+export { FeatureFlagMap, FeatureFlag } from '@superset-ui/core';
 
 export function initFeatureFlags(featureFlags: FeatureFlagMap) {
   if (!window.featureFlags) {

--- a/superset-frontend/src/setup/setupApp.ts
+++ b/superset-frontend/src/setup/setupApp.ts
@@ -22,8 +22,16 @@ import { SupersetClient } from '@superset-ui/core';
 import {
   getClientErrorObject,
   ClientErrorObject,
-} from '../utils/getClientErrorObject';
-import setupErrorMessages from './setupErrorMessages';
+} from 'src/utils/getClientErrorObject';
+import setupErrorMessages from 'src/setup/setupErrorMessages';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+declare global {
+  interface Window {
+    $: any;
+    jQuery: any;
+  }
+}
 
 function showApiMessage(resp: ClientErrorObject) {
   const template =


### PR DESCRIPTION
### SUMMARY

Feature flag typing [has been added to `@superset-ui/core`](https://github.com/apache-superset/superset-ui/pull/982), since there is now two copies of the same typing, sometimes it leads to TS errors when `npm link` is used or when in Jest.

This change means all future feature flags used in the front-end have to be added to `@superset-ui` and go through the npm publish process. This is inconvenient but probably necessary to ensure correctness and consistency. Considering we are merging `superset-ui` to this repo soon, this should not be that much of a problem.

cc @graceguo-supercat @villebro 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

1. `npm link ../superset-ui/packages/superset-ui-core`
2. `npm run type`
3. You will see this error in `master`: 

```
node_modules/@superset-ui/core/src/utils/featureFlags.ts:53:5 - error TS2717: Subsequent property declarations must have the same type.  Property 'featureFlags' must be of type 'FeatureFlagMap', but here has type 'FeatureFlagMap'.

53     featureFlags: FeatureFlagMap;
       ~~~~~~~~~~~~

  src/featureFlags.ts:54:5
    54     featureFlags: FeatureFlagMap;
           ~~~~~~~~~~~~
    'featureFlags' was also declared here.


Found 1 error.
```

This PR should fix it.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache-superset/superset-ui/pull/982
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
