### PR TITLE
chore: Add CODEOWNERS for superset/migrations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Notify all committers of DB migration changes, per SIP-59
+# https://github.com/apache/superset/issues/13351
+/superset/migrations/ @apache/superset-committers


### PR DESCRIPTION
### SUMMARY
Per SIP-59 (https://github.com/apache/superset/issues/13351), add `CODEOWNERS` for DB migrations.

_NOTE: apparently this will not work due to the GitHub team referenced here not being visible, so I'm opening an [INFRA ticket](https://issues.apache.org/jira/browse/INFRA-21611) change the team visibility._

### TEST PLAN
Any changes to files under `/superset/migrations/` should notify all committers.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: https://github.com/apache/superset/issues/13351
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
