### PR TITLE
fix: enable installing docker/requirements-local.txt in docker-compos…

### DIFF
--- a/docker-compose-non-dev.yml
+++ b/docker-compose-non-dev.yml
@@ -44,6 +44,8 @@ services:
     env_file: docker/.env-non-dev
     image: *superset-image
     container_name: superset_app
+    command: ["/app/docker/docker-bootstrap.sh", "app-gunicorn"]
+    user: "root"
     restart: unless-stopped
     ports:
       - 8088:8088

--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -45,4 +45,7 @@ elif [[ "${1}" == "beat" ]]; then
 elif [[ "${1}" == "app" ]]; then
   echo "Starting web app..."
   flask run -p 8088 --with-threads --reload --debugger --host=0.0.0.0
+elif [[ "${1}" == "app-gunicorn" ]]; then
+  echo "Starting web app..."
+  /app/docker/docker-entrypoint.sh
 fi


### PR DESCRIPTION
…e-non-dev.yml


### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The current service definition for the web app in `docker-compose-non-dev.yml` uses the default entrypoint for the container which skips over installing the packages listed in `docker/requirements-local.txt`. This PR fixes that issue by adding another variant to the `docker-bootstrap.sh` script to run the default entrypoint script after packages have been installed. 
Note: setting the user as `root` is necessary in order to install packages. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- run `docker-compose -f docker-compose-non-dev.yml up` and confirm:
  - packages listed in `docker/requirements-local.txt` are installed on container boot
  - the web app is being served by gunicorn. 
  
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #13640
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
