### PR TITLE
refactor(utils): replace strtobool with parse_boolean_string

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -29,7 +29,6 @@ import re
 import sys
 from collections import OrderedDict
 from datetime import date
-from distutils.util import strtobool
 from typing import Any, Callable, Dict, List, Optional, Type, TYPE_CHECKING, Union
 
 from cachelib.base import BaseCache
@@ -44,7 +43,7 @@ from superset.jinja_context import (  # pylint: disable=unused-import
 )
 from superset.stats_logger import DummyStatsLogger
 from superset.typing import CacheConfig
-from superset.utils.core import is_test
+from superset.utils.core import is_test, parse_boolean_string
 from superset.utils.encrypt import SQLAlchemyUtilsAdapter
 from superset.utils.log import DBEventLogger
 from superset.utils.logging_configurator import DefaultLoggingConfigurator
@@ -388,7 +387,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
 # Feature flags may also be set via 'SUPERSET_FEATURE_' prefixed environment vars.
 DEFAULT_FEATURE_FLAGS.update(
     {
-        k[len("SUPERSET_FEATURE_") :]: bool(strtobool(v))
+        k[len("SUPERSET_FEATURE_") :]: parse_boolean_string(v)
         for k, v in os.environ.items()
         if re.search(r"^SUPERSET_FEATURE_\w+", k)
     }

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -17,7 +17,6 @@
 import json
 import logging
 from datetime import datetime
-from distutils.util import strtobool
 from io import BytesIO
 from typing import Any
 from zipfile import is_zipfile, ZipFile
@@ -62,6 +61,7 @@ from superset.datasets.schemas import (
     get_delete_ids_schema,
     get_export_ids_schema,
 )
+from superset.utils.core import parse_boolean_string
 from superset.views.base import DatasourceFilter, generate_download_headers
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
@@ -302,7 +302,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
               $ref: '#/components/responses/500'
         """
         override_columns = (
-            bool(strtobool(request.args["override_columns"]))
+            parse_boolean_string(request.args["override_columns"])
             if "override_columns" in request.args
             else False
         )


### PR DESCRIPTION
### SUMMARY
When adding some boolean string parsing for #14483 , I figured we could use this in all places where `distutils.util.strtobool` is used to pick up some variations that `strtobool` can't handle, like upper/mixedcase.

This is the new util:
https://github.com/apache/superset/blob/68058b0ad968a96abac65855ac1cc6cc327786e8/superset/utils/core.py#L1686-L1715

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
