### PR TITLE
fix: consistent left margin for dashboard layout. Fixes #13863

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -112,6 +112,10 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
   const filters = useFilters();
   const filterValues = Object.values<Filter>(filters);
 
+  const nativeFiltersEnabled = isFeatureEnabled(
+    FeatureFlag.DASHBOARD_NATIVE_FILTERS,
+  );
+
   const [dashboardFiltersOpen, setDashboardFiltersOpen] = useState(true);
 
   const toggleDashboardFiltersOpen = (visible?: boolean) => {
@@ -150,7 +154,11 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
     (topLevelTabs ? TABS_HEIGHT : 0);
 
   useEffect(() => {
-    if (filterValues.length === 0 && dashboardFiltersOpen) {
+    if (
+      filterValues.length === 0 &&
+      dashboardFiltersOpen &&
+      nativeFiltersEnabled
+    ) {
       toggleDashboardFiltersOpen(false);
     }
   }, [filterValues.length]);
@@ -215,7 +223,7 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
         className="dashboard-content"
         dashboardFiltersOpen={dashboardFiltersOpen}
       >
-        {isFeatureEnabled(FeatureFlag.DASHBOARD_NATIVE_FILTERS) && !editMode && (
+        {nativeFiltersEnabled && !editMode && (
           <StickyVerticalBar
             filtersOpen={dashboardFiltersOpen}
             topOffset={barTopOffset}


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A recent PR, #13723, made some changes around how the sidebar works for the native filter features. This looks great when the feature flag is on, but when the feature flag is off, we lose the left margin, as reported in #13863. 

This PR makes sure the styling is consistent, by considering feature flag setting, and only toggling off `dashboardFiltersOpen` (which sets the margin) when the feature is indeed enabled.

@simcha90 if you have a more elegant way to tackle this, or ideas for sufficient testing to cover this possible regression, please let me know your thoughts.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

BEFORE (`DASHBOARD_NATIVE_FILTERS` set to False):
![image](https://user-images.githubusercontent.com/812905/113099845-74cf9e80-91af-11eb-8fde-894052c4a489.png)

AFTER (`DASHBOARD_NATIVE_FILTERS` set to False):
![image](https://user-images.githubusercontent.com/812905/113100191-ee678c80-91af-11eb-9ee7-6e831756e5a1.png)
![image](https://user-images.githubusercontent.com/812905/113100648-84031c00-91b0-11eb-8bec-ea2e74f7e9b6.png)

AFTER (`DASHBOARD_NATIVE_FILTERS` set to True):
![Toggling](https://user-images.githubusercontent.com/812905/113100475-55854100-91b0-11eb-84b0-59f57c12f9fb.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Verified that the margin is restored, in view and edit mode, with the `DASHBOARD_NATIVE_FILTERS` flag on and off.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
