### PR TITLE
fix: do not run containers as root by default in Helm chart

### DIFF
--- a/helm/superset/templates/_helpers.tpl
+++ b/helm/superset/templates/_helpers.tpl
@@ -49,19 +49,6 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "superset-bootstrap" -}}
-#!/bin/sh
-{{ if .Values.additionalAptPackages }}
-apt-get update -y \
-  && apt-get install -y --no-install-recommends \
-     {{ range .Values.additionalAptPackages }}{{ . }} {{ end }}\
-  && rm -rf /var/lib/apt/lists/*
-{{ end -}}
-{{ if .Values.additionalRequirements }}
-pip install {{ range .Values.additionalRequirements }}{{ . }} {{ end }}
-{{ end -}}
-{{ end -}}
-
 {{- define "superset-config" }}
 import os
 from cachelib.redis import RedisCache

--- a/helm/superset/templates/deployment-beat.yaml
+++ b/helm/superset/templates/deployment-beat.yaml
@@ -49,7 +49,7 @@ spec:
         release: {{ .Release.Name }}
     spec:
       securityContext:
-        runAsUser: 0 # Needed in order to allow pip install to work in bootstrap
+        runAsUser: {{ .Values.runAsUser }}
       {{- if .Values.supersetCeleryBeat.initContainers }}
       initContainers:
       {{-  tpl (toYaml .Values.supersetCeleryBeat.initContainers) . | nindent 6 }}

--- a/helm/superset/templates/deployment-worker.yaml
+++ b/helm/superset/templates/deployment-worker.yaml
@@ -47,7 +47,7 @@ spec:
         release: {{ .Release.Name }}
     spec:
       securityContext:
-        runAsUser: 0 # Needed in order to allow pip install to work in bootstrap
+        runAsUser: {{ .Values.runAsUser }}
       {{- if .Values.supersetWorker.initContainers }}
       initContainers:
       {{-  tpl (toYaml .Values.supersetWorker.initContainers) . | nindent 6 }}

--- a/helm/superset/templates/deployment.yaml
+++ b/helm/superset/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         # Force reload on config changes
         checksum/superset_config.py: {{ include "superset-config" . | sha256sum }}
         checksum/superset_init.sh: {{ tpl .Values.init.initscript . | sha256sum }}
-        checksum/superset_bootstrap.sh: {{ include "superset-bootstrap" . | sha256sum }}
+        checksum/superset_bootstrap.sh: {{ tpl .Values.bootstrapScript . | sha256sum }}
         checksum/connections: {{ .Values.supersetNode.connections | toYaml | sha256sum }}
         checksum/extraConfigs: {{ .Values.extraConfigs | toYaml | sha256sum }}
         checksum/extraSecrets: {{ .Values.extraSecrets | toYaml | sha256sum }}
@@ -50,7 +50,7 @@ spec:
         release: {{ .Release.Name }}
     spec:
       securityContext:
-        runAsUser: 0 # Needed in order to allow pip install to work in bootstrap
+        runAsUser: {{ .Values.runAsUser }}
       {{- if .Values.supersetNode.initContainers }}
       initContainers:
       {{-  tpl (toYaml .Values.supersetNode.initContainers) . | nindent 6 }}

--- a/helm/superset/templates/init-job.yaml
+++ b/helm/superset/templates/init-job.yaml
@@ -28,7 +28,7 @@ spec:
       name: {{ template "superset.name" . }}-init-db
     spec:
       securityContext:
-        runAsUser: 0 # Needed in order to allow pip install to work in bootstrap
+        runAsUser: {{ .Values.runAsUser }}
       {{- if .Values.init.initContainers }}
       initContainers:
       {{-  tpl (toYaml .Values.init.initContainers) . | nindent 6 }}
@@ -57,6 +57,8 @@ spec:
             readOnly: true
         {{- end }}
         command: {{  tpl (toJson .Values.init.command) . }}
+        resources:
+{{ toYaml .Values.init.resources | indent 10 }}
       volumes:
         - name: superset-config
           secret:

--- a/helm/superset/templates/secret-superset-config.yaml
+++ b/helm/superset/templates/secret-superset-config.yaml
@@ -30,7 +30,7 @@ stringData:
   superset_init.sh: |
 {{- tpl .Values.init.initscript . | nindent 4 }}
   superset_bootstrap.sh: |
-{{- include "superset-bootstrap" . | nindent 4 }}
+{{- tpl .Values.bootstrapScript . | nindent 4 }}
 
 {{- if .Values.extraSecrets }}
 {{- range $path, $config := .Values.extraSecrets }}

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -21,15 +21,19 @@
 
 replicaCount: 1
 
-## These requirements are used to build a requirements file which is then applied on init
-## of superset containers
-additionalRequirements:
-  - "psycopg2==2.8.5"
-  - "redis==3.2.1"
+# User ID directive
+# Note that this user must have appropriate permissions to run the bootstrap script
+runAsUser: 1000
 
-## These apt packages are applied on init of superset containers
-additionalAptPackages: {}
-  # - nano
+# Install additional packages and do any other bootstrap configuration in this script
+# For production clusters it's recommended to build own image with this step done in CI
+bootstrapScript: |
+  #!/bin/bash
+  # apt-get update -y &&\
+  #  apt-get install -y --no-install-recommends nano &&\
+  #  rm -rf /var/lib/apt/lists/*
+  # pip install psycopg2==2.8.5 redis==3.2.1
+  if [ ! -f ~/bootstrap ]; then echo "Running Superset with uid {{ .Values.runAsUser }}" > ~/bootstrap; fi
 
 ## The name of the secret which we will use to generate a superset_config.py file
 ## Note: this secret must have the key superset_config.py in it and can include other files as well
@@ -198,6 +202,16 @@ supersetCeleryBeat:
 ##
 ## Init job configuration
 init:
+  # Configure resources
+  # Warning: fab commant consumes a lot of ram and can
+  # cause the process to be killed due to OOM if it exceeds limit
+  resources: {}
+    # limits:
+    #   cpu:
+    #   memory:
+    # requests:
+    #   cpu:
+    #   memory:
   command:
     - "/bin/sh"
     - "-c"

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -21,18 +21,18 @@
 
 replicaCount: 1
 
-# User ID directive
-# Note that this user must have appropriate permissions to run the bootstrap script
-runAsUser: 1000
+# User ID directive. This user must have enough permissions to run the bootstrap script
+# Runn containers as root is not recommended in production. Change this to another UID - e.g. 1000 to be more secure
+runAsUser: 0
 
 # Install additional packages and do any other bootstrap configuration in this script
 # For production clusters it's recommended to build own image with this step done in CI
 bootstrapScript: |
   #!/bin/bash
-  # apt-get update -y &&\
-  #  apt-get install -y --no-install-recommends nano &&\
-  #  rm -rf /var/lib/apt/lists/*
-  # pip install psycopg2==2.8.5 redis==3.2.1
+  apt-get update -y &&\
+   apt-get install -y --no-install-recommends nano &&\
+   rm -rf /var/lib/apt/lists/*
+  pip install psycopg2==2.8.5 redis==3.2.1
   if [ ! -f ~/bootstrap ]; then echo "Running Superset with uid {{ .Values.runAsUser }}" > ~/bootstrap; fi
 
 ## The name of the secret which we will use to generate a superset_config.py file


### PR DESCRIPTION
### SUMMARY
This allows the user to control bootstrap behavior to avoid running containers with uid 0. Fixes #13869 

Some additions to documentation might be needed. Let me know if that's the case.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - No change in behavior

### TEST PLAN
N/A - Helm chart does not currently have tests

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: #13869 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
