### PR TITLE
fix(sqla-query): order by aggregations in Presto and Hive

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -858,7 +858,7 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
             if table_column:
                 sqla_column = table_column.get_sqla_col()
             else:
-                sqla_column = table(self.table_name, column(column_name)).c[column_name]
+                sqla_column = column(column_name)
             sqla_metric = self.sqla_aggregations[metric["aggregate"]](sqla_column)
         elif expression_type == utils.AdhocMetricExpressionType.SQL:
             sqla_metric = literal_column(metric.get("sqlExpression"))

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -49,7 +49,7 @@ from sqlalchemy.engine.url import URL
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import quoted_name, text
-from sqlalchemy.sql.expression import ColumnClause, ColumnElement, Select, TextAsFrom
+from sqlalchemy.sql.expression import ColumnClause, Select, TextAsFrom
 from sqlalchemy.types import String, TypeEngine, UnicodeText
 
 from superset import app, security_manager, sql_parse

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -145,6 +145,9 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
                                        used in ORDER BY when a column in SELECT
                                        has an alias that is the same as a source
                                        column.
+        allows_hidden_orderby_agg:     Whether the engine allows ORDER BY to
+                                       directly use aggregation clauses, without
+                                       having to add the same aggregation in SELECT.
     """
 
     engine = "base"  # str as defined in sqlalchemy.engine.engine
@@ -248,8 +251,16 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     allows_subqueries = True
     allows_alias_in_select = True
     allows_alias_in_orderby = True
-    allows_alias_to_source_column = False
     allows_sql_comments = True
+
+    # Whether ORDER BY clause can use aliases created in SELECT
+    # that are the same as a source column
+    allows_alias_to_source_column = True
+
+    # Whether ORDER BY clause must appear in SELECT
+    # if TRUE, then it doesn't have to.
+    allows_hidden_ordeby_agg = True
+
     force_column_alias_quotes = False
     arraysize = 0
     max_column_name_length = 0
@@ -449,20 +460,6 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
                 ),
             )
         )
-
-    @classmethod
-    def make_select_compatible(
-        cls, groupby_exprs: Dict[str, ColumnElement], select_exprs: List[ColumnElement]
-    ) -> List[ColumnElement]:
-        """
-        Some databases will just return the group-by field into the select, but don't
-        allow the group-by field to be put into the select list.
-
-        :param groupby_exprs: mapping between column name and column object
-        :param select_exprs: all columns in the select clause
-        :return: columns to be included in the final select clause
-        """
-        return select_exprs
 
     @classmethod
     def fetch_data(

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -137,7 +137,15 @@ class LimitMethod:  # pylint: disable=too-few-public-methods
 
 
 class BaseEngineSpec:  # pylint: disable=too-many-public-methods
-    """Abstract class for database engine specific configurations"""
+    """Abstract class for database engine specific configurations
+
+    Attributes:
+        allows_alias_to_source_column: Whether the engine is able to pick the
+                                       source column for aggregation clauses
+                                       used in ORDER BY when a column in SELECT
+                                       has an alias that is the same as a source
+                                       column.
+    """
 
     engine = "base"  # str as defined in sqlalchemy.engine.engine
     engine_aliases: Optional[Tuple[str]] = None
@@ -240,6 +248,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     allows_subqueries = True
     allows_alias_in_select = True
     allows_alias_in_orderby = True
+    allows_alias_to_source_column = False
     allows_sql_comments = True
     force_column_alias_quotes = False
     arraysize = 0

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -81,6 +81,8 @@ class HiveEngineSpec(PrestoEngineSpec):
     engine = "hive"
     engine_name = "Apache Hive"
     max_column_name_length = 767
+    allows_hidden_ordeby_agg = False
+
     # pylint: disable=line-too-long
     _time_grain_expressions = {
         None: "{col}",

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -81,6 +81,7 @@ class HiveEngineSpec(PrestoEngineSpec):
     engine = "hive"
     engine_name = "Apache Hive"
     max_column_name_length = 767
+    allows_alias_to_source_column = True
     allows_hidden_ordeby_agg = False
 
     # pylint: disable=line-too-long

--- a/superset/db_engine_specs/pinot.py
+++ b/superset/db_engine_specs/pinot.py
@@ -14,10 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
-from sqlalchemy.sql.expression import ColumnClause, ColumnElement
-
+from sqlalchemy.sql.expression import ColumnClause
 from superset.db_engine_specs.base import BaseEngineSpec, TimestampExpression
 
 

--- a/superset/db_engine_specs/pinot.py
+++ b/superset/db_engine_specs/pinot.py
@@ -17,6 +17,7 @@
 from typing import Dict, Optional
 
 from sqlalchemy.sql.expression import ColumnClause
+
 from superset.db_engine_specs.base import BaseEngineSpec, TimestampExpression
 
 

--- a/superset/db_engine_specs/pinot.py
+++ b/superset/db_engine_specs/pinot.py
@@ -112,9 +112,3 @@ class PinotEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method
             time_expr = f"DATETIMECONVERT({{col}}, '{tf}', '{tf}', '{granularity}')"
 
         return TimestampExpression(time_expr, col)
-
-    @classmethod
-    def make_select_compatible(
-        cls, groupby_exprs: Dict[str, ColumnElement], select_exprs: List[ColumnElement]
-    ) -> List[ColumnElement]:
-        return select_exprs

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -128,6 +128,7 @@ def get_children(column: Dict[str, str]) -> List[Dict[str, str]]:
 class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-methods
     engine = "presto"
     engine_name = "Presto"
+    need_table_name_in_orderby = True
 
     _time_grain_expressions = {
         None: "{col}",

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -128,7 +128,7 @@ def get_children(column: Dict[str, str]) -> List[Dict[str, str]]:
 class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-methods
     engine = "presto"
     engine_name = "Presto"
-    need_table_name_in_orderby = True
+    allows_alias_to_source_column = False
 
     _time_grain_expressions = {
         None: "{col}",

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1631,6 +1631,22 @@ def find_duplicates(items: Iterable[InputType]) -> List[InputType]:
     return [item for item, count in collections.Counter(items).items() if count > 1]
 
 
+def remove_duplicates(
+    items: Iterable[InputType], key: Optional[Callable[[InputType], Any]] = None
+) -> List[InputType]:
+    """Remove duplicate items in an iterable."""
+    if not key:
+        return list(dict.fromkeys(items).keys())
+    seen = set()
+    result = []
+    for item in items:
+        item_key = key(item)
+        if item_key not in seen:
+            seen.add(item_key)
+            result.append(item)
+    return result
+
+
 def normalize_dttm_col(
     df: pd.DataFrame,
     timestamp_format: Optional[str],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ from sqlalchemy.engine import Engine
 from tests.test_app import app
 
 from superset import db
-from superset.utils.core import get_example_database
+from superset.utils.core import get_example_database, json_dumps_w_dates
 
 
 CTAS_SCHEMA_NAME = "sqllab_test_db"
@@ -73,13 +73,22 @@ def drop_from_schema(engine: Engine, schema_name: str):
 
 def setup_presto_if_needed():
     backend = app.config["SQLALCHEMY_EXAMPLES_URI"].split("://")[0]
+    database = get_example_database()
+    extra = database.get_extra()
+
     if backend == "presto":
         # decrease poll interval for tests
-        presto_poll_interval = app.config["PRESTO_POLL_INTERVAL"]
-        extra = f'{{"engine_params": {{"connect_args": {{"poll_interval": {presto_poll_interval}}}}}}}'
-        database = get_example_database()
-        database.extra = extra
-        db.session.commit()
+        extra = {
+            **extra,
+            "engine_params": {
+                "connect_args": {"poll_interval": app.config["PRESTO_POLL_INTERVAL"]}
+            },
+        }
+    else:
+        # remove `poll_interval` from databases that do not support it
+        extra = {**extra, "engine_params": {}}
+    database.extra = json_dumps_w_dates(extra)
+    db.session.commit()
 
     if backend in {"presto", "hive"}:
         database = get_example_database()

--- a/tests/databases/commands_tests.py
+++ b/tests/databases/commands_tests.py
@@ -82,7 +82,10 @@ class TestExportDatabasesCommand(SupersetTestCase):
             "schemas_allowed_for_csv_upload": [],
         }
         if backend() == "presto":
-            expected_extra = {"engine_params": {"connect_args": {"poll_interval": 0.1}}}
+            expected_extra = {
+                **expected_extra,
+                "engine_params": {"connect_args": {"poll_interval": 0.1}},
+            }
 
         assert core_files.issubset(set(contents.keys()))
 

--- a/tests/fixtures/query_context.py
+++ b/tests/fixtures/query_context.py
@@ -56,21 +56,47 @@ QUERY_OBJECTS: Dict[str, Dict[str, object]] = {
         "metrics": [
             {
                 "expressionType": "SIMPLE",
+                "column": {"column_name": "num_girls", "type": "BIGINT(20)"},
+                "aggregate": "SUM",
+                "label": "num_girls",
+            },
+            {
+                "expressionType": "SIMPLE",
                 "column": {"column_name": "num_boys", "type": "BIGINT(20)"},
                 "aggregate": "SUM",
                 "label": "num_boys",
-            }
+            },
         ],
         "orderby": [
             [
                 {
                     "expressionType": "SIMPLE",
-                    "column": {"column_name": "num_boys", "type": "BIGINT(20)"},
+                    "column": {"column_name": "num_girls", "type": "BIGINT(20)"},
                     "aggregate": "SUM",
-                    "label": "SUM(num_boys)",
+                    # the same underlying expression, but different label
+                    "label": "SUM(num_girls)",
                 },
                 False,
-            ]
+            ],
+            # reference the ambiguous alias in SIMPLE metric
+            [
+                {
+                    "expressionType": "SIMPLE",
+                    "column": {"column_name": "num_boys", "type": "BIGINT(20)"},
+                    "aggregate": "AVG",
+                    "label": "AVG(num_boys)",
+                },
+                False,
+            ],
+            # reference the ambiguous alias in CUSTOM SQL metric
+            [
+                {
+                    "expressionType": "SQL",
+                    "sqlExpression": "MAX(CASE WHEN num_boys > 0 THEN 1 ELSE 0 END)",
+                    "label": "MAX(CASE WHEN...",
+                },
+                True,
+            ],
         ],
     },
     "birth_names:only_orderby_has_metric": {"metrics": [],},

--- a/tests/query_context_tests.py
+++ b/tests/query_context_tests.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import re
+from typing import Any, Dict
 
 import pytest
 
@@ -24,7 +25,6 @@ from superset.common.query_context import QueryContext
 from superset.common.query_object import QueryObject
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.extensions import cache_manager
-from superset.models.cache import CacheKey
 from superset.utils.core import (
     AdhocMetricExpressionType,
     backend,
@@ -37,7 +37,7 @@ from tests.fixtures.birth_names_dashboard import load_birth_names_dashboard_with
 from tests.fixtures.query_context import get_query_context
 
 
-def get_sql_text(payload: QueryContext) -> str:
+def get_sql_text(payload: Dict[str, Any]) -> str:
     payload["result_type"] = ChartDataResultType.QUERY.value
     query_context = ChartDataQueryContextSchema().load(payload)
     responses = query_context.get_payload()


### PR DESCRIPTION
### SUMMARY

Bugfixes for a couple of engine-specific issues in SQLA generator:

1. Issue 1 in #13228 (in Presto, SELECT alias cannot be the same as a source column if used in ORDER BY). 
2. ORDER BY metrics in Hive could not reference a metric not used in SELECT.

Adding two `DBEngineSpec` attributes to handle these cases. We can potentially just: 1) always use random strings for column aliases; 2) always add ORDER BY metrics to SELECT, but adding these flags helps keep the generated SQL clean.


Closes #13228 
Closes #13426

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### Presto / Before

When a metric has a label named the same as an existing column, adding "Sort by" aggregations on this column will generate invalid Presto queries and throw an error:

<img width="902" alt="dup-alias-before-query" src="https://user-images.githubusercontent.com/335541/112191181-fda07600-8bc2-11eb-9731-58fcc2aac439.png">

<img width="881" alt="dup-alias-before" src="https://user-images.githubusercontent.com/335541/112191148-f4170e00-8bc2-11eb-91ba-817525271407.png">

The root cause in Presto is https://github.com/prestodb/presto/issues/4698 but it seems Presto has no plan to fix this issue.

### Presto / After

<img width="867" alt="dup-alias-after" src="https://user-images.githubusercontent.com/335541/112191517-55d77800-8bc3-11eb-87fe-66d6449b4996.png">

<img width="905" alt="dup-alias-after-query" src="https://user-images.githubusercontent.com/335541/112191538-5a039580-8bc3-11eb-8477-67ee4396501e.png">

Column alias in the SELECT query was updated but it shouldn't affect column names in charts (including the Data preview panel) because columns are updated post-query anyway.

### Hive / Before

<img width="894" alt="hive-before" src="https://user-images.githubusercontent.com/335541/112191772-959e5f80-8bc3-11eb-884f-47eb8ec9b86d.png">

Sort by metrics (aggregation clause) are directly created in ORDER BY, which doesn't work in Hive. It throws a "Invalid table alias or column reference" error.

### Hive / After

<img width="893" alt="hive-after" src="https://user-images.githubusercontent.com/335541/112191999-cbdbdf00-8bc3-11eb-947b-190c7a94166d.png">

Always add ORDER BY clauses to select and use aliases to reference them in ORDER BY.

### TEST PLAN

Manually tested with local Presto and Hive clusters. To start your own, run these commands:

```
# start a Presto cluster in the foreground
docker run -d -p 127.0.0.1:17777:8080 --name presto starburstdata/presto

# Start a local Hive cluster in the foreground
docker-compose -f scripts/databases/hive/docker-compose.yml up
```

Then create new Databases in Superset.

Go to SQL Lab, use this query to create a sample virtual table:

```sql
SELECT name, score
FROM (
  SELECT 'aaa' as name, 1.1231 as score
  UNION
  SELECT 'bac', 0.39e-14
  UNION
  SELECT 'aaa', 10e19
) t
```

Also added some unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
