### PR TITLE
fix(annotations): pass force param to annotation request

### DIFF
--- a/superset-frontend/src/chart/chartAction.js
+++ b/superset-frontend/src/chart/chartAction.js
@@ -248,6 +248,7 @@ export function runAnnotationQuery(
   formData = null,
   key,
   isDashboardRequest = false,
+  force = false,
 ) {
   return function (dispatch, getState) {
     const sliceKey = key || Object.keys(getState().charts)[0];
@@ -286,7 +287,12 @@ export function runAnnotationQuery(
     }
 
     const isNative = annotation.sourceType === ANNOTATION_SOURCE_TYPES.NATIVE;
-    const url = getAnnotationJsonUrl(annotation.value, sliceFormData, isNative);
+    const url = getAnnotationJsonUrl(
+      annotation.value,
+      sliceFormData,
+      isNative,
+      force,
+    );
     const controller = new AbortController();
     const { signal } = controller;
 
@@ -462,7 +468,14 @@ export function exploreJSON(
       dispatch(updateQueryFormData(formData, key)),
       ...annotationLayers.map(x =>
         dispatch(
-          runAnnotationQuery(x, timeout, formData, key, isDashboardRequest),
+          runAnnotationQuery(
+            x,
+            timeout,
+            formData,
+            key,
+            isDashboardRequest,
+            force,
+          ),
         ),
       ),
     ]);

--- a/superset-frontend/src/explore/exploreUtils/index.js
+++ b/superset-frontend/src/explore/exploreUtils/index.js
@@ -57,7 +57,7 @@ export function getHostName(allowDomainSharding = false) {
   return availableDomains[currentIndex];
 }
 
-export function getAnnotationJsonUrl(slice_id, form_data, isNative) {
+export function getAnnotationJsonUrl(slice_id, form_data, isNative, force) {
   if (slice_id === null || slice_id === undefined) {
     return null;
   }
@@ -69,6 +69,7 @@ export function getAnnotationJsonUrl(slice_id, form_data, isNative) {
       form_data: safeStringify(form_data, (key, value) =>
         value === null ? undefined : value,
       ),
+      force,
     })
     .toString();
 }

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1681,3 +1681,35 @@ def normalize_dttm_col(
         df[DTTM_ALIAS] += timedelta(hours=offset)
     if time_shift is not None:
         df[DTTM_ALIAS] += time_shift
+
+
+def parse_boolean_string(bool_str: Optional[str]) -> bool:
+    """
+    Convert a string representation of a true/false value into a boolean
+
+    >>> parse_boolean_string(None)
+    False
+    >>> parse_boolean_string('false')
+    False
+    >>> parse_boolean_string('true')
+    True
+    >>> parse_boolean_string('False')
+    False
+    >>> parse_boolean_string('True')
+    True
+    >>> parse_boolean_string('foo')
+    False
+    >>> parse_boolean_string('0')
+    False
+    >>> parse_boolean_string('1')
+    True
+
+    :param bool_str: string representation of a value that is assumed to be boolean
+    :return: parsed boolean value
+    """
+    if bool_str is None:
+        return False
+    try:
+        return bool(strtobool(bool_str.lower()))
+    except ValueError:
+        return False

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -19,6 +19,7 @@ import logging
 import re
 from contextlib import closing
 from datetime import datetime, timedelta
+from distutils.util import strtobool
 from typing import Any, Callable, cast, Dict, List, Optional, Union
 from urllib import parse
 
@@ -485,7 +486,14 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         self, layer_id: int
     ) -> FlaskResponse:
         form_data = get_form_data()[0]
-        force = request.args.get("force") == "true"
+        force_arg = request.args.get("force", "false")
+        try:
+            force = strtobool(force_arg.lower())
+        except ValueError:
+            return json_error_response(
+                _("Invalid boolean value: %(force)", force=force_arg), 400
+            )
+
         form_data["layer_id"] = layer_id
         form_data["filters"] = [{"col": "layer_id", "op": "==", "val": layer_id}]
         # Set all_columns to ensure the TableViz returns the necessary columns to the

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -19,7 +19,6 @@ import logging
 import re
 from contextlib import closing
 from datetime import datetime, timedelta
-from distutils.util import strtobool
 from typing import Any, Callable, cast, Dict, List, Optional, Union
 from urllib import parse
 
@@ -486,13 +485,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         self, layer_id: int
     ) -> FlaskResponse:
         form_data = get_form_data()[0]
-        force_arg = request.args.get("force", "false")
-        try:
-            force = strtobool(force_arg.lower())
-        except ValueError:
-            return json_error_response(
-                _("Invalid boolean value: %(force)", force=force_arg), 400
-            )
+        force = utils.parse_boolean_string(request.args.get("force"))
 
         form_data["layer_id"] = layer_id
         form_data["filters"] = [{"col": "layer_id", "op": "==", "val": layer_id}]

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -485,6 +485,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         self, layer_id: int
     ) -> FlaskResponse:
         form_data = get_form_data()[0]
+        force = request.args.get("force") == "true"
         form_data["layer_id"] = layer_id
         form_data["filters"] = [{"col": "layer_id", "op": "==", "val": layer_id}]
         # Set all_columns to ensure the TableViz returns the necessary columns to the
@@ -503,7 +504,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             "changed_by_fk",
         ]
         datasource = AnnotationDatasource()
-        viz_obj = viz.viz_types["table"](datasource, form_data=form_data, force=False)
+        viz_obj = viz.viz_types["table"](datasource, form_data=form_data, force=force)
         payload = viz_obj.get_payload()
         return data_payload_response(*viz_obj.payload_json_and_has_error(payload))
 


### PR DESCRIPTION
### SUMMARY
Currently force refreshing a chart will always return cached results for annotations in the legacy timeseries charts. This PR force refreshes the annotation data when calling the legacy annotation endpoint with `force=true`.

### BEFORE
In this example an annotation range was cached with the range 2000-2005, and updated to 1995-2000. Force refreshing does nothing:
https://user-images.githubusercontent.com/33317356/117115243-86e7c280-ad95-11eb-9a3e-cd2b044f515a.mp4

### AFTER
With this PR, the annotation data is refreshed from the datasource:
https://user-images.githubusercontent.com/33317356/117115289-98c96580-ad95-11eb-9250-fe4aee5acbdf.mp4

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
