### PR TITLE
fix: select country in examples chart

### DIFF
--- a/superset/examples/country_map.py
+++ b/superset/examples/country_map.py
@@ -100,6 +100,7 @@ def load_country_map_data(only_metadata: bool = False, force: bool = False) -> N
             "optionName": "metric_112342",
         },
         "row_limit": 500000,
+        "select_country": "france",
     }
 
     print("Creating a slice")


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fix the "Birth in France by department in 2016" chart by selecting "France" as the country.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

![Screenshot_2021-05-10 Birth in France by department in 2016(1)](https://user-images.githubusercontent.com/1534870/117746758-c2352780-b1c1-11eb-884d-1fbfaafc06a6.png)

After:

![Screenshot_2021-05-10 Birth in France by department in 2016](https://user-images.githubusercontent.com/1534870/117746767-c5c8ae80-b1c1-11eb-83c6-4430eda3348d.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
