### PR TITLE
docs: Update trino connection docs

### DIFF
--- a/docs/src/pages/docs/Connecting to Databases/trino.mdx
+++ b/docs/src/pages/docs/Connecting to Databases/trino.mdx
@@ -8,6 +8,8 @@ version: 1
 
 ## Trino
 
+Supported trino version 352 and higher
+
 The [sqlalchemy-trino](https://pypi.org/project/sqlalchemy-trino/) library is the recommended way to connect to Trino through SQLAlchemy.
 
 The expected connection string is formatted as follows:
@@ -15,3 +17,11 @@ The expected connection string is formatted as follows:
 ```
 trino://{username}:{password}@{hostname}:{port}/{catalog}
 ```
+If you are running trino with docker on local machine please use the following connection URL
+
+```
+trino://trino@host.docker.internal:8080
+```
+
+Reference:
+[Trino-Superset-Podcast](https://trino.io/episodes/12.html)


### PR DESCRIPTION
### SUMMARY
- The recent changes in `sqlalchemy-trino` will make it incompatible to work with the trino version with 351 or lower. So it is important to notify users that Trino connector for Superset about the supported version of trino. 
- It would be helpful to include the connection string for the local docker environment as people might need to spend a lot of time debugging this. 
- Additionally, I have added the trino superset podcast link for reference as users might find it useful.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
BEFORE
![image](https://user-images.githubusercontent.com/14219201/115141096-8a7d0900-a075-11eb-8c81-29565d7078b3.png)

AFTER
![image](https://user-images.githubusercontent.com/14219201/115141104-97016180-a075-11eb-80fb-83748d7d717e.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
