### PR TITLE
fix(dashboard): rename native filter configuration property

### DIFF
--- a/superset/migrations/versions/989bbe479899_rename_filter_configuration_in_.py
+++ b/superset/migrations/versions/989bbe479899_rename_filter_configuration_in_.py
@@ -1,0 +1,103 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""rename_filter_configuration_in_dashboard_metadata.py
+
+Revision ID: 989bbe479899
+Revises: 67da9ef1ef9c
+Create Date: 2021-03-24 09:47:21.569508
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "989bbe479899"
+down_revision = "67da9ef1ef9c"
+
+import json
+
+from alembic import op
+from sqlalchemy import and_, Column, Integer, Text
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
+
+Base = declarative_base()
+
+
+class Dashboard(Base):
+    """Declarative class to do query in upgrade"""
+
+    __tablename__ = "dashboards"
+    id = Column(Integer, primary_key=True)
+    json_metadata = Column(Text)
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    dashboards = (
+        session.query(Dashboard)
+        .filter(Dashboard.json_metadata.like('%"filter_configuration"%'))
+        .all()
+    )
+    changes = 0
+    for dashboard in dashboards:
+        try:
+            json_metadata = json.loads(dashboard.json_metadata)
+            filter_configuration = json_metadata.pop("filter_configuration", None)
+            if filter_configuration:
+                changes += 1
+                json_metadata["native_filter_configuration"] = filter_configuration
+                dashboard.json_metadata = json.dumps(json_metadata, sort_keys=True)
+        except Exception as e:
+            print(e)
+            print(f"Parsing json_metadata for dashboard {dashboard.id} failed.")
+            pass
+
+    session.commit()
+    session.close()
+    print(f"Updated {changes} native filter configurations.")
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    dashboards = (
+        session.query(Dashboard)
+        .filter(Dashboard.json_metadata.like('%"native_filter_configuration"%'))
+        .all()
+    )
+    changes = 0
+    for dashboard in dashboards:
+        try:
+            json_metadata = json.loads(dashboard.json_metadata)
+            native_filter_configuration = json_metadata.pop(
+                "native_filter_configuration", None
+            )
+            if native_filter_configuration:
+                changes += 1
+                json_metadata["filter_configuration"] = native_filter_configuration
+                dashboard.json_metadata = json.dumps(json_metadata, sort_keys=True)
+        except Exception as e:
+            print(e)
+            print(f"Parsing json_metadata for dashboard {dashboard.id} failed.")
+            pass
+
+    session.commit()
+    session.close()
+    print(f"Updated {changes} pie chart labels.")


### PR DESCRIPTION
### SUMMARY
The PR #13625 introduced a regression in the native filters feature, causing existing filter configurations to not show up on the Filter Tab and making it impossible to save affected dashboards. The reason for the regression was that the `filter_configuration` property in the dashboard's `json_metadata` object that contains all native filters had changed name to `native_filter_configuration`.

This PR migrates all existing dashboards that include native filter configurations from using the now deprecated `filter_configuration` to the new `native_filter_configuration`. Dashboards that were already using the new name are unaffected. The migration also limits the migration to dashboards that have native filter configurations, making this migration fairly light weight (won't touch any rows if the native filters feature was not activated).

### TEST PLAN
1) Tested that a dashboard with the old metadata failed to load existing native filters and failed to update metadata
2) Tested up migration, and made sure it only modified dashboards with the old `filter_configuration` property to use the new `native_filter_configuration` property. Also made sure the dashboards loaded the filter configurations correctly, and were able to to save updated metadata.
3) Tested down migration, and made sure it changed the dashboards to use the old `filter_configuration` property. Also reran the up migration, and made sure dashboards with native filters were working again.
 
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
