### PR TITLE
fix: null exception from adhoc metric popover

### DIFF
--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover.jsx
@@ -318,7 +318,7 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
         option.filterBy.toLowerCase().indexOf(input.toLowerCase()) >= 0,
     };
 
-    if (this.props.datasourceType === 'druid') {
+    if (this.props.datasourceType === 'druid' && aggregateSelectProps.options) {
       aggregateSelectProps.options = aggregateSelectProps.options.filter(
         aggregate => aggregate !== 'AVG',
       );


### PR DESCRIPTION
### SUMMARY
This PR is to fix a JS exception, which is specific to druid dataset. When user tried to add/edit Metrics for a druid dataset, JS exception is thrown.


**Before**
<img width="1301" alt="Screen Shot 2021-04-05 at 4 42 43 PM" src="https://user-images.githubusercontent.com/27990562/113639436-061a9700-962e-11eb-968b-c11d93b665d1.png">


**After**
Show adhoc metrics popovers.

### TEST PLAN
CI and manual test

