### PR TITLE
feat(alert&report):  set image width for email

### DIFF
--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -76,7 +76,7 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
             """,
             description=self._content.description or "",
             url=self._content.url,
-            img_tag='<img src="cid:{}">'.format(msgid)
+            img_tag='<img width="1000px" src="cid:{}">'.format(msgid)
             if self._content.screenshot
             else "",
         )


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When sending a report of a dashboard or a chart, the image in the email is very wide and requires users to scroll to the right to the see the entire report.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
