### PR TITLE
chore(docker-compose): use dev image for docker-compose-non-dev.yml

### DIFF
--- a/docker-compose-non-dev.yml
+++ b/docker-compose-non-dev.yml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-x-superset-image: &superset-image apache/superset:latest
+x-superset-image: &superset-image apache/superset:latest-dev
 x-superset-depends-on: &superset-depends-on
   - db
   - redis
@@ -26,7 +26,7 @@ x-superset-volumes: &superset-volumes
 version: "3.7"
 services:
   redis:
-    image: redis:6.2
+    image: redis:latest
     container_name: superset_cache
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
### SUMMARY
Since https://github.com/apache/superset/pull/14267 added support for alerts/reports (and thumbnails) to the docker file it makes sense to use the dev image in `docker-compose-non-dev.yml` so that users can take advantage of the alerts/reports functionality. This PR also bumps redis to `latest` as it's already being used in the default docker compose file. 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A
### TEST PLAN
<!--- What steps should be taken to verify the changes -->
`docker-compose -f docker-compose-non-dev.yml pull && docker-compose -f docker-compose-non-dev.yml up` brings up a working version of superset at localhost:8088

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
