### PR TITLE
chore: Moves WarningIconWithTooltip to own folder

### DIFF
--- a/superset-frontend/src/components/WarningIconWithTooltip/WarningIconWithTooltip.stories.tsx
+++ b/superset-frontend/src/components/WarningIconWithTooltip/WarningIconWithTooltip.stories.tsx
@@ -17,32 +17,28 @@
  * under the License.
  */
 import React from 'react';
-import { supersetTheme, SafeMarkdown } from '@superset-ui/core';
-import Icon from 'src/components/Icon';
-import { Tooltip } from 'src/components/Tooltip';
+import WarningIconWithTooltip, { WarningIconWithTooltipProps } from '.';
 
-interface WarningIconWithTooltipProps {
-  warningMarkdown: string;
-  size?: number;
-}
+export default {
+  title: 'WarningIconWithTooltip',
+  component: WarningIconWithTooltip,
+};
 
-function WarningIconWithTooltip({
-  warningMarkdown,
-  size = 24,
-}: WarningIconWithTooltipProps) {
-  return (
-    <Tooltip
-      id="warning-tooltip"
-      title={<SafeMarkdown source={warningMarkdown} />}
-    >
-      <Icon
-        color={supersetTheme.colors.alert.base}
-        height={size}
-        width={size}
-        name="alert-solid"
-      />
-    </Tooltip>
-  );
-}
+export const InteractiveWarningIcon = (args: WarningIconWithTooltipProps) => (
+  <div css={{ margin: 40 }}>
+    <WarningIconWithTooltip {...args} />
+  </div>
+);
 
-export default WarningIconWithTooltip;
+InteractiveWarningIcon.args = {
+  warningMarkdown: 'Markdown example',
+  size: 20,
+};
+
+InteractiveWarningIcon.story = {
+  parameters: {
+    knobs: {
+      disable: true,
+    },
+  },
+};

--- a/superset-frontend/src/components/WarningIconWithTooltip/index.tsx
+++ b/superset-frontend/src/components/WarningIconWithTooltip/index.tsx
@@ -16,27 +16,34 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import '../../stylesheets/less/variables.less';
+import React from 'react';
+import { useTheme, SafeMarkdown } from '@superset-ui/core';
+import Icon from 'src/components/Icon';
+import { Tooltip } from 'src/components/Tooltip';
 
-.TableSelector .fa-refresh {
-  padding-left: 9px;
+export interface WarningIconWithTooltipProps {
+  warningMarkdown: string;
+  size?: number;
 }
 
-.TableSelector .section {
-  padding-bottom: 5px;
-  display: flex;
-  flex-direction: row;
+function WarningIconWithTooltip({
+  warningMarkdown,
+  size = 24,
+}: WarningIconWithTooltipProps) {
+  const theme = useTheme();
+  return (
+    <Tooltip
+      id="warning-tooltip"
+      title={<SafeMarkdown source={warningMarkdown} />}
+    >
+      <Icon
+        color={theme.colors.alert.base}
+        height={size}
+        width={size}
+        name="alert-solid"
+      />
+    </Tooltip>
+  );
 }
 
-.TableSelector .select {
-  flex-grow: 1;
-}
-
-.TableSelector .divider {
-  border-bottom: 1px solid @gray-bg;
-  margin: 15px 0;
-}
-
-.TableLabel {
-  white-space: nowrap;
-}
+export default WarningIconWithTooltip;


### PR DESCRIPTION
### SUMMARY
- Moves `WarningIconWithTooltip` to own folder and creates a storybook for it.
- Removes `TableSelector.less`

No tests were added because this component will be merged with `CertifiedIcon`, `ChartIcon`, `FaveStar`, `IconTooltip`, `RefreshLabel`, `WarningIconWithTooltip`.

This work is part of [SIP-61](https://github.com/apache/superset/issues/13632)

@rusackas @junlincc 

### TEST PLAN
1 - Execute all tests
2 - All tests should pass

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
