### PR TITLE
fix: Big Query Edit Form

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1372,7 +1372,9 @@ class BasicParametersMixin:
         )
 
     @classmethod
-    def get_parameters_from_uri(cls, uri: str) -> BasicParametersType:
+    def get_parameters_from_uri(
+        cls, uri: str, encrypted_extra: Optional[Dict[str, Any]] = None
+    ) -> BasicParametersType:
         url = make_url(uri)
         encryption = all(
             item in url.query.items() for item in cls.encryption_parameters.items()

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -49,7 +49,7 @@ ma_plugin = MarshmallowPlugin()
 
 class BigQueryParametersSchema(Schema):
     credentials_info = EncryptedField(
-        description="Contents of BigQuery JSON credentials.",
+        required=True, description="Contents of BigQuery JSON credentials.",
     )
 
 

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -246,7 +246,7 @@ class Database(
             self.db_engine_spec, "get_parameters_from_uri"
         ):
             uri = make_url(self.sqlalchemy_uri_decrypted)
-            return {**parameters, **self.db_engine_spec.get_parameters_from_uri(uri)}  # type: ignore
+            return {**parameters, **self.db_engine_spec.get_parameters_from_uri(uri, self.get_encrypted_extra())}  # type: ignore
 
         return parameters
 

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -246,7 +246,8 @@ class Database(
             self.db_engine_spec, "get_parameters_from_uri"
         ):
             uri = make_url(self.sqlalchemy_uri_decrypted)
-            return {**parameters, **self.db_engine_spec.get_parameters_from_uri(uri, self.get_encrypted_extra())}  # type: ignore
+            encrypted_extra = self.get_encrypted_extra()
+            return {**parameters, **self.db_engine_spec.get_parameters_from_uri(uri, encrypted_extra=encrypted_extra)}  # type: ignore
 
         return parameters
 

--- a/tests/databases/api_tests.py
+++ b/tests/databases/api_tests.py
@@ -1446,7 +1446,8 @@ class TestDatabaseApi(SupersetTestCase):
                                 "description": "Contents of BigQuery JSON credentials.",
                                 "type": "string",
                                 "x-encrypted-extra": True,
-                            }
+                            },
+                            "required": ["credentials_info"],
                         },
                         "type": "object",
                     },

--- a/tests/databases/api_tests.py
+++ b/tests/databases/api_tests.py
@@ -1446,9 +1446,9 @@ class TestDatabaseApi(SupersetTestCase):
                                 "description": "Contents of BigQuery JSON credentials.",
                                 "type": "string",
                                 "x-encrypted-extra": True,
-                            },
-                            "required": ["credentials_info"],
+                            }
                         },
+                        "required": ["credentials_info"],
                         "type": "object",
                     },
                     "preferred": True,


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
With new DatabaseModal we aren't able to edit, users are getting a fatal error due to missing encrypted_extra when building the uri

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
