### PR TITLE
fix(CI): use Presto docker image from starburst

### DIFF
--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -33,7 +33,7 @@ jobs:
           # GitHub action runner's default installations
           - 15432:5432
       presto:
-        image: prestosql/presto:339
+        image: starburstdata/presto:350-e.6
         env:
           POSTGRES_USER: superset
           POSTGRES_PASSWORD: superset


### PR DESCRIPTION
### SUMMARY

Docker image `prestosql/presto` is renamed to `trinodb/trino` and [`prestosql/presto`](https://hub.docker.com/u/prestosql/presto) now returns 404. 

TrinoDB is also open source, however, it does not support connecting with PyHive's Presto client (you will get a `must use Basic Auth or provide a "X-Trino-User" user header` error if you try to do it).

The company behind Trino, Startburst, does provide a Presto-compatible version of Trino, published under [`starburstdata/presto`](https://hub.docker.com/r/starburstdata/presto).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

CI should be fixed.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
