### PR TITLE
fix: SQLLab role permissions

### DIFF
--- a/superset/constants.py
+++ b/superset/constants.py
@@ -116,6 +116,8 @@ MODEL_API_RW_METHOD_PERMISSION_MAP = {
     "data_from_cache": "read",
     "get_charts": "read",
     "get_datasets": "read",
+    "function_names": "read",
+    "available": "read",
 }
 
 EXTRA_FORM_DATA_APPEND_KEYS = {

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -185,16 +185,17 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
     ACCESSIBLE_PERMS = {"can_userinfo", "resetmypassword"}
 
     SQLLAB_PERMISSION_VIEWS = {
-        ("menu_access", "SQL Lab"),
-        ("menu_access", "SQL Editor"),
-        ("menu_access", "Saved Queries"),
-        ("menu_access", "Query History"),
+        ("can_csv", "Superset"),
+        ("can_read", "SavedQuery"),
+        ("can_read", "Database"),
         ("can_sql_json", "Superset"),
         ("can_sqllab_viz", "Superset"),
         ("can_sqllab_table_viz", "Superset"),
         ("can_sqllab", "Superset"),
-        ("can_read", "SavedQuery"),
-        ("can_read", "Database"),
+        ("menu_access", "SQL Lab"),
+        ("menu_access", "SQL Editor"),
+        ("menu_access", "Saved Queries"),
+        ("menu_access", "Query History"),
     }
 
     data_access_permissions = (

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -195,7 +195,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         ("menu_access", "SQL Lab"),
         ("menu_access", "SQL Editor"),
         ("menu_access", "Saved Queries"),
-        ("menu_access", "Query History"),
+        ("menu_access", "Query Search"),
     }
 
     data_access_permissions = (

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -184,6 +184,19 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
 
     ACCESSIBLE_PERMS = {"can_userinfo", "resetmypassword"}
 
+    SQLLAB_PERMISSION_VIEWS = {
+        ("menu_access", "SQL Lab"),
+        ("menu_access", "SQL Editor"),
+        ("menu_access", "Saved Queries"),
+        ("menu_access", "Query History"),
+        ("can_sql_json", "Superset"),
+        ("can_sqllab_viz", "Superset"),
+        ("can_sqllab_table_viz", "Superset"),
+        ("can_sqllab", "Superset"),
+        ("can_read", "SavedQuery"),
+        ("can_read", "Database"),
+    }
+
     data_access_permissions = (
         "database_access",
         "schema_access",
@@ -820,24 +833,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         :param pvm: The FAB permission/view
         :returns: Whether the FAB object is SQL Lab related
         """
-
-        return (
-            pvm.view_menu.name
-            in {"SQL Lab", "SQL Editor", "Query Search", "Saved Queries"}
-            or pvm.permission.name
-            in {
-                "can_sql_json",
-                "can_csv",
-                "can_search_queries",
-                "can_sqllab_viz",
-                "can_sqllab_table_viz",
-                "can_sqllab",
-            }
-            or (
-                pvm.view_menu.name in self.USER_MODEL_VIEWS
-                and pvm.permission.name == "can_list"
-            )
-        )
+        return (pvm.permission.name, pvm.view_menu.name) in self.SQLLAB_PERMISSION_VIEWS
 
     def _is_granter_pvm(  # pylint: disable=no-self-use
         self, pvm: PermissionView

--- a/tests/databases/api_tests.py
+++ b/tests/databases/api_tests.py
@@ -614,9 +614,7 @@ class TestDatabaseApi(SupersetTestCase):
         assert rv.status_code == 200
         assert "can_read" in data["permissions"]
         assert "can_write" in data["permissions"]
-        assert "can_function_names" in data["permissions"]
-        assert "can_available" in data["permissions"]
-        assert len(data["permissions"]) == 4
+        assert len(data["permissions"]) == 2
 
     def test_get_invalid_database_table_metadata(self):
         """

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -843,7 +843,7 @@ class TestRolePermission(SupersetTestCase):
         self.assertIn(("menu_access", "SQL Lab"), sql_lab_set)
         self.assertIn(("menu_access", "SQL Editor"), sql_lab_set)
         self.assertIn(("menu_access", "Saved Queries"), sql_lab_set)
-        self.assertIn(("menu_access", "Query History"), sql_lab_set)
+        self.assertIn(("menu_access", "Query Search"), sql_lab_set)
 
         self.assert_cannot_alpha(sql_lab_set)
 

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -832,9 +832,18 @@ class TestRolePermission(SupersetTestCase):
 
     def test_sql_lab_permissions(self):
         sql_lab_set = get_perm_tuples("sql_lab")
-        self.assertIn(("can_sql_json", "Superset"), sql_lab_set)
         self.assertIn(("can_csv", "Superset"), sql_lab_set)
-        self.assertIn(("can_search_queries", "Superset"), sql_lab_set)
+        self.assertIn(("can_read", "Database"), sql_lab_set)
+        self.assertIn(("can_read", "SavedQuery"), sql_lab_set)
+        self.assertIn(("can_sql_json", "Superset"), sql_lab_set)
+        self.assertIn(("can_sqllab_viz", "Superset"), sql_lab_set)
+        self.assertIn(("can_sqllab_table_viz", "Superset"), sql_lab_set)
+        self.assertIn(("can_sqllab", "Superset"), sql_lab_set)
+
+        self.assertIn(("menu_access", "SQL Lab"), sql_lab_set)
+        self.assertIn(("menu_access", "SQL Editor"), sql_lab_set)
+        self.assertIn(("menu_access", "Saved Queries"), sql_lab_set)
+        self.assertIn(("menu_access", "Query History"), sql_lab_set)
 
         self.assert_cannot_alpha(sql_lab_set)
 


### PR DESCRIPTION
### SUMMARY
Fixes SQLLab role permissions, missing access to fetching database function names. Opted for declaring explicitly the necessary permissions that make up SQLLab role.

Previously a user with SQLLab role (could be Gamma + SQLLab), would see the following toast:

![Screenshot 2021-04-27 at 11 26 33](https://user-images.githubusercontent.com/4025227/116226900-71e2b200-a74b-11eb-87a9-fbcbb402df98.png)

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
