### PR TITLE
feat(native-filters): make fetch predicate optional

### DIFF
--- a/superset-frontend/src/filters/components/Range/buildQuery.ts
+++ b/superset-frontend/src/filters/components/Range/buildQuery.ts
@@ -19,8 +19,8 @@
 import {
   buildQueryContext,
   ColumnType,
-  QueryFormData,
 } from '@superset-ui/core';
+import { DEFAULT_FORM_DATA, PluginFilterRangeQueryFormData } from './types';
 
 /**
  * The buildQuery function is used to create an instance of QueryContext that's
@@ -36,14 +36,17 @@ import {
  * it is possible to define post processing operations in the QueryObject, or multiple queries
  * if a viz needs multiple different result sets.
  */
-export default function buildQuery(formData: QueryFormData) {
-  const { groupby } = formData;
+export default function buildQuery(formData: PluginFilterRangeQueryFormData) {
+  const { groupby, applyFetchValuesPredicate } = {
+    ...DEFAULT_FORM_DATA,
+    ...formData,
+  };
   const [column = ''] = groupby || [];
   // @ts-ignore (need update interface Column )
   return buildQueryContext(formData, baseQueryObject => [
     {
       ...baseQueryObject,
-      apply_fetch_values_predicate: true,
+      apply_fetch_values_predicate: applyFetchValuesPredicate,
       columns: [],
       groupby: [],
       metrics: [

--- a/superset-frontend/src/filters/components/Range/controlPanel.ts
+++ b/superset-frontend/src/filters/components/Range/controlPanel.ts
@@ -22,6 +22,7 @@ import {
   sections,
   sharedControls,
 } from '@superset-ui/chart-controls';
+import { DEFAULT_FORM_DATA } from './types';
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
@@ -38,6 +39,18 @@ const config: ControlPanelConfig = {
               label: 'Column',
               description:
                 'The numeric column based on which to calculate the range',
+            },
+          },
+        ],
+        [
+          {
+            name: 'applyFetchValuesPredicate',
+            config: {
+              type: 'CheckboxControl',
+              renderTrigger: true,
+              label: t('Apply dataset filter predicate'),
+              default: DEFAULT_FORM_DATA.apply_fetch_values_predicate,
+              description: t('Apply filter predicate if defined in dataset'),
             },
           },
         ],

--- a/superset-frontend/src/filters/components/Range/types.ts
+++ b/superset-frontend/src/filters/components/Range/types.ts
@@ -27,8 +27,7 @@ import { RefObject } from 'react';
 import { PluginFilterStylesProps } from '../types';
 
 interface PluginFilterSelectCustomizeProps {
-  max?: number;
-  min?: number;
+  applyFetchValuesPredicate: boolean;
 }
 
 export type PluginFilterRangeQueryFormData = QueryFormData &
@@ -42,4 +41,8 @@ export type PluginFilterRangeProps = PluginFilterStylesProps & {
   filterState: FilterState;
   behaviors: Behavior[];
   inputRef: RefObject<any>;
+};
+
+export const DEFAULT_FORM_DATA = {
+  apply_fetch_values_predicate: true,
 };

--- a/superset-frontend/src/filters/components/Select/buildQuery.ts
+++ b/superset-frontend/src/filters/components/Select/buildQuery.ts
@@ -20,7 +20,10 @@ import { buildQueryContext } from '@superset-ui/core';
 import { DEFAULT_FORM_DATA, PluginFilterSelectQueryFormData } from './types';
 
 export default function buildQuery(formData: PluginFilterSelectQueryFormData) {
-  const { sortAscending, sortMetric } = { ...DEFAULT_FORM_DATA, ...formData };
+  const { applyFetchValuesPredicate, sortAscending, sortMetric } = {
+    ...DEFAULT_FORM_DATA,
+    ...formData,
+  };
   return buildQueryContext(formData, baseQueryObject => {
     const { columns = [], filters = [] } = baseQueryObject;
 
@@ -28,7 +31,7 @@ export default function buildQuery(formData: PluginFilterSelectQueryFormData) {
     return [
       {
         ...baseQueryObject,
-        apply_fetch_values_predicate: true,
+        apply_fetch_values_predicate: applyFetchValuesPredicate,
         groupby: columns,
         filters: filters.concat(
           columns.map(column => ({ col: column, op: 'IS NOT NULL' })),

--- a/superset-frontend/src/filters/components/Select/controlPanel.ts
+++ b/superset-frontend/src/filters/components/Select/controlPanel.ts
@@ -26,6 +26,7 @@ const {
   multiSelect,
   defaultToFirstItem,
   sortAscending,
+  applyFetchValuesPredicate,
 } = DEFAULT_FORM_DATA;
 
 const config: ControlPanelConfig = {
@@ -106,6 +107,18 @@ const config: ControlPanelConfig = {
               label: t('Inverse selection'),
               default: inverseSelection,
               description: t('Exclude selected values'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'applyFetchValuesPredicate',
+            config: {
+              type: 'CheckboxControl',
+              renderTrigger: true,
+              label: t('Apply dataset filter predicate'),
+              default: applyFetchValuesPredicate,
+              description: t('Apply filter predicate if defined in dataset'),
             },
           },
         ],

--- a/superset-frontend/src/filters/components/Select/types.ts
+++ b/superset-frontend/src/filters/components/Select/types.ts
@@ -34,12 +34,13 @@ export const FIRST_VALUE = '__FIRST_VALUE__';
 export type SelectValue = (number | string)[] | null;
 
 interface PluginFilterSelectCustomizeProps {
+  applyFetchValuesPredicate: boolean;
+  defaultToFirstItem: boolean;
   defaultValue?: SelectValue | typeof FIRST_VALUE;
   enableEmptyFilter: boolean;
+  inputRef?: RefObject<HTMLInputElement>;
   inverseSelection: boolean;
   multiSelect: boolean;
-  defaultToFirstItem: boolean;
-  inputRef?: RefObject<HTMLInputElement>;
   sortAscending: boolean;
   sortMetric?: string;
 }
@@ -69,4 +70,5 @@ export const DEFAULT_FORM_DATA: PluginFilterSelectCustomizeProps = {
   defaultToFirstItem: false,
   multiSelect: true,
   sortAscending: true,
+  applyFetchValuesPredicate: true,
 };


### PR DESCRIPTION
### SUMMARY
Make fetch values predicate optional in Select and Range filters.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
