### PR TITLE
docs: add helm  repo to kubernetes installation instructions

### DIFF
--- a/docs/src/pages/docs/installation/kubernetes.mdx
+++ b/docs/src/pages/docs/installation/kubernetes.mdx
@@ -8,7 +8,7 @@ version: 1
 
 ## Running on Kubernetes
 
-Running on Kubernetes is supported with the provided [Helm](helm.sh/) chart included in the Github repository under [helm/superset](https://github.com/apache/superset/tree/master/helm/superset).
+Running on Kubernetes is supported with the provided [Helm](https://helm.sh/) chart found in the official [Superset helm repository](https://apache.github.io/superset/index.yaml).
 
 ### Prerequisites
 
@@ -16,6 +16,20 @@ Running on Kubernetes is supported with the provided [Helm](helm.sh/) chart incl
 * Helm installed
 
 ### Running
+
+1. Add the Superset helm repository
+
+```sh
+helm repo add superset https://apache.github.io/superset
+"superset" has been added to your repositories
+```
+
+1. View charts in repo
+```sh
+helm search repo superset
+NAME                    CHART VERSION   APP VERSION     DESCRIPTION
+superset/superset       0.1.1           1.0             Apache Superset is a modern, enterprise-ready b...
+```
 
 1. Configure your setting overrides
 
@@ -29,8 +43,7 @@ More info down below on some important overrides you might need.
 1. Install and run
 
 ```sh
-# From the root of the repository
-helm upgrade --install --values my-values.yaml my-superset helm/superset
+helm upgrade --install --values my-values.yaml superset superset/superset
 ```
 
 You should see various pods popping up, such as:


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This adds the superset helm repository
` https://apache.github.io/superset`
to kubernetes installation instructions.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X ] Has associated issue: https://github.com/apache/superset/pull/14163 https://github.com/apache/superset/issues/14037
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
@amitmiran137 @craig-rueda 