### PR TITLE
refactor: helm chart: Use stringData instead of data in Secrets and remove manual base64 encoding

### DIFF
--- a/helm/superset/templates/secret-env.yaml
+++ b/helm/superset/templates/secret-env.yaml
@@ -24,16 +24,16 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque
-data:
-    REDIS_HOST: {{ tpl .Values.supersetNode.connections.redis_host . | b64enc | quote }}
-    REDIS_PORT: {{ .Values.supersetNode.connections.redis_port | b64enc | quote }}
-    DB_HOST: {{ tpl .Values.supersetNode.connections.db_host . | b64enc | quote }}
-    DB_PORT: {{ .Values.supersetNode.connections.db_port | b64enc | quote }}
-    DB_USER: {{ .Values.supersetNode.connections.db_user | b64enc | quote }}
-    DB_PASS: {{ .Values.supersetNode.connections.db_pass | b64enc | quote }}
-    DB_NAME: {{ .Values.supersetNode.connections.db_name | b64enc | quote }}
+stringData:
+    REDIS_HOST: {{ tpl .Values.supersetNode.connections.redis_host . | quote }}
+    REDIS_PORT: {{ .Values.supersetNode.connections.redis_port | quote }}
+    DB_HOST: {{ tpl .Values.supersetNode.connections.db_host . | quote }}
+    DB_PORT: {{ .Values.supersetNode.connections.db_port | quote }}
+    DB_USER: {{ .Values.supersetNode.connections.db_user | quote }}
+    DB_PASS: {{ .Values.supersetNode.connections.db_pass | quote }}
+    DB_NAME: {{ .Values.supersetNode.connections.db_name | quote }}
     {{- if .Values.extraSecretEnv }}
     {{- range $key, $value := .Values.extraSecretEnv }}
-    {{ $key }}: {{ $value | b64enc | quote }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}

--- a/helm/superset/templates/secret-superset-config.yaml
+++ b/helm/superset/templates/secret-superset-config.yaml
@@ -24,7 +24,10 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque
-data:
-  superset_config.py: {{ include "superset-config" . | b64enc }}
-  superset_init.sh: {{ tpl .Values.init.initscript . | b64enc }}
-  superset_bootstrap.sh: {{ include "superset-bootstrap" . | b64enc }}
+stringData:
+  superset_config.py: |
+{{- include "superset-config" . | nindent 4 }}
+  superset_init.sh: |
+{{- tpl .Values.init.initscript . | nindent 4 }}
+  superset_bootstrap.sh: |
+{{- include "superset-bootstrap" . | nindent 4 }}


### PR DESCRIPTION
### SUMMARY
This PR switches to using Kubernetes' stringData field for Secrets instead of the data field. The benefits are:
* we can avoid the manual base64 encoding of every field
* when templating the helm chart, you can actually read the secrets and therefore better validate the generated template (e.g. injected config values).


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
