### PR TITLE
fix(native-filters): default value not populated on second opening

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -124,19 +124,7 @@ export const FiltersConfigForm: React.FC<FiltersConfigFormProps> = ({
   const forceUpdate = useForceUpdate();
   const [datasetDetails, setDatasetDetails] = useState<Record<string, any>>();
 
-  // make sure the formFilter is populated
-  if (!form.getFieldValue('filters')) {
-    setNativeFilterFieldValues(form, filterId, filterToEdit || {});
-    forceUpdate();
-  }
-  const formFilter = form.getFieldValue('filters')[filterId];
-
-  useEffect(() => {
-    setNativeFilterFieldValues(form, filterId, {
-      defaultValue: filterToEdit?.defaultValue,
-    });
-    forceUpdate();
-  }, [form, forceUpdate, filterId, filterToEdit?.defaultValue]);
+  const formFilter = form.getFieldValue('filters')?.[filterId] || {};
 
   const nativeFilterItems = getChartMetadataRegistry().items;
   const nativeFilterVizTypes = Object.entries(nativeFilterItems)

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/state.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/state.ts
@@ -45,11 +45,4 @@ export const useBackendFormUpdate = (
     forceUpdate,
     filterId,
   ]);
-
-  useEffect(() => {
-    setNativeFilterFieldValues(form, filterId, {
-      defaultValue: formFilter?.defaultValue,
-    });
-    forceUpdate();
-  }, [form, formFilter?.defaultValue, forceUpdate, filterId]);
 };


### PR DESCRIPTION
### SUMMARY
When opening the filter config modal the second time, the default value is not populated correctly. This was caused by two conflicting `useEffect` hooks that were updating `defaultValue` in the form data.

### BEFORE
https://user-images.githubusercontent.com/33317356/116503336-77143e00-a8be-11eb-88cb-af93508af984.mp4

### AFTER
https://user-images.githubusercontent.com/33317356/116503075-e178ae80-a8bd-11eb-983f-bf1e53a32dae.mp4

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
