### PR TITLE
fix(native-filters): merge_extra_form_data extras processing

### DIFF
--- a/superset/constants.py
+++ b/superset/constants.py
@@ -133,14 +133,14 @@ EXTRA_FORM_DATA_OVERRIDE_REGULAR_MAPPINGS = {
     "time_column": "time_column",
     "time_grain": "time_grain",
     "time_range": "time_range",
+    "druid_time_origin": "druid_time_origin",
+    "time_grain_sqla": "time_grain_sqla",
+    "time_range_endpoints": "time_range_endpoints",
 }
 
 EXTRA_FORM_DATA_OVERRIDE_EXTRA_KEYS = {
-    "druid_time_origin",
     "relative_start",
     "relative_end",
-    "time_grain_sqla",
-    "time_range_endpoints",
 }
 
 EXTRA_FORM_DATA_OVERRIDE_KEYS = (

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1088,10 +1088,10 @@ def merge_extra_form_data(form_data: Dict[str, Any]) -> None:
     extras = form_data.get("extras", {})
     for key in EXTRA_FORM_DATA_OVERRIDE_EXTRA_KEYS:
         value = extra_form_data.get(key)
-        extra = extras.get(key)
-        if value and extra:
+        if value is not None:
             extras[key] = value
-    form_data.update(extras)
+    if extras:
+        form_data["extras"] = extras
 
     adhoc_filters = form_data.get("adhoc_filters", [])
     form_data["adhoc_filters"] = adhoc_filters

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -927,6 +927,7 @@ class TestUtils(SupersetTestCase):
                     }
                 ],
                 "time_range": "Last 100 years",
+                "time_grain_sqla": "PT1M",
             },
         }
         merge_extra_form_data(form_data)
@@ -948,6 +949,7 @@ class TestUtils(SupersetTestCase):
             "subject": "foo",
         }
         assert form_data["time_range"] == "Last 100 years"
+        assert form_data["extras"]["time_grain_sqla"] == "PT1M"
 
     def test_ssl_certificate_parse(self):
         parsed_certificate = parse_ssl_cert(ssl_certificate)

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -928,6 +928,7 @@ class TestUtils(SupersetTestCase):
                 ],
                 "time_range": "Last 100 years",
                 "time_grain_sqla": "PT1M",
+                "relative_start": "now",
             },
         }
         merge_extra_form_data(form_data)
@@ -949,7 +950,8 @@ class TestUtils(SupersetTestCase):
             "subject": "foo",
         }
         assert form_data["time_range"] == "Last 100 years"
-        assert form_data["extras"]["time_grain_sqla"] == "PT1M"
+        assert form_data["time_grain_sqla"] == "PT1M"
+        assert form_data["extras"]["relative_start"] == "now"
 
     def test_ssl_certificate_parse(self):
         parsed_certificate = parse_ssl_cert(ssl_certificate)


### PR DESCRIPTION
### SUMMARY
The utility function that merges `extra_form_data` into the main `form_data` processed `extras` incorrectly. This fixes the error and adds a test that would have caught it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
CI + new tests

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
