### PR TITLE
fix(native-filters): fix filter scope error

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.ts
@@ -129,11 +129,10 @@ export const findFilterScope = (
   // looking for charts to be excluded: iterate over all charts
   // and looking for charts that have one of their parents in `rootPath` and not in selected items
   Object.entries(layout).forEach(([key, value]) => {
+    const parents = value.parents || [];
     if (
       value.type === CHART_TYPE &&
-      [DASHBOARD_ROOT_ID, ...value.parents]?.find(parent =>
-        isExcluded(parent, key),
-      )
+      [DASHBOARD_ROOT_ID, ...parents]?.find(parent => isExcluded(parent, key))
     ) {
       excluded.push(value.meta.chartId);
     }


### PR DESCRIPTION
### SUMMARY
If `parents` in the filter scope is undefined, an error is raised, making it impossible to change filter scope.

### BEFORE
![scope-before](https://user-images.githubusercontent.com/33317356/116670511-7b1c8a80-a9a8-11eb-84f7-bc195ea63443.gif)

### AFTER
![scope-after](https://user-images.githubusercontent.com/33317356/116670598-97202c00-a9a8-11eb-9cfd-34c757d12e70.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #14422
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
