### PR TITLE
fix: bringing metric type icon styles into SelectControl

### DIFF
--- a/superset-frontend/src/explore/components/controls/SelectControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.jsx
@@ -18,7 +18,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { t } from '@superset-ui/core';
+import { t, css } from '@superset-ui/core';
 import { Select, CreatableSelect, OnPasteSelect } from 'src/components/Select';
 import ControlHeader from 'src/explore/components/ControlHeader';
 
@@ -294,7 +294,17 @@ export default class SelectControl extends React.PureComponent {
     }
 
     return (
-      <div>
+      <div
+        css={theme => css`
+          .type-label {
+            margin-right: ${theme.gridUnit * 2}px;
+            width: ${theme.gridUnit * 7}px;
+            display: inline-block;
+            text-align: center;
+            font-weight: ${theme.typography.weights.bold};
+          }
+        `}
+      >
         {this.props.showHeader && <ControlHeader {...this.props} />}
         {isMulti ? (
           <OnPasteSelect {...selectProps} selectWrap={SelectComponent} />


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
PR #14485 cleaned up a bunch of LESS styles and moved them into Emotion. One style was also needed by the `SelectControl` component, and there was fallout from moving it away. This PR fixes it forward, putting the Emotion based styles where they're needed. 

I believe this is further indication that we need to standardize our Select components (there are several), to minimize these surprise regressions.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![image](https://user-images.githubusercontent.com/812905/117526181-472d0080-af78-11eb-8b32-95d5b99249e5.png)

After:
![image](https://user-images.githubusercontent.com/812905/117525183-dedd1f80-af75-11eb-9c52-564f927b0071.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Pick any viz with a `group by` control - e.g. the Table viz. Check that the options in the menu don't look broken.

Test all over the place for related fallout.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
