### PR TITLE
fix: Empty tab component in Dashboard cannot be deleted

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -89,6 +89,10 @@ const StyledTabsContainer = styled.div`
   .ant-tabs {
     overflow: visible;
 
+    .ant-tabs-nav-wrap {
+      min-height: ${({ theme }) => theme.gridUnit * 12.5}px;
+    }
+
     .ant-tabs-content-holder {
       overflow: visible;
     }


### PR DESCRIPTION
### SUMMARY
Adds a min-height to the tabs component so that when empty the user can still reach the trash icon to delete the component from the dashboard

### BEFORE

https://user-images.githubusercontent.com/60598000/119870962-9dafae00-bf2a-11eb-967e-125cb883d0ff.mp4

### AFTER

https://user-images.githubusercontent.com/60598000/119871058-bfa93080-bf2a-11eb-8091-d74389979ac8.mp4

### TESTING INSTRUCTIONS
1. Open a dashboard
2. Add a tab component
3. Delete all the tabs
4. Make sure you can reach the trash icon far left when hovering the tab component

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #14820
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
