### PR TITLE
fix: DatabaseConnection Modal Margin Bottom

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
@@ -81,7 +81,6 @@ export const antDModalNoPaddingStyles = css`
   .ant-modal-body {
     padding-left: 0;
     padding-right: 0;
-    margin-bottom: 110px;
   }
 `;
 


### PR DESCRIPTION
### SUMMARY
The margin bottom for the modal form was too large. This PR fixers it. 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: 
![Screen Shot 2021-05-26 at 1 49 25 PM](https://user-images.githubusercontent.com/48933336/119707514-3c53e600-be29-11eb-9be7-e7f8dee707ab.png)
After:
![Screen Shot 2021-05-26 at 1 48 22 PM](https://user-images.githubusercontent.com/48933336/119707528-41b13080-be29-11eb-8890-9cc5341703d3.png)


### TESTING INSTRUCTIONS
Go into Database, create a new database. 
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
