### PR TITLE
fix(explore-utils): URL_IS_TOO_LONG_TO_SHARE - reload issue fix

### DIFF
--- a/superset-frontend/src/explore/exploreUtils/index.js
+++ b/superset-frontend/src/explore/exploreUtils/index.js
@@ -110,6 +110,7 @@ export function getExploreLongUrl(
     const minimalFormData = {
       datasource: formData.datasource,
       viz_type: formData.viz_type,
+      slice_id: formData.slice_id,
     };
     return getExploreLongUrl(minimalFormData, endpointType, false, {
       URL_IS_TOO_LONG_TO_SHARE: null,


### PR DESCRIPTION
### SUMMARY
Chart screen: When the URL_IS_TOO_LONG_TO_SHARE scenario occurs, reloading the page, goes to the new chart screen


### TEST PLAN
Create a chart and make changes in form-data until 'URL_IS_TOO_LONG_TO_SHARE ' scenario appears and save the chart, now reload the page
Before fix:
The screen will lose the context and goes to new chart creation screen
After fix:
The screen will retain the save chart context, since the slice_id is added to URL param

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
