### PR TITLE
fix(sqllab): warning message when displayed rows limited

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -515,6 +515,7 @@ export default class ResultSet extends React.PureComponent<
     const { results, rows } = this.props.query;
     const limitReached = results?.displayLimitReached;
     const limitWarning = <Icon className="returnedRowsImage" name="warning" />;
+    const queryLimit = this.props.query.queryLimit;
     return (
       <ReturnedRows>
         {limitReached && limitWarning}
@@ -522,10 +523,10 @@ export default class ResultSet extends React.PureComponent<
         {limitReached && (
           <span className="limitMessage">
             {t(
-              `It appears that the number of rows in the query results displayed
-           was limited on the server side to
-           the %s limit.`,
-              rows,
+            `The number of results displayed is limited to %s. Please add
+            additional limits/filters or download to csv to see more rows up to
+            the %s limit.`,
+            rows, queryLimit
             )}
           </span>
         )}


### PR DESCRIPTION
### SUMMARY
Better error message when the displayed rows in SQL Lab are limited to 10000. Based on user feedback, currently the error is not very actionable for user, because the displayed rows are limited to 10000 but if user selected higher limit (e.g. 100 000) in the dropdown limit, they can still get more results (up to the max rows limit base don config) when downloading CSV. Alternatively they can add filters and rerun the query to get less results. 

This new warning message clarifies this for the user making the error more actionable.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="719" alt="Screen Shot 2021-03-28 at 12 33 00 PM" src="https://user-images.githubusercontent.com/61221714/112769869-582d3e00-8fd8-11eb-9c34-b6fedf50ee0e.png">


After:
![sqllab_after](https://user-images.githubusercontent.com/61221714/112769850-32079e00-8fd8-11eb-8f18-7b7f72208323.png)


### TEST PLAN
Validated in local, took screenshots of new warning message.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
