### PR TITLE
fix(aarch64): Bump pyarrow version to 4.0.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -189,7 +189,7 @@ prison==0.1.3
     # via flask-appbuilder
 py==1.9.0
     # via retry
-pyarrow==3.0.0
+pyarrow==4.0.0
     # via apache-superset
 pycparser==2.20
     # via cffi

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -189,7 +189,7 @@ prison==0.1.3
     # via flask-appbuilder
 py==1.9.0
     # via retry
-pyarrow==4.0.0
+pyarrow==4.0.1
     # via apache-superset
 pycparser==2.20
     # via cffi

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
         "python-dateutil",
         "python-dotenv",
         "python-geohash",
-        "pyarrow>=4.0.0, <4.1",
+        "pyarrow>=4.0.1, <4.1",
         "pyyaml>=5.4",
         "PyJWT>=1.7.1, <2",
         "redis",

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
         "python-dateutil",
         "python-dotenv",
         "python-geohash",
-        "pyarrow>=3.0.0, <3.1",
+        "pyarrow>=4.0.0, <4.1",
         "pyyaml>=5.4",
         "PyJWT>=1.7.1, <2",
         "redis",


### PR DESCRIPTION
### SUMMARY
Could not build docker image on arm64 (Oracle Cloud A1) with current master. Bumped pyarrow from 3.0.0 to 4.0.0 and now it builds with no issues.

This patch means that superset can probably now run on a 64bit Raspberry Pi 4.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
```make
  Building wheel for pyarrow (PEP 517): started
  Building wheel for pyarrow (PEP 517): finished with status 'error'
  ERROR: Command errored out with exit status 1:
   command: /usr/local/bin/python /usr/local/lib/python3.7/site-packages/pip/_vendor/pep517/_in_process.py build_wheel /tmp/tmprvqae40j
       cwd: /tmp/pip-install-m5v1__qr/pyarrow_9a6b8b5a74ea4aafb0ee5dfe67163556
  Complete output (182 lines):
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.linux-aarch64-3.7
  creating build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/util.py -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/parquet.py -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/dataset.py -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/compat.py -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/pandas_compat.py -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/types.py -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/_generated_version.py -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/flight.py -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/fs.py -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/plasma.py -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/json.py -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/benchmark.py -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/compute.py -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/orc.py -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/feather.py -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/serialization.py -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/filesystem.py -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/jvm.py -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/cffi.py -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/hdfs.py -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/__init__.py -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/csv.py -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/ipc.py -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/cuda.py -> build/lib.linux-aarch64-3.7/pyarrow
  creating build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_scalars.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_io.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_filesystem.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/util.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_dataset.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_ipc.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_serialization.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_adhoc_memory_leak.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_plasma.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_builder.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_csv.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_serialization_deprecated.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_deprecations.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_flight.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_memory.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_table.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_compute.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_types.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_jvm.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/conftest.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_orc.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_strategies.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_feather.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_misc.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_cffi.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_tensor.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_plasma_tf_op.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_fs.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/pandas_threaded_import.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/__init__.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_sparse_tensor.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_json.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_convert_builtin.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_schema.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_cython.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_cuda_numba_interop.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/deserialize_buffer.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/pandas_examples.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_gandiva.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_hdfs.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_array.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_extension_type.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/arrow_7980.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_pandas.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/test_cuda.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  copying pyarrow/tests/strategies.py -> build/lib.linux-aarch64-3.7/pyarrow/tests
  running egg_info
  writing pyarrow.egg-info/PKG-INFO
  writing dependency_links to pyarrow.egg-info/dependency_links.txt
  writing entry points to pyarrow.egg-info/entry_points.txt
  writing requirements to pyarrow.egg-info/requires.txt
  writing top-level names to pyarrow.egg-info/top_level.txt
  reading manifest file 'pyarrow.egg-info/SOURCES.txt'
  reading manifest template 'MANIFEST.in'
  warning: no files found matching '../LICENSE.txt'
  warning: no files found matching '../NOTICE.txt'
  warning: no previously-included files matching '*.so' found anywhere in distribution
  warning: no previously-included files matching '*.pyc' found anywhere in distribution
  warning: no previously-included files matching '*~' found anywhere in distribution
  warning: no previously-included files matching '#*' found anywhere in distribution
  warning: no previously-included files matching '.git*' found anywhere in distribution
  warning: no previously-included files matching '.DS_Store' found anywhere in distribution
  no previously-included directories found matching '.asv'
  writing manifest file 'pyarrow.egg-info/SOURCES.txt'
  copying pyarrow/__init__.pxd -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/_compute.pxd -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/_compute.pyx -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/_csv.pxd -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/_csv.pyx -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/_cuda.pxd -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/_cuda.pyx -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/_dataset.pyx -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/_flight.pyx -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/_fs.pxd -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/_fs.pyx -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/_hdfs.pyx -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/_json.pyx -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/_orc.pxd -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/_orc.pyx -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/_parquet.pxd -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/_parquet.pyx -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/_plasma.pyx -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/_s3fs.pyx -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/array.pxi -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/benchmark.pxi -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/builder.pxi -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/compat.pxi -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/config.pxi -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/error.pxi -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/feather.pxi -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/gandiva.pyx -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/io-hdfs.pxi -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/io.pxi -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/ipc.pxi -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/lib.pxd -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/lib.pyx -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/memory.pxi -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/pandas-shim.pxi -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/public-api.pxi -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/scalar.pxi -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/serialization.pxi -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/table.pxi -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/tensor.pxi -> build/lib.linux-aarch64-3.7/pyarrow
  copying pyarrow/types.pxi -> build/lib.linux-aarch64-3.7/pyarrow
  creating build/lib.linux-aarch64-3.7/pyarrow/includes
  copying pyarrow/includes/__init__.pxd -> build/lib.linux-aarch64-3.7/pyarrow/includes
  copying pyarrow/includes/common.pxd -> build/lib.linux-aarch64-3.7/pyarrow/includes
  copying pyarrow/includes/libarrow.pxd -> build/lib.linux-aarch64-3.7/pyarrow/includes
  copying pyarrow/includes/libarrow_cuda.pxd -> build/lib.linux-aarch64-3.7/pyarrow/includes
  copying pyarrow/includes/libarrow_dataset.pxd -> build/lib.linux-aarch64-3.7/pyarrow/includes
  copying pyarrow/includes/libarrow_flight.pxd -> build/lib.linux-aarch64-3.7/pyarrow/includes
  copying pyarrow/includes/libarrow_fs.pxd -> build/lib.linux-aarch64-3.7/pyarrow/includes
  copying pyarrow/includes/libgandiva.pxd -> build/lib.linux-aarch64-3.7/pyarrow/includes
  copying pyarrow/includes/libplasma.pxd -> build/lib.linux-aarch64-3.7/pyarrow/includes
  creating build/lib.linux-aarch64-3.7/pyarrow/tensorflow
  copying pyarrow/tensorflow/plasma_op.cc -> build/lib.linux-aarch64-3.7/pyarrow/tensorflow
  copying pyarrow/tests/pyarrow_cython_example.pyx -> build/lib.linux-aarch64-3.7/pyarrow/tests
  creating build/lib.linux-aarch64-3.7/pyarrow/tests/data
  creating build/lib.linux-aarch64-3.7/pyarrow/tests/data/feather
  copying pyarrow/tests/data/feather/v0.17.0.version=2-compression=lz4.feather -> build/lib.linux-aarch64-3.7/pyarrow/tests/data/feather
  creating build/lib.linux-aarch64-3.7/pyarrow/tests/data/orc
  copying pyarrow/tests/data/orc/README.md -> build/lib.linux-aarch64-3.7/pyarrow/tests/data/orc
  copying pyarrow/tests/data/orc/TestOrcFile.emptyFile.jsn.gz -> build/lib.linux-aarch64-3.7/pyarrow/tests/data/orc
  copying pyarrow/tests/data/orc/TestOrcFile.emptyFile.orc -> build/lib.linux-aarch64-3.7/pyarrow/tests/data/orc
  copying pyarrow/tests/data/orc/TestOrcFile.test1.jsn.gz -> build/lib.linux-aarch64-3.7/pyarrow/tests/data/orc
  copying pyarrow/tests/data/orc/TestOrcFile.test1.orc -> build/lib.linux-aarch64-3.7/pyarrow/tests/data/orc
  copying pyarrow/tests/data/orc/TestOrcFile.testDate1900.jsn.gz -> build/lib.linux-aarch64-3.7/pyarrow/tests/data/orc
  copying pyarrow/tests/data/orc/TestOrcFile.testDate1900.orc -> build/lib.linux-aarch64-3.7/pyarrow/tests/data/orc
  copying pyarrow/tests/data/orc/decimal.jsn.gz -> build/lib.linux-aarch64-3.7/pyarrow/tests/data/orc
  copying pyarrow/tests/data/orc/decimal.orc -> build/lib.linux-aarch64-3.7/pyarrow/tests/data/orc
  creating build/lib.linux-aarch64-3.7/pyarrow/tests/data/parquet
  copying pyarrow/tests/data/parquet/v0.7.1.all-named-index.parquet -> build/lib.linux-aarch64-3.7/pyarrow/tests/data/parquet
  copying pyarrow/tests/data/parquet/v0.7.1.column-metadata-handling.parquet -> build/lib.linux-aarch64-3.7/pyarrow/tests/data/parquet
  copying pyarrow/tests/data/parquet/v0.7.1.parquet -> build/lib.linux-aarch64-3.7/pyarrow/tests/data/parquet
  copying pyarrow/tests/data/parquet/v0.7.1.some-named-index.parquet -> build/lib.linux-aarch64-3.7/pyarrow/tests/data/parquet
  creating build/lib.linux-aarch64-3.7/pyarrow/tests/parquet
  copying pyarrow/tests/parquet/common.py -> build/lib.linux-aarch64-3.7/pyarrow/tests/parquet
  copying pyarrow/tests/parquet/conftest.py -> build/lib.linux-aarch64-3.7/pyarrow/tests/parquet
  copying pyarrow/tests/parquet/test_basic.py -> build/lib.linux-aarch64-3.7/pyarrow/tests/parquet
  copying pyarrow/tests/parquet/test_data_types.py -> build/lib.linux-aarch64-3.7/pyarrow/tests/parquet
  copying pyarrow/tests/parquet/test_dataset.py -> build/lib.linux-aarch64-3.7/pyarrow/tests/parquet
  copying pyarrow/tests/parquet/test_datetime.py -> build/lib.linux-aarch64-3.7/pyarrow/tests/parquet
  copying pyarrow/tests/parquet/test_metadata.py -> build/lib.linux-aarch64-3.7/pyarrow/tests/parquet
  copying pyarrow/tests/parquet/test_pandas.py -> build/lib.linux-aarch64-3.7/pyarrow/tests/parquet
  copying pyarrow/tests/parquet/test_parquet_file.py -> build/lib.linux-aarch64-3.7/pyarrow/tests/parquet
  copying pyarrow/tests/parquet/test_parquet_writer.py -> build/lib.linux-aarch64-3.7/pyarrow/tests/parquet
  running build_ext
  creating /tmp/pip-install-m5v1__qr/pyarrow_9a6b8b5a74ea4aafb0ee5dfe67163556/build/temp.linux-aarch64-3.7
  -- Running cmake for pyarrow
  cmake -DPYTHON_EXECUTABLE=/usr/local/bin/python -DPython3_EXECUTABLE=/usr/local/bin/python  -DPYARROW_BUILD_CUDA=off -DPYARROW_BUILD_FLIGHT=off -DPYARROW_BUILD_GANDIVA=off -DPYARROW_BUILD_DATASET=off -DPYARROW_BUILD_ORC=off -DPYARROW_BUILD_PARQUET=off -DPYARROW_BUILD_PLASMA=off -DPYARROW_BUILD_S3=off -DPYARROW_BUILD_HDFS=off -DPYARROW_USE_TENSORFLOW=off -DPYARROW_BUNDLE_ARROW_CPP=off -DPYARROW_BUNDLE_BOOST=off -DPYARROW_GENERATE_COVERAGE=off -DPYARROW_BOOST_USE_SHARED=on -DPYARROW_PARQUET_USE_SHARED=on -DCMAKE_BUILD_TYPE=release /tmp/pip-install-m5v1__qr/pyarrow_9a6b8b5a74ea4aafb0ee5dfe67163556
  error: command 'cmake' failed with exit status 1
  ----------------------------------------
  ERROR: Failed building wheel for pyarrow
```

After:
```make
Running setup.py develop for apache-superset
Successfully installed aiohttp-3.7.2 alembic-1.4.3 amqp-2.6.1 apache-superset apispec-3.3.2 async-timeout-3.0.1 attrs-20.2.0 babel-2.8.0 backoff-1.10.0 billiard-3.6.3.0 bleach-3.2.1 boto3-1.16.10 botocore-1.19.10 brotli-1.0.9 cached-property-1.5.2 cachelib-0.1.1 celery-4.4.7 certifi-2020.6.20 cffi-1.14.3 chardet-3.0.4 click-7.1.2 colorama-0.4.4 contextlib2-0.6.0.post1 convertdate-2.3.0 cron-descriptor-1.2.24 croniter-0.3.36 cryptography-3.2.1 decorator-4.4.2 defusedxml-0.6.0 deprecated-1.2.11 dnspython-2.0.0 email-validator-1.1.1 et-xmlfile-1.0.1 flask-1.1.2 flask-appbuilder-3.3.0 flask-babel-1.0.0 flask-caching-1.9.0 flask-compress-1.8.0 flask-cors-3.0.9 flask-jwt-extended-3.24.1 flask-login-0.4.1 flask-migrate-2.5.3 flask-openid-1.2.5 flask-sqlalchemy-2.4.4 flask-talisman-0.7.0 flask-wtf-0.14.3 future-0.18.2 geographiclib-1.50 geopy-2.0.0 graphlib-backport-1.0.3 gunicorn-20.0.4 holidays-0.10.3 humanize-3.1.0 idna-2.10 ijson-3.1.2.post0 importlib-metadata-2.1.1 isodate-0.6.0 itsdangerous-1.1.0 jdcal-1.4.1 jinja2-2.11.3 jmespath-0.10.0 jsonlines-1.2.0 jsonschema-3.2.0 kombu-4.6.11 korean-lunar-calendar-0.2.1 linear-tsv-1.1.0 mako-1.1.3 markdown-3.3.3 markupsafe-1.1.1 marshmallow-3.9.0 marshmallow-enum-1.5.1 marshmallow-sqlalchemy-0.23.1 msgpack-1.0.0 multidict-5.0.0 mysqlclient-1.4.2.post1 natsort-7.0.1 numpy-1.19.4 openpyxl-3.0.5 packaging-20.4 pandas-1.2.2 parsedatetime-2.6 pathlib2-2.3.5 pgsanity-0.2.9 pillow-7.2.0 polyline-1.4.0 prison-0.1.3 psycopg2-binary-2.8.5 py-1.9.0 pyarrow-4.0.0 pycparser-2.20 pydruid-0.6.1 pygithub-1.54.1 pyhive-0.6.3 pyjwt-1.7.1 pymeeus-0.3.7 pyparsing-2.4.7 pyrsistent-0.16.1 python-dateutil-2.8.1 python-dotenv-0.15.0 python-editor-1.0.4 python-geohash-0.8.5 python3-openid-3.2.0 pytz-2020.4 pyyaml-5.4.1 redis-3.5.3 requests-2.24.0 retry-0.9.2 rfc3986-1.4.0 s3transfer-0.3.3 sasl-0.2.1 selenium-3.141.0 simplejson-3.17.2 six-1.15.0 slackclient-2.5.0 sqlalchemy-1.3.20 sqlalchemy-utils-0.36.8 sqlparse-0.3.0 tableschema-1.20.0 tabulator-1.52.5 thrift-0.13.0 thrift-sasl-0.4.2 typing-extensions-3.7.4.3 unicodecsv-0.14.1 urllib3-1.25.11 vine-1.3.0 webencodings-0.5.1 werkzeug-1.0.1 wrapt-1.12.1 wtforms-2.3.3 wtforms-json-0.3.3 xlrd-1.2.0 yarl-1.6.2 zipp-3.4.1
```

### TESTING INSTRUCTIONS
Ran all the integration tests and E2E tests with no issues.
Currently running a test instance on aarch64  and amd64 with these changes, I have yet to find anything broken.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #8688 for arm64/aarch64
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
