### PR TITLE
fix: the calculated columns explicit type convert into date

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -309,7 +309,8 @@ class TableColumn(Model, BaseColumn):
         ],
     ) -> str:
         """Convert datetime object to a SQL expression string"""
-        sql = self.db_engine_spec.convert_dttm(self.type, dttm) if self.type else None
+        dttm_type = self.type or ("DATETIME" if self.is_dttm else None)
+        sql = self.db_engine_spec.convert_dttm(dttm_type, dttm) if dttm_type else None
 
         if sql:
             return sql


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
datetime column(grain columns) get default column type when this column lack of column type.

This situation occurs in the calculated columns. 

related issue: https://github.com/apache/superset/issues/13702

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### make a `calculated columns` and selected `is temporal` checkbox
<img width="717" alt="image" src="https://user-images.githubusercontent.com/2016594/119501100-1ed83b00-bd9b-11eb-9feb-288eb01dcf83.png">

#### make `calculated columns` as `time columns` and do query.
<img width="1458" alt="image" src="https://user-images.githubusercontent.com/2016594/119501422-6eb70200-bd9b-11eb-9ec3-07fe9826060f.png">



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes https://github.com/apache/superset/issues/13702
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
