### PR TITLE
fix(explore): Fix column number calculation

### DIFF
--- a/superset-frontend/src/components/Select/styles.tsx
+++ b/superset-frontend/src/components/Select/styles.tsx
@@ -101,7 +101,7 @@ export const defaultTheme: (
     controlHeight: 34,
     lineHeight: 19,
     fontSize: 14,
-    minWidth: '7.5em', // just enough to display 'No options'
+    minWidth: '6.5em',
   },
 });
 

--- a/superset-frontend/src/explore/components/ControlRow.tsx
+++ b/superset-frontend/src/explore/components/ControlRow.tsx
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ExpandedControlItem } from '@superset-ui/chart-controls';
 import React from 'react';
 
 const NUM_COLUMNS = 12;
@@ -24,9 +23,14 @@ const NUM_COLUMNS = 12;
 export default function ControlRow({
   controls,
 }: {
-  controls: ExpandedControlItem[];
+  controls: React.ReactElement[];
 }) {
-  const colSize = NUM_COLUMNS / controls.length;
+  // ColorMapControl renders null and should not be counted
+  // in the columns number
+  const countableControls = controls.filter(
+    control => !['ColorMapControl'].includes(control.props.type),
+  );
+  const colSize = NUM_COLUMNS / countableControls.length;
   return (
     <div className="row space-1">
       {controls.map((control, i) => (

--- a/superset-frontend/src/explore/components/ControlRow.tsx
+++ b/superset-frontend/src/explore/components/ControlRow.tsx
@@ -20,15 +20,13 @@ import React from 'react';
 
 const NUM_COLUMNS = 12;
 
-export default function ControlRow({
-  controls,
-}: {
-  controls: React.ReactElement[];
-}) {
+type Control = React.ReactElement | null;
+
+export default function ControlRow({ controls }: { controls: Control[] }) {
   // ColorMapControl renders null and should not be counted
   // in the columns number
   const countableControls = controls.filter(
-    control => !['ColorMapControl'].includes(control.props.type),
+    control => !['ColorMapControl'].includes(control?.props.type),
   );
   const colSize = NUM_COLUMNS / countableControls.length;
   return (


### PR DESCRIPTION
### SUMMARY
Fixes #14605 

It decreases the min-width of a Select which is necessary when 3 or more columns are present. It also excludes the `ColorMapControl` from the column number calculation as its content is `null` / invisible to the end-user.

### BEFORE
![Screen Shot 2021-05-17 at 18 07 22](https://user-images.githubusercontent.com/60598000/118511691-d4234700-b73a-11eb-8d11-37ab20ca0926.png)

### AFTER
![Screen Shot 2021-05-17 at 18 01 56](https://user-images.githubusercontent.com/60598000/118511726-dbe2eb80-b73a-11eb-9bd7-6ac6c99dd23b.png)

### TEST PLAN
1. Open a deck.gl Scatterplot
2. Make sure that elements are not overlapping in the Point Color config

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #14605 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
