### PR TITLE
fix: do not render favorite favStars and filters for anonymous user

### DIFF
--- a/superset-frontend/src/explore/components/ExploreChartHeader.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader.jsx
@@ -148,13 +148,15 @@ export class ExploreChartHeader extends React.PureComponent {
 
           {this.props.slice && (
             <StyledButtons>
-              <FaveStar
-                itemId={this.props.slice.slice_id}
-                fetchFaveStar={this.props.actions.fetchFaveStar}
-                saveFaveStar={this.props.actions.saveFaveStar}
-                isStarred={this.props.isStarred}
-                showTooltip
-              />
+              {this.props.userId && (
+                <FaveStar
+                  itemId={this.props.slice.slice_id}
+                  fetchFaveStar={this.props.actions.fetchFaveStar}
+                  saveFaveStar={this.props.actions.saveFaveStar}
+                  isStarred={this.props.isStarred}
+                  showTooltip
+                />
+              )}
               <PropertiesModal
                 show={this.state.isPropertiesModalOpen}
                 onHide={this.closePropertiesModal}

--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -250,6 +250,7 @@ const ExploreChartPanel = props => {
       form_data={props.form_data}
       timeout={props.timeout}
       chart={props.chart}
+      userId={props.userId}
     />
   );
 

--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -592,6 +592,7 @@ function mapStateToProps(state) {
     timeout: explore.common.conf.SUPERSET_WEBSERVER_TIMEOUT,
     ownState: dataMask[form_data.slice_id]?.ownState,
     impressionId,
+    userId: explore.user_id,
   };
 }
 

--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -42,6 +42,7 @@ import SubMenu, { SubMenuProps } from 'src/components/Menu/SubMenu';
 import FaveStar from 'src/components/FaveStar';
 import ListView, {
   ListViewProps,
+  Filter,
   Filters,
   SelectOption,
   FilterOperator,
@@ -195,23 +196,27 @@ function ChartList(props: ChartListProps) {
 
   const columns = useMemo(
     () => [
-      {
-        Cell: ({
-          row: {
-            original: { id },
-          },
-        }: any) => (
-          <FaveStar
-            itemId={id}
-            saveFaveStar={saveFavoriteStatus}
-            isStarred={favoriteStatus[id]}
-          />
-        ),
-        Header: '',
-        id: 'id',
-        disableSortBy: true,
-        size: 'xs',
-      },
+      ...(props.user.userId
+        ? [
+            {
+              Cell: ({
+                row: {
+                  original: { id },
+                },
+              }: any) => (
+                <FaveStar
+                  itemId={id}
+                  saveFaveStar={saveFavoriteStatus}
+                  isStarred={favoriteStatus[id]}
+                />
+              ),
+              Header: '',
+              id: 'id',
+              disableSortBy: true,
+              size: 'xs',
+            },
+          ]
+        : []),
       {
         Cell: ({
           row: {
@@ -377,7 +382,12 @@ function ChartList(props: ChartListProps) {
         hidden: !canEdit && !canDelete,
       },
     ],
-    [canEdit, canDelete, canExport, favoriteStatus],
+    [
+      canEdit,
+      canDelete,
+      canExport,
+      ...(props.user.userId ? [favoriteStatus] : []),
+    ],
   );
 
   const filters: Filters = [
@@ -465,18 +475,22 @@ function ChartList(props: ChartListProps) {
       ),
       paginate: false,
     },
-    {
-      Header: t('Favorite'),
-      id: 'id',
-      urlDisplay: 'favorite',
-      input: 'select',
-      operator: FilterOperator.chartIsFav,
-      unfilteredLabel: t('Any'),
-      selects: [
-        { label: t('Yes'), value: true },
-        { label: t('No'), value: false },
-      ],
-    },
+    ...(props.user.userId
+      ? [
+          {
+            Header: t('Favorite'),
+            id: 'id',
+            urlDisplay: 'favorite',
+            input: 'select',
+            operator: FilterOperator.chartIsFav,
+            unfilteredLabel: t('Any'),
+            selects: [
+              { label: t('Yes'), value: true },
+              { label: t('No'), value: false },
+            ],
+          } as Filter,
+        ]
+      : []),
     {
       Header: t('Search'),
       id: 'slice_name',

--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -390,6 +390,19 @@ function ChartList(props: ChartListProps) {
     ],
   );
 
+  const favoritesFilter: Filter = {
+    Header: t('Favorite'),
+    id: 'id',
+    urlDisplay: 'favorite',
+    input: 'select',
+    operator: FilterOperator.chartIsFav,
+    unfilteredLabel: t('Any'),
+    selects: [
+      { label: t('Yes'), value: true },
+      { label: t('No'), value: false },
+    ],
+  };
+
   const filters: Filters = [
     {
       Header: t('Owner'),
@@ -475,22 +488,7 @@ function ChartList(props: ChartListProps) {
       ),
       paginate: false,
     },
-    ...(props.user.userId
-      ? [
-          {
-            Header: t('Favorite'),
-            id: 'id',
-            urlDisplay: 'favorite',
-            input: 'select',
-            operator: FilterOperator.chartIsFav,
-            unfilteredLabel: t('Any'),
-            selects: [
-              { label: t('Yes'), value: true },
-              { label: t('No'), value: false },
-            ],
-          } as Filter,
-        ]
-      : []),
+    ...(props.user.userId ? [favoritesFilter] : []),
     {
       Header: t('Search'),
       id: 'slice_name',

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
@@ -370,6 +370,19 @@ function DashboardList(props: DashboardListProps) {
     ],
   );
 
+  const favoritesFilter: Filter = {
+    Header: t('Favorite'),
+    id: 'id',
+    urlDisplay: 'favorite',
+    input: 'select',
+    operator: FilterOperator.dashboardIsFav,
+    unfilteredLabel: t('Any'),
+    selects: [
+      { label: t('Yes'), value: true },
+      { label: t('No'), value: false },
+    ],
+  };
+
   const filters: Filters = [
     {
       Header: t('Owner'),
@@ -424,22 +437,7 @@ function DashboardList(props: DashboardListProps) {
         { label: t('Draft'), value: false },
       ],
     },
-    ...(props.user.userId
-      ? [
-          {
-            Header: t('Favorite'),
-            id: 'id',
-            urlDisplay: 'favorite',
-            input: 'select',
-            operator: FilterOperator.dashboardIsFav,
-            unfilteredLabel: t('Any'),
-            selects: [
-              { label: t('Yes'), value: true },
-              { label: t('No'), value: false },
-            ],
-          } as Filter,
-        ]
-      : []),
+    ...(props.user.userId ? [favoritesFilter] : []),
     {
       Header: t('Search'),
       id: 'dashboard_title',

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
@@ -32,6 +32,7 @@ import ConfirmStatusChange from 'src/components/ConfirmStatusChange';
 import SubMenu, { SubMenuProps } from 'src/components/Menu/SubMenu';
 import ListView, {
   ListViewProps,
+  Filter,
   Filters,
   FilterOperator,
 } from 'src/components/ListView';
@@ -189,23 +190,27 @@ function DashboardList(props: DashboardListProps) {
 
   const columns = useMemo(
     () => [
-      {
-        Cell: ({
-          row: {
-            original: { id },
-          },
-        }: any) => (
-          <FaveStar
-            itemId={id}
-            saveFaveStar={saveFavoriteStatus}
-            isStarred={favoriteStatus[id]}
-          />
-        ),
-        Header: '',
-        id: 'id',
-        disableSortBy: true,
-        size: 'xs',
-      },
+      ...(props.user.userId
+        ? [
+            {
+              Cell: ({
+                row: {
+                  original: { id },
+                },
+              }: any) => (
+                <FaveStar
+                  itemId={id}
+                  saveFaveStar={saveFavoriteStatus}
+                  isStarred={favoriteStatus[id]}
+                />
+              ),
+              Header: '',
+              id: 'id',
+              disableSortBy: true,
+              size: 'xs',
+            },
+          ]
+        : []),
       {
         Cell: ({
           row: {
@@ -357,7 +362,12 @@ function DashboardList(props: DashboardListProps) {
         disableSortBy: true,
       },
     ],
-    [canEdit, canDelete, canExport, favoriteStatus],
+    [
+      canEdit,
+      canDelete,
+      canExport,
+      ...(props.user.userId ? [favoriteStatus] : []),
+    ],
   );
 
   const filters: Filters = [
@@ -414,18 +424,22 @@ function DashboardList(props: DashboardListProps) {
         { label: t('Draft'), value: false },
       ],
     },
-    {
-      Header: t('Favorite'),
-      id: 'id',
-      urlDisplay: 'favorite',
-      input: 'select',
-      operator: FilterOperator.dashboardIsFav,
-      unfilteredLabel: t('Any'),
-      selects: [
-        { label: t('Yes'), value: true },
-        { label: t('No'), value: false },
-      ],
-    },
+    ...(props.user.userId
+      ? [
+          {
+            Header: t('Favorite'),
+            id: 'id',
+            urlDisplay: 'favorite',
+            input: 'select',
+            operator: FilterOperator.dashboardIsFav,
+            unfilteredLabel: t('Any'),
+            selects: [
+              { label: t('Yes'), value: true },
+              { label: t('No'), value: false },
+            ],
+          } as Filter,
+        ]
+      : []),
     {
       Header: t('Search'),
       id: 'dashboard_title',

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1748,9 +1748,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     ) -> FlaskResponse:
         """Toggle favorite stars on Slices and Dashboard"""
         if not g.user.get_id():
-            return json_error_response(
-                f"ERROR: Favstar toggling denied", status=403
-            )
+            return json_error_response(f"ERROR: Favstar toggling denied", status=403)
         session = db.session()
         count = 0
         favs = (

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1748,7 +1748,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     ) -> FlaskResponse:
         """Toggle favorite stars on Slices and Dashboard"""
         if not g.user.get_id():
-            return json_error_response(f"ERROR: Favstar toggling denied", status=403)
+            return json_error_response("ERROR: Favstar toggling denied", status=403)
         session = db.session()
         count = 0
         favs = (

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1747,6 +1747,10 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         self, class_name: str, obj_id: int, action: str
     ) -> FlaskResponse:
         """Toggle favorite stars on Slices and Dashboard"""
+        if not g.user.get_id():
+            return json_error_response(
+                f"ERROR: Favstar toggling denied", status=403
+            )
         session = db.session()
         count = 0
         favs = (


### PR DESCRIPTION
### Do not render favorite favStars and filters for charts and dashboards lists for anonymous user

When browsing browsing those lists as anonymous user then 2 issues appears:
1. ~A flash message popup with the text: "There was an error fetching the favorite status: Internal Server Error"~ => fixed in #14287
2. Favorites switches (favStar) and filter are displayed

### Screenshots

Before:
See issue #14070 screenshot.

After:
![image](https://user-images.githubusercontent.com/875021/114688243-d269fc00-9d14-11eb-896f-32341531240a.png)

### TEST PLAN

Manually:
1. add some charts and dashbords to be visible by Public role
2. browse as an anonymous user to charts and dashboards lists as anonymous user
3. verify that above described issue (2) doesn't happens

Automatic test:
...
