### PR TITLE
feat(db-connection-ui): Allow users to pick engine

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -82,7 +82,6 @@ enum ActionType {
   parametersChange,
   reset,
   textChange,
-  allowSelectDB,
 }
 
 interface DBReducerPayloadType {
@@ -121,10 +120,6 @@ type DBReducerActionType =
       type: ActionType.configMethodChange;
       payload: { configuration_method: CONFIGURATION_METHOD };
     }
-  | {
-      type: ActionType.allowSelectDB;
-      payload: { available: [] };
-    };
 
 function dbReducer(
   state: Partial<DatabaseObject> | null,

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -538,10 +538,21 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
               <Select
                 defaultValue={'bigquery'}
                 style={{ width: '100%' }}
-                onChange={option => console.log('hi')}
+                onChange={option => {
+                  console.log(option);
+                  setDB({
+                    type: ActionType.dbSelected,
+                    payload: {
+                      configuration_method: CONFIGURATION_METHOD.DYNAMIC_FORM,
+                      engine: option,
+                    },
+                  });
+                }}
               >
-                {availableDbs?.databases?.map((engine) => (
-                  <Select.Option key={engine.engine} >{engine.name}</Select.Option>
+                {availableDbs?.databases?.map(database => (
+                  <Select.Option value={database.engine} key={database.engine}>
+                    {database.name}
+                  </Select.Option>
                 ))}
               </Select>
             </>

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -180,7 +180,7 @@ function dbReducer(
       };
     case ActionType.reset:
     default:
-      return {};
+      return null;
   }
 }
 

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -134,8 +134,6 @@ function dbReducer(
     ...(state || {}),
   };
 
-  console.log(action);
-
   switch (action.type) {
     case ActionType.inputChange:
       if (action.payload.type === 'checkbox') {
@@ -173,6 +171,9 @@ function dbReducer(
         ...action.payload,
       };
     case ActionType.dbSelected:
+      return {
+        ...action.payload,
+      };
     case ActionType.configMethodChange:
       return {
         ...action.payload,
@@ -205,7 +206,6 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
   const [isLoading, setLoading] = useState<boolean>(false);
   const conf = useCommonConf();
 
-  const isSelectMode = true;
   const isEditMode = !!databaseId;
   const useSqlAlchemyForm =
     db?.configuration_method === CONFIGURATION_METHOD.SQLALCHEMY_URI;
@@ -530,16 +530,14 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
             getValidation={() => getValidation(db)}
             validationErrors={validationErrors}
           />
-          {isSelectMode && !isLoading && (
+          {!isLoading && !db && (
             <>
               <label className="label-select">
                 What database would you like to connect?
               </label>
               <Select
-                defaultValue={'bigquery'}
                 style={{ width: '100%' }}
                 onChange={option => {
-                  console.log(option);
                   setDB({
                     type: ActionType.dbSelected,
                     payload: {

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -59,6 +59,7 @@ import {
   formHelperStyles,
   formStyles,
   StyledBasicTab,
+  SelectDatabaseStyles,
 } from './styles';
 
 const DOCUMENTATION_LINK =
@@ -524,7 +525,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
             validationErrors={validationErrors}
           />
           {!isLoading && !db && (
-            <>
+            <SelectDatabaseStyles>
               <label className="label-select">
                 What database would you like to connect?
               </label>
@@ -546,7 +547,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
                   </Select.Option>
                 ))}
               </Select>
-            </>
+            </SelectDatabaseStyles>
           )}
           <Button
             buttonStyle="link"

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -329,10 +329,8 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
   useEffect(() => {
     if (isLoading) {
       setLoading(false);
-      console.log('done loading');
-      console.log(availableDbs);
     }
-  }, [availableDbs]);
+  }, [availableDbs, isLoading]);
 
   const tabChange = (key: string) => {
     setTabKey(key);

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
@@ -338,3 +338,7 @@ export const EditHeaderSubtitle = styled.div`
   font-size: ${({ theme }) => theme.typography.sizes.l}px;
   font-weight: bold;
 `;
+
+export const SelectDatabaseStyles = styled.div`
+  margin: ${({ theme }) => theme.gridUnit * 4}px;
+`;


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Create step 1 Database UI connection flow to allow users to pick the type of engine before entering credentials

add on to #14881

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://www.loom.com/share/70d28352ab1746ffa416b31d986b857e

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
