### PR TITLE
fix: check limiting factor on query results

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -527,6 +527,7 @@ export default class ResultSet extends React.PureComponent<
     let limitMessage;
     const limitReached = results?.displayLimitReached;
     const isAdmin = !!this.props.user?.roles.Admin;
+    const limit = queryLimit || results.query.limit;
     const displayMaxRowsReachedMessage = {
       withAdmin: t(
         `The number of results displayed is limited to %(rows)d by the configuration DISPLAY_MAX_ROWS. `,
@@ -535,7 +536,9 @@ export default class ResultSet extends React.PureComponent<
         t(
           `Please add additional limits/filters or download to csv to see more rows up to the`,
         ),
-        t(`the %(queryLimit)d limit.`, { queryLimit }),
+        t(`the %(limit)d limit.`, {
+          limit,
+        }),
       ),
       withoutAdmin: t(
         `The number of results displayed is limited to %(rows)d. `,
@@ -544,8 +547,8 @@ export default class ResultSet extends React.PureComponent<
         t(
           `Please add additional limits/filters, download to csv, or contact an admin`,
         ),
-        t(`to see more rows up to the the %(queryLimit)d limit.`, {
-          queryLimit,
+        t(`to see more rows up to the the %(limit)d limit.`, {
+          limit,
         }),
       ),
     };

--- a/superset-frontend/src/SqlLab/types.ts
+++ b/superset-frontend/src/SqlLab/types.ts
@@ -52,6 +52,7 @@ export type Query = {
     data: Record<string, unknown>[];
     expanded_columns: Column[];
     selected_columns: Column[];
+    query: { limit: number };
   };
   resultsKey: string | null;
   schema: string;


### PR DESCRIPTION
### SUMMARY
There were errors on sql lab rendering because a translation key had a null replacement

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before in ticket

after: 

https://user-images.githubusercontent.com/5186919/118870234-28ddd380-b89b-11eb-8e11-86b91207d9b6.mov



### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: https://github.com/apache/superset/issues/14711
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

closes #14711
