### PR TITLE
fix: homepage card layout

### DIFF
--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -301,15 +301,13 @@ export const mq = breakpoints.map(bp => `@media (max-width: ${bp}px)`);
 export const CardContainer = styled.div`
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(31%, 31%));
-  ${[mq[3]]} {
+  ${mq[3]} {
     grid-template-columns: repeat(auto-fit, minmax(31%, 31%));
   }
-
-  ${[mq[2]]} {
+  ${mq[2]} {
     grid-template-columns: repeat(auto-fit, minmax(48%, 48%));
   }
-
-  ${[mq[1]]} {
+  ${mq[1]} {
     grid-template-columns: repeat(auto-fit, minmax(50%, 80%));
   }
   grid-gap: ${({ theme }) => theme.gridUnit * 8}px;

--- a/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
@@ -93,7 +93,7 @@ const ActivityContainer = styled.div`
     grid-template-columns: repeat(auto-fit, minmax(42%, max-content));
   }
   ${mq[1]} {
-    grid-template-columns: repeat(auto-fit, minmax(63%, max-content));
+    grid-template-columns: repeat(auto-fit, minmax(80%, max-content));
   }
 `;
 

--- a/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
@@ -74,15 +74,7 @@ const ActivityContainer = styled.div`
   margin-top: ${({ theme }) => theme.gridUnit * -4}px;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(31%, max-content));
-  ${[mq[3]]} {
-    grid-template-columns: repeat(auto-fit, minmax(31%, max-content));
-  }
-  ${[mq[2]]} {
-    grid-template-columns: repeat(auto-fit, minmax(42%, max-content));
-  }
-  ${[mq[1]]} {
-    grid-template-columns: repeat(auto-fit, minmax(63%, max-content));
-  }
+
   grid-gap: ${({ theme }) => theme.gridUnit * 8}px;
   justify-content: left;
   padding: ${({ theme }) => theme.gridUnit * 6}px;
@@ -93,6 +85,15 @@ const ActivityContainer = styled.div`
   }
   .ant-card-meta-title {
     font-weight: ${({ theme }) => theme.typography.weights.bold};
+  }
+  ${mq[3]} {
+    grid-template-columns: repeat(auto-fit, minmax(31%, max-content));
+  }
+  ${mq[2]} {
+    grid-template-columns: repeat(auto-fit, minmax(42%, max-content));
+  }
+  ${mq[1]} {
+    grid-template-columns: repeat(auto-fit, minmax(63%, max-content));
   }
 `;
 


### PR DESCRIPTION
### SUMMARY
This pr fixes the broken card layout for homepage and card size. Before the cards would not align correctly that was set by media query. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before
https://user-images.githubusercontent.com/17326228/118894996-2a6ac400-b8ba-11eb-9bfe-5e057dd69ed5.mov

after

https://user-images.githubusercontent.com/17326228/118895431-052a8580-b8bb-11eb-9c98-9b4b048318bd.mov



### TEST PLAN
resize homepage screen to view correct layout

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
