### PR TITLE
chore: log multiple errors

### DIFF
--- a/superset/commands/exceptions.py
+++ b/superset/commands/exceptions.py
@@ -67,7 +67,9 @@ class CommandInvalidError(CommandException):
         self._invalid_exceptions.extend(exceptions)
 
     def get_list_classnames(self) -> List[str]:
-        return [ex.__class__.__name__ for ex in self._invalid_exceptions]
+        return list(
+            dict.fromkeys([ex.__class__.__name__ for ex in self._invalid_exceptions])
+        )
 
     def normalized_messages(self) -> Dict[Any, Any]:
         errors: Dict[Any, Any] = {}

--- a/superset/commands/exceptions.py
+++ b/superset/commands/exceptions.py
@@ -66,6 +66,9 @@ class CommandInvalidError(CommandException):
     def add_list(self, exceptions: List[ValidationError]) -> None:
         self._invalid_exceptions.extend(exceptions)
 
+    def get_list_classnames(self) -> List[str]:
+        return [ex.__class__.__name__ for ex in self._invalid_exceptions]
+
     def normalized_messages(self) -> Dict[Any, Any]:
         errors: Dict[Any, Any] = {}
         for exception in self._invalid_exceptions:

--- a/superset/commands/exceptions.py
+++ b/superset/commands/exceptions.py
@@ -67,9 +67,7 @@ class CommandInvalidError(CommandException):
         self._invalid_exceptions.extend(exceptions)
 
     def get_list_classnames(self) -> List[str]:
-        return list(
-            sorted({ ex.__class__.__name__ for ex in self._invalid_exceptions})
-        )
+        return list(sorted({ex.__class__.__name__ for ex in self._invalid_exceptions}))
 
     def normalized_messages(self) -> Dict[Any, Any]:
         errors: Dict[Any, Any] = {}

--- a/superset/commands/exceptions.py
+++ b/superset/commands/exceptions.py
@@ -68,7 +68,7 @@ class CommandInvalidError(CommandException):
 
     def get_list_classnames(self) -> List[str]:
         return list(
-            dict.fromkeys([ex.__class__.__name__ for ex in self._invalid_exceptions])
+            sorted({ ex.__class__.__name__ for ex in self._invalid_exceptions})
         )
 
     def normalized_messages(self) -> Dict[Any, Any]:

--- a/superset/databases/commands/create.py
+++ b/superset/databases/commands/create.py
@@ -92,6 +92,9 @@ class CreateDatabaseCommand(BaseCommand):
             exception = DatabaseInvalidError()
             exception.add_list(exceptions)
             event_logger.log_with_context(
-                action=f"db_connection_failed.{exception.__class__.__name__}"
+                action="db_connection_failed.{}.{}".format(
+                    exception.__class__.__name__,
+                    ".".join(exception.get_list_classnames()),
+                )
             )
             raise exception

--- a/tests/integration_tests/databases/commands_tests.py
+++ b/tests/integration_tests/databases/commands_tests.py
@@ -83,8 +83,8 @@ class TestCreateDatabaseCommand(SupersetTestCase):
         mock_logger.assert_called_with(
             action="db_connection_failed."
             "DatabaseInvalidError."
-            "DatabaseRequiredFieldValidationError."
-            "DatabaseExistsValidationError"
+            "DatabaseExistsValidationError."
+            "DatabaseRequiredFieldValidationError"
         )
 
     @mock.patch(

--- a/tests/integration_tests/databases/commands_tests.py
+++ b/tests/integration_tests/databases/commands_tests.py
@@ -81,9 +81,25 @@ class TestCreateDatabaseCommand(SupersetTestCase):
         assert str(excinfo.value) == ("Database parameters are invalid.")
         # logger should list classnames of all errors
         mock_logger.assert_called_with(
-            action="db_connection_failed.DatabaseInvalidError."
+            action="db_connection_failed."
+            "DatabaseInvalidError."
             "DatabaseRequiredFieldValidationError."
             "DatabaseExistsValidationError"
+        )
+
+    @mock.patch(
+        "superset.databases.commands.test_connection.event_logger.log_with_context"
+    )
+    def test_multiple_error_logging(self, mock_logger):
+        command = CreateDatabaseCommand(security_manager.find_user("admin"), {})
+        with pytest.raises(DatabaseInvalidError) as excinfo:
+            command.run()
+        assert str(excinfo.value) == ("Database parameters are invalid.")
+        # logger should list a unique set of errors with no duplicates
+        mock_logger.assert_called_with(
+            action="db_connection_failed."
+            "DatabaseInvalidError."
+            "DatabaseRequiredFieldValidationError"
         )
 
 

--- a/tests/integration_tests/databases/commands_tests.py
+++ b/tests/integration_tests/databases/commands_tests.py
@@ -26,7 +26,9 @@ from superset import db, event_logger, security_manager
 from superset.commands.exceptions import CommandInvalidError
 from superset.commands.importers.exceptions import IncorrectVersionError
 from superset.connectors.sqla.models import SqlaTable
+from superset.databases.commands.create import CreateDatabaseCommand
 from superset.databases.commands.exceptions import (
+    DatabaseInvalidError,
     DatabaseNotFoundError,
     DatabaseSecurityUnsafeError,
     DatabaseTestConnectionDriverError,
@@ -62,6 +64,27 @@ from tests.integration_tests.fixtures.importexport import (
     dataset_config,
     dataset_metadata_config,
 )
+
+
+class TestCreateDatabaseCommand(SupersetTestCase):
+    @mock.patch(
+        "superset.databases.commands.test_connection.event_logger.log_with_context"
+    )
+    def test_create_duplicate_error(self, mock_logger):
+        example_db = get_example_database()
+        command = CreateDatabaseCommand(
+            security_manager.find_user("admin"),
+            {"database_name": example_db.database_name},
+        )
+        with pytest.raises(DatabaseInvalidError) as excinfo:
+            command.run()
+        assert str(excinfo.value) == ("Database parameters are invalid.")
+        # logger should list classnames of all errors
+        mock_logger.assert_called_with(
+            action="db_connection_failed.DatabaseInvalidError."
+            "DatabaseRequiredFieldValidationError."
+            "DatabaseExistsValidationError"
+        )
 
 
 class TestExportDatabasesCommand(SupersetTestCase):


### PR DESCRIPTION
### SUMMARY
The database create command can have multiple errors, but when they are logged, we only see the `DatabaseInvalidError`. This change passes all of the errors to the logger

### TEST PLAN
unit test added 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
