### PR TITLE
fix: change status code for generic errors to 400

### DIFF
--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -59,7 +59,7 @@ class SupersetTimeoutException(SupersetErrorException):
 
 
 class SupersetGenericDBErrorException(SupersetErrorException):
-    status = 500
+    status = 422
 
     def __init__(
         self,

--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -59,7 +59,7 @@ class SupersetTimeoutException(SupersetErrorException):
 
 
 class SupersetGenericDBErrorException(SupersetErrorException):
-    status = 422
+    status = 400
 
     def __init__(
         self,


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
With generic db errors we'll be returning 422 instead of 500

![Screen Shot 2021-03-30 at 10 42 50 AM](https://user-images.githubusercontent.com/27827808/113008166-cd1d8680-9144-11eb-93d3-f0953b84f60a.png)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
1. Goto sql lab
2. Write malformed query
3. Check network tab for `sql_json` to be 422 instead of 500

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
