### PR TITLE
feat: add endpoint to fetch available DBs

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -1061,6 +1061,18 @@ SQL_VALIDATORS_BY_ENGINE = {
     "postgresql": "PostgreSQLValidator",
 }
 
+# A list of preferred databases, in order. These databases will be
+# displayed prominently in the "Add Database" dialog. You should
+# use the "engine" attribute of the corresponding DB engine spec in
+# `superset/db_engine_specs/`.
+PREFERRED_DATABASES: List[str] = [
+    # "postgresql",
+    # "presto",
+    # "mysql",
+    # "sqlite",
+    # etc.
+]
+
 # Do you want Talisman enabled?
 TALISMAN_ENABLED = False
 # If you want Talisman, how do you want it configured??

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -18,7 +18,7 @@ import json
 import logging
 from datetime import datetime
 from io import BytesIO
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional
 from zipfile import ZipFile
 
 from flask import g, request, Response, send_file
@@ -27,7 +27,7 @@ from flask_appbuilder.models.sqla.interface import SQLAInterface
 from marshmallow import ValidationError
 from sqlalchemy.exc import NoSuchTableError, OperationalError, SQLAlchemyError
 
-from superset import event_logger
+from superset import app, event_logger
 from superset.commands.exceptions import CommandInvalidError
 from superset.commands.importers.v1.utils import get_contents_from_bundle
 from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP, RouteMethod
@@ -63,6 +63,10 @@ from superset.databases.schemas import (
     TableMetadataResponseSchema,
 )
 from superset.databases.utils import get_table_metadata
+from superset.db_engine_specs import get_available_engine_specs
+from superset.db_engine_specs.base import BaseParametersMixin
+from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
+from superset.exceptions import SupersetErrorException
 from superset.extensions import security_manager
 from superset.models.core import Database
 from superset.typing import FlaskResponse
@@ -84,6 +88,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         "test_connection",
         "related_objects",
         "function_names",
+        "available",
     }
     resource_name = "database"
     class_permission_name = "Database"
@@ -822,7 +827,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
               type: integer
           responses:
             200:
-            200:
               description: Query result
               content:
                 application/json:
@@ -839,3 +843,67 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         if not database:
             return self.response_404()
         return self.response(200, function_names=database.function_names,)
+
+    @expose("/available/", methods=["GET"])
+    @protect()
+    @statsd_metrics
+    @event_logger.log_this_with_context(
+        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}" f".available",
+        log_to_statsd=False,
+    )
+    def available(self) -> Response:
+        """Return names of databases currently available
+        ---
+        get:
+          description:
+            Get names of databases currently available
+          responses:
+            200:
+              description: Database names
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          description: Name of the database
+                          type: string
+                        preferred:
+                          description: Is the database preferred?
+                          type: bool
+                        sqlalchemy_uri_placeholder:
+                          description: Example placeholder for the SQLAlchemy URI
+                          type: string
+                        parameters:
+                          description: JSON schema defining the needed parameters
+            400:
+              $ref: '#/components/responses/400'
+            500:
+              $ref: '#/components/responses/500'
+        """
+        preferred_databases: List[str] = app.config.get("PREFERRED_DATABASES", [])
+        available_databases = []
+        for engine_spec in get_available_engine_specs():
+            payload: Dict[str, Any] = {
+                "name": engine_spec.engine_name,
+                "engine": engine_spec.engine,
+                "preferred": engine_spec.engine in preferred_databases,
+            }
+
+            if issubclass(engine_spec, BaseParametersMixin):
+                payload["parameters"] = engine_spec.parameters_json_schema()
+                payload[
+                    "sqlalchemy_uri_placeholder"
+                ] = engine_spec.sqlalchemy_uri_placeholder
+
+            available_databases.append(payload)
+
+        available_databases.sort(
+            key=lambda payload: preferred_databases.index(payload["engine"])
+            if payload["engine"] in preferred_databases
+            else len(preferred_databases)
+        )
+
+        return self.response(200, databases=available_databases)

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -65,8 +65,6 @@ from superset.databases.schemas import (
 from superset.databases.utils import get_table_metadata
 from superset.db_engine_specs import get_available_engine_specs
 from superset.db_engine_specs.base import BaseParametersMixin
-from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
-from superset.exceptions import SupersetErrorException
 from superset.extensions import security_manager
 from superset.models.core import Database
 from superset.typing import FlaskResponse

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -30,6 +30,7 @@ from typing import (
     NamedTuple,
     Optional,
     Pattern,
+    Set,
     Tuple,
     Type,
     TYPE_CHECKING,
@@ -38,18 +39,22 @@ from typing import (
 
 import pandas as pd
 import sqlparse
+from apispec import APISpec
+from apispec.ext.marshmallow import MarshmallowPlugin
 from flask import g
 from flask_babel import gettext as __, lazy_gettext as _
+from marshmallow import fields, Schema
 from sqlalchemy import column, DateTime, select, types
 from sqlalchemy.engine.base import Engine
 from sqlalchemy.engine.interfaces import Compiled, Dialect
 from sqlalchemy.engine.reflection import Inspector
-from sqlalchemy.engine.url import URL
+from sqlalchemy.engine.url import make_url, URL
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import quoted_name, text
 from sqlalchemy.sql.expression import ColumnClause, Select, TextAsFrom
 from sqlalchemy.types import String, TypeEngine, UnicodeText
+from typing_extensions import TypedDict
 
 from superset import app, security_manager, sql_parse
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
@@ -150,7 +155,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     """
 
     engine = "base"  # str as defined in sqlalchemy.engine.engine
-    engine_aliases: Optional[Tuple[str]] = None
+    engine_aliases: Set[str] = set()
     engine_name: Optional[
         str
     ] = None  # used for user messages, overridden in child classes
@@ -1293,3 +1298,90 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
                 sqla_type=column_type, generic_type=generic_type, is_dttm=is_dttm
             )
         return None
+
+
+# schema for adding a database by providing parameters instead of the
+# full SQLAlchemy URI
+class BaseParametersSchema(Schema):
+    username = fields.String(allow_none=True, description=__("Username"))
+    password = fields.String(allow_none=True, description=__("Password"))
+    host = fields.String(required=True, description=__("Hostname or IP address"))
+    port = fields.Integer(required=True, description=__("Database port"))
+    database = fields.String(required=True, description=__("Database name"))
+    query = fields.Dict(
+        keys=fields.Str(), values=fields.Raw(), description=__("Additinal parameters")
+    )
+
+
+class BaseParametersType(TypedDict, total=False):
+    username: Optional[str]
+    password: Optional[str]
+    host: str
+    port: int
+    database: str
+    query: Dict[str, Any]
+
+
+class BaseParametersMixin:
+
+    """
+    Mixin for configuring DB engine specs via a dictionary.
+
+    With this mixin the SQLAlchemy engine can be configured through
+    individual parameters, instead of the full SQLAlchemy URI. This
+    mixin is for the most common pattern of URI:
+
+        drivername://user:password@host:port/dbname[?key=value&key=value...]
+
+    """
+
+    # schema describing the parameters used to configure the DB
+    parameters_schema = BaseParametersSchema()
+
+    # recommended driver name for the DB engine spec
+    drivername = ""
+
+    # placeholder with the SQLAlchemy URI template
+    sqlalchemy_uri_placeholder = (
+        "drivername://user:password@host:port/dbname[?key=value&key=value...]"
+    )
+
+    @classmethod
+    def build_sqlalchemy_url(cls, parameters: BaseParametersType) -> str:
+        return str(
+            URL(
+                cls.drivername,
+                username=parameters.get("username"),
+                password=parameters.get("password"),
+                host=parameters["host"],
+                port=parameters["port"],
+                database=parameters["database"],
+                query=parameters.get("query", {}),
+            )
+        )
+
+    @classmethod
+    def get_parameters_from_uri(cls, uri: str) -> BaseParametersType:
+        url = make_url(uri)
+        return {
+            "username": url.username,
+            "password": url.password,
+            "host": url.host,
+            "port": url.port,
+            "database": url.database,
+            "query": url.query,
+        }
+
+    @classmethod
+    def parameters_json_schema(cls) -> Any:
+        """
+        Return configuration parameters as OpenAPI.
+        """
+        spec = APISpec(
+            title="Database Parameters",
+            version="1.0.0",
+            openapi_version="3.0.2",
+            plugins=[MarshmallowPlugin()],
+        )
+        spec.components.schema(cls.__name__, schema=cls.parameters_schema)
+        return spec.to_dict()["components"]["schemas"][cls.__name__]

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -942,6 +942,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         :param cols: Columns to include in query
         :return: SQL query
         """
+        # pylint: disable=redefined-outer-name
         fields: Union[str, List[Any]] = "*"
         cols = cols or []
         if (show_cols or latest_partition) and not cols:

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -37,7 +37,7 @@ from sqlalchemy.dialects.postgresql import ARRAY, DOUBLE_PRECISION, ENUM, JSON
 from sqlalchemy.dialects.postgresql.base import PGInspector
 from sqlalchemy.types import String, TypeEngine
 
-from superset.db_engine_specs.base import BaseEngineSpec
+from superset.db_engine_specs.base import BaseEngineSpec, BaseParametersMixin
 from superset.errors import SupersetErrorType
 from superset.exceptions import SupersetException
 from superset.utils import core as utils
@@ -143,9 +143,15 @@ class PostgresBaseEngineSpec(BaseEngineSpec):
         return "(timestamp 'epoch' + {col} * interval '1 second')"
 
 
-class PostgresEngineSpec(PostgresBaseEngineSpec):
+class PostgresEngineSpec(PostgresBaseEngineSpec, BaseParametersMixin):
     engine = "postgresql"
-    engine_aliases = ("postgres",)
+    engine_aliases = {"postgres"}
+
+    drivername = "postgresql+psycopg2"
+    sqlalchemy_uri_placeholder = (
+        "postgresql+psycopg2://user:password@host:port/dbname[?key=value&key=value...]"
+    )
+
     max_column_name_length = 63
     try_remove_schema_from_table_name = False
 

--- a/tests/databases/schema_tests.py
+++ b/tests/databases/schema_tests.py
@@ -1,0 +1,125 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest import mock
+
+from marshmallow import fields, Schema, ValidationError
+
+from superset.databases.schemas import DatabaseParametersSchemaMixin
+from superset.db_engine_specs.base import BaseParametersMixin
+
+
+class DummySchema(Schema, DatabaseParametersSchemaMixin):
+    sqlalchemy_uri = fields.String()
+
+
+class DummyEngine(BaseParametersMixin):
+    drivername = "dummy"
+
+
+class InvalidEngine:
+    pass
+
+
+@mock.patch("superset.databases.schemas.get_engine_specs")
+def test_database_parameters_schema_mixin(get_engine_specs):
+    get_engine_specs.return_value = {"dummy_engine": DummyEngine}
+    payload = {
+        "parameters": {
+            "engine": "dummy_engine",
+            "username": "username",
+            "password": "password",
+            "host": "localhost",
+            "port": 12345,
+            "database": "dbname",
+        }
+    }
+    schema = DummySchema()
+    result = schema.load(payload)
+    assert result == {
+        "sqlalchemy_uri": "dummy://username:password@localhost:12345/dbname"
+    }
+
+
+def test_database_parameters_schema_mixin_no_engine():
+    payload = {
+        "parameters": {
+            "username": "username",
+            "password": "password",
+            "host": "localhost",
+            "port": 12345,
+            "dbname": "dbname",
+        }
+    }
+    schema = DummySchema()
+    try:
+        schema.load(payload)
+    except ValidationError as err:
+        assert err.messages == {
+            "_schema": [
+                "An engine must be specified when passing individual parameters to a database."
+            ]
+        }
+
+
+@mock.patch("superset.databases.schemas.get_engine_specs")
+def test_database_parameters_schema_mixin_invalid_engine(get_engine_specs):
+    get_engine_specs.return_value = {}
+    payload = {
+        "parameters": {
+            "engine": "dummy_engine",
+            "username": "username",
+            "password": "password",
+            "host": "localhost",
+            "port": 12345,
+            "dbname": "dbname",
+        }
+    }
+    schema = DummySchema()
+    try:
+        schema.load(payload)
+    except ValidationError as err:
+        assert err.messages == {
+            "_schema": ['Engine "dummy_engine" is not a valid engine.']
+        }
+
+
+@mock.patch("superset.databases.schemas.get_engine_specs")
+def test_database_parameters_schema_no_mixin(get_engine_specs):
+    get_engine_specs.return_value = {"invalid_engine": InvalidEngine}
+    payload = {
+        "parameters": {
+            "engine": "invalid_engine",
+            "username": "username",
+            "password": "password",
+            "host": "localhost",
+            "port": 12345,
+            "database": "dbname",
+        }
+    }
+    schema = DummySchema()
+    try:
+        schema.load(payload)
+    except ValidationError as err:
+        assert err.messages == {
+            "_schema": [
+                (
+                    'Engine spec "InvalidEngine" does not support '
+                    "being configured via individual parameters."
+                )
+            ]
+        }

--- a/tests/db_engine_specs/postgres_tests.py
+++ b/tests/db_engine_specs/postgres_tests.py
@@ -388,3 +388,44 @@ psql: error: could not connect to server: Operation timed out
                 },
             )
         ]
+
+
+def test_base_parameters_mixin():
+    parameters = {
+        "username": "username",
+        "password": "password",
+        "host": "localhost",
+        "port": 5432,
+        "database": "dbname",
+        "query": {"foo": "bar"},
+    }
+    sqlalchemy_uri = PostgresEngineSpec.build_sqlalchemy_url(parameters)
+    assert (
+        sqlalchemy_uri
+        == "postgresql+psycopg2://username:password@localhost:5432/dbname?foo=bar"
+    )
+
+    parameters_from_uri = PostgresEngineSpec.get_parameters_from_uri(sqlalchemy_uri)
+    assert parameters_from_uri == parameters
+
+    json_schema = PostgresEngineSpec.parameters_json_schema()
+    assert json_schema == {
+        "type": "object",
+        "properties": {
+            "host": {"type": "string", "description": "Hostname or IP address"},
+            "username": {"type": "string", "nullable": True, "description": "Username"},
+            "password": {"type": "string", "nullable": True, "description": "Password"},
+            "database": {"type": "string", "description": "Database name"},
+            "query": {
+                "type": "object",
+                "description": "Additinal parameters",
+                "additionalProperties": {},
+            },
+            "port": {
+                "type": "integer",
+                "format": "int32",
+                "description": "Database port",
+            },
+        },
+        "required": ["database", "host", "port"],
+    }


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

We're working on redesigning the "Add Database" dialog so that users don't have to type a SQLAlchemy URI or figure out which driver should be used for each database. Instead, in the new flow:

1. User clicks "Add Database".
2. User chooses a database from the list of available databases, eg, "PostgreSQL". This list is built based on the installed SQLAlchemy dialects.
3. User types in the DB-specific information. For PostgreSQL:
- username
- password
- host
- port
- database name
- additional parameters

These parameters are passed to the backend, which builds the SQLAlchemy URI depending on the selected database. Since the logic of building the SQLAlchemy URI is DB-dependent we opted against doing it in the frontend, and store the logic in each DB engine spec.

To make this work, this PR introduces:

1. A `BaseParametersMixin` mixin for DB engine specs, which can be progressively added to DB engine specs in order to allow them to be configured via parameters instead of the SQLAlchemy URI. The mixin defines a **schema** for the parameters (so the frontend knows what do prompt), and methods to convert between the parameters and the SQLAlchemy URI.
2. A schema mixin, `DatabaseParametersSchemaMixin`. The schema mixin handles the job of building the SQLAlchemy URI from the parameters before validating a payload representing a database. This way, APIs don't need to be updated to support the new way of configuring databases.
3. A new endpoint `/api/v1/database/available/` that list the available databases. Users can specify in `superset/config.py` a list of **preferred databases**, which will then be displayed prominently to the user (with logos, eg).

With this work we hope to simplify the task of adding a new database, removing a lot of the guesswork that is needed today. Users will immediately know which databases are available and what information is needed to configure them. And they will always have the option of falling back to a SQLAlchemy URI if they want or need.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Added unit tests and tested manually that `test_connection` works with the new payload.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
