### PR TITLE
feat: TrinoEngineSpec.adjust_database_uri

### DIFF
--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -16,8 +16,11 @@
 # under the License.
 from datetime import datetime
 from typing import Optional
+from urllib import parse
 
-from superset.db_engine_specs import BaseEngineSpec
+from sqlalchemy.engine.url import URL
+
+from superset.db_engine_specs.base import BaseEngineSpec
 from superset.utils import core as utils
 
 
@@ -56,3 +59,13 @@ class TrinoEngineSpec(BaseEngineSpec):
     @classmethod
     def epoch_to_dttm(cls) -> str:
         return "from_unixtime({col})"
+
+    @classmethod
+    def adjust_database_uri(
+        cls, uri: URL, selected_schema: Optional[str] = None
+    ) -> None:
+        database = uri.database
+        if selected_schema and database:
+            selected_schema = parse.quote(selected_schema, safe="")
+            database = database.split("/")[0] + "/" + selected_schema
+            uri.database = database

--- a/tests/db_engine_specs/trino_tests.py
+++ b/tests/db_engine_specs/trino_tests.py
@@ -14,12 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from sqlalchemy.engine.url import URL
 
 from superset.db_engine_specs.trino import TrinoEngineSpec
 from tests.db_engine_specs.base_tests import TestDbEngineSpec
 
 
-class TestPrestoDbEngineSpec(TestDbEngineSpec):
+class TestTrinoDbEngineSpec(TestDbEngineSpec):
     def test_convert_dttm(self):
         dttm = self.get_dttm()
 
@@ -32,3 +33,22 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
             TrinoEngineSpec.convert_dttm("TIMESTAMP", dttm),
             "from_iso8601_timestamp('2019-01-02T03:04:05.678900')",
         )
+
+    def test_adjust_database_uri(self):
+        url = URL(drivername="trino", database="hive")
+        TrinoEngineSpec.adjust_database_uri(url, selected_schema="foobar")
+        self.assertEqual(url.database, "hive/foobar")
+
+    def test_adjust_database_uri_when_database_contain_schema(self):
+        url = URL(drivername="trino", database="hive/default")
+        TrinoEngineSpec.adjust_database_uri(url, selected_schema="foobar")
+        self.assertEqual(url.database, "hive/foobar")
+
+    def test_adjust_database_uri_when_selected_schema_is_none(self):
+        url = URL(drivername="trino", database="hive")
+        TrinoEngineSpec.adjust_database_uri(url, selected_schema=None)
+        self.assertEqual(url.database, "hive")
+
+        url.database = "hive/default"
+        TrinoEngineSpec.adjust_database_uri(url, selected_schema=None)
+        self.assertEqual(url.database, "hive/default")


### PR DESCRIPTION
### SUMMARY
Currently, when query data in Trino, you need to specify schema name along side with table name.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![Screenshot from 2021-04-14 16-47-10](https://user-images.githubusercontent.com/6848311/114694013-5be4f280-9d44-11eb-9b91-a771b980dccc.png)
After:
![Screenshot from 2021-04-14 16-58-17](https://user-images.githubusercontent.com/6848311/114694036-61423d00-9d44-11eb-9df7-1721a5acdf97.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
