### PR TITLE
fix: Check for permissions in FilterBox

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -61,6 +61,7 @@ from superset.exceptions import (
     NullValueException,
     QueryObjectValidationError,
     SpatialException,
+    SupersetSecurityException,
 )
 from superset.extensions import cache_manager, security_manager
 from superset.models.cache import CacheKey
@@ -439,7 +440,13 @@ class BaseViz:
     def get_payload(self, query_obj: Optional[QueryObjectDict] = None) -> VizPayload:
         """Returns a payload of metadata and data"""
 
-        self.run_extra_queries()
+        try:
+            self.run_extra_queries()
+        except SupersetSecurityException as ex:
+            error = dataclasses.asdict(ex.error)
+            self.errors.append(error)
+            self.status = utils.QueryStatus.FAILED
+
         payload = self.get_df_payload(query_obj)
 
         df = payload.get("df")
@@ -2037,6 +2044,8 @@ class FilterBoxViz(BaseViz):
         return {}
 
     def run_extra_queries(self) -> None:
+        from superset.common.query_context import QueryContext
+
         qry = super().query_obj()
         filters = self.form_data.get("filter_configs") or []
         qry["row_limit"] = self.filter_row_limit
@@ -2050,6 +2059,10 @@ class FilterBoxViz(BaseViz):
             qry["groupby"] = [col]
             metric = flt.get("metric")
             qry["metrics"] = [metric] if metric else []
+            QueryContext(
+                datasource={"id": self.datasource.id, "type": self.datasource.type},
+                queries=[qry],
+            ).raise_for_access()
             df = self.get_df_payload(query_obj=qry).get("df")
             self.dataframes[col] = df
 


### PR DESCRIPTION
### SUMMARY
If a filter box uses data that the user shouldn't have access to, they don't currently get restricted from using the filter box. This is because filterboxes are kinda hacky to begin with, and it looks like we don't check permissions for the extra queries it runs. This PR builds a QueryContext for each query the filterbox runs and calls `raise_for_access` on it. Then we catch that exception and set the error on the response if it fails.

The big thing I'm unhappy with here is the import within the `run_extra_queries` function o_O I tried to get around this, but circular imports were pretty impossible here... Would love it if others have better thoughts about how to resolve this.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
Manually test with a FilterBox that accesses data I don't have access to, see the failure. See it pass when I do have access to the data.

No unit tests currently exist for the `FilterBox` viz. I've got the sense that this will be deprecated soon so 🤷 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @villebro @serenajiang @michellethomas @ktmud 
cc: @junlincc 