### PR TITLE
feat: redirect to /login when CSRF expired

### DIFF
--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -23,7 +23,16 @@ from typing import Any, Callable, cast, Dict, List, Optional, TYPE_CHECKING, Uni
 
 import simplejson as json
 import yaml
-from flask import abort, flash, g, get_flashed_messages, redirect, Response, session
+from flask import (
+    abort,
+    flash,
+    g,
+    get_flashed_messages,
+    redirect,
+    Response,
+    session,
+    url_for,
+)
 from flask_appbuilder import BaseView, Model, ModelView
 from flask_appbuilder.actions import action
 from flask_appbuilder.forms import DynamicForm
@@ -32,6 +41,7 @@ from flask_appbuilder.security.sqla.models import Role, User
 from flask_appbuilder.widgets import ListWidget
 from flask_babel import get_locale, gettext as __, lazy_gettext as _
 from flask_jwt_extended.exceptions import NoAuthorizationError
+from flask_wtf.csrf import CSRFError
 from flask_wtf.form import FlaskForm
 from sqlalchemy import or_
 from sqlalchemy.orm import Query
@@ -359,6 +369,13 @@ def show_superset_error(ex: SupersetErrorException) -> FlaskResponse:
 def show_superset_errors(ex: SupersetErrorsException) -> FlaskResponse:
     logger.warning(ex)
     return json_errors_response(errors=ex.errors, status=ex.status)
+
+
+# Redirect to login if the CSRF token is expired
+@superset_app.errorhandler(CSRFError)
+def refresh_csrf_token(ex: CSRFError) -> FlaskResponse:
+    logger.warning(ex)
+    return redirect(appbuilder.get_url_for_login)
 
 
 @superset_app.errorhandler(HTTPException)

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -32,7 +32,6 @@ from flask import (
     request,
     Response,
     session,
-    url_for,
 )
 from flask_appbuilder import BaseView, Model, ModelView
 from flask_appbuilder.actions import action
@@ -377,11 +376,9 @@ def show_superset_errors(ex: SupersetErrorsException) -> FlaskResponse:
 def refresh_csrf_token(ex: CSRFError) -> FlaskResponse:
     logger.warning(ex)
 
-    # show JSON error payload for API requests
-    if request.path.startswith("/api"):
+    if request.is_json:
         return show_http_exception(ex)
 
-    # return login page for non-API requests
     return redirect(appbuilder.get_url_for_login)
 
 

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -29,6 +29,7 @@ from flask import (
     g,
     get_flashed_messages,
     redirect,
+    request,
     Response,
     session,
     url_for,
@@ -375,6 +376,12 @@ def show_superset_errors(ex: SupersetErrorsException) -> FlaskResponse:
 @superset_app.errorhandler(CSRFError)
 def refresh_csrf_token(ex: CSRFError) -> FlaskResponse:
     logger.warning(ex)
+
+    # show JSON error payload for API requests
+    if request.path.startswith("/api"):
+        return show_http_exception(ex)
+
+    # return login page for non-API requests
     return redirect(appbuilder.get_url_for_login)
 
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Redirect user to `/login` when the CSRF token is expired. Currently this shows a JSON payload with a generic error.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

I did a `curl` with an expired CSRF token and got redirected:

```bash
$ curl -v 'http://localhost:8089/api/v1/database/test_connection' -H 'X-CSRFToken: XXX' ...
...
< HTTP/1.0 302 FOUND
< Content-Type: text/html; charset=utf-8
< Content-Length: 221
< Location: http://localhost:8089/login/
< Server: Werkzeug/1.0.1 Python/3.8.8
< Date: Mon, 17 May 2021 18:57:57 GMT
<
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>Redirecting...</title>
<h1>Redirecting...</h1>
* Closing connection 0
<p>You should be redirected automatically to target URL: <a href="/login/">/login/</a>.  If not click the link.%
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
