### PR TITLE
fix: restart superset container in test script

### DIFF
--- a/scripts/tests/run.sh
+++ b/scripts/tests/run.sh
@@ -38,7 +38,7 @@ function reset_db() {
 EOF
 "
   docker exec -i superset_db bash -c "${RESET_DB_CMD}"
-  docker-compose start superset-tests-worker
+  docker-compose start superset-tests-worker superset
 }
 
 #


### PR DESCRIPTION
### SUMMARY

In the test script, on line 29, the `superset` container is stopped to reset the database. However, it is not restarted after the database is brought back up.
