### PR TITLE
feat(dashboard): Highlight tabs that contain a chart in scope of focused native filter

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
@@ -18,6 +18,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { styled } from '@superset-ui/core';
 
 import DashboardComponent from '../../containers/DashboardComponent';
 import DragDroppable from '../dnd/DragDroppable';
@@ -61,6 +62,17 @@ const defaultProps = {
   onResize() {},
   onResizeStop() {},
 };
+
+const TabTitleContainer = styled.div`
+  ${({ isHighlighted, theme: { gridUnit, colors } }) => `
+    padding: ${gridUnit}px ${gridUnit * 2}px;
+    margin: ${-gridUnit}px ${gridUnit * -2}px;
+    transition: box-shadow 0.2s ease-in-out;
+    ${
+      isHighlighted && `box-shadow: 0 0 ${gridUnit}px ${colors.primary.light1};`
+    }
+  `}
+`;
 
 export default class Tab extends React.PureComponent {
   constructor(props) {
@@ -206,10 +218,10 @@ export default class Tab extends React.PureComponent {
         editMode={editMode}
       >
         {({ dropIndicatorProps, dragSourceRef }) => (
-          <div
+          <TabTitleContainer
+            isHighlighted={isHighlighted}
             className="dragdroppable-tab"
             ref={dragSourceRef}
-            style={isHighlighted ? { backgroundColor: 'red' } : {}}
           >
             <EditableTitle
               title={component.meta.text}
@@ -230,7 +242,7 @@ export default class Tab extends React.PureComponent {
             )}
 
             {dropIndicatorProps && <div {...dropIndicatorProps} />}
-          </div>
+          </TabTitleContainer>
         )}
       </DragDroppable>
     );

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
@@ -192,6 +192,7 @@ export default class Tab extends React.PureComponent {
       editMode,
       filters,
       isFocused,
+      isHighlighted,
     } = this.props;
 
     return (
@@ -205,7 +206,11 @@ export default class Tab extends React.PureComponent {
         editMode={editMode}
       >
         {({ dropIndicatorProps, dragSourceRef }) => (
-          <div className="dragdroppable-tab" ref={dragSourceRef}>
+          <div
+            className="dragdroppable-tab"
+            ref={dragSourceRef}
+            style={isHighlighted ? { backgroundColor: 'red' } : {}}
+          >
             <EditableTitle
               title={component.meta.text}
               defaultTitle={component.meta.defaultText}

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -47,12 +47,11 @@ const findTabsWithChartsInScope = (
     dashboardLayout[childId].type === CHART_TYPE &&
     chartsInScope.includes(dashboardLayout[childId].meta.chartId)
   ) {
-    tabsToHighlight.push(...tabIdsInTheTree);
+    tabsToHighlight.add(...tabIdsInTheTree);
   }
   if (
     dashboardLayout[childId].children.length === 0 ||
-    (dashboardLayout[childId].type === TAB_TYPE &&
-      tabsToHighlight.includes(childId))
+    (dashboardLayout[childId].type === TAB_TYPE && tabsToHighlight.has(childId))
   ) {
     return;
   }
@@ -309,13 +308,13 @@ class Tabs extends React.PureComponent {
     const { children: tabIds } = tabsComponent;
     const { tabIndex: selectedTabIndex, activeKey } = this.state;
 
-    const tabsToHighlight = [];
+    const tabsToHighlight = new Set();
     if (focusedFilterScope) {
       const chartsInScope = getChartIdsInFilterScope({
         filterScope: focusedFilterScope.scope,
       });
       tabIds.forEach(tabId => {
-        if (!tabsToHighlight.includes(tabId)) {
+        if (!tabsToHighlight.has(tabId)) {
           findTabsWithChartsInScope(
             dashboardLayout,
             chartsInScope,
@@ -376,7 +375,7 @@ class Tabs extends React.PureComponent {
                       onDropOnTab={this.handleDropOnTab}
                       isFocused={activeKey === tabId}
                       isHighlighted={
-                        activeKey !== tabId && tabsToHighlight.includes(tabId)
+                        activeKey !== tabId && tabsToHighlight.has(tabId)
                       }
                     />
                   }

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -40,14 +40,14 @@ const findTabsWithChartsInScope = (
   dashboardLayout,
   chartsInScope,
   childId,
-  tabIdsInTheTree,
+  tabId,
   tabsToHighlight,
 ) => {
   if (
     dashboardLayout[childId].type === CHART_TYPE &&
     chartsInScope.includes(dashboardLayout[childId].meta.chartId)
   ) {
-    tabsToHighlight.add(...tabIdsInTheTree);
+    tabsToHighlight.add(tabId);
   }
   if (
     dashboardLayout[childId].children.length === 0 ||
@@ -60,9 +60,7 @@ const findTabsWithChartsInScope = (
       dashboardLayout,
       chartsInScope,
       childId,
-      dashboardLayout[childId].type === TAB_TYPE
-        ? [...tabIdsInTheTree, childId]
-        : tabIdsInTheTree,
+      tabId,
       tabsToHighlight,
     ),
   );
@@ -319,7 +317,7 @@ class Tabs extends React.PureComponent {
             dashboardLayout,
             chartsInScope,
             tabId,
-            [tabId],
+            tabId,
             tabsToHighlight,
           );
         }

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -55,11 +55,11 @@ const findTabsWithChartsInScope = (
   ) {
     return;
   }
-  dashboardLayout[childId].children.forEach(childId =>
+  dashboardLayout[childId].children.forEach(subChildId =>
     findTabsWithChartsInScope(
       dashboardLayout,
       chartsInScope,
-      childId,
+      subChildId,
       tabId,
       tabsToHighlight,
     ),

--- a/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
+++ b/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
@@ -107,6 +107,7 @@ function mapStateToProps(
   const component = dashboardLayout[id];
   const props = {
     component,
+    dashboardLayout,
     parentComponent: dashboardLayout[parentId],
     editMode: dashboardState.editMode,
     undoLength: undoableLayout.past.length,


### PR DESCRIPTION
### SUMMARY
When a user focuses a native filter, tabs that contain charts in scope of that filter should get highlighted to indicate that the native filter affects contents of those tabs.
I didn't highlight active tabs as I thought it would be an overkill, since we also highlight visible charts

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/15073128/119819282-7dfb9400-bef0-11eb-852a-608c6f08af55.mov

### TESTING INSTRUCTIONS
1. Set `DASHBOARD_NATIVE_FILTERS` feature flag to true
2. Create a dashboard with tabs (dashboard level tabs and nested tabs)
3. Create a native filter, play around with scoping
4. Focus on the native filter and verify that tabs that contain charts in scope of that filter are highlighed

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @villebro @junlincc @graceguo-supercat 