### PR TITLE
feat(show-badges): Dashboard level config for showing/hiding filter badge and cross filter badge

### DIFF
--- a/superset-frontend/src/dashboard/components/SliceHeader/SliceHeader.test.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeader/SliceHeader.test.tsx
@@ -37,6 +37,8 @@ jest.mock('src/dashboard/components/SliceHeaderControls', () => ({
       data-slice-can-edit={props.sliceCanEdit}
       data-component-id={props.componentId}
       data-dashboard-id={props.dashboardId}
+      show-filter-badge={props.showFilterBadge}
+      show-cross-filter-badge={props.showCrossFilterBadge}
       data-is-full-size={props.isFullSize}
       data-chart-status={props.chartStatus}
     >
@@ -147,6 +149,8 @@ const createProps = () => ({
   } as unknown) as Slice,
   componentId: 'CHART-aGfmWtliqA',
   dashboardId: 26,
+  showFilterBadge: true,
+  showCrossFilterBadge: true,
   isFullSize: false,
   chartStatus: 'rendered',
   addSuccessToast: jest.fn(),
@@ -326,6 +330,14 @@ test('Correct props to "SliceHeaderControls"', () => {
   expect(screen.getByTestId('SliceHeaderControls')).toHaveAttribute(
     'data-dashboard-id',
     '26',
+  );
+  expect(screen.getByTestId('SliceHeaderControls')).toHaveAttribute(
+    'show-filter-badge',
+    'true',
+  );
+  expect(screen.getByTestId('SliceHeaderControls')).toHaveAttribute(
+    'show-cross-filter-badge',
+    'true',
   );
   expect(screen.getByTestId('SliceHeaderControls')).toHaveAttribute(
     'data-is-cached',

--- a/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
@@ -50,6 +50,8 @@ type SliceHeaderProps = {
   supersetCanCSV?: boolean;
   sliceCanEdit?: boolean;
   componentId: string;
+  showFilterBadge: boolean;
+  showCrossFilterBadge: boolean;
   dashboardId: number;
   filters: object;
   addSuccessToast: Function;
@@ -90,6 +92,8 @@ const SliceHeader: FC<SliceHeaderProps> = ({
   slice,
   componentId,
   dashboardId,
+  showFilterBadge,
+  showCrossFilterBadge,
   addSuccessToast,
   addDangerToast,
   handleToggleFullSize,
@@ -146,7 +150,7 @@ const SliceHeader: FC<SliceHeaderProps> = ({
       <div className="header-controls">
         {!editMode && (
           <>
-            {crossFilterValue && (
+            {crossFilterValue && showCrossFilterBadge && (
               <Tooltip
                 placement="top"
                 title={
@@ -161,7 +165,7 @@ const SliceHeader: FC<SliceHeaderProps> = ({
                 <CrossFilterIcon name="cross-filter-badge" />
               </Tooltip>
             )}
-            <FiltersBadge chartId={slice.slice_id} />
+            {showFilterBadge && <FiltersBadge chartId={slice.slice_id} />}
             <SliceHeaderControls
               slice={slice}
               isCached={isCached}

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -40,6 +40,8 @@ const propTypes = {
   id: PropTypes.number.isRequired,
   componentId: PropTypes.string.isRequired,
   dashboardId: PropTypes.number.isRequired,
+  showFilterBadge: PropTypes.bool.isRequired,
+  showCrossFilterBadge: PropTypes.bool.isRequired,
   width: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired,
   updateSliceName: PropTypes.func.isRequired,
@@ -246,6 +248,8 @@ export default class Chart extends React.Component {
       id,
       componentId,
       dashboardId,
+      showFilterBadge,
+      showCrossFilterBadge,
       chart,
       slice,
       datasource,
@@ -320,6 +324,8 @@ export default class Chart extends React.Component {
           sliceCanEdit={sliceCanEdit}
           componentId={componentId}
           dashboardId={dashboardId}
+          showFilterBadge={showFilterBadge}
+          showCrossFilterBadge={showCrossFilterBadge}
           filters={filters}
           addSuccessToast={addSuccessToast}
           addDangerToast={addDangerToast}

--- a/superset-frontend/src/dashboard/containers/Chart.jsx
+++ b/superset-frontend/src/dashboard/containers/Chart.jsx
@@ -83,6 +83,8 @@ function mapStateToProps(
     formData,
     editMode: dashboardState.editMode,
     isExpanded: !!dashboardState.expandedSlices[id],
+    showFilterBadge: dashboardInfo.metadata?.showFilterBadge ?? true,
+    showCrossFilterBadge: dashboardInfo.metadata?.showCrossFilterBadge ?? true,
     supersetCanExplore: !!dashboardInfo.superset_can_explore,
     supersetCanShare: !!dashboardInfo.superset_can_share,
     supersetCanCSV: !!dashboardInfo.superset_can_csv,

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -126,6 +126,8 @@ class DashboardJSONMetadataSchema(Schema):
     # used for v0 import/export
     import_time = fields.Integer()
     remote_id = fields.Integer()
+    showFilterBadge = fields.Boolean()
+    showCrossFilterBadge = fields.Boolean()
 
 
 class UserSchema(Schema):


### PR DESCRIPTION
### SUMMARY
There is a requirement to show/hide the existing badges in the slice/chart header
This feature is focused on optionally hiding the filter badge indicator and the cross filter indicator by configuring them from dashboard metadata

a follow-up PR might add UI checkboxes to configure them

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/47772523/115427495-30617c80-a20a-11eb-8c7f-8c68467ed417.mov



### TEST PLAN
backward compatibility:
0. DASHBOARD_CROSS_FILTERS
1. check an existing dashboard that doesn't have keys
  "showFilterBadge"
  "showCrossFilterBadge,
  in the metadata
  2. see that badges does exist
  
    use-case 1
1.  add "showFilterBadge": false to the dashboard metadata 
2. see that filter badges are hidden

    use-case 2
  0 . enable DASHBOARD_CROSS_FILTERS ff  
1.  add "showCrossFilterBadge": false to the dashboard metadata 
2. see that cross filter badge is not shown for the echarts pie chart that configuredto emit filter events 

use-case 3 :

play with combinations of showFilterBadge and showCrossFilterBadge and see that they act accordingly


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
