### PR TITLE
ci: set remote URL to https and bump sha

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -38,4 +38,4 @@
 	url = https://github.com/helm/chart-releaser-action
 [submodule ".github/actions/github-action-push-to-another-repository"]
 	path = .github/actions/github-action-push-to-another-repository
-	url = git@github.com:cpina/github-action-push-to-another-repository.git
+	url = https://github.com/cpina/github-action-push-to-another-repository


### PR DESCRIPTION
### SUMMARY
This change updates the remote submodule from `git@github` to `https`. Was causing problems with our CI.

Also bumped the action SHA to the latest

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
