### PR TITLE
chore: bump @superset-ui/plugin-chart-table to 0.17.28

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -100,7 +100,7 @@
     "bootstrap": "^3.4.1",
     "bootstrap-slider": "^10.0.0",
     "brace": "^0.11.1",
-    "chrono-node": "^2.2.1",
+    "chrono-node": "^2.2.6",
     "classnames": "^2.2.5",
     "core-js": "^3.6.5",
     "d3-array": "^1.2.4",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -90,7 +90,7 @@
     "@superset-ui/legacy-preset-chart-deckgl": "^0.4.6",
     "@superset-ui/legacy-preset-chart-nvd3": "^0.17.27",
     "@superset-ui/plugin-chart-echarts": "^0.17.27",
-    "@superset-ui/plugin-chart-table": "^0.17.27",
+    "@superset-ui/plugin-chart-table": "^0.17.28",
     "@superset-ui/plugin-chart-word-cloud": "^0.17.27",
     "@superset-ui/preset-chart-xy": "^0.17.27",
     "@vx/responsive": "^0.0.195",


### PR DESCRIPTION
### SUMMARY

bump @superset-ui/plugin-chart-table to 0.17.28 to bring in https://github.com/apache-superset/superset-ui/pull/1039

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

See https://github.com/apache-superset/superset-ui/pull/1039

### TEST PLAN

Manual testing and visual confirmation

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
