### PR TITLE
fix(dependency): Pin pystan after breaking prophet install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,7 @@ setup(
         "postgres": ["psycopg2-binary==2.8.5"],
         "presto": ["pyhive[presto]>=0.4.0"],
         "trino": ["sqlalchemy-trino>=0.2"],
-        "prophet": ["fbprophet>=0.6, <0.7"],
+        "prophet": ["fbprophet>=0.7.1, <0.8", "pystan<3.0"],
         "redshift": ["sqlalchemy-redshift>=0.8.1, < 0.9"],
         "snowflake": ["snowflake-sqlalchemy>=1.2.3, <1.3"],
         "teradata": ["sqlalchemy-teradata==0.9.0.dev0"],


### PR DESCRIPTION
### SUMMARY
Prophet is heavily dependent on Pystan: https://facebook.github.io/prophet/docs/installation.html

Pystan has recently (2021-03-25) release its v3.0.0.

This release is not backward compatible and breaks fbprophet: https://github.com/facebook/prophet/issues/1856

(Indeed, fbprophet 0.6 specifies `pystan>=2.14` — but doesn't restrict upgrading to next major release: https://github.com/facebook/prophet/blob/0.6/python/requirements.txt#L3)

So we need to pin pystan to the lastest non 3.x release, while fbprophet fixes the dependency on their side.

### TEST PLAN
`pip install '.[prophet]'`?

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #13851
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
