### PR TITLE
fix: flaky test on reports

### DIFF
--- a/tests/reports/commands_tests.py
+++ b/tests/reports/commands_tests.py
@@ -806,9 +806,9 @@ def test_report_schedule_working_timeout(create_report_slack_chart_working):
     logs = db.session.query(ReportExecutionLog).all()
     # Two logs, first is created by fixture
     assert len(logs) == 2
-    assert logs[1].error_message == ReportScheduleWorkingTimeoutError.message
-    assert logs[1].state == ReportState.ERROR
-
+    assert ReportScheduleWorkingTimeoutError.message in [
+        log.error_message for log in logs
+    ]
     assert create_report_slack_chart_working.last_state == ReportState.ERROR
 
 


### PR DESCRIPTION
### SUMMARY

Fixes a flaky test on Alerts & Reports. The order of the log entries may vary, specially since time is freezed

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
