### PR TITLE
fix: Redshift parameters not rendering

### DIFF
--- a/superset/db_engine_specs/redshift.py
+++ b/superset/db_engine_specs/redshift.py
@@ -50,6 +50,7 @@ class RedshiftEngineSpec(PostgresBaseEngineSpec, BasicParametersMixin):
     engine = "redshift"
     engine_name = "Amazon Redshift"
     max_column_name_length = 127
+    default_driver = "psycopg2"
 
     sqlalchemy_uri_placeholder = (
         "redshift+psycopg2://user:password@host:port/dbname[?key=value&key=value...]"

--- a/tests/databases/api_tests.py
+++ b/tests/databases/api_tests.py
@@ -1506,7 +1506,7 @@ class TestDatabaseApi(SupersetTestCase):
                 },
                 {
                     "available_drivers": ["psycopg2"],
-                    "default_driver": "",
+                    "default_driver": "psycopg2",
                     "engine": "redshift",
                     "name": "Amazon Redshift",
                     "parameters": {
@@ -1548,6 +1548,7 @@ class TestDatabaseApi(SupersetTestCase):
                         "type": "object",
                     },
                     "preferred": False,
+                    "sqlalchemy_uri_placeholder": "redshift+psycopg2://user:password@host:port/dbname[?key=value&key=value...]",
                 },
                 {
                     "available_drivers": ["mysqlconnector", "mysqldb"],
@@ -1594,39 +1595,6 @@ class TestDatabaseApi(SupersetTestCase):
                     },
                     "preferred": False,
                     "sqlalchemy_uri_placeholder": "mysql://user:password@host:port/dbname[?key=value&key=value...]",
-                },
-                {
-                    "available_drivers": [""],
-                    "engine": "hana",
-                    "name": "SAP HANA",
-                    "preferred": False,
-                },
-            ]
-        }
-
-    @mock.patch("superset.databases.api.get_available_engine_specs")
-    @mock.patch("superset.databases.api.app")
-    def test_available_no_default(self, app, get_available_engine_specs):
-        app.config = {"PREFERRED_DATABASES": ["MySQL"]}
-        get_available_engine_specs.return_value = {
-            MySQLEngineSpec: {"mysqlconnector"},
-            HanaEngineSpec: {""},
-        }
-
-        self.login(username="admin")
-        uri = "api/v1/database/available/"
-
-        rv = self.client.get(uri)
-        response = json.loads(rv.data.decode("utf-8"))
-        assert rv.status_code == 200
-        assert response == {
-            "databases": [
-                {
-                    "available_drivers": ["mysqlconnector"],
-                    "default_driver": "mysqldb",
-                    "engine": "mysql",
-                    "name": "MySQL",
-                    "preferred": True,
                 },
                 {
                     "available_drivers": [""],

--- a/tests/databases/api_tests.py
+++ b/tests/databases/api_tests.py
@@ -1509,6 +1509,44 @@ class TestDatabaseApi(SupersetTestCase):
                     "default_driver": "",
                     "engine": "redshift",
                     "name": "Amazon Redshift",
+                    "parameters": {
+                        "properties": {
+                            "database": {
+                                "description": "Database name",
+                                "type": "string",
+                            },
+                            "encryption": {
+                                "description": "Use an encrypted connection to the database",
+                                "type": "boolean",
+                            },
+                            "host": {
+                                "description": "Hostname or IP address",
+                                "type": "string",
+                            },
+                            "password": {
+                                "description": "Password",
+                                "nullable": True,
+                                "type": "string",
+                            },
+                            "port": {
+                                "description": "Database port",
+                                "format": "int32",
+                                "type": "integer",
+                            },
+                            "query": {
+                                "additionalProperties": {},
+                                "description": "Additional parameters",
+                                "type": "object",
+                            },
+                            "username": {
+                                "description": "Username",
+                                "nullable": True,
+                                "type": "string",
+                            },
+                        },
+                        "required": ["database", "host", "port", "username"],
+                        "type": "object",
+                    },
                     "preferred": False,
                 },
                 {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Redshift's BasicMixinParams weren't rendering since we were missing a default driver reference

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
