### PR TITLE
fix: Use g.user for getting the user_id for async queries

### DIFF
--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -595,7 +595,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
             except AsyncQueryTokenException:
                 return self.response_401()
 
-            result = command.run_async()
+            result = command.run_async(g.user.get_id())
             return self.response(202, **result)
 
         return self.get_data_response(command)

--- a/superset/charts/commands/data.py
+++ b/superset/charts/commands/data.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from flask import Request
 from marshmallow import ValidationError
@@ -67,7 +67,7 @@ class ChartDataCommand(BaseCommand):
 
         return return_value
 
-    def run_async(self, user_id: int) -> Dict[str, Any]:
+    def run_async(self, user_id: Optional[int]) -> Dict[str, Any]:
         job_metadata = async_query_manager.init_job(self._async_channel_id, user_id)
         load_chart_data_into_cache.delay(job_metadata, self._form_data)
 

--- a/superset/charts/commands/data.py
+++ b/superset/charts/commands/data.py
@@ -67,8 +67,8 @@ class ChartDataCommand(BaseCommand):
 
         return return_value
 
-    def run_async(self) -> Dict[str, Any]:
-        job_metadata = async_query_manager.init_job(self._async_channel_id)
+    def run_async(self, user_id: int) -> Dict[str, Any]:
+        job_metadata = async_query_manager.init_job(self._async_channel_id, user_id)
         load_chart_data_into_cache.delay(job_metadata, self._form_data)
 
         return job_metadata

--- a/superset/charts/commands/data.py
+++ b/superset/charts/commands/data.py
@@ -67,7 +67,7 @@ class ChartDataCommand(BaseCommand):
 
         return return_value
 
-    def run_async(self, user_id: Optional[int]) -> Dict[str, Any]:
+    def run_async(self, user_id: Optional[str]) -> Dict[str, Any]:
         job_metadata = async_query_manager.init_job(self._async_channel_id, user_id)
         load_chart_data_into_cache.delay(job_metadata, self._form_data)
 

--- a/superset/utils/async_query_manager.py
+++ b/superset/utils/async_query_manager.py
@@ -35,7 +35,7 @@ class AsyncQueryJobException(Exception):
 
 
 def build_job_metadata(
-    channel_id: str, job_id: str, user_id: Optional[int], **kwargs: Any
+    channel_id: str, job_id: str, user_id: Optional[str], **kwargs: Any
 ) -> Dict[str, Any]:
     return {
         "channel_id": channel_id,
@@ -169,7 +169,7 @@ class AsyncQueryManager:
             logger.warning(exc)
             raise AsyncQueryTokenException("Failed to parse token")
 
-    def init_job(self, channel_id: str, user_id: Optional[int]) -> Dict[str, Any]:
+    def init_job(self, channel_id: str, user_id: Optional[str]) -> Dict[str, Any]:
         job_id = str(uuid.uuid4())
         return build_job_metadata(
             channel_id, job_id, user_id, status=self.STATUS_PENDING

--- a/superset/utils/async_query_manager.py
+++ b/superset/utils/async_query_manager.py
@@ -119,11 +119,8 @@ class AsyncQueryManager:
         ) -> Response:
             user_id = None
 
-            try:
-                user_id = g.user.get_id()
-                user_id = int(user_id)
-            except Exception:  # pylint: disable=broad-except
-                pass
+            if hasattr(g, "user") and g.user.get_id() is not None:
+                user_id = int(g.user.get_id())
 
             reset_token = (
                 not request.cookies.get(self._jwt_cookie_name)

--- a/superset/utils/async_query_manager.py
+++ b/superset/utils/async_query_manager.py
@@ -120,7 +120,7 @@ class AsyncQueryManager:
             user_id = None
 
             try:
-                user_id = int(g.user.get_id())
+                user_id = g.user.id
             except AttributeError:
                 pass
 

--- a/superset/utils/async_query_manager.py
+++ b/superset/utils/async_query_manager.py
@@ -35,12 +35,12 @@ class AsyncQueryJobException(Exception):
 
 
 def build_job_metadata(
-    channel_id: str, job_id: str, user_id: int, **kwargs: Any
+    channel_id: str, job_id: str, user_id: Optional[int], **kwargs: Any
 ) -> Dict[str, Any]:
     return {
         "channel_id": channel_id,
         "job_id": job_id,
-        "user_id": int(user_id),
+        "user_id": int(user_id) if user_id else None,
         "status": kwargs.get("status"),
         "errors": kwargs.get("errors", []),
         "result_url": kwargs.get("result_url"),
@@ -120,8 +120,9 @@ class AsyncQueryManager:
             user_id = None
 
             try:
-                user_id = g.user.id
-            except AttributeError:
+                user_id = g.user.get_id()
+                user_id = int(user_id)
+            except Exception:  # pylint: disable=broad-except
                 pass
 
             reset_token = (
@@ -168,7 +169,7 @@ class AsyncQueryManager:
             logger.warning(exc)
             raise AsyncQueryTokenException("Failed to parse token")
 
-    def init_job(self, channel_id: str, user_id: int) -> Dict[str, Any]:
+    def init_job(self, channel_id: str, user_id: Optional[int]) -> Dict[str, Any]:
         job_id = str(uuid.uuid4())
         return build_job_metadata(
             channel_id, job_id, user_id, status=self.STATUS_PENDING

--- a/superset/utils/async_query_manager.py
+++ b/superset/utils/async_query_manager.py
@@ -119,8 +119,11 @@ class AsyncQueryManager:
         ) -> Response:
             user_id = None
 
-            if hasattr(g, "user") and g.user.get_id() is not None:
-                user_id = int(g.user.get_id())
+            try:
+                user_id = g.user.get_id()
+                user_id = int(user_id)
+            except Exception:  # pylint: disable=broad-except
+                pass
 
             reset_token = (
                 not request.cookies.get(self._jwt_cookie_name)

--- a/superset/utils/async_query_manager.py
+++ b/superset/utils/async_query_manager.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import jwt
 import redis
-from flask import Flask, request, Request, Response, session
+from flask import Flask, g, request, Request, Response, session
 
 logger = logging.getLogger(__name__)
 
@@ -34,11 +34,13 @@ class AsyncQueryJobException(Exception):
     pass
 
 
-def build_job_metadata(channel_id: str, job_id: str, **kwargs: Any) -> Dict[str, Any]:
+def build_job_metadata(
+    channel_id: str, job_id: str, user_id: int, **kwargs: Any
+) -> Dict[str, Any]:
     return {
         "channel_id": channel_id,
         "job_id": job_id,
-        "user_id": session.get("user_id"),
+        "user_id": int(user_id),
         "status": kwargs.get("status"),
         "errors": kwargs.get("errors", []),
         "result_url": kwargs.get("result_url"),
@@ -115,7 +117,12 @@ class AsyncQueryManager:
         def validate_session(  # pylint: disable=unused-variable
             response: Response,
         ) -> Response:
-            user_id = session["user_id"] if "user_id" in session else None
+            user_id = None
+
+            try:
+                user_id = int(g.user.get_id())
+            except AttributeError:
+                pass
 
             reset_token = (
                 not request.cookies.get(self._jwt_cookie_name)
@@ -161,9 +168,11 @@ class AsyncQueryManager:
             logger.warning(exc)
             raise AsyncQueryTokenException("Failed to parse token")
 
-    def init_job(self, channel_id: str) -> Dict[str, Any]:
+    def init_job(self, channel_id: str, user_id: int) -> Dict[str, Any]:
         job_id = str(uuid.uuid4())
-        return build_job_metadata(channel_id, job_id, status=self.STATUS_PENDING)
+        return build_job_metadata(
+            channel_id, job_id, user_id, status=self.STATUS_PENDING
+        )
 
     def read_events(
         self, channel: str, last_id: Optional[str]

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -611,7 +611,9 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
                     async_channel_id = async_query_manager.parse_jwt_from_request(
                         request
                     )["channel"]
-                    job_metadata = async_query_manager.init_job(async_channel_id)
+                    job_metadata = async_query_manager.init_job(
+                        async_channel_id, g.user.get_id()
+                    )
                     load_explore_json_into_cache.delay(
                         job_metadata, form_data, response_type, force
                     )


### PR DESCRIPTION
### SUMMARY

During some tests in a production-like environment, the `user_id` in the `job_metadata` was not being set properly. This causes any charts that reference `g.user` to fail since we are relying on the `user_id` to set `g.user` in the Celery workers.

### TEST PLAN

I cannot reproduce the broken behavior locally. However, I did test that this change will correctly set the user_id value.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @robdiciuccio 