### PR TITLE
fix: unable to apply logging format

### DIFF
--- a/superset/app.py
+++ b/superset/app.py
@@ -549,13 +549,13 @@ class SupersetAppInitializer:
         order to fully init the app
         """
         self.pre_init()
+        self.configure_logging()
         self.setup_db()
         self.configure_celery()
         self.setup_event_logger()
         self.setup_bundle_manifest()
         self.register_blueprints()
         self.configure_wtf()
-        self.configure_logging()
         self.configure_middlewares()
         self.configure_cache()
 

--- a/superset/app.py
+++ b/superset/app.py
@@ -549,6 +549,7 @@ class SupersetAppInitializer:
         order to fully init the app
         """
         self.pre_init()
+        # Configuration of logging must be done first to apply the formatter properly
         self.configure_logging()
         self.setup_db()
         self.configure_celery()


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Now the Python logging formatter does not apply correctly. This is because there was already `root logger` hander before this code was executed.
https://github.com/apache/superset/blob/a4fd6b8f33e9e780084a71f3e5b579468cdd635b/superset/utils/logging_configurator.py#L54-L55

There are two ways to solve this problem.
1. Instance logger as early as possible
2. add `force` argument to  `logging.basicConfig`. https://docs.python.org/3/library/logging.html#logging.basicConfig

This PR uses the first.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### Before
<img width="1288" alt="image" src="https://user-images.githubusercontent.com/2016594/114291242-655a2a80-9ab8-11eb-8965-128c9d958332.png">

#### After
<img width="1246" alt="image" src="https://user-images.githubusercontent.com/2016594/114291268-a5211200-9ab8-11eb-8997-8ada66e90547.png">


### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Tested in my local laptop.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
