### PR TITLE
feat(helm): add pod and deployment annotations to template

### DIFF
--- a/helm/superset/templates/deployment-beat.yaml
+++ b/helm/superset/templates/deployment-beat.yaml
@@ -24,6 +24,10 @@ metadata:
     chart: {{ template "superset.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.supersetCeleryBeat.deploymentAnnotations }}
+  annotations:
+    {{ toYaml .Values.supersetCeleryBeat.deploymentAnnotations | nindent 4 }}
+{{- end }}
 spec:
   # This must be a singleton
   replicas: 1
@@ -44,6 +48,9 @@ spec:
         # Optionally force the thing to reload
         force-reload: {{ randAlphaNum 5 | quote }}
         {{ end }}
+      {{- if .Values.supersetCeleryBeat.podAnnotations }}
+        {{ toYaml .Values.supersetCeleryBeat.podAnnotations | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ template "superset.name" . }}-celerybeat
         release: {{ .Release.Name }}

--- a/helm/superset/templates/deployment-worker.yaml
+++ b/helm/superset/templates/deployment-worker.yaml
@@ -23,6 +23,10 @@ metadata:
     chart: {{ template "superset.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.supersetWorker.deploymentAnnotations }}
+  annotations:
+    {{ toYaml .Values.supersetWorker.deploymentAnnotations | nindent 4 }}
+{{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -42,6 +46,9 @@ spec:
         # Optionally force the thing to reload
         force-reload: {{ randAlphaNum 5 | quote }}
         {{ end }}
+      {{- if .Values.supersetWorker.podAnnotations }}
+        {{ toYaml .Values.supersetWorker.podAnnotations | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ template "superset.name" . }}-worker
         release: {{ .Release.Name }}

--- a/helm/superset/templates/deployment.yaml
+++ b/helm/superset/templates/deployment.yaml
@@ -23,6 +23,10 @@ metadata:
     chart: {{ template "superset.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.supersetNode.deploymentAnnotations }}
+  annotations:
+    {{ toYaml .Values.supersetNode.deploymentAnnotations | nindent 4 }}
+{{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -45,6 +49,9 @@ spec:
         # Optionally force the thing to reload
         force-reload: {{ randAlphaNum 5 | quote }}
         {{- end }}
+      {{- if .Values.supersetNode.podAnnotations }}
+        {{ toYaml .Values.supersetNode.podAnnotations | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ template "superset.name" . }}
         release: {{ .Release.Name }}

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -163,6 +163,12 @@ supersetNode:
             name: '{{ tpl .Values.envFromSecret . }}'
       command: [ "/bin/sh", "-c", "until nc -zv $DB_HOST $DB_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
 
+  ## Annotations to be added to supersetNode deployment
+  deploymentAnnotations: {}
+
+  ## Annotations to be added to supersetNode pods
+  podAnnotations: {}
+
 ##
 ## Superset worker configuration
 supersetWorker:
@@ -179,6 +185,12 @@ supersetWorker:
         - secretRef:
             name: '{{ tpl .Values.envFromSecret . }}'
       command: [ "/bin/sh", "-c", "until nc -zv $DB_HOST $DB_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
+
+  ## Annotations to be added to supersetWorker deployment
+  deploymentAnnotations: {}
+
+  ## Annotations to be added to supersetWorker pods
+  podAnnotations: {}
 
 ##
 ## Superset beat configuration (to trigger scheduled jobs like reports)
@@ -198,6 +210,12 @@ supersetCeleryBeat:
         - secretRef:
             name: '{{ tpl .Values.envFromSecret . }}'
       command: [ "/bin/sh", "-c", "until nc -zv $DB_HOST $DB_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
+
+  ## Annotations to be added to supersetCeleryBeat deployment
+  deploymentAnnotations: {}
+
+  ## Annotations to be added to supersetCeleryBeat pods
+  podAnnotations: {}
 
 ##
 ## Init job configuration


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The goal of this PR is to have the ability to set annotations on pod and deployments

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
