### PR TITLE
fix(sqla): apply sqla type on calculated columns

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -224,12 +224,12 @@ class TableColumn(Model, BaseColumn):
 
     def get_sqla_col(self, label: Optional[str] = None) -> Column:
         label = label or self.column_name
+        db_engine_spec = self.table.database.db_engine_spec
+        column_spec = db_engine_spec.get_column_spec(self.type)
+        type_ = column_spec.sqla_type if column_spec else None
         if self.expression:
-            col = literal_column(self.expression)
+            col = literal_column(self.expression, type_=type_)
         else:
-            db_engine_spec = self.table.database.db_engine_spec
-            column_spec = db_engine_spec.get_column_spec(self.type)
-            type_ = column_spec.sqla_type if column_spec else None
             col = column(self.column_name, type_=type_)
         col = self.table.make_sqla_column_compatible(col, label)
         return col


### PR DESCRIPTION
### SUMMARY
In the SQLA model, currently the inferred column type is only applied to regular columns but not calculated columns, which causes an exception to be raised when using a native select filter with temporal values. This change ensures that mapped column types are properly applied to both regular and calculated columns.

### AFTER
![image](https://user-images.githubusercontent.com/33317356/113977544-66d2eb00-984b-11eb-968c-da4684d96274.png)

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/113977585-7baf7e80-984b-11eb-9c16-4d310ca630e9.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
