### PR TITLE
feat: Add etag caching to dashboard APIs

### DIFF
--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -119,7 +119,11 @@ def memoized_func(
 
 
 def etag_cache(
-    cache: Cache = cache_manager.cache, max_age: Optional[Union[int, float]] = None,
+    cache: Cache = cache_manager.cache,
+    get_last_modified: Optional[Callable[..., datetime]] = None,
+    max_age: Optional[Union[int, float]] = None,
+    raise_for_access: Optional[Callable[..., Any]] = None,
+    skip: Optional[Callable[..., bool]] = None,
 ) -> Callable[..., Any]:
     """
     A decorator for caching views and handling etag conditional requests.
@@ -139,10 +143,19 @@ def etag_cache(
     def decorator(f: Callable[..., Any]) -> Callable[..., Any]:
         @wraps(f)
         def wrapper(*args: Any, **kwargs: Any) -> ETagResponseMixin:
+            # Check if the user can access the resource
+            if raise_for_access:
+                try:
+                    raise_for_access(*args, **kwargs)
+                except Exception:  # pylint: disable=broad-except
+                    # If there's no access, bypass the cache and let the function
+                    # handle the response.
+                    return f(*args, **kwargs)
+
             # for POST requests we can't set cache headers, use the response
             # cache nor use conditional requests; this will still use the
             # dataframe cache in `superset/viz.py`, though.
-            if request.method == "POST":
+            if request.method == "POST" or (skip and skip(*args, **kwargs)):
                 return f(*args, **kwargs)
 
             response = None
@@ -161,13 +174,37 @@ def etag_cache(
                     raise
                 logger.exception("Exception possibly due to cache backend.")
 
+            # Check if the cache is stale. Default the content_changed_time to now
+            # if we don't know when it was last modified.
+            content_changed_time = datetime.utcnow()
+            if get_last_modified:
+                content_changed_time = get_last_modified(*args, **kwargs)
+                if (
+                    response
+                    and response.last_modified
+                    and response.last_modified.timestamp()
+                    < content_changed_time.timestamp()
+                ):
+                    # Bypass the cache if the response is stale
+                    response = None
+
             # if no response was cached, compute it using the wrapped function
             if response is None:
                 response = f(*args, **kwargs)
 
                 # add headers for caching: Last Modified, Expires and ETag
-                response.cache_control.public = True
-                response.last_modified = datetime.utcnow()
+                # always revalidate the cache if we're checking permissions or
+                # if the response was modified
+                if get_last_modified or raise_for_access:
+                    # `Cache-Control: no-cache` asks the browser to always store
+                    # the cache, but also must validate it with the server.
+                    response.cache_control.no_cache = True
+                else:
+                    # `Cache-Control: Public` asks the browser to always store
+                    # the cache.
+                    response.cache_control.public = True
+
+                response.last_modified = content_changed_time
                 expiration = max_age or ONE_YEAR  # max_age=0 also means far future
                 response.expires = response.last_modified + timedelta(
                     seconds=expiration


### PR DESCRIPTION
### SUMMARY
Reimplementation of https://github.com/apache/superset/pull/10963 and https://github.com/apache/superset/pull/11137 now that APIs aren't user specific

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Non etag cached:
<img width="624" alt="Screen Shot 2021-04-26 at 6 04 53 PM" src="https://user-images.githubusercontent.com/7409244/116169806-65624900-a6ba-11eb-8a4d-24a3509a0f9e.png">


Etag cached:
<img width="619" alt="Screen Shot 2021-04-26 at 6 06 31 PM" src="https://user-images.githubusercontent.com/7409244/116169819-6a26fd00-a6ba-11eb-91f1-ff9b87cd6699.png">


### TEST PLAN
Unit tests, validate that the proper headers are set on responses, ensure that non-first loads of dashboards load faster, and that dashboard loads after edits load slower and with the fresh data

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @ktmud @suddjian @graceguo-supercat 