### PR TITLE
docs: details on configuring Docker Compose setup

### DIFF
--- a/docs/src/pages/docs/installation/index.mdx
+++ b/docs/src/pages/docs/installation/index.mdx
@@ -32,12 +32,13 @@ part of the base Docker installation on Linux, once you have a working engine, f
 
 **Windows**
 
-Superset is not officially supported on Windows unfortunately. The best option for Windows users to
+Superset is not officially supported on Windows unfortunately. One option for Windows users to
 try out Superset locally is to install an Ubuntu Desktop VM via
 [VirtualBox](https://www.virtualbox.org/) and proceed with the Docker on Linux instructions inside
 of that VM. We recommend assigning at least 8GB of RAM to the virtual machine as well as
 provisioning a hard drive of at least 40GB, so that there will be enough space for both the OS and
-all of the required dependencies.
+all of the required dependencies. Docker Desktop [recently added support for Windows Subsystem for Linux (WSL) 2](https://docs.docker.com/docker-for-windows/wsl/), which may be another option.
+
 
 ### 2. Clone Superset's Github repository
 
@@ -59,12 +60,6 @@ Navigate to the folder you created in step 1:
 $ cd superset
 ```
 
-We recommend that you check out and run the code from the last tagged release:
-
-```bash
-$ git checkout latest
-```
-
 Then, run the following command:
 
 ```bash
@@ -74,14 +69,20 @@ $ docker-compose -f docker-compose-non-dev.yml up
 You should see a wall of logging output from the containers being launched on your machine. Once
 this output slows, you should have a running instance of Superset on your local machine!
 
-**Note:** this will bring up superset in a non-dev mode, changes to the codebase will not be reflected.
-If you would like to run superset in dev mode, simply replace the previous command with:
-
-```bash
-$ docker-compose up
-```
-
+**Note:** This will bring up superset in a non-dev mode, changes to the codebase will not be reflected.
+If you would like to run superset in dev mode to test local changes, simply replace the previous command with: `docker-compose up`,
 and wait for the `superset_node` container to finish building the assets.
+
+#### Configuring Docker Compose
+
+The following is for users who want to configure how Superset starts up in Docker Compose; otherwise, you can skip to the next section.
+
+You can configure the Docker Compose settings for dev and non-dev mode with `docker/.env` and `docker/.env-non-dev` respectively. These environment files set the environment for most containers in the Docker Compose setup, and some variables affect multiple containers and others only single ones.
+
+One important variable is `SUPERSET_LOAD_EXAMPLES` which determines whether the `superset_init` container will load example data and visualizations into the database and Superset. Thiese examples are quite helpful for most people, but probably unnecessary for experienced users. The loading process can sometimes take a few minutes and a good amount of CPU, so you may want to disable it on a resource-constrained device.
+
+**Note:** Users often want to connect to other databases from Superset. Currently, the easiest way to do this is to modify the `docker-compose-non-dev.yml` file and add your database as a service that the other services depend on (via `x-superset-depends-on`). Others have attempted to set `network_mode: host` on the Superset services, but these generally break the installation, because the configuration requires use of the Docker Compose DNS resolver for the service names. If you have a good solution for this, let us know!
+
 
 ### 4. Log in to Superset
 
@@ -99,6 +100,3 @@ username: admin
 ```bash
 password: admin
 ```
-
-Congrats! You have successfully installed Superset! Click 'Next' to learn how to connect a database
-driver.


### PR DESCRIPTION
Added details on configuring Docker Compose. Closes #13957

Also updated some things I noticed on the way (e.g. Windows WSL + Docker, the `latest` tag doesn't have the `docker-compose-non-dev.yml` in the same place, the next page is not about connecting a DB driver)

I also have a potential other section to add, which I've included here for discussion (it's more a WIP, and I don't know how much is useful/should be on the main installation page):

#### Debugging Docker Compose

If you don't make any changes to the configuration described above, you shouldn't run into any issues.

However, if you are tweaking the setup, `docker-compose down -v` will remove the volumes associated with the Superset containers. 

You can choose whether to do this
1. If you do and you have examples enabled it may take a while to re-load them.
2. If you don't: you can run into issues where the service has written to the volume and is in an unmanageable state (e.g. the permissions and users in the DB are messed up, or there's a `service_name.pid` file somewhere so the service errors saying it's running)

Docker-compose has sometimes treated volumes marked `external` differently, so you may need to investigate whether they are actually removed.