### PR TITLE
feat(nvd3-viz): don't return empty time-series

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1263,17 +1263,17 @@ class NVD3TimeSeriesViz(NVD3Viz):
                     series_title = series_title + (title_suffix,)
 
             values = []
-            non_nan_cnt = 0
+            non_value_cnt = 0
             for ds in df.index:
                 if ds in ys:
                     d = {"x": ds, "y": ys[ds]}
-                    if not np.isnan(ys[ds]):
-                        non_nan_cnt += 1
+                    if not np.isnan(ys[ds]) and ys[ds] != 0:
+                        non_value_cnt += 1
                 else:
                     d = {}
                 values.append(d)
 
-            if non_nan_cnt == 0:
+            if non_value_cnt == 0:
                 continue
 
             d = {"key": series_title, "values": values}


### PR DESCRIPTION
### SUMMARY
When debugging a performance issue today, I ran into a situation where a stacked bar chart had about 20k series, but all of them except 1 were filled with 0s and Nones. This took ~1 minute to render in a dashboard and froze chrome.

This PR removes empty time series from time series visualizations. I'm not sure what the consequences of this might be, so would appreciate feedback from folks. If this seems reasonable, then I'll follow up by adding some tests.

### TEST PLAN
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


to: @graceguo-supercat @ktmud @villebro @mistercrunch 