### PR TITLE
fix: DB parameter validation API

### DIFF
--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -278,7 +278,7 @@ class DatabaseValidateParametersSchema(Schema):
     engine = fields.String(required=True, description="SQLAlchemy engine to use")
     parameters = fields.Dict(
         keys=fields.String(),
-        values=fields.Raw(),
+        values=fields.Raw(allow_none=True),
         description="DB-specific parameters for configuration",
     )
     database_name = fields.String(

--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from collections import defaultdict
 from typing import Any, Dict, List, Optional
 
 from flask_babel import gettext as _
@@ -175,6 +176,11 @@ class InvalidPayloadSchemaError(SupersetErrorException):
     status = 422
 
     def __init__(self, error: ValidationError):
+        # dataclasses.asdict does not work with defaultdict, convert to dict
+        # https://bugs.python.org/issue35540
+        for k, v in error.messages.items():
+            if isinstance(v, defaultdict):
+                error.messages[k] = dict(v)
         error = SupersetError(
             message="An error happened when validating the request",
             error_type=SupersetErrorType.INVALID_PAYLOAD_SCHEMA_ERROR,

--- a/tests/databases/api_tests.py
+++ b/tests/databases/api_tests.py
@@ -19,6 +19,7 @@
 """Unit tests for Superset"""
 import dataclasses
 import json
+from collections import defaultdict
 from io import BytesIO
 from unittest import mock
 from zipfile import is_zipfile, ZipFile
@@ -1369,15 +1370,18 @@ class TestDatabaseApi(SupersetTestCase):
         url = "api/v1/database/validate_parameters"
         payload = {
             "engine": "postgresql",
-            "parameters": {
+            "parameters": defaultdict(dict),
+        }
+        payload["parameters"].update(
+            {
                 "host": "",
                 "port": 5432,
                 "username": "",
                 "password": "",
                 "database": "",
                 "query": {},
-            },
-        }
+            }
+        )
         rv = self.client.post(url, json=payload)
         response = json.loads(rv.data.decode("utf-8"))
 
@@ -1409,15 +1413,18 @@ class TestDatabaseApi(SupersetTestCase):
         url = "api/v1/database/validate_parameters"
         payload = {
             "engine": "postgresql",
-            "parameters": {
+            "parameters": defaultdict(dict),
+        }
+        payload["parameters"].update(
+            {
                 "host": "localhost",
                 "port": 5432,
                 "username": "",
                 "password": "",
                 "database": "",
                 "query": {},
-            },
-        }
+            }
+        )
         rv = self.client.post(url, json=payload)
         response = json.loads(rv.data.decode("utf-8"))
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

I was testing the new validation API for DB parameters and realized that it would fail in certain cases because the SIP-41 handler uses `dataclasses.asdict`, which doesn't play nice with `defaultdict` (https://bugs.python.org/issue35540).

I added custom code to handle the payload with `defaultdict` in case there's a validation error, converting to a normal dict.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Added a unit test covering the regression.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
