### PR TITLE
feat: postgres connection form

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
@@ -30,7 +30,7 @@ import Icons from 'src/components/Icons';
 import ListView, { FilterOperator, Filters } from 'src/components/ListView';
 import { commonMenuData } from 'src/views/CRUD/data/common';
 import ImportModelsModal from 'src/components/ImportModal/index';
-import DatabaseModal from './DatabaseModal';
+import DatabaseModal from './databaseModal';
 import { DatabaseObject } from './types';
 
 const PAGE_SIZE = 25;

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
@@ -147,10 +147,13 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
     );
   }
 
-  function handleDatabaseEdit(database: DatabaseObject) {
-    // Set database and open modal
+  function handleDatabaseEditModal({
+    database = null,
+    modalOpen = false,
+  }: { database?: DatabaseObject | null; modalOpen?: boolean } = {}) {
+    // Set database and modal
     setCurrentDatabase(database);
-    setDatabaseModalOpen(true);
+    setDatabaseModalOpen(modalOpen);
   }
 
   const canCreate = hasPerm('can_write');
@@ -176,8 +179,7 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
         buttonStyle: 'primary',
         onClick: () => {
           // Ensure modal will be opened in add mode
-          setCurrentDatabase(null);
-          setDatabaseModalOpen(true);
+          handleDatabaseEditModal({ modalOpen: true });
         },
       },
     ];
@@ -298,7 +300,8 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
       },
       {
         Cell: ({ row: { original } }: any) => {
-          const handleEdit = () => handleDatabaseEdit(original);
+          const handleEdit = () =>
+            handleDatabaseEditModal({ database: original, modalOpen: true });
           const handleDelete = () => openDatabaseDeleteModal(original);
           const handleExport = () => handleDatabaseExport(original);
           if (!canEdit && !canDelete && !canExport) {
@@ -416,7 +419,7 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
       <DatabaseModal
         databaseId={currentDatabase?.id}
         show={databaseModalOpen}
-        onHide={() => setDatabaseModalOpen(false)}
+        onHide={handleDatabaseEditModal}
         onDatabaseAdd={() => {
           refreshData();
         }}

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
@@ -29,8 +29,8 @@ import { Tooltip } from 'src/components/Tooltip';
 import Icons from 'src/components/Icons';
 import ListView, { FilterOperator, Filters } from 'src/components/ListView';
 import { commonMenuData } from 'src/views/CRUD/data/common';
+import DatabaseModal from 'src/views/CRUD/data/database/DatabaseModal';
 import ImportModelsModal from 'src/components/ImportModal/index';
-import DatabaseModal from './databaseModal';
 import { DatabaseObject } from './types';
 
 const PAGE_SIZE = 25;

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm.tsx
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import cx from 'classnames';
+import { FormGroup, FormControl } from 'react-bootstrap';
+import FormLabel from 'src/components/Form/FormLabel';
+
+export const FormFieldOrder = [
+  'host',
+  'port',
+  'database',
+  'username',
+  'password',
+];
+
+const FORM_FIELD_MAP = {
+  host: {
+    description: 'Host',
+    type: 'text',
+    className: 'w-50',
+    placeholder: 'e.g. 127.0.0.1',
+  },
+  port: {
+    description: 'Port',
+    type: 'text',
+    className: 'w-50',
+    placeholder: 'e.g. 5432',
+  },
+  database: {
+    description: 'Database name',
+    type: 'text',
+    label:
+      'Copy the name of the PostgreSQL database you are trying to connect to.',
+    placeholder: 'e.g. world_population',
+  },
+  username: {
+    description: 'Username',
+    type: 'text',
+    placeholder: 'e.g. Analytics',
+  },
+  password: {
+    description: 'Password',
+    type: 'text',
+    placeholder: 'e.g. ********',
+  },
+  query: {
+    additionalProperties: {},
+    description: 'Additional parameters',
+    type: 'object',
+  },
+};
+
+const DatabaseConnectionForm = ({
+  field,
+  required,
+}: {
+  field: string;
+  required: boolean;
+}) => {
+  const inputObj = FORM_FIELD_MAP[field];
+  return (
+    <FormGroup
+      className={cx(inputObj.className && `form-group-${inputObj.className}`)}
+    >
+      <FormLabel htmlFor={field} required={required}>
+        {inputObj.description}
+      </FormLabel>
+      <FormControl
+        type={inputObj.text}
+        id={field}
+        bsSize="sm"
+        autoComplete="off"
+        onChange={() => {}}
+        placeholder={inputObj.placeholder}
+      />
+      <p className="helper">{inputObj.label}</p>
+    </FormGroup>
+  );
+};
+
+export const FormFieldMap = FORM_FIELD_MAP;
+
+export default DatabaseConnectionForm;

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/SqlAlchemyForm.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/SqlAlchemyForm.tsx
@@ -71,15 +71,15 @@ const SqlAlchemyTab = ({
         />
       </div>
       <div className="helper">
-        {t('Refer to the ')}
+        {t('Refer to the')}{' '}
         <a
           href={conf?.SQLALCHEMY_DOCS_URL ?? ''}
           target="_blank"
           rel="noopener noreferrer"
         >
           {conf?.SQLALCHEMY_DISPLAY_TEXT ?? ''}
-        </a>
-        {t(' for more information on how to structure your URI.')}
+        </a>{' '}
+        {t('for more information on how to structure your URI.')}
       </div>
     </StyledInputContainer>
     <Button

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
@@ -28,6 +28,23 @@ const EXPOSE_ALL_FORM_HEIGHT = EXPOSE_IN_SQLLAB_FORM_HEIGHT + 102;
 
 const anticonHeight = 12;
 
+export const StyledFormHeader = styled.header`
+  border-bottom: ${({ theme }) => `${theme.gridUnit * 0.25}px solid
+    ${theme.colors.grayscale.light2};`}
+  padding-left: ${({ theme }) => theme.gridUnit * 4}px;
+  padding-right: ${({ theme }) => theme.gridUnit * 4}px;
+  margin-bottom: ${({ theme }) => theme.gridUnit * 4}px;
+  .helper {
+    color: ${({ theme }) => theme.colors.grayscale.base};
+    font-size: ${({ theme }) => theme.typography.sizes.s - 1}px;
+  }
+  h4 {
+    color: ${({ theme }) => theme.colors.grayscale.dark2};
+    font-weight: bold;
+    font-size: ${({ theme }) => theme.typography.sizes.l}px;
+  }
+`;
+
 export const StyledModal = styled(Modal)`
   .ant-collapse {
     .ant-collapse-header {
@@ -81,6 +98,43 @@ export const StyledModal = styled(Modal)`
   }
   .ant-modal-title > h4 {
     font-weight: bold;
+  }
+`;
+export const StyledFormModal = styled(Modal)`
+  .ant-modal-body {
+    padding-left: 0;
+    padding-right: 0;
+  }
+`;
+export const StyledForm = styled.div`
+  overflow-y: scroll;
+  padding-left: ${({ theme }) => theme.gridUnit * 4}px;
+  padding-right: ${({ theme }) => theme.gridUnit * 4}px;
+  .form-group {
+    margin-bottom: ${({ theme }) => theme.gridUnit * 8}px;
+    &-w-50 {
+      display: inline-block;
+      width: ${({ theme }) => `calc(50% - ${theme.gridUnit * 4}px)`};
+      & + .form-group-w-50 {
+        margin-left: ${({ theme }) => theme.gridUnit * 8}px;
+      }
+    }
+    .text-danger {
+      color: ${({ theme }) => theme.colors.error.base};
+      font-size: ${({ theme }) => theme.typography.sizes.s - 1}px;
+      strong {
+        font-weight: normal;
+      }
+    }
+  }
+  .control-label {
+    color: ${({ theme }) => theme.colors.grayscale.dark1};
+    font-size: ${({ theme }) => theme.typography.sizes.s - 1}px;
+  }
+  .helper {
+    color: ${({ theme }) => theme.colors.grayscale.light1};
+    font-size: ${({ theme }) => theme.typography.sizes.s - 1}px;
+    margin-top: ${({ theme }) => theme.gridUnit * 1.5}px;
   }
 `;
 

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -18,7 +18,7 @@
  */
 import rison from 'rison';
 import { useState, useEffect, useCallback } from 'react';
-import { makeApi, SupersetClient, t } from '@superset-ui/core';
+import { makeApi, SupersetClient, t, JsonObject } from '@superset-ui/core';
 
 import { createErrorHandler } from 'src/views/CRUD/utils';
 import { FetchDataConfig } from 'src/components/ListView';
@@ -643,3 +643,17 @@ export const testDatabaseConnection = (
     }),
   );
 };
+
+export function useAvailableDatabases() {
+  const [availableDbs, setAvailableDbs] = useState<JsonObject | null>(null);
+
+  const getAvailable = useCallback(() => {
+    SupersetClient.get({
+      endpoint: `/api/v1/database/available`,
+    }).then(({ json }) => {
+      setAvailableDbs(json);
+    });
+  }, [setAvailableDbs]);
+
+  return [availableDbs, getAvailable] as const;
+}


### PR DESCRIPTION
### SUMMARY
This PR adds the functionality of calling databases/available api to get a list of databases that have drivers loaded and available to use. The form is built dynamically based on that information. This is currently behind a local flag, and there are no visual changes, but the piece in development is as shown below. More work is needed to hook the form up to the api on connect/save, but I'm merging often to reduce any rebasing issues and also keep PRs small.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
This is behind a local flag `useSqlAlchemyForm` which is set to 'false'
<img width="529" alt="_DEV__Superset" src="https://user-images.githubusercontent.com/5186919/116950067-d2d12500-ac38-11eb-80af-3ed519b72424.png">


### TEST PLAN
visual changes only right now, so all existing tests should pass

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
