### PR TITLE
fix: Pie chart not displayed in viz type selection

### DIFF
--- a/superset-frontend/src/explore/components/controls/VizTypeControl.jsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl.jsx
@@ -107,6 +107,11 @@ function VizSupportValidation({ vizType }) {
   );
 }
 
+const nativeFilterGate = behaviors =>
+  !behaviors.includes(Behavior.NATIVE_FILTER) ||
+  (isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS) &&
+    behaviors.includes(Behavior.CROSS_FILTER));
+
 const VizTypeControl = props => {
   const [showModal, setShowModal] = useState(false);
   const [filter, setFilter] = useState('');
@@ -168,11 +173,7 @@ const VizTypeControl = props => {
   const filteredTypes = DEFAULT_ORDER.filter(type => registry.has(type))
     .filter(type => {
       const behaviors = registry.get(type)?.behaviors || [];
-      return (
-        (isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS) &&
-          behaviors.includes(Behavior.CROSS_FILTER)) ||
-        !behaviors.length
-      );
+      return nativeFilterGate(behaviors);
     })
     .map(type => ({
       key: type,
@@ -183,11 +184,7 @@ const VizTypeControl = props => {
         .entries()
         .filter(entry => {
           const behaviors = entry.value?.behaviors || [];
-          return (
-            (isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS) &&
-              behaviors.includes(Behavior.CROSS_FILTER)) ||
-            !behaviors.length
-          );
+          return nativeFilterGate(behaviors);
         })
         .filter(({ key }) => !typesWithDefaultOrder.has(key)),
     )


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix can not be displayed chart when some chart support cross filter behavior.
 
closes: https://github.com/apache/superset/issues/13962


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

#### before
![image](https://user-images.githubusercontent.com/2016594/113836103-2c237100-97bf-11eb-93aa-8996b6c0ceff.png)


#### after
![image](https://user-images.githubusercontent.com/2016594/113835564-a69fc100-97be-11eb-86d7-180e1368c218.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->
tested in my local. would be adding more UT/IT for this case in the future.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
