### PR TITLE
feat: make tabs sticky in homepage

### DIFF
--- a/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
@@ -19,6 +19,9 @@
 import React, { useState } from 'react';
 import moment from 'moment';
 import { styled, t } from '@superset-ui/core';
+import {
+  setInLocalStorage,
+} from 'src/utils/localStorageHelpers';
 
 import Loading from 'src/components/Loading';
 import ListViewCard from 'src/components/ListViewCard';
@@ -162,6 +165,7 @@ export default function ActivityTable({
 }: ActivityProps) {
   const [editedObjs, setEditedObjs] = useState<Array<ActivityData>>();
   const [loadingState, setLoadingState] = useState(false);
+
   const getEditedCards = () => {
     setLoadingState(true);
     getEditedObjects(user.userId).then(r => {
@@ -175,6 +179,7 @@ export default function ActivityTable({
       label: t('Edited'),
       onClick: () => {
         setActiveChild('Edited');
+        setInLocalStorage('activity', {activity: 'Edited'})
         getEditedCards();
       },
     },
@@ -183,6 +188,7 @@ export default function ActivityTable({
       label: t('Created'),
       onClick: () => {
         setActiveChild('Created');
+        setInLocalStorage('activity', {activity: 'Created'})
       },
     },
   ];
@@ -193,6 +199,7 @@ export default function ActivityTable({
       label: t('Viewed'),
       onClick: () => {
         setActiveChild('Viewed');
+        setInLocalStorage('activity', {activity: 'Viewed'})
       },
     });
   } else {
@@ -201,6 +208,7 @@ export default function ActivityTable({
       label: t('Examples'),
       onClick: () => {
         setActiveChild('Examples');
+        setInLocalStorage('activity', {activity: 'Examples'})
       },
     });
   }

--- a/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
@@ -19,9 +19,7 @@
 import React, { useState } from 'react';
 import moment from 'moment';
 import { styled, t } from '@superset-ui/core';
-import {
-  setInLocalStorage,
-} from 'src/utils/localStorageHelpers';
+import { setInLocalStorage } from 'src/utils/localStorageHelpers';
 
 import Loading from 'src/components/Loading';
 import ListViewCard from 'src/components/ListViewCard';
@@ -179,7 +177,7 @@ export default function ActivityTable({
       label: t('Edited'),
       onClick: () => {
         setActiveChild('Edited');
-        setInLocalStorage('activity', {activity: 'Edited'})
+        setInLocalStorage('activity', { activity: 'Edited' });
         getEditedCards();
       },
     },
@@ -188,7 +186,7 @@ export default function ActivityTable({
       label: t('Created'),
       onClick: () => {
         setActiveChild('Created');
-        setInLocalStorage('activity', {activity: 'Created'})
+        setInLocalStorage('activity', { activity: 'Created' });
       },
     },
   ];
@@ -199,7 +197,7 @@ export default function ActivityTable({
       label: t('Viewed'),
       onClick: () => {
         setActiveChild('Viewed');
-        setInLocalStorage('activity', {activity: 'Viewed'})
+        setInLocalStorage('activity', { activity: 'Viewed' });
       },
     });
   } else {
@@ -208,7 +206,7 @@ export default function ActivityTable({
       label: t('Examples'),
       onClick: () => {
         setActiveChild('Examples');
-        setInLocalStorage('activity', {activity: 'Examples'})
+        setInLocalStorage('activity', { activity: 'Examples' });
       },
     });
   }

--- a/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import moment from 'moment';
 import { styled, t } from '@superset-ui/core';
 import { setInLocalStorage } from 'src/utils/localStorageHelpers';
@@ -163,6 +163,14 @@ export default function ActivityTable({
 }: ActivityProps) {
   const [editedObjs, setEditedObjs] = useState<Array<ActivityData>>();
   const [loadingState, setLoadingState] = useState(false);
+
+  useEffect(() => {
+    setLoadingState(true);
+    getEditedObjects(user.userId).then(r => {
+      setEditedObjs([...r.editedChart, ...r.editedDash]);
+      setLoadingState(false);
+    });
+  });
 
   const getEditedCards = () => {
     setLoadingState(true);

--- a/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
@@ -165,7 +165,7 @@ export default function ActivityTable({
   const [loadingState, setLoadingState] = useState(false);
 
   useEffect(() => {
-    if(activeChild === 'Edited') {
+    if (activeChild === 'Edited') {
       setLoadingState(true);
       getEditedObjects(user.userId).then(r => {
         setEditedObjs([...r.editedChart, ...r.editedDash]);

--- a/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
@@ -165,11 +165,13 @@ export default function ActivityTable({
   const [loadingState, setLoadingState] = useState(false);
 
   useEffect(() => {
-    setLoadingState(true);
-    getEditedObjects(user.userId).then(r => {
-      setEditedObjs([...r.editedChart, ...r.editedDash]);
-      setLoadingState(false);
-    });
+    if(activeChild === 'Edited') {
+      setLoadingState(true);
+      getEditedObjects(user.userId).then(r => {
+        setEditedObjs([...r.editedChart, ...r.editedDash]);
+        setLoadingState(false);
+      });
+    }
   }, []);
 
   const getEditedCards = () => {

--- a/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
@@ -170,7 +170,7 @@ export default function ActivityTable({
       setEditedObjs([...r.editedChart, ...r.editedDash]);
       setLoadingState(false);
     });
-  });
+  },[]);
 
   const getEditedCards = () => {
     setLoadingState(true);

--- a/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
@@ -170,7 +170,7 @@ export default function ActivityTable({
       setEditedObjs([...r.editedChart, ...r.editedDash]);
       setLoadingState(false);
     });
-  },[]);
+  }, []);
 
   const getEditedCards = () => {
     setLoadingState(true);

--- a/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
@@ -75,9 +75,7 @@ function ChartTable({
     false,
   );
 
-  useEffect(() => {
-
-  })
+  useEffect(() => {});
   const chartIds = useMemo(() => charts.map(c => c.id), [charts]);
   const [saveFavoriteStatus, favoriteStatus] = useFavoriteStatus(
     'chart',
@@ -95,10 +93,10 @@ function ChartTable({
 
   useEffect(() => {
     const filter = getFromLocalStorage('chart', null);
-    if(!filter) {
+    if (!filter) {
       setChartFilter('Mine');
     } else setChartFilter(filter.tab);
-  }, [])
+  }, []);
 
   const getFilters = (filterName: string) => {
     const filters = [];
@@ -152,18 +150,19 @@ function ChartTable({
             name: 'Favorite',
             label: t('Favorite'),
             onClick: () =>
-              getData('Favorite').then(() => { 
-                setChartFilter('Favorite') 
-                setInLocalStorage('chart', {tab: 'Favorite'})
-            }),
+              getData('Favorite').then(() => {
+                setChartFilter('Favorite');
+                setInLocalStorage('chart', { tab: 'Favorite' });
+              }),
           },
           {
             name: 'Mine',
             label: t('Mine'),
-            onClick: () => getData('Mine').then(() => { 
-              setChartFilter('Mine')
-              setInLocalStorage('chart', {tab: 'Mine'})
-            }),
+            onClick: () =>
+              getData('Mine').then(() => {
+                setChartFilter('Mine');
+                setInLocalStorage('chart', { tab: 'Mine' });
+              }),
           },
         ]}
         buttons={[

--- a/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
@@ -16,13 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { t } from '@superset-ui/core';
 import {
   useListViewResource,
   useChartEditModal,
   useFavoriteStatus,
 } from 'src/views/CRUD/hooks';
+import {
+  setInLocalStorage,
+  getFromLocalStorage,
+} from 'src/utils/localStorageHelpers';
 import withToasts from 'src/messageToasts/enhancers/withToasts';
 import { useHistory } from 'react-router-dom';
 import PropertiesModal from 'src/explore/components/PropertiesModal';
@@ -71,6 +75,9 @@ function ChartTable({
     false,
   );
 
+  useEffect(() => {
+
+  })
   const chartIds = useMemo(() => charts.map(c => c.id), [charts]);
   const [saveFavoriteStatus, favoriteStatus] = useFavoriteStatus(
     'chart',
@@ -85,6 +92,13 @@ function ChartTable({
   } = useChartEditModal(setCharts, charts);
 
   const [chartFilter, setChartFilter] = useState('Mine');
+
+  useEffect(() => {
+    const filter = getFromLocalStorage('chart', null);
+    if(!filter) {
+      setChartFilter('Mine');
+    } else setChartFilter(filter.tab);
+  }, [])
 
   const getFilters = (filterName: string) => {
     const filters = [];
@@ -138,12 +152,18 @@ function ChartTable({
             name: 'Favorite',
             label: t('Favorite'),
             onClick: () =>
-              getData('Favorite').then(() => setChartFilter('Favorite')),
+              getData('Favorite').then(() => { 
+                setChartFilter('Favorite') 
+                setInLocalStorage('chart', {tab: 'Favorite'})
+            }),
           },
           {
             name: 'Mine',
             label: t('Mine'),
-            onClick: () => getData('Mine').then(() => setChartFilter('Mine')),
+            onClick: () => getData('Mine').then(() => { 
+              setChartFilter('Mine')
+              setInLocalStorage('chart', {tab: 'Mine'})
+            }),
           },
         ]}
         buttons={[

--- a/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
@@ -16,11 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { SupersetClient, t } from '@superset-ui/core';
 import { useListViewResource, useFavoriteStatus } from 'src/views/CRUD/hooks';
 import { Dashboard, DashboardTableProps } from 'src/views/CRUD/types';
 import { useHistory } from 'react-router-dom';
+import {
+  setInLocalStorage,
+  getFromLocalStorage,
+} from 'src/utils/localStorageHelpers';
 import withToasts from 'src/messageToasts/enhancers/withToasts';
 import Loading from 'src/components/Loading';
 import PropertiesModal from 'src/dashboard/components/PropertiesModal';
@@ -68,6 +72,13 @@ function DashboardTable({
   );
   const [editModal, setEditModal] = useState<Dashboard>();
   const [dashboardFilter, setDashboardFilter] = useState('Mine');
+
+  useEffect(() => {
+    const filter = getFromLocalStorage('dashboard', null);
+    if(!filter) {
+      setDashboardFilter('Mine');
+    } else setDashboardFilter(filter.tab);
+  }, [])
 
   const handleDashboardEdit = (edits: Dashboard) =>
     SupersetClient.get({
@@ -139,14 +150,20 @@ function DashboardTable({
             name: 'Favorite',
             label: t('Favorite'),
             onClick: () => {
-              getData('Favorite').then(() => setDashboardFilter('Favorite'));
+              getData('Favorite').then(() => { 
+                setDashboardFilter('Favorite')
+                setInLocalStorage('dashboard', {tab: 'Favorite'})
+              });
             },
           },
           {
             name: 'Mine',
             label: t('Mine'),
             onClick: () => {
-              getData('Mine').then(() => setDashboardFilter('Mine'));
+              getData('Mine').then(() => { 
+                setDashboardFilter('Mine')
+                setInLocalStorage('dashboard', {tab: 'Mine'})
+              });
             },
           },
         ]}

--- a/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
@@ -75,10 +75,10 @@ function DashboardTable({
 
   useEffect(() => {
     const filter = getFromLocalStorage('dashboard', null);
-    if(!filter) {
+    if (!filter) {
       setDashboardFilter('Mine');
     } else setDashboardFilter(filter.tab);
-  }, [])
+  }, []);
 
   const handleDashboardEdit = (edits: Dashboard) =>
     SupersetClient.get({
@@ -150,9 +150,9 @@ function DashboardTable({
             name: 'Favorite',
             label: t('Favorite'),
             onClick: () => {
-              getData('Favorite').then(() => { 
-                setDashboardFilter('Favorite')
-                setInLocalStorage('dashboard', {tab: 'Favorite'})
+              getData('Favorite').then(() => {
+                setDashboardFilter('Favorite');
+                setInLocalStorage('dashboard', { tab: 'Favorite' });
               });
             },
           },
@@ -160,9 +160,9 @@ function DashboardTable({
             name: 'Mine',
             label: t('Mine'),
             onClick: () => {
-              getData('Mine').then(() => { 
-                setDashboardFilter('Mine')
-                setInLocalStorage('dashboard', {tab: 'Mine'})
+              getData('Mine').then(() => {
+                setDashboardFilter('Mine');
+                setInLocalStorage('dashboard', { tab: 'Mine' });
               });
             },
           },

--- a/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
@@ -125,7 +125,10 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
         if (res.viewed) {
           const filtered = reject(res.viewed, ['item_url', null]).map(r => r);
           data.Viewed = filtered;
-          setActiveChild('Viewed');
+          let savedActivity = getFromLocalStorage('activity', null);
+          if(!savedActivity) {
+            setActiveChild('Viewed');
+          } else setActiveChild(savedActivity.activity);
         } else {
           data.Examples = res.examples;
           setActiveChild('Examples');

--- a/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
@@ -125,8 +125,8 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
         if (res.viewed) {
           const filtered = reject(res.viewed, ['item_url', null]).map(r => r);
           data.Viewed = filtered;
-          let savedActivity = getFromLocalStorage('activity', null);
-          if(!savedActivity) {
+          const savedActivity = getFromLocalStorage('activity', null);
+          if (!savedActivity) {
             setActiveChild('Viewed');
           } else setActiveChild(savedActivity.activity);
         } else {


### PR DESCRIPTION
### SUMMARY
Before when user would click on tabs in homepage and navigate away it would default back to original tab setting. This pr makes the tabs sticky using local storage to get users last tab click. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/17326228/118705773-7db31880-b7cd-11eb-9988-1ebd97931d76.mov


### TEST PLAN
click tabs in welcome submenus and reload page to ensure they "stick"

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x ] Has associated issue: https://github.com/apache/superset/issues/14670
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
