### PR TITLE
chore: Removes tabs pane animation by default

### DIFF
--- a/superset-frontend/spec/javascripts/dashboard/components/DashboardBuilder_spec.jsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/DashboardBuilder_spec.jsx
@@ -131,7 +131,7 @@ describe('DashboardBuilder', () => {
   it('should set animated=true on Tabs for perf', () => {
     const wrapper = setup({ dashboardLayout: undoableDashboardLayoutWithTabs });
     const tabProps = wrapper.find(ParentSize).find(Tabs).props();
-    expect(tabProps.animated).toBe(true);
+    expect(tabProps.animated).toEqual({ inkBar: true, tabPane: false });
   });
 
   it('should render a TabPane and DashboardGrid for first Tab', () => {

--- a/superset-frontend/src/components/Tabs/Tabs.tsx
+++ b/superset-frontend/src/components/Tabs/Tabs.tsx
@@ -104,7 +104,7 @@ const Tabs = Object.assign(StyledTabs, {
 
 Tabs.defaultProps = {
   fullWidth: true,
-  animated: true,
+  animated: { inkBar: true, tabPane: false },
 };
 
 const StyledEditableTabs = styled(StyledTabs)`
@@ -138,6 +138,7 @@ export const EditableTabs = Object.assign(StyledEditableTabs, {
 EditableTabs.defaultProps = {
   type: 'editable-card',
   fullWidth: false,
+  animated: { inkBar: true, tabPane: false },
 };
 
 EditableTabs.TabPane.defaultProps = {


### PR DESCRIPTION
### SUMMARY
Removes tabs pane animation by default. Keeps the animation of the ink bar. Some screens were presenting weird behaviour because of the animations.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/70410625/117181849-084a4f80-adac-11eb-9067-caba01b4a635.mov

https://user-images.githubusercontent.com/70410625/117181951-2617b480-adac-11eb-8800-8f4bf8f5d099.mov

@rusackas @pkdotson 

### TEST PLAN
All tabs should have only ink bar animation by default.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
