### PR TITLE
fix: Add impersonate_user setting to import/export datasource

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -162,6 +162,7 @@ class Database(
         "allow_ctas",
         "allow_cvas",
         "allow_file_upload",
+        "impersonate_user",
         "extra",
     ]
     extra_import_fields = ["password"]

--- a/tests/integration_tests/databases/commands_tests.py
+++ b/tests/integration_tests/databases/commands_tests.py
@@ -306,6 +306,7 @@ class TestExportDatabasesCommand(SupersetTestCase):
             "allow_ctas",
             "allow_cvas",
             "allow_csv_upload",
+            "impersonate_user",
             "extra",
             "uuid",
             "version",


### PR DESCRIPTION
When exporting or importing a datasource/DB, it is necessary get the impersonate_user setting, as it is a key part of the configuration of that datasource. This unfortunately requires a code change, as this list of fields is whitelisted today.

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The UI lets a user control whether a particular datasource supports impersonation, which is very helpful when creating it interactively. However, when exporting the datasource or importing it programmatically, the value for `impersonate_user` is not exported/imported, leading to a gap in functionality.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
