### PR TITLE
refactor: Bootstrap to AntD - Slider

### DIFF
--- a/superset-frontend/src/components/Slider/Slider.stories.tsx
+++ b/superset-frontend/src/components/Slider/Slider.stories.tsx
@@ -16,12 +16,42 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import '../../../stylesheets/less/variables.less';
+import React from 'react';
+import Slider, { SliderSingleProps } from '.';
 
-.BootstrapSliderWrapper .slider-selection {
-  background: @gray-bg;
-}
+export default {
+  title: 'Slider',
+  component: Slider,
+};
 
-.BootstrapSliderWrapper .slider-handle {
-  background: @gray-light;
-}
+export const InteractiveSlider = (args: SliderSingleProps) => (
+  <Slider {...args} style={{ width: 400, height: 400 }} />
+);
+
+InteractiveSlider.args = {
+  min: 0,
+  max: 100,
+  defaultValue: 70,
+  step: 1,
+};
+
+InteractiveSlider.argTypes = {
+  onChange: { action: 'onChange' },
+  disabled: {
+    control: { type: 'boolean' },
+  },
+  reverse: {
+    control: { type: 'boolean' },
+  },
+  vertical: {
+    control: { type: 'boolean' },
+  },
+};
+
+InteractiveSlider.story = {
+  parameters: {
+    knobs: {
+      disable: true,
+    },
+  },
+};

--- a/superset-frontend/src/components/Slider/index.tsx
+++ b/superset-frontend/src/components/Slider/index.tsx
@@ -17,14 +17,13 @@
  * under the License.
  */
 import React from 'react';
-import ReactBootstrapSlider from 'react-bootstrap-slider';
-import 'bootstrap-slider/dist/css/bootstrap-slider.min.css';
-import './BootstrapSliderWrapper.less';
+import AntDSlider, {
+  SliderSingleProps,
+  SliderRangeProps,
+} from 'antd/lib/slider';
 
-export default function BootstrapSliderWrapper(props) {
-  return (
-    <span className="BootstrapSliderWrapper">
-      <ReactBootstrapSlider {...props} />
-    </span>
-  );
+export { SliderSingleProps, SliderRangeProps };
+
+export default function Slider(props: SliderSingleProps | SliderRangeProps) {
+  return <AntDSlider {...props} css={{ marginLeft: 0, marginRight: 0 }} />;
 }

--- a/superset-frontend/src/explore/components/controls/SliderControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SliderControl.jsx
@@ -18,8 +18,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-
-import BootstrapSliderWrapper from 'src/components/BootstrapSliderWrapper';
+import Slider from 'src/components/Slider';
 import ControlHeader from 'src/explore/components/ControlHeader';
 
 const propTypes = {
@@ -32,17 +31,11 @@ const defaultProps = {
 };
 
 export default function SliderControl(props) {
-  // This wouldn't be necessary but might as well
   return (
-    <div>
+    <>
       <ControlHeader {...props} />
-      <BootstrapSliderWrapper
-        {...props}
-        change={obj => {
-          props.onChange(obj.target.value);
-        }}
-      />
-    </div>
+      <Slider {...props} defaultValue={props.default} />
+    </>
   );
 }
 


### PR DESCRIPTION
### SUMMARY
- Migrates the `Slider` component from Bootstrap to AntD
- Creates a storybook entry for `Slider`
- Removes `ReactBootstrapSlider`

PS: No tests were added because we don't add any custom behavior to the component. Relying on AntD tests.

See: #10254

@mihir174 I didn't found the `Slider` component in the North Star specification so I used AntD default, which I think fits very well with our theme. Let me know if we need to change it.

@rusackas @junlincc @pkdotson 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="357" alt="Screen Shot 2021-04-07 at 8 41 49 AM" src="https://user-images.githubusercontent.com/70410625/113861779-f3af7300-977d-11eb-9e02-f5997bc70f22.png">
<img width="346" alt="Screen Shot 2021-04-07 at 8 58 19 AM" src="https://user-images.githubusercontent.com/70410625/113863005-80a6fc00-977f-11eb-8365-37c372fd0e46.png">
<img width="1024" alt="Screen Shot 2021-04-07 at 8 47 15 AM" src="https://user-images.githubusercontent.com/70410625/113861780-f4480980-977d-11eb-8606-ba2938be4bd2.png">

### TEST PLAN
1 - Execute all tests
2 - All tests should pass
3 - Additional testing can be done using Storybook

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
