### PR TITLE
fix: QueryPane horizontal scroll

### DIFF
--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -294,7 +294,8 @@ div.Workspace {
   .queryPane {
     flex: 1 1 auto;
     padding-left: 10px;
-    overflow: visible;
+    overflow-y: visible;
+    overflow-x: scroll;
   }
 
   .schemaPane-enter-done,


### PR DESCRIPTION
### SUMMARY
adding new preview tables would push the save button out of view, and also was getting into situations where some tables were inaccesible. We added overflow-x: scroll to the queryPane class, which seems like it solves the issue. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: 
![Screen Shot 2021-04-14 at 12 13 30 PM](https://user-images.githubusercontent.com/48933336/114743621-da2c9f00-9d1a-11eb-9425-ca9ea96a1cf6.png)

After:
![Screen Shot 2021-04-14 at 12 09 32 PM](https://user-images.githubusercontent.com/48933336/114743373-a0f42f00-9d1a-11eb-8c31-59a3fc75f11d.png)
![Screen Shot 2021-04-14 at 12 09 39 PM](https://user-images.githubusercontent.com/48933336/114743387-a5204c80-9d1a-11eb-80d1-58a58337daf7.png)

### TEST PLAN
This was visually tested. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: https://github.com/apache/superset/issues/13817
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
