### PR TITLE
fix(explore): Filter box full chart height

### DIFF
--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -183,9 +183,11 @@ const ExploreChartPanel = props => {
   };
 
   const renderChart = useCallback(() => {
-    const { chart } = props;
+    const { chart, vizType } = props;
     const newHeight =
-      calcSectionHeight(splitSizes[0]) - CHART_PANEL_PADDING_VERTICAL;
+      vizType === 'filter_box'
+        ? calcSectionHeight(100) - CHART_PANEL_PADDING_VERTICAL
+        : calcSectionHeight(splitSizes[0]) - CHART_PANEL_PADDING_VERTICAL;
     const chartWidth = chartPanelWidth - CHART_PANEL_PADDING_HORIZ;
     return (
       chartWidth > 0 && (


### PR DESCRIPTION
### SUMMARY
Fixes #14604 

The `filter_box` wasn't getting all the available height, making the 'Apply' button appear cut.

### BEFORE
<img width="1680" alt="btn_b4" src="https://user-images.githubusercontent.com/81597121/118100835-c4e37880-b38b-11eb-8667-952189932350.png">

### AFTER
<img width="1680" alt="btn_after" src="https://user-images.githubusercontent.com/60598000/118396526-96e68880-b658-11eb-82d7-2b981fd1d957.png">

### TEST PLAN
1. Open a chart in Explore
2. Set viz type 'Filter box'
3. Add at least 5 filters
4. Make sure the 'Apply' button appears correctly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #14604
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
