### PR TITLE
chore: Displays row limit warning with the Alert component

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -27,7 +27,6 @@ import shortid from 'shortid';
 import rison from 'rison';
 import { styled, t, makeApi } from '@superset-ui/core';
 import { debounce } from 'lodash';
-import Icon from 'src/components/Icon';
 import ErrorMessageWithStackTrace from 'src/components/ErrorMessage/ErrorMessageWithStackTrace';
 import { SaveDatasetModal } from 'src/SqlLab/components/SaveDatasetModal';
 import { put as updateDatset } from 'src/api/dataset';
@@ -104,15 +103,6 @@ const MonospaceDiv = styled.div`
 const ReturnedRows = styled.div`
   font-size: 13px;
   line-height: 24px;
-  .returnedRowsImage {
-    color: ${({ theme }) => theme.colors.warning.base};
-    vertical-align: bottom;
-    margin-right: ${({ theme }) => theme.gridUnit * 2}px;
-  }
-  .limitMessage {
-    color: ${({ theme }) => theme.colors.secondary.light1};
-    margin-left: ${({ theme }) => theme.gridUnit * 2}px;
-  }
 `;
 const ResultSetControls = styled.div`
   display: flex;
@@ -514,21 +504,20 @@ export default class ResultSet extends React.PureComponent<
   renderRowsReturned() {
     const { results, rows, queryLimit } = this.props.query;
     const limitReached = results?.displayLimitReached;
-    const limitWarning = <Icon className="returnedRowsImage" name="warning" />;
     return (
       <ReturnedRows>
-        {limitReached && limitWarning}
-        <span>{t(`%s rows returned`, rows)}</span>
+        {!limitReached && <span>{t(`%s rows returned`, rows)}</span>}
         {limitReached && (
-          <span className="limitMessage">
-            {t(
+          <Alert
+            type="warning"
+            message={t(
               `The number of results displayed is limited to %s. Please add
-              additional limits/filters or download to csv to see more rows up to
-              the %s limit.`,
+            additional limits/filters or download to csv to see more rows up to
+            the %s limit.`,
               rows,
               queryLimit,
             )}
-          </span>
+          />
         )}
       </ReturnedRows>
     );


### PR DESCRIPTION
### SUMMARY
Displays row limit warning with the `Alert` component. 

See also: https://github.com/apache/superset/pull/13841

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![112777601-79e9ed80-8ff7-11eb-9298-25f62fee872c](https://user-images.githubusercontent.com/70410625/112888487-c9d5bc80-90aa-11eb-99c0-5f481f1d43e8.png)

<img width="1788" alt="Screen Shot 2021-03-29 at 4 21 48 PM" src="https://user-images.githubusercontent.com/70410625/112888568-e3770400-90aa-11eb-8cf1-758d3f75bd2a.png">

@rusackas @junlincc @etr2460 @zuzana-vej 

### TEST PLAN
1 - Execute all tests
2 - All tests should pass

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
