### PR TITLE
feat: update default cron settings for new alerts and reports

### DIFF
--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -114,7 +114,7 @@ const RETENTION_OPTIONS = [
 
 const DEFAULT_RETENTION = 90;
 const DEFAULT_WORKING_TIMEOUT = 3600;
-const DEFAULT_CRON_VALUE = '* * * * *'; // every minute
+const DEFAULT_CRON_VALUE = '0 * * * *'; // every hour
 const DEFAULT_ALERT = {
   active: true,
   crontab: DEFAULT_CRON_VALUE,


### PR DESCRIPTION
### SUMMARY
Updates default cron settings in the Add Alert and Add Report modals from "every minute" to "every hour"

#### rationale: 
Preset users are setting alerts at a higher frequency than expected, which is sometimes causing issues with queuing and the system getting backed up.
Setting the default schedule to a less frequent cadence may help set the users expectation that the alerts aren't meant to be set up to be checking every minute.



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before:
![Screen Shot 2021-04-26 at 5 23 04 PM](https://user-images.githubusercontent.com/12817097/116167013-3052f800-a6b4-11eb-9926-677c50025a63.png)

after:
![Screen Shot 2021-04-26 at 5 23 21 PM](https://user-images.githubusercontent.com/12817097/116167019-3517ac00-a6b4-11eb-8ec6-1dc9ea0af34e.png)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
