### PR TITLE
feat: do not redirect on 404/500

### DIFF
--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -31,6 +31,7 @@ from flask import (
     redirect,
     request,
     Response,
+    send_file,
     session,
 )
 from flask_appbuilder import BaseView, Model, ModelView
@@ -43,6 +44,7 @@ from flask_babel import get_locale, gettext as __, lazy_gettext as _
 from flask_jwt_extended.exceptions import NoAuthorizationError
 from flask_wtf.csrf import CSRFError
 from flask_wtf.form import FlaskForm
+from pkg_resources import resource_filename
 from sqlalchemy import or_
 from sqlalchemy.orm import Query
 from werkzeug.exceptions import HTTPException
@@ -390,7 +392,8 @@ def show_http_exception(ex: HTTPException) -> FlaskResponse:
         and not config["DEBUG"]
         and ex.code in {404, 500}
     ):
-        return redirect(f"/static/assets/{ex.code}.html")
+        path = resource_filename("superset", f"static/assets/{ex.code}.html")
+        return send_file(path)
 
     return json_errors_response(
         errors=[


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Instead of redirecting on 404/500 (which produces a 302), with this PR we simply show the static content.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before user would be sent to `/static/assets/404.html`. With this PR they stay in the same page and the status code is preserved:

![Screen Shot 2021-05-19 at 3 06 29 PM](https://user-images.githubusercontent.com/1534870/118890786-276cd500-b8b4-11eb-85a2-ca79e004d3ec.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
