### PR TITLE
fix: parse simple string error message values

### DIFF
--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -39,13 +39,18 @@ interface ListViewResourceState<D extends object = any> {
 }
 
 const parsedErrorMessage = (
-  errorMessage: Record<string, string[]> | string,
+  errorMessage: Record<string, string[] | string> | string,
 ) => {
   if (typeof errorMessage === 'string') {
     return errorMessage;
   }
   return Object.entries(errorMessage)
-    .map(([key, value]) => `(${key}) ${value.join(', ')}`)
+    .map(([key, value]) => {
+      if (Array.isArray(value)) {
+        return `(${key}) ${value.join(', ')}`;
+      }
+      return `(${key}) ${value}`;
+    })
     .join('\n');
 };
 

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -205,7 +205,7 @@ export function useListViewResource<D extends object = any>(
 interface SingleViewResourceState<D extends object = any> {
   loading: boolean;
   resource: D | null;
-  error: string | Record<string, string[]> | null;
+  error: string | Record<string, string[] | string> | null;
 }
 
 export function useSingleViewResource<D extends object = any>(
@@ -241,7 +241,7 @@ export function useSingleViewResource<D extends object = any>(
             });
             return json.result;
           },
-          createErrorHandler((errMsg: Record<string, string[]>) => {
+          createErrorHandler((errMsg: Record<string, string[] | string>) => {
             handleErrorMsg(
               t(
                 'An error occurred while fetching %ss: %s',
@@ -282,7 +282,7 @@ export function useSingleViewResource<D extends object = any>(
             });
             return json.id;
           },
-          createErrorHandler((errMsg: Record<string, string[]>) => {
+          createErrorHandler((errMsg: Record<string, string[] | string>) => {
             handleErrorMsg(
               t(
                 'An error occurred while creating %ss: %s',
@@ -396,19 +396,21 @@ export function useImportResource(
     payload.includes('already exists and `overwrite=true` was not passed');
 
   const getPasswordsNeeded = (
-    errMsg: Record<string, Record<string, string[]>>,
+    errMsg: Record<string, Record<string, string[] | string>>,
   ) =>
     Object.entries(errMsg)
       .filter(([, validationErrors]) => isNeedsPassword(validationErrors))
       .map(([fileName]) => fileName);
 
-  const getAlreadyExists = (errMsg: Record<string, Record<string, string[]>>) =>
+  const getAlreadyExists = (
+    errMsg: Record<string, Record<string, string[] | string>>,
+  ) =>
     Object.entries(errMsg)
       .filter(([, validationErrors]) => isAlreadyExists(validationErrors))
       .map(([fileName]) => fileName);
 
   const hasTerminalValidation = (
-    errMsg: Record<string, Record<string, string[]>>,
+    errMsg: Record<string, Record<string, string[] | string>>,
   ) =>
     Object.values(errMsg).some(
       validationErrors =>
@@ -636,7 +638,7 @@ export const testDatabaseConnection = (
     () => {
       addSuccessToast(t('Connection looks good!'));
     },
-    createErrorHandler((errMsg: Record<string, string[]> | string) => {
+    createErrorHandler((errMsg: Record<string, string[] | string> | string) => {
       handleErrorMsg(t(`${t('ERROR: ')}${parsedErrorMessage(errMsg)}`));
     }),
   );

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -155,7 +155,9 @@ export const createFetchRelated = createFetchResourceMethod('related');
 export const createFetchDistinct = createFetchResourceMethod('distinct');
 
 export function createErrorHandler(
-  handleErrorFunc: (errMsg?: string | Record<string, string[]>) => void,
+  handleErrorFunc: (
+    errMsg?: string | Record<string, string[] | string>,
+  ) => void,
 ) {
   return async (e: SupersetClientResponse | string) => {
     const parsedError = await getClientErrorObject(e);


### PR DESCRIPTION
### SUMMARY
[Some error messages](https://github.com/apache/superset/blob/c7112d1c48205eceda97968cded63e40c83cf86e/superset/databases/commands/exceptions.py#L35) are returned in the format `Record<string, string>`

This change expands the typescript types to expect this, and modifies the parsing function to account for this possibility.

### SCREEENSHOTS
![Screen Shot 2021-04-26 at 1 37 12 PM](https://user-images.githubusercontent.com/12817097/116147595-caa34380-a694-11eb-8a7c-4675bcbe5ff5.png)


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
