### PR TITLE
feat: Add health endpoint to WebSocket server

### DIFF
--- a/superset-websocket/README.md
+++ b/superset-websocket/README.md
@@ -81,6 +81,8 @@ GLOBAL_ASYNC_QUERIES_WEBSOCKET_URL = "ws://<host>:<port>/"
 
 Note that the WebSocket server must be run on the same hostname (different port) for cookies to be shared between the Flask app and the WebSocket server.
 
+Note also that `localhost` and `127.0.0.1` are not considered the same host. For example, if you're pointing your browser to `localhost:<port>` for Superset, then the WebSocket url will need to be configured as `localhost:<port>`.
+
 The following config values must contain the same values in both the Flask app config and `config.json`:
 ```
 GLOBAL_ASYNC_QUERIES_REDIS_CONFIG
@@ -103,4 +105,20 @@ Running in production:
 npm run build && npm start
 ```
 
-*TODO: containerization*
+## Health check
+
+The WebSocket server supports health checks via one of:
+
+```
+GET /health
+```
+
+OR
+
+```
+HEAD /health
+```
+
+## Containerization
+
+*TODO: containerize websocket server*

--- a/superset-websocket/spec/index.test.ts
+++ b/superset-websocket/spec/index.test.ts
@@ -63,6 +63,60 @@ describe('server', () => {
     server.resetState();
   });
 
+  describe('HTTP requests', () => {
+    test('services health checks', () => {
+      const endMock = jest.fn();
+      const writeHeadMock = jest.fn();
+
+      const request = {
+        url: '/health',
+        method: 'GET',
+        headers: {
+          host: 'example.com',
+        },
+      };
+
+      const response = {
+        writeHead: writeHeadMock,
+        end: endMock,
+      };
+
+      server.httpRequest(request as any, response as any);
+
+      expect(writeHeadMock).toBeCalledTimes(1);
+      expect(writeHeadMock).toHaveBeenLastCalledWith(200);
+
+      expect(endMock).toBeCalledTimes(1);
+      expect(endMock).toHaveBeenLastCalledWith('OK');
+    });
+
+    test('reponds with a 404 otherwise', () => {
+      const endMock = jest.fn();
+      const writeHeadMock = jest.fn();
+
+      const request = {
+        url: '/unsupported',
+        method: 'GET',
+        headers: {
+          host: 'example.com',
+        },
+      };
+
+      const response = {
+        writeHead: writeHeadMock,
+        end: endMock,
+      };
+
+      server.httpRequest(request as any, response as any);
+
+      expect(writeHeadMock).toBeCalledTimes(1);
+      expect(writeHeadMock).toHaveBeenLastCalledWith(404);
+
+      expect(endMock).toBeCalledTimes(1);
+      expect(endMock).toHaveBeenLastCalledWith('Not Found');
+    });
+  });
+
   describe('incrementId', () => {
     test('it increments a valid Redis stream ID', () => {
       expect(server.incrementId('1607477697866-0')).toEqual('1607477697866-1');


### PR DESCRIPTION
### SUMMARY

Application servers will need some sort of health check for deployment. This adds a simple endpoint for the purposes of health checks to the WebSocket server.

This endpoint follows the same url/response as the Flask server for health checks.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
