### PR TITLE
feat: add SSL to new DB parameters

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1351,6 +1351,8 @@ class BasicParametersMixin:
     def build_sqlalchemy_uri(cls, parameters: BasicParametersType) -> str:
         query = parameters.get("query", {})
         if parameters.get("encryption"):
+            if not cls.encryption_parameters:
+                raise Exception("Unable to build a URL with encryption enabled")
             query.update(cls.encryption_parameters)
 
         return str(

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1304,6 +1304,9 @@ class BasicParametersSchema(Schema):
     query = fields.Dict(
         keys=fields.Str(), values=fields.Raw(), description=__("Additional parameters")
     )
+    encryption = fields.Boolean(
+        required=False, description=__("Use an encrypted connection to the database")
+    )
 
 
 class BasicParametersType(TypedDict, total=False):
@@ -1313,6 +1316,7 @@ class BasicParametersType(TypedDict, total=False):
     port: int
     database: str
     query: Dict[str, Any]
+    encryption: bool
 
 
 class BasicParametersMixin:
@@ -1339,8 +1343,16 @@ class BasicParametersMixin:
         "drivername://user:password@host:port/dbname[?key=value&key=value...]"
     )
 
+    # query parameter to enable encryption in the database connection
+    # for Postgres this would be `{"sslmode": "verify-ca"}`, eg.
+    encryption_parameters: Dict[str, str] = {}
+
     @classmethod
     def build_sqlalchemy_uri(cls, parameters: BasicParametersType) -> str:
+        query = parameters.get("query", {})
+        if parameters.get("encryption"):
+            query.update(cls.encryption_parameters)
+
         return str(
             URL(
                 cls.drivername,
@@ -1349,13 +1361,16 @@ class BasicParametersMixin:
                 host=parameters["host"],
                 port=parameters["port"],
                 database=parameters["database"],
-                query=parameters.get("query", {}),
+                query=query,
             )
         )
 
-    @staticmethod
-    def get_parameters_from_uri(uri: str) -> BasicParametersType:
+    @classmethod
+    def get_parameters_from_uri(cls, uri: str) -> BasicParametersType:
         url = make_url(uri)
+        encryption = all(
+            item in url.query.items() for item in cls.encryption_parameters.items()
+        )
         return {
             "username": url.username,
             "password": url.password,
@@ -1363,6 +1378,7 @@ class BasicParametersMixin:
             "port": url.port,
             "database": url.database,
             "query": url.query,
+            "encryption": encryption,
         }
 
     @classmethod

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -163,6 +163,8 @@ class PostgresEngineSpec(PostgresBaseEngineSpec, BasicParametersMixin):
     sqlalchemy_uri_placeholder = (
         "postgresql+psycopg2://user:password@host:port/dbname[?key=value&key=value...]"
     )
+    # https://www.postgresql.org/docs/9.1/libpq-ssl.html#LIBQ-SSL-CERTIFICATES
+    encryption_parameters = {"sslmode": "verify-ca"}
 
     max_column_name_length = 63
     try_remove_schema_from_table_name = False

--- a/tests/databases/api_tests.py
+++ b/tests/databases/api_tests.py
@@ -1391,6 +1391,10 @@ class TestDatabaseApi(SupersetTestCase):
                                 "description": "Database name",
                                 "type": "string",
                             },
+                            "encryption": {
+                                "description": "Use an encrypted connection to the database",
+                                "type": "boolean",
+                            },
                             "host": {
                                 "description": "Hostname or IP address",
                                 "type": "string",

--- a/tests/db_engine_specs/postgres_tests.py
+++ b/tests/db_engine_specs/postgres_tests.py
@@ -430,11 +430,12 @@ def test_base_parameters_mixin():
         "port": 5432,
         "database": "dbname",
         "query": {"foo": "bar"},
+        "encryption": True,
     }
     sqlalchemy_uri = PostgresEngineSpec.build_sqlalchemy_uri(parameters)
-    assert (
-        sqlalchemy_uri
-        == "postgresql+psycopg2://username:password@localhost:5432/dbname?foo=bar"
+    assert sqlalchemy_uri == (
+        "postgresql+psycopg2://username:password@localhost:5432/dbname?"
+        "foo=bar&sslmode=verify-ca"
     )
 
     parameters_from_uri = PostgresEngineSpec.get_parameters_from_uri(sqlalchemy_uri)
@@ -458,6 +459,10 @@ def test_base_parameters_mixin():
                 "additionalProperties": {},
             },
             "database": {"type": "string", "description": "Database name"},
+            "encryption": {
+                "type": "boolean",
+                "description": "Use an encrypted connection to the database",
+            },
         },
         "required": ["database", "host", "port", "username"],
     }


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Expose an option to configure an encrypted connection when adding a new database with the new parameters flow.

In the new flow, users can just specify that they want SSL on, and we'll build a SQLAlchemy URI that enforces encryption. For Postgres, eg, this is done by adding `sslmode=verify-ca` to the query parameters.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Updated unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
