### PR TITLE
feat(explore): collapse time section if no ts columns

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
@@ -111,7 +111,7 @@ describe('VizType control', () => {
     // should load mathjs for line chart
     cy.get('script[src*="mathjs"]').should('have.length', 1);
     cy.get('script').then(nodes => {
-      expect(nodes.length).to.eq(numScripts);
+      expect(nodes.length).to.greaterThan(numScripts);
     });
 
     cy.get('button[data-test="run-query-button"]').click();

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -124,7 +124,7 @@ const hasTimeColumn = (datasource: DatasourceMeta): boolean =>
 const sectionsToExpand = (
   sections: ControlPanelSectionConfig[],
   datasource: DatasourceMeta,
-) =>
+): string[] =>
   // avoid expanding time section if datasource doesn't include time column
   sections.reduce(
     (acc, section) =>


### PR DESCRIPTION
### SUMMARY
This is a follow-up of #12093 , which aims to automatically hide/expand the time section based on presence of temporal columns in the dataset.

Previously the `ControlPanelsContainer` component was using the `defaultActiveKey` prop in `Collapse` to control which panels were active. To be able to make the panels collapse automatically when we change datasources to one with/without temporal columns, we have to switch to `activeKey` and manage the state within the component. To do this some code had to be moved out of the render method, but the majority of the logic is untouched.

Previous flow:
- Time section is always expanded by default, but possible to collapse/expand manually
- Changing to a datasource without any temporal columns did not collapse the time section.

New flow:
- By default the time section opens up in a collapsed state if there is no temporal column in the dataset
- Time section can still be manually expanded/collapsed manually like before
- By changing to a dataset with (without) at least one temporal column will cause the time section to expand (collapse) the time section.
- When changing viz type, the time section will be automatically expanded/collapsed based on the logic described above

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Previously the time section was always expanded, and changing the dataset to/from one with/without any temporal columns didn't change anything:
https://user-images.githubusercontent.com/33317356/117162820-ca5d2380-adcb-11eb-923d-d1281668f5a0.mp4

### AFTER
Now the time section is automatically expanded/collapsed when changing to a dataset with/without a temporal column.
https://user-images.githubusercontent.com/33317356/117162867-d2b55e80-adcb-11eb-9dae-3f26fcaf9e45.mp4

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
