### PR TITLE
chore: Update `make py-format` to use pre-commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,8 @@ pre-commit:
 
 format: py-format js-format
 
-py-format:
-	python -m black superset
+py-format: pre-commit
+	pre-commit run black --all-files
 
 js-format:
 	cd superset-frontend; npm run prettier


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Before `make format` was using black package which would cause tons of files to change to leveraging `pre-commit run black --all-files command for consistency

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
