### PR TITLE
fix: Use consistent chart value

### DIFF
--- a/helm/superset/templates/secret-superset-config.yaml
+++ b/helm/superset/templates/secret-superset-config.yaml
@@ -20,7 +20,7 @@ metadata:
   name: {{ template "superset.fullname" . }}-config
   labels:
     app: {{ template "superset.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "superset.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque


### PR DESCRIPTION
### SUMMARY
Fixes #14032 . It replaces the chart version with the helper function, which generates a string that fits within the metadata.labels regex validation

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
Verify the chart renders properly

### ADDITIONAL INFORMATION
Our chart release/version process uses a semver2 pattern where the git ref is appended with a `+`. 

By switching from the string interpolated format to the `superset.chart` template, it changes the rendered output from:

```
labels:
  chart: superset-0.0.1+44068e96a # This is not a valid k8s resource label
```

to:

```
labels:
  chart: superset-0.0.1_44068e96a # Accepted by the k8s API, and used in all other chart resources
```
