### PR TITLE
refactor: Boostrap to AntD - Tabs

### DIFF
--- a/superset-frontend/spec/javascripts/dashboard/components/DashboardBuilder_spec.jsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/DashboardBuilder_spec.jsx
@@ -24,7 +24,7 @@ import fetchMock from 'fetch-mock';
 import { ParentSize } from '@vx/responsive';
 import { supersetTheme, ThemeProvider } from '@superset-ui/core';
 import { Sticky, StickyContainer } from 'react-sticky';
-import { TabContainer, TabContent, TabPane } from 'react-bootstrap';
+import Tabs from 'src/components/Tabs';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import BuilderComponentPane from 'src/dashboard/components/BuilderComponentPane';
@@ -39,7 +39,10 @@ import {
 } from 'spec/fixtures/mockDashboardLayout';
 import { mockStoreWithTabs, storeWithState } from 'spec/fixtures/mockStore';
 import mockState from 'spec/fixtures/mockState';
-import { DASHBOARD_ROOT_ID } from 'src/dashboard/util/constants';
+import {
+  DASHBOARD_ROOT_ID,
+  DASHBOARD_GRID_ID,
+} from 'src/dashboard/util/constants';
 
 fetchMock.get('glob:*/csstemplateasyncmodelview/api/read', {});
 
@@ -118,19 +121,17 @@ describe('DashboardBuilder', () => {
     });
   });
 
-  it('should render a TabContainer and TabContent', () => {
+  it('should render one Tabs and two TabPane', () => {
     const wrapper = setup({ dashboardLayout: undoableDashboardLayoutWithTabs });
     const parentSize = wrapper.find(ParentSize);
-    expect(parentSize.find(TabContainer)).toHaveLength(1);
-    expect(parentSize.find(TabContent)).toHaveLength(1);
+    expect(parentSize.find(Tabs)).toHaveLength(1);
+    expect(parentSize.find(Tabs.TabPane)).toHaveLength(2);
   });
 
-  it('should set animation=true, mountOnEnter=true, and unmounOnExit=false on TabContainer for perf', () => {
+  it('should set animated=true on Tabs for perf', () => {
     const wrapper = setup({ dashboardLayout: undoableDashboardLayoutWithTabs });
-    const tabProps = wrapper.find(ParentSize).find(TabContainer).props();
-    expect(tabProps.animation).toBe(true);
-    expect(tabProps.mountOnEnter).toBe(true);
-    expect(tabProps.unmountOnExit).toBe(false);
+    const tabProps = wrapper.find(ParentSize).find(Tabs).props();
+    expect(tabProps.animated).toBe(true);
   });
 
   it('should render a TabPane and DashboardGrid for first Tab', () => {
@@ -138,10 +139,10 @@ describe('DashboardBuilder', () => {
     const parentSize = wrapper.find(ParentSize);
     const expectedCount =
       undoableDashboardLayoutWithTabs.present.TABS_ID.children.length;
-    expect(parentSize.find(TabPane)).toHaveLength(expectedCount);
-    expect(parentSize.find(TabPane).first().find(DashboardGrid)).toHaveLength(
-      1,
-    );
+    expect(parentSize.find(Tabs.TabPane)).toHaveLength(expectedCount);
+    expect(
+      parentSize.find(Tabs.TabPane).first().find(DashboardGrid),
+    ).toHaveLength(1);
   });
 
   it('should render a TabPane and DashboardGrid for second Tab', () => {
@@ -155,8 +156,10 @@ describe('DashboardBuilder', () => {
     const parentSize = wrapper.find(ParentSize);
     const expectedCount =
       undoableDashboardLayoutWithTabs.present.TABS_ID.children.length;
-    expect(parentSize.find(TabPane)).toHaveLength(expectedCount);
-    expect(parentSize.find(TabPane).at(1).find(DashboardGrid)).toHaveLength(1);
+    expect(parentSize.find(Tabs.TabPane)).toHaveLength(expectedCount);
+    expect(
+      parentSize.find(Tabs.TabPane).at(1).find(DashboardGrid),
+    ).toHaveLength(1);
   });
 
   it('should render a BuilderComponentPane if editMode=false and user selects "Insert Components" pane', () => {
@@ -179,7 +182,7 @@ describe('DashboardBuilder', () => {
       dashboardLayout: undoableDashboardLayoutWithTabs,
     });
 
-    expect(wrapper.find(TabContainer).prop('activeKey')).toBe(0);
+    expect(wrapper.find(Tabs).prop('activeKey')).toBe(DASHBOARD_GRID_ID);
 
     wrapper
       .find('.dashboard-component-tabs .ant-tabs .ant-tabs-tab')

--- a/superset-frontend/src/common/components/common.stories.tsx
+++ b/superset-frontend/src/common/components/common.stories.tsx
@@ -18,13 +18,11 @@
  */
 import React, { useState, useRef, useCallback } from 'react';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean } from '@storybook/addon-knobs';
+import { withKnobs } from '@storybook/addon-knobs';
 import { CronPicker, CronError } from 'src/components/CronPicker';
 import Modal from 'src/components/Modal';
 import InfoTooltip from 'src/components/InfoTooltip';
-import { Dropdown } from 'src/components/Dropdown';
-import Tabs, { EditableTabs } from 'src/components/Tabs';
-import { Menu, Input, Divider } from '.';
+import { Input, Divider } from '.';
 
 export default {
   title: 'Common components',
@@ -43,80 +41,6 @@ export const StyledModal = () => (
   >
     <div>hi!</div>
   </Modal>
-);
-
-export const StyledTabs = () => (
-  <Tabs
-    defaultActiveKey="1"
-    centered={boolean('Center tabs', false)}
-    fullWidth={boolean('Full width', true)}
-  >
-    <Tabs.TabPane
-      tab="Tab 1"
-      key="1"
-      disabled={boolean('Tab 1 disabled', false)}
-    >
-      Tab 1 Content!
-    </Tabs.TabPane>
-    <Tabs.TabPane
-      tab="Tab 2"
-      key="2"
-      disabled={boolean('Tab 2 disabled', false)}
-    >
-      Tab 2 Content!
-    </Tabs.TabPane>
-  </Tabs>
-);
-
-export const StyledEditableTabs = () => (
-  <EditableTabs
-    defaultActiveKey="1"
-    centered={boolean('Center tabs', false)}
-    fullWidth={boolean('Full width', true)}
-  >
-    <Tabs.TabPane
-      tab="Tab 1"
-      key="1"
-      disabled={boolean('Tab 1 disabled', false)}
-    >
-      Tab 1 Content!
-    </Tabs.TabPane>
-    <Tabs.TabPane
-      tab="Tab 2"
-      key="2"
-      disabled={boolean('Tab 2 disabled', false)}
-    >
-      Tab 2 Content!
-    </Tabs.TabPane>
-  </EditableTabs>
-);
-
-export const TabsWithDropdownMenu = () => (
-  <EditableTabs
-    defaultActiveKey="1"
-    centered={boolean('Center tabs', false)}
-    fullWidth={boolean('Full width', true)}
-  >
-    <Tabs.TabPane
-      tab={
-        <>
-          <Dropdown
-            overlay={
-              <Menu>
-                <Menu.Item key="1">Item 1</Menu.Item>
-                <Menu.Item key="2">Item 2</Menu.Item>
-              </Menu>
-            }
-          />
-          Tab with dropdown menu
-        </>
-      }
-      key="1"
-      disabled={boolean('Tab 1 disabled', false)}
-    >
-      Tab 1 Content!
-    </Tabs.TabPane>
-  </EditableTabs>
 );
 
 export const StyledInfoTooltip = (args: any) => {

--- a/superset-frontend/src/components/Tabs/Tabs.stories.tsx
+++ b/superset-frontend/src/components/Tabs/Tabs.stories.tsx
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import Tabs, { TabsProps } from '.';
+
+const { TabPane } = Tabs;
+
+export default {
+  title: 'Tabs',
+  component: Tabs,
+};
+
+export const InteractiveTabs = (args: TabsProps) => (
+  <Tabs {...args}>
+    <TabPane tab="Tab 1" key="1">
+      Content of Tab Pane 1
+    </TabPane>
+    <TabPane tab="Tab 2" key="2">
+      Content of Tab Pane 2
+    </TabPane>
+    <TabPane tab="Tab 3" key="3">
+      Content of Tab Pane 3
+    </TabPane>
+  </Tabs>
+);
+
+InteractiveTabs.args = {
+  defaultActiveKey: '1',
+  animated: true,
+  centered: false,
+  fullWidth: false,
+  allowOverflow: false,
+};
+
+InteractiveTabs.argTypes = {
+  onChange: { action: 'onChange' },
+  type: {
+    defaultValue: 'line',
+    control: {
+      type: 'inline-radio',
+      options: ['line', 'card', 'editable-card'],
+    },
+  },
+};
+
+InteractiveTabs.story = {
+  parameters: {
+    knobs: {
+      disable: true,
+    },
+  },
+};

--- a/superset-frontend/src/components/Tabs/Tabs.tsx
+++ b/superset-frontend/src/components/Tabs/Tabs.tsx
@@ -18,17 +18,17 @@
  */
 import React from 'react';
 import { css, styled } from '@superset-ui/core';
-import { Tabs as AntdTabs } from 'src/common/components';
+import AntDTabs, { TabsProps as AntDTabsProps } from 'antd/lib/tabs';
 import Icon from 'src/components/Icon';
 
-interface TabsProps {
+export interface TabsProps extends AntDTabsProps {
   fullWidth?: boolean;
   allowOverflow?: boolean;
 }
 
 const notForwardedProps = ['fullWidth', 'allowOverflow'];
 
-const StyledTabs = styled(AntdTabs, {
+const StyledTabs = styled(AntDTabs, {
   shouldForwardProp: prop => !notForwardedProps.includes(prop),
 })<TabsProps>`
   overflow: ${({ allowOverflow }) => (allowOverflow ? 'visible' : 'hidden')};
@@ -96,7 +96,7 @@ const StyledTabs = styled(AntdTabs, {
   }
 `;
 
-const StyledTabPane = styled(AntdTabs.TabPane)``;
+const StyledTabPane = styled(AntDTabs.TabPane)``;
 
 const Tabs = Object.assign(StyledTabs, {
   TabPane: StyledTabPane,
@@ -104,6 +104,7 @@ const Tabs = Object.assign(StyledTabs, {
 
 Tabs.defaultProps = {
   fullWidth: true,
+  animated: true,
 };
 
 const StyledEditableTabs = styled(StyledTabs)`

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -237,10 +237,7 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
             </ErrorBoundary>
           </StickyVerticalBar>
         )}
-        <DashboardContainer
-          topLevelTabs={topLevelTabs}
-          handleChangeTab={handleChangeTab}
-        />
+        <DashboardContainer topLevelTabs={topLevelTabs} />
         {editMode && <BuilderComponentPane topOffset={barTopOffset} />}
       </StyledDashboardContent>
       <ToastPresenter />

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
@@ -19,8 +19,8 @@
 // ParentSize uses resize observer so the dashboard will update size
 // when its container size changes, due to e.g., builder side panel opening
 import { ParentSize } from '@vx/responsive';
-import { TabContainer, TabContent, TabPane } from 'react-bootstrap';
-import React, { FC, SyntheticEvent, useEffect, useState } from 'react';
+import Tabs from 'src/components/Tabs';
+import React, { FC, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import DashboardGrid from 'src/dashboard/containers/DashboardGrid';
 import getLeafComponentIdFromPath from 'src/dashboard/util/getLeafComponentIdFromPath';
@@ -33,13 +33,9 @@ import { getRootLevelTabIndex } from './utils';
 
 type DashboardContainerProps = {
   topLevelTabs?: LayoutItem;
-  handleChangeTab: (event: SyntheticEvent<TabContainer, Event>) => void;
 };
 
-const DashboardContainer: FC<DashboardContainerProps> = ({
-  topLevelTabs,
-  handleChangeTab,
-}) => {
+const DashboardContainer: FC<DashboardContainerProps> = ({ topLevelTabs }) => {
   const dashboardLayout = useSelector<RootState, DashboardLayout>(
     state => state.dashboardLayout.present,
   );
@@ -58,6 +54,9 @@ const DashboardContainer: FC<DashboardContainerProps> = ({
     ? topLevelTabs.children
     : [DASHBOARD_GRID_ID];
 
+  const min = Math.min(tabIndex, childIds.length - 1);
+  const activeKey = min === 0 ? DASHBOARD_GRID_ID : min.toString();
+
   return (
     <div className="grid-container" data-test="grid-container">
       <ParentSize>
@@ -68,35 +67,29 @@ const DashboardContainer: FC<DashboardContainerProps> = ({
             the entire dashboard upon adding/removing top-level tabs, which would otherwise
             happen because of React's diffing algorithm
           */
-          <TabContainer
+          <Tabs
             id={DASHBOARD_GRID_ID}
-            activeKey={Math.min(tabIndex, childIds.length - 1)}
-            onSelect={handleChangeTab}
-            // @ts-ignore
-            animation
-            mountOnEnter
-            unmountOnExit={false}
+            activeKey={activeKey}
+            renderTabBar={() => <></>}
+            fullWidth={false}
           >
-            <TabContent>
-              {childIds.map((id, index) => (
-                // Matching the key of the first TabPane irrespective of topLevelTabs
-                // lets us keep the same React component tree when !!topLevelTabs changes.
-                // This avoids expensive mounts/unmounts of the entire dashboard.
-                <TabPane
-                  key={index === 0 ? DASHBOARD_GRID_ID : id}
-                  eventKey={index}
-                >
-                  <DashboardGrid
-                    gridComponent={dashboardLayout[id]}
-                    // see isValidChild for why tabs do not increment the depth of their children
-                    depth={DASHBOARD_ROOT_DEPTH + 1} // (topLevelTabs ? 0 : 1)}
-                    width={width}
-                    isComponentVisible={index === tabIndex}
-                  />
-                </TabPane>
-              ))}
-            </TabContent>
-          </TabContainer>
+            {childIds.map((id, index) => (
+              // Matching the key of the first TabPane irrespective of topLevelTabs
+              // lets us keep the same React component tree when !!topLevelTabs changes.
+              // This avoids expensive mounts/unmounts of the entire dashboard.
+              <Tabs.TabPane
+                key={index === 0 ? DASHBOARD_GRID_ID : index.toString()}
+              >
+                <DashboardGrid
+                  gridComponent={dashboardLayout[id]}
+                  // see isValidChild for why tabs do not increment the depth of their children
+                  depth={DASHBOARD_ROOT_DEPTH + 1} // (topLevelTabs ? 0 : 1)}
+                  width={width}
+                  isComponentVisible={index === tabIndex}
+                />
+              </Tabs.TabPane>
+            ))}
+          </Tabs>
         )}
       </ParentSize>
     </div>


### PR DESCRIPTION
### SUMMARY
- Migrates remaining `TabContainer`, `TabPanel` and `TabContent` components from Bootstrap to AntD
- Improves the storybook to support interactive controls

See: #10254

@rusackas @junlincc @pkdotson

@villebro I'm tagging you also because of the changes in `DashboardContainer`. Can you help with the review? I'll add some comments to the code to provide more context. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1776" alt="Screen Shot 2021-04-08 at 4 35 51 PM" src="https://user-images.githubusercontent.com/70410625/114177966-6c940380-9913-11eb-9bcb-b9f7a1b0b73c.png">
<img width="1783" alt="Screen Shot 2021-04-08 at 4 37 03 PM" src="https://user-images.githubusercontent.com/70410625/114177975-70c02100-9913-11eb-98db-64b186d8c213.png">
<img width="1764" alt="Screen Shot 2021-04-08 at 4 40 06 PM" src="https://user-images.githubusercontent.com/70410625/114177977-7158b780-9913-11eb-939a-b79e74d23972.png">
<img width="1770" alt="Screen Shot 2021-04-08 at 4 36 15 PM" src="https://user-images.githubusercontent.com/70410625/114177971-6ef65d80-9913-11eb-9ac8-e08e2222e92b.png">
<img width="1781" alt="Screen Shot 2021-04-09 at 9 06 00 AM" src="https://user-images.githubusercontent.com/70410625/114177983-74ec3e80-9913-11eb-8859-871085d34704.png">

These are the impacted screens. No perceived difference after the changes.

### TEST PLAN
1 - Access different dashboard layouts, with different tab levels
2 - Check that all layouts are working

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
