### PR TITLE
fix: OrderDate is a bad reference

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -996,17 +996,17 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
         need_groupby = bool(metrics is not None or groupby)
         metrics = metrics or []
 
+        metrics_by_name: Dict[str, SqlMetric] = {m.metric_name: m for m in self.metrics}
+        columns_by_name: Dict[str, TableColumn] = {
+            col.column_name: col for col in self.columns
+        }
+
         # For backward compatibility
-        if granularity not in self.dttm_cols:
+        if granularity not in self.dttm_cols and granularity in columns_by_name:
             granularity = self.main_dttm_col
 
         # Database spec supports join-free timeslot grouping
         time_groupby_inline = db_engine_spec.time_groupby_inline
-
-        columns_by_name: Dict[str, TableColumn] = {
-            col.column_name: col for col in self.columns
-        }
-        metrics_by_name: Dict[str, SqlMetric] = {m.metric_name: m for m in self.metrics}
 
         if not granularity and is_timeseries:
             raise QueryObjectValidationError(

--- a/superset/examples/configs/datasets/examples/cleaned_sales_data.yaml
+++ b/superset/examples/configs/datasets/examples/cleaned_sales_data.yaml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 table_name: cleaned_sales_data
-main_dttm_col: OrderDate
+main_dttm_col: order_date
 description: null
 default_endpoint: null
 offset: 0


### PR DESCRIPTION
Creating this as pointer to an issue. 

To reproduce:
<img width="618" alt="Screen Shot 2021-05-05 at 3 11 41 PM" src="https://user-images.githubusercontent.com/487433/117216211-421f5400-adb4-11eb-8005-800895c378ea.png">

Bug:
<img width="1275" alt="Screen Shot 2021-05-05 at 3 11 53 PM" src="https://user-images.githubusercontent.com/487433/117216230-49466200-adb4-11eb-99b6-851cc9b2bc60.png">

I think somewhere we need to make sure that the column exists if we're going to use it.

This field is a big of a legacy field in the sense that I don't think it can be set in the dataset editor.
