### PR TITLE
feat(Explore): add sort to edit dataset modal

### DIFF
--- a/superset-frontend/src/CRUD/CollectionTable.tsx
+++ b/superset-frontend/src/CRUD/CollectionTable.tsx
@@ -91,7 +91,7 @@ const CrudTableWrapper = styled.div<{ stickyHeader?: boolean }>`
       }
     `}
   th span {
-    vertical-align: ${({theme}) => theme.gridUnit * -2}px;
+    vertical-align: ${({ theme }) => theme.gridUnit * -2}px;
   }
 `;
 
@@ -210,7 +210,7 @@ export default class CRUDCollection extends React.PureComponent<
   sortColumn(col: string, sort = 0) {
     const { sortColumns } = this.props;
     // default sort logic sorting string, boolean and number
-    const compareSort = (m:Sort, n:Sort) => {
+    const compareSort = (m: Sort, n: Sort) => {
       if (typeof m === 'string') {
         return (m || ' ').localeCompare(n);
       }

--- a/superset-frontend/src/CRUD/CollectionTable.tsx
+++ b/superset-frontend/src/CRUD/CollectionTable.tsx
@@ -46,6 +46,8 @@ interface CRUDCollectionProps {
   stickyHeader?: boolean;
 }
 
+type Sort = number | string | boolean | any;
+
 interface CRUDCollectionState {
   collection: object;
   collectionArray: Array<object>;
@@ -89,7 +91,7 @@ const CrudTableWrapper = styled.div<{ stickyHeader?: boolean }>`
       }
     `}
   th span {
-    vertical-align: -8px;
+    vertical-align: ${({theme}) => theme.gridUnit * -2}px;
   }
 `;
 
@@ -208,7 +210,7 @@ export default class CRUDCollection extends React.PureComponent<
   sortColumn(col: string, sort = 0) {
     const { sortColumns } = this.props;
     // default sort logic sorting string, boolean and number
-    const compareSort = (m: any, n: any) => {
+    const compareSort = (m:Sort, n:Sort) => {
       if (typeof m === 'string') {
         return (m || ' ').localeCompare(n);
       }

--- a/superset-frontend/src/CRUD/CollectionTable.tsx
+++ b/superset-frontend/src/CRUD/CollectionTable.tsx
@@ -48,7 +48,7 @@ interface CRUDCollectionProps {
 
 interface CRUDCollectionState {
   collection: object;
-  collectionArray: object;
+  collectionArray: Array<object>;
   expandedColumns: object;
   sortColumn: string;
   sort: number;
@@ -77,15 +77,23 @@ const CrudTableWrapper = styled.div<{ stickyHeader?: boolean }>`
     stickyHeader &&
     `
       height: 350px;
-      overflow: auto;
+      overflow-y: auto;
+      overflow-x: auto;
 
+      .table {
+        min-width: 800px;
+      }
       thead th {
         background: #fff;
         position: sticky;
         top: 0;
         z-index: 9;
+        min
       }
     `}
+    th span {
+      vertical-align: -8px;  
+    }
 `;
 
 const CrudButtonWrapper = styled.div`
@@ -203,9 +211,9 @@ export default class CRUDCollection extends React.PureComponent<
   sortColumn(col:string, sort = 0){
     const { sortColumns } = this.props;
     // default sort logic sorting string, boolean and number
-    const compareSort = (m,n) => {
+    const compareSort = (m: any,n: any) => {
       if(typeof m === "string") {
-        return (m || "").localeCompare((n));
+        return (m || " ").localeCompare((n));
       } else {
         return m - n; 
       }
@@ -223,10 +231,10 @@ export default class CRUDCollection extends React.PureComponent<
           return;
         }
         // newly ordered collection
-        const newCollection = this.state.collectionArray.sort((a,b)=>{
+        const newCollection = this.state.collectionArray.sort((a: object,b: object)=>{
           return sort === 1 ?
             compareSort(a[col], b[col]) : compareSort(b[col], a[col]);
-        }).map(v=>v);
+        }).map((v: object) =>v);
 
         this.setState({
           collectionArray: newCollection,

--- a/superset-frontend/src/CRUD/CollectionTable.tsx
+++ b/superset-frontend/src/CRUD/CollectionTable.tsx
@@ -48,6 +48,12 @@ interface CRUDCollectionProps {
 
 type Sort = number | string | boolean | any;
 
+enum SortOrder {
+  asc = 1,
+  desc = 2,
+  unsort = 0,
+}
+
 interface CRUDCollectionState {
   collection: object;
   collectionArray: Array<object>;
@@ -207,7 +213,7 @@ export default class CRUDCollection extends React.PureComponent<
     }));
   }
 
-  sortColumn(col: string, sort = 0) {
+  sortColumn(col: string, sort = SortOrder.unsort) {
     const { sortColumns } = this.props;
     // default sort logic sorting string, boolean and number
     const compareSort = (m: Sort, n: Sort) => {
@@ -219,7 +225,7 @@ export default class CRUDCollection extends React.PureComponent<
     return () => {
       if (sortColumns?.includes(col)) {
         // display in unsorted order if no sort specified
-        if (sort === 0) {
+        if (sort === SortOrder.unsort) {
           const collection = createKeyedCollection(this.props.collection);
           this.setState({
             collectionArray: createCollectionArray(collection),
@@ -234,7 +240,8 @@ export default class CRUDCollection extends React.PureComponent<
           const sorted = [
             ...prevState.collectionArray,
           ].sort((a: object, b: object) => compareSort(a[col], b[col]));
-          const newCollection = sort === 1 ? sorted : sorted.reverse();
+          const newCollection =
+            sort === SortOrder.asc ? sorted : sorted.reverse();
           return {
             ...prevState,
             collectionArray: newCollection,
@@ -247,10 +254,10 @@ export default class CRUDCollection extends React.PureComponent<
   }
 
   renderSortIcon(col: string) {
-    if (this.state.sortColumn === col && this.state.sort === 1) {
+    if (this.state.sortColumn === col && this.state.sort === SortOrder.asc) {
       return <Icons.SortAsc onClick={this.sortColumn(col, 2)} />;
     }
-    if (this.state.sortColumn === col && this.state.sort === 2) {
+    if (this.state.sortColumn === col && this.state.sort === SortOrder.desc) {
       return <Icons.SortDesc onClick={this.sortColumn(col, 0)} />;
     }
     return <Icons.Sort onClick={this.sortColumn(col, 1)} />;

--- a/superset-frontend/src/CRUD/CollectionTable.tsx
+++ b/superset-frontend/src/CRUD/CollectionTable.tsx
@@ -53,11 +53,8 @@ interface CRUDCollectionState {
   sortColumn: string;
   sort: number;
 }
-function createCollectionArray(collection: object)
-{
-  return Object.keys(collection).map(
-    k => collection[k],
-  );
+function createCollectionArray(collection: object) {
+  return Object.keys(collection).map(k => collection[k]);
 }
 
 function createKeyedCollection(arr: Array<object>) {
@@ -91,9 +88,9 @@ const CrudTableWrapper = styled.div<{ stickyHeader?: boolean }>`
         min
       }
     `}
-    th span {
-      vertical-align: -8px;  
-    }
+  th span {
+    vertical-align: -8px;
+  }
 `;
 
 const CrudButtonWrapper = styled.div`
@@ -111,10 +108,10 @@ export default class CRUDCollection extends React.PureComponent<
     const collection = createKeyedCollection(props.collection);
     this.state = {
       expandedColumns: {},
-      collection: collection,
+      collection,
       collectionArray: createCollectionArray(collection),
       sortColumn: '',
-      sort: 0
+      sort: 0,
     };
     this.renderItem = this.renderItem.bind(this);
     this.onAddItem = this.onAddItem.bind(this);
@@ -131,8 +128,8 @@ export default class CRUDCollection extends React.PureComponent<
     if (nextProps.collection !== this.props.collection) {
       const collection = createKeyedCollection(nextProps.collection);
       this.setState({
-        collection: collection,
-        collectionArray: createCollectionArray(collection)
+        collection,
+        collectionArray: createCollectionArray(collection),
       });
     }
   }
@@ -208,16 +205,15 @@ export default class CRUDCollection extends React.PureComponent<
     }));
   }
 
-  sortColumn(col:string, sort = 0){
+  sortColumn(col: string, sort = 0) {
     const { sortColumns } = this.props;
     // default sort logic sorting string, boolean and number
-    const compareSort = (m: any,n: any) => {
-      if(typeof m === "string") {
-        return (m || " ").localeCompare((n));
-      } else {
-        return m - n; 
+    const compareSort = (m: any, n: any) => {
+      if (typeof m === 'string') {
+        return (m || ' ').localeCompare(n);
       }
-    }
+      return m - n;
+    };
     return () => {
       if (sortColumns?.includes(col)) {
         // display in random order if no sort specified
@@ -227,37 +223,48 @@ export default class CRUDCollection extends React.PureComponent<
             collectionArray: createCollectionArray(collection),
             sortColumn: '',
             sort,
-          })
+          });
           return;
         }
-        // newly ordered collection
-        const newCollection = this.state.collectionArray.sort((a: object,b: object)=>{
-          return sort === 1 ?
-            compareSort(a[col], b[col]) : compareSort(b[col], a[col]);
-        }).map((v: object) =>v);
 
-        this.setState({
-          collectionArray: newCollection,
-          sortColumn: col,
-          sort
+        this.setState(prevState => {
+          // newly ordered collection
+          const newCollection = prevState.collectionArray
+            .sort((a: object, b: object) =>
+              sort === 1
+                ? compareSort(a[col], b[col])
+                : compareSort(b[col], a[col]),
+            )
+            .map((v: object) => v);
+          return {
+            ...prevState,
+            collectionArray: newCollection,
+            sortColumn: col,
+            sort,
+          };
         });
       }
-    }
+    };
   }
 
   renderSortIcon(col: string) {
-     if (this.state.sortColumn === col && this.state.sort === 1) {
-      return <Icons.SortAsc onClick={this.sortColumn(col, 2)}/>
-     }
-     if (this.state.sortColumn === col && this.state.sort === 2) {
-      return <Icons.SortDesc onClick={this.sortColumn(col, 0)}/>
-     }
-     return <Icons.Sort onClick={this.sortColumn(col, 1)}/>
+    if (this.state.sortColumn === col && this.state.sort === 1) {
+      return <Icons.SortAsc onClick={this.sortColumn(col, 2)} />;
+    }
+    if (this.state.sortColumn === col && this.state.sort === 2) {
+      return <Icons.SortDesc onClick={this.sortColumn(col, 0)} />;
+    }
+    return <Icons.Sort onClick={this.sortColumn(col, 1)} />;
   }
 
   renderHeaderRow() {
     const cols = this.effectiveTableColumns();
-    const { allowDeletes, expandFieldset, extraButtons, sortColumns} = this.props;
+    const {
+      allowDeletes,
+      expandFieldset,
+      extraButtons,
+      sortColumns,
+    } = this.props;
     return (
       <thead>
         <tr>
@@ -375,7 +382,7 @@ export default class CRUDCollection extends React.PureComponent<
   }
 
   renderTableBody() {
-    const data = this.state.collectionArray; 
+    const data = this.state.collectionArray;
     const content = data.length
       ? data.map(d => this.renderItem(d))
       : this.renderEmptyCell();

--- a/superset-frontend/src/CRUD/CollectionTable.tsx
+++ b/superset-frontend/src/CRUD/CollectionTable.tsx
@@ -59,8 +59,9 @@ interface CRUDCollectionState {
   collectionArray: Array<object>;
   expandedColumns: object;
   sortColumn: string;
-  sort: number;
+  sort: SortOrder;
 }
+
 function createCollectionArray(collection: object) {
   return Object.keys(collection).map(k => collection[k]);
 }

--- a/superset-frontend/src/CRUD/CollectionTable.tsx
+++ b/superset-frontend/src/CRUD/CollectionTable.tsx
@@ -218,7 +218,7 @@ export default class CRUDCollection extends React.PureComponent<
     };
     return () => {
       if (sortColumns?.includes(col)) {
-        // display in random order if no sort specified
+        // display in unsorted order if no sort specified
         if (sort === 0) {
           const collection = createKeyedCollection(this.props.collection);
           this.setState({
@@ -231,13 +231,10 @@ export default class CRUDCollection extends React.PureComponent<
 
         this.setState(prevState => {
           // newly ordered collection
-          const newCollection = prevState.collectionArray
-            .sort((a: object, b: object) =>
-              sort === 1
-                ? compareSort(a[col], b[col])
-                : compareSort(b[col], a[col]),
-            )
-            .map((v: object) => v);
+          const sorted = [
+            ...prevState.collectionArray,
+          ].sort((a: object, b: object) => compareSort(a[col], b[col]));
+          const newCollection = sort === 1 ? sorted : sorted.reverse();
           return {
             ...prevState,
             collectionArray: newCollection,

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -862,11 +862,7 @@ class DatasourceEditor extends React.PureComponent {
     return (
       <CollectionTable
         tableColumns={['metric_name', 'verbose_name', 'expression']}
-        sortColumns={[
-          'metric_name',
-          'verbose_name',
-          'expression'
-        ]}
+        sortColumns={['metric_name', 'verbose_name', 'expression']}
         columnLabels={{
           metric_name: t('Metric'),
           verbose_name: t('Label'),

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -141,6 +141,7 @@ function ColumnCollectionTable({
     <CollectionTable
       collection={columns}
       tableColumns={['column_name', 'type', 'is_dttm', 'filterable', 'groupby']}
+      sortColumns={['column_name', 'type', 'is_dttm', 'filterable', 'groupby']}
       allowDeletes
       allowAddItem={allowAddItem}
       itemGenerator={itemGenerator}
@@ -861,6 +862,11 @@ class DatasourceEditor extends React.PureComponent {
     return (
       <CollectionTable
         tableColumns={['metric_name', 'verbose_name', 'expression']}
+        sortColumns={[
+          'metric_name',
+          'verbose_name',
+          'expression'
+        ]}
         columnLabels={{
           metric_name: t('Metric'),
           verbose_name: t('Label'),


### PR DESCRIPTION
### SUMMARY
This pr adds sort to the edit dataset modal so that user can now sort by column property.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before

https://user-images.githubusercontent.com/17326228/119910796-c628af80-bf0c-11eb-88a8-95d06631cd07.mov

after

https://user-images.githubusercontent.com/17326228/119910855-ed7f7c80-bf0c-11eb-82ea-4ec4d83e56a0.mov




### TESTING INSTRUCTIONS
Go to edit data set in explore and click the tabs columns and metrics to sort rows.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
