### PR TITLE
fix: Removing specific column widths, letting things flex naturally.

### DIFF
--- a/superset-frontend/src/components/Menu/SubMenu.tsx
+++ b/superset-frontend/src/components/Menu/SubMenu.tsx
@@ -158,7 +158,6 @@ const SubMenuComponent: React.FunctionComponent<SubMenuProps> = props => {
   const [navRightStyle, setNavRightStyle] = useState('nav-right');
   const [navRightCol, setNavRightCol] = useState(8);
 
-  const { headerSize = 2 } = props;
   let hasHistory = true;
   // If no parent <Router> component exists, useHistory throws an error
   try {
@@ -195,17 +194,15 @@ const SubMenuComponent: React.FunctionComponent<SubMenuProps> = props => {
     return () => window.removeEventListener('resize', resize);
   }, [props.buttons]);
 
-  const offset = props.name ? headerSize : 0;
-
   return (
     <StyledHeader>
       <Row className="menu" role="navigation">
         {props.name && (
-          <Col md={offset} xs={24}>
+          <Col flex="none">
             <div className="header">{props.name}</div>
           </Col>
         )}
-        <Col md={16 - offset} sm={24} xs={24}>
+        <Col flex="auto" xs={24}>
           <Menu mode={showMenu} style={{ backgroundColor: 'transparent' }}>
             {props.tabs &&
               props.tabs.map(tab => {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The SubMenu component was recently re-jiggered to use a grid (row/col) layout, and the text/header was given a fixed width, which caused line-wrapping. This PR uses the Row component's automatic layout to avoid this.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![image](https://user-images.githubusercontent.com/812905/118234914-dccd0200-b448-11eb-9063-e10776ceb891.png)

After:
![image](https://user-images.githubusercontent.com/812905/118234380-16e9d400-b448-11eb-8d87-f087616da34a.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Go to Alerts and Reports, and make sure you don't see awkward line-wrapping when the browser is narrow.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
