### PR TITLE
refactor: Convert TableElement.jsx component from class to functional with hooks

### DIFF
--- a/superset-frontend/spec/javascripts/sqllab/TableElement_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/TableElement_spec.jsx
@@ -43,7 +43,7 @@ describe('TableElement', () => {
   it('renders with props', () => {
     expect(React.isValidElement(<TableElement {...mockedProps} />)).toBe(true);
   });
-  it('has 4 IconTooltip elements', () => {
+  it('has 5 IconTooltip elements', () => {
     const wrapper = mount(
       <Provider store={store}>
         <TableElement {...mockedProps} />
@@ -55,7 +55,7 @@ describe('TableElement', () => {
         },
       },
     );
-    expect(wrapper.find(IconTooltip)).toHaveLength(4);
+    expect(wrapper.find(IconTooltip)).toHaveLength(5);
   });
   it('has 14 columns', () => {
     const wrapper = shallow(<TableElement {...mockedProps} />);
@@ -110,20 +110,20 @@ describe('TableElement', () => {
       },
     );
     expect(
-      wrapper.find(IconTooltip).at(1).hasClass('fa-sort-alpha-asc'),
+      wrapper.find(IconTooltip).at(2).hasClass('fa-sort-alpha-asc'),
     ).toEqual(true);
     expect(
-      wrapper.find(IconTooltip).at(1).hasClass('fa-sort-numeric-asc'),
+      wrapper.find(IconTooltip).at(2).hasClass('fa-sort-numeric-asc'),
     ).toEqual(false);
     wrapper.find('.header-container').hostNodes().simulate('click');
     expect(wrapper.find(ColumnElement).first().props().column.name).toBe('id');
     wrapper.find('.header-container').simulate('mouseEnter');
     wrapper.find('.sort-cols').hostNodes().simulate('click');
     expect(
-      wrapper.find(IconTooltip).at(1).hasClass('fa-sort-numeric-asc'),
+      wrapper.find(IconTooltip).at(2).hasClass('fa-sort-numeric-asc'),
     ).toEqual(true);
     expect(
-      wrapper.find(IconTooltip).at(1).hasClass('fa-sort-alpha-asc'),
+      wrapper.find(IconTooltip).at(2).hasClass('fa-sort-alpha-asc'),
     ).toEqual(false);
     expect(wrapper.find(ColumnElement).first().props().column.name).toBe(
       'active',

--- a/superset-frontend/spec/javascripts/sqllab/TableElement_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/TableElement_spec.jsx
@@ -86,13 +86,11 @@ describe('TableElement', () => {
         },
       },
     );
-    expect(wrapper.find(TableElement).state().hovered).toBe(false);
     expect(wrapper.find('[data-test="fade"]').first().props().hovered).toBe(
       false,
     );
     wrapper.find('.header-container').hostNodes().simulate('mouseEnter');
     await waitForComponentToPaint(wrapper, 300);
-    expect(wrapper.find(TableElement).state().hovered).toBe(true);
     expect(wrapper.find('[data-test="fade"]').first().props().hovered).toBe(
       true,
     );
@@ -111,12 +109,22 @@ describe('TableElement', () => {
         },
       },
     );
-    expect(wrapper.find(TableElement).state().sortColumns).toBe(false);
+    expect(
+      wrapper.find(IconTooltip).at(1).hasClass('fa-sort-alpha-asc'),
+    ).toEqual(true);
+    expect(
+      wrapper.find(IconTooltip).at(1).hasClass('fa-sort-numeric-asc'),
+    ).toEqual(false);
     wrapper.find('.header-container').hostNodes().simulate('click');
     expect(wrapper.find(ColumnElement).first().props().column.name).toBe('id');
     wrapper.find('.header-container').simulate('mouseEnter');
     wrapper.find('.sort-cols').hostNodes().simulate('click');
-    expect(wrapper.find(TableElement).state().sortColumns).toBe(true);
+    expect(
+      wrapper.find(IconTooltip).at(1).hasClass('fa-sort-numeric-asc'),
+    ).toEqual(true);
+    expect(
+      wrapper.find(IconTooltip).at(1).hasClass('fa-sort-alpha-asc'),
+    ).toEqual(false);
     expect(wrapper.find(ColumnElement).first().props().column.name).toBe(
       'active',
     );

--- a/superset-frontend/spec/javascripts/sqllab/TableElement_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/TableElement_spec.jsx
@@ -62,7 +62,7 @@ describe('TableElement', () => {
     expect(wrapper.find(ColumnElement)).toHaveLength(14);
   });
   it('mounts', () => {
-    mount(
+    const wrapper = mount(
       <Provider store={store}>
         <TableElement {...mockedProps} />
       </Provider>,
@@ -73,6 +73,8 @@ describe('TableElement', () => {
         },
       },
     );
+
+    expect(wrapper.find(TableElement)).toHaveLength(1);
   });
   it('fades table', async () => {
     const wrapper = mount(

--- a/superset-frontend/src/SqlLab/components/TableElement.jsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.jsx
@@ -249,8 +249,9 @@ const TableElement = props => {
       >
         {renderWell()}
         <div>
-          {cols &&
-            cols.map(col => <ColumnElement column={col} key={col.name} />)}
+          {cols?.map(col => (
+            <ColumnElement column={col} key={col.name} />
+          ))}
         </div>
       </div>
     );

--- a/superset-frontend/src/SqlLab/components/TableElement.jsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.jsx
@@ -32,6 +32,7 @@ import ColumnElement from './ColumnElement';
 import ShowSQL from './ShowSQL';
 import ModalTrigger from '../../components/ModalTrigger';
 import Loading from '../../components/Loading';
+import { UpOutlined } from '@ant-design/icons';
 
 const propTypes = {
   table: PropTypes.object,
@@ -60,7 +61,7 @@ const TableElement = props => {
   const [sortColumns, setSortColumns] = useState(false);
   const [hovered, setHovered] = useState(false);
 
-  const { table, actions } = props;
+  const { table, actions, isActive } = props;
 
   const setHover = hovered => {
     debounce(() => setHovered(hovered), 100)();
@@ -161,13 +162,15 @@ const TableElement = props => {
         {table.selectStar && (
           <CopyToClipboard
             copyNode={
-              <IconTooltip aria-label="Copy">
+              <IconTooltip
+                aria-label="Copy"
+                tooltip={t('Copy SELECT statement to the clipboard')}
+              >
                 <i aria-hidden className="fa fa-clipboard pull-left m-l-2" />
               </IconTooltip>
             }
             text={table.selectStar}
             shouldShowText={false}
-            tooltipText={t('Copy SELECT statement to the clipboard')}
           />
         )}
         {table.view && (
@@ -258,12 +261,31 @@ const TableElement = props => {
     return metadata;
   };
 
+  const collapseExpandIcon = () => {
+    return (
+      <IconTooltip
+        style={{
+          position: 'absolute',
+          right: '4%',
+          height: '1em',
+        }}
+        aria-label="Collapse"
+        tooltip={t(`${!isActive ? 'Expand' : 'Collapse'} table preview`)}
+      >
+        <UpOutlined
+          style={!isActive ? { transform: 'rotate(180deg)' } : null}
+        />
+      </IconTooltip>
+    );
+  };
+
   return (
     <Collapse.Panel
       {...props}
       header={renderHeader()}
       className="TableElement"
-      forceRender="true"
+      forceRender={true}
+      expandIcon={collapseExpandIcon}
     >
       {renderBody()}
     </Collapse.Panel>

--- a/superset-frontend/src/SqlLab/components/TableElement.jsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.jsx
@@ -32,7 +32,7 @@ import ColumnElement from './ColumnElement';
 import ShowSQL from './ShowSQL';
 import ModalTrigger from '../../components/ModalTrigger';
 import Loading from '../../components/Loading';
-import { UpOutlined } from '@ant-design/icons';
+import { RightOutlined } from '@ant-design/icons';
 
 const propTypes = {
   table: PropTypes.object,
@@ -265,15 +265,22 @@ const TableElement = props => {
     return (
       <IconTooltip
         style={{
-          position: 'absolute',
-          right: '4%',
+          position: 'fixed',
+          right: '16px',
+          left: 'auto',
           height: '1em',
+          width: '1em',
+          fontSize: '12px',
+          transform: 'rotate(90deg)',
+          display: 'flex',
+          alignItems: 'center',
         }}
         aria-label="Collapse"
         tooltip={t(`${!isActive ? 'Expand' : 'Collapse'} table preview`)}
       >
-        <UpOutlined
-          style={!isActive ? { transform: 'rotate(180deg)' } : null}
+        <RightOutlined
+          className="anticon"
+          style={isActive ? { transform: 'rotate(180deg)' } : null}
         />
       </IconTooltip>
     );

--- a/superset-frontend/src/SqlLab/components/TableElement.jsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.jsx
@@ -123,7 +123,7 @@ const TableElement = props => {
 
   const renderControls = () => {
     let keyLink;
-    if (table.indexes && table.indexes.length > 0) {
+    if (table?.indexes.length > 0) {
       keyLink = (
         <ModalTrigger
           modalTitle={

--- a/superset-frontend/src/SqlLab/components/TableElement.jsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.jsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Collapse from 'src/components/Collapse';
 import Card from 'src/components/Card';
@@ -56,44 +56,37 @@ const Fade = styled.div`
   opacity: ${props => (props.hovered ? 1 : 0)};
 `;
 
-class TableElement extends React.PureComponent {
-  constructor(props) {
-    super(props);
-    this.state = {
-      sortColumns: false,
-      hovered: false,
-    };
-    this.toggleSortColumns = this.toggleSortColumns.bind(this);
-    this.removeTable = this.removeTable.bind(this);
-    this.setHover = debounce(this.setHover.bind(this), 100);
-  }
+const TableElement = props => {
+  const [sortColumns, setSortColumns] = useState(false);
+  const [hovered, setHovered] = useState(false);
 
-  setHover(hovered) {
-    this.setState({ hovered });
-  }
+  const { table, actions } = props;
 
-  popSelectStar() {
+  const setHover = hovered => {
+    debounce(() => setHovered(hovered), 100)();
+  };
+
+  const popSelectStar = () => {
     const qe = {
       id: shortid.generate(),
-      title: this.props.table.name,
-      dbId: this.props.table.dbId,
+      title: table.name,
+      dbId: table.dbId,
       autorun: true,
-      sql: this.props.table.selectStar,
+      sql: table.selectStar,
     };
-    this.props.actions.addQueryEditor(qe);
-  }
+    actions.addQueryEditor(qe);
+  };
 
-  removeTable() {
-    this.props.actions.removeDataPreview(this.props.table);
-    this.props.actions.removeTable(this.props.table);
-  }
+  const removeTable = () => {
+    actions.removeDataPreview(table);
+    actions.removeTable(table);
+  };
 
-  toggleSortColumns() {
-    this.setState(prevState => ({ sortColumns: !prevState.sortColumns }));
-  }
+  const toggleSortColumns = () => {
+    setSortColumns(prevState => !prevState);
+  };
 
-  renderWell() {
-    const { table } = this.props;
+  const renderWell = () => {
     let header;
     if (table.partitions) {
       let partitionQuery;
@@ -126,11 +119,10 @@ class TableElement extends React.PureComponent {
       );
     }
     return header;
-  }
+  };
 
-  renderControls() {
+  const renderControls = () => {
     let keyLink;
-    const { table } = this.props;
     if (table.indexes && table.indexes.length > 0) {
       keyLink = (
         <ModalTrigger
@@ -156,12 +148,12 @@ class TableElement extends React.PureComponent {
         {keyLink}
         <IconTooltip
           className={
-            `fa fa-sort-${!this.state.sortColumns ? 'alpha' : 'numeric'}-asc ` +
+            `fa fa-sort-${!sortColumns ? 'alpha' : 'numeric'}-asc ` +
             'pull-left sort-cols m-l-2 pointer'
           }
-          onClick={this.toggleSortColumns}
+          onClick={toggleSortColumns}
           tooltip={
-            !this.state.sortColumns
+            !sortColumns
               ? t('Sort columns alphabetically')
               : t('Original table column order')
           }
@@ -187,20 +179,19 @@ class TableElement extends React.PureComponent {
         )}
         <IconTooltip
           className="fa fa-times table-remove pull-left m-l-2 pointer"
-          onClick={this.removeTable}
+          onClick={removeTable}
           tooltip={t('Remove table preview')}
         />
       </ButtonGroup>
     );
-  }
+  };
 
-  renderHeader() {
-    const { table } = this.props;
+  const renderHeader = () => {
     return (
       <div
         className="clearfix header-container"
-        onMouseEnter={() => this.setHover(true)}
-        onMouseLeave={() => this.setHover(false)}
+        onMouseEnter={() => setHover(true)}
+        onMouseLeave={() => setHover(false)}
       >
         <Tooltip
           id="copy-to-clipboard-tooltip"
@@ -220,23 +211,22 @@ class TableElement extends React.PureComponent {
           ) : (
             <Fade
               data-test="fade"
-              hovered={this.state.hovered}
+              hovered={hovered}
               onClick={e => e.stopPropagation()}
             >
-              {this.renderControls()}
+              {renderControls()}
             </Fade>
           )}
         </div>
       </div>
     );
-  }
+  };
 
-  renderBody() {
-    const { table } = this.props;
+  const renderBody = () => {
     let cols;
     if (table.columns) {
       cols = table.columns.slice();
-      if (this.state.sortColumns) {
+      if (sortColumns) {
         cols.sort((a, b) => {
           const colA = a.name.toUpperCase();
           const colB = b.name.toUpperCase();
@@ -253,11 +243,11 @@ class TableElement extends React.PureComponent {
 
     const metadata = (
       <div
-        onMouseEnter={() => this.setHover(true)}
-        onMouseLeave={() => this.setHover(false)}
+        onMouseEnter={() => setHover(true)}
+        onMouseLeave={() => setHover(false)}
         css={{ paddingTop: 6 }}
       >
-        {this.renderWell()}
+        {renderWell()}
         <div>
           {cols &&
             cols.map(col => <ColumnElement column={col} key={col.name} />)}
@@ -265,21 +255,19 @@ class TableElement extends React.PureComponent {
       </div>
     );
     return metadata;
-  }
+  };
 
-  render() {
-    return (
-      <Collapse.Panel
-        {...this.props}
-        header={this.renderHeader()}
-        className="TableElement"
-        forceRender="true"
-      >
-        {this.renderBody()}
-      </Collapse.Panel>
-    );
-  }
-}
+  return (
+    <Collapse.Panel
+      {...props}
+      header={renderHeader()}
+      className="TableElement"
+      forceRender="true"
+    >
+      {renderBody()}
+    </Collapse.Panel>
+  );
+};
 
 TableElement.propTypes = propTypes;
 TableElement.defaultProps = defaultProps;

--- a/superset-frontend/src/SqlLab/components/TableElement.jsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.jsx
@@ -21,18 +21,17 @@ import PropTypes from 'prop-types';
 import Collapse from 'src/components/Collapse';
 import Card from 'src/components/Card';
 import ButtonGroup from 'src/components/ButtonGroup';
-import shortid from 'shortid';
 import { t, styled } from '@superset-ui/core';
 import { debounce } from 'lodash';
 
 import { Tooltip } from 'src/components/Tooltip';
+import Icons from 'src/components/Icons';
 import CopyToClipboard from '../../components/CopyToClipboard';
 import { IconTooltip } from '../../components/IconTooltip';
 import ColumnElement from './ColumnElement';
 import ShowSQL from './ShowSQL';
 import ModalTrigger from '../../components/ModalTrigger';
 import Loading from '../../components/Loading';
-import Icons from 'src/components/Icons';
 
 const propTypes = {
   table: PropTypes.object,
@@ -65,17 +64,6 @@ const TableElement = props => {
 
   const setHover = hovered => {
     debounce(() => setHovered(hovered), 100)();
-  };
-
-  const popSelectStar = () => {
-    const qe = {
-      id: shortid.generate(),
-      title: table.name,
-      dbId: table.dbId,
-      autorun: true,
-      sql: table.selectStar,
-    };
-    actions.addQueryEditor(qe);
   };
 
   const removeTable = () => {
@@ -189,41 +177,39 @@ const TableElement = props => {
     );
   };
 
-  const renderHeader = () => {
-    return (
-      <div
-        className="clearfix header-container"
-        onMouseEnter={() => setHover(true)}
-        onMouseLeave={() => setHover(false)}
+  const renderHeader = () => (
+    <div
+      className="clearfix header-container"
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+    >
+      <Tooltip
+        id="copy-to-clipboard-tooltip"
+        placement="topLeft"
+        style={{ cursor: 'pointer' }}
+        title={table.name}
+        trigger={['hover']}
       >
-        <Tooltip
-          id="copy-to-clipboard-tooltip"
-          placement="topLeft"
-          style={{ cursor: 'pointer' }}
-          title={table.name}
-          trigger={['hover']}
-        >
-          <StyledSpan data-test="collapse" className="table-name">
-            <strong>{table.name}</strong>
-          </StyledSpan>
-        </Tooltip>
+        <StyledSpan data-test="collapse" className="table-name">
+          <strong>{table.name}</strong>
+        </StyledSpan>
+      </Tooltip>
 
-        <div className="pull-right header-right-side">
-          {table.isMetadataLoading || table.isExtraMetadataLoading ? (
-            <Loading position="inline" />
-          ) : (
-            <Fade
-              data-test="fade"
-              hovered={hovered}
-              onClick={e => e.stopPropagation()}
-            >
-              {renderControls()}
-            </Fade>
-          )}
-        </div>
+      <div className="pull-right header-right-side">
+        {table.isMetadataLoading || table.isExtraMetadataLoading ? (
+          <Loading position="inline" />
+        ) : (
+          <Fade
+            data-test="fade"
+            hovered={hovered}
+            onClick={e => e.stopPropagation()}
+          >
+            {renderControls()}
+          </Fade>
+        )}
       </div>
-    );
-  };
+    </div>
+  );
 
   const renderBody = () => {
     let cols;
@@ -261,35 +247,33 @@ const TableElement = props => {
     return metadata;
   };
 
-  const collapseExpandIcon = () => {
-    return (
-      <IconTooltip
-        style={{
-          position: 'fixed',
-          right: '16px',
-          left: 'auto',
-          fontSize: '12px',
-          transform: 'rotate(90deg)',
-          display: 'flex',
-          alignItems: 'center',
-        }}
-        aria-label="Collapse"
-        tooltip={t(`${!isActive ? 'Expand' : 'Collapse'} table preview`)}
-      >
-        <Icons.RightOutlined
-          iconSize={'s'}
-          style={isActive ? { transform: 'rotateY(180deg)' } : null}
-        />
-      </IconTooltip>
-    );
-  };
+  const collapseExpandIcon = () => (
+    <IconTooltip
+      style={{
+        position: 'fixed',
+        right: '16px',
+        left: 'auto',
+        fontSize: '12px',
+        transform: 'rotate(90deg)',
+        display: 'flex',
+        alignItems: 'center',
+      }}
+      aria-label="Collapse"
+      tooltip={t(`${!isActive ? 'Expand' : 'Collapse'} table preview`)}
+    >
+      <Icons.RightOutlined
+        iconSize="s"
+        style={isActive ? { transform: 'rotateY(180deg)' } : null}
+      />
+    </IconTooltip>
+  );
 
   return (
     <Collapse.Panel
       {...props}
       header={renderHeader()}
       className="TableElement"
-      forceRender={true}
+      forceRender
       expandIcon={collapseExpandIcon}
     >
       {renderBody()}

--- a/superset-frontend/src/SqlLab/components/TableElement.jsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.jsx
@@ -32,7 +32,7 @@ import ColumnElement from './ColumnElement';
 import ShowSQL from './ShowSQL';
 import ModalTrigger from '../../components/ModalTrigger';
 import Loading from '../../components/Loading';
-import { RightOutlined } from '@ant-design/icons';
+import Icons from 'src/components/Icons';
 
 const propTypes = {
   table: PropTypes.object,
@@ -268,8 +268,6 @@ const TableElement = props => {
           position: 'fixed',
           right: '16px',
           left: 'auto',
-          height: '1em',
-          width: '1em',
           fontSize: '12px',
           transform: 'rotate(90deg)',
           display: 'flex',
@@ -278,9 +276,9 @@ const TableElement = props => {
         aria-label="Collapse"
         tooltip={t(`${!isActive ? 'Expand' : 'Collapse'} table preview`)}
       >
-        <RightOutlined
-          className="anticon"
-          style={isActive ? { transform: 'rotate(180deg)' } : null}
+        <Icons.RightOutlined
+          iconSize={'s'}
+          style={isActive ? { transform: 'rotateY(180deg)' } : null}
         />
       </IconTooltip>
     );

--- a/superset-frontend/src/SqlLab/components/TableElement.jsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.jsx
@@ -112,7 +112,7 @@ const TableElement = props => {
 
   const renderControls = () => {
     let keyLink;
-    if (table?.indexes.length > 0) {
+    if (table?.indexes?.length) {
       keyLink = (
         <ModalTrigger
           modalTitle={
@@ -137,7 +137,7 @@ const TableElement = props => {
         {keyLink}
         <IconTooltip
           className={
-            `fa fa-sort-${!sortColumns ? 'alpha' : 'numeric'}-asc ` +
+            `fa fa-sort-${sortColumns ? 'numeric' : 'alpha'}-asc ` +
             'pull-left sort-cols m-l-2 pointer'
           }
           onClick={toggleSortColumns}
@@ -259,7 +259,7 @@ const TableElement = props => {
         alignItems: 'center',
       }}
       aria-label="Collapse"
-      tooltip={t(`${!isActive ? 'Expand' : 'Collapse'} table preview`)}
+      tooltip={t(`${isActive ? 'Collapse' : 'Expand'} table preview`)}
     >
       <Icons.RightOutlined
         iconSize="s"


### PR DESCRIPTION
### SUMMARY
Update the TableElement class component to be a functional component using hooks.

Modified the tests slightly where needed to check the changes to DOM from updating the state instead of checking the component state itself. Was necessary because functional components using hooks don't have an accessible state like class components.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
The component should look and function the same

### TESTING INSTRUCTIONS
To run the tests for TableElement navigate to superset-frontend and run `npm run test -- spec/javascripts/sqllab/TableElement_spec.jsx`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
