### PR TITLE
fix(chart-data): handle url_params in csv export and native filters

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/utils.ts
@@ -28,6 +28,7 @@ import {
 import { Charts } from 'src/dashboard/types';
 import { RefObject } from 'react';
 import { DataMaskStateWithId } from 'src/dataMask/types';
+import extractUrlParams from 'src/dashboard/util/extractUrlParams';
 import { Filter } from './types';
 
 export const getFormData = ({
@@ -76,7 +77,7 @@ export const getFormData = ({
     defaultValue: defaultDataMask?.filterState?.value,
     time_range,
     time_range_endpoints: ['inclusive', 'exclusive'],
-    url_params: {},
+    url_params: extractUrlParams('regular'),
     viz_type: filterType,
     inputRef,
   };

--- a/superset-frontend/src/dashboard/util/extractUrlParams.test.ts
+++ b/superset-frontend/src/dashboard/util/extractUrlParams.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import extractUrlParams from './extractUrlParams';
+
+const originalWindowLocation = window.location;
+
+describe('extractUrlParams', () => {
+  beforeAll(() => {
+    // @ts-ignore
+    delete window.location;
+    // @ts-ignore
+    window.location = { search: '?edit=true&abc=123' };
+  });
+
+  afterAll(() => {
+    window.location = originalWindowLocation;
+  });
+
+  it('returns all urlParams', () => {
+    expect(extractUrlParams('all')).toEqual({
+      edit: 'true',
+      abc: '123',
+    });
+  });
+
+  it('returns reserved urlParams', () => {
+    expect(extractUrlParams('reserved')).toEqual({
+      edit: 'true',
+    });
+  });
+
+  it('returns regular urlParams', () => {
+    expect(extractUrlParams('regular')).toEqual({
+      abc: '123',
+    });
+  });
+});

--- a/superset-frontend/src/dashboard/util/extractUrlParams.ts
+++ b/superset-frontend/src/dashboard/util/extractUrlParams.ts
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import querystring from 'query-string';
+import { JsonObject } from '@superset-ui/core';
+
+const reservedQueryParams = new Set(['standalone', 'edit']);
+
+export type UrlParamType = 'reserved' | 'regular' | 'all';
+
+/**
+ * Returns the url params that are used to customize queries
+ */
+export default function extractUrlParams(
+  urlParamType: UrlParamType,
+): JsonObject {
+  const queryParams = querystring.parse(window.location.search);
+  return Object.entries(queryParams).reduce((acc, [key, value]) => {
+    if (
+      (urlParamType === 'regular' && reservedQueryParams.has(key)) ||
+      (urlParamType === 'reserved' && !reservedQueryParams.has(key))
+    )
+      return acc;
+    // if multiple url params share the same key (?foo=bar&foo=baz), they will appear as an array.
+    // Only one value can be used for a given query param, so we just take the first one.
+    if (Array.isArray(value)) {
+      return {
+        ...acc,
+        [key]: value[0],
+      };
+    }
+    return { ...acc, [key]: value };
+  }, {});
+}

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -124,7 +124,7 @@ def loads_request_json(request_json_data: str) -> Dict[Any, Any]:
         return {}
 
 
-def get_form_data(
+def get_form_data(  # pylint: disable=too-many-locals
     slice_id: Optional[int] = None, use_slice_data: bool = False
 ) -> Tuple[Dict[str, Any], Optional[Slice]]:
     form_data = {}
@@ -139,7 +139,13 @@ def get_form_data(
     if request_json_data:
         form_data.update(request_json_data)
     if request_form_data:
-        form_data.update(loads_request_json(request_form_data))
+        parsed_form_data = loads_request_json(request_form_data)
+        # some chart data api requests are form_data
+        queries = parsed_form_data.get("queries")
+        if isinstance(queries, list):
+            form_data.update(queries[0])
+        else:
+            form_data.update(parsed_form_data)
     # request params can overwrite the body
     if request_args_data:
         form_data.update(loads_request_json(request_args_data))

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -1015,6 +1015,26 @@ class TestUtils(SupersetTestCase):
 
             self.assertEqual(slc, None)
 
+    def test_get_form_data_request_form_with_queries(self) -> None:
+        # the CSV export uses for requests, even when sending requests to
+        # /api/v1/chart/data
+        with app.test_request_context(
+            data={
+                "form_data": json.dumps({"queries": [{"url_params": {"foo": "bar"}}]})
+            }
+        ):
+            form_data, slc = get_form_data()
+
+            self.assertEqual(
+                form_data,
+                {
+                    "url_params": {"foo": "bar"},
+                    "time_range_endpoints": get_time_range_endpoints(form_data={}),
+                },
+            )
+
+            self.assertEqual(slc, None)
+
     def test_get_form_data_request_args_and_form(self) -> None:
         with app.test_request_context(
             data={"form_data": json.dumps({"foo": "bar"})},


### PR DESCRIPTION
### SUMMARY
URL params are currently not being picked up correctly on native filters or CSV export. This PR does the following:
- Add `url_param` to the native filter `formData` payload
- Move the `extractUrlParams` util from the dashboard hydration reducer to a separate util + add tests
- Add handling for form-based v1 chart data requests to `get_form_data()` on the backend + add tests

### BEFORE
Native filters don't pick up the url param despite a table chart referencing the same column shows the value correctly:
![image](https://user-images.githubusercontent.com/33317356/117470326-594e7500-af5f-11eb-9c91-a2fc3ec28e84.png)
Same on native filter config default value picker:
![image](https://user-images.githubusercontent.com/33317356/117470462-80a54200-af5f-11eb-90f5-753c0331e682.png)
CSV export of the table chart doesn't pick up the url param, despite the table chart showing it:
![image](https://user-images.githubusercontent.com/33317356/117470582-a2062e00-af5f-11eb-9084-e41abcd376d6.png)

### AFTER
Now URL params are being picked up properly on the native filter data request:
![image](https://user-images.githubusercontent.com/33317356/117469952-f066fd00-af5e-11eb-9371-9af6378eee39.png)
Also native filter config default value picker:
![image](https://user-images.githubusercontent.com/33317356/117470097-1be9e780-af5f-11eb-817c-f7847d067d90.png)
And CSV export of table:
![image](https://user-images.githubusercontent.com/33317356/117470232-4045c400-af5f-11eb-9975-925fc2b842f9.png)

### TEST PLAN
CI + new tests

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
