### PR TITLE
fix: Data table z index in sql Editor

### DIFF
--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -300,7 +300,7 @@ div.Workspace {
   .schemaPane-enter-done,
   .schemaPane-exit {
     transform: translateX(0);
-    z-index: 1020;
+    z-index: 7;
   }
 
   .schemaPane-exit-active {


### PR DESCRIPTION
### SUMMARY
Data dropdown was underneath the table and dataset dropdowns. This fixes that. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:  

![image](https://user-images.githubusercontent.com/48933336/113742953-20598100-96d1-11eb-8070-75aef027b4a8.png)


after: 

![image](https://user-images.githubusercontent.com/48933336/113742992-29e2e900-96d1-11eb-8748-a03d5c312474.png)


![Screen Shot 2021-04-06 at 12 17 17 PM](https://user-images.githubusercontent.com/48933336/113743822-171ce400-96d2-11eb-8afa-3de9c6f825ec.png)

![Screen Shot 2021-04-06 at 12 16 55 PM](https://user-images.githubusercontent.com/48933336/113743839-1be19800-96d2-11eb-9f82-b7c005045c61.png)

### TEST PLAN
visually test places where it is used. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
