### PR TITLE
fix: import dataset with extra; Vertica URI

### DIFF
--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -550,6 +550,6 @@ class ImportV1DatabaseSchema(Schema):
     def validate_password(self, data: Dict[str, Any], **kwargs: Any) -> None:
         """If sqlalchemy_uri has a masked password, password is required"""
         uri = data["sqlalchemy_uri"]
-        password = urllib.parse.urlparse(uri).password
+        password = make_url(uri).password
         if password == PASSWORD_MASK and data.get("password") is None:
             raise ValidationError("Must provide a password for the database")

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -16,7 +16,6 @@
 # under the License.
 import inspect
 import json
-import urllib.parse
 from typing import Any, Dict
 
 from flask import current_app

--- a/superset/datasets/commands/export.py
+++ b/superset/datasets/commands/export.py
@@ -31,7 +31,7 @@ from superset.utils.dict_import_export import EXPORT_VERSION
 
 logger = logging.getLogger(__name__)
 
-JSON_KEYS = {"params", "template_params", "extra"}
+JSON_KEYS = {"params", "template_params"}
 
 
 class ExportDatasetsCommand(ExportModelsCommand):

--- a/superset/datasets/commands/importers/v1/utils.py
+++ b/superset/datasets/commands/importers/v1/utils.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 CHUNKSIZE = 512
 VARCHAR = re.compile(r"VARCHAR\((\d+)\)", re.IGNORECASE)
 
-JSON_KEYS = {"params", "template_params", "extra"}
+JSON_KEYS = {"params", "template_params"}
 
 
 type_map = {

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -162,7 +162,7 @@ class ImportV1DatasetSchema(Schema):
     template_params = fields.Dict(allow_none=True)
     filter_select_enabled = fields.Boolean()
     fetch_values_predicate = fields.String(allow_none=True)
-    extra = fields.Dict(allow_none=True)
+    extra = fields.String(allow_none=True)
     uuid = fields.UUID(required=True)
     columns = fields.List(fields.Nested(ImportV1ColumnSchema))
     metrics = fields.List(fields.Nested(ImportV1MetricSchema))

--- a/tests/databases/api_tests.py
+++ b/tests/databases/api_tests.py
@@ -1314,7 +1314,7 @@ class TestDatabaseApi(SupersetTestCase):
         masked_database_config = database_config.copy()
         masked_database_config[
             "sqlalchemy_uri"
-        ] = "postgresql://username:XXXXXXXXXX@host:12345/db"
+        ] = "vertica+vertica_python://hackathon:XXXXXXXXXX@host:5433/dbname?ssl=1"
 
         buf = BytesIO()
         with ZipFile(buf, "w") as bundle:
@@ -1341,7 +1341,8 @@ class TestDatabaseApi(SupersetTestCase):
         )
         assert database.database_name == "imported_database"
         assert (
-            database.sqlalchemy_uri == "postgresql://username:XXXXXXXXXX@host:12345/db"
+            database.sqlalchemy_uri
+            == "vertica+vertica_python://hackathon:XXXXXXXXXX@host:5433/dbname?ssl=1"
         )
         assert database.password == "SECRET"
 

--- a/tests/datasets/commands_tests.py
+++ b/tests/datasets/commands_tests.py
@@ -315,7 +315,7 @@ class TestImportDatasetsCommand(SupersetTestCase):
         assert dataset.template_params == "{}"
         assert dataset.filter_select_enabled
         assert dataset.fetch_values_predicate is None
-        assert dataset.extra is None
+        assert dataset.extra == "dttm > sysdate() -10 "
 
         # database is also imported
         assert str(dataset.database.uuid) == "b8a1ccd3-779d-4ab7-8ad8-9ab119d7fe89"

--- a/tests/fixtures/importexport.py
+++ b/tests/fixtures/importexport.py
@@ -375,7 +375,7 @@ dataset_config: Dict[str, Any] = {
     "template_params": {},
     "filter_select_enabled": True,
     "fetch_values_predicate": None,
-    "extra": None,
+    "extra": "dttm > sysdate() -10 ",
     "metrics": [
         {
             "metric_name": "count",


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Two small fixes for the import functionality:

1. The schema for importing the `extra` field in datasets was incorrect, preventing datasets to be imported.
2. The SQLAlchemy URI was being parsed with `urllib.parse.urlparse` to extract the password, but that failed on a Vertica URI (`vertica+vertica_python://hackathon:XXXXXXXXXX@host:5433/dbname?ssl=1`).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Added unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
