### PR TITLE
fix: annotation modal dateRangePicker saved invalid value

### DIFF
--- a/superset-frontend/src/views/CRUD/annotation/AnnotationModal.tsx
+++ b/superset-frontend/src/views/CRUD/annotation/AnnotationModal.tsx
@@ -311,14 +311,13 @@ const AnnotationModal: FunctionComponent<AnnotationModalProps> = ({
           <span className="required">*</span>
         </div>
         <RangePicker
-          format="YYYY-MM-DD hh:mm a"
+          format="YYYY-MM-DD HH:mm"
           onChange={onDateChange}
           showTime={{ format: 'hh:mm a' }}
           use12Hours
           value={
-            currentAnnotation &&
-            (currentAnnotation?.start_dttm.length ||
-              currentAnnotation?.end_dttm.length)
+            currentAnnotation?.start_dttm?.length ||
+            currentAnnotation?.end_dttm?.length
               ? [
                   moment(currentAnnotation.start_dttm),
                   moment(currentAnnotation.end_dttm),


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Since moment.js cannot parse `YYY-MM-DD hh:mm a` format, an error will occur.  

Now we use a  consistent format for saving and parsing datetime object.

closes: https://github.com/apache/superset/issues/13958

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### before
![image](https://user-images.githubusercontent.com/2244895/113648059-d759ec00-9640-11eb-8b9b-34271b32c3f0.png)

#### After
![image](https://user-images.githubusercontent.com/2016594/113732113-e2d61180-972b-11eb-8816-289fc99d012e.png)



### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
