### PR TITLE
fix: Fix #13831

### DIFF
--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
@@ -23,7 +23,7 @@ import { FormGroup } from 'react-bootstrap';
 import Tabs from 'src/components/Tabs';
 import Button from 'src/components/Button';
 import { NativeSelect as Select } from 'src/components/Select';
-import { t } from '@superset-ui/core';
+import { t, styled } from '@superset-ui/core';
 
 import FormLabel from 'src/components/FormLabel';
 import { SQLEditor } from 'src/components/AsyncAceEditor';
@@ -58,6 +58,18 @@ const defaultProps = {
   columns: [],
   getCurrentTab: noOp,
 };
+
+const StyledSelect = styled(Select)`
+  .metric-option {
+    & > svg {
+      min-width: ${({ theme }) => `${theme.gridUnit * 4}px`};
+    }
+    & > .option-label {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+`;
 
 export const SAVED_TAB_KEY = 'SAVED';
 
@@ -344,7 +356,7 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
               <FormLabel>
                 <strong>{t('Saved metric')}</strong>
               </FormLabel>
-              <Select
+              <StyledSelect
                 {...savedSelectProps}
                 name="select-saved"
                 getPopupContainer={triggerNode => triggerNode.parentNode}
@@ -361,7 +373,7 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
                       <StyledMetricOption metric={savedMetric} showType />
                     </Select.Option>
                   ))}
-              </Select>
+              </StyledSelect>
             </FormGroup>
           </Tabs.TabPane>
           <Tabs.TabPane key={EXPRESSION_TYPES.SIMPLE} tab={t('Simple')}>


### PR DESCRIPTION
### SUMMARY
Closes #13831.

@junlincc @zuzana-vej @rusackas 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Check #13831 for before screenshots.

<img width="356" alt="Screen Shot 2021-05-05 at 11 15 04 AM" src="https://user-images.githubusercontent.com/70410625/117155895-8f3efe00-ad93-11eb-92fb-3b48cb2a79b0.png">
<img width="520" alt="Screen Shot 2021-05-05 at 11 15 18 AM" src="https://user-images.githubusercontent.com/70410625/117155899-9108c180-ad93-11eb-8b92-7a265a094fc9.png">

### TEST PLAN
1 - Try to select a certified saved metric with a big name
2 - Check that the icon appears and the text has an ellipsis

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
