### PR TITLE
chore(git): ignore app folder under superset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ superset.egg-info/
 superset/bin/supersetc
 tmp
 rat-results.txt
+superset/app/
 
 # Node.js, webpack artifacts
 *.entry.js


### PR DESCRIPTION
Uploading a file generates this folder in the form of /app/static/uploads.

I believe it is for runtime/build assets so ignore it would be useful

![image](https://user-images.githubusercontent.com/1297759/112274231-4e7da080-8c8f-11eb-9f55-5df38e6858c7.png)
