### PR TITLE
chore: add some basic instrumentation to Node WebSocket server

### DIFF
--- a/superset-websocket/README.md
+++ b/superset-websocket/README.md
@@ -93,13 +93,21 @@ GLOBAL_ASYNC_QUERIES_JWT_SECRET
 
 More info on Superset configuration values for async queries: https://github.com/apache/superset/blob/master/CONTRIBUTING.md#async-chart-queries
 
-## Prometheus monitoring
+## StatsD monitoring
 
-The application is tracking a couple of metrics using [Prometheus](https://prometheus.io), such as the number of connected clients and the number of failed attempts to send a message to a client.
+The application is tracking a couple of metrics with `statsd` using the [hot-shots](https://www.npmjs.com/package/hot-shots) library, such as the number of connected clients and the number of failed attempts to send a message to a client.
 
-If `collectDefaultMetrics` is `true` in the configuration file, then Prometheus will also track a number of default metrics as it relates to the node process.
+`statsd` can be configured with the `statsd` object in the configuration file. See the [hot-shots](https://www.npmjs.com/package/hot-shots) readme for more info.
 
-All metrics will be exposed via an HTTP endpoint: `GET /metrics`.
+```json
+{
+  "statsd": {
+    "host": "127.0.0.1",
+    "port": 8125,
+    "globalTags": []
+  }
+}
+```
 
 ## Running
 

--- a/superset-websocket/README.md
+++ b/superset-websocket/README.md
@@ -97,7 +97,7 @@ More info on Superset configuration values for async queries: https://github.com
 
 The application is tracking a couple of metrics with `statsd` using the [hot-shots](https://www.npmjs.com/package/hot-shots) library, such as the number of connected clients and the number of failed attempts to send a message to a client.
 
-`statsd` can be configured with the `statsd` object in the configuration file. See the [hot-shots](https://www.npmjs.com/package/hot-shots) readme for more info.
+`statsd` can be configured with the `statsd` object in the configuration file. See the [hot-shots](https://www.npmjs.com/package/hot-shots) readme for more info. The default configuration is:
 
 ```json
 {

--- a/superset-websocket/README.md
+++ b/superset-websocket/README.md
@@ -93,6 +93,14 @@ GLOBAL_ASYNC_QUERIES_JWT_SECRET
 
 More info on Superset configuration values for async queries: https://github.com/apache/superset/blob/master/CONTRIBUTING.md#async-chart-queries
 
+## Prometheus monitoring
+
+The application is tracking a couple of metrics using [Prometheus](https://prometheus.io), such as the number of connected clients and the number of failed attempts to send a message to a client.
+
+If `collectDefaultMetrics` is `true` in the configuration file, then Prometheus will also track a number of default metrics as it relates to the node process.
+
+All metrics will be exposed via an HTTP endpoint: `GET /metrics`.
+
 ## Running
 
 Running locally via dev server:

--- a/superset-websocket/config.example.json
+++ b/superset-websocket/config.example.json
@@ -3,7 +3,11 @@
   "logLevel": "info",
   "logToFile": false,
   "logFilename": "app.log",
-  "collectDefaultMetrics": true,
+  "statsd": {
+    "host": "127.0.0.1",
+    "port": 8125,
+    "globalTags": []
+  },
   "redis": {
     "port": 6379,
     "host": "127.0.0.1",

--- a/superset-websocket/config.example.json
+++ b/superset-websocket/config.example.json
@@ -3,6 +3,7 @@
   "logLevel": "info",
   "logToFile": false,
   "logFilename": "app.log",
+  "collectDefaultMetrics": true,
   "redis": {
     "port": 6379,
     "host": "127.0.0.1",

--- a/superset-websocket/config.test.json
+++ b/superset-websocket/config.test.json
@@ -1,4 +1,5 @@
 {
+  "collectDefaultMetrics": true,
   "redis": {
     "port": 6379,
     "host": "127.0.0.1",

--- a/superset-websocket/config.test.json
+++ b/superset-websocket/config.test.json
@@ -1,11 +1,15 @@
 {
-  "collectDefaultMetrics": true,
   "redis": {
     "port": 6379,
     "host": "127.0.0.1",
     "password": "",
     "db": 10,
     "ssl": false
+  },
+  "statsd": {
+    "host": "127.0.0.1",
+    "port": 8125,
+    "globalTags": []
   },
   "redisStreamPrefix": "test-async-events-",
   "jwtSecret": "test123-test123-test123-test123-test123-test123-test123",

--- a/superset-websocket/package-lock.json
+++ b/superset-websocket/package-lock.json
@@ -11,6 +11,7 @@
         "cookie": "^0.4.1",
         "ioredis": "^4.16.1",
         "jsonwebtoken": "^8.5.1",
+        "prom-client": "^13.1.0",
         "uuid": "^8.3.2",
         "winston": "^3.3.3",
         "ws": "^7.4.2"
@@ -1579,6 +1580,11 @@
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -5498,6 +5504,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-13.1.0.tgz",
+      "integrity": "sha512-jT9VccZCWrJWXdyEtQddCDszYsiuWj5T0ekrPszi/WEegj3IZy6Mm09iOOVM86A4IKMWq8hZkT2dD9MaSe+sng==",
+      "dependencies": {
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
@@ -6696,6 +6713,14 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "dependencies": {
+        "bintrees": "1.0.1"
+      }
     },
     "node_modules/terminal-link": {
       "version": "2.1.1",
@@ -8764,6 +8789,11 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -11928,6 +11958,14 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "prom-client": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-13.1.0.tgz",
+      "integrity": "sha512-jT9VccZCWrJWXdyEtQddCDszYsiuWj5T0ekrPszi/WEegj3IZy6Mm09iOOVM86A4IKMWq8hZkT2dD9MaSe+sng==",
+      "requires": {
+        "tdigest": "^0.1.1"
+      }
+    },
     "prompts": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
@@ -12909,6 +12947,14 @@
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
           "dev": true
         }
+      }
+    },
+    "tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "requires": {
+        "bintrees": "1.0.1"
       }
     },
     "terminal-link": {

--- a/superset-websocket/package-lock.json
+++ b/superset-websocket/package-lock.json
@@ -9,9 +9,9 @@
       "license": "Apache-2.0",
       "dependencies": {
         "cookie": "^0.4.1",
+        "hot-shots": "^8.3.1",
         "ioredis": "^4.16.1",
         "jsonwebtoken": "^8.5.1",
-        "prom-client": "^13.1.0",
         "uuid": "^8.3.2",
         "winston": "^3.3.3",
         "ws": "^7.4.2"
@@ -1581,10 +1581,14 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "node_modules/bintrees": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
-      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2994,6 +2998,12 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -3363,6 +3373,17 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
+    },
+    "node_modules/hot-shots": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-8.3.1.tgz",
+      "integrity": "sha512-eB20m2neM+uV7IM3JDCZg8/NU1+WGM7Qh7kpvC/sGIWNg4Ng+9O8JT/zrLuA+2JStiQLEy9z/9VEDFH0BzYf0A==",
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "optionalDependencies": {
+        "unix-dgram": "2.0.x"
+      }
     },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
@@ -5013,6 +5034,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "optional": true
+    },
     "node_modules/nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -5502,17 +5529,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/prom-client": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-13.1.0.tgz",
-      "integrity": "sha512-jT9VccZCWrJWXdyEtQddCDszYsiuWj5T0ekrPszi/WEegj3IZy6Mm09iOOVM86A4IKMWq8hZkT2dD9MaSe+sng==",
-      "dependencies": {
-        "tdigest": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/prompts": {
@@ -6714,14 +6730,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
     },
-    "node_modules/tdigest": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
-      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
-      "dependencies": {
-        "bintrees": "1.0.1"
-      }
-    },
     "node_modules/terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -7026,6 +7034,20 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unix-dgram": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.4.tgz",
+      "integrity": "sha512-7tpK6x7ls7J7pDrrAU63h93R0dVhRbPwiRRCawR10cl+2e1VOvF3bHlVJc6WI1dl/8qk5He673QU+Ogv7bPNaw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.3.0",
+        "nan": "^2.13.2"
+      },
+      "engines": {
+        "node": ">=0.10.48"
       }
     },
     "node_modules/unset-value": {
@@ -8790,10 +8812,14 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "bintrees": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
-      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -9941,6 +9967,12 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -10232,6 +10264,14 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
+    },
+    "hot-shots": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-8.3.1.tgz",
+      "integrity": "sha512-eB20m2neM+uV7IM3JDCZg8/NU1+WGM7Qh7kpvC/sGIWNg4Ng+9O8JT/zrLuA+2JStiQLEy9z/9VEDFH0BzYf0A==",
+      "requires": {
+        "unix-dgram": "2.0.x"
+      }
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",
@@ -11574,6 +11614,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "optional": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -11957,14 +12003,6 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
-    },
-    "prom-client": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-13.1.0.tgz",
-      "integrity": "sha512-jT9VccZCWrJWXdyEtQddCDszYsiuWj5T0ekrPszi/WEegj3IZy6Mm09iOOVM86A4IKMWq8hZkT2dD9MaSe+sng==",
-      "requires": {
-        "tdigest": "^0.1.1"
-      }
     },
     "prompts": {
       "version": "2.4.0",
@@ -12949,14 +12987,6 @@
         }
       }
     },
-    "tdigest": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
-      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
-      "requires": {
-        "bintrees": "1.0.1"
-      }
-    },
     "terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -13192,6 +13222,16 @@
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
+      }
+    },
+    "unix-dgram": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.4.tgz",
+      "integrity": "sha512-7tpK6x7ls7J7pDrrAU63h93R0dVhRbPwiRRCawR10cl+2e1VOvF3bHlVJc6WI1dl/8qk5He673QU+Ogv7bPNaw==",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.3.0",
+        "nan": "^2.13.2"
       }
     },
     "unset-value": {

--- a/superset-websocket/package.json
+++ b/superset-websocket/package.json
@@ -18,6 +18,7 @@
     "cookie": "^0.4.1",
     "ioredis": "^4.16.1",
     "jsonwebtoken": "^8.5.1",
+    "prom-client": "^13.1.0",
     "uuid": "^8.3.2",
     "winston": "^3.3.3",
     "ws": "^7.4.2"

--- a/superset-websocket/package.json
+++ b/superset-websocket/package.json
@@ -16,9 +16,9 @@
   "license": "Apache-2.0",
   "dependencies": {
     "cookie": "^0.4.1",
+    "hot-shots": "^8.3.1",
     "ioredis": "^4.16.1",
     "jsonwebtoken": "^8.5.1",
-    "prom-client": "^13.1.0",
     "uuid": "^8.3.2",
     "winston": "^3.3.3",
     "ws": "^7.4.2"

--- a/superset-websocket/spec/index.test.ts
+++ b/superset-websocket/spec/index.test.ts
@@ -54,11 +54,6 @@ const streamReturnValue: server.StreamResult[] = [
     ],
   ],
 ];
-const metricsResponse = `
-# HELP ws_connected_client Number of clients connected
-# TYPE ws_connected_client counter
-ws_connected_client 47
-`;
 
 import * as server from '../src/index';
 import { statsd } from '../src/index';
@@ -77,7 +72,7 @@ describe('server', () => {
   });
 
   describe('HTTP requests', () => {
-    test('services health checks', async () => {
+    test('services health checks', () => {
       const endMock = jest.fn();
       const writeHeadMock = jest.fn();
 
@@ -94,7 +89,7 @@ describe('server', () => {
         end: endMock,
       };
 
-      await server.httpRequest(request as any, response as any);
+      server.httpRequest(request as any, response as any);
 
       expect(writeHeadMock).toBeCalledTimes(1);
       expect(writeHeadMock).toHaveBeenLastCalledWith(200);
@@ -103,7 +98,7 @@ describe('server', () => {
       expect(endMock).toHaveBeenLastCalledWith('OK');
     });
 
-    test('reponds with a 404 when not found', async () => {
+    test('reponds with a 404 when not found', () => {
       const endMock = jest.fn();
       const writeHeadMock = jest.fn();
 
@@ -120,7 +115,7 @@ describe('server', () => {
         end: endMock,
       };
 
-      await server.httpRequest(request as any, response as any);
+      server.httpRequest(request as any, response as any);
 
       expect(writeHeadMock).toBeCalledTimes(1);
       expect(writeHeadMock).toHaveBeenLastCalledWith(404);

--- a/superset-websocket/spec/index.test.ts
+++ b/superset-websocket/spec/index.test.ts
@@ -23,6 +23,7 @@ import { describe, expect, test, beforeEach, afterEach } from '@jest/globals';
 import * as http from 'http';
 import * as net from 'net';
 import WebSocket from 'ws';
+import Prometheus from 'prom-client';
 
 // NOTE: these mock variables needs to start with "mock" due to
 // calls to `jest.mock` being hoisted to the top of the file.
@@ -54,17 +55,49 @@ const streamReturnValue: server.StreamResult[] = [
     ],
   ],
 ];
+const metricsResponse = `
+# HELP ws_connected_client Number of clients connected
+# TYPE ws_connected_client counter
+ws_connected_client 47
+`;
 
 import * as server from '../src/index';
+import { clientSendErrorCounter, connectedClientCounter } from '../src/index';
 
 describe('server', () => {
+  let clientSendErrorCounterMock: jest.SpyInstance;
+  let connectedClientCounterMock: jest.SpyInstance;
+
   beforeEach(() => {
     mockRedisXrange.mockClear();
     server.resetState();
+    clientSendErrorCounterMock = jest
+      .spyOn(clientSendErrorCounter, 'inc')
+      .mockReturnValue();
+    connectedClientCounterMock = jest
+      .spyOn(connectedClientCounter, 'inc')
+      .mockReturnValue();
+  });
+
+  afterEach(() => {
+    clientSendErrorCounterMock.mockRestore();
+    connectedClientCounterMock.mockRestore();
   });
 
   describe('HTTP requests', () => {
-    test('services health checks', () => {
+    let metricsMock: jest.SpyInstance;
+
+    beforeEach(() => {
+      metricsMock = jest
+        .spyOn(Prometheus.register, 'metrics')
+        .mockResolvedValue(metricsResponse);
+    });
+
+    afterEach(() => {
+      metricsMock.mockRestore();
+    });
+
+    test('services health checks', async () => {
       const endMock = jest.fn();
       const writeHeadMock = jest.fn();
 
@@ -81,7 +114,7 @@ describe('server', () => {
         end: endMock,
       };
 
-      server.httpRequest(request as any, response as any);
+      await server.httpRequest(request as any, response as any);
 
       expect(writeHeadMock).toBeCalledTimes(1);
       expect(writeHeadMock).toHaveBeenLastCalledWith(200);
@@ -90,7 +123,36 @@ describe('server', () => {
       expect(endMock).toHaveBeenLastCalledWith('OK');
     });
 
-    test('reponds with a 404 otherwise', () => {
+    test('exporting metrics', async () => {
+      const endMock = jest.fn();
+      const writeHeadMock = jest.fn();
+
+      const request = {
+        url: '/metrics',
+        method: 'GET',
+        headers: {
+          host: 'example.com',
+        },
+      };
+
+      const response = {
+        writeHead: writeHeadMock,
+        end: endMock,
+      };
+
+      await server.httpRequest(request as any, response as any);
+
+      expect(writeHeadMock).toBeCalledTimes(1);
+      expect(writeHeadMock).toHaveBeenLastCalledWith(200, {
+        'Content-Type': 'text/plain; version=0.0.4; charset=utf-8',
+      });
+
+      expect(metricsMock).toBeCalledTimes(1);
+      expect(endMock).toBeCalledTimes(1);
+      expect(endMock).toHaveBeenLastCalledWith(metricsResponse);
+    });
+
+    test('reponds with a 404 when not found', async () => {
       const endMock = jest.fn();
       const writeHeadMock = jest.fn();
 
@@ -107,7 +169,7 @@ describe('server', () => {
         end: endMock,
       };
 
-      server.httpRequest(request as any, response as any);
+      await server.httpRequest(request as any, response as any);
 
       expect(writeHeadMock).toBeCalledTimes(1);
       expect(writeHeadMock).toHaveBeenLastCalledWith(404);
@@ -170,7 +232,9 @@ describe('server', () => {
       const socketInstance = { ws: ws, channel: channelId, pongTs: Date.now() };
       server.trackClient(channelId, socketInstance);
 
+      expect(clientSendErrorCounterMock).toBeCalledTimes(0);
       server.processStreamResults(streamReturnValue);
+      expect(clientSendErrorCounterMock).toBeCalledTimes(0);
 
       const message1 = `{"id":"1615426152415-0","channel_id":"${channelId}","job_id":"c9b99965-8f1e-4ce5-aa43-d6fc94d6a510","user_id":"1","status":"done","errors":[],"result_url":"/superset/explore_json/data/ejr-37281682b1282cdb8f25e0de0339b386"}`;
       const message2 = `{"id":"1615426152516-0","channel_id":"${channelId}","job_id":"f1e5bb1f-f2f1-4f21-9b2f-c9b91dcc9b59","user_id":"1","status":"done","errors":[],"result_url":"/api/v1/chart/data/qc-64e8452dc9907dd77746cb75a19202de"}`;
@@ -182,7 +246,9 @@ describe('server', () => {
       const ws = new wsMock('localhost');
       const sendMock = jest.spyOn(ws, 'send');
 
+      expect(clientSendErrorCounterMock).toBeCalledTimes(0);
       server.processStreamResults(streamReturnValue);
+      expect(clientSendErrorCounterMock).toBeCalledTimes(0);
 
       expect(sendMock).not.toHaveBeenCalled();
     });
@@ -196,7 +262,9 @@ describe('server', () => {
       const socketInstance = { ws: ws, channel: channelId, pongTs: Date.now() };
       server.trackClient(channelId, socketInstance);
 
+      expect(clientSendErrorCounterMock).toBeCalledTimes(0);
       server.processStreamResults(streamReturnValue);
+      expect(clientSendErrorCounterMock).toBeCalledTimes(1);
 
       expect(sendMock).toHaveBeenCalled();
       expect(cleanChannelMock).toHaveBeenCalledWith(channelId);
@@ -373,6 +441,16 @@ describe('server', () => {
         listener: server.processStreamResults,
       });
       expect(wsEventMock).toHaveBeenCalledWith('pong', expect.any(Function));
+    });
+  });
+
+  describe('trackClient', () => {
+    test('counts connected clients', () => {
+      const ws = new wsMock('localhost');
+      const socketInstance = { ws: ws, channel: channelId, pongTs: Date.now() };
+      expect(connectedClientCounterMock).toBeCalledTimes(0);
+      server.trackClient(channelId, socketInstance);
+      expect(connectedClientCounterMock).toBeCalledTimes(1);
     });
   });
 

--- a/superset-websocket/src/index.ts
+++ b/superset-websocket/src/index.ts
@@ -110,7 +110,7 @@ export const opts = {
 const startServer = process.argv[2] === 'start';
 const configFile =
   environment === 'test' ? '../config.test.json' : '../config.json';
-let config = {} as typeof opts;
+let config = {};
 try {
   config = require(configFile);
 } catch (err) {
@@ -128,9 +128,7 @@ const logger = createLogger({
 });
 
 export const statsd = new StatsD({
-  host: opts.statsd.host,
-  port: opts.statsd.port,
-  globalTags: opts.statsd.globalTags,
+  ...opts.statsd,
   errorHandler: (e: Error) => {
     logger.error(e);
   },


### PR DESCRIPTION
### SUMMARY
This adds some basic instrumentation to the node WebSocket server. For now, adding two counters:

1. Number of connected clients
2. Number of times the server fails to deliver and event to a client

### TEST PLAN

Unit tests, manual
