### PR TITLE
feat: extra table metadata for Google Sheets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,7 @@ setup(
         "exasol": ["sqlalchemy-exasol>=2.1.0, <2.2"],
         "excel": ["xlrd>=1.2.0, <1.3"],
         "firebird": ["sqlalchemy-firebird>=0.7.0, <0.8"],
-        "gsheets": ["shillelagh[gsheetsapi]>=0.5, <0.6"],
+        "gsheets": ["shillelagh[gsheetsapi]>=0.7, <0.8"],
         "hana": ["hdbcli==2.4.162", "sqlalchemy_hana==0.4.0"],
         "hive": ["pyhive[hive]>=0.6.1", "tableschema", "thrift>=0.11.0, <1.0.0"],
         "impala": ["impyla>0.16.2, <0.17"],

--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,7 @@ setup(
         "exasol": ["sqlalchemy-exasol>=2.1.0, <2.2"],
         "excel": ["xlrd>=1.2.0, <1.3"],
         "firebird": ["sqlalchemy-firebird>=0.7.0, <0.8"],
-        "gsheets": ["shillelagh[gsheetsapi]>=0.7, <0.8"],
+        "gsheets": ["shillelagh[gsheetsapi]>=0.7.1, <0.8"],
         "hana": ["hdbcli==2.4.162", "sqlalchemy_hana==0.4.0"],
         "hive": ["pyhive[hive]>=0.6.1", "tableschema", "thrift>=0.11.0, <1.0.0"],
         "impala": ["impyla>0.16.2, <0.17"],

--- a/superset-frontend/src/SqlLab/components/TableElement.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.tsx
@@ -44,6 +44,7 @@ interface Table {
     partitionQuery: string;
     latest: object[];
   };
+  metadata?: Record<string, string>;
   indexes?: object[];
   selectStar?: string;
   view?: string;
@@ -91,7 +92,8 @@ const TableElement = ({ table, actions, ...props }: TableElementProps) => {
   };
 
   const renderWell = () => {
-    let header;
+    let partitions;
+    let metadata;
     if (table.partitions) {
       let partitionQuery;
       let partitionClipBoard;
@@ -111,18 +113,36 @@ const TableElement = ({ table, actions, ...props }: TableElementProps) => {
         .map(([key, value]) => `${key}=${value}`)
         .join('/');
 
-      header = (
-        <Card size="small">
-          <div>
-            <small>
-              {t('latest partition:')} {latest}
-            </small>{' '}
-            {partitionClipBoard}
-          </div>
-        </Card>
+      partitions = (
+        <div>
+          <small>
+            {t('latest partition:')} {latest}
+          </small>{' '}
+          {partitionClipBoard}
+        </div>
       );
     }
-    return header;
+
+    if (table.metadata) {
+      metadata = Object.entries(table.metadata).map(([key, value]) => (
+        <div>
+          <small>
+            <strong>{key}:</strong> {value}
+          </small>
+        </div>
+      ));
+    }
+
+    if (!partitions && !metadata) {
+      return null;
+    }
+
+    return (
+      <Card size="small">
+        {partitions}
+        {metadata}
+      </Card>
+    );
   };
 
   const renderControls = () => {

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.js
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.js
@@ -117,6 +117,8 @@ export default function getInitialState({
           foreignKeys,
           indexes,
           dataPreviewQueryId,
+          partitions,
+          metadata,
         } = tableSchema.description;
         const table = {
           dbId: tableSchema.database_id,
@@ -133,6 +135,8 @@ export default function getInitialState({
           primaryKey,
           foreignKeys,
           indexes,
+          partitions,
+          metadata,
         };
         tables.push(table);
       });

--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -14,8 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import json
 import re
-from typing import Any, Dict, Optional, Pattern, Tuple
+from contextlib import closing
+from typing import Any, Dict, Optional, Pattern, Tuple, TYPE_CHECKING
 
 from flask_babel import gettext as __
 from sqlalchemy.engine.url import URL
@@ -23,6 +25,10 @@ from sqlalchemy.engine.url import URL
 from superset import security_manager
 from superset.db_engine_specs.sqlite import SqliteEngineSpec
 from superset.errors import SupersetErrorType
+
+if TYPE_CHECKING:
+    from superset.models.core import Database
+
 
 SYNTAX_ERROR_REGEX = re.compile('SQLError: near "(?P<server_error>.*?)": syntax error')
 
@@ -54,3 +60,23 @@ class GSheetsEngineSpec(SqliteEngineSpec):
             user = security_manager.find_user(username=username)
             if user and user.email:
                 url.query["subject"] = user.email
+
+    @classmethod
+    def extra_table_metadata(
+        cls,
+        database: "Database",
+        table_name: str,
+        schema_name: str,
+    ) -> Dict[str, Any]:
+        engine = cls.get_engine(database, schema=schema_name)
+        with closing(engine.raw_connection()) as conn:
+            cursor = conn.cursor()
+            cursor.execute(f'SELECT GET_METADATA("{table_name}")')
+            results = cursor.fetchone()[0]
+
+        try:
+            metadata = json.loads(results)
+        except Exception:
+            metadata = {}
+
+        return {"metadata": metadata["extra"]}

--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -63,10 +63,7 @@ class GSheetsEngineSpec(SqliteEngineSpec):
 
     @classmethod
     def extra_table_metadata(
-        cls,
-        database: "Database",
-        table_name: str,
-        schema_name: str,
+        cls, database: "Database", table_name: str, schema_name: str,
     ) -> Dict[str, Any]:
         engine = cls.get_engine(database, schema=schema_name)
         with closing(engine.raw_connection()) as conn:
@@ -76,7 +73,7 @@ class GSheetsEngineSpec(SqliteEngineSpec):
 
         try:
             metadata = json.loads(results)
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             metadata = {}
 
         return {"metadata": metadata["extra"]}


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR uses the new `GET_METADATA` function in `shillelagh` [0.7.0](https://pypi.org/project/shillelagh/0.7.0/) to show extra metadata about spreadsheets in the metadata browser in SQL Lab, namely the Spreadsheet and Sheet (tab) titles.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

After:

<img width="1792" alt="Screen Shot 2021-06-30 at 9 41 41 PM" src="https://user-images.githubusercontent.com/1534870/124065654-0daec980-d9ec-11eb-9f11-81daa49092be.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Add a Google Sheets database connection **with credentials**.
2. Go to SQL Lab, choose Google Sheets.
3. Choose the "main" schema.
4. The list of spreadsheets should show up as tables. Click one.
5. The metadata should show up correctly.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
