### PR TITLE
chore: update docs to allow user to properly load examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -435,7 +435,7 @@ superset db upgrade
 # Create default roles and permissions
 superset init
 
-# Load some data to play with
+# Load some data to play with (you must create an Admin user with the username `admin` for this command to work)
 superset load-examples
 
 # Start the Flask dev web server from inside your virtualenv.


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
For `superset load-examples` command to work users must create an "Admin" user with the username `admin` or the following error rises:
```
"Admin user does not exist. "
        "Please, check if test users are properly loaded "
        "(`superset load_test_users`)."
```

To fix this I've added a quick note to allow devs to fix the issue quickly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
