### PR TITLE
fix: Adds space under dataset change warning

### DIFF
--- a/superset-frontend/src/components/Alert/Alert.stories.tsx
+++ b/superset-frontend/src/components/Alert/Alert.stories.tsx
@@ -74,10 +74,16 @@ AlertGallery.story = {
   },
 };
 
-export const InteractiveAlert = (args: AlertProps) => <Alert {...args} />;
+export const InteractiveAlert = (args: AlertProps) => (
+  <>
+    <Alert {...args} />
+    Some content to test the `roomBelow` prop
+  </>
+);
 
 InteractiveAlert.args = {
   closable: true,
+  roomBelow: false,
   type: 'info',
   message: smallText,
   description: bigText,

--- a/superset-frontend/src/components/Alert/index.tsx
+++ b/superset-frontend/src/components/Alert/index.tsx
@@ -27,7 +27,7 @@ import Icons from 'src/components/Icons';
 
 export type AlertProps = PropsWithChildren<AntdAlertProps>;
 
-export default function Alert(props: AlertProps & { roomBelow: boolean }) {
+export default function Alert(props: AlertProps & { roomBelow?: boolean }) {
   const {
     type = 'info',
     description,

--- a/superset-frontend/src/components/Alert/index.tsx
+++ b/superset-frontend/src/components/Alert/index.tsx
@@ -25,9 +25,11 @@ import { useTheme } from '@superset-ui/core';
 import Icon from 'src/components/Icon';
 import Icons from 'src/components/Icons';
 
-export type AlertProps = PropsWithChildren<AntdAlertProps>;
+export type AlertProps = PropsWithChildren<
+  AntdAlertProps & { roomBelow?: boolean }
+>;
 
-export default function Alert(props: AlertProps & { roomBelow?: boolean }) {
+export default function Alert(props: AlertProps) {
   const {
     type = 'info',
     description,

--- a/superset-frontend/src/components/Alert/index.tsx
+++ b/superset-frontend/src/components/Alert/index.tsx
@@ -27,17 +27,18 @@ import Icons from 'src/components/Icons';
 
 export type AlertProps = PropsWithChildren<AntdAlertProps>;
 
-export default function Alert(props: AlertProps) {
+export default function Alert(props: AlertProps & { roomBelow: boolean }) {
   const {
     type = 'info',
     description,
     showIcon = true,
     closable = true,
+    roomBelow = false,
     children,
   } = props;
 
   const theme = useTheme();
-  const { colors, typography } = theme;
+  const { colors, typography, gridUnit } = theme;
   const { alert, error, info, success } = colors;
 
   let baseColor = info;
@@ -60,12 +61,13 @@ export default function Alert(props: AlertProps) {
       icon={<AlertIcon aria-label={`${type} icon`} />}
       closeText={closable && <Icon name="x-small" aria-label="close icon" />}
       css={{
-        padding: '6px 10px',
+        marginBottom: roomBelow ? gridUnit * 4 : 0,
+        padding: `${gridUnit * 2}px ${gridUnit * 3}px`,
         alignItems: 'flex-start',
         border: 0,
         backgroundColor: baseColor.light2,
         '& .ant-alert-icon': {
-          marginRight: 10,
+          marginRight: gridUnit * 2,
         },
         '& .ant-alert-message': {
           color: baseColor.dark2,

--- a/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
+++ b/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
@@ -248,9 +248,7 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
         {!confirmChange && (
           <>
             <Alert
-              css={theme => css`
-                margin-bottom: ${theme.gridUnit * 4}px;
-              `}
+              roomBelow
               type="warning"
               message={
                 <>

--- a/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
+++ b/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
@@ -25,7 +25,7 @@ import React, {
 } from 'react';
 import { FormControl, FormControlProps } from 'react-bootstrap';
 import Alert from 'src/components/Alert';
-import { SupersetClient, t, styled } from '@superset-ui/core';
+import { SupersetClient, t, styled, css } from '@superset-ui/core';
 import TableView, { EmptyWrapperType } from 'src/components/TableView';
 import StyledModal from 'src/components/Modal';
 import Button from 'src/components/Button';
@@ -248,6 +248,9 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
         {!confirmChange && (
           <>
             <Alert
+              css={theme => css`
+                margin-bottom: ${theme.gridUnit * 4}px;
+              `}
               type="warning"
               message={
                 <>

--- a/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
+++ b/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
@@ -25,7 +25,7 @@ import React, {
 } from 'react';
 import { FormControl, FormControlProps } from 'react-bootstrap';
 import Alert from 'src/components/Alert';
-import { SupersetClient, t, styled, css } from '@superset-ui/core';
+import { SupersetClient, t, styled } from '@superset-ui/core';
 import TableView, { EmptyWrapperType } from 'src/components/TableView';
 import StyledModal from 'src/components/Modal';
 import Button from 'src/components/Button';


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes a missing gutter under the warning you see when you change datasets in explore. Started doing this as a css override to fix the acute problem, but decided it'd be better to add it as a prop to the Alert itself in case we see this sort of thing again.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![image](https://user-images.githubusercontent.com/812905/117904719-b6f7ff80-b286-11eb-894b-a2761f21adf2.png)

After:
![image](https://user-images.githubusercontent.com/812905/117901424-2cac9d00-b280-11eb-9a31-a0c9e1be8f71.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Check it out in the Explore view by switching dataset. Or try the prop in the Interactive Alert entry of Storybook

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
