### PR TITLE
fix: disable pylint error breaking CI

### DIFF
--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -171,6 +171,7 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
 
     @property
     def datasources(self) -> Set[BaseDatasource]:
+        # pylint: disable=no-member
         return {slc.datasource for slc in self.slices if slc.datasource}
 
     @property

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -171,7 +171,7 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
 
     @property
     def datasources(self) -> Set[BaseDatasource]:
-        # pylint: disable=no-member
+        # pylint: disable=using-constant-test
         return {slc.datasource for slc in self.slices if slc.datasource}
 
     @property


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
CI is broken because of ` W0125: Using a conditional statement with a constant value (using-constant-test)` from pylint

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
