### PR TITLE
fix(viz): time shift read-only error

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1362,8 +1362,10 @@ class NVD3TimeSeriesViz(NVD3Viz):
 
             df2 = self.get_df_payload(query_object, time_compare=option).get("df")
             if df2 is not None and DTTM_ALIAS in df2:
+                dttm_series = df2[DTTM_ALIAS] + delta
+                df2 = df2.drop(DTTM_ALIAS, axis=1)
+                df2 = pd.concat([dttm_series, df2], axis=1)
                 label = "{} offset".format(option)
-                df2[DTTM_ALIAS] += delta
                 df2 = self.process_data(df2)
                 self._extra_chart_data.append((label, df2))
 


### PR DESCRIPTION
### SUMMARY
When using the time shift feature on legacy temporal charts, an exception is raised if the DataFrame has been made read-only during serialization/deserialization. By creating a new DataFrame instead of mutating the old one we can ensure that the operation works for read-only DataFrames, too.

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/115021566-ccb31880-9ec4-11eb-990b-6e5766198012.png)

### AFTER
![image](https://user-images.githubusercontent.com/33317356/115021894-421ee900-9ec5-11eb-92df-84e8d84e017c.png)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
