### PR TITLE
fix: time range in filter box error

### DIFF
--- a/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
@@ -158,6 +158,8 @@ class FilterBox extends React.PureComponent {
     if (options !== null) {
       if (Array.isArray(options)) {
         vals = options.map(opt => (typeof opt === 'string' ? opt : opt.value));
+      } else if (Object.values(TIME_FILTER_MAP).includes(fltr)) {
+        vals = options.value ?? options;
       } else {
         // must use array member for legacy extra_filters's value
         vals = ensureIsArray(options.value ?? options);


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
this PR is an urgent fix for regression introduced by #14841. Before #14841, when multiple select checkbox is unchecked in filterbox, selected filter value can not pass through query and trigger chart render on dashboard.  Unfortunately, this PR introduced a regression that when there's time range filter in the filterbox, time filter value as STRING gets converted into array. This change doesn't affect any other control in the filterbox.

This PR is a fix forward of #14841, and will resolve both the original issue #14804 and the regression mentioned above. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### Before

https://user-images.githubusercontent.com/2016594/119920723-60393800-bf9f-11eb-8e88-b97040b2ca90.mp4




#### After

https://user-images.githubusercontent.com/2016594/119920555-1bad9c80-bf9f-11eb-92ca-41b99557db12.mp4


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
