### PR TITLE
fix: Clear search on deleting search keyword

### DIFF
--- a/superset-frontend/src/components/ListView/Filters/Search.tsx
+++ b/superset-frontend/src/components/ListView/Filters/Search.tsx
@@ -42,6 +42,12 @@ export default function SearchFilter({
     setValue('');
     onSubmit('');
   };
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.currentTarget.value);
+    if (e.currentTarget.value === '') {
+      onClear();
+    }
+  };
 
   return (
     <FilterContainer>
@@ -50,9 +56,7 @@ export default function SearchFilter({
         placeholder={Header}
         name={name}
         value={value}
-        onChange={e => {
-          setValue(e.currentTarget.value);
-        }}
+        onChange={handleChange}
         onSubmit={handleSubmit}
         onClear={onClear}
       />


### PR DESCRIPTION
### SUMMARY
Fixes #14610 
Fixes #13902

It clears out the search results when the search input is emptied.

### BEFORE
https://user-images.githubusercontent.com/60598000/118392171-d73a0c80-b640-11eb-8417-00e1740cc58e.mp4

### AFTER
https://user-images.githubusercontent.com/60598000/118392144-a5c14100-b640-11eb-8731-334687c2b08d.mp4


### TEST PLAN
1. Go to a list view, such as Dashboards
2. Search for a non-existing dashboard title
3. Clear out the search input by deleting the keyword
4. Make sure the search has been reset and the default search results are showing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #14610 #13902
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
