### PR TITLE
chore(cypress): Make the e2e tests more behavior-driven

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/controls.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/controls.test.ts
@@ -21,7 +21,7 @@ import {
   WORLD_HEALTH_DASHBOARD,
   waitForChartLoad,
   ChartSpec,
-  getChartAliases,
+  getChartAliasesBySpec,
 } from './dashboard.helper';
 import { isLegacyResponse } from '../../utils/vizPlugins';
 
@@ -61,7 +61,7 @@ describe('Dashboard top-level controls', () => {
   it('should allow dashboard level force refresh', () => {
     // when charts are not start loading, for example, under a secondary tab,
     // should allow force refresh
-    getChartAliases(WORLD_HEALTH_CHARTS).then(aliases => {
+    getChartAliasesBySpec(WORLD_HEALTH_CHARTS).then(aliases => {
       cy.get('[data-test="more-horiz"]').click();
       cy.get('[data-test="refresh-dashboard-menu-item"]').should(
         'not.have.class',

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/controls.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/controls.test.ts
@@ -16,79 +16,79 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { WORLD_HEALTH_DASHBOARD } from './dashboard.helper';
 import {
+  WORLD_HEALTH_CHARTS,
+  WORLD_HEALTH_DASHBOARD,
+  waitForChartLoad,
+  ChartSpec,
   getChartAliases,
-  isLegacyResponse,
-  DASHBOARD_CHART_ALIAS_PREFIX,
-} from '../../utils/vizPlugins';
+} from './dashboard.helper';
+import { isLegacyResponse } from '../../utils/vizPlugins';
 
 describe('Dashboard top-level controls', () => {
-  let mapId: string;
-  let aliases: string[];
-
   beforeEach(() => {
     cy.login();
     cy.visit(WORLD_HEALTH_DASHBOARD);
-
-    cy.get('#app').then(data => {
-      const bootstrapData = JSON.parse(data[0].dataset.bootstrap || '');
-      const dashboard = bootstrapData.dashboard_data;
-      mapId = dashboard.slices.find(
-        (slice: { form_data: { viz_type: string }; slice_id: number }) =>
-          slice.form_data.viz_type === 'world_map',
-      ).slice_id;
-      aliases = getChartAliases(dashboard.slices);
-    });
   });
 
   // flaky test
   xit('should allow chart level refresh', () => {
-    cy.wait(aliases);
-    cy.get('[data-test="grid-container"]').find('.world_map').should('exist');
-    cy.get(`#slice_${mapId}-controls`).click();
-    cy.get(`[data-test="slice_${mapId}-menu"]`)
-      .find('[data-test="refresh-chart-menu-item"]')
-      .click({ force: true });
-    cy.get('[data-test="refresh-chart-menu-item"]').should(
-      'have.class',
-      'ant-dropdown-menu-item-disabled',
-    );
-
-    cy.wait(`@${DASHBOARD_CHART_ALIAS_PREFIX}${mapId}`);
-    cy.get('[data-test="refresh-chart-menu-item"]').should(
-      'not.have.class',
-      'ant-dropdown-menu-item-disabled',
-    );
+    const mapSpec = WORLD_HEALTH_CHARTS.find(
+      ({ viz }) => viz === 'world_map',
+    ) as ChartSpec;
+    waitForChartLoad(mapSpec).then(gridComponent => {
+      const mapId = gridComponent.attr('data-test-chart-id');
+      cy.get('[data-test="grid-container"]').find('.world_map').should('exist');
+      cy.get(`#slice_${mapId}-controls`).click();
+      cy.get(`[data-test="slice_${mapId}-menu"]`)
+        .find('[data-test="refresh-chart-menu-item"]')
+        .click({ force: true });
+      // likely cause for flakiness:
+      // The query completes before this assertion happens.
+      // Solution: pause the network before clicking, assert, then unpause network.
+      cy.get('[data-test="refresh-chart-menu-item"]').should(
+        'have.class',
+        'ant-dropdown-menu-item-disabled',
+      );
+      waitForChartLoad(mapSpec);
+      cy.get('[data-test="refresh-chart-menu-item"]').should(
+        'not.have.class',
+        'ant-dropdown-menu-item-disabled',
+      );
+    });
   });
 
   it('should allow dashboard level force refresh', () => {
-    cy.wait(aliases);
     // when charts are not start loading, for example, under a secondary tab,
     // should allow force refresh
-    cy.get('[data-test="more-horiz"]').click();
-    cy.get('[data-test="refresh-dashboard-menu-item"]').should(
-      'not.have.class',
-      'ant-dropdown-menu-item-disabled',
-    );
+    getChartAliases(WORLD_HEALTH_CHARTS).then(aliases => {
+      cy.get('[data-test="more-horiz"]').click();
+      cy.get('[data-test="refresh-dashboard-menu-item"]').should(
+        'not.have.class',
+        'ant-dropdown-menu-item-disabled',
+      );
 
-    cy.get('[data-test="refresh-dashboard-menu-item"]').click({ force: true });
-    cy.get('[data-test="refresh-dashboard-menu-item"]').should(
-      'have.class',
-      'ant-dropdown-menu-item-disabled',
-    );
+      cy.get('[data-test="refresh-dashboard-menu-item"]').click({
+        force: true,
+      });
+      cy.get('[data-test="refresh-dashboard-menu-item"]').should(
+        'have.class',
+        'ant-dropdown-menu-item-disabled',
+      );
 
-    // wait all charts force refreshed.
-    cy.wait(aliases).then(xhrs => {
-      xhrs.forEach(async ({ response, request }) => {
-        const responseBody = response?.body;
-        const isCached = isLegacyResponse(responseBody)
-          ? responseBody.is_cached
-          : responseBody.result[0].is_cached;
-        // request url should indicate force-refresh operation
-        expect(request.url).to.have.string('force=true');
-        // is_cached in response should be false
-        expect(isCached).to.equal(false);
+      // wait all charts force refreshed.
+
+      cy.wait(aliases).then(xhrs => {
+        xhrs.forEach(async ({ response, request }) => {
+          const responseBody = response?.body;
+          const isCached = isLegacyResponse(responseBody)
+            ? responseBody.is_cached
+            : responseBody.result[0].is_cached;
+          // request url should indicate force-refresh operation
+          expect(request.url).to.have.string('force=true');
+          // is_cached in response should be false
+          expect(isCached).to.equal(false);
+        });
       });
     });
     cy.get('[data-test="more-horiz"]').click();

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/controls.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/controls.test.ts
@@ -61,6 +61,7 @@ describe('Dashboard top-level controls', () => {
   it('should allow dashboard level force refresh', () => {
     // when charts are not start loading, for example, under a secondary tab,
     // should allow force refresh
+    WORLD_HEALTH_CHARTS.forEach(waitForChartLoad);
     getChartAliasesBySpec(WORLD_HEALTH_CHARTS).then(aliases => {
       cy.get('[data-test="more-horiz"]').click();
       cy.get('[data-test="refresh-dashboard-menu-item"]').should(

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/dashboard.helper.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/dashboard.helper.ts
@@ -37,19 +37,6 @@ export const WORLD_HEALTH_CHARTS = [
   { name: 'Box plot', viz: 'box_plot' },
 ] as const;
 
-export const BIRTH_NAMES_CHARTS = [
-  { name: 'Participants', viz: 'blah' },
-  { name: 'Genders', viz: 'blah' },
-  { name: 'Trends', viz: 'blah' },
-  { name: 'Genders by State', viz: 'blah' },
-  { name: 'Girls', viz: 'blah' },
-  { name: 'Girl Name Cloud', viz: 'blah' },
-  { name: 'Top 10 Girl Name Share', viz: 'blah' },
-  { name: 'Boys', viz: 'blah' },
-  { name: 'Boy Name Cloud', viz: 'blah' },
-  { name: 'Top 10 Boy Name Share', viz: 'blah' },
-] as const;
-
 /** Used to specify charts expected by the test suite */
 export interface ChartSpec {
   name: string;

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/dashboard.helper.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/dashboard.helper.ts
@@ -44,15 +44,9 @@ export interface ChartSpec {
 }
 
 export function getChartGridComponent({ name, viz }: ChartSpec) {
-  return (
-    cy
-      .get('[data-test="grid-content"] [data-test="editable-title"]')
-      .contains(name)
-      // parentsUntil returns the child of the element matching the selector
-      .parentsUntil('[data-test="chart-grid-component"]')
-      .parent()
-      .should('have.attr', 'data-test-viz-type', viz)
-  );
+  return cy
+    .get(`[data-test="chart-grid-component"][data-test-chart-name="${name}"]`)
+    .should('have.attr', 'data-test-viz-type', viz);
 }
 
 export function waitForChartLoad(chart: ChartSpec) {

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/dashboard.helper.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/dashboard.helper.ts
@@ -22,6 +22,19 @@ export const TABBED_DASHBOARD = '/superset/dashboard/tabbed_dash/';
 export const CHECK_DASHBOARD_FAVORITE_ENDPOINT =
   '/superset/favstar/Dashboard/*/count';
 
+export const WORLD_HEALTH_CHARTS = [
+  { name: '% Rural', viz: 'world_map' },
+  { name: 'Most Populated Countries', viz: 'table' },
+  { name: 'Region Filter', viz: 'filter_box' },
+  { name: "World's Population", viz: 'big_number' },
+  { name: 'Growth Rate', viz: 'line' },
+  { name: 'Rural Breakdown', viz: 'sunburst' },
+  { name: "World's Pop Growth", viz: 'area' },
+  { name: 'Life Expectancy VS Rural %', viz: 'bubble' },
+  { name: 'Treemap', viz: 'treemap' },
+  { name: 'Box plot', viz: 'box_plot' },
+] as const;
+
 /**
  * Drag an element and drop it to another element.
  * Usage:

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/dashboard.helper.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/dashboard.helper.ts
@@ -80,7 +80,7 @@ const toSlicelike = ($chart: JQuery<HTMLElement>): Slice => ({
 
 export function getChartAliasBySpec(chart: ChartSpec) {
   return getChartGridComponent(chart).then($chart =>
-    getChartAlias(toSlicelike($chart)),
+    cy.wrap(getChartAlias(toSlicelike($chart))),
   );
 }
 

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/dashboard.helper.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/dashboard.helper.ts
@@ -78,11 +78,17 @@ const toSlicelike = ($chart: JQuery<HTMLElement>): Slice => ({
   },
 });
 
-export function getChartAliases(charts: readonly ChartSpec[]) {
+export function getChartAliasBySpec(chart: ChartSpec) {
+  return getChartGridComponent(chart).then($chart =>
+    getChartAlias(toSlicelike($chart)),
+  );
+}
+
+export function getChartAliasesBySpec(charts: readonly ChartSpec[]) {
   const aliases: string[] = [];
   charts.forEach(chart =>
-    getChartGridComponent(chart).then($chart => {
-      aliases.push(getChartAlias(toSlicelike($chart)));
+    getChartAliasBySpec(chart).then(alias => {
+      aliases.push(alias);
     }),
   );
   // Wrapping the aliases is key.

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/filter.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/filter.test.ts
@@ -55,28 +55,26 @@ describe('Dashboard filter', () => {
       });
 
       cy.get('.filter_box button').click({ force: true });
-      cy.wait(nonFilterChartAliases).then(requests =>
-        Promise.all(
-          requests.map(async ({ response, request }) => {
-            const responseBody = response?.body;
-            let requestFilter;
-            if (isLegacyResponse(responseBody)) {
-              const requestFormData = parsePostForm(request.body);
-              const requestParams = JSON.parse(
-                requestFormData.form_data as string,
-              );
-              requestFilter = requestParams.extra_filters[0];
-            } else {
-              requestFilter = request.body.queries[0].filters[0];
-            }
-            expect(requestFilter).deep.eq({
-              col: 'region',
-              op: '==',
-              val: 'South Asia',
-            });
-          }),
-        ),
-      );
+      cy.wait(nonFilterChartAliases).then(requests => {
+        requests.forEach(({ response, request }) => {
+          const responseBody = response?.body;
+          let requestFilter;
+          if (isLegacyResponse(responseBody)) {
+            const requestFormData = parsePostForm(request.body);
+            const requestParams = JSON.parse(
+              requestFormData.form_data as string,
+            );
+            requestFilter = requestParams.extra_filters[0];
+          } else {
+            requestFilter = request.body.queries[0].filters[0];
+          }
+          expect(requestFilter).deep.eq({
+            col: 'region',
+            op: '==',
+            val: 'South Asia',
+          });
+        });
+      });
     });
 
     // TODO add test with South Asia{enter} type action to select filter

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/filter.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/filter.test.ts
@@ -16,96 +16,66 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { isLegacyResponse, parsePostForm } from 'cypress/utils';
 import {
+  WORLD_HEALTH_CHARTS,
+  WORLD_HEALTH_DASHBOARD,
   getChartAliases,
-  DASHBOARD_CHART_ALIAS_PREFIX,
-  isLegacyResponse,
-  parsePostForm,
-} from 'cypress/utils';
-import { WORLD_HEALTH_DASHBOARD } from './dashboard.helper';
-
-interface Slice {
-  slice_id: number;
-  form_data: {
-    viz_type: string;
-    [key: string]: JSONValue;
-  };
-}
-
-interface DashboardData {
-  slices: Slice[];
-}
+} from './dashboard.helper';
 
 describe('Dashboard filter', () => {
-  let filterId: number;
-  let aliases: string[];
-
-  const getAlias = (id: number) => `@${DASHBOARD_CHART_ALIAS_PREFIX}${id}`;
-
-  beforeEach(() => {
+  before(() => {
     cy.login();
-
     cy.visit(WORLD_HEALTH_DASHBOARD);
-
-    cy.get('#app').then(app => {
-      const bootstrapData = app.data('bootstrap');
-      const dashboard = bootstrapData.dashboard_data as DashboardData;
-      const { slices } = dashboard;
-      filterId =
-        dashboard.slices.find(
-          slice => slice.form_data.viz_type === 'filter_box',
-        )?.slice_id || 0;
-
-      aliases = getChartAliases(slices);
-
-      // wait the initial page load requests
-      cy.wait(aliases);
-    });
   });
 
   it('should apply filter', () => {
-    cy.get('.Select__placeholder:first').click();
+    getChartAliases(
+      WORLD_HEALTH_CHARTS.filter(({ viz }) => viz !== 'filter_box'),
+    ).then(nonFilterChartAliases => {
+      cy.get('.Select__placeholder:first').click();
 
-    // should show the filter indicator
-    cy.get('svg[data-test="filter"]:visible').should(nodes => {
-      expect(nodes.length).to.least(9);
+      // should show the filter indicator
+      cy.get('svg[data-test="filter"]:visible').should(nodes => {
+        expect(nodes.length).to.least(9);
+      });
+
+      cy.get('.Select__control:first input[type=text]').type('So', {
+        force: true,
+        delay: 100,
+      });
+
+      cy.get('.Select__menu').first().contains('South Asia').click();
+
+      // should still have all filter indicators
+      cy.get('svg[data-test="filter"]:visible').should(nodes => {
+        expect(nodes.length).to.least(9);
+      });
+
+      cy.get('.filter_box button').click({ force: true });
+      cy.wait(nonFilterChartAliases).then(requests =>
+        Promise.all(
+          requests.map(async ({ response, request }) => {
+            const responseBody = response?.body;
+            let requestFilter;
+            if (isLegacyResponse(responseBody)) {
+              const requestFormData = parsePostForm(request.body);
+              const requestParams = JSON.parse(
+                requestFormData.form_data as string,
+              );
+              requestFilter = requestParams.extra_filters[0];
+            } else {
+              requestFilter = request.body.queries[0].filters[0];
+            }
+            expect(requestFilter).deep.eq({
+              col: 'region',
+              op: '==',
+              val: 'South Asia',
+            });
+          }),
+        ),
+      );
     });
-
-    cy.get('.Select__control:first input[type=text]').type('So', {
-      force: true,
-      delay: 100,
-    });
-
-    cy.get('.Select__menu').first().contains('South Asia').click();
-
-    // should still have all filter indicators
-    cy.get('svg[data-test="filter"]:visible').should(nodes => {
-      expect(nodes.length).to.least(9);
-    });
-
-    cy.get('.filter_box button').click({ force: true });
-    cy.wait(aliases.filter(x => x !== getAlias(filterId))).then(requests =>
-      Promise.all(
-        requests.map(async ({ response, request }) => {
-          const responseBody = response?.body;
-          let requestFilter;
-          if (isLegacyResponse(responseBody)) {
-            const requestFormData = parsePostForm(request.body);
-            const requestParams = JSON.parse(
-              requestFormData.form_data as string,
-            );
-            requestFilter = requestParams.extra_filters[0];
-          } else {
-            requestFilter = request.body.queries[0].filters[0];
-          }
-          expect(requestFilter).deep.eq({
-            col: 'region',
-            op: '==',
-            val: 'South Asia',
-          });
-        }),
-      ),
-    );
 
     // TODO add test with South Asia{enter} type action to select filter
   });

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/filter.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/filter.test.ts
@@ -20,7 +20,7 @@ import { isLegacyResponse, parsePostForm } from 'cypress/utils';
 import {
   WORLD_HEALTH_CHARTS,
   WORLD_HEALTH_DASHBOARD,
-  getChartAliases,
+  getChartAliasesBySpec,
   waitForChartLoad,
 } from './dashboard.helper';
 
@@ -32,7 +32,7 @@ describe('Dashboard filter', () => {
 
   it('should apply filter', () => {
     WORLD_HEALTH_CHARTS.forEach(waitForChartLoad);
-    getChartAliases(
+    getChartAliasesBySpec(
       WORLD_HEALTH_CHARTS.filter(({ viz }) => viz !== 'filter_box'),
     ).then(nonFilterChartAliases => {
       cy.get('.Select__placeholder:first').click();

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/filter.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/filter.test.ts
@@ -21,6 +21,7 @@ import {
   WORLD_HEALTH_CHARTS,
   WORLD_HEALTH_DASHBOARD,
   getChartAliases,
+  waitForChartLoad,
 } from './dashboard.helper';
 
 describe('Dashboard filter', () => {
@@ -30,6 +31,7 @@ describe('Dashboard filter', () => {
   });
 
   it('should apply filter', () => {
+    WORLD_HEALTH_CHARTS.forEach(waitForChartLoad);
     getChartAliases(
       WORLD_HEALTH_CHARTS.filter(({ viz }) => viz !== 'filter_box'),
     ).then(nonFilterChartAliases => {

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/load.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/load.test.ts
@@ -17,32 +17,18 @@
  * under the License.
  */
 import {
+  waitForChartLoad,
   WORLD_HEALTH_CHARTS,
   WORLD_HEALTH_DASHBOARD,
 } from './dashboard.helper';
 
 describe('Dashboard load', () => {
-  beforeEach(() => {
+  before(() => {
     cy.login();
     cy.visit(WORLD_HEALTH_DASHBOARD);
   });
 
   it('should load dashboard', () => {
-    // wait and verify one-by-one
-    WORLD_HEALTH_CHARTS.forEach(({ name, viz }) => {
-      // prettier-ignore
-      cy.get('[data-test="grid-content"] [data-test="editable-title"]').contains(name)
-        // use the chart title to find the chart grid component,
-        // which has the chart id and viz type info
-        .parentsUntil('[data-test="chart-grid-component"]').parent()
-        .should('have.attr', 'data-test-viz-type', viz)
-        .then(chartElement => {
-          const chartId = chartElement.attr('data-test-chart-id');
-          // the chart should load in under a minute
-          // (big timeout so that it works in CI)
-          cy.wrap(chartElement).find(`#chart-id-${chartId}`, { timeout: 30000 })
-            .should('be.visible');
-        });
-    });
+    WORLD_HEALTH_CHARTS.forEach(waitForChartLoad);
   });
 });

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/load.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/load.test.ts
@@ -17,53 +17,32 @@
  * under the License.
  */
 import {
-  getChartAliases,
-  isLegacyResponse,
-  getSliceIdFromRequestUrl,
-  JsonObject,
-} from '../../utils/vizPlugins';
-import { WORLD_HEALTH_DASHBOARD } from './dashboard.helper';
+  WORLD_HEALTH_CHARTS,
+  WORLD_HEALTH_DASHBOARD,
+} from './dashboard.helper';
 
 describe('Dashboard load', () => {
-  let dashboard;
-  let aliases: string[];
   beforeEach(() => {
     cy.login();
-
     cy.visit(WORLD_HEALTH_DASHBOARD);
-
-    cy.get('#app').then(nodes => {
-      const bootstrapData = JSON.parse(nodes[0].dataset.bootstrap || '');
-      dashboard = bootstrapData.dashboard_data;
-      const { slices } = dashboard;
-      // then define routes and create alias for each requests
-      aliases = getChartAliases(slices);
-    });
   });
 
   it('should load dashboard', () => {
     // wait and verify one-by-one
-    cy.wait(aliases).then(requests =>
-      Promise.all(
-        requests.map(async ({ response, request }) => {
-          const responseBody = response?.body;
-          let sliceId;
-          if (isLegacyResponse(responseBody)) {
-            expect(responseBody).to.have.property('errors');
-            expect(responseBody.errors.length).to.eq(0);
-            sliceId = responseBody.form_data.slice_id;
-          } else {
-            sliceId = getSliceIdFromRequestUrl(request.url);
-            responseBody.result.forEach((element: JsonObject) => {
-              expect(element).to.have.property('error', null);
-              expect(element).to.have.property('status', 'success');
-            });
-          }
-          cy.get('[data-test="grid-content"]')
-            .find(`#chart-id-${sliceId}`)
+    WORLD_HEALTH_CHARTS.forEach(({ name, viz }) => {
+      // prettier-ignore
+      cy.get('[data-test="grid-content"] [data-test="editable-title"]').contains(name)
+        // use the chart title to find the chart grid component,
+        // which has the chart id and viz type info
+        .parentsUntil('[data-test="chart-grid-component"]').parent()
+        .should('have.attr', 'data-test-viz-type', viz)
+        .then(chartElement => {
+          const chartId = chartElement.attr('data-test-chart-id');
+          // the chart should load in under a minute
+          // (big timeout so that it works in CI)
+          cy.wrap(chartElement).find(`#chart-id-${chartId}`, { timeout: 30000 })
             .should('be.visible');
-        }),
-      ),
-    );
+        });
+    });
   });
 });

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/save.test.js
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/save.test.js
@@ -31,28 +31,32 @@ describe('Dashboard save action', () => {
     cy.login();
     cy.visit(WORLD_HEALTH_DASHBOARD);
     cy.get('#app').then(data => {
-      const bootstrapData = JSON.parse(data[0].dataset.bootstrap);
-      const dashboard = bootstrapData.dashboard_data;
-      const dashboardId = dashboard.id;
-      cy.intercept('POST', `/superset/copy_dash/${dashboardId}/`).as(
-        'copyRequest',
-      );
+      cy.get('[data-test="dashboard-header"]')
+        .then(headerElement => {
+          const dashboardId = headerElement.attr('data-test-id');
 
-      cy.get('[data-test="more-horiz"]').trigger('click', { force: true });
-      cy.get('[data-test="save-as-menu-item"]').trigger('click', {
-        force: true,
-      });
-      cy.get('[data-test="modal-save-dashboard-button"]').trigger('click', {
-        force: true,
-      });
+          cy.intercept('POST', `/superset/copy_dash/${dashboardId}/`).as(
+            'copyRequest',
+          );
+
+          cy.get('[data-test="more-horiz"]').trigger('click', { force: true });
+          cy.get('[data-test="save-as-menu-item"]').trigger('click', {
+            force: true,
+          });
+          cy.get('[data-test="modal-save-dashboard-button"]').trigger('click', {
+            force: true,
+          });
+        })
     });
   });
 
+  // change to what the title should be
   it('should save as new dashboard', () => {
     cy.wait('@copyRequest').then(xhr => {
-      expect(xhr.response.body.dashboard_title).to.not.equal(
-        `World Bank's Data`,
-      );
+      cy.get('[data-test="editable-title-input"]').then(element => {
+        const dashboardTitle = element.attr('title') 
+        expect(dashboardTitle).to.not.equal(`World Bank's Data`)
+      });
     });
   });
 

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/save.test.js
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/save.test.js
@@ -31,22 +31,21 @@ describe('Dashboard save action', () => {
     cy.login();
     cy.visit(WORLD_HEALTH_DASHBOARD);
     cy.get('#app').then(data => {
-      cy.get('[data-test="dashboard-header"]')
-        .then(headerElement => {
-          const dashboardId = headerElement.attr('data-test-id');
+      cy.get('[data-test="dashboard-header"]').then(headerElement => {
+        const dashboardId = headerElement.attr('data-test-id');
 
-          cy.intercept('POST', `/superset/copy_dash/${dashboardId}/`).as(
-            'copyRequest',
-          );
+        cy.intercept('POST', `/superset/copy_dash/${dashboardId}/`).as(
+          'copyRequest',
+        );
 
-          cy.get('[data-test="more-horiz"]').trigger('click', { force: true });
-          cy.get('[data-test="save-as-menu-item"]').trigger('click', {
-            force: true,
-          });
-          cy.get('[data-test="modal-save-dashboard-button"]').trigger('click', {
-            force: true,
-          });
-        })
+        cy.get('[data-test="more-horiz"]').trigger('click', { force: true });
+        cy.get('[data-test="save-as-menu-item"]').trigger('click', {
+          force: true,
+        });
+        cy.get('[data-test="modal-save-dashboard-button"]').trigger('click', {
+          force: true,
+        });
+      });
     });
   });
 
@@ -54,8 +53,8 @@ describe('Dashboard save action', () => {
   it('should save as new dashboard', () => {
     cy.wait('@copyRequest').then(xhr => {
       cy.get('[data-test="editable-title-input"]').then(element => {
-        const dashboardTitle = element.attr('title') 
-        expect(dashboardTitle).to.not.equal(`World Bank's Data`)
+        const dashboardTitle = element.attr('title');
+        expect(dashboardTitle).to.not.equal(`World Bank's Data`);
       });
     });
   });

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/save.test.js
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/save.test.js
@@ -18,7 +18,11 @@
  */
 
 import shortid from 'shortid';
-import { WORLD_HEALTH_DASHBOARD } from './dashboard.helper';
+import {
+  waitForChartLoad,
+  WORLD_HEALTH_CHARTS,
+  WORLD_HEALTH_DASHBOARD,
+} from './dashboard.helper';
 
 function openDashboardEditProperties() {
   cy.get('.dashboard-header [data-test=edit-alt]').click();
@@ -61,8 +65,7 @@ describe('Dashboard save action', () => {
 
   it('should save/overwrite dashboard', () => {
     // should load chart
-    cy.get('.dashboard-grid', { timeout: 30000 });
-    cy.get('.box_plot').should('be.visible');
+    WORLD_HEALTH_CHARTS.forEach(waitForChartLoad);
 
     // remove box_plot chart from dashboard
     cy.get('[data-test="edit-alt"]').click({ timeout: 5000 });

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
@@ -127,10 +127,10 @@ describe('Dashboard tabs', () => {
       });
     });
 
-    // click row level tab, send 1 more query
-    cy.get('.ant-tabs-tab').contains('row tab 2').click();
-
     getChartAliasBySpec(LINE_CHART).then(lineChartAlias => {
+      // click row level tab, send 1 more query
+      cy.get('.ant-tabs-tab').contains('row tab 2').click();
+
       cy.wait(lineChartAlias).then(({ request }) => {
         const requestBody = parsePostForm(request.body);
         const requestParams = JSON.parse(requestBody.form_data as string);

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
@@ -16,11 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { interceptChart, parsePostForm, Slice } from 'cypress/utils';
+import { parsePostForm } from 'cypress/utils';
 import {
-  ChartSpec,
   TABBED_DASHBOARD,
-  getChartAliasesBySpec,
   waitForChartLoad,
   getChartAliasBySpec,
 } from './dashboard.helper';

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
@@ -186,19 +186,16 @@ describe('Dashboard tabs', () => {
           val: 'South Asia',
         });
       });
-    });
 
-    // navigate to filter and clear filter
-    cy.get('.ant-tabs-tab').contains('Tab A').click();
-    cy.get('.ant-tabs-tab').contains('row tab 1').click();
+      // navigate to filter and clear filter
+      cy.get('.ant-tabs-tab').contains('Tab A').click();
+      cy.get('.ant-tabs-tab').contains('row tab 1').click();
 
-    cy.get('.Select__clear-indicator').click();
-    cy.get('.filter_box button:not(:disabled)').contains('Apply').click();
+      cy.get('.Select__clear-indicator').click();
+      cy.get('.filter_box button:not(:disabled)').contains('Apply').click();
 
-    // trigger 1 new query
-    waitForChartLoad(TREEMAP);
-
-    getChartAliasBySpec(BOX_PLOT).then(boxPlotAlias => {
+      // trigger 1 new query
+      waitForChartLoad(TREEMAP);
       // make sure query API not requested multiple times
       cy.on('fail', err => {
         expect(err.message).to.include('timed out waiting');

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
@@ -127,11 +127,11 @@ describe('Dashboard tabs', () => {
       });
     });
 
-    cy.intercept('/superset/explore_json/*').as('lineChartDataRequest');
+    cy.intercept('/superset/explore_json/*').as('chartDataRequest');
     // click row level tab, send 1 more query
     cy.get('.ant-tabs-tab').contains('row tab 2').click();
 
-    cy.wait('@lineChartDataRequest').then(({ request }) => {
+    cy.wait('@chartDataRequest').then(({ request }) => {
       const requestBody = parsePostForm(request.body);
       const requestParams = JSON.parse(requestBody.form_data as string);
       expect(requestParams.extra_filters[0]).deep.eq({
@@ -142,20 +142,21 @@ describe('Dashboard tabs', () => {
       expect(requestParams.viz_type).eq(LINE_CHART.viz);
     });
 
-    getChartAliasBySpec(BOX_PLOT).then(boxPlotAlias => {
-      // click top level tab, send 1 more query
-      cy.get('.ant-tabs-tab').contains('Tab B').click();
+    // click top level tab, send 1 more query
+    cy.get('.ant-tabs-tab').contains('Tab B').click();
 
-      cy.wait(boxPlotAlias).then(({ request }) => {
-        const requestBody = request.body;
-        const requestParams = requestBody.queries[0];
-        expect(requestParams.filters[0]).deep.eq({
-          col: 'region',
-          op: '==',
-          val: 'South Asia',
-        });
+    cy.wait('@chartDataRequest').then(({ request }) => {
+      const requestBody = request.body;
+      const requestParams = requestBody.queries[0];
+      expect(requestParams.filters[0]).deep.eq({
+        col: 'region',
+        op: '==',
+        val: 'South Asia',
       });
+      expect(requestParams.viz_type).eq(BOX_PLOT.viz);
+    });
 
+    getChartAliasBySpec(BOX_PLOT).then(boxPlotAlias => {
       // navigate to filter and clear filter
       cy.get('.ant-tabs-tab').contains('Tab A').click();
       cy.get('.ant-tabs-tab').contains('row tab 1').click();

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
@@ -31,11 +31,6 @@ const LINE_CHART = { name: 'Growth Rate', viz: 'line' };
 const BOX_PLOT = { name: 'Box plot', viz: 'box_plot' };
 
 describe('Dashboard tabs', () => {
-  // let filterId;
-  // let treemapId;
-  // let linechartId;
-  // let boxplotId;
-
   // cypress can not handle window.scrollTo
   // https://github.com/cypress-io/cypress/issues/2761
   // add this exception handler to pass test
@@ -49,30 +44,6 @@ describe('Dashboard tabs', () => {
     cy.login();
 
     cy.visit(TABBED_DASHBOARD);
-    // cy.get('#app').then(data => {
-    //   const bootstrapData = JSON.parse(data[0].dataset.bootstrap || '');
-    //   const dashboard = bootstrapData.dashboard_data as { slices: Slice[] };
-    //   filterId = dashboard.slices.find(
-    //     slice => slice.form_data.viz_type === 'filter_box',
-    //   )?.slice_id;
-    //   boxplotId = dashboard.slices.find(
-    //     slice => slice.form_data.viz_type === 'box_plot',
-    //   )?.slice_id;
-    //   treemapId = dashboard.slices.find(
-    //     slice => slice.form_data.viz_type === 'treemap',
-    //   )?.slice_id;
-    //   linechartId = dashboard.slices.find(
-    //     slice => slice.form_data.viz_type === 'line',
-    //   )?.slice_id;
-    //   interceptChart({ sliceId: filterId, legacy: true }).as('filterRequest');
-    //   interceptChart({ sliceId: treemapId, legacy: true }).as('treemapRequest');
-    //   interceptChart({ sliceId: linechartId, legacy: true }).as(
-    //     'linechartRequest',
-    //   );
-    //   interceptChart({ sliceId: boxplotId, legacy: false }).as(
-    //     'boxplotRequest',
-    //   );
-    // });
   });
 
   it('should switch active tab on click', () => {

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
@@ -17,7 +17,19 @@
  * under the License.
  */
 import { interceptChart, parsePostForm, Slice } from 'cypress/utils';
-import { TABBED_DASHBOARD } from './dashboard.helper';
+import { ChartSpec, TABBED_DASHBOARD } from './dashboard.helper';
+
+const TAB_A_WITH_ROW_1: ChartSpec[] = [
+  { name: 'Treemap', viz: 'treemap' },
+  { name: 'Region Filter', viz: 'filter_box' },
+];
+
+const TAB_A_WITH_ROW_2: ChartSpec[] = [
+  { name: 'Treemap', viz: 'treemap' },
+  { name: 'Growth Rate', viz: 'line' },
+];
+
+const TAB_B_CHARTS: ChartSpec[] = [{ name: 'Box plot', viz: 'box_plot' }];
 
 describe('Dashboard tabs', () => {
   let filterId;

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
@@ -104,13 +104,7 @@ describe('Dashboard tabs', () => {
   it('should load charts when tab is visible', () => {
     // landing in first tab, should see 2 charts
     waitForChartLoad(FILTER_BOX);
-    cy.get('[data-test="grid-container"]')
-      .find('.filter_box')
-      .should('be.visible');
     waitForChartLoad(TREEMAP);
-    cy.get('[data-test="grid-container"]')
-      .find('.treemap')
-      .should('be.visible');
     cy.get('[data-test="grid-container"]')
       .find('.box_plot')
       .should('not.exist');

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
@@ -127,19 +127,19 @@ describe('Dashboard tabs', () => {
       });
     });
 
-    getChartAliasBySpec(LINE_CHART).then(lineChartAlias => {
-      // click row level tab, send 1 more query
-      cy.get('.ant-tabs-tab').contains('row tab 2').click();
+    cy.intercept('/superset/explore_json/*').as('lineChartDataRequest');
+    // click row level tab, send 1 more query
+    cy.get('.ant-tabs-tab').contains('row tab 2').click();
 
-      cy.wait(lineChartAlias).then(({ request }) => {
-        const requestBody = parsePostForm(request.body);
-        const requestParams = JSON.parse(requestBody.form_data as string);
-        expect(requestParams.extra_filters[0]).deep.eq({
-          col: 'region',
-          op: '==',
-          val: 'South Asia',
-        });
+    cy.wait('@lineChartDataRequest').then(({ request }) => {
+      const requestBody = parsePostForm(request.body);
+      const requestParams = JSON.parse(requestBody.form_data as string);
+      expect(requestParams.extra_filters[0]).deep.eq({
+        col: 'region',
+        op: '==',
+        val: 'South Asia',
       });
+      expect(requestParams.viz_type).eq(LINE_CHART.viz);
     });
 
     getChartAliasBySpec(BOX_PLOT).then(boxPlotAlias => {

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
@@ -158,10 +158,10 @@ describe('Dashboard tabs', () => {
       });
     });
 
-    getChartAliasBySpec(LINE_CHART).then(lineChartAlias => {
-      // click row level tab, send 1 more query
-      cy.get('.ant-tabs-tab').contains('row tab 2').click();
+    // click row level tab, send 1 more query
+    cy.get('.ant-tabs-tab').contains('row tab 2').click();
 
+    getChartAliasBySpec(LINE_CHART).then(lineChartAlias => {
       cy.wait(lineChartAlias).then(({ request }) => {
         const requestBody = parsePostForm(request.body);
         const requestParams = JSON.parse(requestBody.form_data as string);

--- a/superset-frontend/cypress-base/cypress/utils/vizPlugins.ts
+++ b/superset-frontend/cypress-base/cypress/utils/vizPlugins.ts
@@ -57,18 +57,20 @@ export function getSliceIdFromRequestUrl(url: string) {
   return query?.match(/\d+/)?.[0];
 }
 
-export function getChartAlias(slice: Slice): string {
+export function getChartDataRouteForSlice(slice: Slice) {
   const vizType = slice.form_data.viz_type;
   const isLegacy = isLegacyChart(vizType);
-  const alias = `${DASHBOARD_CHART_ALIAS_PREFIX}${slice.slice_id}_${slice.form_data.viz_type}`;
   const formData = encodeURIComponent(`{"slice_id":${slice.slice_id}}`);
   if (isLegacy) {
-    const route = `/superset/explore_json/?*${formData}*`;
-    cy.intercept('POST', `${route}`).as(alias);
-    return `@${alias}`;
+    return `/superset/explore_json/?*${formData}*`;
   }
-  const route = `/api/v1/chart/data?*${formData}*`;
-  cy.intercept('POST', `${route}`).as(alias);
+  return `/api/v1/chart/data?*${formData}*`;
+}
+
+export function getChartAlias(slice: Slice): string {
+  const alias = `${DASHBOARD_CHART_ALIAS_PREFIX}${slice.slice_id}_${slice.form_data.viz_type}`;
+  const route = getChartDataRouteForSlice(slice);
+  cy.intercept('POST', route).as(alias);
   return `@${alias}`;
 }
 

--- a/superset-frontend/cypress-base/cypress/utils/vizPlugins.ts
+++ b/superset-frontend/cypress-base/cypress/utils/vizPlugins.ts
@@ -41,7 +41,7 @@ const V1_PLUGINS = [
   'pie',
   'table',
 ];
-export const DASHBOARD_CHART_ALIAS_PREFIX = 'getJson_';
+export const DASHBOARD_CHART_ALIAS_PREFIX = 'getChartData_';
 
 export function isLegacyChart(vizType: string): boolean {
   return !V1_PLUGINS.includes(vizType);
@@ -60,7 +60,7 @@ export function getSliceIdFromRequestUrl(url: string) {
 export function getChartAlias(slice: Slice): string {
   const vizType = slice.form_data.viz_type;
   const isLegacy = isLegacyChart(vizType);
-  const alias = `${DASHBOARD_CHART_ALIAS_PREFIX}${slice.slice_id}`;
+  const alias = `${DASHBOARD_CHART_ALIAS_PREFIX}${slice.slice_id}_${slice.form_data.viz_type}`;
   const formData = encodeURIComponent(`{"slice_id":${slice.slice_id}}`);
   if (isLegacy) {
     const route = `/superset/explore_json/?*${formData}*`;

--- a/superset-frontend/src/dashboard/components/Header.jsx
+++ b/superset-frontend/src/dashboard/components/Header.jsx
@@ -387,6 +387,7 @@ class Header extends React.PureComponent {
       <StyledDashboardHeader
         className="dashboard-header"
         data-test="dashboard-header"
+        data-test-id={`${dashboardInfo.id}`}
       >
         <div className="dashboard-component-header header-large">
           <EditableTitle

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -293,6 +293,7 @@ export default class Chart extends React.Component {
         data-test="chart-grid-component"
         data-test-chart-id={id}
         data-test-viz-type={slice.viz_type}
+        data-test-chart-name={slice.slice_name}
       >
         <SliceHeader
           innerRef={this.setHeaderRef}

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -288,7 +288,12 @@ export default class Chart extends React.Component {
         })
       : {};
     return (
-      <div className="chart-slice">
+      <div
+        className="chart-slice"
+        data-test="chart-grid-component"
+        data-test-chart-id={id}
+        data-test-viz-type={slice.viz_type}
+      >
         <SliceHeader
           innerRef={this.setHeaderRef}
           slice={slice}


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This removes a dependency on dashboard bootstrap data from the e2e test suite, so that we can change the implementation without breaking tests.
This is blocking #13306. Decided to open up a separate PR instead of addressing the issue there, for easier review.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
