### PR TITLE
chore: Improves the native filters UI/UX - iteration 1

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.tsx
@@ -64,7 +64,6 @@ const FilterScope: FC<FilterScopeProps> = ({
 
   return (
     <Wrapper>
-      <Typography.Title level={5}>{t('Scoping')}</Typography.Title>
       <CleanFormItem
         name={[...pathToFormValue, 'scoping']}
         initialValue={initialScoping}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
@@ -39,6 +39,7 @@ import { useOpenModal, useRemoveCurrentFilter } from './state';
 
 export const StyledModalBody = styled.div`
   display: flex;
+  height: 500px;
   flex-direction: row;
   .filters-list {
     width: ${({ theme }) => theme.gridUnit * 50}px;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/Footer/CancelConfirmationAlert.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/Footer/CancelConfirmationAlert.tsx
@@ -36,6 +36,7 @@ export function CancelConfirmationAlert({
 }: ConfirmationAlertProps) {
   return (
     <Alert
+      closable={false}
       type="warning"
       key="alert"
       message={title}
@@ -47,20 +48,20 @@ export function CancelConfirmationAlert({
       action={
         <div css={{ display: 'flex' }}>
           <Button
-            key="submit"
-            buttonSize="small"
-            buttonStyle="primary"
-            onClick={onConfirm}
-          >
-            {t('Yes, cancel')}
-          </Button>
-          <Button
             key="cancel"
             buttonSize="small"
             buttonStyle="secondary"
             onClick={onDismiss}
           >
             {t('Keep editing')}
+          </Button>
+          <Button
+            key="submit"
+            buttonSize="small"
+            buttonStyle="primary"
+            onClick={onConfirm}
+          >
+            {t('Yes, cancel')}
           </Button>
         </div>
       }


### PR DESCRIPTION
### SUMMARY
Improves the native filters UI/UX - iteration 1.

- Sets a fixed `height` for the modal
- Splits the configuration and scoping into different tabs
- Inverts the order of the buttons of the confirmation message
- Removes the x icon of the confirmation message
- Fixes the tests to account for the async nature of the screen

PS: A future PR will handle the case of automatically selecting a tab/collapse when an error occurs.

@villebro @rusackas @junlincc 

This work is part of the [Native dashboard filter project](https://github.com/apache/superset/projects/12)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/118834003-49585e80-b898-11eb-855a-34a301d46c71.mov

https://user-images.githubusercontent.com/70410625/118834020-4c534f00-b898-11eb-900f-aeb15c8dafba.mov

### TEST PLAN
1 - Execute all tests
2 - All tests should pass

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
