### PR TITLE
fix: added float support to postgres

### DIFF
--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -32,7 +32,7 @@ from typing import (
 )
 
 from pytz import _FixedOffset  # type: ignore
-from sqlalchemy.dialects.postgresql import ARRAY, DOUBLE_PRECISION, ENUM, JSON
+from sqlalchemy.dialects.postgresql import ARRAY, DOUBLE_PRECISION, ENUM, FLOAT, JSON
 from sqlalchemy.dialects.postgresql.base import PGInspector
 from sqlalchemy.types import String, TypeEngine
 
@@ -92,6 +92,11 @@ class PostgresEngineSpec(PostgresBaseEngineSpec):
     try_remove_schema_from_table_name = False
 
     column_type_mappings = (
+        (
+            re.compile(r"^float", re.IGNORECASE),
+            FLOAT(),
+            GenericDataType.NUMERIC,
+        ),
         (
             re.compile(r"^double precision", re.IGNORECASE),
             DOUBLE_PRECISION(),


### PR DESCRIPTION
Postgres columns of type FLOAT were not being properly considered as numeric.

Filters contain strings and have to be converted to numbers before creating SQLAlchemy where/having conditions.

Trying a second pull request. First one I'm unable to run pre-commit hooks. Hopefully this one is good. Will delete previous pull-request.