### PR TITLE
feat(alerts & reports): Easier to read execution logs

### DIFF
--- a/superset-frontend/spec/javascripts/views/CRUD/alert/ExecutionLog_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/alert/ExecutionLog_spec.jsx
@@ -43,6 +43,7 @@ const mockannotations = [...new Array(3)].map((_, i) => ({
   start_dttm: new Date().toISOString,
   state: 'Success',
   value: `report ${i} value`,
+  uuid: "f44da495-b067-4645-b463-3be98d5f3206",
 }));
 
 fetchMock.get(executionLogsEndpoint, {

--- a/superset-frontend/spec/javascripts/views/CRUD/alert/ExecutionLog_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/alert/ExecutionLog_spec.jsx
@@ -43,7 +43,7 @@ const mockannotations = [...new Array(3)].map((_, i) => ({
   start_dttm: new Date().toISOString,
   state: 'Success',
   value: `report ${i} value`,
-  uuid: "f44da495-b067-4645-b463-3be98d5f3206",
+  uuid: 'f44da495-b067-4645-b463-3be98d5f3206',
 }));
 
 fetchMock.get(executionLogsEndpoint, {

--- a/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
+++ b/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
@@ -83,6 +83,11 @@ function ExecutionLog({ addDangerToast, isReportEnabled }: ExecutionLogProps) {
   const columns = useMemo(
     () => [
       {
+        Cell: ({
+          row: {
+            original: { execution_id: executionId },
+          },
+        }: any) => executionId.slice(0, 6),
         accessor: 'execution_id',
         Header: t('Execution ID'),
         size: 'xs',

--- a/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
+++ b/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
@@ -85,17 +85,6 @@ function ExecutionLog({ addDangerToast, isReportEnabled }: ExecutionLogProps) {
       {
         Cell: ({
           row: {
-            original: { execution_id: executionId },
-          },
-        }: any) => executionId.slice(0, 6),
-        accessor: 'execution_id',
-        Header: t('Execution ID'),
-        size: 'xs',
-        disableSortBy: true,
-      },
-      {
-        Cell: ({
-          row: {
             original: { state },
           },
         }: any) => (
@@ -103,6 +92,17 @@ function ExecutionLog({ addDangerToast, isReportEnabled }: ExecutionLogProps) {
         ),
         accessor: 'state',
         Header: t('State'),
+        size: 'xs',
+        disableSortBy: true,
+      },
+      {
+        Cell: ({
+          row: {
+            original: { execution_id: executionId },
+          },
+        }: any) => executionId.slice(0, 6),
+        accessor: 'execution_id',
+        Header: t('Execution ID'),
         size: 'xs',
         disableSortBy: true,
       },

--- a/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
+++ b/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
@@ -98,10 +98,10 @@ function ExecutionLog({ addDangerToast, isReportEnabled }: ExecutionLogProps) {
       {
         Cell: ({
           row: {
-            original: { execution_id: executionId },
+            original: { uuid: executionId },
           },
         }: any) => executionId.slice(0, 6),
-        accessor: 'execution_id',
+        accessor: 'uuid',
         Header: t('Execution ID'),
         size: 'xs',
         disableSortBy: true,

--- a/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
+++ b/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
@@ -83,6 +83,12 @@ function ExecutionLog({ addDangerToast, isReportEnabled }: ExecutionLogProps) {
   const columns = useMemo(
     () => [
       {
+        accessor: 'execution_id',
+        Header: t('Execution ID'),
+        size: 'xs',
+        disableSortBy: true,
+      },
+      {
         Cell: ({
           row: {
             original: { state },

--- a/superset-frontend/src/views/CRUD/alert/types.ts
+++ b/superset-frontend/src/views/CRUD/alert/types.ts
@@ -91,7 +91,7 @@ export type LogObject = {
   start_dttm: string;
   state: string;
   value: string;
-  execution_id: number;
+  execution_id: string;
 };
 
 export enum AlertState {

--- a/superset-frontend/src/views/CRUD/alert/types.ts
+++ b/superset-frontend/src/views/CRUD/alert/types.ts
@@ -91,6 +91,7 @@ export type LogObject = {
   start_dttm: string;
   state: string;
   value: string;
+  execution_id: number;
 };
 
 export enum AlertState {

--- a/superset-frontend/src/views/CRUD/alert/types.ts
+++ b/superset-frontend/src/views/CRUD/alert/types.ts
@@ -91,7 +91,7 @@ export type LogObject = {
   start_dttm: string;
   state: string;
   value: string;
-  execution_id: string;
+  uuid: string;
 };
 
 export enum AlertState {

--- a/superset/migrations/versions/301362411006_add_execution_id_to_report_execution_.py
+++ b/superset/migrations/versions/301362411006_add_execution_id_to_report_execution_.py
@@ -28,12 +28,13 @@ down_revision = '67da9ef1ef9c'
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy_utils import UUIDType
 
 
 def upgrade():
     op.add_column(
         'report_execution_log',
-        sa.Column('execution_id', sa.VARCHAR(length=50), nullable=True)
+        sa.Column('uuid', UUIDType(binary=True))
     )
 
   

--- a/superset/migrations/versions/301362411006_add_execution_id_to_report_execution_.py
+++ b/superset/migrations/versions/301362411006_add_execution_id_to_report_execution_.py
@@ -33,7 +33,7 @@ import sqlalchemy as sa
 def upgrade():
     op.add_column(
         'report_execution_log',
-        sa.Column('execution_id', sa.Integer(), nullable=True)
+        sa.Column('execution_id', sa.VARCHAR(length=50), nullable=True)
     )
 
   

--- a/superset/migrations/versions/301362411006_add_execution_id_to_report_execution_.py
+++ b/superset/migrations/versions/301362411006_add_execution_id_to_report_execution_.py
@@ -17,14 +17,14 @@
 """add_execution_id_to_report_execution_log_model.py
 
 Revision ID: 301362411006
-Revises: 67da9ef1ef9c
+Revises: 989bbe479899
 Create Date: 2021-03-23 05:23:15.641856
 
 """
 
 # revision identifiers, used by Alembic.
 revision = "301362411006"
-down_revision = "67da9ef1ef9c"
+down_revision = "989bbe479899"
 
 import sqlalchemy as sa
 from alembic import op

--- a/superset/migrations/versions/301362411006_add_execution_id_to_report_execution_.py
+++ b/superset/migrations/versions/301362411006_add_execution_id_to_report_execution_.py
@@ -23,20 +23,17 @@ Create Date: 2021-03-23 05:23:15.641856
 """
 
 # revision identifiers, used by Alembic.
-revision = '301362411006'
-down_revision = '67da9ef1ef9c'
+revision = "301362411006"
+down_revision = "67da9ef1ef9c"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy_utils import UUIDType
 
 
 def upgrade():
-    op.add_column(
-        'report_execution_log',
-        sa.Column('uuid', UUIDType(binary=True))
-    )
+    op.add_column("report_execution_log", sa.Column("uuid", UUIDType(binary=True)))
 
-  
+
 def downgrade():
-    op.drop_column('report_execution_log', 'execution_id')
+    op.drop_column("report_execution_log", "execution_id")

--- a/superset/migrations/versions/301362411006_add_execution_id_to_report_execution_.py
+++ b/superset/migrations/versions/301362411006_add_execution_id_to_report_execution_.py
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add_execution_id_to_report_execution_log_model.py
+
+Revision ID: 301362411006
+Revises: 67da9ef1ef9c
+Create Date: 2021-03-23 05:23:15.641856
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '301362411006'
+down_revision = '67da9ef1ef9c'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column(
+        'report_execution_log',
+        sa.Column('execution_id', sa.Integer(), nullable=True)
+    )
+
+  
+def downgrade():
+    op.drop_column('report_execution_log', 'execution_id')

--- a/superset/models/reports.py
+++ b/superset/models/reports.py
@@ -171,6 +171,7 @@ class ReportExecutionLog(Model):  # pylint: disable=too-few-public-methods
 
     __tablename__ = "report_execution_log"
     id = Column(Integer, primary_key=True)
+    execution_id = Column(Integer)
 
     # Timestamps
     scheduled_dttm = Column(DateTime, nullable=False)

--- a/superset/models/reports.py
+++ b/superset/models/reports.py
@@ -171,7 +171,7 @@ class ReportExecutionLog(Model):  # pylint: disable=too-few-public-methods
 
     __tablename__ = "report_execution_log"
     id = Column(Integer, primary_key=True)
-    execution_id = Column(Integer)
+    execution_id = Column(String(50))
 
     # Timestamps
     scheduled_dttm = Column(DateTime, nullable=False)

--- a/superset/models/reports.py
+++ b/superset/models/reports.py
@@ -33,6 +33,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import backref, relationship
 from sqlalchemy.schema import UniqueConstraint
+from sqlalchemy_utils import UUIDType
 
 from superset.extensions import security_manager
 from superset.models.core import Database
@@ -171,7 +172,7 @@ class ReportExecutionLog(Model):  # pylint: disable=too-few-public-methods
 
     __tablename__ = "report_execution_log"
     id = Column(Integer, primary_key=True)
-    execution_id = Column(String(50))
+    uuid = Column(UUIDType(binary=True))
 
     # Timestamps
     scheduled_dttm = Column(DateTime, nullable=False)

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -17,7 +17,7 @@
 import logging
 from datetime import datetime, timedelta
 from typing import Any, List, Optional
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from celery.exceptions import SoftTimeLimitExceeded
 from flask_appbuilder.security.sqla.models import User

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -407,7 +407,7 @@ class ReportScheduleStateMachine:  # pylint: disable=too-few-public-methods
         self._session = session
         self._report_schedule = report_schedule
         self._scheduled_dttm = scheduled_dttm
-        self._execution_id = randint(1, 99999)
+        self._execution_id = randint(10000, 99999)
 
     def run(self) -> None:
         state_found = False

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -17,7 +17,7 @@
 import logging
 from datetime import datetime, timedelta
 from typing import Any, List, Optional
-from uuid import uuid4
+from uuid import uuid4, UUID
 
 from celery.exceptions import SoftTimeLimitExceeded
 from flask_appbuilder.security.sqla.models import User
@@ -74,7 +74,7 @@ class BaseReportState:
         session: Session,
         report_schedule: ReportSchedule,
         scheduled_dttm: datetime,
-        execution_id: str
+        execution_id: UUID,
     ) -> None:
         self._session = session
         self._report_schedule = report_schedule
@@ -120,7 +120,7 @@ class BaseReportState:
             state=state,
             error_message=error_message,
             report_schedule=self._report_schedule,
-            execution_id=self._execution_id,
+            uuid=self._execution_id,
         )
         self._session.add(log)
         self._session.commit()
@@ -407,7 +407,7 @@ class ReportScheduleStateMachine:  # pylint: disable=too-few-public-methods
         self._session = session
         self._report_schedule = report_schedule
         self._scheduled_dttm = scheduled_dttm
-        self._execution_id = str(uuid4())
+        self._execution_id = uuid4()
 
     def run(self) -> None:
         state_found = False

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -407,7 +407,7 @@ class ReportScheduleStateMachine:  # pylint: disable=too-few-public-methods
         self._session = session
         self._report_schedule = report_schedule
         self._scheduled_dttm = scheduled_dttm
-        self._execution_id = randint(10000, 99999)
+        self._execution_id = randint(10000000, 99999999)
 
     def run(self) -> None:
         state_found = False

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -17,7 +17,7 @@
 import logging
 from datetime import datetime, timedelta
 from typing import Any, List, Optional
-from random import randint
+from uuid import uuid4
 
 from celery.exceptions import SoftTimeLimitExceeded
 from flask_appbuilder.security.sqla.models import User
@@ -407,7 +407,7 @@ class ReportScheduleStateMachine:  # pylint: disable=too-few-public-methods
         self._session = session
         self._report_schedule = report_schedule
         self._scheduled_dttm = scheduled_dttm
-        self._execution_id = randint(10000000, 99999999)
+        self._execution_id = str(uuid4())
 
     def run(self) -> None:
         state_found = False

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -74,7 +74,7 @@ class BaseReportState:
         session: Session,
         report_schedule: ReportSchedule,
         scheduled_dttm: datetime,
-        execution_id: int
+        execution_id: str
     ) -> None:
         self._session = session
         self._report_schedule = report_schedule

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -17,7 +17,7 @@
 import logging
 from datetime import datetime, timedelta
 from typing import Any, List, Optional
-from uuid import uuid4, UUID
+from uuid import UUID, uuid4
 
 from celery.exceptions import SoftTimeLimitExceeded
 from flask_appbuilder.security.sqla.models import User
@@ -419,7 +419,7 @@ class ReportScheduleStateMachine:  # pylint: disable=too-few-public-methods
                     self._session,
                     self._report_schedule,
                     self._scheduled_dttm,
-                    self._execution_id
+                    self._execution_id,
                 ).next()
                 state_found = True
                 break

--- a/superset/reports/logs/api.py
+++ b/superset/reports/logs/api.py
@@ -49,7 +49,7 @@ class ReportExecutionLogRestApi(BaseSupersetModelRestApi):
         "value_row_json",
         "state",
         "error_message",
-        "execution_id",
+        "uuid",
     ]
     list_columns = [
         "id",
@@ -60,7 +60,7 @@ class ReportExecutionLogRestApi(BaseSupersetModelRestApi):
         "value_row_json",
         "state",
         "error_message",
-        "execution_id",
+        "uuid",
     ]
     order_columns = [
         "state",

--- a/superset/reports/logs/api.py
+++ b/superset/reports/logs/api.py
@@ -49,6 +49,7 @@ class ReportExecutionLogRestApi(BaseSupersetModelRestApi):
         "value_row_json",
         "state",
         "error_message",
+        "execution_id",
     ]
     list_columns = [
         "id",
@@ -59,6 +60,7 @@ class ReportExecutionLogRestApi(BaseSupersetModelRestApi):
         "value_row_json",
         "state",
         "error_message",
+        "execution_id",
     ]
     order_columns = [
         "state",

--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -63,8 +63,9 @@ def scheduler() -> None:
 @celery_app.task(name="reports.execute")
 def execute(report_schedule_id: int, scheduled_dttm: str) -> None:
     try:
+        task_id = execute.request.id
         scheduled_dttm_ = parser.parse(scheduled_dttm)
-        AsyncExecuteReportScheduleCommand(report_schedule_id, scheduled_dttm_).run()
+        AsyncExecuteReportScheduleCommand(task_id, report_schedule_id, scheduled_dttm_).run()
     except ReportScheduleUnexpectedError as ex:
         logger.error("An unexpected occurred while executing the report: %s", ex)
     except CommandException as ex:

--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -66,9 +66,7 @@ def execute(report_schedule_id: int, scheduled_dttm: str) -> None:
         task_id = execute.request.id
         scheduled_dttm_ = parser.parse(scheduled_dttm)
         AsyncExecuteReportScheduleCommand(
-            task_id,
-            report_schedule_id,
-            scheduled_dttm_,
+            task_id, report_schedule_id, scheduled_dttm_,
         ).run()
     except ReportScheduleUnexpectedError as ex:
         logger.error("An unexpected occurred while executing the report: %s", ex)

--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -65,7 +65,11 @@ def execute(report_schedule_id: int, scheduled_dttm: str) -> None:
     try:
         task_id = execute.request.id
         scheduled_dttm_ = parser.parse(scheduled_dttm)
-        AsyncExecuteReportScheduleCommand(task_id, report_schedule_id, scheduled_dttm_).run()
+        AsyncExecuteReportScheduleCommand(
+            task_id,
+            report_schedule_id,
+            scheduled_dttm_,
+        ).run()
     except ReportScheduleUnexpectedError as ex:
         logger.error("An unexpected occurred while executing the report: %s", ex)
     except CommandException as ex:

--- a/tests/reports/commands_tests.py
+++ b/tests/reports/commands_tests.py
@@ -18,6 +18,7 @@ import json
 from datetime import datetime, timedelta
 from typing import List, Optional
 from unittest.mock import Mock, patch
+from uuid import uuid4
 
 import pytest
 from contextlib2 import contextmanager
@@ -63,6 +64,8 @@ from tests.utils import read_fixture
 pytestmark = pytest.mark.usefixtures(
     "load_world_bank_dashboard_with_slices_module_scope"
 )
+
+test_id = str(uuid4())
 
 
 def get_target_from_report_schedule(report_schedule: ReportSchedule) -> List[str]:
@@ -518,7 +521,7 @@ def test_email_chart_report_schedule(
 
     with freeze_time("2020-01-01T00:00:00Z"):
         AsyncExecuteReportScheduleCommand(
-            create_report_email_chart.id, datetime.utcnow()
+            test_id, create_report_email_chart.id, datetime.utcnow()
         ).run()
 
         notification_targets = get_target_from_report_schedule(
@@ -556,7 +559,7 @@ def test_email_dashboard_report_schedule(
 
     with freeze_time("2020-01-01T00:00:00Z"):
         AsyncExecuteReportScheduleCommand(
-            create_report_email_dashboard.id, datetime.utcnow()
+            test_id, create_report_email_dashboard.id, datetime.utcnow()
         ).run()
 
         notification_targets = get_target_from_report_schedule(
@@ -588,7 +591,7 @@ def test_slack_chart_report_schedule(
 
     with freeze_time("2020-01-01T00:00:00Z"):
         AsyncExecuteReportScheduleCommand(
-            create_report_slack_chart.id, datetime.utcnow()
+            test_id, create_report_slack_chart.id, datetime.utcnow()
         ).run()
 
         notification_targets = get_target_from_report_schedule(
@@ -608,7 +611,7 @@ def test_report_schedule_not_found(create_report_slack_chart):
     """
     max_id = db.session.query(func.max(ReportSchedule.id)).scalar()
     with pytest.raises(ReportScheduleNotFoundError):
-        AsyncExecuteReportScheduleCommand(max_id + 1, datetime.utcnow()).run()
+        AsyncExecuteReportScheduleCommand(test_id, max_id + 1, datetime.utcnow()).run()
 
 
 @pytest.mark.usefixtures("create_report_slack_chart_working")
@@ -620,7 +623,7 @@ def test_report_schedule_working(create_report_slack_chart_working):
     with freeze_time("2020-01-01T00:00:00Z"):
         with pytest.raises(ReportSchedulePreviousWorkingError):
             AsyncExecuteReportScheduleCommand(
-                create_report_slack_chart_working.id, datetime.utcnow()
+                test_id, create_report_slack_chart_working.id, datetime.utcnow()
             ).run()
 
         assert_log(
@@ -643,7 +646,7 @@ def test_report_schedule_working_timeout(create_report_slack_chart_working):
     with freeze_time(current_time):
         with pytest.raises(ReportScheduleWorkingTimeoutError):
             AsyncExecuteReportScheduleCommand(
-                create_report_slack_chart_working.id, datetime.utcnow()
+                test_id, create_report_slack_chart_working.id, datetime.utcnow()
             ).run()
 
     # Only needed for MySQL, understand why
@@ -668,7 +671,7 @@ def test_report_schedule_success_grace(create_alert_slack_chart_success):
 
     with freeze_time(current_time):
         AsyncExecuteReportScheduleCommand(
-            create_alert_slack_chart_success.id, datetime.utcnow()
+            test_id, create_alert_slack_chart_success.id, datetime.utcnow()
         ).run()
 
     db.session.commit()
@@ -687,7 +690,7 @@ def test_report_schedule_success_grace_end(create_alert_slack_chart_grace):
 
     with freeze_time(current_time):
         AsyncExecuteReportScheduleCommand(
-            create_alert_slack_chart_grace.id, datetime.utcnow()
+            test_id, create_alert_slack_chart_grace.id, datetime.utcnow()
         ).run()
 
     db.session.commit()
@@ -711,7 +714,7 @@ def test_alert_limit_is_applied(screenshot_mock, email_mock, create_alert_email_
             return_value=None,
         ) as fetch_data_mock:
             AsyncExecuteReportScheduleCommand(
-                create_alert_email_chart.id, datetime.utcnow()
+                test_id, create_alert_email_chart.id, datetime.utcnow()
             ).run()
             assert "LIMIT 2" in execute_mock.call_args[0][1]
 
@@ -736,7 +739,7 @@ def test_email_dashboard_report_fails(
 
     with pytest.raises(ReportScheduleNotificationError):
         AsyncExecuteReportScheduleCommand(
-            create_report_email_dashboard.id, datetime.utcnow()
+            test_id, create_report_email_dashboard.id, datetime.utcnow()
         ).run()
 
     assert_log(ReportState.ERROR, error_message="Could not connect to SMTP XPTO")
@@ -757,7 +760,7 @@ def test_slack_chart_alert(screenshot_mock, email_mock, create_alert_email_chart
 
     with freeze_time("2020-01-01T00:00:00Z"):
         AsyncExecuteReportScheduleCommand(
-            create_alert_email_chart.id, datetime.utcnow()
+            test_id, create_alert_email_chart.id, datetime.utcnow()
         ).run()
 
         notification_targets = get_target_from_report_schedule(create_alert_email_chart)
@@ -789,7 +792,7 @@ def test_slack_token_callable_chart_report(
 
     with freeze_time("2020-01-01T00:00:00Z"):
         AsyncExecuteReportScheduleCommand(
-            create_report_slack_chart.id, datetime.utcnow()
+            test_id, create_report_slack_chart.id, datetime.utcnow()
         ).run()
         app.config["SLACK_API_TOKEN"].assert_called_once()
         assert slack_client_mock_class.called_with(token="cool_code", proxy="")
@@ -803,7 +806,7 @@ def test_email_chart_no_alert(create_no_alert_email_chart):
     """
     with freeze_time("2020-01-01T00:00:00Z"):
         AsyncExecuteReportScheduleCommand(
-            create_no_alert_email_chart.id, datetime.utcnow()
+            test_id, create_no_alert_email_chart.id, datetime.utcnow()
         ).run()
     assert_log(ReportState.NOOP)
 
@@ -818,7 +821,7 @@ def test_email_mul_alert(create_mul_alert_email_chart):
             (AlertQueryMultipleRowsError, AlertQueryMultipleColumnsError)
         ):
             AsyncExecuteReportScheduleCommand(
-                create_mul_alert_email_chart.id, datetime.utcnow()
+                test_id, create_mul_alert_email_chart.id, datetime.utcnow()
             ).run()
 
 
@@ -839,7 +842,7 @@ def test_soft_timeout_alert(email_mock, create_alert_email_chart):
         execute_mock.side_effect = SoftTimeLimitExceeded()
         with pytest.raises(AlertQueryTimeout):
             AsyncExecuteReportScheduleCommand(
-                create_alert_email_chart.id, datetime.utcnow()
+                test_id, create_alert_email_chart.id, datetime.utcnow()
             ).run()
 
     notification_targets = get_target_from_report_schedule(create_alert_email_chart)
@@ -866,7 +869,7 @@ def test_soft_timeout_screenshot(screenshot_mock, email_mock, create_alert_email
     screenshot_mock.side_effect = SoftTimeLimitExceeded()
     with pytest.raises(ReportScheduleScreenshotTimeout):
         AsyncExecuteReportScheduleCommand(
-            create_alert_email_chart.id, datetime.utcnow()
+            test_id, create_alert_email_chart.id, datetime.utcnow()
         ).run()
 
     notification_targets = get_target_from_report_schedule(create_alert_email_chart)
@@ -893,7 +896,7 @@ def test_fail_screenshot(screenshot_mock, email_mock, create_alert_email_chart):
     screenshot_mock.side_effect = Exception("Unexpected error")
     with pytest.raises(ReportScheduleScreenshotFailedError):
         AsyncExecuteReportScheduleCommand(
-            create_alert_email_chart.id, datetime.utcnow()
+            test_id, create_alert_email_chart.id, datetime.utcnow()
         ).run()
 
     notification_targets = get_target_from_report_schedule(create_alert_email_chart)
@@ -914,7 +917,7 @@ def test_invalid_sql_alert(email_mock, create_invalid_sql_alert_email_chart):
     with freeze_time("2020-01-01T00:00:00Z"):
         with pytest.raises((AlertQueryError, AlertQueryInvalidTypeError)):
             AsyncExecuteReportScheduleCommand(
-                create_invalid_sql_alert_email_chart.id, datetime.utcnow()
+                test_id, create_invalid_sql_alert_email_chart.id, datetime.utcnow()
             ).run()
 
         notification_targets = get_target_from_report_schedule(
@@ -933,7 +936,7 @@ def test_grace_period_error(email_mock, create_invalid_sql_alert_email_chart):
     with freeze_time("2020-01-01T00:00:00Z"):
         with pytest.raises((AlertQueryError, AlertQueryInvalidTypeError)):
             AsyncExecuteReportScheduleCommand(
-                create_invalid_sql_alert_email_chart.id, datetime.utcnow()
+                test_id, create_invalid_sql_alert_email_chart.id, datetime.utcnow()
             ).run()
 
         # Only needed for MySQL, understand why
@@ -950,7 +953,7 @@ def test_grace_period_error(email_mock, create_invalid_sql_alert_email_chart):
     with freeze_time("2020-01-01T00:30:00Z"):
         with pytest.raises((AlertQueryError, AlertQueryInvalidTypeError)):
             AsyncExecuteReportScheduleCommand(
-                create_invalid_sql_alert_email_chart.id, datetime.utcnow()
+                test_id, create_invalid_sql_alert_email_chart.id, datetime.utcnow()
             ).run()
         db.session.commit()
         assert (
@@ -961,7 +964,7 @@ def test_grace_period_error(email_mock, create_invalid_sql_alert_email_chart):
     with freeze_time("2020-01-01T01:30:00Z"):
         with pytest.raises((AlertQueryError, AlertQueryInvalidTypeError)):
             AsyncExecuteReportScheduleCommand(
-                create_invalid_sql_alert_email_chart.id, datetime.utcnow()
+                test_id, create_invalid_sql_alert_email_chart.id, datetime.utcnow()
             ).run()
         db.session.commit()
         assert (
@@ -981,7 +984,7 @@ def test_grace_period_error_flap(
     with freeze_time("2020-01-01T00:00:00Z"):
         with pytest.raises((AlertQueryError, AlertQueryInvalidTypeError)):
             AsyncExecuteReportScheduleCommand(
-                create_invalid_sql_alert_email_chart.id, datetime.utcnow()
+                test_id, create_invalid_sql_alert_email_chart.id, datetime.utcnow()
             ).run()
         db.session.commit()
         # Assert we have 1 notification sent on the log
@@ -992,7 +995,7 @@ def test_grace_period_error_flap(
     with freeze_time("2020-01-01T00:30:00Z"):
         with pytest.raises((AlertQueryError, AlertQueryInvalidTypeError)):
             AsyncExecuteReportScheduleCommand(
-                create_invalid_sql_alert_email_chart.id, datetime.utcnow()
+                test_id, create_invalid_sql_alert_email_chart.id, datetime.utcnow()
             ).run()
         db.session.commit()
         assert (
@@ -1008,11 +1011,11 @@ def test_grace_period_error_flap(
     with freeze_time("2020-01-01T00:31:00Z"):
         # One success
         AsyncExecuteReportScheduleCommand(
-            create_invalid_sql_alert_email_chart.id, datetime.utcnow()
+            test_id, create_invalid_sql_alert_email_chart.id, datetime.utcnow()
         ).run()
         # Grace period ends
         AsyncExecuteReportScheduleCommand(
-            create_invalid_sql_alert_email_chart.id, datetime.utcnow()
+            test_id, create_invalid_sql_alert_email_chart.id, datetime.utcnow()
         ).run()
 
         db.session.commit()
@@ -1027,7 +1030,7 @@ def test_grace_period_error_flap(
     with freeze_time("2020-01-01T00:32:00Z"):
         with pytest.raises((AlertQueryError, AlertQueryInvalidTypeError)):
             AsyncExecuteReportScheduleCommand(
-                create_invalid_sql_alert_email_chart.id, datetime.utcnow()
+                test_id, create_invalid_sql_alert_email_chart.id, datetime.utcnow()
             ).run()
         db.session.commit()
         assert (


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Currently, reading execution logs for alerts and reports can be confusing.  Several log entries can be created by a single execution run, but nothing indicates that they are part of the same execution, except that they have the same timestamp.

This PR gives each execution a UUID which is truncated to 6 characters on the execution log view.  This way, it will be much easier to tell which log entries belong to which execution.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:
![Screen Shot 2021-03-23 at 1 33 22 PM](https://user-images.githubusercontent.com/47196419/112214412-6516ef80-8bdc-11eb-984b-77bbfdfc8de7.png)

After:
![Screen Shot 2021-03-23 at 1 34 44 PM](https://user-images.githubusercontent.com/47196419/112214567-955e8e00-8bdc-11eb-9bae-e14a07bd11e2.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
I've only tested manually.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [x] Requires DB Migration.
- [x] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
