### PR TITLE
fix: dashboard datasources filter None

### DIFF
--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -171,7 +171,7 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
 
     @property
     def datasources(self) -> Set[BaseDatasource]:
-        return {slc.datasource for slc in self.slices}
+        return {slc.datasource for slc in self.slices if slc.datasource}
 
     @property
     def charts(self) -> List[BaseDatasource]:

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -100,7 +100,7 @@ class Slice(
         return ConnectorRegistry.sources[self.datasource_type]
 
     @property
-    def datasource(self) -> "BaseDatasource":
+    def datasource(self) -> Optional["BaseDatasource"]:
         return self.get_datasource
 
     def clone(self) -> "Slice":
@@ -160,8 +160,9 @@ class Slice(
     def viz(self) -> Optional[BaseViz]:
         form_data = json.loads(self.params)
         viz_class = viz_types.get(self.viz_type)
-        if viz_class:
-            return viz_class(datasource=self.datasource, form_data=form_data)
+        datasource = self.datasource
+        if viz_class and datasource:
+            return viz_class(datasource=datasource, form_data=form_data)
         return None
 
     @property

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -462,6 +462,10 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         form_data, slc = get_form_data(slice_id, use_slice_data=True)
         if not slc:
             return json_error_response("The slice does not exist")
+
+        if not slc.datasource:
+            return json_error_response("The slice's datasource does not exist")
+
         try:
             viz_obj = get_viz(
                 datasource_type=slc.datasource.type,
@@ -1708,6 +1712,9 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
                         if extra_filters
                         else get_dashboard_extra_filters(slc.id, dashboard_id)
                     )
+
+                if not slc.datasource:
+                    raise Exception("Slice's datasource does not exist")
 
                 obj = get_viz(
                     datasource_type=slc.datasource.type,

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -290,7 +290,7 @@ def get_time_range_endpoints(
             if not slc:
                 slc = db.session.query(Slice).filter_by(id=slice_id).one_or_none()
 
-            if slc:
+            if slc and slc.datasource:
                 endpoints = slc.datasource.database.get_extra().get(
                     "time_range_endpoints"
                 )
@@ -533,7 +533,7 @@ def check_slice_perms(_self: Any, slice_id: int) -> None:
 
     form_data, slc = get_form_data(slice_id, use_slice_data=True)
 
-    if slc:
+    if slc and slc.datasource:
         try:
             viz_obj = get_viz(
                 datasource_type=slc.datasource.type,


### PR DESCRIPTION
### SUMMARY
Mypy types led me astray and proved that `dashboard.datasources` was actually a `Set[Optional[BaseDatasource]]`. I've updated logic to filter out None datasources for dashboards, updated the types to be correct, and handle `slice.datasource == None` throughout the app

### TEST PLAN
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @villebro @john-bodley @graceguo-supercat @ktmud @suddjian 