### PR TITLE
feat: add 2 hour granularity for bigquery and druid

### DIFF
--- a/superset-frontend/src/explore/controls.jsx
+++ b/superset-frontend/src/explore/controls.jsx
@@ -280,6 +280,7 @@ export const controls = {
       ['PT5M', '5 minutes'],
       ['PT30M', '30 minutes'],
       ['PT1H', '1 hour'],
+      ['PT2H', '2 hours'],
       ['PT6H', '6 hour'],
       ['P1D', '1 day'],
       ['P7D', '7 days'],

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -134,6 +134,7 @@ TIME_GRAINS = (
     "PT15M",
     "PT0.5H",
     "PT1H",
+    "PT2H",
     "P1D",
     "P1W",
     "P1M",

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -760,6 +760,7 @@ class DruidDatasource(Model, BaseDatasource):
             "5 minutes": "PT5M",
             "30 minutes": "PT30M",
             "1 hour": "PT1H",
+            "2 hours": "PT2H",
             "6 hour": "PT6H",
             "one day": "P1D",
             "1 day": "P1D",

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -86,7 +86,7 @@ builtin_time_grains: Dict[Optional[str], str] = {
     "PT15M": __("15 minute"),
     "PT0.5H": __("Half hour"),
     "PT1H": __("Hour"),
-    "PT2H": __("2 Hours"),
+    "PT2H": __("2 hour"),
     "P1D": __("Day"),
     "P1W": __("Week"),
     "P1M": __("Month"),

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -86,6 +86,7 @@ builtin_time_grains: Dict[Optional[str], str] = {
     "PT15M": __("15 minute"),
     "PT0.5H": __("Half hour"),
     "PT1H": __("Hour"),
+    "PT2H": __("2 Hours"),
     "P1D": __("Day"),
     "P1W": __("Week"),
     "P1M": __("Month"),

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -79,6 +79,9 @@ class BigQueryEngineSpec(BaseEngineSpec):
         "30*60 * DIV(UNIX_SECONDS(CAST({col} AS TIMESTAMP)), 30*60)"
         ") AS {type})",
         "PT1H": "{func}({col}, HOUR)",
+        "PT2H": "CAST(TIMESTAMP_SECONDS("
+        "60*60*2 * DIV(UNIX_SECONDS(CAST({col} AS TIMESTAMP)), 60*60*2)"
+        ") AS {type})",
         "P1D": "{func}({col}, DAY)",
         "P1W": "{func}({col}, WEEK)",
         "P1M": "{func}({col}, MONTH)",

--- a/superset/db_engine_specs/druid.py
+++ b/superset/db_engine_specs/druid.py
@@ -47,6 +47,7 @@ class DruidEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method
         "PT15M": "TIME_FLOOR({col}, 'PT15M')",
         "PT0.5H": "TIME_FLOOR({col}, 'PT30M')",
         "PT1H": "FLOOR({col} TO HOUR)",
+        "PT2H": "TIME_FLOOR({col}, 'PT2H')",
         "P1D": "FLOOR({col} TO DAY)",
         "P1W": "FLOOR({col} TO WEEK)",
         "P1M": "FLOOR({col} TO MONTH)",

--- a/tests/druid_tests.py
+++ b/tests/druid_tests.py
@@ -548,6 +548,7 @@ class TestDruid(SupersetTestCase):
             "1 minute": "PT1M",
             "5 minutes": "PT5M",
             "1 hour": "PT1H",
+            "2 hours": "PT2H",
             "6 hour": "PT6H",
             "one day": "P1D",
             "1 day": "P1D",


### PR DESCRIPTION
### SUMMARY
Adds 2 hour time granularity for bigquery and druid
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
For BigQuery
Data: 
<img width="466" alt="Screenshot_3_17_21__6_57_PM" src="https://user-images.githubusercontent.com/5186919/111562718-e9d4ba00-8753-11eb-8c5f-6fe9bac82c52.png">

With time granularity:
<img width="1141" alt="_DEV__Explore_-_cases_ts_03_17_2021_18_36_16" src="https://user-images.githubusercontent.com/5186919/111562746-f527e580-8753-11eb-9589-acb9132d98a4.png">


UI with BigQuery: 
<img width="518" alt="_DEV__Explore_-_cases_ts_03_17_2021_19_09_53" src="https://user-images.githubusercontent.com/5186919/111563142-9c0c8180-8754-11eb-8d38-1cbdd32d30b2.png">


### TEST PLAN
I could use help testing on Druid from someone who has access to a db

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
