### PR TITLE
fix(cross-filters): Make chart emitting cross-filter exclude itself from filtering

### DIFF
--- a/superset-frontend/src/dashboard/util/activeAllDashboardFilters.ts
+++ b/superset-frontend/src/dashboard/util/activeAllDashboardFilters.ts
@@ -92,7 +92,7 @@ export const getAllActiveFilters = ({
     const scope = nativeFilters?.[filterId]?.scope ??
       chartConfiguration?.[filterId]?.crossFilters?.scope ?? {
         rootPath: [DASHBOARD_ROOT_ID],
-        excluded: [],
+        excluded: [filterId],
       };
     // Iterate over all roots to find all affected charts
     scope.rootPath.forEach(layoutItemId => {


### PR DESCRIPTION
### SUMMARY
When a chart emits cross-filter, the filter is applied to the chart-emitter. The result is that the user cannot add another value to that filter, because every value other than the current filter had been filtered out. This PR prevents the chart from applying a filter to itself, by adding it's ID to `excluded` array.
To test, enable the flag `DASHBOARD_CROSS_FILTERS`, go to USA Birth Names dashboard (from sample data), enable cross filtering for pie chart and try to emit a cross filter.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
https://user-images.githubusercontent.com/15073128/114161279-2b5a1e80-9928-11eb-9c1d-451519753e20.mov

After:
https://user-images.githubusercontent.com/15073128/114161311-33b25980-9928-11eb-907e-9cfd14c32eca.mov

CC: @villebro @junlincc 

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
