### PR TITLE
docs: replace deprecated EMAIL_REPORTS_WEBDRIVER with the new WEBDRIVER_TYPE

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1207,7 +1207,7 @@ To render dashboards you need to install a local browser on your superset instan
   * `geckodriver <https://github.com/mozilla/geckodriver>`_ and Firefox is preferred
   * `chromedriver <http://chromedriver.chromium.org/>`_ is a good option too
 
-You need to adjust the ``EMAIL_REPORTS_WEBDRIVER`` accordingly in your configuration.
+You need to adjust the ``WEBDRIVER_TYPE`` accordingly in your configuration.
 
 You also need to specify on behalf of which username to render the dashboards. In general
 dashboards and charts are not accessible to unauthorized requests, that is why the

--- a/docs/src/pages/docs/installation/alerts_reports.mdx
+++ b/docs/src/pages/docs/installation/alerts_reports.mdx
@@ -337,7 +337,7 @@ To render dashboards you need to install a local browser on your Superset instan
 - [geckodriver](https://github.com/mozilla/geckodriver) for Firefox
 - [chromedriver](http://chromedriver.chromium.org/) for Chrome
 
-You'll need to adjust the `EMAIL_REPORTS_WEBDRIVER` accordingly in your configuration. You also need
+You'll need to adjust the `WEBDRIVER_TYPE` accordingly in your configuration. You also need
 to specify on behalf of which username to render the dashboards. In general dashboards and charts
 are not accessible to unauthorized requests, that is why the worker needs to take over credentials
 of an existing user to take a snapshot.


### PR DESCRIPTION
### SUMMARY

Since #10562
> EMAIL_REPORTS_WEBDRIVER is deprecated use WEBDRIVER_TYPE instead.

The old variable was still used a couple of times in the docs.