### PR TITLE
fix(chart): bar chart does not fail on columns of all null values

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1755,7 +1755,9 @@ class DistributionBarViz(BaseViz):
 
         row = df.groupby(self.groupby).sum()[metrics[0]].copy()
         row.sort_values(ascending=False, inplace=True)
-        pt = df.pivot_table(index=self.groupby, columns=columns, values=metrics)
+        pt = df.pivot_table(
+            index=self.groupby, columns=columns, values=metrics, dropna=False
+        )
         if fd.get("contribution"):
             pt = pt.T
             pt = (pt / pt.sum()).T

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -532,6 +532,38 @@ class TestDistBarViz(SupersetTestCase):
         ]
         self.assertEqual(expected, data)
 
+    def test_column_metric_nan(self):
+        self.maxDiff = None
+        form_data = {
+            "metrics": ["z_column", "votes"],
+            "adhoc_filters": [],
+            "groupby": ["toppings"],
+            "columns": [],
+        }
+        datasource = self.get_datasource_mock()
+        df = pd.DataFrame(
+            {
+                "toppings": ["cheese", "pepperoni", "cheese", "pepperoni"],
+                "votes": [3, 5, 1, 2],
+                "z_column": [nan, nan, nan, nan],
+            }
+        )
+        test_viz = viz.DistributionBarViz(datasource, form_data)
+        data = test_viz.get_data(df)
+
+        expected = [
+            {
+                "key": "z_column",
+                "values": [{"x": "cheese", "y": nan}, {"x": "pepperoni", "y": nan}],
+            },
+            {
+                "key": "votes",
+                "values": [{"x": "cheese", "y": 2.0}, {"x": "pepperoni", "y": 3.5}],
+            },
+        ]
+
+        np.testing.assert_equal(expected, data)
+
     def test_column_metrics_in_order(self):
         form_data = {
             "metrics": ["z_column", "votes", "a_column"],


### PR DESCRIPTION
### SUMMARY
Querying a column that returns only `null` values in a bar chart such as `sum(num_boys) + null` currently results in an error because `df.pivot_table()` [by default has `dropna=True`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.pivot_table.html#pandas.pivot_table):
 >    Do not include columns whose entries are all NaN.
 
 The behaviour before superset version 1.0.1 was to show those values in the chart with a `NULL` value, which is what this PR does

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://user-images.githubusercontent.com/15089539/111791849-ee1fe500-88c3-11eb-898b-c26d90d2c225.png)
After:
![image](https://user-images.githubusercontent.com/15089539/111792620-b6656d00-88c4-11eb-856f-54999044f5db.png)


### TEST PLAN
Open a bar chart for the birth_names example dataset and use `sum(num_boys) + null` as a metric (or any metric that always results in a null value)

### ADDITIONAL INFORMATION
- [X] Has associated issue: fixes #13612 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
