### PR TITLE
fix: Remove Icon and align close button on DatasetModal

### DIFF
--- a/superset-frontend/src/views/CRUD/data/dataset/AddDatasetModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDatasetModal.tsx
@@ -20,7 +20,6 @@ import React, { FunctionComponent, useState } from 'react';
 import { styled, t } from '@superset-ui/core';
 import { useSingleViewResource } from 'src/views/CRUD/hooks';
 import { isEmpty, isNil } from 'lodash';
-import Icon from 'src/components/Icon';
 import Modal from 'src/components/Modal';
 import TableSelector from 'src/components/TableSelector';
 import withToasts from 'src/messageToasts/enhancers/withToasts';
@@ -38,10 +37,6 @@ interface DatasetModalProps {
   onHide: () => void;
   show: boolean;
 }
-
-const StyledIcon = styled(Icon)`
-  margin: auto ${({ theme }) => theme.gridUnit * 2}px auto 0;
-`;
 
 const TableSelectorContainer = styled.div`
   padding-bottom: 340px;
@@ -105,12 +100,7 @@ const DatasetModal: FunctionComponent<DatasetModalProps> = ({
       onHide={onHide}
       primaryButtonName={t('Add')}
       show={show}
-      title={
-        <>
-          <StyledIcon name="warning-solid" />
-          {t('Add dataset')}
-        </>
-      }
+      title={<>{t('Add dataset')}</>}
     >
       <TableSelectorContainer>
         <TableSelector

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDatasetModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDatasetModal.tsx
@@ -100,7 +100,7 @@ const DatasetModal: FunctionComponent<DatasetModalProps> = ({
       onHide={onHide}
       primaryButtonName={t('Add')}
       show={show}
-      title={<>{t('Add dataset')}</>}
+      title={t('Add dataset')}
     >
       <TableSelectorContainer>
         <TableSelector


### PR DESCRIPTION
### SUMMARY
The Dataset Modal had a ! icon that didn't make sense and was causing the header to be misaligned. This removes that, which aligns everything.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: 
![image](https://user-images.githubusercontent.com/48933336/120014226-ce85f680-bfaf-11eb-9fab-b7ccec6f6500.png)

After: 
![image](https://user-images.githubusercontent.com/48933336/120014239-d2b21400-bfaf-11eb-9135-ec6cb52b08c2.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Go to Datasets
Add a dataset

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
