### PR TITLE
fix(Explore): fixes broken layout of tooltips

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/ControlPanelsContainer_spec.tsx
+++ b/superset-frontend/spec/javascripts/explore/components/ControlPanelsContainer_spec.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { shallow } from 'enzyme';
+import { styledShallow as shallow } from 'spec/helpers/theming';
 import {
   DatasourceType,
   getChartControlPanelRegistry,
@@ -98,6 +98,8 @@ describe('ControlPanelsContainer', () => {
 
   it('renders ControlPanelSections', () => {
     wrapper = shallow(<ControlPanelsContainer {...getDefaultProps()} />);
-    expect(wrapper.find(Collapse.Panel)).toHaveLength(5);
+    expect(
+      wrapper.find('[data-test="collapsible-control-panel"]'),
+    ).toHaveLength(5);
   });
 });

--- a/superset-frontend/spec/javascripts/explore/components/ControlPanelsContainer_spec.tsx
+++ b/superset-frontend/spec/javascripts/explore/components/ControlPanelsContainer_spec.tsx
@@ -29,7 +29,6 @@ import {
   ControlPanelsContainer,
   ControlPanelsContainerProps,
 } from 'src/explore/components/ControlPanelsContainer';
-import Collapse from 'src/components/Collapse';
 
 describe('ControlPanelsContainer', () => {
   let wrapper;

--- a/superset-frontend/src/explore/components/ControlHeader.jsx
+++ b/superset-frontend/src/explore/components/ControlHeader.jsx
@@ -18,7 +18,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { t } from '@superset-ui/core';
+import { t, css } from '@superset-ui/core';
 import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
 import { Tooltip } from 'src/components/Tooltip';
 import { FormLabel } from 'src/components/Form';
@@ -49,7 +49,16 @@ export default class ControlHeader extends React.Component {
   renderOptionalIcons() {
     if (this.props.hovered) {
       return (
-        <span>
+        <span
+          css={theme => css`
+            position: absolute;
+            top: 50%;
+            right: 0;
+            padding-left: ${theme.gridUnit}px;
+            transform: translate(100%, -50%);
+            white-space: nowrap;
+          `}
+        >
           {this.props.description && (
             <span>
               <InfoTooltipWithTrigger
@@ -85,7 +94,13 @@ export default class ControlHeader extends React.Component {
     return (
       <div className="ControlHeader" data-test={`${this.props.name}-header`}>
         <div className="pull-left">
-          <FormLabel css={{ marginBottom: 0 }}>
+          <FormLabel
+            css={{
+              marginBottom: 0,
+              position: 'relative',
+              whiteSpace: 'nowrap',
+            }}
+          >
             {this.props.leftNode && <span>{this.props.leftNode}</span>}
             <span
               role="button"

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -26,6 +26,7 @@ import {
   getChartControlPanelRegistry,
   QueryFormData,
   DatasourceType,
+  css,
 } from '@superset-ui/core';
 import {
   ControlPanelSectionConfig,
@@ -211,7 +212,35 @@ export class ControlPanelsContainer extends React.Component<ControlPanelsContain
 
     return (
       <Collapse.Panel
-        className="control-panel-section"
+        css={theme => css`
+          margin-bottom: 0;
+          box-shadow: none;
+
+          &:last-child {
+            padding-bottom: ${theme.gridUnit * 10}px;
+          }
+
+          .panel-body {
+            margin-left: ${theme.gridUnit * 4}px;
+            padding-bottom: 0px;
+          }
+
+          .control-label {
+            margin-bottom: 0px;
+            position: relative;
+            span + span {
+              // this is targeting the little info icons
+              position: absolute;
+              top: 50%;
+              right: ${theme.gridUnit * -3}px;
+              transform: translateY(-50%);
+            }
+          }
+
+          span.label {
+            display: inline-block;
+          }
+        `}
         header={PanelHeader()}
         key={sectionId}
       >

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -212,6 +212,7 @@ export class ControlPanelsContainer extends React.Component<ControlPanelsContain
 
     return (
       <Collapse.Panel
+        data-test="collapsible-control-panel"
         css={theme => css`
           margin-bottom: 0;
           box-shadow: none;

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -226,18 +226,6 @@ export class ControlPanelsContainer extends React.Component<ControlPanelsContain
             padding-bottom: 0px;
           }
 
-          .control-label {
-            margin-bottom: 0px;
-            position: relative;
-            span + span {
-              // this is targeting the little info icons
-              position: absolute;
-              top: 50%;
-              right: ${theme.gridUnit * -3}px;
-              transform: translateY(-50%);
-            }
-          }
-
           span.label {
             display: inline-block;
           }

--- a/superset-frontend/src/explore/main.less
+++ b/superset-frontend/src/explore/main.less
@@ -47,32 +47,8 @@
   margin-right: 3px;
 }
 
-.control-panel-section {
-  margin-bottom: 0;
-  box-shadow: none;
-
-  &:last-child {
-    padding-bottom: 40px;
-  }
-}
-
 .background-transparent {
   background-color: transparent !important;
-}
-
-.control-panel-section {
-  .panel-body {
-    margin-left: 15px;
-    padding-bottom: 0px;
-  }
-
-  .control-label {
-    margin-bottom: 0px;
-  }
-
-  span.label {
-    display: inline-block;
-  }
 }
 
 .fa.expander {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes an issue where Explore control panels with long label text cause funky line-wrapping on mouseover. This was due to the `span` containing the tooltip(s) appearing inline, and getting to wide. This PR makes the tooltips absolutely positioned, so that they can't cause a line wrap. They might hang a little too far over to the right, but it's an improvement.

As bycatch, this moves a bunch of CSS from LESS files to the component itself, using Emotion and theme variables.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

https://user-images.githubusercontent.com/67837651/118920442-4c306f00-b8eb-11eb-8756-11c88bb52dcb.mov


After:
![fixed](https://user-images.githubusercontent.com/812905/117484740-5d0cd800-af1c-11eb-9522-7c6865ef5ca4.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: Fixes #12689
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
