### PR TITLE
chore: Align down icons on header

### DIFF
--- a/superset-frontend/src/components/Menu/Menu.tsx
+++ b/superset-frontend/src/components/Menu/Menu.tsx
@@ -90,6 +90,9 @@ const StyledHeader = styled.header`
     flex-direction: column;
     justify-content: center;
   }
+  .main-nav .ant-menu-submenu-title > svg {
+    top: ${({ theme }) => theme.gridUnit * 5.25}px;
+  }
   @media (max-width: 767px) {
     .navbar-brand {
       float: none;

--- a/superset-frontend/src/components/Menu/MenuRight.tsx
+++ b/superset-frontend/src/components/Menu/MenuRight.tsx
@@ -59,6 +59,9 @@ const StyledDiv = styled.div<{ align: string }>`
   justify-content: ${({ align }) => align};
   align-items: center;
   margin-right: ${({ theme }) => theme.gridUnit}px;
+  .ant-menu-submenu-title > svg {
+    top: ${({ theme }) => theme.gridUnit * 5.25}px;
+  }
 `;
 
 const StyledAnchor = styled.a`


### PR DESCRIPTION
### SUMMARY
On the top nav header, the down arrow icons were slightly too low - they should be aligned with the center of the + button across all of the icons. I adjusted the svg icons from `top: 23` to `top: 21`.

### BEFORE/AFTER SCREENSHOTS

#### BEFORE:
<img width="889" alt="down-icons-before" src="https://user-images.githubusercontent.com/55605634/119698728-25a49380-be17-11eb-8761-a5cec6d62ccd.png">

#### AFTER:
<img width="889" alt="down-icons-after" src="https://user-images.githubusercontent.com/55605634/119698739-289f8400-be17-11eb-940f-db2ff4772181.png">


### TESTING INSTRUCTIONS
- Navigate to any Superset page and observe the properly-aligned down arrow svg icons in the top navbar.

### ADDITIONAL INFORMATION
- [x] Has associated issue: [`Clubhouse Ticket`](https://app.clubhouse.io/preset/story/16040/align-down-icons-on-header)
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
