### PR TITLE
fix: make dataset list sort case insensitive

### DIFF
--- a/superset/views/chart/views.py
+++ b/superset/views/chart/views.py
@@ -68,7 +68,10 @@ class SliceModelView(
             for d in ConnectorRegistry.get_all_datasources(db.session)
         ]
         payload = {
-            "datasources": sorted(datasources, key=lambda d: d["label"]),
+            "datasources": sorted(
+                datasources,
+                key=lambda d: d["label"].lower() if isinstance(d["label"], str) else "",
+            ),
             "common": common_bootstrap_payload(),
             "user": bootstrap_user_data(g.user),
         }


### PR DESCRIPTION
### SUMMARY
On `chart/add`, current sort is case sensitive which is no good.  

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="843" alt="Screen Shot 2021-05-07 at 9 14 28 AM" src="https://user-images.githubusercontent.com/487433/117478977-a5c09300-af14-11eb-978d-46895f6fc5c8.png">
<img width="672" alt="Screen Shot 2021-05-07 at 9 14 07 AM" src="https://user-images.githubusercontent.com/487433/117478987-a78a5680-af14-11eb-8c3d-3ccd4d41a99c.png">
