### PR TITLE
fix: Query History

### DIFF
--- a/superset-frontend/src/SqlLab/components/SouthPane/SouthPane.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/SouthPane.tsx
@@ -168,6 +168,7 @@ export default function SouthPane({
         onChange={switchTab}
         id={shortid.generate()}
         fullWidth={false}
+        animated={false}
       >
         <Tabs.TabPane tab={t('Results')} key="Results">
           {renderResults()}

--- a/superset-frontend/src/components/Tabs/Tabs.tsx
+++ b/superset-frontend/src/components/Tabs/Tabs.tsx
@@ -104,7 +104,7 @@ const Tabs = Object.assign(StyledTabs, {
 
 Tabs.defaultProps = {
   fullWidth: true,
-  animated: true,
+  animated: false,
 };
 
 const StyledEditableTabs = styled(StyledTabs)`

--- a/superset-frontend/src/components/Tabs/Tabs.tsx
+++ b/superset-frontend/src/components/Tabs/Tabs.tsx
@@ -104,7 +104,7 @@ const Tabs = Object.assign(StyledTabs, {
 
 Tabs.defaultProps = {
   fullWidth: true,
-  animated: false,
+  animated: true,
 };
 
 const StyledEditableTabs = styled(StyledTabs)`


### PR DESCRIPTION
### SUMMARY
Query History Tab in SQL Lab was animated which gives it a margin-left of -100%

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/48933336/117198414-0043dd00-adb7-11eb-8c05-4d5e676ee0da.mov

AFter:
<img width="973" alt="Screen Shot 2021-05-05 at 3 32 01 PM" src="https://user-images.githubusercontent.com/48933336/117198462-0e91f900-adb7-11eb-9647-97bd349f17b1.png">


### TEST PLAN
Visual Test
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
