### PR TITLE
docs: fix wrong filename mentioned in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,6 +18,6 @@ under the License.
 -->
 # INSTALL / BUILD instructions for Apache Superset
 
-At this time, the docker file at RELEASING/Dockerfile.from_tarball
+At this time, the docker file at RELEASING/Dockerfile.from_local_tarball
 constitutes the recipe on how to get to a working release from a source
 release tarball.


### PR DESCRIPTION
### SUMMARY

`INSTALL.md` mentions `Dockerfile.from_tarball`, but it's actually `Dockerfile.from_local_tarball`

### ADDITIONAL INFORMATION

- [ x ] Has associated issue: Fixes #14629