### PR TITLE
feat: Expanded Parameters for Mysql

### DIFF
--- a/superset/db_engine_specs/mysql.py
+++ b/superset/db_engine_specs/mysql.py
@@ -35,7 +35,7 @@ from sqlalchemy.dialects.mysql import (
 from sqlalchemy.engine.url import URL
 from sqlalchemy.types import TypeEngine
 
-from superset.db_engine_specs.base import BaseEngineSpec
+from superset.db_engine_specs.base import BaseEngineSpec, BasicParametersMixin
 from superset.errors import SupersetErrorType
 from superset.utils import core as utils
 from superset.utils.core import ColumnSpec, GenericDataType
@@ -53,7 +53,7 @@ CONNECTION_HOST_DOWN_REGEX = re.compile(
 CONNECTION_UNKNOWN_DATABASE_REGEX = re.compile("Unknown database '(?P<database>.*?)'")
 
 
-class MySQLEngineSpec(BaseEngineSpec):
+class MySQLBaseEngineSpec(BaseEngineSpec):
     engine = "mysql"
     engine_name = "MySQL"
     max_column_name_length = 64
@@ -111,22 +111,22 @@ class MySQLEngineSpec(BaseEngineSpec):
         CONNECTION_ACCESS_DENIED_REGEX: (
             __('Either the username "%(username)s" or the password is incorrect.'),
             SupersetErrorType.CONNECTION_ACCESS_DENIED_ERROR,
-            {},
+            {"invalid": ["username", "password"]},
         ),
         CONNECTION_INVALID_HOSTNAME_REGEX: (
             __('Unknown MySQL server host "%(hostname)s".'),
             SupersetErrorType.CONNECTION_INVALID_HOSTNAME_ERROR,
-            {},
+            {"invalid": ["host"]},
         ),
         CONNECTION_HOST_DOWN_REGEX: (
             __('The host "%(hostname)s" might be down and can\'t be reached.'),
             SupersetErrorType.CONNECTION_HOST_DOWN_ERROR,
-            {},
+            {"invalid": ["host", "port"]},
         ),
         CONNECTION_UNKNOWN_DATABASE_REGEX: (
             __('Unable to connect to database "%(database)s".'),
             SupersetErrorType.CONNECTION_UNKNOWN_DATABASE_ERROR,
-            {},
+            {"invalid": ["database"]},
         ),
     }
 
@@ -201,3 +201,12 @@ class MySQLEngineSpec(BaseEngineSpec):
         return super().get_column_spec(
             native_type, column_type_mappings=column_type_mappings
         )
+
+
+class MySQLEngineSpec(MySQLBaseEngineSpec, BasicParametersMixin):
+    engine = "mySQL"
+
+    drivername = "mysql"
+    sqlalchemy_uri_placeholder = (
+        "mysql://user:password@host:post/dbname[?key=value&key=value...]"
+    )

--- a/superset/db_engine_specs/mysql.py
+++ b/superset/db_engine_specs/mysql.py
@@ -60,8 +60,10 @@ class MySQLEngineSpec(BaseEngineSpec, BasicParametersMixin):
 
     drivername = "mysql+mysqldb"
     sqlalchemy_uri_placeholder = (
-        "mysql://user:password@host:post/dbname[?key=value&key=value...]"
+        "mysql://user:password@host:port/dbname[?key=value&key=value...]"
     )
+
+    encryption_parameters = {"ssl": "1"}
 
     column_type_mappings: Tuple[
         Tuple[

--- a/superset/db_engine_specs/mysql.py
+++ b/superset/db_engine_specs/mysql.py
@@ -53,10 +53,15 @@ CONNECTION_HOST_DOWN_REGEX = re.compile(
 CONNECTION_UNKNOWN_DATABASE_REGEX = re.compile("Unknown database '(?P<database>.*?)'")
 
 
-class MySQLBaseEngineSpec(BaseEngineSpec):
+class MySQLEngineSpec(BaseEngineSpec, BasicParametersMixin):
     engine = "mysql"
     engine_name = "MySQL"
     max_column_name_length = 64
+
+    drivername = "mysql"
+    sqlalchemy_uri_placeholder = (
+        "mysql://user:password@host:post/dbname[?key=value&key=value...]"
+    )
 
     column_type_mappings: Tuple[
         Tuple[
@@ -201,12 +206,3 @@ class MySQLBaseEngineSpec(BaseEngineSpec):
         return super().get_column_spec(
             native_type, column_type_mappings=column_type_mappings
         )
-
-
-class MySQLEngineSpec(MySQLBaseEngineSpec, BasicParametersMixin):
-    engine = "mySQL"
-
-    drivername = "mysql"
-    sqlalchemy_uri_placeholder = (
-        "mysql://user:password@host:post/dbname[?key=value&key=value...]"
-    )

--- a/superset/db_engine_specs/mysql.py
+++ b/superset/db_engine_specs/mysql.py
@@ -58,7 +58,7 @@ class MySQLEngineSpec(BaseEngineSpec, BasicParametersMixin):
     engine_name = "MySQL"
     max_column_name_length = 64
 
-    drivername = "mysql"
+    drivername = "mysql+mysqldb"
     sqlalchemy_uri_placeholder = (
         "mysql://user:password@host:post/dbname[?key=value&key=value...]"
     )

--- a/tests/databases/api_tests.py
+++ b/tests/databases/api_tests.py
@@ -1582,3 +1582,25 @@ class TestDatabaseApi(SupersetTestCase):
                 },
             ]
         }
+
+    def test_validate_parameters_with_mysql(self):
+        example_db = get_example_database()
+        test_database = self.insert_database(
+            "test-database", example_db.sqlalchemy_uri_decrypted
+        )
+        test_database.password = "password"
+        self.login(username="admin")
+        url = "api/v1/database/validate_parameters"
+        payload = {
+            "engine": "mysql",
+            "parameters": {
+                "host": "localhost",
+                "port": 5432,
+                "username": "admin",
+                "password": test_database.password,
+                "database": test_database.database_name,
+                "query": {},
+            },
+        }
+        rv = self.client.post(url, json=payload)
+        assert rv.status_code == 422

--- a/tests/databases/api_tests.py
+++ b/tests/databases/api_tests.py
@@ -1380,7 +1380,6 @@ class TestDatabaseApi(SupersetTestCase):
 
         rv = self.client.get(uri)
         response = json.loads(rv.data.decode("utf-8"))
-        print(response)
         assert rv.status_code == 200
         assert response == {
             "databases": [
@@ -1427,6 +1426,72 @@ class TestDatabaseApi(SupersetTestCase):
                     },
                     "preferred": True,
                     "sqlalchemy_uri_placeholder": "postgresql+psycopg2://user:password@host:port/dbname[?key=value&key=value...]",
+                },
+                {"engine": "hana", "name": "SAP HANA", "preferred": False},
+            ]
+        }
+
+    @mock.patch("superset.databases.api.get_available_engine_specs")
+    @mock.patch("superset.databases.api.app")
+    def test_available_with_mysql(self, app, get_available_engine_specs):
+        app.config = {"PREFERRED_DATABASES": ["mysql"]}
+        get_available_engine_specs.return_value = [
+            MySQLEngineSpec,
+            HanaEngineSpec,
+        ]
+
+        self.login(username="admin")
+        uri = "api/v1/database/available/"
+
+        rv = self.client.get(uri)
+        response = json.loads(rv.data.decode("utf-8"))
+        print(response)
+        assert rv.status_code == 200
+        assert response == {
+            "databases": [
+                {
+                    "engine": "mysql",
+                    "name": "MySQL",
+                    "parameters": {
+                        "properties": {
+                            "database": {
+                                "description": "Database name",
+                                "type": "string",
+                            },
+                            "encryption": {
+                                "description": "Use an encrypted connection to the database",
+                                "type": "boolean",
+                            },
+                            "host": {
+                                "description": "Hostname or IP address",
+                                "type": "string",
+                            },
+                            "password": {
+                                "description": "Password",
+                                "nullable": True,
+                                "type": "string",
+                            },
+                            "port": {
+                                "description": "Database port",
+                                "format": "int32",
+                                "type": "integer",
+                            },
+                            "query": {
+                                "additionalProperties": {},
+                                "description": "Additional parameters",
+                                "type": "object",
+                            },
+                            "username": {
+                                "description": "Username",
+                                "nullable": True,
+                                "type": "string",
+                            },
+                        },
+                        "required": ["database", "host", "port", "username"],
+                        "type": "object",
+                    },
+                    "preferred": True,
+                    "sqlalchemy_uri_placeholder": "mysql://user:password@host:port/dbname[?key=value&key=value...]",
                 },
                 {"engine": "hana", "name": "SAP HANA", "preferred": False},
             ]

--- a/tests/db_engine_specs/mysql_tests.py
+++ b/tests/db_engine_specs/mysql_tests.py
@@ -115,6 +115,7 @@ class TestMySQLEngineSpecsDbEngineSpec(TestDbEngineSpec):
                 message='Either the username "test" or the password is incorrect.',
                 level=ErrorLevel.ERROR,
                 extra={
+                    "invalid": ["username", "password"],
                     "engine_name": "MySQL",
                     "issue_codes": [
                         {
@@ -140,6 +141,7 @@ class TestMySQLEngineSpecsDbEngineSpec(TestDbEngineSpec):
                 message='Unknown MySQL server host "badhostname.com".',
                 level=ErrorLevel.ERROR,
                 extra={
+                    "invalid": ["host"],
                     "engine_name": "MySQL",
                     "issue_codes": [
                         {
@@ -161,6 +163,7 @@ class TestMySQLEngineSpecsDbEngineSpec(TestDbEngineSpec):
                 "down and can't be reached.",
                 level=ErrorLevel.ERROR,
                 extra={
+                    "invalid": ["host", "port"],
                     "engine_name": "MySQL",
                     "issue_codes": [
                         {
@@ -181,6 +184,7 @@ class TestMySQLEngineSpecsDbEngineSpec(TestDbEngineSpec):
                 message='The host "93.184.216.34" might be down and can\'t be reached.',
                 level=ErrorLevel.ERROR,
                 extra={
+                    "invalid": ["host", "port"],
                     "engine_name": "MySQL",
                     "issue_codes": [
                         {
@@ -195,12 +199,14 @@ class TestMySQLEngineSpecsDbEngineSpec(TestDbEngineSpec):
 
         msg = "mysql: Unknown database 'badDB'"
         result = MySQLEngineSpec.extract_errors(Exception(msg))
+        print(result)
         assert result == [
             SupersetError(
                 message='Unable to connect to database "badDB".',
                 error_type=SupersetErrorType.CONNECTION_UNKNOWN_DATABASE_ERROR,
                 level=ErrorLevel.ERROR,
                 extra={
+                    "invalid": ["database"],
                     "engine_name": "MySQL",
                     "issue_codes": [
                         {


### PR DESCRIPTION
### SUMMARY
MySQL databases can now use the expanded parameters provided by the BasicParametersMixin to create new databases. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TEST PLAN
Added unit tests. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
