### PR TITLE
feat(db_engine_specs): Add quirks to support Ascend.io/HiveServer2 with Impala driver.

### DIFF
--- a/docs/src/pages/docs/Connecting to Databases/ascend.mdx
+++ b/docs/src/pages/docs/Connecting to Databases/ascend.mdx
@@ -1,0 +1,17 @@
+---
+name: Ascend.io
+menu: Connecting to Databases
+route: /docs/databases/ascend
+index: 7
+version: 1
+---
+
+## Ascend.io
+
+The recommended connector library to Ascend.io is [impyla](https://github.com/cloudera/impyla).
+
+The expected connection string is formatted as follows:
+
+```
+ascend://{username}:{password}@{hostname}:{port}/{database}?auth_mechanism=PLAIN;use_ssl=true
+```

--- a/docs/src/pages/docs/Connecting to Databases/index.mdx
+++ b/docs/src/pages/docs/Connecting to Databases/index.mdx
@@ -33,6 +33,7 @@ A list of some of the recommended packages.
 |[Apache Pinot](/docs/databases/pinot)|```pip install pinotdb```|```pinot://BROKER:5436/query?server=http://CONTROLLER:5983/```|
 |[Apache Solr](/docs/databases/solr)|```pip install sqlalchemy-solr```|```solr://{username}:{password}@{hostname}:{port}/{server_path}/{collection}```
 |[Apache Spark SQL](/docs/databases/spark-sql)|```pip install pyhive```|```hive://hive@{hostname}:{port}/{database}```
+|[Ascend.io](/docs/databases/ascend)|```pip install impyla```|```ascend://{username}:{password}@{hostname}:{port}/{database}?auth_mechanism=PLAIN;use_ssl=true```|
 |[Azure MS SQL](/docs/databases/sql-server)|```pip install pymssql``` |```mssql+pymssql://UserName@presetSQL:TestPassword@presetSQL.database.windows.net:1433/TestSchema```
 |[Big Query](/docs/databases/bigquery)|```pip install pybigquery```|```bigquery://{project_id}```|
 |[ClickHouse](/docs/databases/clickhouse)|```pip install clickhouse-driver==0.2.0 && pip install clickhouse-sqlalchemy==0.1.6```|```clickhouse+native://{username}:{password}@{hostname}:{port}/{database}```|

--- a/superset/db_engine_specs/ascend.py
+++ b/superset/db_engine_specs/ascend.py
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from sqlalchemy.dialects import registry
+
+from superset.db_engine_specs.impala import ImpalaEngineSpec
+
+
+class AscendEngineSpec(ImpalaEngineSpec):
+    """Engine spec for Ascend.io (Hive2+TLS) using Cloudera's Impala"""
+
+    engine = "ascend"
+    registry.register("ascend", "impala.sqlalchemy", "ImpalaDialect")
+
+    engine_name = "Ascend"
+
+    _time_grain_expressions = {
+        None: "{col}",
+        "PT1S": "DATE_TRUNC('second', {col})",
+        "PT1M": "DATE_TRUNC('minute', {col})",
+        "PT1H": "DATE_TRUNC('hour', {col})",
+        "P1D": "DATE_TRUNC('day', {col})",
+        "P1W": "DATE_TRUNC('week', {col})",
+        "P1M": "DATE_TRUNC('month', {col})",
+        "P0.25Y": "DATE_TRUNC('quarter', {col})",
+        "P1Y": "DATE_TRUNC('year', {col})",
+    }

--- a/tests/db_engine_specs/ascend_tests.py
+++ b/tests/db_engine_specs/ascend_tests.py
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from superset.db_engine_specs.ascend import AscendEngineSpec
+from tests.db_engine_specs.base_tests import TestDbEngineSpec
+
+
+class TestAscendDbEngineSpec(TestDbEngineSpec):
+    def test_convert_dttm(self):
+        dttm = self.get_dttm()
+
+        self.assertEqual(
+            AscendEngineSpec.convert_dttm("DATE", dttm), "CAST('2019-01-02' AS DATE)"
+        )
+
+        self.assertEqual(
+            AscendEngineSpec.convert_dttm("TIMESTAMP", dttm),
+            "CAST('2019-01-02T03:04:05.678900' AS TIMESTAMP)",
+        )


### PR DESCRIPTION
### SUMMARY
This adds the quirks of Ascend.io's database to be handled using the Impala driver.

Note: I'm unsure if this approach for adding the db_engine_specs is the desired method, so I welcome feedback for needed changes.

Edit: I have modified the PR as my proposed changes for modifying get_table_names has been accepted in the latest Impala driver upstream, so there is no need for that when using impyla>=0.17a8 (should be released shortly).

Changes:
1. Adds ascend:// db_engine_spec that uses the Impala/Impyla driver
2. Use the default postgres time grain expressions to make charts work
3. Updated docs.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
