### PR TITLE
chore: [WIP] bumping superset-ui/core, and only importing Emotion from there

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -116,6 +116,11 @@ module.exports = {
                 message:
                   'Please import Ant components from the index of common/components',
               },
+              {
+                name: '@emotion/core',
+                message:
+                  'Please import Emotion components from @superset-ui/core',
+              },
             ],
           },
         ],

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -65,7 +65,7 @@
     "@babel/runtime-corejs3": "^7.12.5",
     "@data-ui/sparkline": "^0.0.84",
     "@superset-ui/chart-controls": "^0.17.36",
-    "@superset-ui/core": "^0.17.32",
+    "@superset-ui/core": "^0.17.40",
     "@superset-ui/legacy-plugin-chart-calendar": "^0.17.36",
     "@superset-ui/legacy-plugin-chart-chord": "^0.17.36",
     "@superset-ui/legacy-plugin-chart-country-map": "^0.17.36",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -64,8 +64,6 @@
     "@ant-design/icons": "^4.2.2",
     "@babel/runtime-corejs3": "^7.12.5",
     "@data-ui/sparkline": "^0.0.84",
-    "@emotion/cache": "^11.1.3",
-    "@emotion/core": "^10.0.39",
     "@superset-ui/chart-controls": "^0.17.36",
     "@superset-ui/core": "^0.17.32",
     "@superset-ui/legacy-plugin-chart-calendar": "^0.17.36",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -65,7 +65,7 @@
     "@babel/runtime-corejs3": "^7.12.5",
     "@data-ui/sparkline": "^0.0.84",
     "@emotion/cache": "^11.1.3",
-    "@emotion/core": "^10.0.35",
+    "@emotion/core": "^10.0.39",
     "@superset-ui/chart-controls": "^0.17.36",
     "@superset-ui/core": "^0.17.32",
     "@superset-ui/legacy-plugin-chart-calendar": "^0.17.36",

--- a/superset-frontend/src/SqlLab/components/ColumnElement.tsx
+++ b/superset-frontend/src/SqlLab/components/ColumnElement.tsx
@@ -18,8 +18,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ClassNames } from '@emotion/core';
-import { styled, useTheme } from '@superset-ui/core';
+import { styled, useTheme, ClassNames } from '@superset-ui/core';
 
 import { Tooltip } from 'src/components/Tooltip';
 

--- a/superset-frontend/src/components/Modal/Modal.tsx
+++ b/superset-frontend/src/components/Modal/Modal.tsx
@@ -18,10 +18,9 @@
  */
 import React from 'react';
 import { isNil } from 'lodash';
-import { styled, SupersetThemeProps, t } from '@superset-ui/core';
+import { styled, SupersetThemeProps, t, css } from '@superset-ui/core';
 import { Modal as BaseModal } from 'src/common/components';
 import Button from 'src/components/Button';
-import { css } from '@emotion/core';
 
 interface ModalProps {
   className?: string;

--- a/superset-frontend/src/components/Select/styles.tsx
+++ b/superset-frontend/src/components/Select/styles.tsx
@@ -17,8 +17,12 @@
  * under the License.
  */
 import React, { CSSProperties, ComponentType, ReactNode } from 'react';
-import { css, SerializedStyles, ClassNames } from '@emotion/core';
-import { SupersetTheme } from '@superset-ui/core';
+import {
+  SupersetTheme,
+  css,
+  SerializedStyles,
+  ClassNames,
+} from '@superset-ui/core';
 import {
   Styles,
   Theme,

--- a/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel/index.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useState } from 'react';
-import { t, useTheme, css } from '@superset-ui/core';
+import { t, useTheme, css, Global } from '@superset-ui/core';
 import {
   MinusCircleFilled,
   CheckCircleFilled,
@@ -25,7 +25,6 @@ import {
 } from '@ant-design/icons';
 import Popover from 'src/components/Popover';
 import Collapse from 'src/components/Collapse';
-import { Global } from '@emotion/core';
 import Icon from 'src/components/Icon';
 import {
   Indent,

--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -21,12 +21,11 @@ import React, { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { styled, t, supersetTheme, css } from '@superset-ui/core';
+import { styled, t, supersetTheme, css, Global } from '@superset-ui/core';
 import { debounce } from 'lodash';
 import { Resizable } from 're-resizable';
 
 import { useDynamicPluginContext } from 'src/components/DynamicPlugins';
-import { Global } from '@emotion/core';
 import { Tooltip } from 'src/components/Tooltip';
 import { usePrevious } from 'src/common/hooks/usePrevious';
 import Icon from 'src/components/Icon';

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/components/DateFunctionTooltip.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/components/DateFunctionTooltip.tsx
@@ -17,10 +17,9 @@
  * under the License.
  */
 import React from 'react';
-import { useTheme, t } from '@superset-ui/core';
+import { ClassNames, useTheme, t } from '@superset-ui/core';
 
 import { Tooltip } from 'src/components/Tooltip';
-import { ClassNames } from '@emotion/core';
 
 const TIME_PICKER_HELPER = (
   <>

--- a/superset-frontend/src/explore/components/controls/FixedOrMetricControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/FixedOrMetricControl/index.jsx
@@ -18,8 +18,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { css } from '@emotion/core';
-import { t } from '@superset-ui/core';
+import { t, css } from '@superset-ui/core';
 import Label from 'src/components/Label';
 import Collapse from 'src/components/Collapse';
 import TextControl from 'src/explore/components/controls/TextControl';

--- a/superset-frontend/src/views/menu.tsx
+++ b/superset-frontend/src/views/menu.tsx
@@ -21,8 +21,7 @@
 // eg, backend rendered views
 import React from 'react';
 import ReactDOM from 'react-dom';
-import createCache from '@emotion/cache';
-import { ThemeProvider, CacheProvider } from '@superset-ui/core';
+import { ThemeProvider, CacheProvider, createCache } from '@superset-ui/core';
 import Menu from 'src/components/Menu/Menu';
 import { theme } from 'src/preamble';
 

--- a/superset-frontend/src/views/menu.tsx
+++ b/superset-frontend/src/views/menu.tsx
@@ -21,9 +21,8 @@
 // eg, backend rendered views
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { CacheProvider } from '@emotion/core';
 import createCache from '@emotion/cache';
-import { ThemeProvider } from '@superset-ui/core';
+import { ThemeProvider, CacheProvider } from '@superset-ui/core';
 import Menu from 'src/components/Menu/Menu';
 import { theme } from 'src/preamble';
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR does a few things.
1) Imports the latest `superset-ui/core` which includes all required Emotion modules
2) Pulls all Emotion imports from Superset-UI
3) Removes Emotion from Superset
4) Adds linting rule to prevent future direct `@emotion/core` use

The intent of all of the above is _part of_ the effort to get the dual-React-Apps to play nicely together in production. This should be visible when the global nav on these dual-app pages (e.g. Sql Editor or Explore view) looks consistent with the single-app pages (CRUD views, homepage). 

Reference reading about this issue: https://github.com/emotion-js/emotion/issues/2210

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
