### PR TITLE
fix: bring back dashboard perf logger

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/load.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/load.test.ts
@@ -47,4 +47,9 @@ describe('Dashboard load', () => {
     cy.get('[data-test="discard-changes-button"]').should('be.visible');
     cy.get('#app-menu').should('not.exist');
   });
+
+  it('should send log data', () => {
+    cy.visit(WORLD_HEALTH_DASHBOARD);
+    cy.intercept('/superset/log/?explode=events&dashboard_id=*');
+  });
 });

--- a/superset-frontend/src/dashboard/actions/hydrate.js
+++ b/superset-frontend/src/dashboard/actions/hydrate.js
@@ -18,7 +18,6 @@
  */
 /* eslint-disable camelcase */
 import { isString, keyBy } from 'lodash';
-import shortid from 'shortid';
 import {
   Behavior,
   CategoricalColorNamespace,
@@ -376,8 +375,6 @@ export const hydrateDashboard = (dashboardData, chartData, datasourcesData) => (
         lastModifiedTime: dashboardData.changed_on,
       },
       dashboardLayout,
-      messageToasts: [],
-      impressionId: shortid.generate(),
     },
   });
 };

--- a/superset-frontend/src/views/store.ts
+++ b/superset-frontend/src/views/store.ts
@@ -29,6 +29,8 @@ import nativeFilters from 'src/dashboard/reducers/nativeFilters';
 import datasources from 'src/dashboard/reducers/datasources';
 import sliceEntities from 'src/dashboard/reducers/sliceEntities';
 import dashboardLayout from 'src/dashboard/reducers/undoableDashboardLayout';
+import logger from 'src/middleware/loggerMiddleware';
+import shortid from 'shortid';
 
 // Some reducers don't do anything, and redux is just used to reference the initial "state".
 // This may change later, as the client application takes on more responsibilities.
@@ -57,12 +59,12 @@ export const rootReducer = combineReducers({
   messageToasts: messageToastReducer,
   common: noopReducer(bootstrap.common || {}),
   user: noopReducer(bootstrap.user || {}),
-  impressionId: noopReducer(''),
+  impressionId: noopReducer(shortid.generate()),
   ...dashboardReducers,
 });
 
 export const store = createStore(
   rootReducer,
   {},
-  compose(applyMiddleware(thunk), initEnhancer(false)),
+  compose(applyMiddleware(thunk, logger), initEnhancer(false)),
 );


### PR DESCRIPTION
### SUMMARY
The dashboard perf logging function was lost during #14356. 


### Expected behavior 
Dashboard should send perf logging data:
<img width="1213" alt="Screen Shot 2021-05-11 at 7 05 41 PM" src="https://user-images.githubusercontent.com/27990562/117908043-aa76a580-b28c-11eb-89b2-f93889797188.png">


### TEST PLAN
CI and manual test

