### PR TITLE
fix: actually write changes on "superset import-datasources"

### DIFF
--- a/superset/commands/dataset/importers/v0.py
+++ b/superset/commands/dataset/importers/v0.py
@@ -260,6 +260,7 @@ class ImportDatasetsCommand(BaseCommand):
                     )
                     dataset["database_id"] = database.id
                     SqlaTable.import_from_dict(dataset, sync=self.sync)
+                db.session.commit()
 
     def validate(self) -> None:
         # ensure all files are YAML


### PR DESCRIPTION
### SUMMARY

When running the following command:

    superset import-datasources --path=datasource.json

the data stored in "datasources.json" may either be dict or a list. In the case
of a dataset exported from a live superset instance, it is a list. When it is
re-imported, the `SqlaTable.import_from_dict` utility method is used. This
method does not commit changes to the database, so the imported datasets are
never saved to the database, causing frustration and sadness.


### TESTING INSTRUCTIONS

1. Create and export dataset
2. Change the name of the dataset in the exported file
3. Re-import dataset
 
Prior to the fix, the new dataset is not created.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
