### PR TITLE
fix(cross-filters): only apply filters if ff is set

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/state.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/state.ts
@@ -51,8 +51,9 @@ export function useFilterScopeTree(
   const validNodes = useMemo(
     () =>
       Object.values(layout).reduce<string[]>((acc, cur) => {
-        if (cur?.type === CHART_TYPE && currentChartId !== cur?.meta?.chartId) {
-          return [...new Set([...acc, ...cur?.parents, cur.id])];
+        const { id, parents = [], type, meta } = cur;
+        if (type === CHART_TYPE && currentChartId !== meta?.chartId) {
+          return [...new Set([...acc, ...parents, id])];
         }
         return acc;
       }, []),

--- a/superset-frontend/src/dataMask/actions.ts
+++ b/superset-frontend/src/dataMask/actions.ts
@@ -18,6 +18,7 @@
  */
 import { DataMaskType, MaskWithId } from './types';
 import { FilterConfiguration } from '../dashboard/components/nativeFilters/types';
+import { FeatureFlag, isFeatureEnabled } from '../featureFlags';
 
 export const UPDATE_DATA_MASK = 'UPDATE_DATA_MASK';
 export interface UpdateDataMask {
@@ -50,10 +51,22 @@ export function updateDataMask(
     ownFilters?: Omit<MaskWithId, 'id'>;
   },
 ): UpdateDataMask {
+  const { nativeFilters, crossFilters, ownFilters } = dataMask;
+  const filteredDataMask: {
+    nativeFilters?: Omit<MaskWithId, 'id'>;
+    crossFilters?: Omit<MaskWithId, 'id'>;
+    ownFilters?: Omit<MaskWithId, 'id'>;
+  } = { ownFilters };
+  if (isFeatureEnabled(FeatureFlag.DASHBOARD_NATIVE_FILTERS) && nativeFilters) {
+    filteredDataMask.nativeFilters = nativeFilters;
+  }
+  if (isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS) && crossFilters) {
+    filteredDataMask.crossFilters = crossFilters;
+  }
   return {
     type: UPDATE_DATA_MASK,
     filterId,
-    ...dataMask,
+    ...filteredDataMask,
   };
 }
 


### PR DESCRIPTION
### SUMMARY
Currently charts that emit cross filtering events will apply to the dashboard even if the feature flag isn't set. This PR makes sure that the `dataMask` object doesn't contain any properties that haven't been explicitly enabled. Note that `ownFilters` is passed through irrespective of either the `DASHBOARD_NATIVE_FILTERS` or `DASHBOARD_CROSS_FILTERS` being set.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
