### PR TITLE
fix(cypress): avoid referencing detached dom nodes

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/dashboard.helper.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/dashboard.helper.ts
@@ -56,8 +56,9 @@ export function waitForChartLoad(chart: ChartSpec) {
     return (
       cy
         // this id only becomes visible when the chart is loaded
-        .wrap(gridComponent)
-        .find(`#chart-id-${chartId}`, { timeout: 30000 })
+        .get(`[data-test="chart-grid-component"] #chart-id-${chartId}`, {
+          timeout: 30000,
+        })
         .should('be.visible')
         // return the chart grid component
         .then(() => gridComponent)


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Bug seen [here](https://github.com/apache/superset/pull/13822/checks?check_run_id=2205131219#step:14:67) believed to be caused by my recently merged Cypress refactor. Hopefully this fixes it, though I can't be sure because I can't reproduce the issue locally.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
