### PR TITLE
fix(explore): DndColumnSelect not handling controls with "multi: false"

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
@@ -28,7 +28,7 @@ import { DndItemType } from 'src/explore/components/DndItemType';
 import { StyledColumnOption } from 'src/explore/components/optionRenderers';
 
 export const DndColumnSelect = (props: LabelProps) => {
-  const { value, options } = props;
+  const { value, options, multi = true } = props;
   const optionSelector = new OptionSelector(options, value);
   const [values, setValues] = useState<ColumnMeta[]>(optionSelector.values);
 
@@ -44,6 +44,7 @@ export const DndColumnSelect = (props: LabelProps) => {
   };
 
   const canDrop = (item: DatasourcePanelDndItem) =>
+    (multi || optionSelector.values.length === 0) &&
     !optionSelector.has((item.value as ColumnMeta).column_name);
 
   const onClickClose = (index: number) => {
@@ -77,6 +78,7 @@ export const DndColumnSelect = (props: LabelProps) => {
       canDrop={canDrop}
       valuesRenderer={valuesRenderer}
       accept={DndItemType.Column}
+      displayGhostButton={multi || optionSelector.values.length === 0}
       {...props}
     />
   );

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import React, { useState } from 'react';
+import { tn } from '@superset-ui/core';
 import { ColumnMeta } from '@superset-ui/chart-controls';
 import { isEmpty } from 'lodash';
 import { LabelProps } from 'src/explore/components/controls/DndColumnSelectControl/types';
@@ -79,6 +80,7 @@ export const DndColumnSelect = (props: LabelProps) => {
       valuesRenderer={valuesRenderer}
       accept={DndItemType.Column}
       displayGhostButton={multi || optionSelector.values.length === 0}
+      ghostButtonText={tn('Drop column', 'Drop columns', multi ? 2 : 1)}
       {...props}
     />
   );

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
@@ -31,5 +31,10 @@ const defaultProps = {
 
 test('renders with default props', () => {
   render(<DndMetricSelect {...defaultProps} />, { useDnd: true });
+  expect(screen.getByText('Drop column or metric')).toBeInTheDocument();
+});
+
+test('renders with default props and multi = true', () => {
+  render(<DndMetricSelect {...defaultProps} multi />, { useDnd: true });
   expect(screen.getByText('Drop columns or metrics')).toBeInTheDocument();
 });

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -18,7 +18,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { ensureIsArray, Metric, t } from '@superset-ui/core';
+import { ensureIsArray, Metric, tn } from '@superset-ui/core';
 import { ColumnMeta } from '@superset-ui/chart-controls';
 import { isEqual } from 'lodash';
 import { usePrevious } from 'src/common/hooks/usePrevious';
@@ -268,7 +268,11 @@ export const DndMetricSelect = (props: any) => {
         canDrop={canDrop}
         valuesRenderer={valuesRenderer}
         accept={[DndItemType.Column, DndItemType.Metric]}
-        ghostButtonText={t('Drop columns or metrics')}
+        ghostButtonText={tn(
+          'Drop column or metric',
+          'Drop columns or metrics',
+          multi ? 2 : 1,
+        )}
         displayGhostButton={multi || value.length === 0}
         {...props}
       />

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
@@ -39,6 +39,7 @@ export interface LabelProps<T = string[] | string> {
   value?: T;
   onChange: (value?: T) => void;
   options: { string: ColumnMeta };
+  multi?: boolean;
 }
 
 export interface DndColumnSelectProps<


### PR DESCRIPTION
### SUMMARY
`DndColumnSelect` was working correctly only for controls that accept multiple values. When used with controls that had `multi: false` prop, it displayed a prompt to add more columns and behaved weirdly - sometimes it allowed adding more values, sometimes it replaced the first value with whatever user dropped last. This PR fixes those glitches and unifies the behaviour with with `DndMetricSelect` - after the first value is added, prompt disappears and adding new columns is disabled.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/67837651/119038421-f352ec00-b967-11eb-96e4-16daf1f439ee.mov

After:

https://user-images.githubusercontent.com/67837651/119038451-fa79fa00-b967-11eb-952a-c110f298d8cf.mov


### TEST PLAN
Open a chart that uses `DndColumnSelect` for single value controls (e.g. Country Map and "ISO 3166-2 CODES" control), verify that only 1 value can be added and there are no glitches when you try to add more values. Please don't mind type label overlapping with column name, the fix is ready in a different PR 🙂 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @villebro @junlincc 