### PR TITLE
fix: fixing mysql error message

### DIFF
--- a/superset/db_engine_specs/mysql.py
+++ b/superset/db_engine_specs/mysql.py
@@ -50,7 +50,7 @@ CONNECTION_INVALID_HOSTNAME_REGEX = re.compile(
 CONNECTION_HOST_DOWN_REGEX = re.compile(
     "Can't connect to MySQL server on '(?P<hostname>.*?)'"
 )
-CONNECTION_UNKNOWN_DATABASE_REGEX = re.compile("Unknown database '(?P<database>.*?)'.")
+CONNECTION_UNKNOWN_DATABASE_REGEX = re.compile("Unknown database '(?P<database>.*?)'")
 
 
 class MySQLEngineSpec(BaseEngineSpec):

--- a/superset/db_engine_specs/mysql.py
+++ b/superset/db_engine_specs/mysql.py
@@ -42,13 +42,13 @@ from superset.utils.core import ColumnSpec, GenericDataType
 
 # Regular expressions to catch custom errors
 CONNECTION_ACCESS_DENIED_REGEX = re.compile(
-    "Access denied for user '(?P<username>.*?)'@'(?P<hostname>.*?)'. "
+    "Access denied for user '(?P<username>.*?)'@'(?P<hostname>.*?)' "
 )
 CONNECTION_INVALID_HOSTNAME_REGEX = re.compile(
-    "Unknown MySQL server host '(?P<hostname>.*?)'."
+    "Unknown MySQL server host '(?P<hostname>.*?)'"
 )
 CONNECTION_HOST_DOWN_REGEX = re.compile(
-    "Can't connect to MySQL server on '(?P<hostname>.*?)'."
+    "Can't connect to MySQL server on '(?P<hostname>.*?)'"
 )
 CONNECTION_UNKNOWN_DATABASE_REGEX = re.compile("Unknown database '(?P<database>.*?)'.")
 

--- a/superset/db_engine_specs/mysql.py
+++ b/superset/db_engine_specs/mysql.py
@@ -42,7 +42,7 @@ from superset.utils.core import ColumnSpec, GenericDataType
 
 # Regular expressions to catch custom errors
 CONNECTION_ACCESS_DENIED_REGEX = re.compile(
-    "Access denied for user '(?P<username>.*?)'@'(?P<hostname>.*?)' "
+    "Access denied for user '(?P<username>.*?)'@'(?P<hostname>.*?)'"
 )
 CONNECTION_INVALID_HOSTNAME_REGEX = re.compile(
     "Unknown MySQL server host '(?P<hostname>.*?)'"

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -62,7 +62,7 @@ CONNECTION_INVALID_USERNAME_REGEX = re.compile(
 CONNECTION_INVALID_PASSWORD_REGEX = re.compile(
     'password authentication failed for user "(?P<username>.*?)"'
 )
-CONNECTION_INVALID_CHANGE_USERNAME_REGEX = re.compile("no password supplied")
+CONNECTION_INVALID_PASSWORD_NEEDED_REGEX = re.compile("no password supplied")
 CONNECTION_INVALID_HOSTNAME_REGEX = re.compile(
     'could not translate host name "(?P<hostname>.*?)" to address: '
     "nodename nor servname provided, or not known"
@@ -109,8 +109,8 @@ class PostgresBaseEngineSpec(BaseEngineSpec):
             __('The password provided for username "%(username)s" is incorrect.'),
             SupersetErrorType.CONNECTION_INVALID_PASSWORD_ERROR,
         ),
-        CONNECTION_INVALID_CHANGE_USERNAME_REGEX: (
-            __("Either the username or the password is incorrect."),
+        CONNECTION_INVALID_PASSWORD_NEEDED_REGEX: (
+            __("Please re-enter the password."),
             SupersetErrorType.CONNECTION_ACCESS_DENIED_ERROR,
         ),
         CONNECTION_INVALID_HOSTNAME_REGEX: (

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -62,6 +62,7 @@ CONNECTION_INVALID_USERNAME_REGEX = re.compile(
 CONNECTION_INVALID_PASSWORD_REGEX = re.compile(
     'password authentication failed for user "(?P<username>.*?)"'
 )
+CONNECTION_INVALID_CHANGE_USERNAME_REGEX = re.compile("no password supplied")
 CONNECTION_INVALID_HOSTNAME_REGEX = re.compile(
     'could not translate host name "(?P<hostname>.*?)" to address: '
     "nodename nor servname provided, or not known"
@@ -107,6 +108,10 @@ class PostgresBaseEngineSpec(BaseEngineSpec):
         CONNECTION_INVALID_PASSWORD_REGEX: (
             __('The password provided for username "%(username)s" is incorrect.'),
             SupersetErrorType.CONNECTION_INVALID_PASSWORD_ERROR,
+        ),
+        CONNECTION_INVALID_CHANGE_USERNAME_REGEX: (
+            __("Either the username or the password is incorrect."),
+            SupersetErrorType.CONNECTION_ACCESS_DENIED_ERROR,
         ),
         CONNECTION_INVALID_HOSTNAME_REGEX: (
             __('The hostname "%(hostname)s" cannot be resolved.'),

--- a/tests/db_engine_specs/mysql_tests.py
+++ b/tests/db_engine_specs/mysql_tests.py
@@ -110,7 +110,7 @@ class TestMySQLEngineSpecsDbEngineSpec(TestDbEngineSpec):
         """
         Test that custom error messages are extracted correctly.
         """
-        msg = "mysql: Access denied for user 'test'@'testuser.com'. "
+        msg = "mysql: Access denied for user 'test'@'testuser.com' "
         result = MySQLEngineSpec.extract_errors(Exception(msg))
         assert result == [
             SupersetError(
@@ -135,7 +135,7 @@ class TestMySQLEngineSpecsDbEngineSpec(TestDbEngineSpec):
             )
         ]
 
-        msg = "mysql: Unknown MySQL server host 'badhostname.com'. "
+        msg = "mysql: Unknown MySQL server host 'badhostname.com' "
         result = MySQLEngineSpec.extract_errors(Exception(msg))
         assert result == [
             SupersetError(
@@ -155,7 +155,7 @@ class TestMySQLEngineSpecsDbEngineSpec(TestDbEngineSpec):
             )
         ]
 
-        msg = "mysql: Can't connect to MySQL server on 'badconnection.com'."
+        msg = "mysql: Can't connect to MySQL server on 'badconnection.com'"
         result = MySQLEngineSpec.extract_errors(Exception(msg))
         assert result == [
             SupersetError(
@@ -176,7 +176,7 @@ class TestMySQLEngineSpecsDbEngineSpec(TestDbEngineSpec):
             )
         ]
 
-        msg = "mysql: Can't connect to MySQL server on '93.184.216.34'."
+        msg = "mysql: Can't connect to MySQL server on '93.184.216.34'"
         result = MySQLEngineSpec.extract_errors(Exception(msg))
         assert result == [
             SupersetError(
@@ -196,7 +196,7 @@ class TestMySQLEngineSpecsDbEngineSpec(TestDbEngineSpec):
             )
         ]
 
-        msg = "mysql: Unknown database 'badDB'."
+        msg = "mysql: Unknown database 'badDB'.ß"
         result = MySQLEngineSpec.extract_errors(Exception(msg))
         assert result == [
             SupersetError(

--- a/tests/db_engine_specs/mysql_tests.py
+++ b/tests/db_engine_specs/mysql_tests.py
@@ -135,7 +135,7 @@ class TestMySQLEngineSpecsDbEngineSpec(TestDbEngineSpec):
             )
         ]
 
-        msg = "mysql: Unknown MySQL server host 'badhostname.com' "
+        msg = "mysql: Unknown MySQL server host 'badhostname.com'"
         result = MySQLEngineSpec.extract_errors(Exception(msg))
         assert result == [
             SupersetError(

--- a/tests/db_engine_specs/mysql_tests.py
+++ b/tests/db_engine_specs/mysql_tests.py
@@ -110,7 +110,7 @@ class TestMySQLEngineSpecsDbEngineSpec(TestDbEngineSpec):
         """
         Test that custom error messages are extracted correctly.
         """
-        msg = "mysql: Access denied for user 'test'@'testuser.com' "
+        msg = "mysql: Access denied for user 'test'@'testuser.com'"
         result = MySQLEngineSpec.extract_errors(Exception(msg))
         assert result == [
             SupersetError(

--- a/tests/db_engine_specs/mysql_tests.py
+++ b/tests/db_engine_specs/mysql_tests.py
@@ -196,7 +196,7 @@ class TestMySQLEngineSpecsDbEngineSpec(TestDbEngineSpec):
             )
         ]
 
-        msg = "mysql: Unknown database 'badDB'.ß"
+        msg = "mysql: Unknown database 'badDB'"
         result = MySQLEngineSpec.extract_errors(Exception(msg))
         assert result == [
             SupersetError(

--- a/tests/db_engine_specs/postgres_tests.py
+++ b/tests/db_engine_specs/postgres_tests.py
@@ -394,7 +394,7 @@ psql: error: could not connect to server: Operation timed out
         assert result == [
             SupersetError(
                 error_type=SupersetErrorType.CONNECTION_ACCESS_DENIED_ERROR,
-                message="Either the username or the password is incorrect.",
+                message="Please re-enter the password.",
                 level=ErrorLevel.ERROR,
                 extra={
                     "engine_name": "PostgreSQL",

--- a/tests/db_engine_specs/postgres_tests.py
+++ b/tests/db_engine_specs/postgres_tests.py
@@ -389,6 +389,31 @@ psql: error: could not connect to server: Operation timed out
             )
         ]
 
+        msg = "no password supplied"
+        result = PostgresEngineSpec.extract_errors(Exception(msg))
+        assert result == [
+            SupersetError(
+                error_type=SupersetErrorType.CONNECTION_ACCESS_DENIED_ERROR,
+                message="Either the username or the password is incorrect.",
+                level=ErrorLevel.ERROR,
+                extra={
+                    "engine_name": "PostgreSQL",
+                    "issue_codes": [
+                        {
+                            "code": 1014,
+                            "message": "Issue 1014 - Either the"
+                            " username or the password is wrong.",
+                        },
+                        {
+                            "code": 1015,
+                            "message": "Issue 1015 - Either the database is "
+                            "spelled incorrectly or does not exist.",
+                        },
+                    ],
+                },
+            )
+        ]
+
 
 def test_base_parameters_mixin():
     parameters = {


### PR DESCRIPTION
### SUMMARY
The previous regex for custom database errors for mySQL had an extra period, this fixes that. The same was true for postgres when you are editing an already existing database. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before (postgres):
![Screen Shot 2021-04-30 at 3 08 11 PM](https://user-images.githubusercontent.com/48933336/116743008-45869a00-a9c6-11eb-936d-abc85f15ce78.png)
After (postgres)
![Screen Shot 2021-04-30 at 3 11 55 PM](https://user-images.githubusercontent.com/48933336/116743098-6d75fd80-a9c6-11eb-8243-529b8f003371.png)


After
![Screen Shot 2021-04-29 at 11 31 15 AM](https://user-images.githubusercontent.com/48933336/116577398-6d023780-a8de-11eb-925d-9bb71aaf47df.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
