### PR TITLE
feat: Adding limiting_factor column to Query model

### DIFF
--- a/superset/migrations/versions/d416d0d715cc_add_limiting_factor_column_to_query_.py
+++ b/superset/migrations/versions/d416d0d715cc_add_limiting_factor_column_to_query_.py
@@ -26,47 +26,17 @@ Create Date: 2021-04-16 17:38:40.342260
 revision = "d416d0d715cc"
 down_revision = "19e978e1b9c3"
 
-from enum import Enum
-
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.dialects import postgresql
-from sqlalchemy.dialects.postgresql.base import PGDialect
-
-limiting_factor = postgresql.ENUM(
-    "DROPDOWN",
-    "QUERY",
-    "NOT_LIMITED",
-    "QUERY_AND_DROPDOWN",
-    "UNKNOWN",
-    name="limitingfactor",
-)
 
 
 def upgrade():
-    bind = op.get_bind()
-    if isinstance(bind.dialect, PGDialect):
-        limiting_factor.create(bind)
     with op.batch_alter_table("query") as batch_op:
         batch_op.add_column(
-            sa.Column(
-                "limiting_factor",
-                sa.Enum(
-                    "DROPDOWN",
-                    "QUERY",
-                    "NOT_LIMITED",
-                    "QUERY_AND_DROPDOWN",
-                    "UNKNOWN",
-                    name="limitingfactor",
-                ),
-                server_default="UNKNOWN",
-            )
+            sa.Column("limiting_factor", sa.VARCHAR(255), server_default="UNKNOWN",)
         )
 
 
 def downgrade():
     with op.batch_alter_table("query") as batch_op:
         batch_op.drop_column("limiting_factor")
-        bind = op.get_bind()
-    if isinstance(bind.dialect, PGDialect):
-        limiting_factor.drop(bind)

--- a/superset/migrations/versions/d416d0d715cc_add_limiting_factor_column_to_query_.py
+++ b/superset/migrations/versions/d416d0d715cc_add_limiting_factor_column_to_query_.py
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add_limiting_factor_column_to_query_model.py
+
+Revision ID: d416d0d715cc
+Revises: 19e978e1b9c3
+Create Date: 2021-04-16 17:38:40.342260
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "d416d0d715cc"
+down_revision = "19e978e1b9c3"
+
+from enum import Enum
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects.postgresql.base import PGDialect
+
+limiting_factor = postgresql.ENUM(
+    "DROPDOWN",
+    "QUERY",
+    "NOT_LIMITED",
+    "QUERY_AND_DROPDOWN",
+    "UNKNOWN",
+    name="limitingfactor",
+)
+
+
+def upgrade():
+    bind = op.get_bind()
+    if isinstance(bind.dialect, PGDialect):
+        limiting_factor.create(bind)
+    with op.batch_alter_table("query") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "limiting_factor",
+                sa.Enum(
+                    "DROPDOWN",
+                    "QUERY",
+                    "NOT_LIMITED",
+                    "QUERY_AND_DROPDOWN",
+                    "UNKNOWN",
+                    name="limitingfactor",
+                ),
+                server_default="UNKNOWN",
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("query") as batch_op:
+        batch_op.drop_column("limiting_factor")
+        bind = op.get_bind()
+    if isinstance(bind.dialect, PGDialect):
+        limiting_factor.drop(bind)


### PR DESCRIPTION
### SUMMARY
Adding a new enum column to the query table which would indicate if the query model is limited and what the limiting factor would be.

### Reason
Will be used in the frontend for better user facing messages. Previously several users had complained that they had downloaded the CSV of a query not realizing that the query had been limited either by the dropdown select or their own query parameters. This column will address using backend logic to determine what type of limiting factor, if any, has been placed on the query.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
Benchmarking the migration using https://github.com/apache/superset/pull/13561:
```
% python scripts/benchmark_migration.py superset/migrations/versions/b5676c717e8b_add_new_columns_to_query_model.py --limit 10000000 --no-auto-cleanup
Loaded your LOCAL configuration at [/Users/beto/Projects/incubator-superset/superset_config.py]
logging was configured successfully
2021-04-14 22:54:24,887:INFO:superset.utils.logging_configurator:logging was configured successfully
2021-04-14 22:54:24,900:INFO:root:Configured event logger of type <class 'superset.utils.log.DBEventLogger'>
/Users/beto/Projects/incubator-superset/venv/lib/python3.8/site-packages/flask_caching/__init__.py:191: UserWarning: Flask-Caching: CACHE_TYPE is set to null, caching is effectively disabled.
  warnings.warn(
2021-04-14 22:54:26,086:WARNING:root:ENABLE_ALERTS is deprecated and will be removed in version 2.0.0
Importing migration script: superset/migrations/versions/b5676c717e8b_add_new_columns_to_query_model.py
Migration goes from 070c043f2fdb to b5676c717e8b
Current version of the DB is b5676c717e8b

Identifying models used in the migration:
- Query (0 rows in table query)

Running benchmark will downgrade the Superset DB to 070c043f2fdb and upgrade to b5676c717e8b again. There may be data loss in downgrades. Continue? [y/N]: y
INFO  [alembic.runtime.migration] Context impl MySQLImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade b5676c717e8b -> 070c043f2fdb, add new columns to query model
Benchmarking migration
INFO  [alembic.runtime.migration] Context impl MySQLImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 070c043f2fdb -> b5676c717e8b, add new columns to query model
Migration on current DB took: 0.23 seconds
INFO  [alembic.runtime.migration] Context impl MySQLImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade b5676c717e8b -> 070c043f2fdb, add new columns to query model
Running with at least 10 entities of each model
- Adding 10 entities to the Query model
INFO  [alembic.runtime.migration] Context impl MySQLImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 070c043f2fdb -> b5676c717e8b, add new columns to query model
Migration for 10+ entities took: 0.22 seconds
INFO  [alembic.runtime.migration] Context impl MySQLImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade b5676c717e8b -> 070c043f2fdb, add new columns to query model
Running with at least 100 entities of each model
- Adding 90 entities to the Query model
INFO  [alembic.runtime.migration] Context impl MySQLImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 070c043f2fdb -> b5676c717e8b, add new columns to query model
Migration for 100+ entities took: 0.33 seconds
INFO  [alembic.runtime.migration] Context impl MySQLImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade b5676c717e8b -> 070c043f2fdb, add new columns to query model
Running with at least 1000 entities of each model
- Adding 900 entities to the Query model
INFO  [alembic.runtime.migration] Context impl MySQLImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 070c043f2fdb -> b5676c717e8b, add new columns to query model
Migration for 1000+ entities took: 0.20 seconds
INFO  [alembic.runtime.migration] Context impl MySQLImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade b5676c717e8b -> 070c043f2fdb, add new columns to query model
Running with at least 10000 entities of each model
- Adding 9000 entities to the Query model
INFO  [alembic.runtime.migration] Context impl MySQLImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 070c043f2fdb -> b5676c717e8b, add new columns to query model
Migration for 10000+ entities took: 0.22 seconds
INFO  [alembic.runtime.migration] Context impl MySQLImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade b5676c717e8b -> 070c043f2fdb, add new columns to query model
Running with at least 100000 entities of each model
- Adding 90000 entities to the Query model
INFO  [alembic.runtime.migration] Context impl MySQLImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 070c043f2fdb -> b5676c717e8b, add new columns to query model
Migration for 100000+ entities took: 0.23 seconds
INFO  [alembic.runtime.migration] Context impl MySQLImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade b5676c717e8b -> 070c043f2fdb, add new columns to query model
Running with at least 1000000 entities of each model
- Adding 900000 entities to the Query model
INFO  [alembic.runtime.migration] Context impl MySQLImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 070c043f2fdb -> b5676c717e8b, add new columns to query model
Migration for 1000000+ entities took: 0.35 seconds
INFO  [alembic.runtime.migration] Context impl MySQLImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade b5676c717e8b -> 070c043f2fdb, add new columns to query model
Running with at least 10000000 entities of each model
- Adding 9000000 entities to the Query model
INFO  [alembic.runtime.migration] Context impl MySQLImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 070c043f2fdb -> b5676c717e8b, add new columns to query model
Migration for 10000000+ entities took: 7.42 seconds

Results:

Current: 0.23 s
10+: 0.22 s
100+: 0.33 s
1000+: 0.20 s
10000+: 0.22 s
100000+: 0.23 s
1000000+: 0.35 s
10000000+: 7.42 s
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Requires DB Migration.
