### PR TITLE
fix: Disallows negative options remaining in SelectControl

### DIFF
--- a/superset-frontend/src/explore/components/controls/SelectControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.jsx
@@ -204,7 +204,7 @@ export default class SelectControl extends React.PureComponent {
     if (this.optionsIncludesSelectAll(options)) {
       remainingOptions -= 1;
     }
-    return remainingOptions;
+    return remainingOptions < 0 ? 0 : remainingOptions;
   }
 
   createMetaSelectAllOption() {


### PR DESCRIPTION
### SUMMARY
Disallows negative options remaining in `SelectControl`. When a `SelectControl` has no options available, the user can still enter values and this caused the assistive text to contain negative values.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="193" alt="Screen Shot 2021-03-23 at 3 19 33 PM" src="https://user-images.githubusercontent.com/70410625/112198003-71567900-8beb-11eb-9f20-c03d1ddf31b6.png">
<img width="194" alt="Screen Shot 2021-03-23 at 3 20 14 PM" src="https://user-images.githubusercontent.com/70410625/112198006-7287a600-8beb-11eb-8f40-486b5a59073a.png">

### TEST PLAN
1 - Find a `SelectControl` with no options available (polygon chart -> customize for example).
2 - Enter arbitrary text as a value.
3 - No assistive text should be displayed.

@rusackas @junlincc 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
