### PR TITLE
feat: Adding configuration_method column to Database Model

### DIFF
--- a/superset/migrations/versions/453530256cea_add_save_option_column_to_db_model.py
+++ b/superset/migrations/versions/453530256cea_add_save_option_column_to_db_model.py
@@ -34,7 +34,9 @@ def upgrade():
     with op.batch_alter_table("dbs") as batch_op:
         batch_op.add_column(
             sa.Column(
-                "configuration_method", sa.VARCHAR(255), server_default="SQLALCHEMY_URI"
+                "configuration_method",
+                sa.VARCHAR(255),
+                server_default="sqlalchemy_form",
             )
         )
 

--- a/superset/migrations/versions/453530256cea_add_save_option_column_to_db_model.py
+++ b/superset/migrations/versions/453530256cea_add_save_option_column_to_db_model.py
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add_save_form_column_to_db_model
+
+Revision ID: 453530256cea
+Revises: d416d0d715cc
+Create Date: 2021-04-30 10:55:07.009994
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "453530256cea"
+down_revision = "d416d0d715cc"
+
+import sqlalchemy as sa
+from alembic import op
+
+
+def upgrade():
+    with op.batch_alter_table("dbs") as batch_op:
+        batch_op.add_column(
+            sa.Column("save_option", sa.VARCHAR(255), server_default="SQL_ALCHEMY")
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("dbs") as batch_op:
+        batch_op.drop_column("save_option")

--- a/superset/migrations/versions/453530256cea_add_save_option_column_to_db_model.py
+++ b/superset/migrations/versions/453530256cea_add_save_option_column_to_db_model.py
@@ -33,10 +33,12 @@ from alembic import op
 def upgrade():
     with op.batch_alter_table("dbs") as batch_op:
         batch_op.add_column(
-            sa.Column("save_option", sa.VARCHAR(255), server_default="SQL_ALCHEMY")
+            sa.Column(
+                "configuration_method", sa.VARCHAR(255), server_default="SQLALCHEMY_URI"
+            )
         )
 
 
 def downgrade():
     with op.batch_alter_table("dbs") as batch_op:
-        batch_op.drop_column("save_option")
+        batch_op.drop_column("configuration_method")

--- a/superset/migrations/versions/453530256cea_add_save_option_column_to_db_model.py
+++ b/superset/migrations/versions/453530256cea_add_save_option_column_to_db_model.py
@@ -17,14 +17,14 @@
 """add_save_form_column_to_db_model
 
 Revision ID: 453530256cea
-Revises: d416d0d715cc
+Revises: f1410ed7ec95
 Create Date: 2021-04-30 10:55:07.009994
 
 """
 
 # revision identifiers, used by Alembic.
 revision = "453530256cea"
-down_revision = "d416d0d715cc"
+down_revision = "f1410ed7ec95"
 
 import sqlalchemy as sa
 from alembic import op

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -16,7 +16,6 @@
 # under the License.
 # pylint: disable=line-too-long,unused-argument,ungrouped-imports
 """A collection of ORM sqlalchemy models for Superset"""
-import enum
 import json
 import logging
 import textwrap

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -16,6 +16,7 @@
 # under the License.
 # pylint: disable=line-too-long,unused-argument,ungrouped-imports
 """A collection of ORM sqlalchemy models for Superset"""
+import enum
 import json
 import logging
 import textwrap


### PR DESCRIPTION
### SUMMARY
We are adding a new enum column to the Database model that identifies which method was used in its' creation or updating. 

The logic for this is written here: https://github.com/apache/superset/pull/14451
### Reason
This column is necessary so that front end components know what information to present to the user when they are editing a database. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
Coming Soon. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
