### PR TITLE
fix(docker): superset permissions and firefox config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,8 +84,8 @@ ENV LANG=C.UTF-8 \
     SUPERSET_HOME="/app/superset_home" \
     SUPERSET_PORT=8088
 
-RUN useradd --user-group --no-create-home --no-log-init --shell /bin/bash superset \
-        && mkdir -p ${SUPERSET_HOME} ${PYTHONPATH} \
+RUN useradd --user-group -d ${SUPERSET_HOME} --no-log-init --shell /bin/bash superset \
+        && mkdir -p ${PYTHONPATH} \
         && apt-get update -y \
         && apt-get install -y --no-install-recommends \
             build-essential \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 x-superset-image: &superset-image apache/superset:latest-dev
+x-superset-user: &superset-user root
 x-superset-depends-on: &superset-depends-on
   - db
   - redis
@@ -55,7 +56,7 @@ services:
     restart: unless-stopped
     ports:
       - 8088:8088
-    user: "root"
+    user: *superset-user
     depends_on: *superset-depends-on
     volumes: *superset-volumes
     environment:
@@ -95,7 +96,7 @@ services:
     command: ["/app/docker/docker-init.sh"]
     env_file: docker/.env
     depends_on: *superset-depends-on
-    user: "root"
+    user: *superset-user
     volumes: *superset-volumes
     environment:
       CYPRESS_CONFIG: "${CYPRESS_CONFIG}"
@@ -115,7 +116,7 @@ services:
     env_file: docker/.env
     restart: unless-stopped
     depends_on: *superset-depends-on
-    user: "root"
+    user: *superset-user
     volumes: *superset-volumes
 
   superset-worker-beat:
@@ -125,7 +126,7 @@ services:
     env_file: docker/.env
     restart: unless-stopped
     depends_on: *superset-depends-on
-    user: "root"
+    user: *superset-user
     volumes: *superset-volumes
 
   superset-tests-worker:
@@ -141,7 +142,7 @@ services:
       REDIS_HOST: localhost
     network_mode: host
     depends_on: *superset-depends-on
-    user: "root"
+    user: *superset-user
     volumes: *superset-volumes
 
 volumes:

--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -41,7 +41,7 @@ if [[ "${1}" == "worker" ]]; then
   celery worker --app=superset.tasks.celery_app:app -Ofair -l INFO
 elif [[ "${1}" == "beat" ]]; then
   echo "Starting Celery beat..."
-  celery beat --app=superset.tasks.celery_app:app --pidfile /tmp/celerybeat.pid -l INFO -s /app/superset_home/celerybeat-schedule
+  celery beat --app=superset.tasks.celery_app:app --pidfile /tmp/celerybeat.pid -l INFO -s "${SUPERSET_HOME}"/celerybeat-schedule
 elif [[ "${1}" == "app" ]]; then
   echo "Starting web app..."
   flask run -p 8088 --with-threads --reload --debugger --host=0.0.0.0

--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -41,7 +41,7 @@ if [[ "${1}" == "worker" ]]; then
   celery worker --app=superset.tasks.celery_app:app -Ofair -l INFO
 elif [[ "${1}" == "beat" ]]; then
   echo "Starting Celery beat..."
-  celery beat --app=superset.tasks.celery_app:app --pidfile /tmp/celerybeat.pid -l INFO
+  celery beat --app=superset.tasks.celery_app:app --pidfile /tmp/celerybeat.pid -l INFO -s /app/superset_home/celerybeat-schedule
 elif [[ "${1}" == "app" ]]; then
   echo "Starting web app..."
   flask run -p 8088 --with-threads --reload --debugger --host=0.0.0.0

--- a/superset/config.py
+++ b/superset/config.py
@@ -1027,17 +1027,12 @@ WEBDRIVER_WINDOW = {"dashboard": (1600, 2000), "slice": (3000, 1200)}
 WEBDRIVER_AUTH_FUNC = None
 
 # Any config options to be passed as-is to the webdriver
-WEBDRIVER_CONFIGURATION: Dict[Any, Any] = {
-    "service_log_path": "/dev/null"
-}
+WEBDRIVER_CONFIGURATION: Dict[Any, Any] = {"service_log_path": "/dev/null"}
 
 # Additional args to be passed as arguments to the config object
 # Note: these options are Chrome-specific. For FF, these should
 # only include the "--headless" arg
-WEBDRIVER_OPTION_ARGS = [
-    "--headless",
-    "--marionette"
-]
+WEBDRIVER_OPTION_ARGS = ["--headless", "--marionette"]
 
 # The base URL to query for accessing the user interface
 WEBDRIVER_BASEURL = "http://0.0.0.0:8080/"

--- a/superset/config.py
+++ b/superset/config.py
@@ -1027,15 +1027,16 @@ WEBDRIVER_WINDOW = {"dashboard": (1600, 2000), "slice": (3000, 1200)}
 WEBDRIVER_AUTH_FUNC = None
 
 # Any config options to be passed as-is to the webdriver
-WEBDRIVER_CONFIGURATION: Dict[Any, Any] = {}
+WEBDRIVER_CONFIGURATION: Dict[Any, Any] = {
+    "service_log_path": "/dev/null"
+}
 
 # Additional args to be passed as arguments to the config object
 # Note: these options are Chrome-specific. For FF, these should
 # only include the "--headless" arg
 WEBDRIVER_OPTION_ARGS = [
-    "--force-device-scale-factor=2.0",
-    "--high-dpi-support=2.0",
     "--headless",
+    "--marionette"
 ]
 
 # The base URL to query for accessing the user interface


### PR DESCRIPTION
### SUMMARY
This PR fixes/improves the following:

- Fixes firefox config for thumbnails and alerts & report when running with a low privilege user.
- Easier way to run dev docker-compose with a low privilege user eg: superset
- Fixes superset homedir

### ADDITIONAL INFORMATION
- [X] Has associated issue: #14330
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
