### PR TITLE
fix: adjusted tab height

### DIFF
--- a/superset-frontend/src/SqlLab/components/SouthPane/SouthPane.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/SouthPane.tsx
@@ -33,7 +33,7 @@ import {
   LOCALSTORAGE_MAX_QUERY_AGE_MS,
 } from '../../constants';
 
-const TAB_HEIGHT = 82;
+const TAB_HEIGHT = 90;
 
 /*
     editorQueries are queries executed by users passed from SqlEditor component
@@ -153,7 +153,7 @@ export default function SouthPane({
           csv={false}
           actions={actions}
           cache
-          height={innerTabContentHeight - 10}
+          height={innerTabContentHeight}
           displayLimit={displayLimit}
         />
       </Tabs.TabPane>

--- a/superset-frontend/src/SqlLab/components/SouthPane/SouthPane.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/SouthPane.tsx
@@ -33,7 +33,7 @@ import {
   LOCALSTORAGE_MAX_QUERY_AGE_MS,
 } from '../../constants';
 
-const TAB_HEIGHT = 64;
+const TAB_HEIGHT = 76;
 
 /*
     editorQueries are queries executed by users passed from SqlEditor component
@@ -63,7 +63,7 @@ const StyledPane = styled.div`
     flex-direction: column;
   }
   .tab-content {
-    overflow: hidden;
+    height: 100%;
     .alert {
       margin-top: ${({ theme }) => theme.gridUnit * 2}px;
     }

--- a/superset-frontend/src/SqlLab/components/SouthPane/SouthPane.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/SouthPane.tsx
@@ -33,7 +33,7 @@ import {
   LOCALSTORAGE_MAX_QUERY_AGE_MS,
 } from '../../constants';
 
-const TAB_HEIGHT = 76;
+const TAB_HEIGHT = 82;
 
 /*
     editorQueries are queries executed by users passed from SqlEditor component
@@ -63,7 +63,6 @@ const StyledPane = styled.div`
     flex-direction: column;
   }
   .tab-content {
-    height: 100%;
     .alert {
       margin-top: ${({ theme }) => theme.gridUnit * 2}px;
     }
@@ -154,7 +153,7 @@ export default function SouthPane({
           csv={false}
           actions={actions}
           cache
-          height={innerTabContentHeight}
+          height={innerTabContentHeight - 10}
           displayLimit={displayLimit}
         />
       </Tabs.TabPane>

--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -56,7 +56,7 @@ body {
   position: relative;
   background-color: @lightest;
   overflow-x: auto;
-  overflow-y: hidden;
+  overflow-y: auto;
 
   > .ant-tabs-tabpane {
     position: absolute;

--- a/superset-frontend/src/components/ProgressBar/index.tsx
+++ b/superset-frontend/src/components/ProgressBar/index.tsx
@@ -30,6 +30,10 @@ const ProgressBar = styled(({ striped, ...props }: ProgressBarProps) => (
   <AntdProgress {...props} />
 ))`
   line-height: 0;
+  position: inherit;
+  .ant-progress-inner {
+    position: inherit;
+  }
   .ant-progress-outer {
     ${({ percent }) => !percent && `display: none;`}
   }
@@ -37,6 +41,7 @@ const ProgressBar = styled(({ striped, ...props }: ProgressBarProps) => (
     font-size: ${({ theme }) => theme.typography.sizes.s}px;
   }
   .ant-progress-bg {
+    position: inherit;
     ${({ striped }) =>
       striped &&
       `

--- a/superset-frontend/src/components/ProgressBar/index.tsx
+++ b/superset-frontend/src/components/ProgressBar/index.tsx
@@ -30,9 +30,9 @@ const ProgressBar = styled(({ striped, ...props }: ProgressBarProps) => (
   <AntdProgress {...props} />
 ))`
   line-height: 0;
-  position: inherit;
+  position: static;
   .ant-progress-inner {
-    position: inherit;
+    position: static;
   }
   .ant-progress-outer {
     ${({ percent }) => !percent && `display: none;`}
@@ -41,7 +41,7 @@ const ProgressBar = styled(({ striped, ...props }: ProgressBarProps) => (
     font-size: ${({ theme }) => theme.typography.sizes.s}px;
   }
   .ant-progress-bg {
-    position: inherit;
+    position: static;
     ${({ striped }) =>
       striped &&
       `


### PR DESCRIPTION
### SUMMARY
The scroll bar on query history disappeared based on a redesign that we did for the results page to add rows returned. 

I adjusted the tab height of rows returned, in order to not have a scroll appear there, and added the scroll back to query history. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://user-images.githubusercontent.com/48933336/112722008-72cebc80-8edd-11eb-8621-2e76a4c62ce9.png)

after:
![Screen Shot 2021-03-26 at 4 09 45 PM](https://user-images.githubusercontent.com/48933336/112687545-06f14300-8e4e-11eb-98fa-4103fceb6f87.png)


### TEST PLAN
Manually checked this through docker to make sure that the portions that invoke the component work as expected. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
