### PR TITLE
feat(alert/report): update content format radio buttons

### DIFF
--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.test.jsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.test.jsx
@@ -255,9 +255,9 @@ describe('AlertReportModal', () => {
     expect(addWrapper.find('input[name="threshold"]')).toExist();
   });
 
-  it('renders four radio buttons', () => {
+  it('renders two radio buttons', () => {
     expect(wrapper.find(Radio)).toExist();
-    expect(wrapper.find(Radio)).toHaveLength(4);
+    expect(wrapper.find(Radio)).toHaveLength(2);
   });
 
   it('renders input element for working timeout', () => {

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -314,6 +314,15 @@ export const StyledInputContainer = styled.div`
   }
 `;
 
+const StyledRadio = styled(Radio)`
+  display: block;
+  line-height: ${({ theme }) => theme.gridUnit * 7}px;
+`;
+
+const StyledRadioGroup = styled(Radio.Group)`
+  margin-left: ${({ theme }) => theme.gridUnit * 5.5}px;
+`;
+
 // Notification Method components
 const StyledNotificationAddButton = styled.div`
   color: ${({ theme }) => theme.colors.primary.dark1};
@@ -1224,18 +1233,19 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
               <h4>{t('Message content')}</h4>
               <span className="required">*</span>
             </StyledSectionTitle>
-            <div className="inline-container add-margin">
-              <Radio.Group onChange={onContentTypeChange} value={contentType}>
-                <Radio value="dashboard">Dashboard</Radio>
-                <Radio value="chart">Chart</Radio>
-              </Radio.Group>
-            </div>
+            <Radio.Group onChange={onContentTypeChange} value={contentType}>
+              <StyledRadio value="dashboard">Dashboard</StyledRadio>
+              <StyledRadio value="chart">Chart</StyledRadio>
+            </Radio.Group>
             {formatOptionEnabled && (
-              <div className="inline-container add-margin">
-                <Radio.Group onChange={onFormatChange} value={reportFormat}>
-                  <Radio value="PNG">PNG</Radio>
-                  <Radio value="CSV">CSV</Radio>
-                </Radio.Group>
+              <div className="inline-container">
+                <StyledRadioGroup
+                  onChange={onFormatChange}
+                  value={reportFormat}
+                >
+                  <StyledRadio value="PNG">Send as PNG</StyledRadio>
+                  <StyledRadio value="CSV">Send as CSV</StyledRadio>
+                </StyledRadioGroup>
               </div>
             )}
             <AsyncSelect

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -1234,8 +1234,8 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
               <span className="required">*</span>
             </StyledSectionTitle>
             <Radio.Group onChange={onContentTypeChange} value={contentType}>
-              <StyledRadio value="dashboard">Dashboard</StyledRadio>
-              <StyledRadio value="chart">Chart</StyledRadio>
+              <StyledRadio value="dashboard">{t('Dashboard')}</StyledRadio>
+              <StyledRadio value="chart">{t('Chart')}</StyledRadio>
             </Radio.Group>
             {formatOptionEnabled && (
               <div className="inline-container">
@@ -1243,8 +1243,8 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                   onChange={onFormatChange}
                   value={reportFormat}
                 >
-                  <StyledRadio value="PNG">Send as PNG</StyledRadio>
-                  <StyledRadio value="CSV">Send as CSV</StyledRadio>
+                  <StyledRadio value="PNG">{t('Send as PNG')}</StyledRadio>
+                  <StyledRadio value="CSV">{t('Send as CSV')}</StyledRadio>
                 </StyledRadioGroup>
               </div>
             )}


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- organizing radio buttons in alert/report modal vertically to create a tree structure

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
AFTER:
<img width="1439" alt="Screen Shot 2021-04-19 at 10 59 21 AM" src="https://user-images.githubusercontent.com/5705598/115281922-6580a880-a0fe-11eb-9dd4-01276bc73a81.png">
<img width="1458" alt="Screen Shot 2021-04-19 at 10 59 28 AM" src="https://user-images.githubusercontent.com/5705598/115281924-66b1d580-a0fe-11eb-855b-aafd30a509cc.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
