### PR TITLE
fix: Tooltip position of table title

### DIFF
--- a/superset-frontend/src/SqlLab/components/TableElement.jsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.jsx
@@ -204,7 +204,7 @@ class TableElement extends React.PureComponent {
       >
         <Tooltip
           id="copy-to-clipboard-tooltip"
-          placement="top"
+          placement="topLeft"
           style={{ cursor: 'pointer' }}
           title={table.name}
           trigger={['hover']}


### PR DESCRIPTION
### SUMMARY
Fixes #14614 

### BEFORE
<img width="1013" alt="tooltip_b4" src="https://user-images.githubusercontent.com/60598000/118393725-36038400-b649-11eb-8910-40c36e5858ce.png">

### AFTER
<img width="1021" alt="tooltip_after" src="https://user-images.githubusercontent.com/60598000/118393732-3e5bbf00-b649-11eb-9ad2-da8eb404d959.png">

### TEST PLAN
1. Open the SQL lab
2. Hover a table name
3. Make sure the tooltip is showing at the right position

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #14614 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
