### PR TITLE
chore: Update docs on MySQL recommended driver

### DIFF
--- a/docs/src/pages/docs/Connecting to Databases/mysql.mdx
+++ b/docs/src/pages/docs/Connecting to Databases/mysql.mdx
@@ -22,7 +22,7 @@ Host:
 - For Docker running in OSX: `docker.for.mac.host.internal`
 Port: `3306` by default
 
-One problem with `mysqlclient` is that it will fail to connect to newer MySQL databases using `caching_sha2_password` for authentication, since the plugin is not included in the client. In the case, you should use [mysql-connector-python](https://pypi.org/project/mysql-connector-python/) instead:
+One problem with `mysqlclient` is that it will fail to connect to newer MySQL databases using `caching_sha2_password` for authentication, since the plugin is not included in the client. In this case, you should use `[mysql-connector-python](https://pypi.org/project/mysql-connector-python/)` instead:
 
 ```
 mysql+mysqlconnector://{username}:{password}@{host}/{database}

--- a/docs/src/pages/docs/Connecting to Databases/mysql.mdx
+++ b/docs/src/pages/docs/Connecting to Databases/mysql.mdx
@@ -8,12 +8,12 @@ version: 1
 
 ## MySQL
 
-The recommended connector library for MySQL is [mysql-connector-python](https://pypi.org/project/mysql-connector-python/).
+The recommended connector library for MySQL is [mysqlclient](https://pypi.org/project/mysqlclient/).
 
 Here's the connection string:
 
 ```
-mysql+mysqlconnector://{username}:{password}@{host}/{database}
+mysql://{username}:{password}@{host}/{database}
 ```
 
 Host:
@@ -21,3 +21,9 @@ Host:
 - For On Prem: IP address or Host name
 - For Docker running in OSX: `docker.for.mac.host.internal`
 Port: `3306` by default
+
+One problem with `mysqlclient` is that it will fail to connect to newer MySQL databases using `caching_sha2_password` for authentication, since the plugin is not included in the client. In the case, you should use [mysql-connector-python](https://pypi.org/project/mysql-connector-python/) instead:
+
+```
+mysql+mysqlconnector://{username}:{password}@{host}/{database}
+```

--- a/docs/src/pages/docs/Connecting to Databases/mysql.mdx
+++ b/docs/src/pages/docs/Connecting to Databases/mysql.mdx
@@ -8,7 +8,7 @@ version: 1
 
 ## MySQL
 
-The recommended connector library for MySQL is [mysqlclient](https://pypi.org/project/mysqlclient/).
+The recommended connector library for MySQL is `[mysqlclient](https://pypi.org/project/mysqlclient/)`.
 
 Here's the connection string:
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Docs said that `mysql-connector-python` was recommended, but the SQLAlchemy docs say:

> The MySQL Connector/Python DBAPI has had many issues since its release, some of which may remain unresolved, and the mysqlconnector dialect is not tested as part of SQLAlchemy’s continuous integration. The recommended MySQL dialects are mysqlclient and PyMySQL.

I updated the docs to recommend `mysqlclient` (the previous recommendation), and to inform when `mysql-connector-python` might be needed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: https://github.com/apache/superset/issues/14746
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
