### PR TITLE
feat: only send alert error emails to owners of the alert

### DIFF
--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -224,8 +224,8 @@ class BaseReportState:
             )
         return NotificationContent(name=name, url=url, screenshot=screenshot_data)
 
+    @staticmethod
     def _send(
-        self,
         notification_content: NotificationContent,
         recipients: List[ReportRecipients]
     ) -> None:
@@ -263,7 +263,6 @@ class BaseReportState:
         notification_content = NotificationContent(name=name, text=message)
 
         # filter recipients to recipients who are also owners
-        
         owner_recipients = [
             ReportRecipients(
                 type=ReportRecipientType.EMAIL,

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -222,7 +222,11 @@ class BaseReportState:
             )
         return NotificationContent(name=name, url=url, screenshot=screenshot_data)
 
-    def _send(self, notification_content: NotificationContent, recipients: List[ReportRecipients]) -> None:
+    def _send(
+        self,
+        notification_content: NotificationContent,
+        recipients: List[ReportRecipients]
+    ) -> None:
         """
         Sends a notification to all recipients
 
@@ -255,10 +259,13 @@ class BaseReportState:
         :raises: ReportScheduleNotificationError
         """
         notification_content = NotificationContent(name=name, text=message)
-        
+
         # filter recipients to recipients who are also owners
         owner_ids = [owner.id for owner in self._report_schedule.owners]
-        owner_recipients = filter(lambda recipient: recipient.id in owner_ids, self._report_schedule.recipients)
+        owner_recipients = filter(
+            lambda recipient: recipient.id in owner_ids,
+            self._report_schedule.recipients
+        )
 
         self._send(notification_content, owner_recipients)
 

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -30,11 +30,11 @@ from superset.commands.exceptions import CommandException
 from superset.extensions import feature_flag_manager
 from superset.models.reports import (
     ReportExecutionLog,
+    ReportRecipients,
     ReportRecipientType,
     ReportSchedule,
     ReportScheduleType,
     ReportState,
-    ReportRecipients
 )
 from superset.reports.commands.alert import AlertCommand
 from superset.reports.commands.exceptions import (
@@ -226,8 +226,7 @@ class BaseReportState:
 
     @staticmethod
     def _send(
-        notification_content: NotificationContent,
-        recipients: List[ReportRecipients]
+        notification_content: NotificationContent, recipients: List[ReportRecipients]
     ) -> None:
         """
         Sends a notification to all recipients
@@ -266,10 +265,9 @@ class BaseReportState:
         owner_recipients = [
             ReportRecipients(
                 type=ReportRecipientType.EMAIL,
-                recipient_config_json=json.dumps({
-                    "target": owner.email
-                }),
-            ) for owner in self._report_schedule.owners
+                recipient_config_json=json.dumps({"target": owner.email}),
+            )
+            for owner in self._report_schedule.owners
         ]
 
         self._send(notification_content, owner_recipients)

--- a/tests/reports/commands_tests.py
+++ b/tests/reports/commands_tests.py
@@ -26,7 +26,7 @@ from flask_sqlalchemy import BaseQuery
 from freezegun import freeze_time
 from sqlalchemy.sql import func
 
-from superset import db
+from superset import db, security_manager
 from superset.models.core import Database
 from superset.models.dashboard import Dashboard
 from superset.models.reports import (
@@ -130,6 +130,12 @@ def create_report_notification(
     report_type = report_type or ReportScheduleType.REPORT
     target = email_target or slack_channel
     config_json = {"target": target}
+    owner = (
+        db.session.query(security_manager.user_model)
+        .filter_by(email="admin@fab.org")
+        .one_or_none()
+    )
+
     if slack_channel:
         recipient = ReportRecipients(
             type=ReportRecipientType.SLACK,
@@ -151,6 +157,7 @@ def create_report_notification(
         dashboard=dashboard,
         database=database,
         recipients=[recipient],
+        owners=[owner],
         validator_type=validator_type,
         validator_config_json=validator_config_json,
         grace_period=grace_period,
@@ -879,7 +886,7 @@ def test_soft_timeout_alert(email_mock, create_alert_email_chart):
 
     notification_targets = get_target_from_report_schedule(create_alert_email_chart)
     # Assert the email smtp address, asserts a notification was sent with the error
-    assert email_mock.call_args[0][0] == notification_targets[0]
+    assert email_mock.call_args[0][0] == "admin@fab.org"
 
     assert_log(
         ReportState.ERROR, error_message="A timeout occurred while executing the query."
@@ -908,9 +915,8 @@ def test_soft_timeout_screenshot(screenshot_mock, email_mock, create_alert_email
             test_id, create_alert_email_chart.id, datetime.utcnow()
         ).run()
 
-    notification_targets = get_target_from_report_schedule(create_alert_email_chart)
     # Assert the email smtp address, asserts a notification was sent with the error
-    assert email_mock.call_args[0][0] == notification_targets[0]
+    assert email_mock.call_args[0][0] == "admin@fab.org"
 
     assert_log(
         ReportState.ERROR, error_message="A timeout occurred while taking a screenshot."
@@ -937,7 +943,7 @@ def test_fail_screenshot(screenshot_mock, email_mock, create_report_email_chart)
 
     notification_targets = get_target_from_report_schedule(create_report_email_chart)
     # Assert the email smtp address, asserts a notification was sent with the error
-    assert email_mock.call_args[0][0] == notification_targets[0]
+    assert email_mock.call_args[0][0] == "admin@fab.org"
 
     assert_log(
         ReportState.ERROR, error_message="Failed taking a screenshot Unexpected error"
@@ -986,7 +992,7 @@ def test_invalid_sql_alert(email_mock, create_invalid_sql_alert_email_chart):
             create_invalid_sql_alert_email_chart
         )
         # Assert the email smtp address, asserts a notification was sent with the error
-        assert email_mock.call_args[0][0] == notification_targets[0]
+        assert email_mock.call_args[0][0] == "admin@fab.org"
 
 
 @pytest.mark.usefixtures("create_invalid_sql_alert_email_chart")
@@ -1007,7 +1013,7 @@ def test_grace_period_error(email_mock, create_invalid_sql_alert_email_chart):
             create_invalid_sql_alert_email_chart
         )
         # Assert the email smtp address, asserts a notification was sent with the error
-        assert email_mock.call_args[0][0] == notification_targets[0]
+        assert email_mock.call_args[0][0] == "admin@fab.org"
         assert (
             get_notification_error_sent_count(create_invalid_sql_alert_email_chart) == 1
         )


### PR DESCRIPTION
### SUMMARY
With this change, alert errors are sent to owners of the alert, instead of the recipients.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
Modified test setup and test cases to assert emails are sent to the alert owner's email address.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
