### PR TITLE
feat: catch errors on do_ping 

### DIFF
--- a/superset/databases/commands/test_connection.py
+++ b/superset/databases/commands/test_connection.py
@@ -73,7 +73,11 @@ class TestConnectionDatabaseCommand(BaseCommand):
             username = self._actor.username if self._actor is not None else None
             engine = database.get_sqla_engine(user_name=username)
             with closing(engine.raw_connection()) as conn:
-                if not engine.dialect.do_ping(conn):
+                try:
+                    alive = engine.dialect.do_ping(conn)
+                except Exception:  # pylint: disable=broad-except
+                    alive = False
+                if not alive:
                     raise DBAPIError(None, None, None)
 
             # Log succesful connection test with engine


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

We saw a few 500x when testing for BigQuery connections, coming from `do_ping`:

`ProgrammingError: Operating on a closed cursor.`

I wrapped the call to `do_ping` on a `try/except` block to fail gracefully.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Added unit test.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
