### PR TITLE
fix: SQL -> Explore Overwrite flow

### DIFF
--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -29,10 +29,9 @@ from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_babel import ngettext
 from marshmallow import ValidationError
 
-from superset import event_logger, is_feature_enabled, db
+from superset import event_logger, is_feature_enabled
 from superset.commands.exceptions import CommandInvalidError
 from superset.commands.importers.v1.utils import get_contents_from_bundle
-from superset.connectors.connector_registry import ConnectorRegistry
 from superset.connectors.sqla.models import SqlaTable
 from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP, RouteMethod
 from superset.databases.filters import DatabaseFilter

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -316,13 +316,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
                 g.user, pk, item, override_columns
             ).run()
             if override_columns:
-              print(5 * '*')
-              print(item)
-              print(5 * '*')
-              datasource = ConnectorRegistry.get_datasource(
-                'table', item['database_id'], db.session
-              )
-              external_metadata = datasource.external_metadata()
+              RefreshDatasetCommand(g.user, pk).run()
             response = self.response(200, id=changed_model.id, result=item)
         except DatasetNotFoundError:
             response = self.response_404()

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -315,7 +315,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
                 g.user, pk, item, override_columns
             ).run()
             if override_columns:
-              RefreshDatasetCommand(g.user, pk).run()
+                RefreshDatasetCommand(g.user, pk).run()
             response = self.response(200, id=changed_model.id, result=item)
         except DatasetNotFoundError:
             response = self.response_404()

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -29,9 +29,10 @@ from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_babel import ngettext
 from marshmallow import ValidationError
 
-from superset import event_logger, is_feature_enabled
+from superset import event_logger, is_feature_enabled, db
 from superset.commands.exceptions import CommandInvalidError
 from superset.commands.importers.v1.utils import get_contents_from_bundle
+from superset.connectors.connector_registry import ConnectorRegistry
 from superset.connectors.sqla.models import SqlaTable
 from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP, RouteMethod
 from superset.databases.filters import DatabaseFilter
@@ -314,6 +315,14 @@ class DatasetRestApi(BaseSupersetModelRestApi):
             changed_model = UpdateDatasetCommand(
                 g.user, pk, item, override_columns
             ).run()
+            if override_columns:
+              print(5 * '*')
+              print(item)
+              print(5 * '*')
+              datasource = ConnectorRegistry.get_datasource(
+                'table', item['database_id'], db.session
+              )
+              external_metadata = datasource.external_metadata()
             response = self.response(200, id=changed_model.id, result=item)
         except DatasetNotFoundError:
             response = self.response_404()

--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -598,11 +598,7 @@ class TestDatasetApi(SupersetTestCase):
         rv = self.put_assert_metric(uri, dataset_data, "put")
         assert rv.status_code == 200
 
-        columns = (
-            db.session.query(TableColumn)
-            .filter_by(table_id=dataset.id)
-            .all()
-        )
+        columns = db.session.query(TableColumn).filter_by(table_id=dataset.id).all()
 
         assert columns[0].column_name == dataset_data["columns"][0]["column_name"]
         assert columns[0].description == dataset_data["columns"][0]["description"]

--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -601,7 +601,6 @@ class TestDatasetApi(SupersetTestCase):
         columns = (
             db.session.query(TableColumn)
             .filter_by(table_id=dataset.id)
-            .order_by("column_name")
             .all()
         )
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In prod overwrite flow causes an error when landing in the explore view. We've fixed this by doing a refresh before returning the payload on update.

![Screen Shot 2021-04-04 at 11 44 23 AM](https://user-images.githubusercontent.com/27827808/113514179-261d5e00-953b-11eb-9470-c6aa2da8cdc2.png)


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
1. Goto SQLLab
2. Write and run query
3. Click Explore
4. Save as new query
5. Edit query in SQLLab
6. Save as overwrite
7. Verify explore view doesn't throw an error

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
