### PR TITLE
fix: reindex when combine metric in legacy pivot table

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -936,7 +936,7 @@ class PivotTableViz(BaseViz):
 
         # Display metrics side by side with each column
         if self.form_data.get("combine_metric"):
-            df = df.stack(0).unstack()
+            df = df.stack(0).unstack().reindex(level=-1, columns=metrics)
         return dict(
             columns=list(df.columns),
             html=df.to_html(


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Make metrics order insistence when combine metric checked.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### Before
![image](https://user-images.githubusercontent.com/2016594/118794626-5abb5e00-b8cc-11eb-8723-253bed06b0f8.png)


#### After
![image](https://user-images.githubusercontent.com/2016594/118794380-1af47680-b8cc-11eb-9c6a-19e7c3e4aaa0.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
tested in my local environment

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes: https://github.com/apache/superset/issues/13427
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
