### PR TITLE
chore: add logging to query execute

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2511,6 +2511,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             session.rollback()
             raise Exception(_("Query record was not created as expected."))
         if not query_id:
+            logger.warning("Not able to find query_id")
             raise Exception(_("Query record was not created as expected."))
 
         logger.info("Triggering query_id: %i", query_id)


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Want to add more context to query logs whenever the query_id is not found vs. SQLA exception

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
