### PR TITLE
fix(country-map): update geojson and control layout

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -69,7 +69,7 @@
     "@superset-ui/core": "^0.17.30",
     "@superset-ui/legacy-plugin-chart-calendar": "^0.17.30",
     "@superset-ui/legacy-plugin-chart-chord": "^0.17.30",
-    "@superset-ui/legacy-plugin-chart-country-map": "^0.17.30",
+    "@superset-ui/legacy-plugin-chart-country-map": "^0.17.31",
     "@superset-ui/legacy-plugin-chart-event-flow": "^0.17.30",
     "@superset-ui/legacy-plugin-chart-force-directed": "^0.17.30",
     "@superset-ui/legacy-plugin-chart-heatmap": "^0.17.30",

--- a/superset/migrations/versions/085f06488938_country_map_use_lowercase_country_name.py
+++ b/superset/migrations/versions/085f06488938_country_map_use_lowercase_country_name.py
@@ -1,0 +1,85 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Country map use lowercase country name
+
+Revision ID: 085f06488938
+Revises: 134cea61c5e7
+Create Date: 2021-04-09 16:14:19.040884
+
+"""
+import json
+
+from alembic import op
+from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
+
+# revision identifiers, used by Alembic.
+revision = "085f06488938"
+down_revision = "134cea61c5e7"
+
+Base = declarative_base()
+
+
+class Slice(Base):
+    __tablename__ = "slices"
+
+    id = Column(Integer, primary_key=True)
+    params = Column(Text)
+    viz_type = Column(String(250))
+
+
+def upgrade():
+    """
+    Convert all country names to lowercase
+    """
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for slc in session.query(Slice).filter(Slice.viz_type == "country_map").all():
+        try:
+            params = json.loads(slc.params)
+            if params.get("select_country"):
+                params["select_country"] = params["select_country"].lower()
+                slc.params = json.dumps(params, sort_keys=True)
+        except Exception:
+            pass
+
+    session.commit()
+    session.close()
+
+
+def downgrade():
+    """
+    Convert all country names to sentence case
+    """
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for slc in session.query(Slice).filter(Slice.viz_type == "country_map").all():
+        try:
+            params = json.loads(slc.params)
+            if params.get("select_country"):
+                country = params["select_country"].lower()
+                params["select_country"] = country[0].upper() + country[1:]
+                slc.params = json.dumps(params, sort_keys=True)
+        except Exception:
+            pass
+
+    session.commit()
+    session.close()


### PR DESCRIPTION
### SUMMARY

[Update the GeoJSON of country maps](https://github.com/apache-superset/superset-ui/pull/1045) with the latest [Natural Earth data](https://www.naturalearthdata.com/downloads/) ([public domain usage](https://www.naturalearthdata.com/about/terms-of-use/)) and fix a bunch of usability issues with this viz type.

How the GeoJSON files was generated can be found [here](https://github.com/apache-superset/superset-ui/blob/eaf332bb7d28484de1609ac72466148c5c9c3c4c/plugins/legacy-plugin-chart-country-map/scripts/Country%20Map%20GeoJSON%20Generator.ipynb).

This should fix https://github.com/apache/superset/issues/4568 (dup https://github.com/apache/superset/issues/11666),  provide a better solution for https://github.com/apache/superset/issues/12987 and supersedes https://github.com/apache-superset/superset-ui/pull/955 .

Also updated the controls of the Country Map viz to move the required field "Country" out of "Chart Options" and converted all select option values to lowercase (for simplicity and consistency).

Includes a light weight db migration that runs on all Country Map visualizations. It should be very fast as this is not a very popular visualization type.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

<img width="1353" alt="UK map - before" src="https://user-images.githubusercontent.com/335541/114250436-8e60ab00-9952-11eb-90bf-a4e306f7bbc3.png">

#### After

<img width="1340" alt="UK map - after" src="https://user-images.githubusercontent.com/335541/114250442-93255f00-9952-11eb-9fbe-da99c449eab7.png">


### TEST PLAN

Tested locally with following virtual dataset:

```
SELECT 'CN-11' as iso_code, 1 as metric
UNION
SELECT 'CN-12', 22
UNION
SELECT 'CN-30', 24
UNION
SELECT 'CN-14', 189
UNION
SELECT 'US-CA', 999
UNION
SELECT 'US-HI', 1930
UNION
SELECT 'US-TX', 1000
UNION
SELECT 'GB-BKM', 2910
UNION
SELECT 'GB-GLS', 2810
UNION
SELECT 'GB-NYK', 2018
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
