### PR TITLE
chore: SQLLab row limit warning using Alert component

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -506,7 +506,9 @@ export default class ResultSet extends React.PureComponent<
     const limitReached = results?.displayLimitReached;
     return (
       <ReturnedRows>
-        {!limitReached && <span>{t(`%s rows returned`, rows)}</span>}
+        {!limitReached && (
+          <Alert type="warning" message={t(`%s rows returned`, rows)} />
+        )}
         {limitReached && (
           <Alert
             type="warning"


### PR DESCRIPTION
### SUMMARY
The longer warning message was using the new Alert component, but the warning message when rows were limited on result (not just what was displayed on UI) was not using the new Alert component. This PR addresses that for consistency.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="599" alt="before" src="https://user-images.githubusercontent.com/61221714/115659851-03879500-a2f0-11eb-9072-f22a4d80ec78.png">

After:
<img width="1257" alt="after" src="https://user-images.githubusercontent.com/61221714/115659841-01253b00-a2f0-11eb-8fa4-0974a7b59a30.png">


### TEST PLAN
Tested on local

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
