### PR TITLE
feat: add pagination to change dataset modal

### DIFF
--- a/superset-frontend/src/components/TableView/TableView.tsx
+++ b/superset-frontend/src/components/TableView/TableView.tsx
@@ -115,7 +115,7 @@ const TableView = ({
     sortBy: initialSortBy,
   };
 
-  /*const {
+  /* const {
     getTableProps,
     getTableBodyProps,
     headerGroups,
@@ -134,7 +134,7 @@ const TableView = ({
     useFilters,
     useSortBy,
     usePagination,
-  );*/
+  ); */
   const states = useTable(
     {
       columns,
@@ -144,7 +144,7 @@ const TableView = ({
     useFilters,
     useSortBy,
     usePagination,
-  ); 
+  );
   const {
     getTableProps,
     getTableBodyProps,
@@ -155,7 +155,7 @@ const TableView = ({
     pageCount: tablePageCount,
     gotoPage,
     state: { pageIndex: tablePageIndex, pageSize },
-  } = states; 
+  } = states;
   console.log(states);
   const pageCount = customPageCount || tablePageCount;
   const pageIndex = customPageIndex || tablePageIndex;

--- a/superset-frontend/src/components/TableView/TableView.tsx
+++ b/superset-frontend/src/components/TableView/TableView.tsx
@@ -139,7 +139,6 @@ const TableView = ({
   const pageIndex = customPageIndex || tablePageIndex;
 
   const content = withPagination ? page : rows;
-  console.log({ rows, page, pageSize });
 
   let EmptyWrapperComponent;
   switch (emptyWrapperType) {

--- a/superset-frontend/src/components/TableView/TableView.tsx
+++ b/superset-frontend/src/components/TableView/TableView.tsx
@@ -139,7 +139,7 @@ const TableView = ({
   const pageIndex = customPageIndex || tablePageIndex;
 
   const content = withPagination ? page : rows;
-  console.log({ rows, page, pageSize});
+  console.log({ rows, page, pageSize });
 
   let EmptyWrapperComponent;
   switch (emptyWrapperType) {
@@ -154,7 +154,6 @@ const TableView = ({
   }
 
   const isEmpty = !loading && content.length === 0;
-  console.log("------", { pageIndex});
   return (
     <TableViewStyles {...props}>
       <TableCollection
@@ -184,11 +183,10 @@ const TableView = ({
             totalPages={pageCount || 0}
             currentPage={pageCount ? pageIndex + 1 : 0}
             onChange={(p: number) => {
-              if(customGotoPage)
-              {
+              if (customGotoPage) {
                 customGotoPage(p);
               } else {
-                gotoPage(p-1);
+                gotoPage(p - 1);
               }
             }}
             hideFirstAndLastPageLinks

--- a/superset-frontend/src/components/TableView/TableView.tsx
+++ b/superset-frontend/src/components/TableView/TableView.tsx
@@ -44,6 +44,10 @@ export interface TableViewProps {
   isPaginationSticky?: boolean;
   showRowCount?: boolean;
   scrollTable?: boolean;
+  customGotoPage?: (p: any) => void;
+  customPageCount?: number;
+  customPageIndex?: number;
+  resourceCount?: number;
 }
 
 const EmptyWrapper = styled.div`

--- a/superset-frontend/src/components/TableView/TableView.tsx
+++ b/superset-frontend/src/components/TableView/TableView.tsx
@@ -115,7 +115,7 @@ const TableView = ({
     sortBy: initialSortBy,
   };
 
-  const {
+  /*const {
     getTableProps,
     getTableBodyProps,
     headerGroups,
@@ -134,7 +134,29 @@ const TableView = ({
     useFilters,
     useSortBy,
     usePagination,
-  );
+  );*/
+  const states = useTable(
+    {
+      columns,
+      data,
+      initialState,
+    },
+    useFilters,
+    useSortBy,
+    usePagination,
+  ); 
+  const {
+    getTableProps,
+    getTableBodyProps,
+    headerGroups,
+    page,
+    rows,
+    prepareRow,
+    pageCount: tablePageCount,
+    gotoPage,
+    state: { pageIndex: tablePageIndex, pageSize },
+  } = states; 
+  console.log(states);
   const pageCount = customPageCount || tablePageCount;
   const pageIndex = customPageIndex || tablePageIndex;
 

--- a/superset-frontend/src/components/TableView/TableView.tsx
+++ b/superset-frontend/src/components/TableView/TableView.tsx
@@ -99,6 +99,10 @@ const TableView = ({
   emptyWrapperType = EmptyWrapperType.Default,
   noDataText,
   showRowCount = true,
+  customGotoPage,
+  customPageCount,
+  customPageIndex,
+  resourceCount,
   ...props
 }: TableViewProps) => {
   const initialState = {
@@ -114,9 +118,9 @@ const TableView = ({
     page,
     rows,
     prepareRow,
-    pageCount,
+    pageCount: tablePageCount,
     gotoPage,
-    state: { pageIndex, pageSize },
+    state: { pageIndex: tablePageIndex, pageSize },
   } = useTable(
     {
       columns,
@@ -127,8 +131,11 @@ const TableView = ({
     useSortBy,
     usePagination,
   );
+  const pageCount = customPageCount || tablePageCount;
+  const pageIndex = customPageIndex || tablePageIndex;
 
   const content = withPagination ? page : rows;
+  console.log({ rows, page, pageSize});
 
   let EmptyWrapperComponent;
   switch (emptyWrapperType) {
@@ -143,7 +150,7 @@ const TableView = ({
   }
 
   const isEmpty = !loading && content.length === 0;
-
+  console.log("------", { pageIndex});
   return (
     <TableViewStyles {...props}>
       <TableCollection
@@ -172,7 +179,14 @@ const TableView = ({
           <Pagination
             totalPages={pageCount || 0}
             currentPage={pageCount ? pageIndex + 1 : 0}
-            onChange={(p: number) => gotoPage(p - 1)}
+            onChange={(p: number) => {
+              if(customGotoPage)
+              {
+                customGotoPage(p);
+              } else {
+                gotoPage(p-1);
+              }
+            }}
             hideFirstAndLastPageLinks
           />
           {showRowCount && (
@@ -182,7 +196,7 @@ const TableView = ({
                   '%s-%s of %s',
                   pageSize * pageIndex + (page.length && 1),
                   pageSize * pageIndex + page.length,
-                  data.length,
+                  resourceCount || data.length,
                 )}
             </div>
           )}

--- a/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
+++ b/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
@@ -114,7 +114,7 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
   const {
     state: { resourceCount, loading, resourceCollection },
     fetchData,
-    setResourceCollection
+    setResourceCollection,
   } = useListViewResource<Dataset>('dataset', t('dataset'), addDangerToast);
 
   const selectDatasource = useCallback((datasource: Datasource) => {
@@ -212,19 +212,19 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
   };
 
   const customGotoPage = (p: number) => {
-    console.log({p})
-    SupersetClient.get({endpoint: `/api/v1/dataset/?q=${rison.encode({
-      order_column: 'changed_on_delta_humanized',
-      order_direction: 'desc',
-      page: p-1,
-      page_size: 20, 
-    })}`,
-    })
-      .then((resources)=> {
-        setPageIndex(p-1);
-        setResourceCollection(resources.json.result)
-      })
-  }
+    console.log({ p });
+    SupersetClient.get({
+      endpoint: `/api/v1/dataset/?q=${rison.encode({
+        order_column: 'changed_on_delta_humanized',
+        order_direction: 'desc',
+        page: p - 1,
+        page_size: 20,
+      })}`,
+    }).then(resources => {
+      setPageIndex(p - 1);
+      setResourceCollection(resources.json.result);
+    });
+  };
 
   return (
     <StyledModal
@@ -284,7 +284,7 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
                 emptyWrapperType={EmptyWrapperType.Small}
                 initialPageIndex={0}
                 customGotoPage={customGotoPage}
-                customPageCount={Math.ceil(resourceCount/20)} 
+                customPageCount={Math.ceil(resourceCount / 20)}
                 customPageIndex={pageIndex}
                 resourceCount={resourceCount}
                 withPagination

--- a/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
+++ b/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
@@ -24,7 +24,7 @@ import React, {
   useCallback,
 } from 'react';
 import Alert from 'src/components/Alert';
-import { SupersetClient, t, styled, css } from '@superset-ui/core';
+import { SupersetClient, t, styled, css, makeApi } from '@superset-ui/core';
 import rison from 'rison';
 import TableView, { EmptyWrapperType } from 'src/components/TableView';
 import StyledModal from 'src/components/Modal';
@@ -212,26 +212,19 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
   };
 
   const customGotoPage = (p: number) => {
-    SupersetClient.get({
-      endpoint: `/api/v1/dataset/?q=${rison.encode({
-        order_column: 'changed_on_delta_humanized',
-        order_direction: 'desc',
-        page: p - 1,
-        page_size: 20,
-      })}`,
-    }).then(resources => {
+    const queryParams = rison.encode({
+      order_column: 'changed_on_delta_humanized',
+      order_direction: 'desc',
+      page: p - 1,
+      page_size: 20,
+    });
+
+    makeApi({ method: 'GET', endpoint: '/api/v1/dataset',
+            })(`q=${queryParams}`).then(resources => {
       setPageIndex(p - 1);
-      setResourceCollection(resources.json.result);
+      setResourceCollection(resources.result);
     });
   };
-
-  const styleOverride = css`
-    .table-condensed {
-      height: 300px;
-      margin-bottom: 16px;
-      overflow: auto;
-    }
-  `;
 
   return (
     <StyledModal
@@ -242,7 +235,13 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
       width={confirmChange ? '432px' : ''}
       height={confirmChange ? 'auto' : '480px'}
       hideFooter={!confirmChange}
-      css={styleOverride}
+      css={theme => css`
+        .table-condensed {
+          height: 300px;
+          margin-bottom: ${theme.gridUnit * 4};
+          overflow: auto;
+        }
+      `}
       footer={
         <>
           {confirmChange && (

--- a/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
+++ b/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
@@ -219,8 +219,9 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
       page_size: 20,
     });
 
-    makeApi({ method: 'GET', endpoint: '/api/v1/dataset',
-            })(`q=${queryParams}`).then(resources => {
+    makeApi({ method: 'GET', endpoint: '/api/v1/dataset' })(
+      `q=${queryParams}`,
+    ).then(resources => {
       setPageIndex(p - 1);
       setResourceCollection(resources.result);
     });

--- a/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
+++ b/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
@@ -24,7 +24,7 @@ import React, {
   useCallback,
 } from 'react';
 import Alert from 'src/components/Alert';
-import { SupersetClient, t, styled } from '@superset-ui/core';
+import { SupersetClient, t, styled, css } from '@superset-ui/core';
 import rison from 'rison';
 import TableView, { EmptyWrapperType } from 'src/components/TableView';
 import StyledModal from 'src/components/Modal';
@@ -212,7 +212,6 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
   };
 
   const customGotoPage = (p: number) => {
-    console.log({ p });
     SupersetClient.get({
       endpoint: `/api/v1/dataset/?q=${rison.encode({
         order_column: 'changed_on_delta_humanized',
@@ -226,6 +225,14 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
     });
   };
 
+  const styleOverride = css`
+    .table-condensed {
+      height: 300px;
+      margin-bottom: 16px;
+      overflow: auto;
+    }
+  `;
+
   return (
     <StyledModal
       show={show}
@@ -235,6 +242,7 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
       width={confirmChange ? '432px' : ''}
       height={confirmChange ? 'auto' : '480px'}
       hideFooter={!confirmChange}
+      css={styleOverride}
       footer={
         <>
           {confirmChange && (

--- a/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
+++ b/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
@@ -211,7 +211,7 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
     return data;
   };
 
-  const customGotoPage = (p) => {
+  const customGotoPage = (p: number) => {
     console.log({p})
     SupersetClient.get({endpoint: `/api/v1/dataset/?q=${rison.encode({
       order_column: 'changed_on_delta_humanized',
@@ -221,16 +221,11 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
     })}`,
     })
       .then((resources)=> {
-        console.log('resources', resources);
         setPageIndex(p-1);
         setResourceCollection(resources.json.result)
       })
-      //setResourceCollection([...resourceCollection, ...resourceCollection.reverse()])
-      //setTimeout(()=> gotoPage(pageIndex - 1));
-
   }
 
-  console.log('resourceCount', resourceCount);
   return (
     <StyledModal
       show={show}
@@ -289,11 +284,10 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
                 emptyWrapperType={EmptyWrapperType.Small}
                 initialPageIndex={0}
                 customGotoPage={customGotoPage}
-                customPageCount = {Math.ceil(resourceCount/20)} 
+                customPageCount={Math.ceil(resourceCount/20)} 
                 customPageIndex={pageIndex}
-                resourceCount= {resourceCount}
+                resourceCount={resourceCount}
                 withPagination
-                //scrollTable
               />
             )}
           </>

--- a/superset-frontend/src/explore/components/DataTablesPane/index.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/index.tsx
@@ -249,7 +249,7 @@ export const DataTablesPane = ({
       if (data[type]?.length === 0) {
         return <span>No data</span>;
       }
-      console.log('filteredData[type]', filteredData[type])
+      console.log('filteredData[type]', filteredData[type]);
       return (
         <TableView
           columns={columns[type]}

--- a/superset-frontend/src/explore/components/DataTablesPane/index.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/index.tsx
@@ -249,6 +249,7 @@ export const DataTablesPane = ({
       if (data[type]?.length === 0) {
         return <span>No data</span>;
       }
+      console.log('filteredData[type]', filteredData[type])
       return (
         <TableView
           columns={columns[type]}

--- a/superset-frontend/src/explore/components/DataTablesPane/index.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/index.tsx
@@ -249,7 +249,6 @@ export const DataTablesPane = ({
       if (data[type]?.length === 0) {
         return <span>No data</span>;
       }
-      console.log('filteredData[type]', filteredData[type]);
       return (
         <TableView
           columns={columns[type]}


### PR DESCRIPTION
### SUMMARY
this pr adds pagination to change dataset modal so that user can go though all their datasets.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/17326228/119700631-503b2000-be08-11eb-9bf0-11e6dffafb92.mov



### TESTING INSTRUCTIONS
will be updating tests. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
