### PR TITLE
fix: Pin itsdangerous

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -127,6 +127,7 @@ isodate==0.6.0
 # via apache-superset
 itsdangerous==1.1.0
 # via
+#   apache-superset
 #   flask
 #   flask-wtf
 jinja2==2.11.3

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setup(
         "graphlib-backport",
         "gunicorn>=20.0.2, <20.1",
         "humanize",
+        "itsdangerous>=1.0.0, <2.0.0",
         "isodate",
         "markdown>=3.0",
         "msgpack>=1.0.0, <1.1",


### PR DESCRIPTION
### SUMMARY

Version 2.0.0 of the [itsdangerous](https://pypi.org/project/itsdangerous/#history) package was recently released (May 12, 2021) which replaces the  `simplejson`  with `json` which cannot decode `decimal.Decimal` objects, i.e., 

```
Traceback (most recent call last):
...
  File "/srv/superset-internal/superset-fork/superset/utils/core.py", line 1407, in time_function
    response = func(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/flask_appbuilder/api/__init__.py", line 1499, in get_list_headless
    return self.response(200, **_response)
...
  File "/usr/lib/python3.8/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type Decimal is not JSON serializable
```

Eventually when we update Flask we will need to deal with this as it also removes `simplejson` (https://github.com/pallets/flask/issues/3555) and doesn't rely on on  `itsdangerous` for defining which JSON package to use per https://github.com/pallets/flask/pull/3562.

I tried using the logic they suggested (to help future proof ourselves), i.e., in `superset/app.py`

```python
from simplejson import JSONEncoder


app = Flask(__name__)
app.json_encoder = JSONEncoder
```

however I ran into a somewhat similar problem, 

```
Traceback (most recent call last):
...
  File "/srv/superset-internal/superset-fork/superset/utils/core.py", line 1407, in time_function
    response = func(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/flask_appbuilder/api/__init__.py", line 1499, in get_list_headless
    return self.response(200, **_response)
...
  File "/usr/local/lib/python3.8/dist-packages/simplejson/encoder.py", line 272, in default
    raise TypeError('Object of type %s is not JSON serializable' %
TypeError: Object of type Table is not JSON serializable
```

which is somewhat perplexing, i.e., I'm not sure why this is problematic and I couldn't find any JSON encoders in Superset, Flask, or Flask-SQLAlchemy which handled serializing SQLAlchemy `Table` objects. For now to remedy any issues resulting from `pip installing` Apache Superset I thought there was merit in simply restricting the version of `itsdangerous`.

Note the generated requirements were updated via, 

```
pip-compile-multi --only-name base --upgrade-package itsdangerous 
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
