### PR TITLE
fix(alerts and reports): Unify timestamp format on execution log view

### DIFF
--- a/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
+++ b/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
@@ -96,16 +96,21 @@ function ExecutionLog({ addDangerToast, isReportEnabled }: ExecutionLogProps) {
         disableSortBy: true,
       },
       {
+        Cell: ({
+          row: {
+            original: { scheduled_dttm: scheduledDttm }
+          }
+        }: any) => moment(new Date(scheduledDttm)).format('YYYY-MM-DD hh:mm:ss a'),
         accessor: 'scheduled_dttm',
-        Header: t('Scheduled at'),
+        Header: t('Scheduled at (UTC)'),
       },
       {
         Cell: ({
           row: {
             original: { start_dttm: startDttm },
           },
-        }: any) => moment(new Date(startDttm)).format('MM/DD/YYYY hh:mm:ss a'),
-        Header: t('Start at'),
+        }: any) => moment(new Date(startDttm)).format('YYYY-MM-DD hh:mm:ss a'),
+        Header: t('Start at (UTC)'),
         accessor: 'start_dttm',
       },
       {

--- a/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
+++ b/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
@@ -98,9 +98,10 @@ function ExecutionLog({ addDangerToast, isReportEnabled }: ExecutionLogProps) {
       {
         Cell: ({
           row: {
-            original: { scheduled_dttm: scheduledDttm }
-          }
-        }: any) => moment(new Date(scheduledDttm)).format('YYYY-MM-DD hh:mm:ss a'),
+            original: { scheduled_dttm: scheduledDttm },
+          },
+        }: any) =>
+          moment(new Date(scheduledDttm)).format('YYYY-MM-DD hh:mm:ss a'),
         accessor: 'scheduled_dttm',
         Header: t('Scheduled at (UTC)'),
       },


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The execution log view for the alerts and reports feature has two timestamp columns which are currently formatted differently.  Additionally, there is nothing indicating the timezone for this data (UTC).

This PR unifies these formats and adds an indicator in the column headers that the data is in UTC.



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![Screen Shot 2021-03-19 at 3 14 41 PM](https://user-images.githubusercontent.com/47196419/111847373-e82b0380-88c5-11eb-88ed-d672106dd1a7.png)

After:
![Screen Shot 2021-03-19 at 3 04 33 PM](https://user-images.githubusercontent.com/47196419/111847582-57a0f300-88c6-11eb-9aa8-cf1b81432676.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
