### PR TITLE
refactor(db_engine_specs): Removing top-level import of app

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -40,7 +40,7 @@ import pandas as pd
 import sqlparse
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
-from flask import g
+from flask import current_app, g
 from flask_babel import gettext as __, lazy_gettext as _
 from marshmallow import fields, Schema
 from sqlalchemy import column, DateTime, select, types
@@ -55,7 +55,7 @@ from sqlalchemy.sql.expression import ColumnClause, Select, TextAsFrom
 from sqlalchemy.types import String, TypeEngine, UnicodeText
 from typing_extensions import TypedDict
 
-from superset import app, security_manager, sql_parse
+from superset import security_manager, sql_parse
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.models.sql_lab import Query
 from superset.models.sql_types.base import literal_dttm_type_factory
@@ -80,7 +80,6 @@ class TimeGrain(NamedTuple):  # pylint: disable=too-few-public-methods
 
 
 QueryStatus = utils.QueryStatus
-config = app.config
 
 builtin_time_grains: Dict[Optional[str], str] = {
     None: __("Original value"),
@@ -369,7 +368,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
 
         ret_list = []
         time_grains = builtin_time_grains.copy()
-        time_grains.update(config["TIME_GRAIN_ADDONS"])
+        time_grains.update(current_app.config["TIME_GRAIN_ADDONS"])
         for duration, func in cls.get_time_grain_expressions().items():
             if duration in time_grains:
                 name = time_grains[duration]
@@ -448,9 +447,9 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         """
         # TODO: use @memoize decorator or similar to avoid recomputation on every call
         time_grain_expressions = cls._time_grain_expressions.copy()
-        grain_addon_expressions = config["TIME_GRAIN_ADDON_EXPRESSIONS"]
+        grain_addon_expressions = current_app.config["TIME_GRAIN_ADDON_EXPRESSIONS"]
         time_grain_expressions.update(grain_addon_expressions.get(cls.engine, {}))
-        denylist: List[str] = config["TIME_GRAIN_DENYLIST"]
+        denylist: List[str] = current_app.config["TIME_GRAIN_DENYLIST"]
         for key in denylist:
             time_grain_expressions.pop(key)
 
@@ -977,7 +976,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         """
         parsed_query = ParsedQuery(statement)
         sql = parsed_query.stripped()
-        sql_query_mutator = config["SQL_QUERY_MUTATOR"]
+        sql_query_mutator = current_app.config["SQL_QUERY_MUTATOR"]
         if sql_query_mutator:
             sql = sql_query_mutator(sql, user_name, security_manager, database)
 

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -39,6 +39,7 @@ from urllib import parse
 
 import pandas as pd
 import simplejson as json
+from flask import current_app
 from flask_babel import gettext as __, lazy_gettext as _
 from sqlalchemy import Column, literal_column, types
 from sqlalchemy.engine.base import Engine
@@ -49,7 +50,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql.expression import ColumnClause, Select
 from sqlalchemy.types import TypeEngine
 
-from superset import app, cache_manager, is_feature_enabled
+from superset import cache_manager, is_feature_enabled
 from superset.db_engine_specs.base import BaseEngineSpec
 from superset.errors import SupersetErrorType
 from superset.exceptions import SupersetTemplateException
@@ -94,7 +95,6 @@ CONNECTION_UNKNOWN_DATABASE_ERROR = re.compile(
 
 
 QueryStatus = utils.QueryStatus
-config = app.config
 logger = logging.getLogger(__name__)
 
 
@@ -940,7 +940,7 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
         """Updates progress information"""
         query_id = query.id
         poll_interval = query.database.connect_args.get(
-            "poll_interval", config["PRESTO_POLL_INTERVAL"]
+            "poll_interval", current_app.config["PRESTO_POLL_INTERVAL"]
         )
         logger.info("Query %i: Polling the cursor for progress", query_id)
         polled = cursor.poll()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,6 @@ import pytest
 from sqlalchemy.engine import Engine
 
 from tests.test_app import app
-
 from superset import db
 from superset.utils.core import get_example_database, json_dumps_w_dates
 
@@ -38,6 +37,9 @@ def app_context():
 
 @pytest.fixture(autouse=True, scope="session")
 def setup_sample_data() -> Any:
+    # TODO(john-bodley): Determine a cleaner way of setting up the sample data without
+    # relying on `tests.test_app.app` leveraging an  `app` fixture which is purposely
+    # scoped to the function level to ensure tests remain idempotent.
     with app.app_context():
         setup_presto_if_needed()
 

--- a/tests/db_engine_specs/athena_tests.py
+++ b/tests/db_engine_specs/athena_tests.py
@@ -14,8 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from tests.test_app import app  # isort:skip
-
 from superset.db_engine_specs.athena import AthenaEngineSpec
 from tests.db_engine_specs.base_tests import TestDbEngineSpec
 


### PR DESCRIPTION
### SUMMARY

Yak shaving at its finest. This PR started due to the fact that some of the database engine specs had the following import logic,

```python
from superset import app
```

which was very problematic due to potential circular imports and app contexts which needed to be invoked. For testing we required magical logic like

```python
from tests.test_app import app
```

prior to importing the actual engine spec.

This change ensures that the engine specs are decoupled from the Flask app and use the `flask.current_app` where necessary when the application configuration is required. 

Note what started out as somewhat of a benign change quickly spiraled out of control in order to ensure that the tests passed as more and more code needed to be touched. The TL;DR is:

- ~~Even though this logic could further be improved, in my opinion the approach is in the direction of the north star, i.e., removing the dependency for `tests.test_app` and using the `app` `pytest` fixture instead.~~
- ~~The `app` fixture is scoped to the function which ensures that the tests are idempotent and thus the `app.config` neither i) needs to be mocked, or ii) reset upon completion of the test.~~
- ~~Migrates a subset of tests to be more `pytest` like so we can leverage the `app` fixture.~~ 

This logic was retracted because even though the individual tests passed they failed as part of the test suite and further debugging the issue resulted in a real nightmare.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
