### PR TITLE
fix(sqllab): don't store user in localstorage

### DIFF
--- a/superset-frontend/src/SqlLab/App.jsx
+++ b/superset-frontend/src/SqlLab/App.jsx
@@ -72,6 +72,8 @@ const sqlLabPersistStateConfig = {
       });
 
       if (subset.sqlLab?.user) {
+        // Don't persist the user.
+        // User should really not be stored under the "sqlLab" field. Oh well.
         delete subset.sqlLab.user;
       }
 
@@ -84,6 +86,16 @@ const sqlLabPersistStateConfig = {
       }
 
       return subset;
+    },
+    merge: (initialState, persistedState = {}) => {
+      const result = {
+        ...initialState,
+        ...persistedState,
+      };
+      // Filter out any user data that may have been persisted in an older version.
+      // Get user from bootstrap data instead, every time
+      result.sqlLab.user = initialState.sqlLab.user;
+      return result;
     },
   },
 };

--- a/superset-frontend/src/SqlLab/App.jsx
+++ b/superset-frontend/src/SqlLab/App.jsx
@@ -71,6 +71,10 @@ const sqlLabPersistStateConfig = {
         }
       });
 
+      if (subset.sqlLab?.user) {
+        delete subset.sqlLab.user;
+      }
+
       const data = JSON.stringify(subset);
       // 2 digit precision
       const currentSize =


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When the feature flag `SQLLAB_BACKEND_PERSISTENCE` is set to False, user data is currently saved in local storage. A recent change added roles information to the bootstrap user object. But with the flag off, local storage data ends up overwriting the bootstrap data, and the roles are lost, which breaks the page. This change removes user data from local storage, and prevents it from overwriting the bootstrap data.

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

- Turn the flag off
- checkout a commit from before [a7a011cce5ea9a9ae6cebf40b6e5bc6257d7746d](https://github.com/apache/superset/commit/a7a011cce5ea9a9ae6cebf40b6e5bc6257d7746d)
- visit sql lab, execute a query (loads your user into localstorage)
- checkout this fix
- visit sql lab (user is removed from localstorage and page should show up)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
