### PR TITLE
fix: dashboard changed on calculation

### DIFF
--- a/superset/dashboards/dao.py
+++ b/superset/dashboards/dao.py
@@ -71,7 +71,8 @@ class DashboardDAO(BaseDAO):
             if isinstance(id_or_slug_or_dashboard, str)
             else id_or_slug_or_dashboard
         )
-        return dashboard.changed_on
+        # drop microseconds in datetime to match with last_modified header
+        return dashboard.changed_on.replace(microsecond=0)
 
     @staticmethod
     def get_dashboard_and_slices_changed_on(  # pylint: disable=invalid-name
@@ -91,7 +92,11 @@ class DashboardDAO(BaseDAO):
             else id_or_slug_or_dashboard
         )
         dashboard_changed_on = DashboardDAO.get_dashboard_changed_on(dashboard)
-        slices_changed_on = max([slc.changed_on for slc in dashboard.slices])
+        slices = dashboard.slices
+        slices_changed_on = max(
+            [slc.changed_on for slc in slices]
+            + ([datetime.fromtimestamp(0)] if len(slices) == 0 else [])
+        )
         # drop microseconds in datetime to match with last_modified header
         return max(dashboard_changed_on, slices_changed_on).replace(microsecond=0)
 
@@ -113,8 +118,10 @@ class DashboardDAO(BaseDAO):
             else id_or_slug_or_dashboard
         )
         dashboard_changed_on = DashboardDAO.get_dashboard_changed_on(dashboard)
+        datasources = dashboard.datasources
         datasources_changed_on = max(
-            [datasource.changed_on for datasource in dashboard.datasources]
+            [datasource.changed_on for datasource in datasources]
+            + ([datetime.fromtimestamp(0)] if len(datasources) == 0 else [])
         )
         # drop microseconds in datetime to match with last_modified header
         return max(dashboard_changed_on, datasources_changed_on).replace(microsecond=0)

--- a/tests/dashboards/dao_tests.py
+++ b/tests/dashboards/dao_tests.py
@@ -86,10 +86,9 @@ class TestDashboardDAO(SupersetTestCase):
         session = db.session()
         dashboard = session.query(Dashboard).filter_by(slug="world_health").first()
 
-        assert dashboard.changed_on == DashboardDAO.get_dashboard_changed_on(dashboard)
-        assert dashboard.changed_on == DashboardDAO.get_dashboard_changed_on(
-            "world_health"
-        )
+        changed_on = dashboard.changed_on.replace(microsecond=0)
+        assert changed_on == DashboardDAO.get_dashboard_changed_on(dashboard)
+        assert changed_on == DashboardDAO.get_dashboard_changed_on("world_health")
 
         old_changed_on = dashboard.changed_on
 
@@ -104,7 +103,14 @@ class TestDashboardDAO(SupersetTestCase):
         DashboardDAO.set_dash_metadata(dashboard, data)
         session.merge(dashboard)
         session.commit()
-        assert old_changed_on < DashboardDAO.get_dashboard_changed_on(dashboard)
+        new_changed_on = DashboardDAO.get_dashboard_changed_on(dashboard)
+        assert old_changed_on.replace(microsecond=0) < new_changed_on
+        assert new_changed_on == DashboardDAO.get_dashboard_and_datasets_changed_on(
+            dashboard
+        )
+        assert new_changed_on == DashboardDAO.get_dashboard_and_slices_changed_on(
+            dashboard
+        )
 
         DashboardDAO.set_dash_metadata(dashboard, original_data)
         session.merge(dashboard)


### PR DESCRIPTION
### SUMMARY
My previous etag PR (#14357) broke creating new dashboards because they wouldn't have any slices or datasets associated with them yet, thus running `max([])` which fails. This sets a min bound for the changed_on time to unixtime 0 which should be safe.

### TEST PLAN
:eyes: and CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @graceguo-supercat @ktmud @suddjian @john-bodley 