### PR TITLE
fix: Add extra requires for shillelagh

### DIFF
--- a/docs/src/pages/docs/Connecting to Databases/google-sheets.mdx
+++ b/docs/src/pages/docs/Connecting to Databases/google-sheets.mdx
@@ -10,8 +10,8 @@ version: 1
 
 Google Sheets has a very limited
 [SQL API](https://developers.google.com/chart/interactive/docs/querylanguage). The recommended
-connector library for Google Sheets is [gsheetsdb](https://github.com/betodealmeida/gsheets-db-api).
+connector library for Google Sheets is [shillelagh](https://github.com/betodealmeida/shillelagh).
 
 There are a few steps involved in connecting Superset to Google Sheets. This
-[tutorial](https://preset.io/blog/2020-06-01-connect-superset-google-sheets/) has the most upto date
+[tutorial](https://preset.io/blog/2020-06-01-connect-superset-google-sheets/) has the most up to date
 instructions on setting up this connection.

--- a/docs/src/pages/docs/Connecting to Databases/index.mdx
+++ b/docs/src/pages/docs/Connecting to Databases/index.mdx
@@ -37,7 +37,7 @@ A list of some of the recommended packages.
 |[Dremio](/docs/databases/dremio)|```pip install sqlalchemy_dremio```|```dremio://user:pwd@host:31010/```|
 |[Elasticsearch](/docs/databases/elasticsearch)|```pip install elasticsearch-dbapi```|```elasticsearch+http://{user}:{password}@{host}:9200/```|
 |[Exasol](/docs/databases/exasol)|```pip install sqlalchemy-exasol```|```exa+pyodbc://{username}:{password}@{hostname}:{port}/my_schema?CONNECTIONLCALL=en_US.UTF-8&driver=EXAODBC```|
-|[Google Sheets](/docs/databases/google-sheets)|```pip install gsheetsdb```|```gsheets://```|
+|[Google Sheets](/docs/databases/google-sheets)|```pip install shillelagh[gsheetsapi]```|```gsheets://```|
 |[Hologres](/docs/databases/hologres)|```pip install psycopg2```|```postgresql+psycopg2://<UserName>:<DBPassword>@<Database Host>/<Database Name>```|
 |[IBM Db2](/docs/databases/ibm-db2)|```pip install ibm_db_sa```|```db2+ibm_db://```|
 |[MySQL](/docs/databases/mysql)|```pip install mysqlclient```|```mysql://<UserName>:<DBPassword>@<Database Host>/<Database Name>```|

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ setup(
         "exasol": ["sqlalchemy-exasol>=2.1.0, <2.2"],
         "excel": ["xlrd>=1.2.0, <1.3"],
         "firebird": ["sqlalchemy-firebird>=0.7.0, <0.8"],
-        "gsheets": ["shillelagh>=0.2, <0.3"],
+        "gsheets": ["shillelagh[gsheetsapi]>=0.2, <0.3"],
         "hana": ["hdbcli==2.4.162", "sqlalchemy_hana==0.4.0"],
         "hive": ["pyhive[hive]>=0.6.1", "tableschema", "thrift>=0.11.0, <1.0.0"],
         "impala": ["impyla>0.16.2, <0.17"],


### PR DESCRIPTION
### SUMMARY
I'm not a python expert, but while trying to enable the gsheets API, I got the error `No module named 'google.auth'`. It looks like we need to add the extra require from shillelagh like this, but i'm not positive that this is the right syntax. I'm hoping CI will help me out, but i'll also test this locally to see if it fixes the issue

Also updates some documentation

### TEST PLAN
CI, dev

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @betodealmeida 