### PR TITLE
fix(native-filters): remove indicators outside scope

### DIFF
--- a/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
@@ -192,20 +192,15 @@ export const selectNativeIndicatorsForChart = (
 
   const getStatus = ({
     value,
-    isAffectedByScope,
     column,
     type = DataMaskType.NativeFilters,
   }: {
     value: any;
-    isAffectedByScope: boolean;
     column?: string;
     type?: DataMaskType;
   }): IndicatorStatus => {
     // a filter is only considered unset if it's value is null
     const hasValue = value !== null;
-    if (!isAffectedByScope) {
-      return IndicatorStatus.Unset;
-    }
     if (type === DataMaskType.CrossFilters && hasValue) {
       return IndicatorStatus.CrossFilterApplied;
     }
@@ -223,14 +218,13 @@ export const selectNativeIndicatorsForChart = (
 
   let nativeFilterIndicators: any = [];
   if (isFeatureEnabled(FeatureFlag.DASHBOARD_NATIVE_FILTERS)) {
-    nativeFilterIndicators = Object.values(nativeFilters.filters).map(
-      nativeFilter => {
-        const isAffectedByScope = getTreeCheckedItems(
-          nativeFilter.scope,
-          dashboardLayout,
-        ).some(
+    nativeFilterIndicators = Object.values(nativeFilters.filters)
+      .filter(nativeFilter =>
+        getTreeCheckedItems(nativeFilter.scope, dashboardLayout).some(
           layoutItem => dashboardLayout[layoutItem]?.meta?.chartId === chartId,
-        );
+        ),
+      )
+      .map(nativeFilter => {
         const column = nativeFilter.targets[0]?.column?.name;
         let value = dataMask[nativeFilter.id]?.filterState?.value ?? null;
         if (!Array.isArray(value) && value !== null) {
@@ -240,7 +234,7 @@ export const selectNativeIndicatorsForChart = (
           column,
           name: nativeFilter.name,
           path: [nativeFilter.id],
-          status: getStatus({ value, isAffectedByScope, column }),
+          status: getStatus({ value, column }),
           value,
         };
       },
@@ -250,15 +244,15 @@ export const selectNativeIndicatorsForChart = (
   let crossFilterIndicators: any = [];
   if (isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS)) {
     crossFilterIndicators = Object.values(chartConfiguration)
-      .map(chartConfig => {
-        const scope = chartConfig?.crossFilters?.scope;
-        const isAffectedByScope = getTreeCheckedItems(
-          scope,
+      .filter(chartConfig =>
+        getTreeCheckedItems(
+          chartConfig?.crossFilters?.scope,
           dashboardLayout,
         ).some(
           layoutItem => dashboardLayout[layoutItem]?.meta?.chartId === chartId,
-        );
-
+        ),
+      )
+      .map(chartConfig => {
         let value = dataMask[chartConfig.id]?.filterState?.value ?? null;
         if (!Array.isArray(value) && value !== null) {
           value = [value];
@@ -270,7 +264,6 @@ export const selectNativeIndicatorsForChart = (
           path: [`${chartConfig.id}`],
           status: getStatus({
             value,
-            isAffectedByScope,
             type: DataMaskType.CrossFilters,
           }),
           value,

--- a/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
@@ -237,8 +237,7 @@ export const selectNativeIndicatorsForChart = (
           status: getStatus({ value, column }),
           value,
         };
-      },
-    );
+      });
   }
 
   let crossFilterIndicators: any = [];


### PR DESCRIPTION
### SUMMARY
Remove native filter indicators for charts that don't have any filters in scope.

### BEFORE
The indicator would display filters that are outside scope (The "% Rural" chart is outside the scope of both filters). Also note that the filter value shows up on the chart that it's not being applied to:
https://user-images.githubusercontent.com/33317356/119633633-9e591f00-be1a-11eb-850c-0a2601e02307.mp4

### AFTER
Now the indicator only shows up for charts that have at least one filter in scope:
https://user-images.githubusercontent.com/33317356/119633660-a4e79680-be1a-11eb-9d65-7b476fc97d74.mp4

### TESTING INSTRUCTIONS
Create a dashboard with native filters and exclude a chart from the scope of all filters. Notice how the filter indicator shows up for the chart with all filters showing as "Unset".

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #14807
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
