### PR TITLE
feat(native-filters): sort selected values on blur

### DIFF
--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -19,6 +19,7 @@
 import {
   AppSection,
   DataMask,
+  DataRecord,
   ensureIsArray,
   ExtraFormData,
   GenericDataType,
@@ -27,10 +28,17 @@ import {
   t,
   tn,
 } from '@superset-ui/core';
-import React, { useCallback, useEffect, useReducer, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useState,
+} from 'react';
 import { Select } from 'src/common/components';
 import debounce from 'lodash/debounce';
 import { SLOW_DEBOUNCE } from 'src/constants';
+import { CheckOutlined, CloseOutlined } from '@ant-design/icons';
 import { PluginFilterSelectProps, SelectValue } from './types';
 import { StyledSelect, Styles } from '../common';
 import { getDataRecordFormatter, getSelectExtraFormData } from '../../utils';
@@ -101,6 +109,23 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
   } = formData;
   const groupby = ensureIsArray<string>(formData.groupby);
   const [col] = groupby;
+  const [selectedValues, setSelectedValues] = useState<SelectValue>(
+    filterState.value,
+  );
+  const sortedData = useMemo(() => {
+    const firstData: DataRecord[] = [];
+    const restData: DataRecord[] = [];
+    data.forEach(row => {
+      // @ts-ignore
+      if (selectedValues?.includes(row[col])) {
+        firstData.push(row);
+      } else {
+        restData.push(row);
+      }
+    });
+    return [...firstData, ...restData];
+  }, [col, selectedValues, data]);
+  const [isDropdownVisible, setIsDropdownVisible] = useState(false);
   const [currentSuggestionSearch, setCurrentSuggestionSearch] = useState('');
   const [dataMask, dispatchDataMask] = useReducer<DataMaskReducer>(reducer, {
     filterState,
@@ -125,6 +150,12 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
       },
     });
   };
+
+  useEffect(() => {
+    if (!isDropdownVisible) {
+      setSelectedValues(filterState.value);
+    }
+  }, [JSON.stringify(filterState.value)]);
 
   const isDisabled =
     appSection === AppSection.FILTER_CONFIG_MODAL && defaultToFirstItem;
@@ -163,6 +194,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
   const handleBlur = () => {
     clearSuggestionSearch();
     unsetFocusedFilter();
+    setSelectedValues(filterState.value);
   };
 
   const datatype: GenericDataType = coltypeMap[col];
@@ -222,14 +254,18 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
         onSearch={searchWrapper}
         onSelect={clearSuggestionSearch}
         onBlur={handleBlur}
+        onDropdownVisibleChange={setIsDropdownVisible}
         onFocus={setFocusedFilter}
         // @ts-ignore
         onChange={handleChange}
         ref={inputRef}
         loading={isRefreshing}
         maxTagCount={5}
+        menuItemSelectedIcon={
+          inverseSelection ? <CloseOutlined /> : <CheckOutlined />
+        }
       >
-        {data.map(row => {
+        {sortedData.map(row => {
           const [value] = groupby.map(col => row[col]);
           return (
             // @ts-ignore

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -38,7 +38,6 @@ import React, {
 import { Select } from 'src/common/components';
 import debounce from 'lodash/debounce';
 import { SLOW_DEBOUNCE } from 'src/constants';
-import { CheckOutlined, CloseOutlined } from '@ant-design/icons';
 import { PluginFilterSelectProps, SelectValue } from './types';
 import { StyledSelect, Styles } from '../common';
 import { getDataRecordFormatter, getSelectExtraFormData } from '../../utils';
@@ -261,9 +260,6 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
         ref={inputRef}
         loading={isRefreshing}
         maxTagCount={5}
-        menuItemSelectedIcon={
-          inverseSelection ? <CloseOutlined /> : <CheckOutlined />
-        }
       >
         {sortedData.map(row => {
           const [value] = groupby.map(col => row[col]);


### PR DESCRIPTION
### SUMMARY
This is a follow up to #14486 and implements @mistercrunch 's suggestion to reorder selected values (https://github.com/apache/superset/pull/14486#issuecomment-834706507). Previously, selected values were left in their original place in the native select filter. **This change emulates that of the GitHub tag component, which places the selected values on top after the new values are persisted.**

The plan is to add this functionality to the main Select component used throughout Superset in the future (probably as a prop that defaults to being disabled). However, to avoid causing potential functional or visual regressions in the application, this functionality will be kept only within the native filter component for now until it has been found to be fully stable.

### BEFORE
Previously, the selected values stayed in their original positions after the dropdown was collapsed:
https://user-images.githubusercontent.com/33317356/119669257-97450780-be40-11eb-909c-34f81518354e.mp4

### AFTER
Now the values are reordered when the dropdown is not visible:
https://user-images.githubusercontent.com/33317356/119669275-9b712500-be40-11eb-86e8-0ff621da784d.mp4

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
