### PR TITLE
fix(explore): Tag component overlap

### DIFF
--- a/superset-frontend/src/components/Label/index.tsx
+++ b/superset-frontend/src/components/Label/index.tsx
@@ -101,6 +101,7 @@ export default function Label(props: LabelProps) {
         padding: '0.35em 0.8em',
         lineHeight: 1,
         color,
+        maxWidth: '100%',
         '&:hover': {
           backgroundColor: backgroundColorHover,
           borderColor: borderColorHover,


### PR DESCRIPTION
### SUMMARY
Fixes #14607 

Reintroduces the max-width that got lost during refactoring. For reference PR #12774

### BEFORE
![Screen Shot 2021-05-17 at 17 17 59](https://user-images.githubusercontent.com/60598000/118504047-dafa8b80-b733-11eb-9835-bb978c4d9b1f.png)

### AFTER
![Screen Shot 2021-05-17 at 17 12 35](https://user-images.githubusercontent.com/60598000/118503629-793a2180-b733-11eb-9231-4d72f0db2214.png)


### TEST PLAN
1. Open a deck.gl Screen Grid chart
2. Make sure the "LONGITUDE AND LATITUDE" Tag component does not overlap with the "WEIGHT"

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #14607 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
