### PR TITLE
feat: Helm Chart: add extraSecrets config to allow specifying extra secret files

### DIFF
--- a/helm/superset/templates/deployment-beat.yaml
+++ b/helm/superset/templates/deployment-beat.yaml
@@ -37,6 +37,7 @@ spec:
         checksum/superset_config.py: {{ include "superset-config" . | sha256sum }}
         checksum/connections: {{ .Values.supersetNode.connections | toYaml | sha256sum }}
         checksum/extraConfigs: {{ .Values.extraConfigs | toYaml | sha256sum }}
+        checksum/extraSecrets: {{ .Values.extraSecrets | toYaml | sha256sum }}
         checksum/extraSecretEnv: {{ .Values.extraSecretEnv | toYaml | sha256sum }}
         checksum/configOverrides: {{ .Values.configOverrides | toYaml | sha256sum }}
         {{ if .Values.supersetCeleryBeat.forceReload }}

--- a/helm/superset/templates/deployment-worker.yaml
+++ b/helm/superset/templates/deployment-worker.yaml
@@ -35,6 +35,7 @@ spec:
         checksum/superset_config.py: {{ include "superset-config" . | sha256sum }}
         checksum/connections: {{ .Values.supersetNode.connections | toYaml | sha256sum }}
         checksum/extraConfigs: {{ .Values.extraConfigs | toYaml | sha256sum }}
+        checksum/extraSecrets: {{ .Values.extraSecrets | toYaml | sha256sum }}
         checksum/extraSecretEnv: {{ .Values.extraSecretEnv | toYaml | sha256sum }}
         checksum/configOverrides: {{ .Values.configOverrides | toYaml | sha256sum }}
         {{ if .Values.supersetWorker.forceReload }}

--- a/helm/superset/templates/deployment.yaml
+++ b/helm/superset/templates/deployment.yaml
@@ -38,6 +38,7 @@ spec:
         checksum/superset_bootstrap.sh: {{ include "superset-bootstrap" . | sha256sum }}
         checksum/connections: {{ .Values.supersetNode.connections | toYaml | sha256sum }}
         checksum/extraConfigs: {{ .Values.extraConfigs | toYaml | sha256sum }}
+        checksum/extraSecrets: {{ .Values.extraSecrets | toYaml | sha256sum }}
         checksum/extraSecretEnv: {{ .Values.extraSecretEnv | toYaml | sha256sum }}
         checksum/configOverrides: {{ .Values.configOverrides | toYaml | sha256sum }}
         {{- if .Values.supersetNode.forceReload }}

--- a/helm/superset/templates/secret-superset-config.yaml
+++ b/helm/superset/templates/secret-superset-config.yaml
@@ -31,3 +31,10 @@ stringData:
 {{- tpl .Values.init.initscript . | nindent 4 }}
   superset_bootstrap.sh: |
 {{- include "superset-bootstrap" . | nindent 4 }}
+
+{{- if .Values.extraSecrets }}
+{{- range $path, $config := .Values.extraSecrets }}
+  {{ $path }}: |
+{{- tpl $config $ | nindent 4 -}}
+{{- end -}}
+{{- end -}}

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -65,6 +65,10 @@ extraConfigs: {}
   #       sqlalchemy_uri: example://example-db.local
   #       tables: []
 
+
+extraSecrets: {}
+
+
 # A dictionary of overrides to append at the end of superset_config.py - the name does not matter
 # WARNING: the order is not guaranteed
 configOverrides: {}


### PR DESCRIPTION
### SUMMARY
This PR adds an `extraSecrets` config to the helm chart. This config allows it to add additional secret files to the superset-secret in the same way, `extraConfigs` allows it to add additional config files to the superset config map.


### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
