### PR TITLE
fix: Cast out of bounds timestamps as objects

### DIFF
--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -174,7 +174,8 @@ class SupersetResultSet:
 
     @staticmethod
     def convert_table_to_df(table: pa.Table) -> pd.DataFrame:
-        return table.to_pandas(integer_object_nulls=True)
+        return table.to_pandas(integer_object_nulls=True,
+                               timestamp_as_object=True)
 
     @staticmethod
     def first_nonempty(items: List[Any]) -> Any:

--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -174,8 +174,7 @@ class SupersetResultSet:
 
     @staticmethod
     def convert_table_to_df(table: pa.Table) -> pd.DataFrame:
-        return table.to_pandas(integer_object_nulls=True,
-                               timestamp_as_object=True)
+        return table.to_pandas(integer_object_nulls=True, timestamp_as_object=True)
 
     @staticmethod
     def first_nonempty(items: List[Any]) -> Any:


### PR DESCRIPTION
### SUMMARY
As a fix to https://github.com/apache/superset/issues/13661, timestamps can be passed as objects https://issues.apache.org/jira/browse/ARROW-7856

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/1605852/113943678-c2a86000-97c8-11eb-999d-501779ac95eb.png)
![image](https://user-images.githubusercontent.com/1605852/113943705-d2c03f80-97c8-11eb-93b7-6ad45500c26d.png)


### TEST PLAN
In a fresh installation set async query for the `examples` database and execute  the next query in sql lab:
```sql
SELECT TIMESTAMP '01-01-1000';
```

### ADDITIONAL INFORMATION
Fixes #13661 
- [x] Has associated issue: #13661 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API