### PR TITLE
Allow to specify `imagePullSecrets`

### DIFF
--- a/helm/superset/templates/deployment-beat.yaml
+++ b/helm/superset/templates/deployment-beat.yaml
@@ -61,6 +61,10 @@ spec:
       initContainers:
       {{-  tpl (toYaml .Values.supersetCeleryBeat.initContainers) . | nindent 6 }}
       {{- end }}
+      {{ if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.image.pullSecrets | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/helm/superset/templates/deployment-worker.yaml
+++ b/helm/superset/templates/deployment-worker.yaml
@@ -59,6 +59,10 @@ spec:
       initContainers:
       {{-  tpl (toYaml .Values.supersetWorker.initContainers) . | nindent 6 }}
       {{- end }}
+      {{ if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.image.pullSecrets | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/helm/superset/templates/deployment.yaml
+++ b/helm/superset/templates/deployment.yaml
@@ -62,6 +62,10 @@ spec:
       initContainers:
       {{-  tpl (toYaml .Values.supersetNode.initContainers) . | nindent 6 }}
       {{- end }}
+      {{ if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.image.pullSecrets | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/helm/superset/templates/init-job.yaml
+++ b/helm/superset/templates/init-job.yaml
@@ -33,6 +33,10 @@ spec:
       initContainers:
       {{-  tpl (toYaml .Values.init.initContainers) . | nindent 6 }}
       {{- end }}
+      {{ if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.image.pullSecrets | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ template "superset.name" . }}-init-db
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -105,6 +105,8 @@ image:
   repository: apache/superset
   tag: latest
   pullPolicy: IfNotPresent
+  # pullSecrets:
+  #   - name: docker-registry
 
 service:
   type: ClusterIP


### PR DESCRIPTION
### SUMMARY

It is recommended to build one's own docker image when using superset on production. However a custom docker image contains confidential information, e.g. the `SECRET_KEY` configuration value. Thus it is necessary to use a docker image hosted in a private registry. Access credentials to a private docker registry are usually provided to Kubernetes via the `imagePullSecrets` field, which references to a secret containing the credentials.

This PR makes it possible to configure this via the `values.yaml`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
none

### TEST PLAN
none

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
