### PR TITLE
fix(dashboard): filter set hydration not working

### DIFF
--- a/superset-frontend/src/dashboard/actions/nativeFilters.ts
+++ b/superset-frontend/src/dashboard/actions/nativeFilters.ts
@@ -19,10 +19,7 @@
 
 import { makeApi } from '@superset-ui/core';
 import { Dispatch } from 'redux';
-import {
-  Filter,
-  FilterConfiguration,
-} from 'src/dashboard/components/nativeFilters/types';
+import { FilterConfiguration } from 'src/dashboard/components/nativeFilters/types';
 import { DataMaskType, DataMaskStateWithId } from 'src/dataMask/types';
 import {
   SET_DATA_MASK_FOR_FILTER_CONFIG_COMPLETE,
@@ -30,7 +27,12 @@ import {
 } from 'src/dataMask/actions';
 import { HYDRATE_DASHBOARD } from './hydrate';
 import { dashboardInfoChanged } from './dashboardInfo';
-import { DashboardInfo, FilterSet } from '../reducers/types';
+import {
+  DashboardInfo,
+  Filters,
+  FilterSet,
+  FilterSets,
+} from '../reducers/types';
 
 export const SET_FILTER_CONFIG_BEGIN = 'SET_FILTER_CONFIG_BEGIN';
 export interface SetFilterConfigBegin {
@@ -111,7 +113,8 @@ export const setFilterConfiguration = (
 
 type BootstrapData = {
   nativeFilters: {
-    filters: Filter;
+    filters: Filters;
+    filterSets: FilterSets;
     filtersState: object;
   };
 };

--- a/superset-frontend/src/dashboard/reducers/nativeFilters.ts
+++ b/superset-frontend/src/dashboard/reducers/nativeFilters.ts
@@ -73,6 +73,7 @@ export default function nativeFilterReducer(
     case HYDRATE_DASHBOARD:
       return {
         filters: action.data.nativeFilters.filters,
+        filterSets: action.data.nativeFilters.filterSets,
       };
     case SAVE_FILTER_SETS:
       return {


### PR DESCRIPTION
### SUMMARY
When loading a dashboard, filter sets were not being loaded (regression introduced by  #13306).

### AFTER
Currently opening a dashboard with defined filter sets, no filter sets are loaded:
![image](https://user-images.githubusercontent.com/33317356/114707749-42877a80-9d33-11eb-9c39-ebbf0a30af05.png)

### AFTER
When opening a dashboard with two filter sets, the filter sets are now initialized properly:
![image](https://user-images.githubusercontent.com/33317356/114707650-2388e880-9d33-11eb-96b6-c2399192a73a.png)

### TEST PLAN
Local testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
