### PR TITLE
feat: sort time grain configs

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -352,6 +352,70 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         return tuple(ret_list)
 
     @classmethod
+    def _sort_time_grains(
+        cls, val: Tuple[Optional[str], str], index: int
+    ) -> Union[float, int, str]:
+        """
+        Return an ordered time-based value of a portion of a time grain
+        for sorting
+        Values are expected to be either None or start with P or PT
+        Have a numerical value in the middle and end with
+        a value for the time interval
+        It can also start or end with epoch start time denoting a range
+        i.e, week beginning or ending with a day
+        """
+        pos = {
+            "FIRST": 0,
+            "SECOND": 1,
+            "THIRD": 2,
+            "LAST": 3,
+        }
+
+        if val[0] is None:
+            return pos["FIRST"]
+
+        prog = re.compile(r"(.*\/)?(P|PT)([0-9\.]+)(S|M|H|D|W|M|Y)(\/.*)?")
+        result = prog.match(val[0])
+
+        # for any time grains that don't match the format, put them at the end
+        if result is None:
+            return pos["LAST"]
+
+        second_minute_hour = ["S", "M", "H"]
+        day_week_month_year = ["D", "W", "M", "Y"]
+        is_less_than_day = result.group(2) == "PT"
+        interval = result.group(4)
+        epoch_time_start_string = result.group(1) or result.group(5)
+        has_starting_or_ending = bool(len(epoch_time_start_string or ""))
+
+        def sort_day_week() -> int:
+            if has_starting_or_ending:
+                return pos["LAST"]
+            elif is_less_than_day:
+                return pos["SECOND"]
+            else:
+                return pos["THIRD"]
+
+        def sort_interval() -> float:
+            if is_less_than_day:
+                return second_minute_hour.index(interval)
+            else:
+                return day_week_month_year.index(interval)
+
+        # 0: all "PT" values should come before "P" values (i.e, PT10M)
+        # 1: order values within the above arrays ("D" before "W")
+        # 2: sort by numeric value (PT10M before PT15M)
+        # 3: sort by any week starting/ending values
+        plist = {
+            0: sort_day_week(),
+            1: pos["SECOND"] if is_less_than_day else pos["THIRD"],
+            2: sort_interval(),
+            3: float(result.group(3)),
+        }
+
+        return plist.get(index, 0)
+
+    @classmethod
     def get_time_grain_expressions(cls) -> Dict[Optional[str], str]:
         """
         Return a dict of all supported time grains including any potential added grains
@@ -366,7 +430,18 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         denylist: List[str] = config["TIME_GRAIN_DENYLIST"]
         for key in denylist:
             time_grain_expressions.pop(key)
-        return time_grain_expressions
+
+        return dict(
+            sorted(
+                time_grain_expressions.items(),
+                key=lambda x: (
+                    cls._sort_time_grains(x, 0),
+                    cls._sort_time_grains(x, 1),
+                    cls._sort_time_grains(x, 2),
+                    cls._sort_time_grains(x, 3),
+                ),
+            )
+        )
 
     @classmethod
     def make_select_compatible(

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -391,16 +391,14 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         def sort_day_week() -> int:
             if has_starting_or_ending:
                 return pos["LAST"]
-            elif is_less_than_day:
+            if is_less_than_day:
                 return pos["SECOND"]
-            else:
-                return pos["THIRD"]
+            return pos["THIRD"]
 
         def sort_interval() -> float:
             if is_less_than_day:
                 return second_minute_hour.index(interval)
-            else:
-                return day_week_month_year.index(interval)
+            return day_week_month_year.index(interval)
 
         # 0: all "PT" values should come before "P" values (i.e, PT10M)
         # 1: order values within the above arrays ("D" before "W")


### PR DESCRIPTION
### SUMMARY
When using the `TIME_GRAIN_ADDONS` and `TIME_GRAIN_ADDON_EXPRESSIONS` configs, the additional configs are normally just appended at the end in the dropdown selections. In order to format it as expected, this sorts the time grains in an order that it expects, and if a value is given that it doesn't expect, it puts it at the end. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
example with adding 2/4/6/8/10/12 hour time grains:

<img width="365" alt="Screenshot_3_19_21__5_42_PM" src="https://user-images.githubusercontent.com/5186919/111855610-1cf98380-88e3-11eb-8f7b-52569f7cdb31.png">
<img width="344" alt="Screenshot_3_19_21__5_42_PM" src="https://user-images.githubusercontent.com/5186919/111855619-25ea5500-88e3-11eb-8e0e-7c96628d96d3.png">
<img width="348" alt="Screenshot_3_19_21__5_43_PM" src="https://user-images.githubusercontent.com/5186919/111855626-38648e80-88e3-11eb-870e-72016c3cc411.png">


### TEST PLAN
visual test and unit tests

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
