### PR TITLE
feat: add support for filters in sqlLab

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1256,6 +1256,37 @@ in this dictionary are made available for users to use in their SQL.
         'my_crazy_macro': lambda x: x*2,
     }
 
+Default values for jinja templates can be specified via ``Parameters`` menu in the SQL Lab user interface.
+In the UI you can assign a set of parameters as JSON
+
+.. code-block:: JSON
+    {
+        "my_table": "foo"
+    }
+
+The parameters become available in your SQL (example:SELECT * FROM {{ my_table }} ) by using Jinja templating syntax.
+SQL Lab template parameters are stored with the dataset as TEMPLATE PARAMETERS.
+
+There is a special ``_filters`` parameter which can be used to test filters used in the jinja template.
+
+.. code-block:: JSON
+    {
+        "_filters": {
+            "col": "action_type",
+            "op": "IN",
+            "val": ["sell", "buy"] 
+    }
+
+.. code-block:: python
+    SELECT action, count(*) as times
+            FROM logs
+            WHERE
+                action in ({{ "'" + "','".join(filter_values('action_type')) + "'" }})
+            GROUP BY action
+
+Note ``_filters`` is not stored with the dataset. It's only used within the SQL Lab UI.
+
+
 Besides default Jinja templating, SQL lab also supports self-defined template
 processor by setting the ``CUSTOM_TEMPLATE_PROCESSORS`` in your superset configuration.
 The values in this dictionary overwrite the default Jinja template processors of the

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1274,7 +1274,7 @@ There is a special ``_filters`` parameter which can be used to test filters used
         "_filters": {
             "col": "action_type",
             "op": "IN",
-            "val": ["sell", "buy"] 
+            "val": ["sell", "buy"]
     }
 
 .. code-block:: python

--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -271,8 +271,20 @@ export default class ResultSet extends React.PureComponent<
       return;
     }
 
-    const { schema, sql, dbId, templateParams } = this.props.query;
+    const { schema, sql, dbId } = this.props.query;
+    let { templateParams } = this.props.query;
     const selectedColumns = this.props.query?.results?.selected_columns || [];
+
+    // The filters param is only used to test jinja templates.
+    // Remove the special filters entry from the templateParams
+    // before saving the dataset.
+    if (templateParams) {
+      const p = JSON.parse(templateParams)
+      if (p.filters) {
+        delete p['filters']
+        templateParams = JSON.stringify(p)
+      }
+    }
 
     this.props.actions
       .createDatasource({

--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -281,6 +281,7 @@ export default class ResultSet extends React.PureComponent<
     if (templateParams) {
       const p = JSON.parse(templateParams);
       if (p.filters) {
+        /* eslint-disable-next-line no-underscore-dangle */
         delete p._filters;
         templateParams = JSON.stringify(p);
       }

--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -279,10 +279,10 @@ export default class ResultSet extends React.PureComponent<
     // Remove the special filters entry from the templateParams
     // before saving the dataset.
     if (templateParams) {
-      const p = JSON.parse(templateParams)
+      const p = JSON.parse(templateParams);
       if (p.filters) {
-        delete p['filters']
-        templateParams = JSON.stringify(p)
+        delete p._filters;
+        templateParams = JSON.stringify(p);
       }
     }
 

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -127,13 +127,16 @@ def loads_request_json(request_json_data: str) -> Dict[Any, Any]:
 def get_form_data(  # pylint: disable=too-many-locals
     slice_id: Optional[int] = None, use_slice_data: bool = False
 ) -> Tuple[Dict[str, Any], Optional[Slice]]:
-    form_data = {}
+    form_data: Dict[Any, Any] = {}
     # chart data API requests are JSON
     request_json_data = (
         request.json["queries"][0]
         if request.is_json and "queries" in request.json
         else None
     )
+
+    add_sqllab_custom_filters(form_data)
+
     request_form_data = request.form.get("form_data")
     request_args_data = request.args.get("form_data")
     if request_json_data:
@@ -194,6 +197,26 @@ def get_form_data(  # pylint: disable=too-many-locals
         )
 
     return form_data, slc
+
+
+def add_sqllab_custom_filters(form_data: Dict[Any, Any]) -> Any:
+    """
+    SQLLab can include a "filters" attribute in the templateParams.
+    The filters attribute is a list of filters to include in the
+    request. Useful for testing templates in SQLLab.
+    """
+    try:
+        data = json.loads(request.data)
+        if isinstance(data, dict):
+            params_str = data.get("templateParams")
+            if isinstance(params_str, str):
+                params = json.loads(params_str)
+                if isinstance(params, dict):
+                    filters = params.get("filters")
+                    if filters:
+                        form_data.update({"filters": filters})
+    except (TypeError, json.JSONDecodeError):
+        data = {}
 
 
 def get_datasource_info(

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -127,7 +127,7 @@ def loads_request_json(request_json_data: str) -> Dict[Any, Any]:
 def get_form_data(  # pylint: disable=too-many-locals
     slice_id: Optional[int] = None, use_slice_data: bool = False
 ) -> Tuple[Dict[str, Any], Optional[Slice]]:
-    form_data: Dict[Any, Any] = {}
+    form_data: Dict[str, Any] = {}
     # chart data API requests are JSON
     request_json_data = (
         request.json["queries"][0]


### PR DESCRIPTION
SQL lab can execute queries containing jinja templates.
![sql_lab_default_value](https://user-images.githubusercontent.com/56140112/119236192-17e3cb00-bb04-11eb-8417-98f796db20c5.png)
You can specify key/values that your  jinja template can use. However it's not possible to add additional filters like the Explore or the Dashboard would do.
![specify_filters_in_sql_lab](https://user-images.githubusercontent.com/56140112/119236195-1adebb80-bb04-11eb-9f25-c43b056b9ee3.png)
This pull request adds support for filters provided in the sql lab parameters
![sql_lab_results](https://user-images.githubusercontent.com/56140112/119236196-1d411580-bb04-11eb-9be7-4264296721f1.png)

This is very convenient to test templates since it behaves like the Explore or Dashboard.

Maybe the implementation details are not 100%. But I'm hoping the concept and ability to do this in sql lab is welcomed.

