### PR TITLE
chore: Bulk Select X Button Alignment

### DIFF
--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -114,6 +114,10 @@ const BulkSelectWrapper = styled(Alert)`
     vertical-align: middle;
     position: relative;
   }
+
+  .ant-alert-close-icon {
+    margin-top: ${({ theme }) => theme.gridUnit * 1.5}px;
+  }
 `;
 
 const bulkSelectColumnConfig = {


### PR DESCRIPTION
### SUMMARY
On all crud views with bulk select, the X button has been aligned so that it's centered vertically.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
- Navigate to the following areas in Superset:
	- Datasets
	- Charts
	- Dashboards
	- Saved Queries
	- Alerts
	- Reports
- Click the "Bulk Select" button
- Observe the aligned close icon to the right

### ADDITIONAL INFORMATION
- [x] Has associated issue: [Clubhouse Ticket](https://app.clubhouse.io/preset/story/16038/crud-views-bulk-select-x-button-alignment)
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
