### PR TITLE
fix: dashboard filter scope bug

### DIFF
--- a/superset-frontend/spec/javascripts/dashboard/util/getFilterScopeFromNodesTree_spec.js
+++ b/superset-frontend/spec/javascripts/dashboard/util/getFilterScopeFromNodesTree_spec.js
@@ -382,84 +382,84 @@ describe('getFilterScopeFromNodesTree', () => {
       });
     });
 
-    // test case 3:
-    // - filter_109
-    // - chart_106
-    // - Tab 1
-    //   - Nested_Tab1
-    //     - chart_101
-    //     - chart_102
-    //   - Nested_Tab2
-    //     - chart_103
-    //     - chart_104
-
-    const nodes3 = [
-      {
-        label: 'All dashboard',
-        type: 'ROOT',
-        value: 'ROOT_ID',
-        children: [
-          {
-            label: 'Time Filter',
-            showCheckbox: true,
-            type: 'CHART',
-            value: 109,
-          },
-          {
-            label: "World's Pop Growth",
-            showCheckbox: true,
-            type: 'CHART',
-            value: 106,
-          },
-          {
-            label: 'Row Tab 1',
-            type: 'TAB',
-            value: 'TAB-w5Fp904Rs',
-            children: [
-              {
-                label: 'Nested Tab 1',
-                type: 'TAB',
-                value: 'TAB-E4mJaZ-uQM',
-                children: [
-                  {
-                    value: 104,
-                    label: 'Rural Breakdown',
-                    type: 'CHART',
-                    showCheckbox: true,
-                  },
-                  {
-                    value: 103,
-                    label: '% Rural',
-                    type: 'CHART',
-                    showCheckbox: true,
-                  },
-                ],
-              },
-              {
-                value: 'TAB-rLYu-Cryu',
-                label: 'Nested Tab 2',
-                type: 'TAB',
-                children: [
-                  {
-                    value: 102,
-                    label: 'Most Populated Countries',
-                    type: 'CHART',
-                    showCheckbox: true,
-                  },
-                  {
-                    value: 101,
-                    label: "World's Population",
-                    type: 'CHART',
-                    showCheckbox: true,
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-    ];
     it('exclude nested sub-tab', () => {
+      // another layout for test:
+      // - filter_109
+      // - chart_106
+      // - Tab 1
+      //   - Nested_Tab1
+      //     - chart_101
+      //     - chart_102
+      //   - Nested_Tab2
+      //     - chart_103
+      //     - chart_104
+      const nodes3 = [
+        {
+          label: 'All dashboard',
+          type: 'ROOT',
+          value: 'ROOT_ID',
+          children: [
+            {
+              label: 'Time Filter',
+              showCheckbox: true,
+              type: 'CHART',
+              value: 109,
+            },
+            {
+              label: "World's Pop Growth",
+              showCheckbox: true,
+              type: 'CHART',
+              value: 106,
+            },
+            {
+              label: 'Row Tab 1',
+              type: 'TAB',
+              value: 'TAB-w5Fp904Rs',
+              children: [
+                {
+                  label: 'Nested Tab 1',
+                  type: 'TAB',
+                  value: 'TAB-E4mJaZ-uQM',
+                  children: [
+                    {
+                      value: 104,
+                      label: 'Rural Breakdown',
+                      type: 'CHART',
+                      showCheckbox: true,
+                    },
+                    {
+                      value: 103,
+                      label: '% Rural',
+                      type: 'CHART',
+                      showCheckbox: true,
+                    },
+                  ],
+                },
+                {
+                  value: 'TAB-rLYu-Cryu',
+                  label: 'Nested Tab 2',
+                  type: 'TAB',
+                  children: [
+                    {
+                      value: 102,
+                      label: 'Most Populated Countries',
+                      type: 'CHART',
+                      showCheckbox: true,
+                    },
+                    {
+                      value: 101,
+                      label: "World's Population",
+                      type: 'CHART',
+                      showCheckbox: true,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
       const checkedChartIds = [103, 104, 106];
       expect(
         getFilterScopeFromNodesTree({

--- a/superset-frontend/spec/javascripts/dashboard/util/getFilterScopeFromNodesTree_spec.js
+++ b/superset-frontend/spec/javascripts/dashboard/util/getFilterScopeFromNodesTree_spec.js
@@ -381,5 +381,96 @@ describe('getFilterScopeFromNodesTree', () => {
         immune: [105, 103, 102, 101, 108, 104],
       });
     });
+
+    // test case 3:
+    // - filter_109
+    // - chart_106
+    // - Tab 1
+    //   - Nested_Tab1
+    //     - chart_101
+    //     - chart_102
+    //   - Nested_Tab2
+    //     - chart_103
+    //     - chart_104
+
+    const nodes3 = [
+      {
+        label: 'All dashboard',
+        type: 'ROOT',
+        value: 'ROOT_ID',
+        children: [
+          {
+            label: 'Time Filter',
+            showCheckbox: true,
+            type: 'CHART',
+            value: 109,
+          },
+          {
+            label: "World's Pop Growth",
+            showCheckbox: true,
+            type: 'CHART',
+            value: 106,
+          },
+          {
+            label: 'Row Tab 1',
+            type: 'TAB',
+            value: 'TAB-w5Fp904Rs',
+            children: [
+              {
+                label: 'Nested Tab 1',
+                type: 'TAB',
+                value: 'TAB-E4mJaZ-uQM',
+                children: [
+                  {
+                    value: 104,
+                    label: 'Rural Breakdown',
+                    type: 'CHART',
+                    showCheckbox: true,
+                  },
+                  {
+                    value: 103,
+                    label: '% Rural',
+                    type: 'CHART',
+                    showCheckbox: true,
+                  },
+                ],
+              },
+              {
+                value: 'TAB-rLYu-Cryu',
+                label: 'Nested Tab 2',
+                type: 'TAB',
+                children: [
+                  {
+                    value: 102,
+                    label: 'Most Populated Countries',
+                    type: 'CHART',
+                    showCheckbox: true,
+                  },
+                  {
+                    value: 101,
+                    label: "World's Population",
+                    type: 'CHART',
+                    showCheckbox: true,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    it('exclude nested sub-tab', () => {
+      const checkedChartIds = [103, 104, 106];
+      expect(
+        getFilterScopeFromNodesTree({
+          filterKey: '109___time_range',
+          nodes: nodes3,
+          checkedChartIds,
+        }),
+      ).toEqual({
+        scope: ['ROOT_ID'],
+        immune: [102, 101],
+      });
+    });
   });
 });

--- a/superset-frontend/src/dashboard/util/getFilterScopeFromNodesTree.js
+++ b/superset-frontend/src/dashboard/util/getFilterScopeFromNodesTree.js
@@ -22,7 +22,7 @@ import { flatMap, isEmpty } from 'lodash';
 import { CHART_TYPE, TAB_TYPE } from './componentTypes';
 import { getChartIdAndColumnFromFilterKey } from './getDashboardFilterKey';
 
-function getChartsFromTabsNotInScope({ tabs = [], tabsInScope = [] }) {
+function getChartIdsFromTabsNotInScope({ tabs = [], tabsInScope = [] }) {
   const chartsNotInScope = [];
   tabs.forEach(({ value: tab, children: tabChildren }) => {
     if (tabChildren && !tabsInScope.includes(tab)) {
@@ -57,7 +57,7 @@ function getTabChildrenScope({
       ))
   ) {
     // get all charts from tabChildren that is not in scope
-    const chartsFromTabsNotInScope = getChartsFromTabsNotInScope({
+    const immuneChartIdsFromTabsNotInScope = getChartIdsFromTabsNotInScope({
       tabs: tabChildren,
       tabsInScope: flatMap(tabScopes, ({ scope }) => scope),
     });
@@ -66,7 +66,10 @@ function getTabChildrenScope({
       ({ immune }) => immune,
     );
     const immuneCharts = [
-      ...new Set([...chartsFromTabsNotInScope, ...immuneChartsFromTabsInScope]),
+      ...new Set([
+        ...immuneChartIdsFromTabsNotInScope,
+        ...immuneChartsFromTabsInScope,
+      ]),
     ];
     return {
       scope: [parentNodeValue],

--- a/superset-frontend/src/dashboard/util/getFilterScopeFromNodesTree.js
+++ b/superset-frontend/src/dashboard/util/getFilterScopeFromNodesTree.js
@@ -22,7 +22,7 @@ import { flatMap, isEmpty } from 'lodash';
 import { CHART_TYPE, TAB_TYPE } from './componentTypes';
 import { getChartIdAndColumnFromFilterKey } from './getDashboardFilterKey';
 
-function getChartIdsFromTabsNotInScope({ tabs = [], tabsInScope = [] }) {
+function getImmuneChartIdsFromTabsNotInScope({ tabs = [], tabsInScope = [] }) {
   const chartsNotInScope = [];
   tabs.forEach(({ value: tab, children: tabChildren }) => {
     if (tabChildren && !tabsInScope.includes(tab)) {
@@ -57,18 +57,20 @@ function getTabChildrenScope({
       ))
   ) {
     // get all charts from tabChildren that is not in scope
-    const immuneChartIdsFromTabsNotInScope = getChartIdsFromTabsNotInScope({
-      tabs: tabChildren,
-      tabsInScope: flatMap(tabScopes, ({ scope }) => scope),
-    });
-    const immuneChartsFromTabsInScope = flatMap(
+    const immuneChartIdsFromTabsNotInScope = getImmuneChartIdsFromTabsNotInScope(
+      {
+        tabs: tabChildren,
+        tabsInScope: flatMap(tabScopes, ({ scope }) => scope),
+      },
+    );
+    const immuneChartIdsFromTabsInScope = flatMap(
       Object.values(tabScopes),
       ({ immune }) => immune,
     );
     const immuneCharts = [
       ...new Set([
         ...immuneChartIdsFromTabsNotInScope,
-        ...immuneChartsFromTabsInScope,
+        ...immuneChartIdsFromTabsInScope,
       ]),
     ];
     return {


### PR DESCRIPTION
### SUMMARY
This PR is to fix a logic bug in dashboard filter scope. 
When calculate filter's scope, if a filter applicable to multiple child nodes (like sub-tab(s), and a chart), we _aggregate_ the filter scope up to their common parent node level, and mark those chart type children that not applicable to the filter as _immune_. The bug was in the _aggregate_ function, which didn't collect all the immune charts.

### TEST PLAN
added new unit test. 
