### PR TITLE
fix(filter box): replace freeform where clause with ilike

### DIFF
--- a/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
@@ -223,10 +223,10 @@ class FilterBox extends React.PureComponent {
         ? [
             {
               clause: 'WHERE',
-              comparator: null,
-              expressionType: 'SQL',
-              // TODO: Evaluate SQL Injection risk
-              sqlExpression: `lower(${key}) like '%${input}%'`,
+              expressionType: 'SIMPLE',
+              subject: key,
+              operator: 'ILIKE',
+              comparator: `%${input}%`,
             },
           ]
         : null,


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This is a backport of #14710 to Filter Box to make the Filter Box less error prone and also be able to use database specific case insensitive LIKEs by utilizing the `ILIKE` SqlAlchemy operator.

### BEFORE
Previously special characters broke the filter box Search All Options feature. In the example below, we are trying to search for the string `' 12` in the options, which should be found:
![image](https://user-images.githubusercontent.com/33317356/119980373-db611500-bfc4-11eb-9f3d-74b25ced1309.png)

### AFTER
Now the special characters are handled properly by SqlAlchemy, and the respective row is found:
![image](https://user-images.githubusercontent.com/33317356/119980640-3bf05200-bfc5-11eb-8f88-5330729e60a9.png)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
