### PR TITLE
fix: is_temporal should overwrite is_dttm

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -230,9 +230,9 @@ class TableColumn(Model, BaseColumn):
 
     @property
     def type_generic(self) -> Optional[utils.GenericDataType]:
-        column_spec = self.db_engine_spec.get_column_spec(self.type)
         if self.is_dttm:
             return GenericDataType.TEMPORAL
+        column_spec = self.db_engine_spec.get_column_spec(self.type)
         return column_spec.generic_type if column_spec else None
 
     def get_sqla_col(self, label: Optional[str] = None) -> Column:

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -231,6 +231,8 @@ class TableColumn(Model, BaseColumn):
     @property
     def type_generic(self) -> Optional[utils.GenericDataType]:
         column_spec = self.db_engine_spec.get_column_spec(self.type)
+        if self.is_dttm:
+            return GenericDataType.TEMPORAL
         return column_spec.generic_type if column_spec else None
 
     def get_sqla_col(self, label: Optional[str] = None) -> Column:

--- a/tests/sqla_models_tests.py
+++ b/tests/sqla_models_tests.py
@@ -102,6 +102,10 @@ class TestDatabaseModel(SupersetTestCase):
             self.assertEqual(col.is_numeric, db_col_type == GenericDataType.NUMERIC)
             self.assertEqual(col.is_string, db_col_type == GenericDataType.STRING)
 
+        for str_type, db_col_type in test_cases.items():
+            col = TableColumn(column_name="foo", type=str_type, table=tbl, is_dttm=True)
+            self.assertTrue(col.is_temporal)
+
     @patch("superset.jinja_context.g")
     def test_extra_cache_keys(self, flask_g):
         flask_g.user.username = "abc"


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Superset now uses `generic_type` to determine the icon that displays the column type. The `generic type` is an abstraction of the database column type, such as:
- integer/number/float mapping to `NUMERIC`
- varchar/text/string mapping to `STRING`
- datetime/timestamp mapping to `TEMPORAL`
- boolean/tinyint mapping to `BOOLEAN`

But there is one exception for historical reasons:
- The user can set a column as a datetime type, even if the column is of another column type. unfortunately this is not done by a SQL cast expression function, just a flag.

This PR resolve returns the `TEMPORAL` by determining whether the column contains the is_dttm flag, no matter what type it is.

NOTICE:  There is no such logic to `calculated column`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### Before
<img width="1445" alt="image" src="https://user-images.githubusercontent.com/2016594/119958530-b5903c00-bfd5-11eb-8f03-2075fbed534c.png">

### After


https://user-images.githubusercontent.com/2016594/119959278-6eef1180-bfd6-11eb-80d9-adf42b1d55e7.mp4



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/14754
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


closes https://github.com/apache/superset/issues/14754