### PR TITLE
fix: make consistent DataMask for explore and dashboard

### DIFF
--- a/superset-frontend/src/chart/Chart.jsx
+++ b/superset-frontend/src/chart/Chart.jsx
@@ -64,6 +64,8 @@ const propTypes = {
   onFilterMenuOpen: PropTypes.func,
   onFilterMenuClose: PropTypes.func,
   ownState: PropTypes.object,
+  filterState: PropTypes.object,
+  extraFormData: PropTypes.object,
 };
 
 const BLANK = {};

--- a/superset-frontend/src/chart/ChartRenderer.jsx
+++ b/superset-frontend/src/chart/ChartRenderer.jsx
@@ -46,6 +46,8 @@ const propTypes = {
   onFilterMenuOpen: PropTypes.func,
   onFilterMenuClose: PropTypes.func,
   ownState: PropTypes.object,
+  filterState: PropTypes.object,
+  extraFormData: PropTypes.object,
 };
 
 const BLANK = {};
@@ -187,6 +189,7 @@ class ChartRenderer extends React.Component {
       initialValues,
       ownState,
       filterState,
+      extraFormData,
       formData,
       queriesResponse,
     } = this.props;
@@ -228,6 +231,7 @@ class ChartRenderer extends React.Component {
         formData={formData}
         ownState={ownState}
         filterState={filterState}
+        extraFormData={extraFormData}
         hooks={this.hooks}
         behaviors={[Behavior.INTERACTIVE_CHART]}
         queriesData={queriesResponse}

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -72,6 +72,7 @@ const propTypes = {
   addDangerToast: PropTypes.func.isRequired,
   ownState: PropTypes.object,
   filterState: PropTypes.object,
+  extraFormData: PropTypes.object,
 };
 
 const defaultProps = {

--- a/superset-frontend/src/dashboard/containers/Chart.jsx
+++ b/superset-frontend/src/dashboard/containers/Chart.jsx
@@ -89,6 +89,7 @@ function mapStateToProps(
     sliceCanEdit: !!dashboardInfo.slice_can_edit,
     ownState: dataMask[id]?.ownState,
     filterState: dataMask[id]?.filterState,
+    extraFormData: dataMask[id]?.extraFormData,
   };
 }
 

--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -48,6 +48,8 @@ const propTypes = {
   vizType: PropTypes.string.isRequired,
   form_data: PropTypes.object,
   ownState: PropTypes.object,
+  filterState: PropTypes.object,
+  extraFormData: PropTypes.object,
   standalone: PropTypes.number,
   timeout: PropTypes.number,
   refreshOverlayVisible: PropTypes.bool,
@@ -191,6 +193,8 @@ const ExploreChartPanel = props => {
           width={Math.floor(chartWidth)}
           height={newHeight}
           ownState={props.ownState}
+          filterState={props.filterState}
+          extraFormData={props.extraFormData}
           annotationData={chart.annotationData}
           chartAlert={chart.chartAlert}
           chartStackTrace={chart.chartStackTrace}

--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -590,6 +590,8 @@ function mapStateToProps(state) {
     chart,
     timeout: explore.common.conf.SUPERSET_WEBSERVER_TIMEOUT,
     ownState: dataMask[form_data.slice_id]?.ownState,
+    filterState: dataMask[form_data.slice_id]?.filterState,
+    extraFormData: dataMask[form_data.slice_id]?.extraFormData,
     impressionId,
   };
 }


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There are inconsistent DataMask properties(filterState, ownState, extraDataMask) for Explore and Dashboard. For consistency and drilldown(new feature), these properties need to be made consistent.

I will also open an associated PR in superset-ui repo.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
