### PR TITLE
chore(CI): dont run Hive tests on Py 3.7

### DIFF
--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        # run unit tests in multiple version just for fun
         python-version: [3.8]
     env:
       PYTHONPATH: ${{ github.workspace }}
@@ -89,8 +88,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        # run unit tests in multiple version just for fun
-        python-version: [3.7, 3.8]
+        python-version: [3.8]
     env:
       PYTHONPATH: ${{ github.workspace }}
       SUPERSET_CONFIG: tests.superset_test_config


### PR DESCRIPTION
### SUMMARY

Skip Python 3.7 for Hive-based unit tests to free up precious CI queue slots.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

CI should pass

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
