### PR TITLE
fix: Fixes group by control icon colors

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/Option.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/Option.tsx
@@ -39,12 +39,12 @@ export default function Option(props: OptionProps) {
         data-test="remove-control-button"
         onClick={() => props.clickClose(props.index)}
       >
-        <Icons.XSmall color={theme.colors.grayscale.light1} />
+        <Icons.XSmall iconColor={theme.colors.grayscale.light1} />
       </CloseContainer>
       <Label data-test="control-label">{props.children}</Label>
       {props.withCaret && (
         <CaretContainer>
-          <Icons.CaretRight color={theme.colors.grayscale.light1} />
+          <Icons.CaretRight iconColor={theme.colors.grayscale.light1} />
         </CaretContainer>
       )}
     </OptionControlContainer>

--- a/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
+++ b/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
@@ -47,19 +47,27 @@ export const OptionControlContainer = styled.div<{
 `;
 
 export const Label = styled.div`
-  display: flex;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  align-items: center;
-  white-space: nowrap;
-  padding-left: ${({ theme }) => theme.gridUnit}px;
-  svg {
-    margin-right: ${({ theme }) => theme.gridUnit}px;
-  }
-  .option-label {
-    display: inline;
-  }
+  ${({ theme }) => `
+    display: flex;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    align-items: center;
+    white-space: nowrap;
+    padding-left: ${theme.gridUnit}px;
+    svg {
+      margin-right: ${theme.gridUnit}px;
+      margin-left: ${theme.gridUnit}px;
+    }
+    .type-label {
+      margin-right: ${theme.gridUnit}px;
+      margin-left: ${theme.gridUnit}px;
+      font-weight: ${theme.typography.weights.normal};
+    }
+    .option-label {
+      display: inline;
+    }
+  `}
 `;
 
 export const CaretContainer = styled.div`

--- a/superset-frontend/src/explore/components/optionRenderers.tsx
+++ b/superset-frontend/src/explore/components/optionRenderers.tsx
@@ -42,8 +42,9 @@ const OptionContainer = styled.div`
     }
   }
   .type-label {
-    margin-right: ${({ theme }) => theme.gridUnit * 2}px;
-    width: ${({ theme }) => theme.gridUnit * 7}px;
+    margin-right: ${({ theme }) => theme.gridUnit * 3}px;
+    margin-left: ${({ theme }) => theme.gridUnit * 3}px;
+    width: ${({ theme }) => theme.gridUnit * 4}px;
     display: inline-block;
     text-align: center;
     font-weight: ${({ theme }) => theme.typography.weights.bold};


### PR DESCRIPTION
### SUMMARY
Fixes group by control icon colors.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="609" alt="Screen Shot 2021-05-17 at 3 50 16 PM" src="https://user-images.githubusercontent.com/70410625/118541199-d203bd00-b727-11eb-9efd-7293aeabaa80.png">
<img width="614" alt="Screen Shot 2021-05-17 at 3 47 11 PM" src="https://user-images.githubusercontent.com/70410625/118541216-d5974400-b727-11eb-8fe3-eb02b14d0fe9.png">

@rusackas @junlincc @kgabryje 

### TEST PLAN
1 - Go to explore
2 - Add a measure, filter and group by
3 - The icons should all look the same

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
