### PR TITLE
fix: Fix unintended cache misses with async queries

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -98,7 +98,7 @@ from superset.exceptions import (
 )
 from superset.typing import FlaskResponse, FormData, Metric
 from superset.utils.dates import datetime_to_epoch, EPOCH
-from superset.utils.hashing import md5_sha_from_str
+from superset.utils.hashing import md5_sha_from_dict, md5_sha_from_str
 
 try:
     from pydruid.utils.having import Having
@@ -1046,7 +1046,6 @@ def to_adhoc(
     result = {
         "clause": clause.upper(),
         "expressionType": expression_type,
-        "filterOptionName": str(uuid.uuid4()),
         "isExtra": bool(filt.get("isExtra")),
     }
 
@@ -1060,6 +1059,9 @@ def to_adhoc(
         )
     elif expression_type == "SQL":
         result.update({"sqlExpression": filt.get(clause)})
+
+    deterministic_name = md5_sha_from_dict(result)
+    result["filterOptionName"] = deterministic_name
 
     return result
 

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -2501,7 +2501,11 @@ class BaseDeckGLViz(BaseViz):
         if fd.get("js_columns"):
             gb += fd.get("js_columns") or []
         metrics = self.get_metrics()
-        gb = list(set(gb))
+        # Ensure this value is sorted so that it does not
+        # cause the cache key generation (which hashes the
+        # query object) to generate different keys for values
+        # that should be considered the same.
+        gb = sorted(set(gb))
         if metrics:
             d["groupby"] = gb
             d["metrics"] = metrics

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -2257,7 +2257,11 @@ class MapboxViz(BaseViz):
             if fd.get("point_radius") != "Auto":
                 d["columns"].append(fd.get("point_radius"))
 
-            d["columns"] = list(set(d["columns"]))
+            # Ensure this value is sorted so that it does not
+            # cause the cache key generation (which hashes the
+            # query object) to generate different keys for values
+            # that should be considered the same.
+            d["columns"] = sorted(set(d["columns"]))
         else:
             # Ensuring columns chosen are all in group by
             if (

--- a/tests/utils/core_tests.py
+++ b/tests/utils/core_tests.py
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=no-self-use
+import pytest
+
+from superset.utils.core import to_adhoc
+
+
+def test_to_adhoc_generates_deterministic_values():
+    input_1 = {
+        "op": "IS NOT NULL",
+        "col": "LATITUDE",
+        "val": "",
+    }
+
+    input_2 = {**input_1, "col": "LONGITUDE"}
+
+    # The result is the same when given the same input
+    assert to_adhoc(input_1) == to_adhoc(input_1)
+    assert to_adhoc(input_1) == {
+        "clause": "WHERE",
+        "expressionType": "SIMPLE",
+        "isExtra": False,
+        "comparator": "",
+        "operator": "IS NOT NULL",
+        "subject": "LATITUDE",
+        "filterOptionName": "d0908f77d950131db7a69fdc820cb739",
+    }
+
+    # The result is different when given different input
+    assert to_adhoc(input_1) != to_adhoc(input_2)
+    assert to_adhoc(input_2) == {
+        "clause": "WHERE",
+        "expressionType": "SIMPLE",
+        "isExtra": False,
+        "comparator": "",
+        "operator": "IS NOT NULL",
+        "subject": "LONGITUDE",
+        "filterOptionName": "c5f283f727d4dfc6258b351d4a8663bc",
+    }

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 # isort:skip_file
-import uuid
 from datetime import date, datetime, timezone
 import logging
 from math import nan
@@ -1179,9 +1178,7 @@ class TestBaseDeckGLViz(SupersetTestCase):
         with self.assertRaises(SpatialException):
             test_viz_deckgl.parse_coordinates("fldkjsalkj,fdlaskjfjadlksj")
 
-    @patch("superset.utils.core.uuid.uuid4")
-    def test_filter_nulls(self, mock_uuid4):
-        mock_uuid4.return_value = uuid.UUID("12345678123456781234567812345678")
+    def test_filter_nulls(self):
         test_form_data = {
             "latlong_key": {"type": "latlong", "lonCol": "lon", "latCol": "lat"},
             "delimited_key": {"type": "delimited", "lonlatCol": "lonlat"},
@@ -1194,7 +1191,7 @@ class TestBaseDeckGLViz(SupersetTestCase):
                 {
                     "clause": "WHERE",
                     "expressionType": "SIMPLE",
-                    "filterOptionName": "12345678-1234-5678-1234-567812345678",
+                    "filterOptionName": "bfa3a42a6f3de3c781b7d4f8e8d6613d",
                     "comparator": "",
                     "operator": "IS NOT NULL",
                     "subject": "lat",
@@ -1203,7 +1200,7 @@ class TestBaseDeckGLViz(SupersetTestCase):
                 {
                     "clause": "WHERE",
                     "expressionType": "SIMPLE",
-                    "filterOptionName": "12345678-1234-5678-1234-567812345678",
+                    "filterOptionName": "2d35d87b57c6f1a5ae139f1a6b0cbd0a",
                     "comparator": "",
                     "operator": "IS NOT NULL",
                     "subject": "lon",
@@ -1214,7 +1211,7 @@ class TestBaseDeckGLViz(SupersetTestCase):
                 {
                     "clause": "WHERE",
                     "expressionType": "SIMPLE",
-                    "filterOptionName": "12345678-1234-5678-1234-567812345678",
+                    "filterOptionName": "89cc0fafe39a4eabc5df2cd52e4d6514",
                     "comparator": "",
                     "operator": "IS NOT NULL",
                     "subject": "lonlat",
@@ -1225,7 +1222,7 @@ class TestBaseDeckGLViz(SupersetTestCase):
                 {
                     "clause": "WHERE",
                     "expressionType": "SIMPLE",
-                    "filterOptionName": "12345678-1234-5678-1234-567812345678",
+                    "filterOptionName": "fa734d9a7bab254a53b41540d46cdb6c",
                     "comparator": "",
                     "operator": "IS NOT NULL",
                     "subject": "geo",


### PR DESCRIPTION
Some charts are rendering errors when `GLOBAL_ASYNC_QUERIES` is turned on (#14289).

Some of the fixes:

1. The background worker stores the `form_data` to be used for validation on subsequent requests when clients request the query results. However, `form_data` is mutated by the code that runs the query and the background worker is storing the mutated object. Since this object is used to derive a unique cache key, any mutations to it will lead to a different key and, subsequently, a cache miss.
2. Even if 1 is solved, in some case, the code will modify `form_data` in a non-deterministic way _before_ the cache key is derived from the object (e.g., adding UUIDs to it). This will always lead to a unique cache key.
3. There were two cases where deduplicating lists seemed to introduce the potential for lists to get out of sync in terms of ordering, causing a different cache key when I _think_ ordering doesn't matter here. Sorting them will ensure the same results. Either way, the ordering should be the same given the same input, and that wasn't always the case.

_Note: even though this is broken in the async queries experience, it will benefit everyone since these fixes should prevent unnecessary cache misses in the regular flow._
