### PR TITLE
fix(native-filters): always show filters without dataset

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -433,7 +433,7 @@ export const FiltersConfigForm: React.FC<FiltersConfigFormProps> = ({
           data-test="default-input"
           label={<StyledLabel>{t('Default Value')}</StyledLabel>}
         >
-          {!isDataDirty && (hasFilledDataset || !hasDataset) && (
+          {(!hasDataset || (!isDataDirty && hasFilledDataset)) && (
             <DefaultValue
               setDataMask={({ filterState }) => {
                 setNativeFilterFieldValues(form, filterId, {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE
Notice how the Time picker doesn't appear:
![image](https://user-images.githubusercontent.com/33317356/116531216-97a4be00-a8e7-11eb-824f-7672475940c3.png)

### AFTER
After the change the time picker automatically appears when choosing the filter type:
![image](https://user-images.githubusercontent.com/33317356/116531148-878cde80-a8e7-11eb-9751-a7380affc54b.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
