### PR TITLE
fix: Use utils.json_iso_dttm_ser to dump jsons when async query execution

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2211,8 +2211,9 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             obj = apply_display_max_row_limit(obj, rows)
 
         return json_success(
-            json.dumps(obj, default=utils.json_iso_dttm_ser, ignore_nan=True,
-                       encoding=None)
+            json.dumps(
+                obj, default=utils.json_iso_dttm_ser, ignore_nan=True, encoding=None
+            )
         )
 
     @has_access_api

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2211,7 +2211,8 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             obj = apply_display_max_row_limit(obj, rows)
 
         return json_success(
-            json.dumps(obj, default=utils.json_iso_dttm_ser, ignore_nan=True)
+            json.dumps(obj, default=utils.json_iso_dttm_ser, ignore_nan=True,
+                       encoding=None)
         )
 
     @has_access_api


### PR DESCRIPTION
### SUMMARY
If encoding is not `None`, the default encoder `utils.json_iso_dttm_ser` is not used for binary data and instead it tries to encode to the default 'utf-8'. 
For data exploration on tables with blob columns doing `SELECT *` will throw an error.
This fixes https://github.com/apache/superset/issues/13829

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before:
![image](https://user-images.githubusercontent.com/1605852/112707412-da9aee00-8e70-11eb-963d-7836c559c194.png)

after:
![image](https://user-images.githubusercontent.com/1605852/112707423-ebe3fa80-8e70-11eb-803c-c33278880a08.png)

### TEST PLAN
Try executing `select decode('DEADBEEF', 'hex');` on the sample DB with async turned on.

### ADDITIONAL INFORMATION
Asynchronous query execution must be enabled for the database.
- [x] Has associated issue: #13829 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API