### PR TITLE
fix(viz): apply uniform sorting to all nvd3 timeseries charts

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1229,6 +1229,17 @@ class NVD3TimeSeriesViz(NVD3Viz):
     is_timeseries = True
     pivot_fill_value: Optional[int] = None
 
+    def query_obj(self) -> QueryObjectDict:
+        d = super().query_obj()
+        sort_by = self.form_data.get("timeseries_limit_metric")
+        if sort_by:
+            sort_by_label = utils.get_metric_name(sort_by)
+            if sort_by_label not in utils.get_metric_names(d["metrics"]):
+                d["metrics"].append(sort_by)
+            if self.form_data.get("order_desc"):
+                d["orderby"] = [(sort_by, not self.form_data.get("order_desc", True))]
+        return d
+
     def to_series(
         self, df: pd.DataFrame, classed: str = "", title_suffix: str = ""
     ) -> List[Dict[str, Any]]:
@@ -1644,17 +1655,6 @@ class NVD3TimeSeriesStackedViz(NVD3TimeSeriesViz):
     verbose_name = _("Time Series - Stacked")
     sort_series = True
     pivot_fill_value = 0
-
-    def query_obj(self) -> QueryObjectDict:
-        d = super().query_obj()
-        sort_by = self.form_data.get("timeseries_limit_metric")
-        if sort_by:
-            sort_by_label = utils.get_metric_name(sort_by)
-            if sort_by_label not in utils.get_metric_names(d["metrics"]):
-                d["metrics"].append(sort_by)
-            if self.form_data.get("order_desc"):
-                d["orderby"] = [(sort_by, not self.form_data.get("order_desc", True))]
-        return d
 
 
 class HistogramViz(BaseViz):
@@ -2210,18 +2210,6 @@ class HorizonViz(NVD3TimeSeriesViz):
         '<a href="https://www.npmjs.com/package/d3-horizon-chart">'
         "d3-horizon-chart</a>"
     )
-
-    def query_obj(self) -> QueryObjectDict:
-        d = super().query_obj()
-        metrics = self.form_data.get("metrics")
-        sort_by = self.form_data.get("timeseries_limit_metric")
-        if sort_by:
-            sort_by_label = utils.get_metric_name(sort_by)
-            if sort_by_label not in utils.get_metric_names(d["metrics"]):
-                d["metrics"].append(sort_by)
-            if self.form_data.get("order_desc"):
-                d["orderby"] = [(sort_by, not self.form_data.get("order_desc", True))]
-        return d
 
 
 class MapboxViz(BaseViz):
@@ -2914,17 +2902,6 @@ class RoseViz(NVD3TimeSeriesViz):
     sort_series = False
     is_timeseries = True
 
-    def query_obj(self) -> QueryObjectDict:
-        d = super().query_obj()
-        sort_by = self.form_data.get("timeseries_limit_metric")
-        if sort_by:
-            sort_by_label = utils.get_metric_name(sort_by)
-            if sort_by_label not in utils.get_metric_names(d["metrics"]):
-                d["metrics"].append(sort_by)
-            if self.form_data.get("order_desc"):
-                d["orderby"] = [(sort_by, not self.form_data.get("order_desc", True))]
-        return d
-
     def get_data(self, df: pd.DataFrame) -> VizData:
         if df.empty:
             return None
@@ -2963,14 +2940,6 @@ class PartitionViz(NVD3TimeSeriesViz):
         time_op = self.form_data.get("time_series_option", "not_time")
         # Return time series data if the user specifies so
         query_obj["is_timeseries"] = time_op != "not_time"
-        sort_by = self.form_data.get("timeseries_limit_metric")
-        if sort_by:
-            sort_by_label = utils.get_metric_name(sort_by)
-            if sort_by_label not in utils.get_metric_names(query_obj["metrics"]):
-                query_obj["metrics"].append(sort_by)
-            query_obj["orderby"] = [
-                (sort_by, not self.form_data.get("order_desc", True))
-            ]
         return query_obj
 
     def levels_for(


### PR DESCRIPTION
### SUMMARY
Many NVD3 timeseries viz' were featured duplicated sorting logic that was missing from others. This introduces sorting logic to the base `NVD3TimeSeriesViz` class removes the same from the following viz':
- `NVD3TimeSeriesStackedViz` (=area chart)
- `HorizonViz`
- `RoseViz`
- `PartitionViz`

By moving the sorting logic to the base class, this logic is now added to the following chart types that were previously missing it:
- `NVD3TimeSeriesViz` (=line chart)
- `NVD3TimeSeriesBarViz`
- `NVD3CompareTimeSeriesViz`

The following charts that extend the `NVD3TimeSeriesViz` class are unaffected, since they don't feature the sorting control:
- `NVD3TimePivotViz`

### TEST PLAN
All eight charts that this PR affects were manually tested to ensure that they work as expected.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #13472
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
