### PR TITLE
feat(native-filters): add option to create value in select filter

### DIFF
--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -72,6 +72,11 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
       ? firstItem
       : initSelectValue,
   );
+  const [currentSuggestionSearch, setCurrentSuggestionSearch] = useState('');
+
+  const clearSuggestionSearch = () => {
+    setCurrentSuggestionSearch('');
+  };
 
   const [col] = groupby;
   const datatype: GenericDataType = coltypeMap[col];
@@ -150,6 +155,9 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
         showSearch={showSearch}
         mode={multiSelect ? 'multiple' : undefined}
         placeholder={placeholderText}
+        onSearch={val => setCurrentSuggestionSearch(val)}
+        onSelect={clearSuggestionSearch}
+        onBlur={clearSuggestionSearch}
         // @ts-ignore
         onChange={handleChange}
         ref={inputRef}
@@ -163,6 +171,14 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
             </Option>
           );
         })}
+        {currentSuggestionSearch &&
+          !(values || []).some(
+            suggestion => suggestion === currentSuggestionSearch,
+          ) && (
+            <Option value={currentSuggestionSearch}>
+              {currentSuggestionSearch}
+            </Option>
+          )}
       </StyledSelect>
     </Styles>
   );

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -142,7 +142,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
   ]);
 
   const placeholderText =
-    (data || []).length === 0
+    data.length === 0
       ? t('No data')
       : tn('%s option', '%s options', data.length, data.length);
   return (
@@ -155,14 +155,14 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
         showSearch={showSearch}
         mode={multiSelect ? 'multiple' : undefined}
         placeholder={placeholderText}
-        onSearch={val => setCurrentSuggestionSearch(val)}
+        onSearch={setCurrentSuggestionSearch}
         onSelect={clearSuggestionSearch}
         onBlur={clearSuggestionSearch}
         // @ts-ignore
         onChange={handleChange}
         ref={inputRef}
       >
-        {(data || []).map(row => {
+        {data.map(row => {
           const [value] = groupby.map(col => row[col]);
           return (
             // @ts-ignore
@@ -172,7 +172,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
           );
         })}
         {currentSuggestionSearch &&
-          !(values || []).some(
+          !ensureIsArray(values).some(
             suggestion => suggestion === currentSuggestionSearch,
           ) && (
             <Option value={currentSuggestionSearch}>

--- a/superset-frontend/src/filters/components/Select/transformProps.ts
+++ b/superset-frontend/src/filters/components/Select/transformProps.ts
@@ -35,7 +35,7 @@ export default function transformProps(
   const newFormData = { ...DEFAULT_FORM_DATA, ...formData };
   const { setDataMask = () => {} } = hooks;
   const [queryData] = queriesData;
-  const { colnames = [], coltypes = [], data } = queryData || [];
+  const { colnames = [], coltypes = [], data = [] } = queryData || {};
   const coltypeMap: Record<string, GenericDataType> = colnames.reduce(
     (accumulator, item, index) => ({ ...accumulator, [item]: coltypes[index] }),
     {},


### PR DESCRIPTION
### SUMMARY
This is a port of #13029 to native filters to make it possible to add select filters that are not contained in the input data.

### SCREENSHOTS
Single select filter:
![native-select-single](https://user-images.githubusercontent.com/33317356/115871913-d6e79080-a449-11eb-992a-d47883dec2fe.gif)

Multiselect filter:
![native-select-multi](https://user-images.githubusercontent.com/33317356/115871927-dbac4480-a449-11eb-85ff-d344d2a9023f.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
