### PR TITLE
fix: don't show busted label for unknown data types

### DIFF
--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -239,7 +239,7 @@ function ColumnCollectionTable({
           ) : (
             v
           ),
-        type: d => <Label>{d}</Label>,
+        type: d => (d ? <Label>{d}</Label> : null),
         is_dttm: checkboxGenerator,
         filterable: checkboxGenerator,
         groupby: checkboxGenerator,


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In the dataset editor modal, data columns with unknown types showed odd looking little empty Label components. This simply doesn't render those. We can add in some other "unknown" icon or other treatment, but it seemed like "less is more" in this case.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:
![image](https://user-images.githubusercontent.com/812905/117919730-61c9e700-b2a2-11eb-8335-066c362b9710.png)

After:
![image](https://user-images.githubusercontent.com/812905/117919679-48c13600-b2a2-11eb-9e7d-41d998ed2cc3.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Pick a dataset in the CRUD view, click the pencil/edit action, and click the "Calculated Columns" tab to (most likely) see a specimen.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: https://github.com/apache/superset/issues/14570
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
