### PR TITLE
fix(explore): Missing border in the Popover SQL Editor

### DIFF
--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
@@ -425,7 +425,7 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
                 }
                 editorProps={{ $blockScrolling: true }}
                 enableLiveAutocompletion
-                className="adhoc-filter-sql-editor"
+                className="filter-sql-editor"
                 wrapEnabled
               />
             ) : (


### PR DESCRIPTION
### SUMMARY
Fixes #14598 

The border was missing due to a change in the class name introduced by PR #14502. The class name has been reverted.

### BEFORE
<img width="1014" alt="Screen Shot 2021-05-13 at 12 05 39" src="https://user-images.githubusercontent.com/60598000/118104242-8ed1e300-b3e3-11eb-982f-cbd5f62fadd7.png">

### AFTER
<img width="998" alt="after_popover_border" src="https://user-images.githubusercontent.com/60598000/118104206-81b4f400-b3e3-11eb-8eff-b0c377d795de.png">


### TEST PLAN
1. Open a chart in Explore
2. Open the Metrics in the control panel
3. Select the "Custom SQL" tab
4. Make sure the textarea has a border

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #14598 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
