### PR TITLE
docs: fixed a link

### DIFF
--- a/docs/src/pages/docs/introduction.mdx
+++ b/docs/src/pages/docs/introduction.mdx
@@ -15,7 +15,7 @@ Here are a **few different ways you can get started with Superset**:
 - Download the [source from Apache Foundation's website](https://dist.apache.org/repos/dist/release/superset/1.0.0/)
 - Download the latest Superset version from [Pypi here](https://pypi.org/project/apache-superset/)
 - Setup Superset locally with one command
-using [Docker Compose](docs/installation/installing-superset-using-docker-compose)
+using [Docker Compose](installation/installing-superset-using-docker-compose)
 - Download the [Docker image](https://hub.docker.com/r/apache/superset) from Dockerhub
 - Install the latest version of Superset
 [from Github](https://github.com/apache/superset/tree/latest)


### PR DESCRIPTION
### SUMMARY
Currently link goes to: https://superset.apache.org/docs/docs/installation/installing-superset-using-docker-compose
It should go to: https://superset.apache.org/docs/installation/installing-superset-using-docker-compose

### TEST PLAN
Click on the link

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
