### PR TITLE
feat(native-filters): improve inverse selection indicators

### DIFF
--- a/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
@@ -226,7 +226,10 @@ export const selectNativeIndicatorsForChart = (
       )
       .map(nativeFilter => {
         const column = nativeFilter.targets[0]?.column?.name;
-        let value = dataMask[nativeFilter.id]?.filterState?.value ?? null;
+        let value =
+          dataMask[nativeFilter.id]?.filterState?.label ??
+          dataMask[nativeFilter.id]?.filterState?.value ??
+          null;
         if (!Array.isArray(value) && value !== null) {
           value = [value];
         }
@@ -252,7 +255,10 @@ export const selectNativeIndicatorsForChart = (
         ),
       )
       .map(chartConfig => {
-        let value = dataMask[chartConfig.id]?.filterState?.value ?? null;
+        let value =
+          dataMask[chartConfig.id]?.filterState?.label ??
+          dataMask[chartConfig.id]?.filterState?.value ??
+          null;
         if (!Array.isArray(value) && value !== null) {
           value = [value];
         }

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -38,7 +38,7 @@ import React, {
 import { Select } from 'src/common/components';
 import debounce from 'lodash/debounce';
 import { SLOW_DEBOUNCE } from 'src/constants';
-import { CheckOutlined, CloseOutlined } from '@ant-design/icons';
+import { CheckOutlined, StopOutlined } from '@ant-design/icons';
 import { PluginFilterSelectProps, SelectValue } from './types';
 import { StyledSelect, Styles } from '../common';
 import { getDataRecordFormatter, getSelectExtraFormData } from '../../utils';
@@ -50,7 +50,7 @@ type DataMaskAction =
   | {
       type: 'filterState';
       extraFormData: ExtraFormData;
-      filterState: { value: SelectValue };
+      filterState: { value: SelectValue; label?: string };
     };
 
 function reducer(state: DataMask, action: DataMaskAction): DataMask {
@@ -136,6 +136,8 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
   const updateDataMask = (values: SelectValue) => {
     const emptyFilter =
       enableEmptyFilter && !inverseSelection && !values?.length;
+    const suffix =
+      inverseSelection && values?.length ? ` (${t('excluded')})` : '';
 
     dispatchDataMask({
       type: 'filterState',
@@ -147,6 +149,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
       ),
       filterState: {
         value: values,
+        label: `${(values || []).join(', ')}${suffix}`,
       },
     });
   };
@@ -262,7 +265,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
         loading={isRefreshing}
         maxTagCount={5}
         menuItemSelectedIcon={
-          inverseSelection ? <CloseOutlined /> : <CheckOutlined />
+          inverseSelection ? <StopOutlined /> : <CheckOutlined />
         }
       >
         {sortedData.map(row => {

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -38,6 +38,7 @@ import React, {
 import { Select } from 'src/common/components';
 import debounce from 'lodash/debounce';
 import { SLOW_DEBOUNCE } from 'src/constants';
+import { CheckOutlined, CloseOutlined } from '@ant-design/icons';
 import { PluginFilterSelectProps, SelectValue } from './types';
 import { StyledSelect, Styles } from '../common';
 import { getDataRecordFormatter, getSelectExtraFormData } from '../../utils';
@@ -260,6 +261,9 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
         ref={inputRef}
         loading={isRefreshing}
         maxTagCount={5}
+        menuItemSelectedIcon={
+          inverseSelection ? <CloseOutlined /> : <CheckOutlined />
+        }
       >
         {sortedData.map(row => {
           const [value] = groupby.map(col => row[col]);


### PR DESCRIPTION
### SUMMARY
Currently setting a select filter to "inverse selection" doesn't visually indicate that the emitted WHERE clause is in fact a "NOT IN" as opposed to the normal "IN". This replaces the normal `CheckOutlined` icon with `StopOutlined` when inverse selection is applied. In addition, a new reserved parameter `label` is introduced on `filterState`, which makes it possible to customize the indicator label.

We might also want to consider adding support for being able to pass `ReactNode` labels to be able to further customize the indicator label. If this seems like a good approach, I'll add the `label` property to the `DataMask` type in `@superset-ui/core`.

### BEFORE
Currently the dropdown icon for both regular and inverse selection are a checkmark:
![image](https://user-images.githubusercontent.com/33317356/119851180-dfcef480-bf16-11eb-8c43-041fc803586a.png)

The filter indicator also only shows the values as such, without indicating that the values are excluded:
![image](https://user-images.githubusercontent.com/33317356/119851372-068d2b00-bf17-11eb-9899-087bdcb79e31.png)

### AFTER
Now the dropdown icon signals that the selected values are excluded:
![image](https://user-images.githubusercontent.com/33317356/119850748-7cdd5d80-bf16-11eb-8edc-ea878a8b51b6.png)

In addition, the filter indicator text now signals that the selected values are in fact excluded, not included:
![image](https://user-images.githubusercontent.com/33317356/119851052-c332bc80-bf16-11eb-9038-1730d094bdf3.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
