### PR TITLE
feat(native-filters): add sort metric to select

### DIFF
--- a/superset-frontend/src/filters/components/Select/buildQuery.test.ts
+++ b/superset-frontend/src/filters/components/Select/buildQuery.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import buildQuery from './buildQuery';
+
+describe('Select buildQuery', () => {
+  const formData = {
+    datasource: '5__table',
+    groupby: ['my_col'],
+    viz_type: 'filter_select',
+    sortAscending: false,
+    sortMetric: undefined,
+    filters: undefined,
+    enableEmptyFilter: false,
+    inverseSelection: false,
+    multiSelect: false,
+    defaultToFirstItem: false,
+    height: 100,
+    width: 100,
+  };
+
+  it('should build a default query', () => {
+    const queryContext = buildQuery(formData);
+    expect(queryContext.queries.length).toEqual(1);
+    const [query] = queryContext.queries;
+    expect(query.groupby).toEqual(['my_col']);
+    expect(query.metrics).toEqual([]);
+    expect(query.apply_fetch_values_predicate).toEqual(true);
+    expect(query.orderby).toEqual([]);
+  });
+
+  it('should handle sort metric correctly', () => {
+    const queryContext = buildQuery({
+      ...formData,
+      sortMetric: 'my_metric',
+      sortAscending: false,
+    });
+    expect(queryContext.queries.length).toEqual(1);
+    const [query] = queryContext.queries;
+    expect(query.groupby).toEqual(['my_col']);
+    expect(query.metrics).toEqual(['my_metric']);
+    expect(query.orderby).toEqual([['my_metric', false]]);
+  });
+});

--- a/superset-frontend/src/filters/components/Select/buildQuery.ts
+++ b/superset-frontend/src/filters/components/Select/buildQuery.ts
@@ -30,6 +30,7 @@ export default function buildQuery(formData: PluginFilterSelectQueryFormData) {
         ...baseQueryObject,
         apply_fetch_values_predicate: true,
         groupby: columns,
+        metrics: sortMetric ? [sortMetric] : [],
         filters: filters.concat(
           columns.map(column => ({ col: column, op: 'IS NOT NULL' })),
         ),


### PR DESCRIPTION
### SUMMARY
Some databases require including the sort metrics in the select. To maximise database compatibility and make it possible to add tooltips to show the metric value used (later PR), we add the metric to the select filter.

### TEST PLAN
CI + new tests added

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
