### PR TITLE
fix: pybabel extract fails

### DIFF
--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -76,7 +76,9 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
             """,
             description=self._content.description or "",
             url=self._content.url,
-            img_tag=f'<img src="cid:{msgid}">' if self._content.screenshot else "",
+            img_tag='<img src="cid:{}">'.format(msgid)
+            if self._content.screenshot
+            else "",
         )
         if self._content.screenshot:
             image = {msgid: self._content.screenshot}


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This pull request fixes a problem that caused pybabel execution to fail.

It can occur in both
Babel-2.5.3 (from superset/translations/requirements.txt) and Babel-2.9.0 (newest).

```
$ pybabel extract -F superset/translations/babel.cfg -o superset/translations/messages.pot -k _ -k __ -k t -k tn -k tct .
...
extracting messages from superset/reports/notifications/email.py
Traceback (most recent call last):
  File "/Users/ume/.pyenv/versions/3.8.5/bin/pybabel", line 8, in <module>
    sys.exit(main())
  File "/Users/ume/.pyenv/versions/3.8.5/lib/python3.8/site-packages/babel/messages/frontend.py", line 929, in main
    return CommandLineInterface().run(sys.argv)
  File "/Users/ume/.pyenv/versions/3.8.5/lib/python3.8/site-packages/babel/messages/frontend.py", line 853, in run
    return cmdinst.run()
  File "/Users/ume/.pyenv/versions/3.8.5/lib/python3.8/site-packages/babel/messages/frontend.py", line 481, in run
    for filename, lineno, message, comments, context in extracted:
  File "/Users/ume/.pyenv/versions/3.8.5/lib/python3.8/site-packages/babel/messages/extract.py", line 149, in extract_from_dir
    for message_tuple in check_and_call_extract_file(
  File "/Users/ume/.pyenv/versions/3.8.5/lib/python3.8/site-packages/babel/messages/extract.py", line 207, in check_and_call_extract_file
    for message_tuple in extract_from_file(
  File "/Users/ume/.pyenv/versions/3.8.5/lib/python3.8/site-packages/babel/messages/extract.py", line 243, in extract_from_file
    return list(extract(method, fileobj, keywords, comment_tags,
  File "/Users/ume/.pyenv/versions/3.8.5/lib/python3.8/site-packages/babel/messages/extract.py", line 325, in extract
    for lineno, funcname, messages, comments in results:
  File "/Users/ume/.pyenv/versions/3.8.5/lib/python3.8/site-packages/babel/messages/extract.py", line 487, in extract_python
    value = eval(code, {'__builtins__': {}}, {})
  File "<string>", line 2, in <module>
NameError: name 'msgid' is not defined
```

f-strings does not seem to be supported.
https://github.com/python-babel/babel/issues/594

### TEST PLAN
run
`pybabel extract -F superset/translations/babel.cfg -o superset/translations/messages.pot -k _ -k __ -k t -k tn -k tct .`


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
