### PR TITLE
fix: roles undefined on public dashboards

### DIFF
--- a/superset-frontend/src/dashboard/util/findPermission.test.ts
+++ b/superset-frontend/src/dashboard/util/findPermission.test.ts
@@ -132,6 +132,13 @@ describe('canUserEditDashboard', () => {
   it('rejects nonexistent users', () => {
     expect(canUserEditDashboard(dashboard, null)).toEqual(false);
   });
+  it('rejects missing roles', () => {
+    // in redux, when there is no user, the user is actually set to an empty object,
+    // so we need to handle missing roles as well as a missing user.s
+    expect(
+      canUserEditDashboard(dashboard, {} as UserWithPermissionsAndRoles),
+    ).toEqual(false);
+  });
   it('rejects "admins" if the admin role does not have edit rights for some reason', () => {
     expect(
       canUserEditDashboard(dashboard, {

--- a/superset-frontend/src/dashboard/util/findPermission.ts
+++ b/superset-frontend/src/dashboard/util/findPermission.ts
@@ -48,6 +48,6 @@ export const canUserEditDashboard = (
   dashboard: Dashboard,
   user?: UserWithPermissionsAndRoles | null,
 ) =>
-  !!user &&
+  !!user?.roles &&
   (isUserAdmin(user) || isUserDashboardOwner(dashboard, user)) &&
   findPermission('can_write', 'Dashboard', user.roles);


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fix for public dashboards where there is no user (but redux still has a "user" which is just an empty object)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Set `PUBLIC_ROLE_LIKE` config value to a role that can view dashboards, and view a dashboard as an anonymous user. It should show up.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #14442 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
