### PR TITLE
fix(native-filters): allowClear only when required not checked

### DIFF
--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -148,7 +148,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
   return (
     <Styles height={height} width={width}>
       <StyledSelect
-        allowClear
+        allowClear={!enableEmptyFilter}
         // @ts-ignore
         value={values}
         disabled={forceFirstValue}

--- a/superset-frontend/src/filters/components/Select/controlPanel.ts
+++ b/superset-frontend/src/filters/components/Select/controlPanel.ts
@@ -71,11 +71,12 @@ const config: ControlPanelConfig = {
             name: 'enableEmptyFilter',
             config: {
               type: 'CheckboxControl',
-              label: t('Enable empty filter'),
+              label: t('Required'),
               default: enableEmptyFilter,
               renderTrigger: true,
               description: t(
-                'When selection is empty, an always false filter event be emitted',
+                'User must select a value for this filter when filter in single select mode. ' +
+                  'If selection is empty, an always false filter is emitted.',
               ),
             },
           },

--- a/superset-frontend/src/filters/components/Select/controlPanel.ts
+++ b/superset-frontend/src/filters/components/Select/controlPanel.ts
@@ -75,7 +75,7 @@ const config: ControlPanelConfig = {
               default: enableEmptyFilter,
               renderTrigger: true,
               description: t(
-                'User must select a value for this filter when filter in single select mode. ' +
+                'User must select a value for this filter when filter is in single select mode. ' +
                   'If selection is empty, an always false filter is emitted.',
               ),
             },


### PR DESCRIPTION
### SUMMARY
Rephrase "Allow empty filter" to be inline with Filter Box "Required" control. Also change behavior so that `allowClear` is set to false when "Required" is set to true.

The control has been renamed and the description updated:
![image](https://user-images.githubusercontent.com/33317356/116113936-9d20bf00-a6c1-11eb-982a-384e67a17aa7.png)

When in the dashboard view, the selection can't be cleared when in single select mode:
![image](https://user-images.githubusercontent.com/33317356/116113804-84b0a480-a6c1-11eb-8b26-9cc73ed39920.png)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
