### PR TITLE
fix: remove caret from psql error message

### DIFF
--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -185,6 +185,11 @@ class PostgresEngineSpec(PostgresBaseEngineSpec, BasicParametersMixin):
     )
 
     @classmethod
+    def _extract_error_message(cls, ex: Exception) -> str:
+        message = super()._extract_error_message(ex)
+        return message.rstrip("^ \n\t")
+
+    @classmethod
     def get_allow_cost_estimate(cls, extra: Dict[str, Any]) -> bool:
         return True
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The Postgres driver returns an error message that looks like this:

```
column "first_name" does not exist
LINE 1: SELECT first_name from birth_names
               ^
```

Which gets displayed in the toaster as:

```
column "first_name" does not exist LINE 1: SELECT first_name from birth_names ^
```

This PR simply strips the caret so the message looks nicer.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

![Screen Shot 2021-05-26 at 4 32 45 PM](https://user-images.githubusercontent.com/1534870/119744047-05d59580-be40-11eb-9a2e-06a0aeb8d36d.png)

After:

![Screen Shot 2021-05-26 at 4 32 07 PM](https://user-images.githubusercontent.com/1534870/119744011-efc7d500-be3f-11eb-8db0-4dea772a8de2.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
