### PR TITLE
chore: Bump @superset-ui/legacy-preset-chart-deckgl to 0.4.7

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -37,7 +37,7 @@
         "@superset-ui/legacy-plugin-chart-treemap": "^0.17.52",
         "@superset-ui/legacy-plugin-chart-world-map": "^0.17.52",
         "@superset-ui/legacy-preset-chart-big-number": "^0.17.52",
-        "@superset-ui/legacy-preset-chart-deckgl": "^0.4.6",
+        "@superset-ui/legacy-preset-chart-deckgl": "^0.4.7",
         "@superset-ui/legacy-preset-chart-nvd3": "^0.17.52",
         "@superset-ui/plugin-chart-echarts": "^0.17.52",
         "@superset-ui/plugin-chart-pivot-table": "^0.17.52",
@@ -14649,9 +14649,9 @@
       }
     },
     "node_modules/@superset-ui/legacy-preset-chart-deckgl": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-deckgl/-/legacy-preset-chart-deckgl-0.4.6.tgz",
-      "integrity": "sha512-xXGNj7WQHMA+QpeiHMrinwWhOwskD9ucXoe10AfFFgar9TwvCE6wpgRwnoyF0hjoaXnMqpYyFbzlucCf3WSfVQ==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-deckgl/-/legacy-preset-chart-deckgl-0.4.7.tgz",
+      "integrity": "sha512-TaAX1PlZ5DhsNelgoOjCfPBlFtHZDFcozJEIAV2qXzXUo6rfIgskqIq4X3VbMuYnngZw5of4hAtOH1+Tgv+Wmw==",
       "dependencies": {
         "@math.gl/web-mercator": "^3.2.2",
         "@types/d3-array": "^2.0.0",
@@ -14671,6 +14671,11 @@
         "underscore": "^1.8.3",
         "urijs": "^1.18.10",
         "xss": "^1.0.6"
+      },
+      "peerDependencies": {
+        "@superset-ui/chart-controls": "^0.17.12",
+        "@superset-ui/core": "^0.17.11",
+        "react": "^15 || ^16"
       }
     },
     "node_modules/@superset-ui/legacy-preset-chart-nvd3": {
@@ -66766,9 +66771,9 @@
       }
     },
     "@superset-ui/legacy-preset-chart-deckgl": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-deckgl/-/legacy-preset-chart-deckgl-0.4.6.tgz",
-      "integrity": "sha512-xXGNj7WQHMA+QpeiHMrinwWhOwskD9ucXoe10AfFFgar9TwvCE6wpgRwnoyF0hjoaXnMqpYyFbzlucCf3WSfVQ==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-deckgl/-/legacy-preset-chart-deckgl-0.4.7.tgz",
+      "integrity": "sha512-TaAX1PlZ5DhsNelgoOjCfPBlFtHZDFcozJEIAV2qXzXUo6rfIgskqIq4X3VbMuYnngZw5of4hAtOH1+Tgv+Wmw==",
       "requires": {
         "@math.gl/web-mercator": "^3.2.2",
         "@types/d3-array": "^2.0.0",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -89,7 +89,7 @@
     "@superset-ui/legacy-plugin-chart-treemap": "^0.17.52",
     "@superset-ui/legacy-plugin-chart-world-map": "^0.17.52",
     "@superset-ui/legacy-preset-chart-big-number": "^0.17.52",
-    "@superset-ui/legacy-preset-chart-deckgl": "^0.4.6",
+    "@superset-ui/legacy-preset-chart-deckgl": "^0.4.7",
     "@superset-ui/legacy-preset-chart-nvd3": "^0.17.52",
     "@superset-ui/plugin-chart-echarts": "^0.17.52",
     "@superset-ui/plugin-chart-pivot-table": "^0.17.52",


### PR DESCRIPTION
### SUMMARY
Introduces changes implemented in https://github.com/apache-superset/superset-ui-plugins-deckgl/pull/33 - DnD controls for deck.gl plugins.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
See linked PR

### TESTING INSTRUCTIONS
1. Verify that deck.gl plugins work as they did before without DnD controls
2. Set `ENABLE_EXPLORE_DRAG_AND_DROP` feature flag to `True`
3. Verify that deck.gl plugins listed in https://github.com/apache-superset/superset-ui-plugins-deckgl/pull/33 use DnD controls
4. Verify that other charts are unaffected by changes

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc @villebro 