### PR TITLE
chore: Configures Jest to ignore storybook files

### DIFF
--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -28,7 +28,7 @@ module.exports = {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/spec/helpers/setup.ts'],
   testURL: 'http://localhost',
-  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}'],
+  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!**/*.stories.*'],
   coverageDirectory: '<rootDir>/coverage/',
   transform: {
     '^.+\\.jsx?$': 'babel-jest',


### PR DESCRIPTION
### SUMMARY
Configures Jest to ignore storybook files when collecting coverage statistics.

@rusackas @junlincc 

### TEST PLAN
1 - Execute all tests
2 - All tests should pass

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
