### PR TITLE
fix: Explore layout is sometimes too short for the viewport

### DIFF
--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -85,6 +85,7 @@ const Styles = styled.div`
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
+  flex-basis: 100vh;
   align-items: stretch;
   border-top: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
   .explore-column {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Flex layout in the explore section _usually_ looks OK, but when things are in an error state, and all three columns are shorter than the viewport, that means the whole _layout_ can get too short, making a weird gap under the menu. This sets a `flex-basis` property that's *plenty* tall (the entire viewport) to take up the space, and then flexbox will shrink things as needed.

Issue reported by @srinify

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![problem2](https://user-images.githubusercontent.com/812905/117107956-56713b80-ad37-11eb-9acc-0b288ea1c114.gif)

After:
![solution](https://user-images.githubusercontent.com/812905/117107968-5a9d5900-ad37-11eb-9b72-a6c9e37c7433.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Select a dataset without too many fields (so the list is short)
Find a viz with a sufficiently short control panel (either tab in the control panel, as seen in the gifs above)
Put the chart in an error state so it loses its height.
Witness the layout shift at the top (or... hopefully not).

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
