### PR TITLE
fix: Full width tabs flaky behavior

### DIFF
--- a/superset-frontend/src/components/Tabs/Tabs.tsx
+++ b/superset-frontend/src/components/Tabs/Tabs.tsx
@@ -66,11 +66,6 @@ const StyledTabs = ({
         .ant-tabs-nav-list {
           width: 100%;
         }
-
-        .ant-tabs-tab {
-          width: 0;
-          margin-right: 0;
-        }
       `};
 
       .ant-tabs-tab-btn {


### PR DESCRIPTION
### SUMMARY
Reverts a style change introduced by PR #14478 that was causing a conflict with the Antd on-the-fly width calculation of the tabs. 

@pkdotson I could not see any obvious issue with removing your code. Please clarify if reverting might cause specific problems anywhere.

### BEFORE

https://user-images.githubusercontent.com/60598000/119661507-0a4a8000-be39-11eb-9991-3fe0210f9117.mp4


### AFTER

https://user-images.githubusercontent.com/60598000/119660646-2b5ea100-be38-11eb-8953-7145d3032759.mp4

### TESTING INSTRUCTIONS
1. Open a Dashboard and edit
2. Zoom out 10%
3. Make sure the tabs on the left are not showing a flaky behavior

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #14763
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
