### PR TITLE
fix: set table name width to not hide icons when name is too long

### DIFF
--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -414,6 +414,7 @@ div.tablePopover {
     display: flex;
     flex: 1;
     align-items: center;
+    width: 100%;
 
     .table-name {
       white-space: nowrap;
@@ -421,7 +422,6 @@ div.tablePopover {
       text-overflow: ellipsis;
       font-size: 16px;
       flex: 1;
-      width: 50px;
     }
 
     .header-right-side {

--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -421,6 +421,7 @@ div.tablePopover {
       text-overflow: ellipsis;
       font-size: 16px;
       flex: 1;
+      width: 50px;
     }
 
     .header-right-side {


### PR DESCRIPTION
### SUMMARY
set table name width to not hide icons when name is too long
resolves: #13889
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![Screen Shot 2021-05-06 at 14 11 19](https://user-images.githubusercontent.com/5047207/117289178-f97b9f80-ae74-11eb-9d1e-fa5e1b8d6a18.png)
After:
![Screen Shot 2021-05-06 at 14 10 42](https://user-images.githubusercontent.com/5047207/117289196-fe405380-ae74-11eb-92a5-ca33c8c38f65.png)
### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
