### PR TITLE
fix: select table overlay

### DIFF
--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -245,7 +245,6 @@ export default function DatabaseSelector({
         placeholder={t('Select a database')}
         autoSelect
         isDisabled={!isDatabaseSelectEnabled || readOnly}
-        menuPortalTarget={document.body}
         menuPosition="fixed"
       />,
       null,

--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -245,6 +245,8 @@ export default function DatabaseSelector({
         placeholder={t('Select a database')}
         autoSelect
         isDisabled={!isDatabaseSelectEnabled || readOnly}
+        menuPortalTarget={document.body}
+        menuPosition="fixed"
       />,
       null,
     );

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -326,6 +326,8 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
           optionRenderer={renderTableOption}
           valueRenderer={renderTableOption}
           isDisabled={readOnly}
+          menuPortalTarget={document.body}
+          menuPosition="fixed"
         />
       );
     } else if (formMode) {

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -326,7 +326,6 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
           optionRenderer={renderTableOption}
           valueRenderer={renderTableOption}
           isDisabled={readOnly}
-          menuPortalTarget={document.body}
           menuPosition="fixed"
         />
       );


### PR DESCRIPTION
### SUMMARY
The table selector was being renderended underneath the footer and the  modal background. This fixes that by giving the menu a fixed position. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before:
![image](https://user-images.githubusercontent.com/48933336/111689444-6920c700-8802-11eb-90cd-88155651c374.png)


after:
![Screen Shot 2021-03-18 at 3 53 26 PM](https://user-images.githubusercontent.com/48933336/111689385-573f2400-8802-11eb-9f97-eacfe5074b8d.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: https://github.com/apache/superset/issues/13192

