### PR TITLE
[WIP] refactor: replace "csv" with "file" used in common (excel) upload cases

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -637,7 +637,7 @@ class Database(
     ) -> List[Dict[str, Any]]:
         return self.inspector.get_foreign_keys(table_name, schema)
 
-    def get_schema_access_for_csv_upload(  # pylint: disable=invalid-name
+    def get_schema_access_for_file_upload(  # pylint: disable=invalid-name
         self,
     ) -> List[str]:
         allowed_databases = self.get_extra().get("schemas_allowed_for_csv_upload", [])

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2936,7 +2936,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         db_id = int(request.args["db_id"])
         database = db.session.query(Database).filter_by(id=db_id).one()
         try:
-            schemas_allowed = database.get_schema_access_for_csv_upload()
+            schemas_allowed = database.get_schema_access_for_file_upload()
             if security_manager.can_access_database(database):
                 return self.json_response(schemas_allowed)
             # the list schemas_allowed should not be empty here

--- a/superset/views/database/forms.py
+++ b/superset/views/database/forms.py
@@ -76,7 +76,7 @@ class CsvToDatabaseForm(DynamicForm):
         """
         if security_manager.can_access_database(database):
             return True
-        schemas = database.get_schema_access_for_csv_upload()
+        schemas = database.get_schema_access_for_file_upload()
         if schemas and security_manager.get_schemas_accessible_by_user(
             database, schemas, False
         ):
@@ -265,7 +265,7 @@ class ExcelToDatabaseForm(DynamicForm):
         """
         if security_manager.can_access_database(database):
             return True
-        schemas = database.get_schema_access_for_csv_upload()
+        schemas = database.get_schema_access_for_file_upload()
         if schemas and security_manager.schemas_accessible_by_user(
             database, schemas, False
         ):

--- a/superset/views/database/validators.py
+++ b/superset/views/database/validators.py
@@ -48,10 +48,10 @@ def sqlalchemy_uri_validator(
         )
 
 
-def schema_allows_csv_upload(database: Database, schema: Optional[str]) -> bool:
+def schema_allows_file_upload(database: Database, schema: Optional[str]) -> bool:
     if not database.allow_csv_upload:
         return False
-    schemas = database.get_schema_access_for_csv_upload()
+    schemas = database.get_schema_access_for_file_upload()
     if schemas:
         return schema in schemas
     return security_manager.can_access_database(database)

--- a/superset/views/database/views.py
+++ b/superset/views/database/views.py
@@ -39,7 +39,7 @@ from superset.views.base import DeleteMixin, SupersetModelView, YamlExportMixin
 
 from .forms import CsvToDatabaseForm, ExcelToDatabaseForm
 from .mixins import DatabaseMixin
-from .validators import schema_allows_csv_upload, sqlalchemy_uri_validator
+from .validators import schema_allows_file_upload, sqlalchemy_uri_validator
 
 if TYPE_CHECKING:
     from werkzeug.datastructures import FileStorage  # pylint: disable=unused-import
@@ -128,7 +128,7 @@ class CsvToDatabaseView(SimpleFormView):
         database = form.con.data
         csv_table = Table(table=form.name.data, schema=form.schema.data)
 
-        if not schema_allows_csv_upload(database, csv_table.schema):
+        if not schema_allows_file_upload(database, csv_table.schema):
             message = _(
                 'Database "%(database_name)s" schema "%(schema_name)s" '
                 "is not allowed for csv uploads. Please contact your Superset Admin.",
@@ -285,7 +285,7 @@ class ExcelToDatabaseView(SimpleFormView):
         database = form.con.data
         excel_table = Table(table=form.name.data, schema=form.schema.data)
 
-        if not schema_allows_csv_upload(database, excel_table.schema):
+        if not schema_allows_file_upload(database, excel_table.schema):
             message = _(
                 'Database "%(database_name)s" schema "%(schema_name)s" '
                 "is not allowed for excel uploads. Please contact your Superset Admin.",


### PR DESCRIPTION
This is just the tip of the iceberg. `allow_csv_upload` is almost everywhere in codebase including the database. Not sure the effects of renaming that. If someone can assist me in creating a db migration I can also do that.

![image](https://user-images.githubusercontent.com/1297759/112597191-da253780-8e1d-11eb-8070-4c61867a5a72.png)


### ADDITIONAL INFORMATION
- [x] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
