### PR TITLE
refactor: Move fields from Extra section III

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -183,6 +183,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       // in order for the button to not be disabled
       updateResource(databaseId as number, db as DatabaseObject).then(
         result => {
+          console.log(result);
           if (result) {
             if (onDatabaseAdd) {
               onDatabaseAdd();

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
@@ -18,12 +18,13 @@
  */
 
 import { styled } from '@superset-ui/core';
+import { css } from '@emotion/react';
 import Modal from 'src/components/Modal';
 import { JsonEditor } from 'src/components/AsyncAceEditor';
 import Tabs from 'src/components/Tabs';
 
 const CTAS_CVAS_SCHEMA_FORM_HEIGHT = 102;
-const EXPOSE_IN_SQLLAB_FORM_HEIGHT = CTAS_CVAS_SCHEMA_FORM_HEIGHT + 52;
+const EXPOSE_IN_SQLLAB_FORM_HEIGHT = CTAS_CVAS_SCHEMA_FORM_HEIGHT + 153;
 const EXPOSE_ALL_FORM_HEIGHT = EXPOSE_IN_SQLLAB_FORM_HEIGHT + 102;
 
 const anticonHeight = 12;
@@ -86,9 +87,6 @@ export const StyledModal = styled(Modal)`
 
 export const StyledInputContainer = styled.div`
   margin-bottom: ${({ theme }) => theme.gridUnit * 6}px;
-  &.mb-0 {
-    margin-bottom: 0;
-  }
   &.mb-8 {
     margin-bottom: ${({ theme }) => theme.gridUnit * 2}px;
   }
@@ -200,4 +198,8 @@ export const StyledBasicTab = styled(Tabs.TabPane)`
   padding-left: ${({ theme }) => theme.gridUnit * 4}px;
   padding-right: ${({ theme }) => theme.gridUnit * 4}px;
   margin-top: ${({ theme }) => theme.gridUnit * 4}px;
+`;
+
+export const no_margin_bottom = css`
+  margin-bottom: 0;
 `;

--- a/superset-frontend/src/views/CRUD/data/database/types.ts
+++ b/superset-frontend/src/views/CRUD/data/database/types.ts
@@ -33,6 +33,7 @@ export type DatabaseObject = {
 
   // Performance
   cache_timeout?: string;
+  metadata_cache_timeout?: {};
   allow_run_async?: boolean;
 
   // SQL Lab
@@ -42,13 +43,17 @@ export type DatabaseObject = {
   allow_dml?: boolean;
   allow_multi_schema_metadata_fetch?: boolean;
   force_ctas_schema?: string;
+  cost_query_enabled?: boolean;
+  allows_virtual_table_explore?: boolean;
 
   // Security
   encrypted_extra?: string;
   server_cert?: string;
+  schemas_allowed_for_csv_upload?: string;
+  impersonate_user?: boolean;
 
   // Extra
-  impersonate_user?: boolean;
   allow_csv_upload?: boolean;
+  version?: string;
   extra?: string;
 };


### PR DESCRIPTION
### SUMMARY
Move the existing fields from the "Extra" section to the following sections. This also includes moving them to be fields instead of one json string.

-  SQL Lab
	- allows_virtual_table_explore
	- cost_query_enabled

- Performance
	- Metadata Cache Timeout with Schema and Table options (metadata_cache_timeout)

- Security
	- Schema select for uploading data (schemas_allowed_for_csv_upload)
	- Impersonate logged in user
	- Allow data upload

- Other
	- engine_params and metadata params (in a json field)
	- version


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

- BEFORE

	**SQL Lab**
	<img width="500" alt="sqllab-before" src="https://user-images.githubusercontent.com/55605634/115647165-f6b37300-a2e8-11eb-9c7c-49b8835d3bce.png">

	**Performance**
	<img width="500" alt="performance-before" src="https://user-images.githubusercontent.com/55605634/115647195-ffa44480-a2e8-11eb-89fd-2ab0ca2083b9.png">

	**Security**
	<img width="500" alt="security-before" src="https://user-images.githubusercontent.com/55605634/115647201-029f3500-a2e9-11eb-82c5-9bbfd3fee560.png">

	**Other**
	<img width="500" alt="other-before" src="https://user-images.githubusercontent.com/55605634/115647217-06cb5280-a2e9-11eb-9892-ec3cfd9e9914.png">


- AFTER

	**SQL Lab**
	<img width="500" alt="sqllab-after" src="https://user-images.githubusercontent.com/55605634/115647267-16e33200-a2e9-11eb-8f2d-bec9f7287b1a.png">

	**Performance**
	<img width="500" alt="performance-after" src="https://user-images.githubusercontent.com/55605634/115647277-19458c00-a2e9-11eb-9ce9-5aa30210e3c6.png">

	**Security**
	<img width="500" alt="security-after-1" src="https://user-images.githubusercontent.com/55605634/115647288-1d71a980-a2e9-11eb-95da-b34ecbf75220.png">
	<img width="500" alt="security-after-2" src="https://user-images.githubusercontent.com/55605634/115647302-21053080-a2e9-11eb-8ece-f622bb6b2c8b.png">

	**Other**
	<img width="501" alt="other-after" src="https://user-images.githubusercontent.com/55605634/116278831-7d82a880-a74c-11eb-834a-ee72eb631f8e.png">



### TEST PLAN

1. From the "Databases" page, open the database modal by clicking either the "+ DATABASE" button or the "Edit" action button on any listed database.
2. Observe the described changes on the following tabs: SQL Lab, Performance, Security, Other

### ADDITIONAL INFORMATION
- [x] Has associated issue: [Clubhouse Ticket](https://app.clubhouse.io/preset/story/6947/step-3-move-fields-from-extra-section)
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API