### PR TITLE
fix(sqla): timeseries limit not applied when using columns

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1278,7 +1278,7 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
             is_timeseries  # pylint: disable=too-many-boolean-expressions
             and timeseries_limit
             and not time_groupby_inline
-            and groupby
+            and groupby_exprs_sans_timestamp
         ):
             if db_engine_spec.allows_joins:
                 # some sql dialects require for order by expressions


### PR DESCRIPTION
### SUMMARY
When a query object is using `columns` over `groupby`, the timeseries limit is not applied. This PR changes the timeseries limit to check `groupby_exprs_sans_timestamp` instead of `groupby`, as that's what's actually referenced in the code block.

### BEFORE
The timeseries limit (set to 5 here) is ignored:
![image](https://user-images.githubusercontent.com/33317356/115657674-f85c5580-a33f-11eb-877b-a359f8bb4855.png)

### AFTER
The timeseries limit applies correctly:
![image](https://user-images.githubusercontent.com/33317356/115657595-d4990f80-a33f-11eb-9e7c-c6e5c5a923f5.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
