### PR TITLE
fix(cross-filters): expand relevant indicator sections

### DIFF
--- a/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel.tsx
@@ -74,11 +74,7 @@ const DetailsPanelPopover = ({
   function handlePopoverStatus(isOpen: boolean) {
     // every time the popover opens, make sure the most relevant panel is active
     if (isOpen) {
-      if (
-        !activePanels.find(panel => getDefaultActivePanel().includes(panel))
-      ) {
-        setActivePanels([...activePanels, ...getDefaultActivePanel()]);
-      }
+      setActivePanels(getDefaultActivePanel());
     }
   }
 


### PR DESCRIPTION
### SUMMARY
Currently the cross filter panel doesn't always expand when clicking the filter indicator. This applies the defaults every time the indicator is clicked.

### AFTER
![image](https://user-images.githubusercontent.com/33317356/111753005-06c9d400-889f-11eb-9009-c15374538ac8.png)

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/111753131-29f48380-889f-11eb-8de0-1dd2bc267627.png)



### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
