### PR TITLE
fix: properly keep state on queryEditorSetSql on tabstateview PUT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,8 @@ pre-commit:
 
 format: py-format js-format
 
-py-format:
-	python -m black superset
+py-format: pre-commit
+	pre-commit run black --all-files
 
 js-format:
 	cd superset-frontend; npm run prettier

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,8 @@ pre-commit:
 
 format: py-format js-format
 
-py-format: pre-commit
-	pre-commit run black --all-files
+py-format:
+	python -m black superset
 
 js-format:
 	cd superset-frontend; npm run prettier

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -897,7 +897,7 @@ export function queryEditorSetSql(queryEditor, sql) {
     const sync = isFeatureEnabled(FeatureFlag.SQLLAB_BACKEND_PERSISTENCE)
       ? SupersetClient.put({
           endpoint: encodeURI(`/tabstateview/${queryEditor.id}`),
-          postPayload: { sql, latest_query: queryEditor.latestQueryId },
+          postPayload: { sql, latest_query_id: queryEditor.latestQueryId },
         })
       : Promise.resolve();
 

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -897,7 +897,7 @@ export function queryEditorSetSql(queryEditor, sql) {
     const sync = isFeatureEnabled(FeatureFlag.SQLLAB_BACKEND_PERSISTENCE)
       ? SupersetClient.put({
           endpoint: encodeURI(`/tabstateview/${queryEditor.id}`),
-          postPayload: { sql },
+          postPayload: { sql, latest_query: queryEditor.latestQueryId },
         })
       : Promise.resolve();
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Pass `latestQueryId` when user updates SQL. Anytime we call the put the update the sql for the current tab, the clientid/latestQueryId changes which cause the sql_json endpoint to fail since we can’t the proper id

The following error is thrown whenever the query id is overwritten and cannot be found.

<img width="1792" alt="Screen Shot 2021-05-10 at 3 54 51 PM" src="https://user-images.githubusercontent.com/27827808/117882691-97f27100-b278-11eb-88f4-39620ccab353.png">

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
