### PR TITLE
fix: execution log crashes for logs with no uuid

### DIFF
--- a/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
+++ b/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
@@ -100,7 +100,7 @@ function ExecutionLog({ addDangerToast, isReportEnabled }: ExecutionLogProps) {
           row: {
             original: { uuid: executionId },
           },
-        }: any) => executionId ? executionId.slice(0, 6) : "none",
+        }: any) => executionId ? executionId.slice(0, 6) : 'none',
         accessor: 'uuid',
         Header: t('Execution ID'),
         size: 'xs',

--- a/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
+++ b/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
@@ -100,7 +100,7 @@ function ExecutionLog({ addDangerToast, isReportEnabled }: ExecutionLogProps) {
           row: {
             original: { uuid: executionId },
           },
-        }: any) => executionId.slice(0, 6),
+        }: any) => executionId ? executionId.slice(0, 6) : "none",
         accessor: 'uuid',
         Header: t('Execution ID'),
         size: 'xs',

--- a/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
+++ b/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
@@ -100,7 +100,7 @@ function ExecutionLog({ addDangerToast, isReportEnabled }: ExecutionLogProps) {
           row: {
             original: { uuid: executionId },
           },
-        }: any) => executionId ? executionId.slice(0, 6) : 'none',
+        }: any) => (executionId ? executionId.slice(0, 6) : 'none'),
         accessor: 'uuid',
         Header: t('Execution ID'),
         size: 'xs',


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
An issue was introduced in #13752 where logs that were created before the `executionId` was created cause the execution log list view to give the following error:

<img width="617" alt="Screen Shot 2021-04-07 at 1 49 37 PM" src="https://user-images.githubusercontent.com/47196419/113933516-8ca7b380-97a9-11eb-8600-f539605fc8e5.png">

This PR fixes this issue, instead displaying "none" for logs without an `executionId`.

