### PR TITLE
feat: redirect 404/500 to static pages

### DIFF
--- a/superset-frontend/src/assets/staticPages/404.html
+++ b/superset-frontend/src/assets/staticPages/404.html
@@ -94,7 +94,7 @@
       <section>
         <h1>Page not found</h1>
         <p>
-          Sorry, we cannot find t he page you are looking for. You may have
+          Sorry, we cannot find the page you are looking for. You may have
           mistyped the address or the page may have moved.
         </p>
         <a href="/" class="button">Back to home</a>

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -364,6 +364,10 @@ def show_superset_errors(ex: SupersetErrorsException) -> FlaskResponse:
 @superset_app.errorhandler(HTTPException)
 def show_http_exception(ex: HTTPException) -> FlaskResponse:
     logger.warning(ex)
+    if not config["DEBUG"] and ex.code == 404:
+        return redirect("/static/assets/404.html")
+    if not config["DEBUG"] and ex.code == 500:
+        return redirect("/static/assets/500.html")
     return json_errors_response(
         errors=[
             SupersetError(


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

We're currently returning a SIP-40 error payload on 404 and 500. I changed it to redirect the user to the static pages for these errors instead when running in production (not development).

@samtfm, @willbarrett how is this handled on the Preset side?

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

![Screenshot_2021-05-17 Screenshot](https://user-images.githubusercontent.com/1534870/118545118-061cb500-b70b-11eb-8221-124055208cbd.png)

After:

![Screenshot_2021-05-17 404 Not found Superset](https://user-images.githubusercontent.com/1534870/118545133-09b03c00-b70b-11eb-9dfa-c9a547357cd3.png)

![Screenshot_2021-05-17 500 Internal server error S uperset](https://user-images.githubusercontent.com/1534870/118545143-0b79ff80-b70b-11eb-8aeb-03aaeb0ad1ac.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
