### PR TITLE
build: healtcheck defined in dockerfile does not apply to all use-cases 

### DIFF
--- a/docker-compose-non-dev.yml
+++ b/docker-compose-non-dev.yml
@@ -60,6 +60,8 @@ services:
     depends_on: *superset-depends-on
     user: "root"
     volumes: *superset-volumes
+    healthcheck:
+      disable: true
 
   superset-worker:
     image: *superset-image
@@ -70,6 +72,8 @@ services:
     depends_on: *superset-depends-on
     user: "root"
     volumes: *superset-volumes
+    healthcheck:
+      disable: true
 
   superset-worker-beat:
     image: *superset-image
@@ -80,6 +84,8 @@ services:
     depends_on: *superset-depends-on
     user: "root"
     volumes: *superset-volumes
+    healthcheck:
+      disable: true
 
 volumes:
   superset_home:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,8 @@ services:
     volumes: *superset-volumes
     environment:
       CYPRESS_CONFIG: "${CYPRESS_CONFIG}"
+    healthcheck:
+      disable: true
 
   superset-node:
     image: node:14
@@ -89,6 +91,8 @@ services:
     depends_on: *superset-depends-on
     user: "root"
     volumes: *superset-volumes
+    healthcheck:
+      disable: true
 
   superset-worker-beat:
     image: *superset-image
@@ -99,6 +103,8 @@ services:
     depends_on: *superset-depends-on
     user: "root"
     volumes: *superset-volumes
+    healthcheck:
+      disable: true
 
   superset-tests-worker:
     image: *superset-image
@@ -115,6 +121,8 @@ services:
     depends_on: *superset-depends-on
     user: "root"
     volumes: *superset-volumes
+    healthcheck:
+      disable: true
 
 volumes:
   superset_home:


### PR DESCRIPTION
healtcheck defined in dockerfile does not apply to all use-cases  (comands) for image, causing healtcheck failed when using compose when no healthcheck exists

### SUMMARY
Container healtcheck from dockerfile checks connectivity to locally running 8088 - which is running only in 'superset' container, not workers or beats or init one

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TEST PLAN
run compose /dev compose - there should be no failed healtcheck containers running

### ADDITIONAL INFORMATION
- [x] Has associated issue: #12895
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
