### PR TITLE
fix: test container image with container-structure-test

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,6 +34,12 @@ jobs:
           docker build --target ci -t ${{ github.sha }} -t "pr-${{ github.event.pull_request.number }}" .
           docker save ${{ github.sha }} | gzip > ./build/${{ github.sha }}.tar.gz
 
+      - name: Test built image
+        uses: brpaz/structure-tests-action@v1.1.2
+        with:
+         image: "pr-${{ github.event.pull_request.number }}"
+         configFile: docker/container_image_test.yml
+
       - name: Upload build artifacts
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,8 +84,8 @@ ENV LANG=C.UTF-8 \
     SUPERSET_HOME="/app/superset_home" \
     SUPERSET_PORT=8088
 
-RUN useradd --user-group -d ${SUPERSET_HOME} --no-log-init --shell /bin/bash superset \
-        && mkdir -p ${PYTHONPATH} \
+RUN mkdir -p ${PYTHONPATH} \
+        && useradd --user-group -d ${SUPERSET_HOME} -m --no-log-init --shell /bin/bash superset \
         && apt-get update -y \
         && apt-get install -y --no-install-recommends \
             build-essential \

--- a/docker/container_image_test.yaml
+++ b/docker/container_image_test.yaml
@@ -1,3 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 schemaVersion: "2.0.0"
 fileExistenceTests:
 - name: superset_home

--- a/docker/container_image_test.yaml
+++ b/docker/container_image_test.yaml
@@ -1,0 +1,11 @@
+schemaVersion: "2.0.0"
+fileExistenceTests:
+- name: superset_home
+  path: /app/superset_home
+  uid: 1000
+  gid: 1000
+metadataTest:
+  env:
+  - key: SUPERSET_HOME
+    value: /app/superset_home
+  exposedPorts: ["8088"]


### PR DESCRIPTION
### SUMMARY
It adds a new step in action workflow for building container image.

I'm using a fix to test this PR and will remove commit https://github.com/apache/superset/pull/14905/commits/3d7903c68e1e679c4fdcfc2d80220317d86d6540 once test is done!

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
```
container-structure-test -i apache/superset:latest -c docker/container_image_test.yaml
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #14904
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


closes #14904