### PR TITLE
fix: add action buttons to time series column popover 

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/BoundsControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/BoundsControl_spec.jsx
@@ -17,47 +17,37 @@
  * under the License.
  */
 import React from 'react';
-import sinon from 'sinon';
-import { styledMount as mount } from 'spec/helpers/theming';
+import { render, screen, waitFor } from 'spec/helpers/testing-library';
+import userEvent from '@testing-library/user-event';
 import BoundsControl from 'src/explore/components/controls/BoundsControl';
-import { Input } from 'src/common/components';
 
 const defaultProps = {
   name: 'y_axis_bounds',
   label: 'Bounds of the y axis',
-  onChange: sinon.spy(),
+  onChange: jest.fn(),
 };
 
-describe('BoundsControl', () => {
-  let wrapper;
+test('renders two inputs', () => {
+  render(<BoundsControl {...defaultProps} />);
+  expect(screen.getAllByRole('spinbutton')).toHaveLength(2);
+});
 
-  beforeEach(() => {
-    wrapper = mount(<BoundsControl {...defaultProps} />);
-  });
+test('receives null on non-numeric', async () => {
+  render(<BoundsControl {...defaultProps} />);
+  const minInput = screen.getAllByRole('spinbutton')[0];
+  userEvent.type(minInput, 'text');
+  await waitFor(() =>
+    expect(defaultProps.onChange).toHaveBeenCalledWith([null, null]),
+  );
+});
 
-  it('renders two Input', () => {
-    expect(wrapper.find(Input)).toHaveLength(2);
-  });
-
-  it('errors on non-numeric', () => {
-    wrapper
-      .find(Input)
-      .first()
-      .simulate('change', { target: { value: 's' } });
-    expect(defaultProps.onChange.calledWith([null, null])).toBe(true);
-    expect(defaultProps.onChange.getCall(0).args[1][0]).toContain(
-      'value should be numeric',
-    );
-  });
-  it('casts to numeric', () => {
-    wrapper
-      .find(Input)
-      .first()
-      .simulate('change', { target: { value: '1' } });
-    wrapper
-      .find(Input)
-      .last()
-      .simulate('change', { target: { value: '5' } });
-    expect(defaultProps.onChange.calledWith([1, 5])).toBe(true);
-  });
+test('calls onChange with correct values', async () => {
+  render(<BoundsControl {...defaultProps} />);
+  const minInput = screen.getAllByRole('spinbutton')[0];
+  const maxInput = screen.getAllByRole('spinbutton')[1];
+  userEvent.type(minInput, '1');
+  userEvent.type(maxInput, '2');
+  await waitFor(() =>
+    expect(defaultProps.onChange).toHaveBeenLastCalledWith([1, 2]),
+  );
 });

--- a/superset-frontend/src/common/components/index.tsx
+++ b/superset-frontend/src/common/components/index.tsx
@@ -18,7 +18,13 @@
  */
 import React from 'react';
 import { styled } from '@superset-ui/core';
-import { Dropdown, Menu as AntdMenu, Input as AntdInput, Skeleton } from 'antd';
+import {
+  Dropdown,
+  Menu as AntdMenu,
+  Input as AntdInput,
+  InputNumber as AntdInputNumber,
+  Skeleton,
+} from 'antd';
 import { DropDownProps } from 'antd/lib/dropdown';
 /*
   Antd is re-exported from here so we can override components with Emotion as needed.
@@ -36,7 +42,6 @@ export {
   Dropdown,
   Form,
   Empty,
-  InputNumber,
   Modal,
   Typography,
   Tree,
@@ -196,6 +201,11 @@ export const MainNav = Object.assign(StyledNav, {
 });
 
 export const Input = styled(AntdInput)`
+  border: 1px solid ${({ theme }) => theme.colors.secondary.light3};
+  border-radius: ${({ theme }) => theme.borderRadius}px;
+`;
+
+export const InputNumber = styled(AntdInputNumber)`
   border: 1px solid ${({ theme }) => theme.colors.secondary.light3};
   border-radius: ${({ theme }) => theme.borderRadius}px;
 `;

--- a/superset-frontend/src/explore/components/controls/BoundsControl.jsx
+++ b/superset-frontend/src/explore/components/controls/BoundsControl.jsx
@@ -18,9 +18,10 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Row, Col, Input } from 'src/common/components';
-import { t } from '@superset-ui/core';
-import ControlHeader from '../ControlHeader';
+import { InputNumber } from 'src/common/components';
+import { t, styled } from '@superset-ui/core';
+import { isEqual, debounce } from 'lodash';
+import ControlHeader from 'src/explore/components/ControlHeader';
 
 const propTypes = {
   onChange: PropTypes.func,
@@ -32,35 +33,63 @@ const defaultProps = {
   value: [null, null],
 };
 
+const StyledDiv = styled.div`
+  display: flex;
+`;
+
+const MinInput = styled(InputNumber)`
+  flex: 1;
+  margin-right: ${({ theme }) => theme.gridUnit}px;
+`;
+
+const MaxInput = styled(InputNumber)`
+  flex: 1;
+  margin-left: ${({ theme }) => theme.gridUnit}px;
+`;
+
 export default class BoundsControl extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       minMax: [
-        props.value[0] === null ? '' : props.value[0],
-        props.value[1] === null ? '' : props.value[1],
+        Number.isNaN(this.props.value[0]) ? '' : props.value[0],
+        Number.isNaN(this.props.value[1]) ? '' : props.value[1],
       ],
     };
-    this.onChange = this.onChange.bind(this);
+    this.onChange = debounce(this.onChange.bind(this), 300);
     this.onMinChange = this.onMinChange.bind(this);
     this.onMaxChange = this.onMaxChange.bind(this);
+    this.update = this.update.bind(this);
   }
 
-  onMinChange(event) {
-    const min = event.target.value;
+  componentDidUpdate(prevProps) {
+    if (!isEqual(prevProps.value, this.props.value)) {
+      this.update();
+    }
+  }
+
+  update() {
+    this.setState({
+      minMax: [
+        Number.isNaN(this.props.value[0]) ? '' : this.props.value[0],
+        Number.isNaN(this.props.value[1]) ? '' : this.props.value[1],
+      ],
+    });
+  }
+
+  onMinChange(value) {
     this.setState(
       prevState => ({
-        minMax: [min, prevState.minMax[1]],
+        minMax: [value, prevState.minMax[1]],
       }),
       this.onChange,
     );
   }
 
-  onMaxChange(event) {
-    const max = event.target.value;
+  onMaxChange(value) {
     this.setState(
       prevState => ({
-        minMax: [prevState.minMax[0], max],
+        minMax: [prevState.minMax[0], value],
       }),
       this.onChange,
     );
@@ -68,44 +97,29 @@ export default class BoundsControl extends React.Component {
 
   onChange() {
     const mm = this.state.minMax;
-    const errors = [];
-    if (mm[0] && Number.isNaN(Number(mm[0]))) {
-      errors.push(t('`Min` value should be numeric or empty'));
-    }
-    if (mm[1] && Number.isNaN(Number(mm[1]))) {
-      errors.push(t('`Max` value should be numeric or empty'));
-    }
-    if (errors.length === 0) {
-      this.props.onChange([parseFloat(mm[0]), parseFloat(mm[1])], errors);
-    } else {
-      this.props.onChange([null, null], errors);
-    }
+    const min = parseFloat(mm[0]) || null;
+    const max = parseFloat(mm[1]) || null;
+    this.props.onChange([min, max]);
   }
 
   render() {
     return (
       <div>
         <ControlHeader {...this.props} />
-        <Row gutter={16}>
-          <Col xs={12}>
-            <Input
-              data-test="min-bound"
-              type="text"
-              placeholder={t('Min')}
-              onChange={this.onMinChange}
-              value={this.state.minMax[0]}
-            />
-          </Col>
-          <Col xs={12}>
-            <Input
-              type="text"
-              data-test="max-bound"
-              placeholder={t('Max')}
-              onChange={this.onMaxChange}
-              value={this.state.minMax[1]}
-            />
-          </Col>
-        </Row>
+        <StyledDiv>
+          <MinInput
+            data-test="min-bound"
+            placeholder={t('Min')}
+            onChange={this.onMinChange}
+            value={this.state.minMax[0]}
+          />
+          <MaxInput
+            data-test="max-bound"
+            placeholder={t('Max')}
+            onChange={this.onMaxChange}
+            value={this.state.minMax[1]}
+          />
+        </StyledDiv>
       </div>
     );
   }


### PR DESCRIPTION
### SUMMARY
Fixes #12672. 
Improves the layout of the elements.

@rusackas will open another PR to globally fix the tooltip wrap. I increased the spacing to avoid wrapping.

@junlincc @zuzana-vej 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![105433267-27164300-5c0e-11eb-91e5-fb0bd1706089](https://user-images.githubusercontent.com/70410625/117458263-7adc3c00-af20-11eb-83c2-7cb7e0d6d940.png)
<img width="352" alt="Screen Shot 2021-05-07 at 10 34 18 AM" src="https://user-images.githubusercontent.com/70410625/117458279-80d21d00-af20-11eb-901d-4623cc3866e9.png">

### TEST PLAN
1 - Create a Time Series table
2 - Check Times Series Columns control

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
