### PR TITLE
fix(explore): Filter edit popover not opening in DnD mode

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/OptionWrapper.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/OptionWrapper.tsx
@@ -44,6 +44,7 @@ export default function OptionWrapper(
     clickClose,
     withCaret,
     children,
+    ...rest
   } = props;
   const ref = useRef<HTMLDivElement>(null);
 
@@ -105,7 +106,7 @@ export default function OptionWrapper(
   drag(drop(ref));
 
   return (
-    <DragContainer ref={ref}>
+    <DragContainer ref={ref} {...rest}>
       <Option index={index} clickClose={clickClose} withCaret={withCaret}>
         {children}
       </Option>


### PR DESCRIPTION
### SUMMARY
When user added a filter with drag and drop feature flag enabled, it couldn't be edited because popover didn't open after clicking the filter label. The reason for that is that popover trigger component implicitly passes control props to its child, and we need to spread those props in the child component - which we didn't do. This PR fixes it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see linked issue
After
https://user-images.githubusercontent.com/15073128/115367100-2c137000-a1c6-11eb-882f-c507feb7c4a8.mov

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes https://github.com/apache/superset/issues/14242
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc 