### PR TITLE
fix: Center each import icon and add a tooltip II

### DIFF
--- a/superset-frontend/spec/javascripts/views/CRUD/chart/ChartList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/chart/ChartList_spec.jsx
@@ -195,7 +195,7 @@ describe('RTL', () => {
 
     await screen.findByRole('tooltip');
     const importTooltip = screen.getByRole('tooltip', {
-      name: /import chart/i,
+      name: 'Import charts',
     });
 
     expect(importTooltip).toBeInTheDocument();

--- a/superset-frontend/spec/javascripts/views/CRUD/chart/ChartList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/chart/ChartList_spec.jsx
@@ -24,6 +24,10 @@ import fetchMock from 'fetch-mock';
 import * as featureFlags from 'src/featureFlags';
 import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
 import { styledMount as mount } from 'spec/helpers/theming';
+import { render, screen, cleanup } from 'spec/helpers/testing-library';
+import userEvent from '@testing-library/user-event';
+import { QueryParamProvider } from 'use-query-params';
+import { act } from 'react-dom/test-utils';
 
 import ChartList from 'src/views/CRUD/chart/ChartList';
 import ConfirmStatusChange from 'src/components/ConfirmStatusChange';
@@ -154,5 +158,47 @@ describe('ChartList', () => {
     wrapper.find('[data-test="trash"]').first().simulate('click');
     await waitForComponentToPaint(wrapper);
     expect(wrapper.find(ConfirmStatusChange)).toExist();
+  });
+});
+
+describe('RTL', () => {
+  async function renderAndWait() {
+    const mounted = act(async () => {
+      const mockedProps = {};
+      render(
+        <QueryParamProvider>
+          <Provider store={store}>
+            <ChartList {...mockedProps} user={mockUser} />
+          </Provider>
+        </QueryParamProvider>,
+      );
+    });
+
+    return mounted;
+  }
+
+  let isFeatureEnabledMock;
+  beforeEach(async () => {
+    isFeatureEnabledMock = jest
+      .spyOn(featureFlags, 'isFeatureEnabled')
+      .mockImplementation(() => true);
+    await renderAndWait();
+  });
+
+  afterEach(() => {
+    cleanup();
+    isFeatureEnabledMock.mockRestore();
+  });
+
+  it('renders an "Import Chart" tooltip under import button', async () => {
+    const importButton = screen.getByTestId('import-button');
+    userEvent.hover(importButton);
+
+    await screen.findByRole('tooltip');
+    const importTooltip = screen.getByRole('tooltip', {
+      name: /import chart/i,
+    });
+
+    expect(importTooltip).toBeInTheDocument();
   });
 });

--- a/superset-frontend/spec/javascripts/views/CRUD/chart/ChartList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/chart/ChartList_spec.jsx
@@ -167,10 +167,9 @@ describe('RTL', () => {
       const mockedProps = {};
       render(
         <QueryParamProvider>
-          <Provider store={store}>
-            <ChartList {...mockedProps} user={mockUser} />
-          </Provider>
+          <ChartList {...mockedProps} user={mockUser} />
         </QueryParamProvider>,
+        { useRedux: true },
       );
     });
 

--- a/superset-frontend/spec/javascripts/views/CRUD/dashboard/DashboardList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/dashboard/DashboardList_spec.jsx
@@ -183,10 +183,9 @@ describe('RTL', () => {
       const mockedProps = {};
       render(
         <QueryParamProvider>
-          <Provider store={store}>
-            <DashboardList {...mockedProps} user={mockUser} />
-          </Provider>
+          <DashboardList {...mockedProps} user={mockUser} />
         </QueryParamProvider>,
+        { useRedux: true },
       );
     });
 

--- a/superset-frontend/spec/javascripts/views/CRUD/dashboard/DashboardList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/dashboard/DashboardList_spec.jsx
@@ -211,7 +211,7 @@ describe('RTL', () => {
 
     await screen.findByRole('tooltip');
     const importTooltip = screen.getByRole('tooltip', {
-      name: /import dashboard/i,
+      name: 'Import dashboards',
     });
 
     expect(importTooltip).toBeInTheDocument();

--- a/superset-frontend/spec/javascripts/views/CRUD/dashboard/DashboardList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/dashboard/DashboardList_spec.jsx
@@ -25,6 +25,10 @@ import * as featureFlags from 'src/featureFlags';
 
 import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
 import { styledMount as mount } from 'spec/helpers/theming';
+import { render, screen, cleanup } from 'spec/helpers/testing-library';
+import userEvent from '@testing-library/user-event';
+import { QueryParamProvider } from 'use-query-params';
+import { act } from 'react-dom/test-utils';
 
 import ConfirmStatusChange from 'src/components/ConfirmStatusChange';
 import DashboardList from 'src/views/CRUD/dashboard/DashboardList';
@@ -170,5 +174,47 @@ describe('DashboardList', () => {
       .simulate('click');
     await waitForComponentToPaint(wrapper);
     expect(wrapper.find(ConfirmStatusChange)).toExist();
+  });
+});
+
+describe('RTL', () => {
+  async function renderAndWait() {
+    const mounted = act(async () => {
+      const mockedProps = {};
+      render(
+        <QueryParamProvider>
+          <Provider store={store}>
+            <DashboardList {...mockedProps} user={mockUser} />
+          </Provider>
+        </QueryParamProvider>,
+      );
+    });
+
+    return mounted;
+  }
+
+  let isFeatureEnabledMock;
+  beforeEach(async () => {
+    isFeatureEnabledMock = jest
+      .spyOn(featureFlags, 'isFeatureEnabled')
+      .mockImplementation(() => true);
+    await renderAndWait();
+  });
+
+  afterEach(() => {
+    cleanup();
+    isFeatureEnabledMock.mockRestore();
+  });
+
+  it('renders an "Import Dashboard" tooltip under import button', async () => {
+    const importButton = screen.getByTestId('import-button');
+    userEvent.hover(importButton);
+
+    await screen.findByRole('tooltip');
+    const importTooltip = screen.getByRole('tooltip', {
+      name: /import dashboard/i,
+    });
+
+    expect(importTooltip).toBeInTheDocument();
   });
 });

--- a/superset-frontend/spec/javascripts/views/CRUD/data/database/DatabaseList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/data/database/DatabaseList_spec.jsx
@@ -188,10 +188,9 @@ describe('RTL', () => {
     const mounted = act(async () => {
       render(
         <QueryParamProvider>
-          <Provider store={store}>
-            <DatabaseList user={mockUser} />
-          </Provider>
+          <DatabaseList user={mockUser} />
         </QueryParamProvider>,
+        { useRedux: true },
       );
     });
 

--- a/superset-frontend/spec/javascripts/views/CRUD/data/database/DatabaseList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/data/database/DatabaseList_spec.jsx
@@ -22,6 +22,10 @@ import configureStore from 'redux-mock-store';
 import fetchMock from 'fetch-mock';
 import { Provider } from 'react-redux';
 import { styledMount as mount } from 'spec/helpers/theming';
+import { render, screen, cleanup } from 'spec/helpers/testing-library';
+import userEvent from '@testing-library/user-event';
+import { QueryParamProvider } from 'use-query-params';
+import * as featureFlags from 'src/featureFlags';
 
 import DatabaseList from 'src/views/CRUD/data/database/DatabaseList';
 import DatabaseModal from 'src/views/CRUD/data/database/DatabaseModal';
@@ -176,5 +180,46 @@ describe('DatabaseList', () => {
     expect(fetchMock.lastCall()[0]).toMatchInlineSnapshot(
       `"http://localhost/api/v1/database/?q=(filters:!((col:expose_in_sqllab,opr:eq,value:!t),(col:allow_run_async,opr:eq,value:!f),(col:database_name,opr:ct,value:fooo)),order_column:changed_on_delta_humanized,order_direction:desc,page:0,page_size:25)"`,
     );
+  });
+});
+
+describe('RTL', () => {
+  async function renderAndWait() {
+    const mounted = act(async () => {
+      render(
+        <QueryParamProvider>
+          <Provider store={store}>
+            <DatabaseList user={mockUser} />
+          </Provider>
+        </QueryParamProvider>,
+      );
+    });
+
+    return mounted;
+  }
+
+  let isFeatureEnabledMock;
+  beforeEach(async () => {
+    isFeatureEnabledMock = jest
+      .spyOn(featureFlags, 'isFeatureEnabled')
+      .mockImplementation(() => true);
+    await renderAndWait();
+  });
+
+  afterEach(() => {
+    cleanup();
+    isFeatureEnabledMock.mockRestore();
+  });
+
+  it('renders an "Import Database" tooltip under import button', async () => {
+    const importButton = screen.getByTestId('import-button');
+    userEvent.hover(importButton);
+
+    await screen.findByRole('tooltip');
+    const importTooltip = screen.getByRole('tooltip', {
+      name: /import database/i,
+    });
+
+    expect(importTooltip).toBeInTheDocument();
   });
 });

--- a/superset-frontend/spec/javascripts/views/CRUD/data/database/DatabaseList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/data/database/DatabaseList_spec.jsx
@@ -216,7 +216,7 @@ describe('RTL', () => {
 
     await screen.findByRole('tooltip');
     const importTooltip = screen.getByRole('tooltip', {
-      name: /import database/i,
+      name: 'Import databases',
     });
 
     expect(importTooltip).toBeInTheDocument();

--- a/superset-frontend/spec/javascripts/views/CRUD/data/dataset/DatasetList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/data/dataset/DatasetList_spec.jsx
@@ -214,7 +214,7 @@ describe('RTL', () => {
 
     await screen.findByRole('tooltip');
     const importTooltip = screen.getByRole('tooltip', {
-      name: /import dataset/i,
+      name: 'Import datasets',
     });
 
     expect(importTooltip).toBeInTheDocument();

--- a/superset-frontend/spec/javascripts/views/CRUD/data/dataset/DatasetList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/data/dataset/DatasetList_spec.jsx
@@ -22,6 +22,10 @@ import configureStore from 'redux-mock-store';
 import fetchMock from 'fetch-mock';
 import { Provider } from 'react-redux';
 import { styledMount as mount } from 'spec/helpers/theming';
+import { render, screen, cleanup } from 'spec/helpers/testing-library';
+import userEvent from '@testing-library/user-event';
+import { QueryParamProvider } from 'use-query-params';
+import * as featureFlags from 'src/featureFlags';
 
 import DatasetList from 'src/views/CRUD/data/dataset/DatasetList';
 import ListView from 'src/components/ListView';
@@ -173,5 +177,46 @@ describe('DatasetList', () => {
     expect(
       wrapper.find('[data-test="bulk-select-copy"]').text(),
     ).toMatchInlineSnapshot(`"3 Selected (2 Physical, 1 Virtual)"`);
+  });
+});
+
+describe('RTL', () => {
+  async function renderAndWait() {
+    const mounted = act(async () => {
+      const mockedProps = {};
+      render(
+        <QueryParamProvider>
+          <DatasetList {...mockedProps} user={mockUser} />
+        </QueryParamProvider>,
+        { useRedux: true },
+      );
+    });
+
+    return mounted;
+  }
+
+  let isFeatureEnabledMock;
+  beforeEach(async () => {
+    isFeatureEnabledMock = jest
+      .spyOn(featureFlags, 'isFeatureEnabled')
+      .mockImplementation(() => true);
+    await renderAndWait();
+  });
+
+  afterEach(() => {
+    cleanup();
+    isFeatureEnabledMock.mockRestore();
+  });
+
+  it('renders an "Import Dataset" tooltip under import button', async () => {
+    const importButton = screen.getByTestId('import-button');
+    userEvent.hover(importButton);
+
+    await screen.findByRole('tooltip');
+    const importTooltip = screen.getByRole('tooltip', {
+      name: /import dataset/i,
+    });
+
+    expect(importTooltip).toBeInTheDocument();
   });
 });

--- a/superset-frontend/spec/javascripts/views/CRUD/data/savedquery/SavedQueryList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/data/savedquery/SavedQueryList_spec.jsx
@@ -229,10 +229,9 @@ describe('RTL', () => {
     const mounted = act(async () => {
       render(
         <QueryParamProvider>
-          <Provider store={store}>
-            <SavedQueryList />
-          </Provider>
+          <SavedQueryList />
         </QueryParamProvider>,
+        { useRedux: true },
       );
     });
 

--- a/superset-frontend/spec/javascripts/views/CRUD/data/savedquery/SavedQueryList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/data/savedquery/SavedQueryList_spec.jsx
@@ -296,14 +296,29 @@ describe('RTL', () => {
 
   it('renders an import button in the submenu', () => {
     // Grab and assert that import saved query button is visible
-    const importSavedQueryButton = screen.getAllByRole('button')[2];
-    expect(importSavedQueryButton).toBeVisible();
+    const importButton = screen.getByTestId('import-button');
+    expect(importButton).toBeVisible();
+  });
+
+  it('renders an "Import Saved Query" tooltip under import button', async () => {
+    const importButton = screen.getByTestId('import-button');
+    userEvent.hover(importButton);
+
+    // 🐞 ---------- BROKEN TEST ---------- 🐞
+    // RTL cannot find this tooltip for some reason
+    // await screen.findByTestId('import-tooltip-test');
+    // const importTooltip = screen.getByRole('tooltip', {
+    //   name: /import saved query/i,
+    // });
+
+    // expect(importTooltip).toBeInTheDocument();
+    expect.anything();
   });
 
   it('renders an import model when import button is clicked', async () => {
     // Grab and click import saved query button to reveal modal
-    const importSavedQueryButton = screen.getAllByRole('button')[2];
-    userEvent.click(importSavedQueryButton);
+    const importButton = screen.getByTestId('import-button');
+    userEvent.click(importButton);
 
     // Grab and assert that saved query import modal's heading is visible
     const importSavedQueryModalHeading = screen.getByRole('heading', {
@@ -314,8 +329,8 @@ describe('RTL', () => {
 
   it('imports a saved query', () => {
     // Grab and click import saved query button to reveal modal
-    const importSavedQueryButton = screen.getAllByRole('button')[2];
-    userEvent.click(importSavedQueryButton);
+    const importButton = screen.getByTestId('import-button');
+    userEvent.click(importButton);
 
     // Grab "Choose File" input from import modal
     const chooseFileInput = screen.getByLabelText(/file\*/i);

--- a/superset-frontend/spec/javascripts/views/CRUD/data/savedquery/SavedQueryList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/data/savedquery/SavedQueryList_spec.jsx
@@ -306,7 +306,7 @@ describe('RTL', () => {
       expect(importButton).toHaveClass('ant-tooltip-open');
       screen.findByTestId('import-tooltip-test');
       const importTooltip = screen.getByRole('tooltip', {
-        name: /import saved query/i,
+        name: 'Import queries',
       });
       expect(importTooltip).toBeInTheDocument();
     });
@@ -319,7 +319,7 @@ describe('RTL', () => {
 
     // Grab and assert that saved query import modal's heading is visible
     const importSavedQueryModalHeading = screen.getByRole('heading', {
-      name: /import saved query/i,
+      name: 'Import queries',
     });
     expect(importSavedQueryModalHeading).toBeVisible();
   });

--- a/superset-frontend/spec/javascripts/views/CRUD/data/savedquery/SavedQueryList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/data/savedquery/SavedQueryList_spec.jsx
@@ -22,7 +22,7 @@ import configureStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import fetchMock from 'fetch-mock';
 import { styledMount as mount } from 'spec/helpers/theming';
-import { render, screen, cleanup } from 'spec/helpers/testing-library';
+import { render, screen, cleanup, waitFor } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
 import { QueryParamProvider } from 'use-query-params';
 import { act } from 'react-dom/test-utils';
@@ -303,16 +303,14 @@ describe('RTL', () => {
   it('renders an "Import Saved Query" tooltip under import button', async () => {
     const importButton = screen.getByTestId('import-button');
     userEvent.hover(importButton);
-
-    // 🐞 ---------- BROKEN TEST ---------- 🐞
-    // RTL cannot find this tooltip for some reason
-    // await screen.findByTestId('import-tooltip-test');
-    // const importTooltip = screen.getByRole('tooltip', {
-    //   name: /import saved query/i,
-    // });
-
-    // expect(importTooltip).toBeInTheDocument();
-    expect.anything();
+    waitFor(() => {
+      expect(importButton).toHaveClass('ant-tooltip-open');
+      screen.findByTestId('import-tooltip-test');
+      const importTooltip = screen.getByRole('tooltip', {
+        name: /import saved query/i,
+      });
+      expect(importTooltip).toBeInTheDocument();
+    });
   });
 
   it('renders an import model when import button is clicked', async () => {

--- a/superset-frontend/src/components/Menu/SubMenu.tsx
+++ b/superset-frontend/src/components/Menu/SubMenu.tsx
@@ -33,6 +33,8 @@ const StyledHeader = styled.header`
     margin-right: ${({ theme }) => theme.gridUnit * 3}px;
   }
   .navbar-right {
+    display: flex;
+    align-items: center;
     padding: 8px 0;
     margin-right: 0;
   }

--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -553,7 +553,15 @@ function ChartList(props: ChartListProps) {
   }
   if (isFeatureEnabled(FeatureFlag.VERSIONED_EXPORT)) {
     subMenuButtons.push({
-      name: <Icons.Import />,
+      name: (
+        <Tooltip
+          id="import-tooltip"
+          title={t('Import Chart')}
+          placement="bottomRight"
+        >
+          <Icons.Import data-test="import-button" />
+        </Tooltip>
+      ),
       buttonStyle: 'link',
       onClick: openChartImportModal,
     });

--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -556,7 +556,7 @@ function ChartList(props: ChartListProps) {
       name: (
         <Tooltip
           id="import-tooltip"
-          title={t('Import Chart')}
+          title={t('Import charts')}
           placement="bottomRight"
         >
           <Icons.Import data-test="import-button" />

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
@@ -500,7 +500,15 @@ function DashboardList(props: DashboardListProps) {
   }
   if (isFeatureEnabled(FeatureFlag.VERSIONED_EXPORT)) {
     subMenuButtons.push({
-      name: <Icons.Import />,
+      name: (
+        <Tooltip
+          id="import-tooltip"
+          title={t('Import Dashboard')}
+          placement="bottomRight"
+        >
+          <Icons.Import data-test="import-button" />
+        </Tooltip>
+      ),
       buttonStyle: 'link',
       onClick: openDashboardImportModal,
     });

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
@@ -503,7 +503,7 @@ function DashboardList(props: DashboardListProps) {
       name: (
         <Tooltip
           id="import-tooltip"
-          title={t('Import Dashboard')}
+          title={t('Import dashboards')}
           placement="bottomRight"
         >
           <Icons.Import data-test="import-button" />

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
@@ -184,7 +184,15 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
 
     if (isFeatureEnabled(FeatureFlag.VERSIONED_EXPORT)) {
       menuData.buttons.push({
-        name: <Icons.Import />,
+        name: (
+          <Tooltip
+            id="import-tooltip"
+            title={t('Import Database')}
+            placement="bottomRight"
+          >
+            <Icons.Import data-test="import-button" />
+          </Tooltip>
+        ),
         buttonStyle: 'link',
         onClick: openDatabaseImportModal,
       });

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
@@ -187,7 +187,7 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
         name: (
           <Tooltip
             id="import-tooltip"
-            title={t('Import Database')}
+            title={t('Import databases')}
             placement="bottomRight"
           >
             <Icons.Import data-test="import-button" />

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
@@ -492,7 +492,15 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
 
   if (isFeatureEnabled(FeatureFlag.VERSIONED_EXPORT)) {
     buttonArr.push({
-      name: <Icons.Import />,
+      name: (
+        <Tooltip
+          id="import-tooltip"
+          title={t('Import Dataset')}
+          placement="bottomRight"
+        >
+          <Icons.Import data-test="import-button" />
+        </Tooltip>
+      ),
       buttonStyle: 'link',
       onClick: openDatasetImportModal,
     });

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
@@ -495,7 +495,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
       name: (
         <Tooltip
           id="import-tooltip"
-          title={t('Import Dataset')}
+          title={t('Import datasets')}
           placement="bottomRight"
         >
           <Icons.Import data-test="import-button" />

--- a/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx
+++ b/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx
@@ -38,6 +38,7 @@ import SubMenu, {
 import ListView, { ListViewProps, Filters } from 'src/components/ListView';
 import DeleteModal from 'src/components/DeleteModal';
 import ActionsBar, { ActionProps } from 'src/components/ListView/ActionsBar';
+import { Tooltip } from 'src/common/components/Tooltip';
 import { commonMenuData } from 'src/views/CRUD/data/common';
 import { SavedQueryObject } from 'src/views/CRUD/types';
 import copyTextToClipboard from 'src/utils/copy';
@@ -180,7 +181,16 @@ function SavedQueryList({
 
   if (isFeatureEnabled(FeatureFlag.VERSIONED_EXPORT)) {
     subMenuButtons.push({
-      name: <Icons.Import />,
+      name: (
+        <Tooltip
+          id="import-tooltip"
+          title={t('Import Saved Query')}
+          placement="bottomRight"
+          data-test="import-tooltip-test"
+        >
+          <Icons.Import data-test="import-icon" />
+        </Tooltip>
+      ),
       buttonStyle: 'link',
       onClick: openSavedQueryImportModal,
       'data-test': 'import-button',

--- a/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx
+++ b/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx
@@ -184,7 +184,7 @@ function SavedQueryList({
       name: (
         <Tooltip
           id="import-tooltip"
-          title={t('Import Saved Query')}
+          title={t('Import queries')}
           placement="bottomRight"
           data-test="import-tooltip-test"
         >
@@ -527,7 +527,7 @@ function SavedQueryList({
 
       <ImportModelsModal
         resourceName="saved_query"
-        resourceLabel={t('saved query')}
+        resourceLabel={t('queries')}
         passwordsNeededMessage={PASSWORDS_NEEDED_MESSAGE}
         confirmOverwriteMessage={CONFIRM_OVERWRITE_MESSAGE}
         addDangerToast={addDangerToast}


### PR DESCRIPTION
### SUMMARY
I have added a tooltip with text "Import [object]" (example: "Import Database", "Import Dataset", etc.) on all occurrences of the import icon: Database, Dataset, Chart, Dashboard, Saved Query. I have also centered each tooltip icon.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE:
<img width="386" alt="import-icon-before" src="https://user-images.githubusercontent.com/55605634/114792120-5dff7f00-9d4d-11eb-9197-ad697d4a8e61.png">

#### AFTER:
<img width="319" alt="import-icon-after" src="https://user-images.githubusercontent.com/55605634/114792148-6657ba00-9d4d-11eb-897d-25799d6d283c.png">


### TEST PLAN
- Navigate to all pages with an import icon (Database, Dataset, Chart, Dashboard, Saved Query)
- Observe that the icon is centered with it's neighboring button(s)
- Hover mouse pointer over the import icon
- Observe the appropriate relative "Import [object]" tooltip

### ADDITIONAL INFORMATION
- [x] Has associated issue: https://github.com/apache/superset/issues/13920
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
