### PR TITLE
[WIP] feat: Remove uppercase styling on FilterBox

### DIFF
--- a/superset-frontend/src/components/Form/FormLabel.tsx
+++ b/superset-frontend/src/components/Form/FormLabel.tsx
@@ -21,20 +21,21 @@ import { styled } from '@superset-ui/core';
 
 export type FormLabelProps = {
   children: ReactNode;
+  className?: string;
   htmlFor?: string;
   required?: boolean;
-  className?: string;
+  uppercase?: boolean;
 };
 
-const Label = styled.label`
-  text-transform: uppercase;
+const Label = styled.label<{ uppercase: boolean }>`
+  text-transform: ${({ uppercase }) => (uppercase ? 'uppercase' : 'none')};
   font-size: ${({ theme }) => theme.typography.sizes.s}px;
   color: ${({ theme }) => theme.colors.grayscale.base};
   margin-bottom: ${({ theme }) => theme.gridUnit}px;
 `;
 
-const RequiredLabel = styled.label`
-  text-transform: uppercase;
+const RequiredLabel = styled.label<{ uppercase: boolean }>`
+  text-transform: ${({ uppercase }) => (uppercase ? 'uppercase' : 'none')};
   font-size: ${({ theme }) => theme.typography.sizes.s}px;
   color: ${({ theme }) => theme.colors.grayscale.base};
   margin-bottom: ${({ theme }) => theme.gridUnit}px;
@@ -48,13 +49,14 @@ const RequiredLabel = styled.label`
 
 export default function FormLabel({
   children,
+  className,
   htmlFor,
   required = false,
-  className,
+  uppercase = true,
 }: FormLabelProps) {
   const StyledLabel = required ? RequiredLabel : Label;
   return (
-    <StyledLabel htmlFor={htmlFor} className={className}>
+    <StyledLabel htmlFor={htmlFor} className={className} uppercase={uppercase}>
       {children}
     </StyledLabel>
   );

--- a/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
@@ -408,7 +408,9 @@ class FilterBox extends React.PureComponent {
       const { label, key } = filterConfig;
       return (
         <div key={key} className="m-b-5 filter-container">
-          <FormLabel htmlFor={`LABEL-${key}`}>{label}</FormLabel>
+          <FormLabel htmlFor={`LABEL-${key}`} uppercase={false}>
+            {label}
+          </FormLabel>
           {this.renderSelect(filterConfig)}
         </div>
       );


### PR DESCRIPTION
### SUMMARY
Transforming to uppercase for the form label in FilterBoxes is problematic because the filter column names are case sensitive.  This should make the labels match the actual case of the column name

This might look a bit worse than the current experience, but i think it's necessary because it can hide a really ugly bug when the columns don't apply to vizes because the case of a column is different

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
TODO

### TEST PLAN
visual inspection

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
