### PR TITLE
fix: docker superset home and datadir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,7 @@ ENV LANG=C.UTF-8 \
     SUPERSET_PORT=8088
 
 RUN useradd --user-group -d ${SUPERSET_HOME} --no-log-init --shell /bin/bash superset \
+        && chown -R superset:superset /app
         && mkdir -p ${PYTHONPATH} \
         && apt-get update -y \
         && apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,7 @@ ENV LANG=C.UTF-8 \
     SUPERSET_PORT=8088
 
 RUN useradd --user-group -d ${SUPERSET_HOME} --create-home --no-log-init --shell /bin/bash superset \
-        && chown -R superset:superset /app
+        && chown -R superset:superset /app \
         && mkdir -p ${PYTHONPATH} \
         && apt-get update -y \
         && apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,8 +84,8 @@ ENV LANG=C.UTF-8 \
     SUPERSET_HOME="/app/superset_home" \
     SUPERSET_PORT=8088
 
-RUN useradd --user-group -d ${SUPERSET_HOME} --create-home --no-log-init --shell /bin/bash superset \
-        && chown -R superset:superset /app \
+RUN useradd --user-group -d ${SUPERSET_HOME} --no-log-init --shell /bin/bash superset \
+        && mkdir -p ${SUPERSET_HOME} \
         && mkdir -p ${PYTHONPATH} \
         && apt-get update -y \
         && apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ ENV LANG=C.UTF-8 \
     SUPERSET_HOME="/app/superset_home" \
     SUPERSET_PORT=8088
 
-RUN useradd --user-group -d ${SUPERSET_HOME} --no-log-init --shell /bin/bash superset \
+RUN useradd --user-group -d ${SUPERSET_HOME} --create-home --no-log-init --shell /bin/bash superset \
         && chown -R superset:superset /app
         && mkdir -p ${PYTHONPATH} \
         && apt-get update -y \


### PR DESCRIPTION
### SUMMARY
Fixes superset home directory on docker, associated issue #14867

Superset actually tries to create superset home:
https://github.com/apache/superset/blob/b38596fd961ae3317554dd79984df710601aa135/superset/app.py#L94

### ADDITIONAL INFORMATION
- [ ] Has associated issue: #14867
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
