### PR TITLE
feat: Containerize WebSocket server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,33 @@ services:
     environment:
       CYPRESS_CONFIG: "${CYPRESS_CONFIG}"
 
+  superset-websocket:
+    container_name: superset_websocket
+    build: ./superset-websocket
+    image: superset-websocket
+    ports:
+      - 8080:8080
+    depends_on:
+      - redis
+    # Mount everything in superset-websocket into container and
+    # then exclude node_modules and dist with bogus volume mount.
+    # This is necessary because host and container need to have
+    # their own, separate versions of these files. .dockerignore
+    # does not seem to work when starting the service through
+    # docker-compose.
+    #
+    # For example, node_modules may contain libs with native bindings.
+    # Those bindings need to be compiled for each OS and the container
+    # OS is not necessarily the same as host OS.
+    volumes:
+      - ./superset-websocket:/home/superset-websocket
+      - /home/superset-websocket/node_modules
+      - /home/superset-websocket/dist
+    environment:
+      - PORT=8080
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+
   superset-init:
     image: *superset-image
     container_name: superset_init

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,7 @@ services:
       - PORT=8080
       - REDIS_HOST=redis
       - REDIS_PORT=6379
+      - REDIS_SSL=false
 
   superset-init:
     image: *superset-image

--- a/superset-websocket/.dockerignore
+++ b/superset-websocket/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/superset-websocket/.dockerignore
+++ b/superset-websocket/.dockerignore
@@ -1,2 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 node_modules/
 dist/

--- a/superset-websocket/Dockerfile
+++ b/superset-websocket/Dockerfile
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,35 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-**/__pycache__/
-**/.git
-**/.apache_superset.egg-info
-**/.github
-**/.mypy_cache
-**/.pytest_cache
-**/.tox
-**/.vscode
-**/.idea
-**/.coverage
-**/.DS_Store
-**/.eggs
-**/.python-version
-**/*.egg-info
-**/*.bak
-**/*.db
-**/*.pyc
-**/*.sqllite
-**/*.swp
-**/.terser-plugin-cache/
-**/.storybook/
-**/node_modules/
+FROM node:14.16.1
 
-tests/
-docs/
-install/
-superset-frontend/cypress-base/
-superset-frontend/coverage/
-superset/static/assets/
-superset-websocket/dist/
-venv
+WORKDIR /home/superset-websocket
+
+COPY . .
+
+RUN npm ci
+RUN npm run build
+
+CMD ["npm", "start"]


### PR DESCRIPTION
### SUMMARY

This adds Docker and `docker-compose` support for the websocket server.

### Notes

Since we support development both with and without Docker, we need to make sure that any `node_modules` and `dist` folders/files from the host machine are not copied into the container, those should be freshly installed/compiled. `.dockerignore` ensures that `COPY` commands in the Dockerfile will not carry those folders over when building the image with `docker build`. However, this did not seem to work when running the service with `docker-compose`. Instead, it works to mount fake volumes for those folders in the compose file. Since the compose file is for development, I think it's ok to go with this somewhat hacky solution (it seems to work fine).

### Try it out

For example, if you want to run superset via docker with async queries via websockets, you can:

1. Ensure you properly configure async queries (and whatever else) in `docker/pythonpath_dev/superset_config_docker.py`
2. Boot relevant superset services with docker-compose, e.g.,
    ```
     docker-compose up superset superset-websocket superset-worker
    ```

cc @robdiciuccio @stevenuray