### PR TITLE
fix(dashboard): missing parents in directPathToFilter

### DIFF
--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -180,7 +180,7 @@ export function saveDashboardRequest(data, id, saveType) {
     Object.values(dashboardFilters).forEach(filter => {
       const { chartId } = filter;
       const componentId = filter.directPathToFilter.slice().pop();
-      const directPathToFilter = (layout[componentId].parents || []).slice();
+      const directPathToFilter = (layout[componentId]?.parents || []).slice();
       directPathToFilter.push(componentId);
       dispatch(updateDirectPathToFilter(chartId, directPathToFilter));
     });


### PR DESCRIPTION
### SUMMARY
When removing a chart and saving a dashboard, I hit a bug where the dashboard wouldn't save (`layout[componentId]` was `undefined`). After the change the dashboard saved successfully.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/33317356/111625881-0a555080-87f6-11eb-9740-16ba31a94295.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
