### PR TITLE
chore: stop logging `SupersetExceptions` if status < 500

### DIFF
--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -167,8 +167,6 @@ def api(f: Callable[..., FlaskResponse]) -> Callable[..., FlaskResponse]:
     def wraps(self: "BaseSupersetView", *args: Any, **kwargs: Any) -> FlaskResponse:
         try:
             return f(self, *args, **kwargs)
-        except SupersetException as ex:
-            return json_error_response(get_error_msg(), status=ex.status)
         except NoAuthorizationError as ex:  # pylint: disable=broad-except
             logger.warning(ex)
             return json_error_response(get_error_msg(), status=401)
@@ -200,7 +198,8 @@ def handle_api_exception(
             logger.warning(ex)
             return json_errors_response(errors=[ex.error], status=ex.status)
         except SupersetException as ex:
-            logger.exception(ex)
+            if ex.status > 500:
+                logger.exception(ex)
             return json_error_response(
                 utils.error_msg_from_exception(ex), status=ex.status
             )

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -198,7 +198,7 @@ def handle_api_exception(
             logger.warning(ex)
             return json_errors_response(errors=[ex.error], status=ex.status)
         except SupersetException as ex:
-            if ex.status > 500:
+            if ex.status >= 500:
                 logger.exception(ex)
             return json_error_response(
                 utils.error_msg_from_exception(ex), status=ex.status

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -167,6 +167,8 @@ def api(f: Callable[..., FlaskResponse]) -> Callable[..., FlaskResponse]:
     def wraps(self: "BaseSupersetView", *args: Any, **kwargs: Any) -> FlaskResponse:
         try:
             return f(self, *args, **kwargs)
+        except SupersetException as ex:
+            return json_error_response(get_error_msg(), status=ex.status)
         except NoAuthorizationError as ex:  # pylint: disable=broad-except
             logger.warning(ex)
             return json_error_response(get_error_msg(), status=401)


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We want to only log exceptions that are 5xx for sentry to pick up

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
