### PR TITLE
feat: enable user impersonation in GSheets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ setup(
         "exasol": ["sqlalchemy-exasol>=2.1.0, <2.2"],
         "excel": ["xlrd>=1.2.0, <1.3"],
         "firebird": ["sqlalchemy-firebird>=0.7.0, <0.8"],
-        "gsheets": ["shillelagh[gsheetsapi]>=0.2, <0.3"],
+        "gsheets": ["shillelagh[gsheetsapi]>=0.5, <0.6"],
         "hana": ["hdbcli==2.4.162", "sqlalchemy_hana==0.4.0"],
         "hive": ["pyhive[hive]>=0.6.1", "tableschema", "thrift>=0.11.0, <1.0.0"],
         "impala": ["impyla>0.16.2, <0.17"],

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx
@@ -291,7 +291,9 @@ const ExtraOptions = ({
               indeterminate={false}
               checked={!!db?.impersonate_user}
               onChange={onInputChange}
-              labelText={t('Impersonate Logged In User (Presto & Hive)')}
+              labelText={t(
+                'Impersonate Logged In User (Presto, Hive, and GSheets)',
+              )}
             />
             <InfoTooltip
               tooltip={t(

--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -14,6 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Optional
+
+from sqlalchemy.engine.url import URL
+
+from superset import security_manager
 from superset.db_engine_specs.sqlite import SqliteEngineSpec
 
 
@@ -24,3 +29,12 @@ class GSheetsEngineSpec(SqliteEngineSpec):
     engine_name = "Google Sheets"
     allows_joins = False
     allows_subqueries = True
+
+    @classmethod
+    def modify_url_for_impersonation(
+        cls, url: URL, impersonate_user: bool, username: Optional[str]
+    ) -> None:
+        if impersonate_user and username is not None:
+            user = security_manager.find_user(username=username)
+            if user and user.email:
+                url.query["subject"] = user.email


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Allow impersonating the user when using GSheets.

Currently, if the user sets up a GSheets DB with credentials, the user has access to **all** spreadsheets from a given domain. With this change, enabling user impersonation will ensure that the user has access only to spreadsheets that they should have.

For example, I have the email roberto@dealmeida.net. If someones shares a spreadsheet with the "Dealmeida.net" organization I'll have access to it. But if someone shares a spreadsheets with "ceo@dealmeida.net", with this PR I won't be able to access it. Without the PR, or with user impersonation disabled, I would have access because the service account credentials have access to everything in the domain.

We had this set up at Lyft via a `DB_CONNECTION_MUTATOR`, but this is a cleaner and simpler approach.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

I tested manually with my domain, "dealmeida.net". I was able to access only the correct spreadsheets.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
