### PR TITLE
fix(explore): Icons width

### DIFF
--- a/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
+++ b/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
@@ -60,7 +60,7 @@ export const Label = styled.div`
       margin-left: ${theme.gridUnit}px;
     }
     .type-label {
-      margin-right: ${theme.gridUnit}px;
+      margin-right: ${theme.gridUnit * 2}px;
       margin-left: ${theme.gridUnit}px;
       font-weight: ${theme.typography.weights.normal};
       width: auto;

--- a/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
+++ b/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
@@ -63,6 +63,7 @@ export const Label = styled.div`
       margin-right: ${theme.gridUnit}px;
       margin-left: ${theme.gridUnit}px;
       font-weight: ${theme.typography.weights.normal};
+      width: auto;
     }
     .option-label {
       display: inline;

--- a/superset-frontend/src/explore/components/optionRenderers.tsx
+++ b/superset-frontend/src/explore/components/optionRenderers.tsx
@@ -42,7 +42,7 @@ const OptionContainer = styled.div`
     }
   }
   .type-label {
-    margin-right: ${({ theme }) => theme.gridUnit * 2}px;
+    margin-right: ${({ theme }) => theme.gridUnit * 3}px;
     width: ${({ theme }) => theme.gridUnit * 7}px;
     display: inline-block;
     text-align: center;

--- a/superset-frontend/src/explore/components/optionRenderers.tsx
+++ b/superset-frontend/src/explore/components/optionRenderers.tsx
@@ -42,9 +42,8 @@ const OptionContainer = styled.div`
     }
   }
   .type-label {
-    margin-right: ${({ theme }) => theme.gridUnit * 3}px;
-    margin-left: ${({ theme }) => theme.gridUnit * 3}px;
-    width: ${({ theme }) => theme.gridUnit * 4}px;
+    margin-right: ${({ theme }) => theme.gridUnit * 2}px;
+    width: ${({ theme }) => theme.gridUnit * 7}px;
     display: inline-block;
     text-align: center;
     font-weight: ${({ theme }) => theme.typography.weights.bold};


### PR DESCRIPTION
### SUMMARY
It reverts a change of width and margin introduced in #14674 and adjusts the width of the icons in the options labels.

Fixes #14697

### BEFORE
![Screen Shot 2021-05-19 at 20 09 18](https://user-images.githubusercontent.com/60598000/118855112-1e90f900-b8de-11eb-9270-dc6795222235.png)

### AFTER
![Screen Shot 2021-05-19 at 20 04 37](https://user-images.githubusercontent.com/60598000/118854879-db368a80-b8dd-11eb-8491-c4f0efd63c2f.png)

### TEST PLAN
1. Open a chart in Explore
2. Make sure the icons have proper paddings in the controls

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #14697
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
