### PR TITLE
fix(sqllab): fix error message

### DIFF
--- a/superset-frontend/src/views/CRUD/data/components/SyntaxHighlighterCopy/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/components/SyntaxHighlighterCopy/index.tsx
@@ -36,11 +36,13 @@ SyntaxHighlighter.registerLanguage('json', jsonSyntax);
 
 const SyntaxHighlighterWrapper = styled.div`
   margin-top: -24px;
+
   &:hover {
     svg {
       visibility: visible;
     }
   }
+
   svg {
     position: relative;
     top: 40px;
@@ -64,13 +66,13 @@ export default function SyntaxHighlighterCopy({
   function copyToClipboard(textToCopy: string) {
     copyTextToClipboard(textToCopy)
       .then(() => {
-        if (addDangerToast) {
-          addDangerToast(t('Sorry, your browser does not support copying.'));
+        if (addSuccessToast) {
+          addSuccessToast(t('SQL Copied!'));
         }
       })
       .catch(() => {
-        if (addSuccessToast) {
-          addSuccessToast(t('SQL Copied!'));
+        if (addDangerToast) {
+          addDangerToast(t('Sorry, your browser does not support copying.'));
         }
       });
   }


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
🐛 Bug Fix
fix error message on the SQL lab.
Expected behavior: when user click on the copy icon, "SQL Copied!" should show in toast msg, instead of "sorry ......"
### BEFORE
<!--- Skip this if not applicable -->
![image](https://user-images.githubusercontent.com/11830681/118364384-cea6ef00-b5ca-11eb-85d6-5d59b33e6537.png)

### AFTER
![image](https://user-images.githubusercontent.com/11830681/118364485-2b0a0e80-b5cb-11eb-9ad5-ea2dc6848b23.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:  Fixes #14615  
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
