### PR TITLE
feat: Icon Button

### DIFF
--- a/superset-frontend/src/components/IconButton/IconButton.stories.tsx
+++ b/superset-frontend/src/components/IconButton/IconButton.stories.tsx
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import IconButton, { IconButtonProps } from '.';
+
+export default {
+  title: 'IconButton',
+  component: IconButton,
+};
+
+export const InteractiveIconButton = (args: IconButtonProps) => (
+  <IconButton
+    buttonText={args.buttonText}
+    altText={args.altText}
+    logo={args.logo}
+    href={args.href}
+    target={args.target}
+    htmlType={args.htmlType}
+  />
+);
+
+InteractiveIconButton.args = {
+  buttonText: 'This is the IconButton text',
+  altText: 'This is an example of non-default alt text',
+  href: 'https://preset.io/',
+  target: '_blank',
+};
+
+InteractiveIconButton.argTypes = {
+  logo: {
+    defaultValue: '/images/icons/sql.svg',
+    control: {
+      type: 'select',
+      options: [
+        '/images/icons/sql.svg',
+        '/images/icons/server.svg',
+        '/images/icons/image.svg',
+        'Click to see example alt text',
+      ],
+    },
+  },
+};

--- a/superset-frontend/src/components/IconButton/IconButton.stories.tsx
+++ b/superset-frontend/src/components/IconButton/IconButton.stories.tsx
@@ -28,7 +28,7 @@ export const InteractiveIconButton = (args: IconButtonProps) => (
   <IconButton
     buttonText={args.buttonText}
     altText={args.altText}
-    logo={args.logo}
+    icon={args.icon}
     href={args.href}
     target={args.target}
     htmlType={args.htmlType}
@@ -43,7 +43,7 @@ InteractiveIconButton.args = {
 };
 
 InteractiveIconButton.argTypes = {
-  logo: {
+  icon: {
     defaultValue: '/images/icons/sql.svg',
     control: {
       type: 'select',

--- a/superset-frontend/src/components/IconButton/IconButton.test.jsx
+++ b/superset-frontend/src/components/IconButton/IconButton.test.jsx
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { render, screen } from 'spec/helpers/testing-library';
+import IconButton from 'src/components/IconButton';
+
+const defaultProps = {
+  buttonText: 'This is the IconButton text',
+  logo: '/images/icons/sql.svg',
+};
+
+describe('IconButton', () => {
+  it('renders an IconButton', () => {
+    render(<IconButton {...defaultProps} />);
+
+    const logo = screen.getByRole('img', { name: /default database log/i });
+    const buttonText = screen.getByText(/this is the iconbutton text/i);
+
+    expect(logo).toBeVisible();
+    expect(buttonText).toBeVisible();
+  });
+});

--- a/superset-frontend/src/components/IconButton/IconButton.test.jsx
+++ b/superset-frontend/src/components/IconButton/IconButton.test.jsx
@@ -29,8 +29,9 @@ describe('IconButton', () => {
   it('renders an IconButton', () => {
     render(<IconButton {...defaultProps} />);
 
-    const logo = screen.getByRole('img', { name: /default database log/i });
+    const logo = screen.getByRole('img');
     const buttonText = screen.getByText(/this is the iconbutton text/i);
+    screen.logTestingPlaygroundURL();
 
     expect(logo).toBeVisible();
     expect(buttonText).toBeVisible();

--- a/superset-frontend/src/components/IconButton/IconButton.test.jsx
+++ b/superset-frontend/src/components/IconButton/IconButton.test.jsx
@@ -22,18 +22,17 @@ import IconButton from 'src/components/IconButton';
 
 const defaultProps = {
   buttonText: 'This is the IconButton text',
-  logo: '/images/icons/sql.svg',
+  icon: '/images/icons/sql.svg',
 };
 
 describe('IconButton', () => {
   it('renders an IconButton', () => {
     render(<IconButton {...defaultProps} />);
 
-    const logo = screen.getByRole('img');
+    const icon = screen.getByRole('img');
     const buttonText = screen.getByText(/this is the iconbutton text/i);
-    screen.logTestingPlaygroundURL();
 
-    expect(logo).toBeVisible();
+    expect(icon).toBeVisible();
     expect(buttonText).toBeVisible();
   });
 });

--- a/superset-frontend/src/components/IconButton/index.tsx
+++ b/superset-frontend/src/components/IconButton/index.tsx
@@ -1,0 +1,126 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { styled } from '@superset-ui/core';
+import Button from 'src/components/Button';
+import { ButtonProps as AntdButtonProps } from 'antd/lib/button';
+
+export interface IconButtonProps extends AntdButtonProps {
+  buttonText: string;
+  logo: string;
+  altText?: string;
+}
+
+const StyledButton = styled(Button)`
+  height: auto;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+`;
+const StyledImage = styled.div`
+  margin: ${({ theme }) => theme.gridUnit * 8}px 0;
+  padding: ${({ theme }) => theme.gridUnit * 4}px;
+
+  &:first-of-type {
+    margin-right: 0;
+  }
+
+  img {
+    width: fit-content;
+
+    &:first-of-type {
+      margin-right: 0;
+    }
+  }
+`;
+
+const StyledInner = styled.div`
+  max-height: calc(1.5em * 2);
+  overflow: hidden;
+  padding-right: 1rem;
+  position: relative;
+  white-space: break-spaces;
+
+  &::before {
+    content: '...';
+    inset-block-end: 0; /* "bottom" */
+    inset-inline-end: ${({ theme }) => theme.gridUnit * 2}px; /* "right" */
+    position: absolute;
+  }
+
+  &::after {
+    background-color: ${({ theme }) => theme.colors.grayscale.light4};
+    content: '';
+    height: 1rem;
+    inset-inline-end: ${({ theme }) => theme.gridUnit * 2}px; /* "right" */
+    position: absolute;
+    top: 4px;
+    width: 1rem;
+  }
+`;
+
+const StyledBottom = styled.div`
+  padding: ${({ theme }) => theme.gridUnit * 6}px
+    ${({ theme }) => theme.gridUnit * 4}px;
+  border-radius: 0 0 ${({ theme }) => theme.borderRadius}px
+    ${({ theme }) => theme.borderRadius}px;
+  background-color: ${({ theme }) => theme.colors.grayscale.light4};
+  width: 100%;
+  line-height: 1.5em;
+  overflow: hidden;
+  white-space: no-wrap;
+  text-overflow: ellipsis;
+
+  &:first-of-type {
+    margin-right: 0;
+  }
+`;
+
+const IconButton = styled(
+  ({ logo, altText, buttonText, ...props }: IconButtonProps) => (
+    <StyledButton {...props}>
+      <StyledImage>
+        <img
+          src={logo || '/images/icons/image.svg'}
+          alt={altText || 'Default database log'}
+        />
+      </StyledImage>
+      <StyledBottom>
+        <StyledInner>{buttonText}</StyledInner>
+      </StyledBottom>
+    </StyledButton>
+  ),
+)`
+  text-transform: none;
+  background-color: ${({ theme }) => theme.colors.grayscale.light5};
+  font-weight: ${({ theme }) => theme.typography.weights.normal};
+  color: ${({ theme }) => theme.colors.grayscale.dark2};
+  border: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
+  margin: 0;
+  width: 100%;
+
+  &:hover,
+  &:focus {
+    background-color: ${({ theme }) => theme.colors.grayscale.light5};
+    color: ${({ theme }) => theme.colors.grayscale.dark2};
+    border: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
+  }
+`;
+
+export default IconButton;

--- a/superset-frontend/src/components/IconButton/index.tsx
+++ b/superset-frontend/src/components/IconButton/index.tsx
@@ -96,10 +96,7 @@ const IconButton = styled(
   ({ icon, altText, buttonText, ...props }: IconButtonProps) => (
     <StyledButton {...props}>
       <StyledImage>
-        <img
-          src={icon || '/images/icons/image.svg'}
-          alt={altText || 'Default database log'}
-        />
+        <img src={icon} alt={altText} />
       </StyledImage>
       <StyledBottom>
         <StyledInner>{buttonText}</StyledInner>

--- a/superset-frontend/src/components/IconButton/index.tsx
+++ b/superset-frontend/src/components/IconButton/index.tsx
@@ -23,7 +23,7 @@ import { ButtonProps as AntdButtonProps } from 'antd/lib/button';
 
 export interface IconButtonProps extends AntdButtonProps {
   buttonText: string;
-  logo: string;
+  icon: string;
   altText?: string;
 }
 
@@ -93,11 +93,11 @@ const StyledBottom = styled.div`
 `;
 
 const IconButton = styled(
-  ({ logo, altText, buttonText, ...props }: IconButtonProps) => (
+  ({ icon, altText, buttonText, ...props }: IconButtonProps) => (
     <StyledButton {...props}>
       <StyledImage>
         <img
-          src={logo || '/images/icons/image.svg'}
+          src={icon || '/images/icons/image.svg'}
           alt={altText || 'Default database log'}
         />
       </StyledImage>

--- a/superset-frontend/src/components/IconButton/index.tsx
+++ b/superset-frontend/src/components/IconButton/index.tsx
@@ -60,7 +60,7 @@ const StyledInner = styled.div`
   &::before {
     content: '...';
     inset-block-end: 0; /* "bottom" */
-    inset-inline-end: ${({ theme }) => theme.gridUnit * 2}px; /* "right" */
+    inset-inline-end: 8px; /* "right" */
     position: absolute;
   }
 
@@ -68,7 +68,7 @@ const StyledInner = styled.div`
     background-color: ${({ theme }) => theme.colors.grayscale.light4};
     content: '';
     height: 1rem;
-    inset-inline-end: ${({ theme }) => theme.gridUnit * 2}px; /* "right" */
+    inset-inline-end: 8px; /* "right" */
     position: absolute;
     top: 4px;
     width: 1rem;


### PR DESCRIPTION
### SUMMARY
I have created a new Icon Button. The button can be customized with the following parameters:
```
buttonText: string;
icon: string;
altText?: string;
```

### SCREENSHOT
<img width="305" alt="IconButton" src="https://user-images.githubusercontent.com/55605634/119887275-8b694c00-bef9-11eb-8278-6c237674ce38.png">


### TESTING INSTRUCTIONS
- Run Storybook
- Click IconButton > Interactive IconButton
- Interact with the available arguments to observe customization

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
