### PR TITLE
fix: Additional ResultSet tests

### DIFF
--- a/superset-frontend/spec/javascripts/sqllab/ResultSet_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/ResultSet_spec.jsx
@@ -190,7 +190,7 @@ describe('RTL ResultSet tests', () => {
     expect(grid.length).toBe(1);
   });
 
-  it('Renders if there is a limit in query.results but not queryLimit', () => {
+  it('renders if there is a limit in query.results but not queryLimit', () => {
     const props = { ...mockedProps, query: queryWithNoQueryLimit };
     render(<ResultSet {...props} />, { useRedux: true });
     const grid = screen.getAllByRole('grid');

--- a/superset-frontend/spec/javascripts/sqllab/ResultSet_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/ResultSet_spec.jsx
@@ -80,118 +80,120 @@ const newProps = {
     },
   },
 };
-describe('ResultSet', () => {
-  it('is valid', () => {
-    expect(React.isValidElement(<ResultSet {...mockedProps} />)).toBe(true);
-  });
-  it('renders a Table', () => {
-    const wrapper = shallow(<ResultSet {...mockedProps} />);
-    expect(wrapper.find(FilterableTable)).toExist();
-  });
-  describe('componentDidMount', () => {
-    const propsWithError = {
-      ...mockedProps,
-      query: { ...queries[0], errorMessage: 'Your session timed out' },
-    };
-    let spy;
-    beforeEach(() => {
-      reRunQuerySpy.resetHistory();
-      spy = sinon.spy(ResultSet.prototype, 'componentDidMount');
-    });
-    afterEach(() => {
-      spy.restore();
-    });
-    it('should call reRunQuery if timed out', () => {
-      shallow(<ResultSet {...propsWithError} />);
-      expect(reRunQuerySpy.callCount).toBe(1);
-    });
 
-    it('should not call reRunQuery if no error', () => {
-      shallow(<ResultSet {...mockedProps} />);
-      expect(reRunQuerySpy.callCount).toBe(0);
-    });
-  });
-  describe('UNSAFE_componentWillReceiveProps', () => {
-    const wrapper = shallow(<ResultSet {...mockedProps} />);
-    let spy;
-    beforeEach(() => {
-      clearQuerySpy.resetHistory();
-      fetchQuerySpy.resetHistory();
-      spy = sinon.spy(ResultSet.prototype, 'UNSAFE_componentWillReceiveProps');
-    });
-    afterEach(() => {
-      spy.restore();
-    });
-    it('should update cached data', () => {
-      wrapper.setProps(newProps);
+test('is valid', () => {
+  expect(React.isValidElement(<ResultSet {...mockedProps} />)).toBe(true);
+});
 
-      expect(wrapper.state().data).toEqual(newProps.query.results.data);
-      expect(clearQuerySpy.callCount).toBe(1);
-      expect(clearQuerySpy.getCall(0).args[0]).toEqual(newProps.query);
-      expect(fetchQuerySpy.callCount).toBe(1);
-      expect(fetchQuerySpy.getCall(0).args[0]).toEqual(newProps.query);
-    });
+test('renders a Table', () => {
+  const wrapper = shallow(<ResultSet {...mockedProps} />);
+  expect(wrapper.find(FilterableTable)).toExist();
+});
+
+describe('componentDidMount', () => {
+  const propsWithError = {
+    ...mockedProps,
+    query: { ...queries[0], errorMessage: 'Your session timed out' },
+  };
+  let spy;
+  beforeEach(() => {
+    reRunQuerySpy.resetHistory();
+    spy = sinon.spy(ResultSet.prototype, 'componentDidMount');
   });
-  describe('render', () => {
-    it('should render success query', () => {
-      const wrapper = shallow(<ResultSet {...mockedProps} />);
-      const filterableTable = wrapper.find(FilterableTable);
-      expect(filterableTable.props().data).toBe(mockedProps.query.results.data);
-      expect(wrapper.find(ExploreResultsButton)).toExist();
-    });
-    it('should render empty results', () => {
-      const props = {
-        ...mockedProps,
-        query: { ...mockedProps.query, results: { data: [] } },
-      };
-      const wrapper = styledMount(
-        <Provider store={store}>
-          <ResultSet {...props} />
-        </Provider>,
-      );
-      expect(wrapper.find(FilterableTable)).not.toExist();
-      expect(wrapper.find(Alert)).toExist();
-      expect(wrapper.find(Alert).render().text()).toBe(
-        'The query returned no data',
-      );
-    });
-    it('should render cached query', () => {
-      const wrapper = shallow(<ResultSet {...cachedQueryProps} />);
-      const cachedData = [{ col1: 'a', col2: 'b' }];
-      wrapper.setState({ data: cachedData });
-      const filterableTable = wrapper.find(FilterableTable);
-      expect(filterableTable.props().data).toBe(cachedData);
-    });
-    it('should render stopped query', () => {
-      const wrapper = shallow(<ResultSet {...stoppedQueryProps} />);
-      expect(wrapper.find(Alert)).toExist();
-    });
-    it('should render running/pending/fetching query', () => {
-      const wrapper = shallow(<ResultSet {...runningQueryProps} />);
-      expect(wrapper.find(ProgressBar)).toExist();
-    });
-    it('should render a failed query with an error message', () => {
-      const wrapper = shallow(
-        <ResultSet {...failedQueryWithErrorMessageProps} />,
-      );
-      expect(wrapper.find(ErrorMessageWithStackTrace)).toExist();
-    });
-    it('should render a failed query with an errors object', () => {
-      const wrapper = shallow(<ResultSet {...failedQueryWithErrorsProps} />);
-      expect(wrapper.find(ErrorMessageWithStackTrace)).toExist();
-    });
+  afterEach(() => {
+    spy.restore();
+  });
+  it('should call reRunQuery if timed out', () => {
+    shallow(<ResultSet {...propsWithError} />);
+    expect(reRunQuerySpy.callCount).toBe(1);
+  });
+
+  it('should not call reRunQuery if no error', () => {
+    shallow(<ResultSet {...mockedProps} />);
+    expect(reRunQuerySpy.callCount).toBe(0);
   });
 });
 
-describe('RTL ResultSet tests', () => {
-  it('renders if there is no limit in query.results but has queryLimit', () => {
-    render(<ResultSet {...mockedProps} />, { useRedux: true });
-    expect(screen.getByRole('grid')).toBeInTheDocument();
+describe('UNSAFE_componentWillReceiveProps', () => {
+  const wrapper = shallow(<ResultSet {...mockedProps} />);
+  let spy;
+  beforeEach(() => {
+    clearQuerySpy.resetHistory();
+    fetchQuerySpy.resetHistory();
+    spy = sinon.spy(ResultSet.prototype, 'UNSAFE_componentWillReceiveProps');
   });
+  afterEach(() => {
+    spy.restore();
+  });
+  it('should update cached data', () => {
+    wrapper.setProps(newProps);
 
-  it('renders if there is a limit in query.results but not queryLimit', () => {
-    const props = { ...mockedProps, query: queryWithNoQueryLimit };
-    render(<ResultSet {...props} />, { useRedux: true });
-    expect(screen.getByRole('grid')).toBeInTheDocument();
+    expect(wrapper.state().data).toEqual(newProps.query.results.data);
+    expect(clearQuerySpy.callCount).toBe(1);
+    expect(clearQuerySpy.getCall(0).args[0]).toEqual(newProps.query);
+    expect(fetchQuerySpy.callCount).toBe(1);
+    expect(fetchQuerySpy.getCall(0).args[0]).toEqual(newProps.query);
   });
+});
+
+test('should render success query', () => {
+  const wrapper = shallow(<ResultSet {...mockedProps} />);
+  const filterableTable = wrapper.find(FilterableTable);
+  expect(filterableTable.props().data).toBe(mockedProps.query.results.data);
+  expect(wrapper.find(ExploreResultsButton)).toExist();
+});
+test('should render empty results', () => {
+  const props = {
+    ...mockedProps,
+    query: { ...mockedProps.query, results: { data: [] } },
+  };
+  const wrapper = styledMount(
+    <Provider store={store}>
+      <ResultSet {...props} />
+    </Provider>,
+  );
+  expect(wrapper.find(FilterableTable)).not.toExist();
+  expect(wrapper.find(Alert)).toExist();
+  expect(wrapper.find(Alert).render().text()).toBe(
+    'The query returned no data',
+  );
+});
+
+test('should render cached query', () => {
+  const wrapper = shallow(<ResultSet {...cachedQueryProps} />);
+  const cachedData = [{ col1: 'a', col2: 'b' }];
+  wrapper.setState({ data: cachedData });
+  const filterableTable = wrapper.find(FilterableTable);
+  expect(filterableTable.props().data).toBe(cachedData);
+});
+
+test('should render stopped query', () => {
+  const wrapper = shallow(<ResultSet {...stoppedQueryProps} />);
+  expect(wrapper.find(Alert)).toExist();
+});
+
+test('should render running/pending/fetching query', () => {
+  const wrapper = shallow(<ResultSet {...runningQueryProps} />);
+  expect(wrapper.find(ProgressBar)).toExist();
+});
+
+test('should render a failed query with an error message', () => {
+  const wrapper = shallow(<ResultSet {...failedQueryWithErrorMessageProps} />);
+  expect(wrapper.find(ErrorMessageWithStackTrace)).toExist();
+});
+
+test('should render a failed query with an errors object', () => {
+  const wrapper = shallow(<ResultSet {...failedQueryWithErrorsProps} />);
+  expect(wrapper.find(ErrorMessageWithStackTrace)).toExist();
+});
+
+test('renders if there is no limit in query.results but has queryLimit', () => {
+  render(<ResultSet {...mockedProps} />, { useRedux: true });
+  expect(screen.getByRole('grid')).toBeInTheDocument();
+});
+
+test('renders if there is a limit in query.results but not queryLimit', () => {
+  const props = { ...mockedProps, query: queryWithNoQueryLimit };
+  render(<ResultSet {...props} />, { useRedux: true });
+  expect(screen.getByRole('grid')).toBeInTheDocument();
 });

--- a/superset-frontend/spec/javascripts/sqllab/ResultSet_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/ResultSet_spec.jsx
@@ -193,7 +193,6 @@ describe('RTL ResultSet tests', () => {
   it('renders if there is a limit in query.results but not queryLimit', () => {
     const props = { ...mockedProps, query: queryWithNoQueryLimit };
     render(<ResultSet {...props} />, { useRedux: true });
-    const grid = screen.getAllByRole('grid');
-    expect(grid.length).toBe(1);
+    expect(screen.getByRole('grid')).toBeInTheDocument());
   });
 });

--- a/superset-frontend/spec/javascripts/sqllab/ResultSet_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/ResultSet_spec.jsx
@@ -184,7 +184,7 @@ describe('ResultSet', () => {
 });
 
 describe('RTL ResultSet tests', () => {
-  it('renders if there props has no limit in query.results but has queryLimit', () => {
+  it('renders if there is no limit in query.results but has queryLimit', () => {
     render(<ResultSet {...mockedProps} />, { useRedux: true });
     const grid = screen.getAllByRole('grid');
     expect(grid.length).toBe(1);

--- a/superset-frontend/spec/javascripts/sqllab/ResultSet_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/ResultSet_spec.jsx
@@ -19,8 +19,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { styledMount } from 'spec/helpers/theming';
-import { render } from 'spec/helpers/testing-library';
-import { screen } from '@testing-library/react';
+import { render, screen } from 'spec/helpers/testing-library';
 import { Provider } from 'react-redux';
 import sinon from 'sinon';
 import Alert from 'src/components/Alert';

--- a/superset-frontend/spec/javascripts/sqllab/ResultSet_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/ResultSet_spec.jsx
@@ -186,13 +186,12 @@ describe('ResultSet', () => {
 describe('RTL ResultSet tests', () => {
   it('renders if there is no limit in query.results but has queryLimit', () => {
     render(<ResultSet {...mockedProps} />, { useRedux: true });
-    const grid = screen.getAllByRole('grid');
-    expect(grid.length).toBe(1);
+    expect(screen.getByRole('grid')).toBeInTheDocument();
   });
 
   it('renders if there is a limit in query.results but not queryLimit', () => {
     const props = { ...mockedProps, query: queryWithNoQueryLimit };
     render(<ResultSet {...props} />, { useRedux: true });
-    expect(screen.getByRole('grid')).toBeInTheDocument());
+    expect(screen.getByRole('grid')).toBeInTheDocument();
   });
 });

--- a/superset-frontend/spec/javascripts/sqllab/fixtures.ts
+++ b/superset-frontend/spec/javascripts/sqllab/fixtures.ts
@@ -283,6 +283,67 @@ export const queries = [
     results: null,
   },
 ];
+export const queryWithNoQueryLimit = {
+  dbId: 1,
+  sql: 'SELECT * FROM superset.slices',
+  sqlEditorId: 'SJ8YO72R',
+  tab: 'Demo',
+  runAsync: false,
+  ctas: false,
+  cached: false,
+  id: 'BkA1CLrJg',
+  progress: 100,
+  startDttm: 1476910566092.96,
+  state: 'success',
+  changedOn: 1476910566000,
+  tempTable: null,
+  userId: 1,
+  executedSql: null,
+  changed_on: '2016-10-19T20:56:06',
+  rows: 42,
+  endDttm: 1476910566798,
+  limit_reached: false,
+  schema: 'test_schema',
+  errorMessage: null,
+  db: 'main',
+  user: 'admin',
+  limit: 1000,
+  serverId: 141,
+  resultsKey: null,
+  results: {
+    columns: [
+      {
+        is_date: true,
+        name: 'ds',
+        type: 'STRING',
+      },
+      {
+        is_date: false,
+        name: 'gender',
+        type: 'STRING',
+      },
+    ],
+    selected_columns: [
+      {
+        is_date: true,
+        name: 'ds',
+        type: 'STRING',
+      },
+      {
+        is_date: false,
+        name: 'gender',
+        type: 'STRING',
+      },
+    ],
+    data: [
+      { col1: 0, col2: 1 },
+      { col1: 2, col2: 3 },
+    ],
+    query: {
+      limit: 100,
+    },
+  },
+};
 export const queryWithBadColumns = {
   ...queries[0],
   results: {

--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -528,7 +528,6 @@ export default class ResultSet extends React.PureComponent<
     const limitReached = results?.displayLimitReached;
     const limit = queryLimit || results.query.limit;
     const isAdmin = !!this.props.user?.roles.Admin;
-    const limit = queryLimit || results.query.limit;
     const displayMaxRowsReachedMessage = {
       withAdmin: t(
         `The number of results displayed is limited to %(rows)d by the configuration DISPLAY_MAX_ROWS. `,

--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -526,6 +526,7 @@ export default class ResultSet extends React.PureComponent<
     const { results, rows, queryLimit, limitingFactor } = this.props.query;
     let limitMessage;
     const limitReached = results?.displayLimitReached;
+    const limit = queryLimit || results.query.limit;
     const isAdmin = !!this.props.user?.roles.Admin;
     const limit = queryLimit || results.query.limit;
     const displayMaxRowsReachedMessage = {
@@ -534,26 +535,24 @@ export default class ResultSet extends React.PureComponent<
         { rows },
       ).concat(
         t(
-          `Please add additional limits/filters or download to csv to see more rows up to the`,
+          `Please add additional limits/filters or download to csv to see more rows up to `,
         ),
-        t(`the %(limit)d limit.`, {
-          limit,
-        }),
+        t(`the %(limit)d limit.`, { limit }),
       ),
       withoutAdmin: t(
         `The number of results displayed is limited to %(rows)d. `,
         { rows },
       ).concat(
         t(
-          `Please add additional limits/filters, download to csv, or contact an admin`,
+          `Please add additional limits/filters, download to csv, or contact an admin `,
         ),
-        t(`to see more rows up to the the %(limit)d limit.`, {
+        t(`to see more rows up to the %(limit)d limit.`, {
           limit,
         }),
       ),
     };
     const shouldUseDefaultDropdownAlert =
-      queryLimit === this.props.defaultQueryLimit &&
+      limit === this.props.defaultQueryLimit &&
       limitingFactor === LIMITING_FACTOR.DROPDOWN;
 
     if (limitingFactor === LIMITING_FACTOR.QUERY && this.props.csv) {


### PR DESCRIPTION
### SUMMARY
This is addressing the fix found in: https://github.com/apache/superset/pull/14719

This adds testing to the ResultSet spec file that checks to make sure that either queryLimit or query.results.limit is present. Without either of these ResultSet throws an error which crashes SqlLab.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TEST PLAN
This adds two new tests to ResultSet, checking to make sure that it renders correctly if either of these are present. I also added limit to the query fixture. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
