### PR TITLE
chore: Adds QueryParamProvider to the testing helper

### DIFF
--- a/superset-frontend/spec/helpers/testing-library.tsx
+++ b/superset-frontend/spec/helpers/testing-library.tsx
@@ -26,16 +26,19 @@ import thunk from 'redux-thunk';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import reducerIndex from 'spec/helpers/reducerIndex';
+import { QueryParamProvider } from 'use-query-params';
 
 type Options = Omit<RenderOptions, 'queries'> & {
   useRedux?: boolean;
   useDnd?: boolean;
+  useQueryParams?: boolean;
   initialState?: {};
   reducers?: {};
 };
 
 function createWrapper(options?: Options) {
-  const { useDnd, useRedux, initialState, reducers } = options || {};
+  const { useDnd, useRedux, useQueryParams, initialState, reducers } =
+    options || {};
 
   return ({ children }: { children?: ReactNode }) => {
     let result = (
@@ -54,6 +57,10 @@ function createWrapper(options?: Options) {
       );
 
       result = <Provider store={store}>{result}</Provider>;
+    }
+
+    if (useQueryParams) {
+      result = <QueryParamProvider>{result}</QueryParamProvider>;
     }
 
     return result;


### PR DESCRIPTION
### SUMMARY
Adds `QueryParamProvider` to the testing helper.

Now we can activate the provider with:
`render(<Component />, { useQueryParams: true });`

@rusackas @junlincc 

### TEST PLAN
1 - Execute all tests
2- All tests should pass

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
