### PR TITLE
fix(explore): Icons in "Customize Columns" in "Customize" tab break to a new line

### DIFF
--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -92,6 +92,13 @@ const Styles = styled.div`
   .Select__menu {
     max-width: 100%;
   }
+  .type-label {
+    margin-right: ${({ theme }) => theme.gridUnit * 3}px;
+    width: ${({ theme }) => theme.gridUnit * 7}px;
+    display: inline-block;
+    text-align: center;
+    font-weight: ${({ theme }) => theme.typography.weights.bold};
+  }
 `;
 
 const ControlPanelsTabs = styled(Tabs)`

--- a/superset-frontend/src/explore/components/controls/SelectControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.jsx
@@ -298,10 +298,6 @@ export default class SelectControl extends React.PureComponent {
         css={theme => css`
           .type-label {
             margin-right: ${theme.gridUnit * 2}px;
-            width: ${theme.gridUnit * 7}px;
-            display: inline-block;
-            text-align: center;
-            font-weight: ${theme.typography.weights.bold};
           }
         `}
       >


### PR DESCRIPTION
### SUMMARY
Applies the style to the "Customize Columns" component and cleans up some repeated styles.

### BEFORE
![Screen Shot 2021-05-26 at 13 16 32](https://user-images.githubusercontent.com/60598000/119644420-83d87300-be25-11eb-8de1-402e39f045fa.png)

### AFTER
![Screen Shot 2021-05-26 at 13 16 32](https://user-images.githubusercontent.com/60598000/119644261-5a1f4c00-be25-11eb-93c6-f9e73c7675e6.png)


### TESTING INSTRUCTIONS
1. Open a "Games" chart in Explore
2. Visit the "Customize" tab
3. Make sure the "Customize Columns" are not breaking into new lines

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #14831 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
