### PR TITLE
fix: Make g.user attribute access safe for public users

### DIFF
--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -954,7 +954,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
         charts = ChartDAO.find_by_ids(requested_ids)
         if not charts:
             return self.response_404()
-        favorited_chart_ids = ChartDAO.favorited_ids(charts, g.user.id)
+        favorited_chart_ids = ChartDAO.favorited_ids(charts, g.user.get_id())
         res = [
             {"id": request_id, "value": request_id in favorited_chart_ids}
             for request_id in requested_ids

--- a/superset/config.py
+++ b/superset/config.py
@@ -409,7 +409,7 @@ FEATURE_FLAGS: Dict[str, bool] = {}
 # from flask import g, request
 # def GET_FEATURE_FLAGS_FUNC(feature_flags_dict: Dict[str, bool]) -> Dict[str, bool]:
 #     if hasattr(g, "user") and g.user.is_active:
-#         feature_flags_dict['some_feature'] = g.user and g.user.id == 5
+#         feature_flags_dict['some_feature'] = g.user and g.user.get_id() == 5
 #     return feature_flags_dict
 GET_FEATURE_FLAGS_FUNC: Optional[Callable[[Dict[str, bool]], Dict[str, bool]]] = None
 

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -826,7 +826,9 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         dashboards = DashboardDAO.find_by_ids(requested_ids)
         if not dashboards:
             return self.response_404()
-        favorited_dashboard_ids = DashboardDAO.favorited_ids(dashboards, g.user.id)
+        favorited_dashboard_ids = DashboardDAO.favorited_ids(
+            dashboards, g.user.get_id()
+        )
         res = [
             {"id": request_id, "value": request_id in favorited_dashboard_ids}
             for request_id in requested_ids

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1024,7 +1024,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         if not cls.get_allow_cost_estimate(extra):
             raise Exception("Database does not support cost estimation")
 
-        user_name = g.user.username if g.user else None
+        user_name = g.user.username if g.user and hasattr(g.user, "username") else None
         parsed_query = sql_parse.ParsedQuery(sql)
         statements = parsed_query.get_statements()
 

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -142,8 +142,8 @@ class ExtraCache:
 
         if hasattr(g, "user") and g.user:
             if add_to_cache_keys:
-                self.cache_key_wrapper(g.user.id)
-            return g.user.id
+                self.cache_key_wrapper(g.user.get_id())
+            return g.user.get_id()
         return None
 
     def current_username(self, add_to_cache_keys: bool = True) -> Optional[str]:
@@ -154,7 +154,7 @@ class ExtraCache:
         :returns: The username
         """
 
-        if g.user:
+        if g.user and hasattr(g.user, "username"):
             if add_to_cache_keys:
                 self.cache_key_wrapper(g.user.username)
             return g.user.username

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -434,7 +434,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             view_menu_names = (
                 base_query.join(assoc_user_role)
                 .join(self.user_model)
-                .filter(self.user_model.id == g.user.id)
+                .filter(self.user_model.id == g.user.get_id())
                 .filter(self.permission_model.name == permission_name)
             ).all()
             return {s.name for s in view_menu_names}
@@ -1044,7 +1044,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
 
             user_roles = (
                 self.get_session.query(assoc_user_role.c.role_id)
-                .filter(assoc_user_role.c.user_id == g.user.id)
+                .filter(assoc_user_role.c.user_id == g.user.get_id())
                 .subquery()
             )
             regular_filter_roles = (

--- a/superset/sql_validators/presto_db.py
+++ b/superset/sql_validators/presto_db.py
@@ -151,7 +151,7 @@ class PrestoDBSQLValidator(BaseSQLValidator):
         For example, "SELECT 1 FROM default.mytable" becomes "EXPLAIN (TYPE
         VALIDATE) SELECT 1 FROM default.mytable.
         """
-        user_name = g.user.username if g.user else None
+        user_name = g.user.username if g.user and hasattr(g.user, "username") else None
         parsed_query = ParsedQuery(sql)
         statements = parsed_query.get_statements()
 

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -116,7 +116,10 @@ class BaseFavoriteFilter(BaseFilter):  # pylint: disable=too-few-public-methods
         if security_manager.current_user is None:
             return query
         users_favorite_query = db.session.query(FavStar.obj_id).filter(
-            and_(FavStar.user_id == g.user.id, FavStar.class_name == self.class_name)
+            and_(
+                FavStar.user_id == g.user.get_id(),
+                FavStar.class_name == self.class_name,
+            )
         )
         if value:
             return query.filter(and_(self.model.id.in_(users_favorite_query)))

--- a/superset/views/base_schemas.py
+++ b/superset/views/base_schemas.py
@@ -113,8 +113,8 @@ class BaseOwnedSchema(BaseSupersetSchema):
     @staticmethod
     def set_owners(instance: Model, owners: List[int]) -> None:
         owner_objs = list()
-        if g.user.id not in owners:
-            owners.append(g.user.id)
+        if g.user.get_id() not in owners:
+            owners.append(g.user.get_id())
         for owner_id in owners:
             user = current_app.appbuilder.get_session.query(
                 current_app.appbuilder.sm.user_model

--- a/superset/views/database/views.py
+++ b/superset/views/database/views.py
@@ -229,7 +229,7 @@ class CsvToDatabaseView(SimpleFormView):
                 sqla_table = SqlaTable(table_name=csv_table.table)
                 sqla_table.database = expore_database
                 sqla_table.database_id = database.id
-                sqla_table.user_id = g.user.id
+                sqla_table.user_id = g.user.get_id()
                 sqla_table.schema = csv_table.schema
                 sqla_table.fetch_metadata()
                 db.session.add(sqla_table)
@@ -381,7 +381,7 @@ class ExcelToDatabaseView(SimpleFormView):
                 sqla_table = SqlaTable(table_name=excel_table.table)
                 sqla_table.database = expore_database
                 sqla_table.database_id = database.id
-                sqla_table.user_id = g.user.id
+                sqla_table.user_id = g.user.get_id()
                 sqla_table.schema = excel_table.schema
                 sqla_table.fetch_metadata()
                 db.session.add(sqla_table)

--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -297,4 +297,4 @@ class SqlLab(BaseSupersetView):
     @has_access
     def my_queries(self) -> FlaskResponse:  # pylint: disable=no-self-use
         """Assigns a list of found users to the given role."""
-        return redirect("/savedqueryview/list/?_flt_0_user={}".format(g.user.id))
+        return redirect("/savedqueryview/list/?_flt_0_user={}".format(g.user.get_id()))


### PR DESCRIPTION
### SUMMARY
Make g.user attribute access safe for public users by:
1. Using the abstract `get_id` method
2. Checking for presence of `g.user.username` before using (this property is not set for public users)

### TEST PLAN
Automated tests should pass.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes #12618
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
