### PR TITLE
feat(filter-box): sort by metric on backend

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -2069,6 +2069,9 @@ class FilterBoxViz(BaseViz):
             qry["groupby"] = [col]
             metric = flt.get("metric")
             qry["metrics"] = [metric] if metric else []
+            asc = flt.get("asc")
+            if metric and asc is not None:
+                qry["orderby"] = [(metric, asc)]
             QueryContext(
                 datasource={"id": self.datasource.id, "type": self.datasource.type},
                 queries=[qry],


### PR DESCRIPTION
### SUMMARY
Currently when sorting a filter box select by metric, the ordering isn't being applied in the query, making it possible for relevant rows to be missing in the query if they fall below the default 1000 row limit.

This was found while working on adding feature parity to the native select filter. While we're aiming to deprecate filter box soon, I wanted to make sure the results in the select filter are consistent with those returned by the select filter when reconciling results.

### SCREENSHOTS
When ordering countries in descending order by population
![image](https://user-images.githubusercontent.com/33317356/116029311-b4c85b00-a661-11eb-97ff-048268ff73c1.png)
Query:
```sql
SELECT country_name AS country_name,
       sum("SP_POP_TOTL") AS "sum__SP_POP_TOTL"
FROM wb_health_population
GROUP BY country_name
ORDER BY "sum__SP_POP_TOTL" DESC
LIMIT 1000
OFFSET 0
```

### SCREENSHOTS
When ordering countries in descending order by population
![image](https://user-images.githubusercontent.com/33317356/116029535-3d46fb80-a662-11eb-8d90-02a492a3012a.png)
Query:
```sql
SELECT country_name AS country_name,
       sum("SP_POP_TOTL") AS "sum__SP_POP_TOTL"
FROM wb_health_population
GROUP BY country_name
ORDER BY "sum__SP_POP_TOTL" ASC
LIMIT 1000
OFFSET 0
```

When ordering 

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
