### PR TITLE
fix: broken port-forward instructions

### DIFF
--- a/helm/superset/templates/NOTES.txt
+++ b/helm/superset/templates/NOTES.txt
@@ -31,7 +31,6 @@
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "superset.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "superset.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8088 to use your application"
-  kubectl port-forward $POD_NAME 8088:80
+  kubectl port-forward service/superset 8088:8088 --namespace {{ .Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The pod listens on port 8088, not port 80. Also if you port-forward from the service then you don't have to bother getting the pod name.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Using correct command:![image](https://user-images.githubusercontent.com/46505081/114110151-ae796700-988b-11eb-8de0-3764d7265146.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [] Has associated issue:
- [] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
