### PR TITLE
fix(sqllab): use get_datasources_accessible_by_user for table metadata access

### DIFF
--- a/superset/databases/decorators.py
+++ b/superset/databases/decorators.py
@@ -21,8 +21,8 @@ from typing import Any, Callable, Optional
 from flask import g
 from flask_babel import lazy_gettext as _
 
+from superset import security_manager
 from superset.models.core import Database
-from superset.sql_parse import Table
 from superset.utils.core import parse_js_uri_path_item
 from superset.views.base_api import BaseSupersetModelRestApi
 
@@ -50,8 +50,8 @@ def check_datasource_access(f: Callable[..., Any]) -> Callable[..., Any]:
                 f"database_not_found_{self.__class__.__name__}.select_star"
             )
             return self.response_404()
-        if not self.appbuilder.sm.can_access_table(
-            database, Table(table_name_parsed, schema_name_parsed)
+        if not security_manager.get_datasources_accessible_by_user(
+            database, [table_name_parsed], schema_name_parsed,
         ):
             self.stats_logger.incr(
                 f"permisssion_denied_{self.__class__.__name__}.select_star"

--- a/superset/db_engine_specs/db2.py
+++ b/superset/db_engine_specs/db2.py
@@ -19,7 +19,7 @@ from superset.db_engine_specs.base import BaseEngineSpec, LimitMethod
 
 class Db2EngineSpec(BaseEngineSpec):
     engine = "db2"
-    engine_aliases = ("ibm_db_sa",)
+    engine_aliases = {"ibm_db_sa"}
     engine_name = "IBM Db2"
     limit_method = LimitMethod.WRAP_SQL
     force_column_alias_quotes = True


### PR DESCRIPTION
### SUMMARY
The `check_datasource_access` decorator calls `can_access_table`, which seems to make sense from the name. However, this decorator is used in the databases API to fetch metadata for tables, not to fetch actual data. This results in some confusing SQL Lab behavior:
*  Users can select a table that they don't have access to, but they will see the confusing message: `An error occurred while fetching table metadata. Please contact your administrator.`
* The table remains in the left hand panel, with no columns displayed. Users are unable to remove the table (`An error occurred while removing the table schema. Please contact your administrator.`), but it disappears on refresh

This PR alters `check_datasource_access` to use `get_datasources_accessible_by_user` instead of `can_access_table`. This is more consistent with how SQL Lab currently fetches tables and schemas for the drop down. Users will be able to see the columns of the table, but the table preview will error due to lack of data access, as intended.

### TEST PLAN
Confirmed that column metadata successfully loaded for tables that previously had failed. Confirmed `select_star` and `table_metadata` endpoints worked as expected.

Will fix tests.

@john-bodley @etr2460 