### PR TITLE
feat(helm): Make local admin optional

### DIFF
--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
   - name: craig-rueda
     email: craig@craigrueda.com
     url: https://github.com/craig-rueda
-version: 0.1.2
+version: 0.1.4
 dependencies:
 - name: postgresql
   version: 10.2.0

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -236,6 +236,7 @@ init:
     - ". {{ .Values.configMountPath }}/superset_bootstrap.sh; . {{ .Values.configMountPath }}/superset_init.sh"
   enabled: true
   loadExamples: false
+  createAdmin: true
   adminUser:
     username: admin
     firstname: Superset
@@ -256,6 +257,7 @@ init:
     superset db upgrade
     echo "Initializing roles..."
     superset init
+    {{ if .Values.init.createAdmin }}
     echo "Creating admin user..."
     superset fab create-admin \
                     --username {{ .Values.init.adminUser.username }} \
@@ -264,6 +266,7 @@ init:
                     --email {{ .Values.init.adminUser.email }} \
                     --password {{ .Values.init.adminUser.password }} \
                     || true
+    {{- end }}
     {{ if .Values.init.loadExamples }}
     echo "Loading examples..."
     superset load_examples


### PR DESCRIPTION
### SUMMARY
Makes local admin an optional parameter in the helm chart. Useful for deploying with no local admin account or existing install.

Defaults to keeping enabled.

Depends on #14704 to make the chart version correct and the linter happy.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
