### PR TITLE
fix: clean up incorrect usage of TypeScript type in PropTypes

### DIFF
--- a/superset-frontend/src/explore/components/controls/MetricControl/MetricDefinitionValue.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/MetricDefinitionValue.jsx
@@ -22,14 +22,9 @@ import columnType from './columnType';
 import AdhocMetricOption from './AdhocMetricOption';
 import AdhocMetric from './AdhocMetric';
 import savedMetricType from './savedMetricType';
-import adhocMetricType from './adhocMetricType';
 
 const propTypes = {
-  option: PropTypes.oneOfType([
-    savedMetricType,
-    adhocMetricType,
-    PropTypes.string,
-  ]).isRequired,
+  option: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
   index: PropTypes.number.isRequired,
   onMetricEdit: PropTypes.func,
   onRemoveMetric: PropTypes.func,

--- a/superset-frontend/src/explore/components/controls/MetricControl/MetricDefinitionValue.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/MetricDefinitionValue.jsx
@@ -18,7 +18,6 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Metric } from '@superset-ui/chart-controls/lib/types';
 import columnType from './columnType';
 import AdhocMetricOption from './AdhocMetricOption';
 import AdhocMetric from './AdhocMetric';
@@ -29,7 +28,6 @@ const propTypes = {
   option: PropTypes.oneOfType([
     savedMetricType,
     adhocMetricType,
-    Metric,
     PropTypes.string,
   ]).isRequired,
   index: PropTypes.number.isRequired,

--- a/superset-frontend/src/explore/components/controls/withAsyncVerification.tsx
+++ b/superset-frontend/src/explore/components/controls/withAsyncVerification.tsx
@@ -23,8 +23,10 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import sharedControlComponents from '@superset-ui/chart-controls/lib/shared-controls/components';
-import { ExtraControlProps } from '@superset-ui/chart-controls';
+import {
+  ExtraControlProps,
+  sharedControlComponents,
+} from '@superset-ui/chart-controls';
 import { JsonArray, JsonValue, t } from '@superset-ui/core';
 import { ControlProps } from 'src/explore/components/Control';
 import builtInControlComponents from 'src/explore/components/controls';


### PR DESCRIPTION
### SUMMARY

`Metric` from `@superset-ui/chart-controls` is a TypeScript type, which cannot be used in a JSX file and `PropTypes`---it'd just become `undefined` at compile time. We noticed this because our internal CI is failing because of the bad imports (we have a couple of somewhat stricter Jest tests that uses some `superset-frontend` components).

Also remove another reference of `@superset-ui/chart-controls/lib/...`----we shouldn't import `lib` files directly unless absolutely necessary as it sometimes messes up with `npm link`.

cc @kgabryje @villebro @graceguo-supercat 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #13575 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
