### PR TITLE
fix(native-filters): force update control value on change

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ControlItems.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ControlItems.test.tsx
@@ -123,6 +123,6 @@ test('Clickin on checkbox when resetConfig:flase', () => {
   expect(props.forceUpdate).not.toBeCalled();
   expect(setNativeFilterFieldValues).not.toBeCalled();
   userEvent.click(screen.getByRole('checkbox'));
-  expect(props.forceUpdate).not.toBeCalled();
+  expect(props.forceUpdate).toBeCalled();
   expect(setNativeFilterFieldValues).not.toBeCalled();
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ControlItems.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ControlItems.tsx
@@ -72,6 +72,7 @@ const ControlItems: FC<ControlItemsProps> = ({
             <Checkbox
               onChange={() => {
                 if (!controlItem.config.resetConfig) {
+                  forceUpdate();
                   return;
                 }
                 setNativeFilterFieldValues(form, filterId, {


### PR DESCRIPTION
### SUMMARY
When changing a control value on native filters, the updated value doesn't get updated to form data before the request goes out, causing the populated values to lag control state by one.

### BEFORE
Notice how Tuvalu (world's least populous country) shows up as the first choice despite sorting by population in descending order, and same for China and ascending order:
![native-control-before](https://user-images.githubusercontent.com/33317356/116351015-939b7200-a7fb-11eb-814e-1280b7363579.gif)

### AFTER
Now ascending/descending properly orders the country names after the control is updated:
![native-control-after](https://user-images.githubusercontent.com/33317356/116350804-37d0e900-a7fb-11eb-886f-8234e52d7eb9.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
