### PR TITLE
fix: Ignore database extra fields when saving

### DIFF
--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -21,7 +21,7 @@ from typing import Any, Dict
 
 from flask import current_app
 from flask_babel import lazy_gettext as _
-from marshmallow import fields, pre_load, Schema, validates_schema
+from marshmallow import EXCLUDE, fields, pre_load, Schema, validates_schema
 from marshmallow.validate import Length, ValidationError
 from sqlalchemy import MetaData
 from sqlalchemy.engine.url import make_url
@@ -275,6 +275,9 @@ class DatabaseParametersSchemaMixin:
 
 
 class DatabasePostSchema(Schema, DatabaseParametersSchemaMixin):
+    class Meta:  # pylint: disable=too-few-public-methods
+        unknown = EXCLUDE
+
     database_name = fields.String(
         description=database_name_description, required=True, validate=Length(1, 250),
     )
@@ -314,6 +317,9 @@ class DatabasePostSchema(Schema, DatabaseParametersSchemaMixin):
 
 
 class DatabasePutSchema(Schema, DatabaseParametersSchemaMixin):
+    class Meta:  # pylint: disable=too-few-public-methods
+        unknown = EXCLUDE
+
     database_name = fields.String(
         description=database_name_description, allow_none=True, validate=Length(1, 250),
     )


### PR DESCRIPTION
### SUMMARY
Ignore database extra fields when saving. This is a fix for a regression that prevented the saving of databases or the creation of new ones. The client is sending more data than it should, and this fix ignores this extra data for now. We should definitely fix the client side to send only the necessary information to the API.

@eschutho I know that you are working on this modal. Can you make this modification? After that, you can undo this hotfix.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1169" alt="Screen Shot 2021-05-04 at 9 55 53 AM" src="https://user-images.githubusercontent.com/70410625/117042363-3f542e80-ace2-11eb-9249-81ad7f644b7b.png">

@rusackas @villebro @dpgaspar @junlincc @eschutho 

### TEST PLAN
1 - Execute all tests
2 - All tests should pass

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
