### PR TITLE
fix: Make credentials_info required field for API Spec

### DIFF
--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -49,6 +49,7 @@ ma_plugin = MarshmallowPlugin()
 
 class BigQueryParametersSchema(Schema):
     credentials_info = EncryptedField(
+        required=True,
         description="Contents of BigQuery JSON credentials.",
     )
 

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -49,8 +49,7 @@ ma_plugin = MarshmallowPlugin()
 
 class BigQueryParametersSchema(Schema):
     credentials_info = EncryptedField(
-        required=True,
-        description="Contents of BigQuery JSON credentials.",
+        required=True, description="Contents of BigQuery JSON credentials.",
     )
 
 

--- a/tests/databases/api_tests.py
+++ b/tests/databases/api_tests.py
@@ -1443,6 +1443,7 @@ class TestDatabaseApi(SupersetTestCase):
                         },
                         "type": "object",
                     },
+                    "required": ["credentials_info"],
                     "preferred": False,
                     "sqlalchemy_uri_placeholder": "bigquery://{project_id}",
                 },
@@ -1464,7 +1465,6 @@ class TestDatabaseApi(SupersetTestCase):
 
         rv = self.client.get(uri)
         response = json.loads(rv.data.decode("utf-8"))
-        print(response)
         assert rv.status_code == 200
         assert response == {
             "databases": [


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The database modal needs to know which fields are required to render.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
