### PR TITLE
fix: White space between Chart and Data panel in Explore

### DIFF
--- a/superset-frontend/src/explore/components/DataTablesPane/index.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/index.tsx
@@ -93,6 +93,7 @@ const CollapseWrapper = styled.div`
         height: calc(100% - ${({ theme }) => theme.gridUnit * 8}px);
 
         .ant-collapse-content-box {
+          padding-top: 0;
           height: 100%;
         }
       }

--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -254,7 +254,7 @@ const ExploreChartPanel = props => {
   );
 
   const elementStyle = (dimension, elementSize, gutterSize) => ({
-    [dimension]: `calc(${elementSize}% - ${gutterSize + gutterMargin}px)`,
+    [dimension]: `calc(${elementSize}% - ${(gutterSize + gutterMargin) * 3}px)`,
   });
 
   return (

--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -58,7 +58,8 @@ const propTypes = {
 
 const GUTTER_SIZE_FACTOR = 1.25;
 
-const CHART_PANEL_PADDING = 30;
+const CHART_PANEL_PADDING_HORIZ = 30;
+const CHART_PANEL_PADDING_VERTICAL = 15;
 const HEADER_PADDING = 15;
 
 const STORAGE_KEYS = {
@@ -183,8 +184,9 @@ const ExploreChartPanel = props => {
 
   const renderChart = useCallback(() => {
     const { chart } = props;
-    const newHeight = calcSectionHeight(splitSizes[0]) - CHART_PANEL_PADDING;
-    const chartWidth = chartPanelWidth - CHART_PANEL_PADDING;
+    const newHeight =
+      calcSectionHeight(splitSizes[0]) - CHART_PANEL_PADDING_VERTICAL;
+    const chartWidth = chartPanelWidth - CHART_PANEL_PADDING_HORIZ;
     return (
       chartWidth > 0 && (
         <ChartContainer
@@ -254,7 +256,7 @@ const ExploreChartPanel = props => {
   );
 
   const elementStyle = (dimension, elementSize, gutterSize) => ({
-    [dimension]: `calc(${elementSize}% - ${(gutterSize + gutterMargin) * 3}px)`,
+    [dimension]: `calc(${elementSize}% - ${gutterSize + gutterMargin}px)`,
   });
 
   return (


### PR DESCRIPTION
### SUMMARY
Fixes #12707

### BEFORE
<img width="1063" alt="before_heatmap" src="https://user-images.githubusercontent.com/60598000/117173382-5fb0e580-add5-11eb-8594-1a44c1fb34af.png">

### AFTER
<img width="1066" alt="after_heatmap" src="https://user-images.githubusercontent.com/60598000/117173069-106ab500-add5-11eb-986d-b573526a00aa.png">


### TEST PLAN
1. Open a chart in Explore
2. Observe the white space between the chart and the data panel
3. Observe the white space between the Data panel title and the Data panel tabs
<img width="1063" alt="before_heatmap" src="https://user-images.githubusercontent.com/60598000/117173307-4f006f80-add5-11eb-918d-3c77ae6e72c0.png">


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #12707
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
