### PR TITLE
feat(explore): Enable the new pivot table

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -90,6 +90,7 @@
     "@superset-ui/legacy-preset-chart-deckgl": "^0.4.6",
     "@superset-ui/legacy-preset-chart-nvd3": "^0.17.32",
     "@superset-ui/plugin-chart-echarts": "^0.17.32",
+    "@superset-ui/plugin-chart-pivot-table": "^0.17.33",
     "@superset-ui/plugin-chart-table": "^0.17.32",
     "@superset-ui/plugin-chart-word-cloud": "^0.17.32",
     "@superset-ui/preset-chart-xy": "^0.17.32",

--- a/superset-frontend/src/visualizations/presets/MainPreset.js
+++ b/superset-frontend/src/visualizations/presets/MainPreset.js
@@ -67,6 +67,7 @@ import {
   TimeColumnFilterPlugin,
   TimeGrainFilterPlugin,
 } from 'src/filters/components/';
+import { PivotTableChartPlugin as PivotTableChartPluginV2 } from '@superset-ui/plugin-chart-pivot-table';
 import FilterBoxChartPlugin from '../FilterBox/FilterBoxChartPlugin';
 import TimeTableChartPlugin from '../TimeTable/TimeTableChartPlugin';
 
@@ -104,6 +105,7 @@ export default class MainPreset extends Preset {
         new PartitionChartPlugin().configure({ key: 'partition' }),
         new EchartsPieChartPlugin().configure({ key: 'pie' }),
         new PivotTableChartPlugin().configure({ key: 'pivot_table' }),
+        new PivotTableChartPluginV2().configure({ key: 'pivot_table_v2' }),
         new RoseChartPlugin().configure({ key: 'rose' }),
         new SankeyChartPlugin().configure({ key: 'sankey' }),
         new SunburstChartPlugin().configure({ key: 'sunburst' }),


### PR DESCRIPTION
### SUMMARY
This PR enables using the new pivot table chart. To use the new pivot table, select "Pivot Table v2" in visualization type modal on Explore view. Until migration is completed, both pivot table plugins will be available. After the migration is done, the legacy pivot table will be removed and the new one will be renamed to "Pivot Table".
The features have been described in https://github.com/apache-superset/superset-ui/pull/1023

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/15073128/114989090-5f3cc300-9e97-11eb-8ce3-8e0222f8d092.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @villebro @junlincc 