### PR TITLE
chore: Improves the native filters UI/UX - iteration 4

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -32,7 +32,14 @@ import {
   Metric,
 } from '@superset-ui/chart-controls';
 import { FormInstance } from 'antd/lib/form';
-import React, { useCallback, useEffect, useState, useMemo } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useState,
+  useMemo,
+  forwardRef,
+  useImperativeHandle,
+} from 'react';
 import { useSelector } from 'react-redux';
 import { Checkbox, Form, Input } from 'src/common/components';
 import { Select } from 'src/components/Select';
@@ -150,6 +157,12 @@ const StyledTabs = styled(Tabs)`
   }
 `;
 
+const StyledAsterisk = styled.span`
+  color: ${({ theme }) => theme.colors.error.base};
+  font-family: SimSun, sans-serif;
+  margin-right: ${({ theme }) => theme.gridUnit - 1}px;
+`;
+
 const FilterTabs = {
   configuration: {
     key: 'configuration',
@@ -196,15 +209,19 @@ const BASIC_CONTROL_ITEMS = ['enableEmptyFilter', 'multiSelect'];
  * The configuration form for a specific filter.
  * Assigns field values to `filters[filterId]` in the form.
  */
-export const FiltersConfigForm: React.FC<FiltersConfigFormProps> = ({
-  filterId,
-  filterToEdit,
-  removed,
-  restoreFilter,
-  form,
-  parentFilters,
-}) => {
+const FiltersConfigForm = (
+  {
+    filterId,
+    filterToEdit,
+    removed,
+    restoreFilter,
+    form,
+    parentFilters,
+  }: FiltersConfigFormProps,
+  ref: React.RefObject<any>,
+) => {
   const [metrics, setMetrics] = useState<Metric[]>([]);
+  const [activeTabKey, setActiveTabKey] = useState<string | undefined>();
   const [hasDefaultValue, setHasDefaultValue] = useState(
     !!filterToEdit?.defaultDataMask?.filterState?.value,
   );
@@ -253,6 +270,12 @@ export const FiltersConfigForm: React.FC<FiltersConfigFormProps> = ({
         });
     }
   }, [datasetId, hasColumn]);
+
+  useImperativeHandle(ref, () => ({
+    changeTab(tab: 'configuration' | 'scoping') {
+      setActiveTabKey(tab);
+    },
+  }));
 
   const hasMetrics = hasColumn && !!metrics.length;
 
@@ -371,7 +394,7 @@ export const FiltersConfigForm: React.FC<FiltersConfigFormProps> = ({
 
   const controlItems = formFilter
     ? getControlItemsMap({
-        disabled: !showDefaultValue,
+        disabled: false,
         forceUpdate,
         form,
         filterId,
@@ -393,7 +416,12 @@ export const FiltersConfigForm: React.FC<FiltersConfigFormProps> = ({
 
   return (
     <>
-      <StyledTabs defaultActiveKey={FilterTabs.configuration.key} centered>
+      <StyledTabs
+        defaultActiveKey={FilterTabs.configuration.key}
+        activeKey={activeTabKey}
+        onChange={activeKey => setActiveTabKey(activeKey)}
+        centered
+      >
         <TabPane
           tab={FilterTabs.configuration.name}
           key={FilterTabs.configuration.key}
@@ -519,6 +547,23 @@ export const FiltersConfigForm: React.FC<FiltersConfigFormProps> = ({
                   initialValue={filterToEdit?.defaultDataMask}
                   data-test="default-input"
                   label={<StyledLabel>{t('Default Value')}</StyledLabel>}
+                  required
+                  rules={[
+                    {
+                      required: true,
+                    },
+                    {
+                      validator: (rule, value) => {
+                        const hasValue = !!value.filterState?.value;
+                        if (hasValue) {
+                          return Promise.resolve();
+                        }
+                        return Promise.reject(
+                          new Error(t('Default value is required')),
+                        );
+                      },
+                    },
+                  ]}
                 >
                   {showDefaultValue ? (
                     <DefaultValue
@@ -526,6 +571,9 @@ export const FiltersConfigForm: React.FC<FiltersConfigFormProps> = ({
                         setNativeFilterFieldValues(form, filterId, {
                           defaultDataMask: dataMask,
                         });
+                        form.validateFields([
+                          ['filters', filterId, 'defaultDataMask'],
+                        ]);
                         forceUpdate();
                       }}
                       filterId={filterId}
@@ -562,12 +610,31 @@ export const FiltersConfigForm: React.FC<FiltersConfigFormProps> = ({
                   <CollapsibleControl
                     title={t('Filter is hierarchical')}
                     checked={!!parentFilter}
+                    onChange={checked => {
+                      if (checked) {
+                        // execute after render
+                        setTimeout(
+                          () =>
+                            form.validateFields([
+                              ['filters', filterId, 'parentFilter'],
+                            ]),
+                          0,
+                        );
+                      }
+                    }}
                   >
                     <StyledRowFormItem
                       name={['filters', filterId, 'parentFilter']}
                       label={<StyledLabel>{t('Parent filter')}</StyledLabel>}
                       initialValue={parentFilter}
                       data-test="parent-filter-input"
+                      required
+                      rules={[
+                        {
+                          required: true,
+                          message: t('Parent filter is required'),
+                        },
+                      ]}
                     >
                       <Select
                         placeholder={t('None')}
@@ -587,10 +654,29 @@ export const FiltersConfigForm: React.FC<FiltersConfigFormProps> = ({
                       !!filterToEdit?.adhoc_filters ||
                       !!filterToEdit?.time_range
                     }
+                    onChange={checked => {
+                      if (checked) {
+                        // execute after render
+                        setTimeout(
+                          () =>
+                            form.validateFields([
+                              ['filters', filterId, 'adhoc_filters'],
+                            ]),
+                          0,
+                        );
+                      }
+                    }}
                   >
                     <StyledRowFormItem
                       name={['filters', filterId, 'adhoc_filters']}
                       initialValue={filterToEdit?.adhoc_filters}
+                      required
+                      rules={[
+                        {
+                          required: true,
+                          message: t('Adhoc filters is required'),
+                        },
+                      ]}
                     >
                       <AdhocFilterControl
                         columns={
@@ -606,7 +692,12 @@ export const FiltersConfigForm: React.FC<FiltersConfigFormProps> = ({
                           });
                           forceUpdate();
                         }}
-                        label={<StyledLabel>{t('Adhoc filters')}</StyledLabel>}
+                        label={
+                          <span>
+                            <StyledAsterisk>*</StyledAsterisk>
+                            <StyledLabel>{t('Adhoc filters')}</StyledLabel>
+                          </span>
+                        }
                       />
                     </StyledRowFormItem>
                     <StyledRowFormItem
@@ -717,4 +808,6 @@ export const FiltersConfigForm: React.FC<FiltersConfigFormProps> = ({
   );
 };
 
-export default FiltersConfigForm;
+export default forwardRef<typeof FiltersConfigForm, FiltersConfigFormProps>(
+  FiltersConfigForm,
+);

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState, useRef } from 'react';
 import { uniq } from 'lodash';
 import { t, styled } from '@superset-ui/core';
 import { Form } from 'src/common/components';
@@ -27,6 +27,7 @@ import { useFilterConfigMap, useFilterConfiguration } from '../state';
 import { FilterRemoval, NativeFiltersForm } from './types';
 import { FilterConfiguration } from '../types';
 import {
+  validateForm,
   createHandleSave,
   createHandleTabEdit,
   generateFilterId,
@@ -88,6 +89,8 @@ export function FiltersConfigModal({
   onCancel,
 }: FiltersConfigModalProps) {
   const [form] = Form.useForm<NativeFiltersForm>();
+
+  const configFormRef = useRef<any>();
 
   // the filter config from redux state, this does not change until modal is closed.
   const filterConfig = useFilterConfiguration();
@@ -187,16 +190,29 @@ export function FiltersConfigModal({
         title: getFilterTitle(id),
       }));
 
-  const handleSave = createHandleSave(
-    form,
-    currentFilterId,
-    filterConfigMap,
-    filterIds,
-    removedFilters,
-    setCurrentFilterId,
-    resetForm,
-    onSave,
-  );
+  const handleSave = async () => {
+    const values: NativeFiltersForm | null = await validateForm(
+      form,
+      currentFilterId,
+      filterConfigMap,
+      filterIds,
+      removedFilters,
+      setCurrentFilterId,
+    );
+
+    if (values) {
+      createHandleSave(
+        filterConfigMap,
+        filterIds,
+        removedFilters,
+        resetForm,
+        onSave,
+        values,
+      )();
+    } else {
+      configFormRef.current.changeTab('configuration');
+    }
+  };
 
   const handleConfirmCancel = () => {
     resetForm();
@@ -264,6 +280,7 @@ export function FiltersConfigModal({
             >
               {(id: string) => (
                 <FiltersConfigForm
+                  ref={configFormRef}
                   form={form}
                   filterId={id}
                   filterToEdit={filterConfigMap[id]}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/utils.ts
@@ -114,25 +114,13 @@ export const validateForm = async (
 };
 
 export const createHandleSave = (
-  form: FormInstance<NativeFiltersForm>,
-  currentFilterId: string,
   filterConfigMap: Record<string, Filter>,
   filterIds: string[],
   removedFilters: Record<string, FilterRemoval>,
-  setCurrentFilterId: Function,
   resetForm: Function,
   saveForm: Function,
+  values: NativeFiltersForm,
 ) => async () => {
-  const values: NativeFiltersForm | null = await validateForm(
-    form,
-    currentFilterId,
-    filterConfigMap,
-    filterIds,
-    removedFilters,
-    setCurrentFilterId,
-  );
-  if (values === null) return;
-
   const newFilterConfig: FilterConfiguration = filterIds
     .filter(id => !removedFilters[id])
     .map(id => {


### PR DESCRIPTION
### SUMMARY
Improves the native filters UI/UX - iteration 4.
- Handle the correct tab selection when validating
- Add a required icon and validation to the controllers when their checkbox is checked
- The controls with affectsDataMask are disabled unless the default value picker is enabled

This work is part of the [Native dashboard filter project](https://github.com/apache/superset/projects/12)

The items below will be handled in the next iterations:
- Add a scroll bar to the left panel
- Fix left panel layout when the scroll is active
- Adjust fonts and colors to match the design
- Make the tabs stick to the top while scrolling
- Remove horizontal scroll when the column select is too wide

The iterations below are optional but recommended:

- Split the FiltersConfigForm into smaller components to make it easier to read
- Unify the select components to use the AntD one. Currently, we have different selects with different themes and interactions.

@villebro @rusackas @junlincc

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/119733570-1db51580-be50-11eb-859e-eed98805bd2a.mp4

https://user-images.githubusercontent.com/70410625/119733621-2dccf500-be50-11eb-9a46-bdcce7056b01.mp4

### TESTING INSTRUCTIONS
1 - Enable native filters feature flag
2 - Enter in a dashboard
3 - Add a native filter
4 - Check the screen

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
