### PR TITLE
feat(trino): add support for user impersonation

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx
@@ -292,12 +292,12 @@ const ExtraOptions = ({
               checked={!!db?.impersonate_user}
               onChange={onInputChange}
               labelText={t(
-                'Impersonate Logged In User (Presto, Hive, and GSheets)',
+                'Impersonate Logged In User (Presto, Trino, Hive, and GSheets)',
               )}
             />
             <InfoTooltip
               tooltip={t(
-                'If Presto, all the queries in SQL Lab are going to be executed as the ' +
+                'If Presto or Trino, all the queries in SQL Lab are going to be executed as the ' +
                   'currently logged on user who must have permission to run them. If Hive ' +
                   'and hive.server2.enable.doAs is enabled, will run the queries as ' +
                   'service account, but impersonate the currently logged on user via ' +

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -86,7 +86,7 @@ class TrinoEngineSpec(BaseEngineSpec):
         url = make_url(uri)
         backend_name = url.get_backend_name()
 
-        # Must be Presto connection, enable impersonation, and set optional param
+        # Must be Trino connection, enable impersonation, and set optional param
         # auth=LDAP|KERBEROS
         # Set principal_username=$effective_username
         if backend_name == "trino" and username is not None:

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -15,10 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 from datetime import datetime
-from typing import Optional
+from typing import Any, Dict, Optional
 from urllib import parse
 
-from sqlalchemy.engine.url import URL
+from sqlalchemy.engine.url import make_url, URL
 
 from superset.db_engine_specs.base import BaseEngineSpec
 from superset.utils import core as utils
@@ -69,3 +69,37 @@ class TrinoEngineSpec(BaseEngineSpec):
             selected_schema = parse.quote(selected_schema, safe="")
             database = database.split("/")[0] + "/" + selected_schema
             uri.database = database
+
+    @classmethod
+    def update_impersonation_config(
+        cls, connect_args: Dict[str, Any], uri: str, username: Optional[str],
+    ) -> None:
+        """
+        Update a configuration dictionary
+        that can set the correct properties for impersonating users
+        :param connect_args: config to be updated
+        :param uri: URI string
+        :param impersonate_user: Flag indicating if impersonation is enabled
+        :param username: Effective username
+        :return: None
+        """
+        url = make_url(uri)
+        backend_name = url.get_backend_name()
+
+        # Must be Presto connection, enable impersonation, and set optional param
+        # auth=LDAP|KERBEROS
+        # Set principal_username=$effective_username
+        if backend_name == "trino" and username is not None:
+            connect_args["user"] = username
+
+    @classmethod
+    def modify_url_for_impersonation(
+        cls, url: URL, impersonate_user: bool, username: Optional[str]
+    ) -> None:
+        """
+        Modify the SQL Alchemy URL object with the user to impersonate if applicable.
+        :param url: SQLAlchemy URL object
+        :param impersonate_user: Flag indicating if impersonation is enabled
+        :param username: Effective username
+        """
+        # Do nothing and let update_impersonation_config take care of impersonation


### PR DESCRIPTION
### SUMMARY
When using authentication with trino, the current behavior is just to modify the URL to replace the username which will result in an unauthorized exception. This PR will fix this by updating the connection argument with the effective user.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
Step 1: Setup database connection to trino with credentials in URL.
Step 2: Enable impersonation from `Other` option
Step 3 : Log in with a different user and run the query via SQL lab and you will see the principal user as admin and user as the logged-in user in trino UI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
