### PR TITLE
fix: filterbox apply single value

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/filter.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/filter.test.ts
@@ -70,8 +70,8 @@ describe('Dashboard filter', () => {
           }
           expect(requestFilter).deep.eq({
             col: 'region',
-            op: '==',
-            val: 'South Asia',
+            op: 'IN',
+            val: ['South Asia'],
           });
         });
       });

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
@@ -121,8 +121,8 @@ describe('Dashboard tabs', () => {
         const requestParams = JSON.parse(requestBody.form_data as string);
         expect(requestParams.extra_filters[0]).deep.eq({
           col: 'region',
-          op: '==',
-          val: 'South Asia',
+          op: 'IN',
+          val: ['South Asia'],
         });
       });
     });
@@ -136,8 +136,8 @@ describe('Dashboard tabs', () => {
       const requestParams = JSON.parse(requestBody.form_data as string);
       expect(requestParams.extra_filters[0]).deep.eq({
         col: 'region',
-        op: '==',
-        val: 'South Asia',
+        op: 'IN',
+        val: '[South Asia]',
       });
       expect(requestParams.viz_type).eq(LINE_CHART.viz);
     });
@@ -150,8 +150,8 @@ describe('Dashboard tabs', () => {
     cy.wait('@v1ChartData').then(({ request }) => {
       expect(request.body.queries[0].filters[0]).deep.eq({
         col: 'region',
-        op: '==',
-        val: 'South Asia',
+        op: 'IN',
+        val: ['South Asia'],
       });
     });
 

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
@@ -137,7 +137,7 @@ describe('Dashboard tabs', () => {
       expect(requestParams.extra_filters[0]).deep.eq({
         col: 'region',
         op: 'IN',
-        val: '[South Asia]',
+        val: ['South Asia'],
       });
       expect(requestParams.viz_type).eq(LINE_CHART.viz);
     });

--- a/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
@@ -159,9 +159,10 @@ class FilterBox extends React.PureComponent {
       if (Array.isArray(options)) {
         vals = options.map(opt => (typeof opt === 'string' ? opt : opt.value));
       } else if (options.value) {
-        vals = options.value;
+        // must use array member for legacy extra_filters's value
+        vals = [options.value];
       } else {
-        vals = options;
+        vals = [options];
       }
     }
 

--- a/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
@@ -22,7 +22,7 @@ import { debounce } from 'lodash';
 import { max as d3Max } from 'd3-array';
 import { AsyncCreatableSelect, CreatableSelect } from 'src/components/Select';
 import Button from 'src/components/Button';
-import { t, SupersetClient } from '@superset-ui/core';
+import { t, SupersetClient, ensureIsArray } from '@superset-ui/core';
 
 import {
   BOOL_FALSE_DISPLAY,
@@ -158,11 +158,9 @@ class FilterBox extends React.PureComponent {
     if (options !== null) {
       if (Array.isArray(options)) {
         vals = options.map(opt => (typeof opt === 'string' ? opt : opt.value));
-      } else if (options.value) {
-        // must use array member for legacy extra_filters's value
-        vals = [options.value];
       } else {
-        vals = [options];
+        // must use array member for legacy extra_filters's value
+        vals = ensureIsArray(options.value ?? options);
       }
     }
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
filter box can not apply a "single value" filter to the other chats on the dashboard.
related issue: https://github.com/apache/superset/issues/14804

How to reproduce
1. create a filterbox chart and do not choose `Allow multiple selections`
![image](https://user-images.githubusercontent.com/2016594/119666754-3b8e7480-be68-11eb-8cd3-b587a261648e.png)
2. create a bignumber chart 
3. save big number chart and filterbox in same dashboard

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->


https://user-images.githubusercontent.com/2016594/119666349-dfc3eb80-be67-11eb-908b-84257d9cb2bf.mp4



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: Fixes: https://github.com/apache/superset/issues/14804
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
