### PR TITLE
fix: dependabot config pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       - dependabot
 
   - package-ecosystem: "pip"
-    directory: "/requirements/"
+    directory: "/"
     schedule:
       interval: "daily"
     labels:


### PR DESCRIPTION
### SUMMARY
Dependabot hasn't opened a pr for python deps, I don't think it can handle our pip-compile-multi setup. I'm interested in seeing what happens when we point it at setup.py
<img width="924" alt="Screen Shot 2021-05-13 at 9 59 26 PM" src="https://user-images.githubusercontent.com/10255196/118223614-efdad480-b43e-11eb-8053-46d770db10cc.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- check dependabot after this pr merges 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
