### PR TITLE
fix: flacky test in test_update_dataset_item_w_override_columns

### DIFF
--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -583,12 +583,12 @@ class TestDatasetApi(SupersetTestCase):
         dataset = self.insert_default_dataset()
         self.login(username="admin")
         new_col_dict = {
-                    "column_name": "new_col",
-                    "description": "description",
-                    "expression": "expression",
-                    "type": "INTEGER",
-                    "verbose_name": "New Col",
-                }
+            "column_name": "new_col",
+            "description": "description",
+            "expression": "expression",
+            "type": "INTEGER",
+            "verbose_name": "New Col",
+        }
         dataset_data = {
             "columns": [new_col_dict],
             "description": "changed description",

--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -582,16 +582,15 @@ class TestDatasetApi(SupersetTestCase):
         # Add default dataset
         dataset = self.insert_default_dataset()
         self.login(username="admin")
-        dataset_data = {
-            "columns": [
-                {
+        new_col_dict = {
                     "column_name": "new_col",
                     "description": "description",
                     "expression": "expression",
                     "type": "INTEGER",
                     "verbose_name": "New Col",
                 }
-            ],
+        dataset_data = {
+            "columns": [new_col_dict],
             "description": "changed description",
         }
         uri = f"api/v1/dataset/{dataset.id}?override_columns=true"
@@ -600,10 +599,10 @@ class TestDatasetApi(SupersetTestCase):
 
         columns = db.session.query(TableColumn).filter_by(table_id=dataset.id).all()
 
-        assert columns[0].column_name == dataset_data["columns"][0]["column_name"]
-        assert columns[0].description == dataset_data["columns"][0]["description"]
-        assert columns[0].expression == dataset_data["columns"][0]["expression"]
-        assert columns[0].type == dataset_data["columns"][0]["type"]
+        assert new_col_dict["column_name"] in [col.column_name for col in columns]
+        assert new_col_dict["description"] in [col.description for col in columns]
+        assert new_col_dict["expression"] in [col.expression for col in columns]
+        assert new_col_dict["type"] in [col.type for col in columns]
 
         db.session.delete(dataset)
         db.session.commit()


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix flack test `tox -e py38-sqlite -vv -- tests/datasets/api_tests.py::TestDatasetApi::test_update_dataset_item_w_override_columns` to make sure the new column is in payload vs. being at a specific index

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
