### PR TITLE
fix: Column name and icons alignment in the Datasource Panel (Explore)

### DIFF
--- a/superset-frontend/src/explore/components/optionRenderers.tsx
+++ b/superset-frontend/src/explore/components/optionRenderers.tsx
@@ -27,8 +27,15 @@ import {
 } from '@superset-ui/chart-controls';
 
 const OptionContainer = styled.div`
+  > span {
+    display: flex;
+    align-items: center;
+  }
+
   .option-label {
     display: inline-block;
+    overflow: hidden;
+    text-overflow: ellipsis;
     & ~ i {
       margin-left: ${({ theme }) => theme.gridUnit}px;
     }

--- a/superset-frontend/src/explore/components/optionRenderers.tsx
+++ b/superset-frontend/src/explore/components/optionRenderers.tsx
@@ -36,6 +36,7 @@ const OptionContainer = styled.div`
     display: inline-block;
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
     & ~ i {
       margin-left: ${({ theme }) => theme.gridUnit}px;
     }


### PR DESCRIPTION
### SUMMARY
Fixes #13449 by changing the alignment of the column name and icons in the Datasource Panel.


### BEFORE
<img width="1680" alt="before" src="https://user-images.githubusercontent.com/60598000/117692321-9451e200-b1c5-11eb-84ae-7118b17aeea8.png">

### AFTER
<img width="1628" alt="after_ellipsis" src="https://user-images.githubusercontent.com/60598000/117692342-9a47c300-b1c5-11eb-8dc1-d2ff4daa26a1.png">


### TEST PLAN
1. Open a chart in Explore
2. Edit the dataset and change the label of a column with a very long one
3. Make sure that the left icons, the column name, and tooltip icon are showing on the same line and that the column name cuts with ellipsis
4. Make sure the responsive behavior works when the Datasource panel width is increased/decreased

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #13449
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
