### PR TITLE
fix: error icon spacing in explore

### DIFF
--- a/superset-frontend/src/explore/components/QueryAndSaveBtns.jsx
+++ b/superset-frontend/src/explore/components/QueryAndSaveBtns.jsx
@@ -93,6 +93,9 @@ export default function QueryAndSaveBtns({
         '& button': {
           width: 100,
         },
+        '.errMsg': {
+          marginLeft: theme.gridUnit * 4,
+        }
       }}
     >
       <ButtonGroup className="query-and-save">
@@ -110,7 +113,7 @@ export default function QueryAndSaveBtns({
         </Button>
       </ButtonGroup>
       {errorMessage && (
-        <span>
+        <span className="errMsg">
           {' '}
           <Tooltip
             id="query-error-tooltip"

--- a/superset-frontend/src/explore/components/QueryAndSaveBtns.jsx
+++ b/superset-frontend/src/explore/components/QueryAndSaveBtns.jsx
@@ -95,7 +95,7 @@ export default function QueryAndSaveBtns({
         },
         '.errMsg': {
           marginLeft: theme.gridUnit * 4,
-        }
+        },
       }}
     >
       <ButtonGroup className="query-and-save">


### PR DESCRIPTION
### SUMMARY
This pr fixes the padding issue for the error message in explore.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before:
<img width="456" alt="Screen Shot 2021-05-12 at 5 45 50 PM" src="https://user-images.githubusercontent.com/17326228/118061513-e754a200-b349-11eb-8cea-d1b6f1bdc92e.png">

after:
<img width="329" alt="Screen Shot 2021-05-12 at 5 46 36 PM" src="https://user-images.githubusercontent.com/17326228/118061583-081cf780-b34a-11eb-8960-9e66d112326c.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x ] Has associated issue: 14570
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
