### PR TITLE
fix(dashboard): incorrect perm for users with multiple roles

### DIFF
--- a/superset-frontend/src/dashboard/actions/hydrate.js
+++ b/superset-frontend/src/dashboard/actions/hydrate.js
@@ -28,7 +28,7 @@ import { getInitialState as getInitialNativeFilterState } from 'src/dashboard/re
 import { getParam } from 'src/modules/utils';
 import { applyDefaultFormData } from 'src/explore/store';
 import { buildActiveFilters } from 'src/dashboard/util/activeDashboardFilters';
-import getPermissions from 'src/dashboard/util/getPermissions';
+import findPermission from 'src/dashboard/util/findPermission';
 import {
   DASHBOARD_FILTER_SCOPE_GLOBAL,
   dashboardFilter,
@@ -311,21 +311,21 @@ export const hydrateDashboard = (dashboardData, chartData, datasourcesData) => (
       dashboardInfo: {
         ...dashboardData,
         userId: String(user.userId), // legacy, please use state.user instead
-        dash_edit_perm: getPermissions('can_write', 'Dashboard', roles),
-        dash_save_perm: getPermissions('can_save_dash', 'Superset', roles),
-        dash_share_perm: getPermissions(
+        dash_edit_perm: findPermission('can_write', 'Dashboard', roles),
+        dash_save_perm: findPermission('can_save_dash', 'Superset', roles),
+        dash_share_perm: findPermission(
           'can_share_dashboard',
           'Superset',
           roles,
         ),
-        superset_can_explore: getPermissions('can_explore', 'Superset', roles),
-        superset_can_share: getPermissions(
+        superset_can_explore: findPermission('can_explore', 'Superset', roles),
+        superset_can_share: findPermission(
           'can_share_chart',
           'Superset',
           roles,
         ),
-        superset_can_csv: getPermissions('can_csv', 'Superset', roles),
-        slice_can_edit: getPermissions('can_slice', 'Superset', roles),
+        superset_can_csv: findPermission('can_csv', 'Superset', roles),
+        slice_can_edit: findPermission('can_slice', 'Superset', roles),
         common: {
           // legacy, please use state.common instead
           flash_messages: common.flash_messages,
@@ -347,7 +347,7 @@ export const hydrateDashboard = (dashboardData, chartData, datasourcesData) => (
         css: dashboardData.css || '',
         colorNamespace: metadata?.color_namespace || null,
         colorScheme: metadata?.color_scheme || null,
-        editMode: getPermissions('can_write', 'Dashboard', roles) && editMode,
+        editMode: findPermission('can_write', 'Dashboard', roles) && editMode,
         isPublished: dashboardData.published,
         hasUnsavedChanges: false,
         maxUndoHistoryExceeded: false,

--- a/superset-frontend/src/dashboard/util/findPermission.test.ts
+++ b/superset-frontend/src/dashboard/util/findPermission.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import findPermission from './findPermission';
+
+test('findPermission for single role', () => {
+  expect(findPermission('abc', 'def', { role: [['abc', 'def']] })).toEqual(
+    true,
+  );
+
+  expect(findPermission('abc', 'def', { role: [['abc', 'de']] })).toEqual(
+    false,
+  );
+
+  expect(findPermission('abc', 'def', { role: [] })).toEqual(false);
+});
+
+test('findPermission for multiple roles', () => {
+  expect(
+    findPermission('abc', 'def', {
+      role1: [
+        ['ccc', 'aaa'],
+        ['abc', 'def'],
+      ],
+      role2: [['abc', 'def']],
+    }),
+  ).toEqual(true);
+
+  expect(
+    findPermission('abc', 'def', {
+      role1: [['abc', 'def']],
+      role2: [['abc', 'dd']],
+    }),
+  ).toEqual(true);
+
+  expect(
+    findPermission('abc', 'def', {
+      role1: [['ccc', 'aaa']],
+      role2: [['aaa', 'ddd']],
+    }),
+  ).toEqual(false);
+
+  expect(findPermission('abc', 'def', { role1: [], role2: [] })).toEqual(false);
+});

--- a/superset-frontend/src/dashboard/util/findPermission.ts
+++ b/superset-frontend/src/dashboard/util/findPermission.ts
@@ -20,12 +20,11 @@ import memoizeOne from 'memoize-one';
 
 type UserRoles = Record<string, [string, string][]>;
 
-function findPermissions(perm: string, view: string, roles: UserRoles) {
-  return !!Object.values(roles).some(permissions =>
-    permissions.some(([perm_, view_]) => perm_ === perm && view_ === view),
-  );
-}
+const findPermission = memoizeOne(
+  (perm: string, view: string, roles: UserRoles) =>
+    Object.values(roles).some(permissions =>
+      permissions.some(([perm_, view_]) => perm_ === perm && view_ === view),
+    ),
+);
 
-const getPermissions = memoizeOne(findPermissions);
-
-export default getPermissions;
+export default findPermission;

--- a/superset-frontend/src/dashboard/util/getPermissions.ts
+++ b/superset-frontend/src/dashboard/util/getPermissions.ts
@@ -18,21 +18,13 @@
  */
 import memoizeOne from 'memoize-one';
 
-const findPermissions = (perm: string, view: string, roles: object) => {
-  const roleList = Object.entries(roles);
-  if (roleList.length === 0) return false;
-  let bool;
+type UserRoles = Record<string, [string, string][]>;
 
-  roleList.forEach(([role, permissions]) => {
-    bool = Boolean(
-      permissions.find(
-        (permission: Array<string>) =>
-          permission[0] === perm && permission[1] === view,
-      ),
-    );
-  });
-  return bool;
-};
+function findPermissions(perm: string, view: string, roles: UserRoles) {
+  return !!Object.values(roles).some(permissions =>
+    permissions.some(([perm_, view_]) => perm_ === perm && view_ === view),
+  );
+}
 
 const getPermissions = memoizeOne(findPermissions);
 


### PR DESCRIPTION
### SUMMARY

This fixes a bug where dashboard permission check is incorrect when users have multiple roles.

The resulted some users not seeing "View chart in Explore" link in dashboards.

cc @suddjian @pkdotson

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

<img width="513" alt="perm-before" src="https://user-images.githubusercontent.com/335541/114775804-92137980-9d26-11eb-86dc-c4139467bb32.png">

Some links in chart menu are missing if the user has multiple roles and the last role does not contain permission for `[Superset, can_explore]`.

#### After

<img width="620" alt="perm-after" src="https://user-images.githubusercontent.com/335541/114775934-bc653700-9d26-11eb-922f-31f4d033c9c8.png">

### TEST PLAN

To reproduce the bug, add  a new role (e.g. `sql_lab`) to the logged in user.

Added unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:  #13306 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
