### PR TITLE
chore: customize adhoc filter icon and fix creatable label

### DIFF
--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.jsx
@@ -369,6 +369,8 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
       labelText: comparator?.length > 0 && this.createSuggestionsPlaceholder(),
       autoFocus: focusComparator,
     };
+    const Icon =
+      operator === 'NOT IN' ? Icons.StopOutlined : Icons.CheckOutlined;
 
     return (
       <>
@@ -418,13 +420,7 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
             onSearch={val => this.setState({ currentSuggestionSearch: val })}
             onSelect={this.clearSuggestionSearch}
             onBlur={this.clearSuggestionSearch}
-            menuItemSelectedIcon={
-              operator === 'NOT IN' ? (
-                <Icons.StopOutlined iconSize="m" />
-              ) : (
-                <Icons.CheckOutlined iconSize="m" />
-              )
-            }
+            menuItemSelectedIcon={<Icon iconSize="m" />}
           >
             {this.state.suggestions.map(suggestion => (
               <Select.Option value={suggestion} key={suggestion}>

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.jsx
@@ -39,7 +39,7 @@ import AdhocFilter, {
   CLAUSES,
 } from 'src/explore/components/controls/FilterControl/AdhocFilter';
 import columnType from 'src/explore/components/controls/FilterControl/columnType';
-import { CheckOutlined, StopOutlined } from '@ant-design/icons';
+import Icons from 'src/components/Icons';
 
 const SelectWithLabel = styled(Select)`
   .ant-select-selector {
@@ -419,7 +419,11 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
             onSelect={this.clearSuggestionSearch}
             onBlur={this.clearSuggestionSearch}
             menuItemSelectedIcon={
-              operator === 'NOT IN' ? <StopOutlined /> : <CheckOutlined />
+              operator === 'NOT IN' ? (
+                <Icons.StopOutlined iconSize="m" />
+              ) : (
+                <Icons.CheckOutlined iconSize="m" />
+              )
             }
           >
             {this.state.suggestions.map(suggestion => (

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.jsx
@@ -39,6 +39,7 @@ import AdhocFilter, {
   CLAUSES,
 } from 'src/explore/components/controls/FilterControl/AdhocFilter';
 import columnType from 'src/explore/components/controls/FilterControl/columnType';
+import { CheckOutlined, StopOutlined } from '@ant-design/icons';
 
 const SelectWithLabel = styled(Select)`
   .ant-select-selector {
@@ -417,6 +418,9 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
             onSearch={val => this.setState({ currentSuggestionSearch: val })}
             onSelect={this.clearSuggestionSearch}
             onBlur={this.clearSuggestionSearch}
+            menuItemSelectedIcon={
+              operator === 'NOT IN' ? <StopOutlined /> : <CheckOutlined />
+            }
           >
             {this.state.suggestions.map(suggestion => (
               <Select.Option value={suggestion} key={suggestion}>
@@ -430,7 +434,7 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
                 suggestion => suggestion === currentSuggestionSearch,
               ) && (
                 <Select.Option value={currentSuggestionSearch}>
-                  {currentSuggestionSearch}
+                  {`${t('Create "%s"', currentSuggestionSearch)}`}
                 </Select.Option>
               )}
           </SelectWithLabel>

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -244,6 +244,8 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
     data.length === 0
       ? t('No data')
       : tn('%s option', '%s options', data.length, data.length);
+  const Icon = inverseSelection ? Icons.StopOutlined : Icons.CheckOutlined;
+
   return (
     <Styles height={height} width={width}>
       <StyledSelect
@@ -264,13 +266,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
         ref={inputRef}
         loading={isRefreshing}
         maxTagCount={5}
-        menuItemSelectedIcon={
-          inverseSelection ? (
-            <Icons.StopOutlined iconSize="m" />
-          ) : (
-            <Icons.CheckOutlined iconSize="m" />
-          )
-        }
+        menuItemSelectedIcon={<Icon iconSize="m" />}
       >
         {sortedData.map(row => {
           const [value] = groupby.map(col => row[col]);

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -282,7 +282,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
             suggestion => suggestion === currentSuggestionSearch,
           ) && (
             <Option value={currentSuggestionSearch}>
-              {currentSuggestionSearch}
+              {`${t('Create "%s"', currentSuggestionSearch)}`}
             </Option>
           )}
       </StyledSelect>

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -38,7 +38,7 @@ import React, {
 import { Select } from 'src/common/components';
 import debounce from 'lodash/debounce';
 import { SLOW_DEBOUNCE } from 'src/constants';
-import { CheckOutlined, StopOutlined } from '@ant-design/icons';
+import Icons from 'src/components/Icons';
 import { PluginFilterSelectProps, SelectValue } from './types';
 import { StyledSelect, Styles } from '../common';
 import { getDataRecordFormatter, getSelectExtraFormData } from '../../utils';
@@ -265,7 +265,11 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
         loading={isRefreshing}
         maxTagCount={5}
         menuItemSelectedIcon={
-          inverseSelection ? <StopOutlined /> : <CheckOutlined />
+          inverseSelection ? (
+            <Icons.StopOutlined iconSize="m" />
+          ) : (
+            <Icons.CheckOutlined iconSize="m" />
+          )
         }
       >
         {sortedData.map(row => {


### PR DESCRIPTION
### SUMMARY
Harmonize AntD Select components that are used in Explore/Dashboard view. This changes the following:
- Changes AdHoc Filter Select to show the `StopOutline` Icon if "NOT IN" operator is selected. This is to align the behavior with the native select filter polish introduced in #14873
- Show "Create: <value>" instead of "<value>" when given the option to create a select option that doesn't exist in the dataset. This is to mimic the behavior of the `react-select` based component used in Filter Box: ![image](https://user-images.githubusercontent.com/33317356/119962068-591a2600-bfaf-11eb-903e-7dd837af7795.png)

### BEFORE
When "NOT IN" is selected in the adhoc filter popover, we currently use the default `CheckOutlined` icon:
![image](https://user-images.githubusercontent.com/33317356/119961520-d4c7a300-bfae-11eb-9178-fe50cf0957e2.png)
When being presented with the option to create a value that doesn't exist in the dataset, the option to use a value that doesn't exist is shown as-is:
![image](https://user-images.githubusercontent.com/33317356/119962266-88c92e00-bfaf-11eb-968d-7e7e6fbbfe3b.png)


### AFTER
When "NOT IN" is selected in the adhoc filter popover, we now use the `StopOutlined`
![image](https://user-images.githubusercontent.com/33317356/119960095-47d01a00-bfad-11eb-81c0-cce508d98212.png)
When being presented with the option to create a value that doesn't exist in the dataset, The creatable value is prefixed with "Create" and the value placed inside quotes:
![image](https://user-images.githubusercontent.com/33317356/119961707-06406e80-bfaf-11eb-8b1e-e9aae7d0442f.png)




### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
