### PR TITLE
fix: import dataset/dashboard empty keys

### DIFF
--- a/superset/dashboards/commands/importers/v1/utils.py
+++ b/superset/dashboards/commands/importers/v1/utils.py
@@ -115,7 +115,7 @@ def import_dashboard(
     # TODO (betodealmeida): move this logic to import_from_dict
     config = config.copy()
     for key, new_name in JSON_KEYS.items():
-        if config.get(key):
+        if config.get(key) is not None:
             value = config.pop(key)
             try:
                 config[new_name] = json.dumps(value)

--- a/superset/datasets/commands/importers/v1/utils.py
+++ b/superset/datasets/commands/importers/v1/utils.py
@@ -92,7 +92,7 @@ def import_dataset(
     # TODO (betodealmeida): move this logic to import_from_dict
     config = config.copy()
     for key in JSON_KEYS:
-        if config.get(key):
+        if config.get(key) is not None:
             try:
                 config[key] = json.dumps(config[key])
             except TypeError:

--- a/tests/datasets/commands_tests.py
+++ b/tests/datasets/commands_tests.py
@@ -312,7 +312,7 @@ class TestImportDatasetsCommand(SupersetTestCase):
         assert dataset.schema == ""
         assert dataset.sql == ""
         assert dataset.params is None
-        assert dataset.template_params is None
+        assert dataset.template_params == "{}"
         assert dataset.filter_select_enabled
         assert dataset.fetch_values_predicate is None
         assert dataset.extra is None

--- a/tests/fixtures/importexport.py
+++ b/tests/fixtures/importexport.py
@@ -368,7 +368,7 @@ dataset_config: Dict[str, Any] = {
     "schema": "",
     "sql": "",
     "params": None,
-    "template_params": None,
+    "template_params": {},
     "filter_select_enabled": True,
     "fetch_values_predicate": None,
     "extra": None,


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Importing virtual datasets fails because `template_params = {}` is not being dumped to a string since it's false.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Added a unit test covering the problem.

Tried to import a virtual dataset with `template_params = {}` and it fails. With this fix, it works.

Did the same with a customer dashboard that was failing.

Note: this was failing in Postgres, but not MySQL.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
