### PR TITLE
chore: Improves Icons storybook

### DIFF
--- a/superset-frontend/src/components/Icons/Icons.stories.tsx
+++ b/superset-frontend/src/components/Icons/Icons.stories.tsx
@@ -17,67 +17,78 @@
  * under the License.
  */
 import React from 'react';
-import { withKnobs, select } from '@storybook/addon-knobs';
 import { styled, supersetTheme } from '@superset-ui/core';
 import Icons from '.';
+import IconType from './IconType';
 import Icon from './Icon';
 
 export default {
   title: 'Icons',
   component: Icon,
-  decorators: [withKnobs],
 };
 
-const palette = {};
+const palette = { Default: null };
 Object.entries(supersetTheme.colors).forEach(([familyName, family]) => {
   Object.entries(family).forEach(([colorName, colorValue]) => {
     palette[`${familyName} / ${colorName}`] = colorValue;
   });
 });
 
-const colorKnob = {
-  label: 'Color',
-  options: {
-    Default: null,
-    ...palette,
-  },
-  defaultValue: null,
-};
-
 const IconSet = styled.div`
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, 200px);
+  grid-auto-rows: 100px;
 `;
 
 const IconBlock = styled.div`
-  flex-grow: 0;
-  flex-shrink: 0;
-  flex-basis: 10%;
-  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   padding: ${({ theme }) => theme.gridUnit * 2}px;
-  div {
-    white-space: nowrap;
-    font-size: ${({ theme }) => theme.typography.sizes.s}px;
-  }
 `;
 
-export const SupersetIcon = () => (
+export const InteractiveIcons = ({
+  showNames,
+  ...rest
+}: IconType & { showNames: boolean }) => (
   <IconSet>
     {Object.keys(Icons).map(k => {
       const IconComponent = Icons[k];
       return (
         <IconBlock key={k}>
-          <IconComponent
-            iconColor={select(
-              colorKnob.label,
-              colorKnob.options,
-              colorKnob.defaultValue,
-              colorKnob.groupId,
-            )}
-          />
+          <IconComponent {...rest} />
+          {showNames && k}
         </IconBlock>
       );
     })}
   </IconSet>
 );
+
+InteractiveIcons.argTypes = {
+  showNames: {
+    name: 'Show names',
+    defaultValue: true,
+    control: { type: 'boolean' },
+  },
+  iconSize: {
+    defaultValue: 'xl',
+    control: { type: 'inline-radio' },
+  },
+  iconColor: {
+    defaultValue: null,
+    control: { type: 'select', options: palette },
+  },
+  theme: {
+    table: {
+      disable: true,
+    },
+  },
+};
+
+InteractiveIcons.story = {
+  parameters: {
+    knobs: {
+      disable: true,
+    },
+  },
+};


### PR DESCRIPTION
### SUMMARY
- Converts `Icons` storybook to typescript
- Replaces knobs with controls
- Enables the display of icon names
- Enables the selection of icons sizes

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/115033182-8055e180-9ea0-11eb-8e85-a008481a0c26.mov

https://user-images.githubusercontent.com/70410625/115033190-8350d200-9ea0-11eb-8de3-b7fad7d69ebf.mov

@rusackas @junlincc @geido 

@geido As you can see in the videos, some icons are not changing colors. That's because AntD has special types of icons called TwoTone and they accept a property called `twoToneColor`. Maybe we can tackle that during the icons revamp.

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
