### PR TITLE
fix(explore): Filters Tooltip is not showing the full content

### DIFF
--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/index.js
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/index.js
@@ -142,6 +142,10 @@ export default class AdhocFilter {
     return label.length < 43 ? label : `${label.substring(0, 40)}...`;
   }
 
+  getTooltipTitle() {
+    return this.translateToSql();
+  }
+
   translateToSql() {
     return translateToSql(this);
   }

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterOption/index.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterOption/index.jsx
@@ -63,6 +63,7 @@ const AdhocFilterOption = ({
   >
     <OptionControlLabel
       label={adhocFilter.getDefaultLabel()}
+      tooltipTitle={adhocFilter.getTooltipTitle()}
       onRemove={onRemoveFilter}
       onMoveLabel={onMoveLabel}
       onDropLabel={onDropLabel}

--- a/superset-frontend/src/explore/components/controls/OptionControls/OptionControls.test.tsx
+++ b/superset-frontend/src/explore/components/controls/OptionControls/OptionControls.test.tsx
@@ -36,6 +36,7 @@ import {
 
 const defaultProps = {
   label: <span>Test label</span>,
+  tooltipTitle: 'This is a tooltip title',
   onRemove: jest.fn(),
   onMoveLabel: jest.fn(),
   onDropLabel: jest.fn(),

--- a/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
+++ b/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
@@ -167,6 +167,7 @@ export const OptionControlLabel = ({
   type,
   index,
   isExtra,
+  tooltipTitle,
   ...props
 }: {
   label: string | React.ReactNode;
@@ -181,6 +182,7 @@ export const OptionControlLabel = ({
   type: string;
   index: number;
   isExtra?: boolean;
+  tooltipTitle: string;
 }) => {
   const theme = useTheme();
   const ref = useRef<HTMLDivElement>(null);
@@ -246,7 +248,7 @@ export const OptionControlLabel = ({
     if (savedMetric?.metric_name) {
       return <StyledMetricOption metric={savedMetric} />;
     }
-    return <Tooltip title={label}>{label}</Tooltip>;
+    return <Tooltip title={tooltipTitle}>{label}</Tooltip>;
   };
 
   const getOptionControlContent = () => (


### PR DESCRIPTION
### SUMMARY
Fixes #14571 

Introduces a function to get the tooltip title in order to show the full content in the tooltip.

### BEFORE
<img width="828" alt="117864886-27ccf680-b24a-11eb-910c-22cd6df3fae3" src="https://user-images.githubusercontent.com/60598000/118110067-a06ab900-b3ea-11eb-8e89-17f0f19693fe.png">

### AFTER
<img width="935" alt="Screen Shot 2021-05-13 at 12 57 36" src="https://user-images.githubusercontent.com/60598000/118110225-d4de7500-b3ea-11eb-8367-76fa277cc2a4.png">

### TEST PLAN
1. Open a chart in Explore
2. Add a new Filter using the IN operator
3. Select a multitude of options and save the filter
4. Hover the newly created filter
5. Make sure that the tooltip is showing all the options

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #14571 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
