### PR TITLE
feat: make config method optional

### DIFF
--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -323,7 +323,6 @@ class DatabasePostSchema(Schema, DatabaseParametersSchemaMixin):
     configuration_method = EnumField(
         ConfigurationMethod,
         by_value=True,
-        required=True,
         description=configuration_method_description,
     )
     force_ctas_schema = fields.String(

--- a/tests/databases/api_tests.py
+++ b/tests/databases/api_tests.py
@@ -275,35 +275,36 @@ class TestDatabaseApi(SupersetTestCase):
         }
         assert rv.status_code == 400
 
-    def test_create_database_no_configuration_method(self):
-        """
-        Database API: Test create with no config method.
-        """
-        extra = {
-            "metadata_params": {},
-            "engine_params": {},
-            "metadata_cache_timeout": {},
-            "schemas_allowed_for_csv_upload": [],
-        }
+    # add this test back in when config method becomes required for creation.
+    # def test_create_database_no_configuration_method(self):
+    #     """
+    #     Database API: Test create with no config method.
+    #     """
+    #     extra = {
+    #         "metadata_params": {},
+    #         "engine_params": {},
+    #         "metadata_cache_timeout": {},
+    #         "schemas_allowed_for_csv_upload": [],
+    #     }
 
-        self.login(username="admin")
-        example_db = get_example_database()
-        if example_db.backend == "sqlite":
-            return
-        database_data = {
-            "database_name": "test-create-database",
-            "sqlalchemy_uri": example_db.sqlalchemy_uri_decrypted,
-            "server_cert": None,
-            "extra": json.dumps(extra),
-        }
+    #     self.login(username="admin")
+    #     example_db = get_example_database()
+    #     if example_db.backend == "sqlite":
+    #         return
+    #     database_data = {
+    #         "database_name": "test-create-database",
+    #         "sqlalchemy_uri": example_db.sqlalchemy_uri_decrypted,
+    #         "server_cert": None,
+    #         "extra": json.dumps(extra),
+    #     }
 
-        uri = "api/v1/database/"
-        rv = self.client.post(uri, json=database_data)
-        response = json.loads(rv.data.decode("utf-8"))
-        assert response == {
-            "message": {"configuration_method": ["Missing data for required field."]}
-        }
-        assert rv.status_code == 400
+    #     uri = "api/v1/database/"
+    #     rv = self.client.post(uri, json=database_data)
+    #     response = json.loads(rv.data.decode("utf-8"))
+    #     assert response == {
+    #         "message": {"configuration_method": ["Missing data for required field."]}
+    #     }
+    #     assert rv.status_code == 400
 
     def test_create_database_server_cert_validate(self):
         """


### PR DESCRIPTION
### SUMMARY
Config method being required is currently not letting people add databases, we are making it optional until we have added functionality in the database create frontend. 


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
