### PR TITLE
docs: add publish step

### DIFF
--- a/.github/workflows/superset-docs.yml
+++ b/.github/workflows/superset-docs.yml
@@ -9,14 +9,15 @@ on:
       - "docs/**"
 
 jobs:
-  docs:
-    name: docs
+  build-deploy:
+    name: Build & Deploy
     runs-on: ubuntu-20.04
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
         with:
           persist-credentials: false
+          submodules: recursive
       - name: npm install
         working-directory: ./docs
         run: |
@@ -29,3 +30,15 @@ jobs:
         working-directory: ./docs
         run: |
           npm run build
+      - name: deploy docs
+        if: github.ref == 'refs/heads/master'
+        uses: ./.github/actions/github-action-push-to-another-repository
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.SUPERSET_SITE_BUILD }}
+        with:
+          source-directory: './docs/public'
+          destination-github-username: 'apache'
+          destination-repository-name: 'superset-site'
+          target-branch: 'asf-site'
+          commit-message: "deploying docs: ${{ github.event.head_commit.message }} (apache/superset@${{ github.sha }})"
+          user-email: dev@superset.apache.org

--- a/.gitmodules
+++ b/.gitmodules
@@ -36,3 +36,6 @@
 [submodule ".github/actions/chart-releaser-action"]
 	path = .github/actions/chart-releaser-action
 	url = https://github.com/helm/chart-releaser-action
+[submodule ".github/actions/github-action-push-to-another-repository"]
+	path = .github/actions/github-action-push-to-another-repository
+	url = git@github.com:cpina/github-action-push-to-another-repository.git

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,6 @@ Here's the source to the documentation hosted at
 The site runs on the Gatsby framework and uses docz for it's
 `Documentation` subsection.
 
-
 ## Getting Started
 
 ```bash
@@ -35,7 +34,10 @@ npm run start
 
 ## To Publish
 
-To publish, the static site that Gatsby generates needs to be pushed
+Github Actions CI automatically publishes the site after changes are
+merged to master.
+
+To manually publish, the static site that Gatsby generates needs to be pushed
 to the `asf-site` branch on the
 [apache/superset-site](https://github.com/apache/superset-site/)
 repository. No need to PR here, simply `git push`.


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds a step to publish docs after merges to master. Uses https://github.com/cpina/github-action-push-to-another-repository github action to push to the https://github.com/apache/superset-site repo
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A
### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- Tested using target branch https://github.com/apache/superset-site/tree/test-branch

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #13599
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
