### PR TITLE
feat: create table with long name

### DIFF
--- a/superset/examples/big_data.py
+++ b/superset/examples/big_data.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import random
+import string
 from typing import List
 
 import sqlalchemy.sql.sqltypes
@@ -68,3 +70,7 @@ def load_big_data() -> None:
     ]
     for i in range(1000):
         add_data(columns=columns, num_rows=10, table_name=f"small_table_{i}")
+
+    print("Creating table with long name")
+    name = "".join(random.choices(string.ascii_letters + string.digits, k=64))
+    add_data(columns=columns, num_rows=10, table_name=name)


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Make `superset load-examples -b` create a table with a long name (64 characters, the limit), so we can test https://github.com/apache/superset/pull/13858.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

1. `superset load-examples -b -t`
2. Verified that table called `zcZ6VHUhetxSu1N6R9DAF1nv6IqmPd4EnmqNuWaL5sXyEYTIiPTZhMJMkoGTg9VE` (random) was created.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
