### PR TITLE
fix(alert|report): allow null on chart and dashboard field

### DIFF
--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -148,8 +148,8 @@ class ReportSchedulePostSchema(Schema):
     sql = fields.String(
         description=sql_description, example="SELECT value FROM time_series_table"
     )
-    chart = fields.Integer(required=False)
-    dashboard = fields.Integer(required=False)
+    chart = fields.Integer(required=False, allow_none=True)
+    dashboard = fields.Integer(required=False, allow_none=True)
     database = fields.Integer(required=False)
     owners = fields.List(fields.Integer(description=owners_description))
     validator_type = fields.String(

--- a/tests/reports/api_tests.py
+++ b/tests/reports/api_tests.py
@@ -496,13 +496,16 @@ class TestReportSchedulesApi(SupersetTestCase):
         db.session.delete(created_model)
         db.session.commit()
 
-    @pytest.mark.usefixtures("create_report_schedules")
+    @pytest.mark.usefixtures(
+        "load_birth_names_dashboard_with_slices", "create_report_schedules"
+    )
     def test_create_report_schedule_schema(self):
         """
         ReportSchedule Api: Test create report schedule schema check
         """
         self.login(username="admin")
         chart = db.session.query(Slice).first()
+        dashboard = db.session.query(Dashboard).first()
         example_db = get_example_database()
 
         # Check that a report does not have a database reference
@@ -589,6 +592,56 @@ class TestReportSchedulesApi(SupersetTestCase):
         uri = "api/v1/report/"
         rv = self.client.post(uri, json=report_schedule_data)
         assert rv.status_code == 400
+
+        # Test that report can be created with null dashboard
+        report_schedule_data = {
+            "type": ReportScheduleType.ALERT,
+            "name": "new4",
+            "description": "description",
+            "crontab": "0 9 * * *",
+            "recipients": [
+                {
+                    "type": ReportRecipientType.EMAIL,
+                    "recipient_config_json": {"target": "target@superset.org"},
+                },
+                {
+                    "type": ReportRecipientType.SLACK,
+                    "recipient_config_json": {"target": "channel"},
+                },
+            ],
+            "working_timeout": 3600,
+            "chart": chart.id,
+            "dashboard": None,
+            "database": example_db.id,
+        }
+        uri = "api/v1/report/"
+        rv = self.client.post(uri, json=report_schedule_data)
+        assert rv.status_code == 201
+
+        # Test that report can be created with null chart
+        report_schedule_data = {
+            "type": ReportScheduleType.ALERT,
+            "name": "new5",
+            "description": "description",
+            "crontab": "0 9 * * *",
+            "recipients": [
+                {
+                    "type": ReportRecipientType.EMAIL,
+                    "recipient_config_json": {"target": "target@superset.org"},
+                },
+                {
+                    "type": ReportRecipientType.SLACK,
+                    "recipient_config_json": {"target": "channel"},
+                },
+            ],
+            "working_timeout": 3600,
+            "chart": None,
+            "dashboard": dashboard.id,
+            "database": example_db.id,
+        }
+        uri = "api/v1/report/"
+        rv = self.client.post(uri, json=report_schedule_data)
+        assert rv.status_code == 201
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_create_report_schedule_chart_dash_validation(self):


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
when attempting to create an alert or report, there is an issue where 
When chart is selected, it errors out with `dashboard may not be null`
When dashboard is selected, it errors out with `chart may not be null`

this pr is allowing chart or dashboard to be null when on `POST`
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
After: 
https://www.loom.com/share/0e41f8fd83ba42a7b1ba2b7aee6fb4e0

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
