### PR TITLE
perf: memoize db_engine_spec in database

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/dashboard.helper.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/dashboard.helper.ts
@@ -45,9 +45,7 @@ export interface ChartSpec {
 
 export function getChartGridComponent({ name, viz }: ChartSpec) {
   return cy
-    .get(`[data-test="chart-grid-component"][data-test-chart-name="${name}"]`, {
-      timeout: 30000,
-    })
+    .get(`[data-test="chart-grid-component"][data-test-chart-name="${name}"]`)
     .should('have.attr', 'data-test-viz-type', viz);
 }
 

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/load.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/load.test.ts
@@ -44,9 +44,7 @@ describe('Dashboard load', () => {
 
   it('should load in edit/standalone mode', () => {
     cy.visit(`${WORLD_HEALTH_DASHBOARD}?edit=true&standalone=true`);
-    cy.get('[data-test="discard-changes-button"]', { timeout: 10000 }).should(
-      'be.visible',
-    );
+    cy.get('[data-test="discard-changes-button"]').should('be.visible');
     cy.get('#app-menu').should('not.exist');
   });
 

--- a/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
+++ b/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
@@ -163,7 +163,7 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
 
   const handleChangeConfirm = () => {
     SupersetClient.get({
-      endpoint: `/datasource/get/${confirmedDataset?.type}/${confirmedDataset?.id}`,
+      endpoint: `/datasource/get/${confirmedDataset?.type}/${confirmedDataset?.id}/`,
     })
       .then(({ json }) => {
         onDatasourceSave(json);

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1255,6 +1255,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         )
 
     @classmethod
+    @utils.memoized
     def get_column_spec(
         cls,
         native_type: Optional[str],

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -568,10 +568,10 @@ class Database(
 
     @property
     def db_engine_spec(self) -> Type[db_engine_specs.BaseEngineSpec]:
-        engines = db_engine_specs.get_engine_specs()
-        return engines.get(self.backend, db_engine_specs.BaseEngineSpec)
+        return self.get_db_engine_spec_for_backend(self.backend)
 
     @classmethod
+    @utils.memoized
     def get_db_engine_spec_for_backend(
         cls, backend: str
     ) -> Type[db_engine_specs.BaseEngineSpec]:


### PR DESCRIPTION
### SUMMARY
A recent PR #14547 introduced a performance regression causing dataset metadata fetching to become very slow for datasets with large numbers of columns. I originally thought the type regexes were the problem, but when researching the problem more closely it turns out that just referencing `self.table.database.db_engine_spec` in a `TableColumn` instance cost ~6ms on my local machine. Multiply that by 1000 columns ~= 6000 ms. To get around this I added memoization to the semi-expensive regex, but also added memoizing for `Database.db_engine_spec`. This should also speed up query rendering a bit, as there was similar logic there.

### BEFORE #14547 (pre-regression)
For the World Bank dataset (328 cols), fetching the data took slightly less than 180ms before on my local machine (including the unnecessary 20 ms redirect):
![image](https://user-images.githubusercontent.com/33317356/118236149-665aef00-b49e-11eb-872f-7f4cbfc637d9.png)

### CURRENT (master)
For the same dataset, retrieval of data now takes ~10s!
![image](https://user-images.githubusercontent.com/33317356/118236606-f00abc80-b49e-11eb-9bc7-ab907f8b9084.png)

### AFTER
Retrieval is now slightly quicker than originally (including no redirect):
![image](https://user-images.githubusercontent.com/33317356/118241602-0582e500-b4a5-11eb-9ca8-ff02d02d8c6a.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
