### PR TITLE
fix(native-filters): fix removing native filter

### DIFF
--- a/superset-frontend/src/dashboard/actions/nativeFilters.ts
+++ b/superset-frontend/src/dashboard/actions/nativeFilters.ts
@@ -96,6 +96,7 @@ export const setFilterConfiguration = (
     });
     dispatch({
       type: SET_DATA_MASK_FOR_FILTER_CONFIG_COMPLETE,
+      unitName: DataMaskType.NativeFilters,
       filterConfig,
     });
   } catch (err) {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.tsx
@@ -240,6 +240,30 @@ const FilterBar: React.FC<FiltersBarProps> = ({
     }
   }, [filterValues.length]);
 
+  useEffect(() => {
+    // Remove deleted filters from local state
+    Object.keys(dataMaskSelected).forEach(selectedId => {
+      if (!filters[selectedId]) {
+        setDataMaskSelected(draft => {
+          delete draft[selectedId];
+        });
+      }
+    });
+    Object.keys(dataMaskApplied).forEach(appliedId => {
+      if (!filters[appliedId]) {
+        setLastAppliedFilterData(draft => {
+          delete draft[appliedId];
+        });
+      }
+    });
+  }, [
+    dataMaskApplied,
+    dataMaskSelected,
+    filters,
+    setDataMaskSelected,
+    setLastAppliedFilterData,
+  ]);
+
   const cascadeChildren = useMemo(
     () => mapParentFiltersToChildren(filterValues),
     [filterValues],

--- a/superset-frontend/src/dataMask/actions.ts
+++ b/superset-frontend/src/dataMask/actions.ts
@@ -33,6 +33,7 @@ export const SET_DATA_MASK_FOR_FILTER_CONFIG_COMPLETE =
 export interface SetDataMaskForFilterConfigComplete {
   type: typeof SET_DATA_MASK_FOR_FILTER_CONFIG_COMPLETE;
   filterConfig: FilterConfiguration;
+  unitName: DataMaskType;
 }
 export const SET_DATA_MASK_FOR_FILTER_CONFIG_FAIL =
   'SET_DATA_MASK_FOR_FILTER_CONFIG_FAIL';

--- a/superset-frontend/src/dataMask/reducer.ts
+++ b/superset-frontend/src/dataMask/reducer.ts
@@ -49,6 +49,7 @@ const setUnitDataMask = (
 
 const dataMaskReducer = produce(
   (draft: DataMaskStateWithId, action: AnyDataMaskAction) => {
+    const oldData = { ...draft };
     switch (action.type) {
       case UPDATE_DATA_MASK:
         Object.values(DataMaskType).forEach(unitName =>
@@ -60,7 +61,7 @@ const dataMaskReducer = produce(
         draft[action.unitName] = {};
         (action.filterConfig ?? []).forEach(filter => {
           draft[action.unitName][filter.id] =
-            draft[action.unitName][filter.id] ?? getInitialMask(filter.id);
+            oldData[action.unitName][filter.id] ?? getInitialMask(filter.id);
         });
         break;
 

--- a/superset-frontend/src/dataMask/reducer.ts
+++ b/superset-frontend/src/dataMask/reducer.ts
@@ -47,14 +47,9 @@ const setUnitDataMask = (
   }
 };
 
-const getEmptyDataMask = () => ({
-  [DataMaskType.NativeFilters]: {},
-  [DataMaskType.CrossFilters]: {},
-  [DataMaskType.OwnFilters]: {},
-});
-
 const dataMaskReducer = produce(
   (draft: DataMaskStateWithId, action: AnyDataMaskAction) => {
+    const oldData = { ...draft };
     switch (action.type) {
       case UPDATE_DATA_MASK:
         Object.values(DataMaskType).forEach(unitName =>
@@ -63,20 +58,21 @@ const dataMaskReducer = produce(
         break;
 
       case SET_DATA_MASK_FOR_FILTER_CONFIG_COMPLETE:
-        Object.values(DataMaskType).forEach(unitName => {
-          draft[unitName] = getEmptyDataMask()[unitName];
-        });
+        draft[action.unitName] = {};
         (action.filterConfig ?? []).forEach(filter => {
-          draft[DataMaskType.NativeFilters][filter.id] =
-            draft[DataMaskType.NativeFilters][filter.id] ??
-            getInitialMask(filter.id);
+          draft[action.unitName][filter.id] =
+            oldData[action.unitName][filter.id] ?? getInitialMask(filter.id);
         });
         break;
 
       default:
     }
   },
-  getEmptyDataMask(),
+  {
+    [DataMaskType.NativeFilters]: {},
+    [DataMaskType.CrossFilters]: {},
+    [DataMaskType.OwnFilters]: {},
+  },
 );
 
 export default dataMaskReducer;

--- a/superset-frontend/src/dataMask/reducer.ts
+++ b/superset-frontend/src/dataMask/reducer.ts
@@ -28,13 +28,11 @@ import {
   UpdateDataMask,
 } from './actions';
 
-export function getInitialMask(id: string): MaskWithId {
-  return {
-    id,
-    extraFormData: {},
-    currentState: {},
-  };
-}
+export const getInitialMask = (id: string): MaskWithId => ({
+  id,
+  extraFormData: {},
+  currentState: {},
+});
 
 const setUnitDataMask = (
   unitName: DataMaskType,
@@ -49,11 +47,11 @@ const setUnitDataMask = (
   }
 };
 
-const emptyDataMask = {
+const getEmptyDataMask = () => ({
   [DataMaskType.NativeFilters]: {},
   [DataMaskType.CrossFilters]: {},
   [DataMaskType.OwnFilters]: {},
-};
+});
 
 const dataMaskReducer = produce(
   (draft: DataMaskStateWithId, action: AnyDataMaskAction) => {
@@ -66,7 +64,7 @@ const dataMaskReducer = produce(
 
       case SET_DATA_MASK_FOR_FILTER_CONFIG_COMPLETE:
         Object.values(DataMaskType).forEach(unitName => {
-          draft[unitName] = emptyDataMask[unitName];
+          draft[unitName] = getEmptyDataMask()[unitName];
         });
         (action.filterConfig ?? []).forEach(filter => {
           draft[DataMaskType.NativeFilters][filter.id] =
@@ -78,7 +76,7 @@ const dataMaskReducer = produce(
       default:
     }
   },
-  emptyDataMask,
+  getEmptyDataMask(),
 );
 
 export default dataMaskReducer;

--- a/superset-frontend/src/dataMask/reducer.ts
+++ b/superset-frontend/src/dataMask/reducer.ts
@@ -49,7 +49,6 @@ const setUnitDataMask = (
 
 const dataMaskReducer = produce(
   (draft: DataMaskStateWithId, action: AnyDataMaskAction) => {
-    const oldData = { ...draft };
     switch (action.type) {
       case UPDATE_DATA_MASK:
         Object.values(DataMaskType).forEach(unitName =>
@@ -61,7 +60,7 @@ const dataMaskReducer = produce(
         draft[action.unitName] = {};
         (action.filterConfig ?? []).forEach(filter => {
           draft[action.unitName][filter.id] =
-            oldData[action.unitName][filter.id] ?? getInitialMask(filter.id);
+            draft[action.unitName][filter.id] ?? getInitialMask(filter.id);
         });
         break;
 

--- a/superset-frontend/src/dataMask/reducer.ts
+++ b/superset-frontend/src/dataMask/reducer.ts
@@ -28,11 +28,13 @@ import {
   UpdateDataMask,
 } from './actions';
 
-export const getInitialMask = (id: string): MaskWithId => ({
-  id,
-  extraFormData: {},
-  currentState: {},
-});
+export function getInitialMask(id: string): MaskWithId {
+  return {
+    id,
+    extraFormData: {},
+    currentState: {},
+  };
+}
 
 const setUnitDataMask = (
   unitName: DataMaskType,


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix next flow:
1. Have one native filter
2. Add new native filter
3. Choose values for second one
4. Remove it

Actual: Charts not updated after second filter was removed
Expected: Charts should be updated after second filter was removed

Also it fix case that when native filters changed it was remove cross filters metadata

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
