### PR TITLE
fix(db2): change engine name and add legacy alias

### DIFF
--- a/superset/db_engine_specs/db2.py
+++ b/superset/db_engine_specs/db2.py
@@ -18,7 +18,8 @@ from superset.db_engine_specs.base import BaseEngineSpec, LimitMethod
 
 
 class Db2EngineSpec(BaseEngineSpec):
-    engine = "ibm_db_sa"
+    engine = "db2"
+    engine_aliases = ("ibm_db_sa",)
     engine_name = "IBM Db2"
     limit_method = LimitMethod.WRAP_SQL
     force_column_alias_quotes = True


### PR DESCRIPTION
### SUMMARY
Currently we only support the legacy engine name `ibm_db_sa ` for DB2. This changes the primary name of the DB2 engine to `db2` and adds the `ibm_db_sa` alias as a fallback per the comment here:

https://github.com/ibmdb/python-ibmdbsa/blob/7c7cef341829a316bf46561920aa5a789f498431/ibm_db_sa/setup.py#L42-L57

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #14263

Ping @ljclour