### PR TITLE
chore: Add Slovenian (sl_SI) translation

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -303,6 +303,7 @@ LANGUAGES = {
     "pt_BR": {"flag": "br", "name": "Brazilian Portuguese"},
     "ru": {"flag": "ru", "name": "Russian"},
     "ko": {"flag": "kr", "name": "Korean"},
+    "sl": {"flag": "si", "name": "Slovenian"},
 }
 # Turning off i18n by default as translation in most languages are
 # incomplete and not well maintained.

--- a/superset/translations/sl/LC_MESSAGES/messages.json
+++ b/superset/translations/sl/LC_MESSAGES/messages.json
@@ -1,0 +1,4501 @@
+{
+  "domain": "superset",
+  "locale_data": {
+    "superset": {
+      "": {
+        "domain": "superset",
+        "plural_forms": "nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100>=3 && n%100<=4 ? 2 : 3);",
+        "lang": "sl_SI"
+      },
+      "Home": ["Domov"],
+      "Annotation Layers": ["Sloji z oznakami"],
+      "Manage": ["Upravljaj"],
+      "Databases": ["Podatkovne baze"],
+      "Data": ["Podatki"],
+      "Datasets": ["Podatkovni seti"],
+      "Charts": ["Grafikoni"],
+      "Dashboards": ["Nadzorne plošče"],
+      "Plugins": ["Vtičniki"],
+      "CSS Templates": ["CSS predloge"],
+      "Row level security": ["Varnost na nivoju vrstic"],
+      "Security": ["Varnost"],
+      "Import Dashboards": ["Uvozi nadzorne plošče"],
+      "SQL Editor": ["SQL urejevalnik"],
+      "SQL Lab": ["SQL laboratorij"],
+      "Saved Queries": ["Shranjene poizvedbe"],
+      "Query History": ["Zgodovina poizvedb"],
+      "Upload a CSV": ["Naloži CSV"],
+      "Upload Excel": ["Naloži Excel"],
+      "Action Log": ["Dnevnik aktivnosti"],
+      "Dashboard Emails": ["E-pošta za nadzorno ploščo"],
+      "Chart Email Schedules": ["Urniki za e-pošto grafikonov"],
+      "Alerts": ["Opozorila"],
+      "Alerts & Reports": ["Opozorila in poročila"],
+      "Access requests": ["Zahteve za dostop"],
+      "Druid Datasources": ["Druid podatkovni viri"],
+      "Druid Clusters": ["Druid gruče"],
+      "Scan New Datasources": ["Preišči nove podatkovne vire"],
+      "Refresh Druid Metadata": ["Osveži metapodatke za Druid"],
+      "Issue 1000 - The datasource is too large to query.": [
+        "Težava 1000 - podatkovni vir je prevelik za poizvedbo."
+      ],
+      "Issue 1001 - The database is under an unusual load.": [
+        "Težava 1001 - podatkovni vir je neobičajno obremenjen."
+      ],
+      "Issue 1002 - The database returned an unexpected error.": [
+        "Težava 1002 - podatkovna baza je vrnila nepričakovano napako."
+      ],
+      "Issue 1003 - There is a syntax error in the SQL query. Perhaps there was a misspelling or a typo.": [
+        "Težava 1003 - v SQL-poizvedbi je sintaktična napaka. Mogoče ste se zatipkali."
+      ],
+      "Issue 1004 - The column was deleted or renamed in the database.": [
+        "Težava 1004 - stolpec je bil izbrisan ali preimenovan v podatkovni bazi."
+      ],
+      "Issue 1005 - The table was deleted or renamed in the database.": [
+        "Težava 1005 - tabela je bila izbrisana ali preimenovana v podatkovni bazi."
+      ],
+      "Issue 1005 - The schema was deleted or renamed in the database.": [
+        "Težava 1005 - shema je bila izbrisana ali preimenovana v podatkovni bazi."
+      ],
+      "Issue 1006 - One or more parameters specified in the query are missing.": [
+        "Težava 1006 - en ali več parametrov v SQL-poizvedbi manjka."
+      ],
+      "Issue 1007 - The hostname provided can't be resolved.": [
+        "Težava 1007 - imena gostitelja ni mogoče razrešiti."
+      ],
+      "Issue 1008 - The port is closed.": ["Težava 1008 - Vrata so zaprta."],
+      "Issue 1009 - The host might be down, and can't be reached on the provided port.": [
+        "Težava 1009 - Gostitelj mogoče ne deluje in ga ni mogoče doseči preko podanih vrat."
+      ],
+      "Issue 1010 - Superset encountered an error while running a command.": [
+        "Težava 1010 - Superset je naletel na napako pri izvajanju ukaza."
+      ],
+      "Issue 1011 - Superset encountered an unexpected error.": [
+        "Težava 1011 - Superset je naletel na nepričakovano napako."
+      ],
+      "Issue 1012 - The username provided when connecting to a database is not valid.": [
+        "Težava 1012 - Uporabniško ime za povezavo s podatkovno bazo je neveljavno."
+      ],
+      "Issue 1013 - The password provided when connecting to a database is not valid.": [
+        "Težava 1013 - Geslo za povezavo s podatkovno bazo je neveljavno."
+      ],
+      "Issue 1014 - Either the username or the password is wrong.": [
+        "Težava 1014 - Uporabniško ime ali/in geslo sta napačna."
+      ],
+      "Issue 1015 - Either the database is spelled incorrectly or does not exist.": [
+        "Težava 1015 - Ime podatkovne baze je zapisano napačno ali pa ne obstaja."
+      ],
+      "Issue 1017 - User doesn't have the proper permissions.": [
+        "Težava 1017 - Uporabnik nima ustreznih dovoljenj."
+      ],
+      "Issue 1018 - One or more parameters needed to configure a database are missing.": [
+        "Težava 1018 - Eden ali več parametrov, potrebnih za nastavitev podatkovne baze, manjka."
+      ],
+      "Issue 1019 - The submitted payload has the incorrect format.": [
+        "Težava 1019 - Podani podatki so v neustrezni obliki."
+      ],
+      "Issue 1020 - The submitted payload has the incorrect schema.": [
+        "Težava 1020 - Podani podatki imajo neustrezno shemo."
+      ],
+      "Invalid certificate": ["Neveljaven certifikat"],
+      "Unsafe return type for function %(func)s: %(value_type)s": [
+        "Nevaren tip rezultata, ki ga vrne funkcija %(func)s: %(value_type)s"
+      ],
+      "Unsupported return value for method %(name)s": [
+        "Nepodprt rezultat vračanja za metodo %(name)s"
+      ],
+      "Unsafe template value for key %(key)s: %(value_type)s": [
+        "Nevaren vzorec za ključ %(key)s: %(value_type)s"
+      ],
+      "Unsupported template value for key %(key)s": [
+        "Nepodprta vrednost vzorca za ključ %(key)s"
+      ],
+      "SQL Lab timeout. This environment's policy is to kill queries after {} seconds.": [
+        "Iztek časa SQL laboratorija. Nastavitev okolja določa prekinitev poizvedb po izteku {} sekund."
+      ],
+      "Only `SELECT` statements are allowed against this database": [
+        "Za to podatkovno bazo so dovoljeni le `SELECT` stavki"
+      ],
+      "CTAS (create table as select) can only be run with a query where the last statement is a SELECT. Please make sure your query has a SELECT as its last statement. Then, try running your query again.": [
+        "CTAS (create table as select) lahko izvajate le v poizvedbah, kjer je zadnji stavek SELECT. Poskrbite, da bo zadnji stavek v vaši poizvedbi SELECT in poskusite ponovno zagnati poizvedbo."
+      ],
+      "CVAS (create view as select) can only be run with a query with a single SELECT statement. Please make sure your query has only a SELECT statement. Then, try running your query again.": [
+        "CVAS (create view as select) lahko izvajate le v poizvedbah z enim SELECT stavkom. Poskrbite, da bo v vaši poizvedbi le en SELECT stavek in poskusite ponovno zagnati poizvedbo."
+      ],
+      "Viz is missing a datasource": ["Vizualizaciji manjka podatkovni vir"],
+      "Applied rolling window did not return any data. Please make sure the source query satisfies the minimum periods defined in the rolling window.": [
+        "Izbrano drseče okno ni vrnilo podatkov. Poskrbite, da izvorna poizvedba ustreza minimalni periodi drsečega okna."
+      ],
+      "From date cannot be larger than to date": [
+        "Začetni datum ne sme biti večji od končnega datuma"
+      ],
+      "Cached value not found": ["Predpomnjena vrednost ni najdena"],
+      "Columns missing in datasource: %(invalid_columns)s": [
+        "V podatkovnem viru manjkajo stolpci: %(invalid_columns)s"
+      ],
+      "Table View": ["Tabelarični pogled"],
+      "You cannot use [Columns] in combination with [Group By]/[Metrics]/[Percentage Metrics]. Please choose one or the other.": [
+        "Ne smete uporabiti [Stolpci] v kombinaciji z [Združevanje]/[Mere]/[Procentualne mere]. Izberite eno ali drugo."
+      ],
+      "Pick a granularity in the Time section or uncheck 'Include Time'": [
+        "Izberite granulacijo v razdelku 'Čas' ali odstranite 'Vključi čas'"
+      ],
+      "Time Table View": ["Pogled urnika"],
+      "Pick at least one metric": ["Izberite vsaj eno mero"],
+      "When using 'Group By' you are limited to use a single metric": [
+        "Ko uporabljate 'Group By', ste omejeni na uporabo ene mere"
+      ],
+      "Pivot Table": ["Vrtilna tabela"],
+      "Please choose at least one 'Group by' field ": [
+        "Izberite vsaj eno 'Group by' polje "
+      ],
+      "Please choose at least one metric": ["Izberite vsaj eno mero"],
+      "Group By' and 'Columns' can't overlap": [
+        "'Združevanje' in 'Stolpci' se ne smeta prekrivati"
+      ],
+      "Treemap": ["Drevesni grafikon s pravokotniki"],
+      "Calendar Heatmap": ["Koledarska barvna lestvica"],
+      "Bubble Chart": ["Mehurčkasti grafikon"],
+      "Please use 3 different metric labels": [
+        "Uporabite 3 različne oznake mer"
+      ],
+      "Pick a metric for x, y and size": ["Izberite mere za x, y in velikost"],
+      "Bullet Chart": ["'Bullet' grafikon"],
+      "Pick a metric to display": ["Izberite mero za prikaz"],
+      "Big Number with Trendline": ["Velika številka s trendno krivuljo"],
+      "Pick a metric!": ["Izberite mero!"],
+      "Big Number": ["Velika številka"],
+      "Time Series - Line Chart": ["Časovna vrsta - Črtni grafikon"],
+      "Pick a time granularity for your time series": [
+        "Izberite granulacijo časa za časovno vrsto"
+      ],
+      "An enclosed time range (both start and end) must be specified when using a Time Comparison.": [
+        "Pri časovni primerjavi mora biti določeno zaprto časovno obdobje (s časom začetka in konca)."
+      ],
+      "Time Series - Multiple Line Charts": [
+        "Časovna vrsta - Veččrtni grafikon"
+      ],
+      "Time Series - Dual Axis Line Chart": [
+        "Časovna vrsta - Črtni grafikon z dvojno osjo"
+      ],
+      "Pick a metric for left axis!": ["Izberite mero za levo os!"],
+      "Pick a metric for right axis!": ["Izberite mero za desno os!"],
+      "Please choose different metrics on left and right axis": [
+        "Izberite različni meri za levo in desno os"
+      ],
+      "Time Series - Bar Chart": ["Časovna vrsta - Stolpčni grafikon"],
+      "Time Series - Period Pivot": ["Časovna vrsta - Vrtenje period"],
+      "Time Series - Percent Change": [
+        "Časovna vrsta - Procentualna sprememba"
+      ],
+      "Time Series - Stacked": ["Časovna vrsta - Naložen graf"],
+      "Histogram": ["Histogram"],
+      "Must have at least one numeric column specified": [
+        "Definiran mora biti vsaj en numerični stolpec"
+      ],
+      "Distribution - Bar Chart": ["Porazdelitev - Stolpčni grafikon"],
+      "Can't have overlap between Series and Breakdowns": [
+        "Ne sme imeti prekrivanja med podatkovnimi serijami in členitvami"
+      ],
+      "Pick at least one field for [Series]": [
+        "Izberite vsaj eno polje za [Serije]"
+      ],
+      "Sunburst": ["Sunburst"],
+      "Sankey": ["Sankey"],
+      "Pick exactly 2 columns as [Source / Target]": [
+        "Izberite natanko dva stolpca za [Izvor / Cilj]"
+      ],
+      "There's a loop in your Sankey, please provide a tree. Here's a faulty link: {}": [
+        "V 'Sankey' je zanka, določite drevo. To je okvarjena povezava: {}"
+      ],
+      "Directed Force Layout": ["Izgled usmerjene sile"],
+      "Country Map": ["Zemljevid držav"],
+      "World Map": ["Zemljevid sveta"],
+      "Filters": ["Filtri"],
+      "Invalid filter configuration, please select a column": [
+        "Neveljavna nastavitev filtrov, izberite stolpec"
+      ],
+      "Parallel Coordinates": ["Vzporedne koordinate"],
+      "Heatmap": ["Toplotni prikaz"],
+      "Horizon Charts": ["Horizontni grafikon"],
+      "Mapbox": ["Mapbox"],
+      "[Longitude] and [Latitude] must be set": [
+        "[Zemljepisna dolžina] in [Zemljepisna širina] morata biti nastavljeni"
+      ],
+      "Must have a [Group By] column to have 'count' as the [Label]": [
+        "Mora imeti stolpec [Združevanje], da ima število (count) kot [Oznaka]"
+      ],
+      "Choice of [Label] must be present in [Group By]": [
+        "Izbira [Oznaka] mora biti prisotna v [Združevanje]"
+      ],
+      "Choice of [Point Radius] must be present in [Group By]": [
+        "Izbran [Point Radius] mora biti prisoten v [Združevanje]"
+      ],
+      "[Longitude] and [Latitude] columns must be present in [Group By]": [
+        "Stolpca [Zemljepisna dolžina] in [Zemljepisna širina] morata biti prisotna v [Združevanje]"
+      ],
+      "Deck.gl - Multiple Layers": ["Deck.gl - Večplastni"],
+      "Bad spatial key": ["Neutrezen prostorski ključ"],
+      "Invalid spatial point encountered: %s": [
+        "Neustrezna prostorska točka: %s"
+      ],
+      "Encountered invalid NULL spatial entry,                                        please consider filtering those out": [
+        "Prišlo je do neveljavnega NULL prostorskega vnosa,                                        poskusite ga izločiti s filtrom"
+      ],
+      "Deck.gl - Scatter plot": ["Deck.gl - Raztreseni graf"],
+      "Deck.gl - Screen Grid": ["Deck.gl - Mreža"],
+      "Deck.gl - 3D Grid": ["Deck.gl - 3D mreža"],
+      "Deck.gl - Paths": ["Deck.gl - Poti"],
+      "Deck.gl - Polygon": ["Deck.gl - Poligon"],
+      "Deck.gl - 3D HEX": ["Deck.gl - 3D HEX"],
+      "Deck.gl - GeoJSON": ["Deck.gl - GeoJSON"],
+      "Deck.gl - Arc": ["Deck.gl - Arc"],
+      "Event flow": ["Potek dogodkov"],
+      "Time Series - Paired t-test": [
+        "Časovna vrsta - t-test za odvisne vzorce"
+      ],
+      "Time Series - Nightingale Rose Chart": [
+        "Časovna vrsta - Nightingale Rose grafikon"
+      ],
+      "Partition Diagram": ["Grafikon s pravokotniki"],
+      "Deleted %(num)d annotation layer": [
+        "Izbrisan je %(num)d sloj z oznakami",
+        "Izbrisana sta %(num)d sloja z oznakami",
+        "Izbrisanih so %(num)d sloji z oznakami",
+        "Izbrisanih je %(num)d slojev z oznakami"
+      ],
+      "All Text": ["Celotno besedilo"],
+      "Deleted %(num)d annotation": [
+        "Izbrisana je %(num)d oznaka",
+        "Izbrisani sta %(num)d oznaki",
+        "Izbrisane so %(num)d oznake",
+        "Izbrisanih je %(num)d oznak"
+      ],
+      "End date must be after start date": [
+        "Končni datum mora biti za začetnim"
+      ],
+      "Short description must be unique for this layer": [
+        "Kratek opis mora biti za ta sloj unikaten"
+      ],
+      "Annotations could not be deleted.": ["Oznak ni mogoče izbrisati."],
+      "Annotation not found.": ["Oznaka ni najdena."],
+      "Annotation parameters are invalid.": ["Parametri oznak so neveljavni."],
+      "Annotation could not be created.": ["Oznake ni mogoče ustvariti."],
+      "Annotation could not be updated.": ["Oznake ni mogoče posodobiti."],
+      "Annotation delete failed.": ["Izbris oznake ni uspel."],
+      "Annotation layer parameters are invalid.": [
+        "Parametri sloja z oznakami so neveljavni."
+      ],
+      "Annotation layer could not be deleted.": [
+        "Sloja z oznakami ni mogoče izbrisati."
+      ],
+      "Annotation layer could not be created.": [
+        "Sloja z oznakami ni mogoče ustvariti."
+      ],
+      "Annotation layer could not be updated.": [
+        "Sloja z oznakami ni mogoče posodobiti."
+      ],
+      "Annotation layer not found.": ["Sloja z oznakami ni mogoče najti."],
+      "Annotation layer delete failed.": ["Izbris sloja z oznakami ni uspel."],
+      "Annotation layer has associated annotations.": [
+        "Sloj z oznakami ima povezane oznake."
+      ],
+      "Name must be unique": ["Ime mora biti unikatno"],
+      "Deleted %(num)d chart": [
+        "Izbrisan je %(num)d grafikon",
+        "Izbrisana sta %(num)d grafikona",
+        "Izbrisani so %(num)d grafikoni",
+        "Izbrisanih je %(num)d grafikonov"
+      ],
+      "Request is not JSON": ["Zahtevek ni JSON"],
+      "Request is incorrect: %(error)s": ["Zahtevek je napačen: %(error)s"],
+      "`confidence_interval` must be between 0 and 1 (exclusive)": [
+        "`confidence_interval` mora biti med 0 in 1 (odprt)"
+      ],
+      "lower percentile must be greater than 0 and less than 100. Must be lower than upper percentile.": [
+        "spodnji percentil mora biti večji od 0 in manjši od 100 ter mora biti manjši od zgornjega percentila."
+      ],
+      "upper percentile must be greater than 0 and less than 100. Must be higher than lower percentile.": [
+        "zgornji percentil mora biti večji od 0 in manjši od 100 ter mora biti večji od spodnjega percentila."
+      ],
+      "`width` must be greater or equal to 0": [
+        "`width` mora biti večja ali enaka 0"
+      ],
+      "`row_limit` must be greater than or equal to 0": [
+        "`row_limit` mora biti večja ali enaka 0"
+      ],
+      "`row_offset` must be greater than or equal to 0": [
+        "`row_offset` mora biti večja ali enaka 1"
+      ],
+      "There are associated alerts or reports: %s,": [
+        "Prisotna so opozorila in poročila: %s,"
+      ],
+      "Time string is unclear. Please specify [%(human_readable)s ago] or [%(human_readable)s later].": [
+        "Časovni izraz je nejasen. Podajte [%(human_readable)s ago] ali [%(human_readable)s later]."
+      ],
+      "Cannot parse time string [%(human_readable)s]": [
+        "Ni mogoče razčleniti časovnega izraza [%(human_readable)s]"
+      ],
+      "Database does not exist": ["Podatkovna baza ne obstaja"],
+      "Dashboards do not exist": ["Nadzorna plošča ne obstaja"],
+      "Datasource type is required when datasource_id is given": [
+        "Ko se podaja datasource_id, je potreben tip podatkovnega vira"
+      ],
+      "Chart parameters are invalid.": ["Parametri grafikona so neveljavni."],
+      "Chart could not be created.": ["Grafikona ni mogoče ustvariti."],
+      "Chart could not be updated.": ["Grafikona ni mogoče posodobiti."],
+      "Chart could not be deleted.": ["Grafikona ni mogoče izbrisati."],
+      "There are associated alerts or reports": [
+        "Prisotna so povezana opozorila in poročila"
+      ],
+      "Changing this chart is forbidden": [
+        "Spreminjanje tega grafikona ni dovoljeno"
+      ],
+      "Charts could not be deleted.": ["Grafikonov ni mogoče izbrisati."],
+      "Import chart failed for an unknown reason": [
+        "Uvoz grafikona ni uspel zaradi neznanega razloga"
+      ],
+      "Owners are invalid": ["Lastniki niso veljavni"],
+      "Some roles do not exist": ["Nekatere vloge ne obstajajo"],
+      "Dataset does not exist": ["Podatkovni set ne obstaja"],
+      "Invalid result type: %(result_type)": [
+        "Neveljaven tip rezultata: %(result_type)"
+      ],
+      "The chart does not exist": ["Grafikon ne obstaja"],
+      "Duplicate column/metric labels: %(labels)s. Please make sure all columns and metrics have a unique label.": [
+        "Podvojene oznake stolpcev/mer: %(labels)s. Poskrbite, da bodo imeli stolpci in mere unikatne oznake."
+      ],
+      "`operation` property of post processing object undefined": [
+        "Lastnost  `operation` poprocesirnega objekta ni definirana"
+      ],
+      "Unsupported post processing operation: %(operation)s": [
+        "Nepodprta poprocesirna operacija: %(operation)s"
+      ],
+      "Adding new datasource [{}]": ["Dodajanje novega podatkovnega vira [{}]"],
+      "Refreshing datasource [{}]": ["Osveževanje podatkovnega vira [{}]"],
+      "Metric(s) {} must be aggregations.": ["Mere {} morajo biti agregacije."],
+      "Unsupported extraction function: ": [
+        "Nepodprta ekstrakcijska funkcija: "
+      ],
+      "Columns": ["Stolpci"],
+      "Show Druid Column": ["Pokaži Druid stolpec"],
+      "Add Druid Column": ["Dodaj Druid stolpec"],
+      "Edit Druid Column": ["Uredi Druid stolpec"],
+      "Column": ["Stolpec"],
+      "Type": ["Tip"],
+      "Datasource": ["Podatkovni vir"],
+      "Groupable": ["Združevanje"],
+      "Filterable": ["Filtriranje"],
+      "Whether this column is exposed in the `Filters` section of the explore view.": [
+        "Če želite, da je ta stolpec na voljo v sekciji `Filtri` v raziskovalnem pogledu."
+      ],
+      "Metrics": ["Mere"],
+      "Show Druid Metric": ["Prikaži Druid mere"],
+      "Add Druid Metric": ["Dodaj Druid mere"],
+      "Edit Druid Metric": ["Uredi Druid mere"],
+      "Metric": ["Mera"],
+      "Description": ["Opis"],
+      "Verbose Name": ["Podrobno ime"],
+      "JSON": ["JSON"],
+      "Druid Datasource": ["Podatkovni vir Druid"],
+      "Warning Message": ["Opozorilo"],
+      "Show Druid Cluster": ["Pokaži Druid gručo"],
+      "Add Druid Cluster": ["Dodaj Druid gručo"],
+      "Edit Druid Cluster": ["Uredi Druid gručo"],
+      "Cluster Name": ["Ime gruče"],
+      "Broker Host": ["Gostitelj posrednika"],
+      "Broker Port": ["Vrata posrednika"],
+      "Broker Username": ["Uporabniško ime posrednika"],
+      "Broker Password": ["Geslo posrednika"],
+      "Broker Endpoint": ["Končna točka posrednika"],
+      "Cache Timeout": ["Trajanje predpomnilnika"],
+      "Metadata Last Refreshed": ["Meta-podatki nazadnje osveženi"],
+      "Duration (in seconds) of the caching timeout for this cluster. A timeout of 0 indicates that the cache never expires. Note this defaults to the global timeout if undefined.": [
+        "Trajanje (v sekundah) predpomnjenja za to gručo. Vrednost 0 označuje, da predpomnilnik nikoli ne poteče. V primeru, da ni definirano, ima globalno nastavitev trajanja."
+      ],
+      "Druid supports basic authentication. See [auth](http://druid.io/docs/latest/design/auth.html) and druid-basic-security extension": [
+        "Druid podpira osnovno avtentikacijo. Glejte [auth](http://druid.io/docs/latest/design/auth.html) in razširitev druid-basic-security"
+      ],
+      "Show Druid Datasource": ["Prikaži podatkovni vir za Druid"],
+      "Add Druid Datasource": ["Dodaj podatkovni vir za Druid"],
+      "Edit Druid Datasource": ["Uredi podatkovni vir za Druid"],
+      "The list of charts associated with this table. By altering this datasource, you may change how these associated charts behave. Also note that charts need to point to a datasource, so this form will fail at saving if removing charts from a datasource. If you want to change the datasource for a chart, overwrite the chart from the 'explore view'": [
+        "Seznam grafikonov, povezanih s to tabelo. S spreminjanjem podatkovnega vira lahko spremenite, kako se povezani grafikoni obnašajo. Poleg tega morajo biti grafikoni povezani s podatkovnim virom. Če odstranite grafikon s podatkovnega vira ne bo mogoče shraniti tega vnosa. Če želite spremeniti podatkovni vir grafikona, prepišite grafikon v raziskovalnem pogledu."
+      ],
+      "Timezone offset (in hours) for this datasource": [
+        "Razlika časovnega pasu (v urah) za ta podatkovni vir"
+      ],
+      "Time expression to use as a predicate when retrieving distinct values to populate the filter component. Only applies when `Enable Filter Select` is on. If you enter `7 days ago`, the distinct list of values in the filter will be populated based on the distinct value over the past week": [
+        "Prednastavljeni časovni izraz za pridobitev različnih vrednosti filtrirne komponente. Upošteva se le v primeru, da je vključeno `Omogoči izbiro filtra`. Če vnesete `7 days ago`, bo seznam vrednosti filtra napolnjen na podlagi različnih vrednosti v prejšnjem tednu"
+      ],
+      "Whether to populate the filter's dropdown in the explore view's filter section with a list of distinct values fetched from the backend on the fly": [
+        "Če želite napolniti spustni seznam filtra v raziskovalnem pogledu filtrske sekcije z različnimi vrednostmi, pridobljenimi sproti v ozadju"
+      ],
+      "Redirects to this endpoint when clicking on the datasource from the datasource list": [
+        "Preusmeri v to končno točko, ko kliknete na podatkovni vir v seznamu podatkovnih virov"
+      ],
+      "Duration (in seconds) of the caching timeout for this datasource. A timeout of 0 indicates that the cache never expires. Note this defaults to the cluster timeout if undefined.": [
+        "Trajanje (v sekundah) predpomnjenja za ta podatkovni vir. Vrednost 0 označuje, da predpomnilnik nikoli ne poteče. V primeru, da ni definirano, ima nastavitev trajanja za gručo."
+      ],
+      "Associated Charts": ["Povezani grafikoni"],
+      "Data Source": ["Podatkovni vir"],
+      "Cluster": ["Gruča"],
+      "Owners": ["Lastniki"],
+      "Is Hidden": ["Skrito"],
+      "Enable Filter Select": ["Omogoči izbiro filtra"],
+      "Default Endpoint": ["Privzeta končna točka"],
+      "Time Offset": ["Časovni zamik"],
+      "Datasource Name": ["Ime podatkovnega vira"],
+      "Fetch Values From": ["Pridobi vrednosti iz"],
+      "Changed By": ["Spremenil/a"],
+      "Modified": ["Sprememba"],
+      "Refreshed metadata from cluster [{}]": [
+        "Osveženi meta-podatki iz gruče [{}]"
+      ],
+      "Only `SELECT` statements are allowed": [
+        "Dovoljeni so le `SELECT` stavki"
+      ],
+      "Only single queries supported": ["Podprte so le enojne poizvedbe"],
+      "Error in jinja expression in fetch values predicate: %(msg)s": [
+        "Napaka v jinja izrazu za pridobivanje vrednosti predikatov: %(msg)s"
+      ],
+      "Virtual dataset query must be read-only": [
+        "Poizvedba na virtualnem podatkovnem setu mora biti samo za branje"
+      ],
+      "Error while rendering virtual dataset query: %(msg)s": [
+        "Napaka pri izvajanju poizvedbe virtualnega podatkovnega seta: %(msg)s"
+      ],
+      "Virtual dataset query cannot be empty": [
+        "Poizvedba na virtualnem podatkovnem setu ne sme biti prazna"
+      ],
+      "Virtual dataset query cannot consist of multiple statements": [
+        "Poizvedba na virtualnem podatkovnem setu ne sme biti sestavljena iz več stavkov"
+      ],
+      "Error in jinja expression in RLS filters: %(msg)s": [
+        "Napaka v jinja izrazu RLS filtrov: %(msg)s"
+      ],
+      "Datetime column not provided as part table configuration and is required by this type of chart": [
+        "Stolpec datum-čas ni podan kot del tabele, čeprav mora biti za ta tip grafikona"
+      ],
+      "Empty query?": ["Prazna poizvedba?"],
+      "Metric '%(metric)s' does not exist": ["Mera '%(metric)s' ne obstaja"],
+      "Unknown column used in orderby: %(col)s": [
+        "Za razvrščanje je uporabljen neznan stolpec: %(col)s"
+      ],
+      "Time column \"%(col)s\" does not exist in dataset": [
+        "Časovni stolpec \"%(col)s\" ne obstaja v podatkovnem setu"
+      ],
+      "Filter value list cannot be empty": [
+        "Seznam vrednosti filtra ne sme biti prazen"
+      ],
+      "Must specify a value for filters with comparison operators": [
+        "Potrebno je podati vrednost za filter s primerjalnim operandom"
+      ],
+      "Invalid filter operation type: %(op)s": [
+        "Neveljaven tip operacije filtra: %(op)s"
+      ],
+      "Error in jinja expression in WHERE clause: %(msg)s": [
+        "Napaka v jinja izrazu WHERE stavka: %(msg)s"
+      ],
+      "Error in jinja expression in HAVING clause: %(msg)s": [
+        "Napaka v jinja izrazu HAVING stavka: %(msg)s"
+      ],
+      "Database does not support subqueries": [
+        "Podatkovna baza ne podpira podpoizvedb"
+      ],
+      "Db engine did not return all queried columns": [
+        "Sitem podatkovne baze ni vrnil vse stolpcev poizvedbe"
+      ],
+      "Show Column": ["Pokaži stolpec"],
+      "Add Column": ["Dodaj stolpec"],
+      "Edit Column": ["Uredi stolpec"],
+      "Whether to make this column available as a [Time Granularity] option, column has to be DATETIME or DATETIME-like": [
+        "Če želite, da bo ta stolpec na razpolago kot možnost [Granulacija časa]. Stolpec mora biti tipa DATETIME ali DATETIME-like"
+      ],
+      "The data type that was inferred by the database. It may be necessary to input a type manually for expression-defined columns in some cases. In most case users should not need to alter this.": [
+        "Podatkovni tip, ki izvira iz podatkovne baze. V nekaterih primerih je potrebno ročno vnesti tip za stolpce, ki temeljijo na izrazih. V večini primerov uporabniku tega ni potrebno spreminjati."
+      ],
+      "Table": ["Tabela"],
+      "Expression": ["Izraz"],
+      "Is temporal": ["Časoven"],
+      "Datetime Format": ["Oblika zapisa datuma,časa"],
+      "Invalid date/timestamp format": ["Neveljaven zapis datuma/časa"],
+      "Show Metric": ["Pokaži mero"],
+      "Add Metric": ["Dodaj mero"],
+      "Edit Metric": ["Uredi mero"],
+      "SQL Expression": ["SQL izraz"],
+      "D3 Format": ["D3 zapis"],
+      "Extra": ["Dodatno"],
+      "Row level security filter": ["Filter za varnost na nivoju vrstic"],
+      "Show Row level security filter": [
+        "Prikaži filter za varnost na nivoju vrstic"
+      ],
+      "Add Row level security filter": [
+        "Dodaj filter za varnost na nivoju vrstic"
+      ],
+      "Edit Row level security filter": [
+        "Uredi filter za varnost na nivoju vrstic"
+      ],
+      "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter. Base filters apply filters to all queries except the roles defined in the filter, and can be used to define what users can see if no RLS filters within a filter group apply to them.": [
+        "Navadni filtri dodajo WHERE stavek v poizvedbe, če ima uporabnik vlogo podano v filtru. Osnovni filtri filtrirajo vse poizvedbe, razen vlog, definiranih v filtru, in jih je mogoče uporabiti za nastavitev tega kaj uporabnik vidi, če v skupini filtrov ni RLS-filtrov, ki bi se nanašali nanje."
+      ],
+      "These are the tables this filter will be applied to.": [
+        "To so tabele, na katere se nanaša ta filter."
+      ],
+      "For regular filters, these are the roles this filter will be applied to. For base filters, these are the roles that the filter DOES NOT apply to, e.g. Admin if admin should see all data.": [
+        "Za regularne filtre so te vloge tiste, ki bodo filtrirane. Za osnovne filtre, so te vloge tiste, ki NE bodo filtrirane, npr. Admin, če naj administrator vidi vse podatke."
+      ],
+      "Filters with the same group key will be ORed together within the group, while different filter groups will be ANDed together. Undefined group keys are treated as unique groups, i.e. are not grouped together. For example, if a table has three filters, of which two are for departments Finance and Marketing (group key = 'department'), and one refers to the region Europe (group key = 'region'), the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe').": [
+        "Filtri z enakim skupinskim ključem bodo znotraj skupine združeni z OR funkcijo, medtem ko bodo različne skupine združene z AND funkcijo. Nedefinirani skupinski ključi so obravnavani kot unikatne skupine in niso združeni v svojo skupino. Npr., če ima tabela tri filtre, pri čemer sta dva za oddelka marketinga in financ (skupinski ključ = 'oddelek') tretji pa se nanaša na regijo Evropa (skupinski ključ = 'regija'), bo filtrski izraz (oddelek = 'Finance' OR oddelek = 'Marketing') AND (regija = 'Evropa')."
+      ],
+      "This is the condition that will be added to the WHERE clause. For example, to only return rows for a particular client, you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role, a base filter can be created with the clause `1 = 0` (always false).": [
+        "To je pogoj, ki bo dodan WHERE stavku. Npr., če želite dobiti vrstice za določeno stranko, lahko definirate regularni filter z izrazom 'id_stranke = 9'. Če ne želimo prikazati vrstic, razen če uporabnik pripada RLS vlogi, lahko filter ustvarimo z izrazom `1 = 0` (vedno neresnično)."
+      ],
+      "Tables": ["Tabele"],
+      "Roles": ["Vloge"],
+      "Clause": ["Stavek"],
+      "Creator": ["Avtor"],
+      "Show Table": ["Prikaži tabelo"],
+      "Import a table definition": ["Uvozi definicijo tabele"],
+      "Edit Table": ["Uredi tabelo"],
+      "Name of the table that exists in the source database": [
+        "Ime tabele, ki obstaja v izvorni podatkovni bazi"
+      ],
+      "Schema, as used only in some databases like Postgres, Redshift and DB2": [
+        "Shema, ki se uporablja pri nekaterih podatkovnih bazah, kot so Postgres, Redshift in DB2"
+      ],
+      "This fields acts a Superset view, meaning that Superset will run a query against this string as a subquery.": [
+        "To polje se obnaša kot Supersetov pogled, kar pomeni, da bo Superset izvedel poizvedbo za ta niz kot podpoizvedbo."
+      ],
+      "Predicate applied when fetching distinct value to populate the filter control component. Supports jinja template syntax. Applies only when `Enable Filter Select` is on.": [
+        "Privzeta vrednost za pridobivanje različnih vrednost pri oblikovanju filtrov. Podpira sintakso za jinja predloge. Potrebno le, ko je vključeno `Omogoči izbiro filtra`."
+      ],
+      "Redirects to this endpoint when clicking on the table from the table list": [
+        "Preusmeri v to končno točko, ko kliknete na tabelo v seznamu tabel"
+      ],
+      "Whether the table was generated by the 'Visualize' flow in SQL Lab": [
+        "Če želite, da je tabela ustvarjena s postopkom 'Vizualizacija' v SQL laboratoriju"
+      ],
+      "A set of parameters that become available in the query using Jinja templating syntax": [
+        "Nabor parametrov, ki postanejo razpoložljivi za poizvedbo z uporabo sintakse za Jinja predloge"
+      ],
+      "Duration (in seconds) of the caching timeout for this table. A timeout of 0 indicates that the cache never expires. Note this defaults to the database timeout if undefined.": [
+        "Trajanje (v sekundah) predpomnjenja za to tabelo. Vrednost 0 označuje, da predpomnilnik nikoli ne poteče. V primeru, da ni definirano, ima nastavitev trajanja za podatkovno bazo."
+      ],
+      "Database": ["Podatkovna baza"],
+      "Last Changed": ["Zadnja sprememba"],
+      "Schema": ["Shema"],
+      "Offset": ["Odmik"],
+      "Table Name": ["Ime tabele"],
+      "Fetch Values Predicate": ["Pridobi vrednosti predikatov"],
+      "Main Datetime Column": ["Glavni stolpec Datum-Čas"],
+      "SQL Lab View": ["Pogled SQL laboratorija"],
+      "Template parameters": ["Parametri predlog"],
+      "The table was created. As part of this two-phase configuration process, you should now click the edit button by the new table to configure it.": [
+        "Tabela je ustvarjena. Sedaj morate v tem dvodelnem postopku klikniti gumb za urejanje nove tabele."
+      ],
+      "Refresh Metadata": ["Osveži metapodatke"],
+      "Refresh column metadata": ["Osveži metapodatke stolpca"],
+      "Metadata refreshed for the following table(s): %(tables)s": [
+        "Metapodatki osveženi za naslednje tabele: %(tables)s"
+      ],
+      "The following tables added new columns: %(tables)s": [
+        "Nove stolpce so dodale naslednje tabele: %(tables)s"
+      ],
+      "The following tables removed columns: %(tables)s": [
+        "Stolpce so odstranile naslednje tabele: %(tables)s"
+      ],
+      "The following tables update column metadata: %(tables)s": [
+        "Metapodatke stolpcev so posodobile naslednje tabele: %(tables)s"
+      ],
+      "Unable to refresh metadata for the following table(s): %(tables)s": [
+        "Ni mogoče osvežiti metapodatkov za naslednje tabele: %(tables)s"
+      ],
+      "Deleted %(num)d css template": [
+        "Izbrisana %(num)d css predloga",
+        "Izbrisani %(num)d css predlogi",
+        "Izbrisane %(num)d css predloge",
+        "Izbrisanih %(num)d css predlog"
+      ],
+      "CSS template could not be deleted.": [
+        "CSS predloge ni mogoče izbrisati."
+      ],
+      "CSS template not found.": ["CSS predloga ni najdena."],
+      "Deleted %(num)d dashboard": [
+        "Izbrisana je %(num)d nadzorna plošča",
+        "Izbrisani sta %(num)d nadzorni plošči",
+        "Izbrisane so %(num)d nadzorne plošče",
+        "Izbrisanih je %(num)d nadzornih plošč"
+      ],
+      "Title or Slug": ["Naslov ali `Slug`"],
+      "Role": ["Vloga"],
+      "Must be unique": ["Mora biti unikaten"],
+      "Dashboard parameters are invalid.": [
+        "Parametri nadzorne plošče so neveljavni."
+      ],
+      "Dashboard not found.": ["Nadzorna plošča ni najdena."],
+      "Dashboard could not be created.": [
+        "Nadzorne plošče ni mogoče ustvariti."
+      ],
+      "Dashboards could not be deleted.": [
+        "Nadzornih plošč ni mogoče izbrisati."
+      ],
+      "Dashboard could not be updated.": [
+        "Nadzorne plošče ni mogoče posodobiti."
+      ],
+      "Dashboard could not be deleted.": [
+        "Nadzorne plošče ni mogoče izbrisati."
+      ],
+      "Changing this Dashboard is forbidden": [
+        "Spreminjanje te nadzorne plošče ni dovoljeno"
+      ],
+      "Import dashboard failed for an unknown reason": [
+        "Uvoz nadzorne plošče ni uspel zaradi neznanega razloga"
+      ],
+      "You don't have access to this dashboard.": [
+        "Nimate dostopa do te nadzorne plošče."
+      ],
+      "No data in file": ["V datoteki ni podatkov"],
+      "Table name undefined": ["Ime tabele ni definirano"],
+      "Invalid connection string, a valid string usually follows: driver://user:password@database-host/database-name": [
+        "Neveljaven niz povezave - veljaven niz običajno sledi: driver://user:password@database-host/database-name"
+      ],
+      "Field cannot be decoded by JSON. %(msg)s": [
+        "Polja ni mogoče dekodirati z JSON. %(msg)s"
+      ],
+      "The metadata_params in Extra field is not configured correctly. The key %(key)s is invalid.": [
+        "Metadata_params v polju Dodatno niso pravilno nastavljeni. Ključ %(key)s je neveljaven."
+      ],
+      "An engine must be specified when passing individual parameters to a database.": [
+        "Pri podajanju posameznih parametrov podatkovne baze mora biti podan njen tip."
+      ],
+      "Engine \"%(engine)s\" is not a valid engine.": [
+        "\"%(engine)s\" ni veljaven tip podatkovne baze."
+      ],
+      "Engine spec \"InvalidEngine\" does not support being configured via individual parameters.": [
+        "Specifikacija baze \"InvalidEngine\" ne podpira konfiguracije s posameznimi parametri."
+      ],
+      "Database parameters are invalid.": [
+        "Parametri podatkovne baze so neveljavni."
+      ],
+      "A database with the same name already exists": [
+        "Podatkovna baza z enakim imenom že obstaja"
+      ],
+      "Field is required": ["Polje je obvezno"],
+      "Field cannot be decoded by JSON.  %{json_error}s": [
+        "Polja ni mogoče dekodirati z JSON.  %{json_error}s"
+      ],
+      "The metadata_params in Extra field is not configured correctly. The key %{key}s is invalid.": [
+        "Metadata_params v polju Dodatno niso pravilno nastavljeni. Ključ %{key}s je neveljaven."
+      ],
+      "Database not found.": ["Podatkovna baza ni najdena."],
+      "Database could not be created.": [
+        "Podatkovne baze ni mogoče ustvariti."
+      ],
+      "Database could not be updated.": [
+        "Podatkovne baze ni mogoče posodobiti."
+      ],
+      "Connection failed, please check your connection settings": [
+        "Povezava neuspešna. Preverite nastavitve povezave"
+      ],
+      "Cannot delete a database that has tables attached": [
+        "Podatkovne baze s povezanimi tabelami ni mogoče izbrisati"
+      ],
+      "Database could not be deleted.": [
+        "Podatkovne baze ni mogoče izbrisati."
+      ],
+      "Stopped an unsafe database connection": [
+        "Nevarna povezava s podatkovno bazo je bila ustavljena"
+      ],
+      "Could not load database driver": [
+        "Ni mogoče naložiti gonilnika podatkovne baze"
+      ],
+      "Unexpected error occurred, please check your logs for details": [
+        "Zgodila se je nepričakovana napaka. Podrobnosti preverite v dnevnikih"
+      ],
+      "Import database failed for an unknown reason": [
+        "Uvoz podatkovne baze ni uspel zaradi neznanega razloga"
+      ],
+      "Could not load database driver: {}": [
+        "Ni mogoče naložiti gonilnika podatkovne baze: {}"
+      ],
+      "Engine \"%(engine)s\" cannot be configured through parameters.": [
+        "Podatkovne baze tipa \"%(engine)s\" ni mogoče konfigurirati s parametri."
+      ],
+      "Database is offline.": ["Podatkovna baza ni povezana."],
+      "Deleted %(num)d dataset": [
+        "Izbrisan %(num)d podatkovni set",
+        "Izbrisana %(num)d podatkovna niza",
+        "Izbrisani %(num)d podatkovni nizi",
+        "Izbrisanih %(num)d podatkovnih nizov"
+      ],
+      "Null or Empty": ["Nič (NULL) ali prazen"],
+      "Dataset column not found.": ["Stolpec podatkovnega seta ni najden."],
+      "Dataset column delete failed.": [
+        "Brisanje stolpca podatkovnega seta neuspešno."
+      ],
+      "Changing this dataset is forbidden.": [
+        "Spreminjanje tega podatkovnega seta ni dovoljeno."
+      ],
+      "Dataset %(name)s already exists": ["Podatkovni set %(name)s že obstaja"],
+      "Database not allowed to change": [
+        "Podatkovne baze ni dovoljeno spreminjati"
+      ],
+      "One or more columns do not exist": ["En ali več stolpcev ne obstaja"],
+      "One or more columns are duplicated": [
+        "En ali več stolpcev je podvojenih"
+      ],
+      "One or more columns already exist": ["En ali več stolpcev že obstaja"],
+      "One or more metrics do not exist": ["Ena ali več mer ne obstaja"],
+      "One or more metrics are duplicated": ["Ena ali več mer je podvojenih"],
+      "One or more metrics already exist": ["Ena ali več mer že obstaja"],
+      "Table [%(table_name)s] could not be found, please double check your database connection, schema, and table name": [
+        "Tabele [%(table_name)s] ni mogoče najti. Preverite povezavo, shemo in ime podatkovne baze"
+      ],
+      "Dataset parameters are invalid.": [
+        "Parametri podatkovnega seta so neveljavni."
+      ],
+      "Dataset could not be created.": [
+        "Podatkovnega niza ni mogoče ustvariti."
+      ],
+      "Dataset could not be updated.": [
+        "Podatkovnega niza ni mogoče posodobiti."
+      ],
+      "Dataset could not be deleted.": [
+        "Podatkovnega niza ni mogoče izbrisati."
+      ],
+      "Dataset(s) could not be bulk deleted.": [
+        "Podatkovnih nizov ni mogoče množično izbrisati."
+      ],
+      "Changing this dataset is forbidden": [
+        "Spreminjanje tega podatkovnega seta ni dovoljeno"
+      ],
+      "Import dataset failed for an unknown reason": [
+        "Uvoz podatkovnega seta ni uspel zaradi neznanega razloga"
+      ],
+      "Dataset metric not found.": ["Mer podatkovnega seta ni najdena."],
+      "Dataset metric delete failed.": [
+        "Brisanje mere podatkovnega seta ni uspelo."
+      ],
+      "Original value": ["Izvorna vrednost"],
+      "Second": ["Sekunda"],
+      "Minute": ["Minuta"],
+      "5 minute": ["5 minut"],
+      "10 minute": ["10 minut"],
+      "15 minute": ["15 minut"],
+      "Half hour": ["Pol ure"],
+      "Hour": ["Ura"],
+      "Day": ["Dan"],
+      "Week": ["Teden"],
+      "Month": ["Mesec"],
+      "Quarter": ["Četrtletje"],
+      "Year": ["Leto"],
+      "Week starting sunday": ["Teden z začetkom v nedeljo"],
+      "Week starting monday": ["Teden z začetkom v ponedeljek"],
+      "Week ending saturday": ["Teden s koncem v soboto"],
+      "Week_ending sunday": ["Teden s koncem v nedeljo"],
+      "Username": ["Uporabniško ime"],
+      "Password": ["Geslo"],
+      "Hostname or IP address": ["Ime gostitelja ali IP naslov"],
+      "Database port": ["Vrata podatkovne baze"],
+      "Database name": ["Ime podatkovne baze"],
+      "Additional parameters": ["Dodatni parametri"],
+      "Use an encrypted connection to the database": [
+        "Uporabite šifrirano povezavo s podatkovno bazo"
+      ],
+      "We were unable to connect to your database. Please confirm that your service account has the Viewer and Job User roles on the project.": [
+        "Povezava s podatkovno bazo ni uspela. Preverite, da ima vaš dostop dodeljeni vlogi Viewer in Job User."
+      ],
+      "Either the username \"%(username)s\", password, or database name \"%(database)s\" is incorrect.": [
+        "Uporabniško ime \"%(username)s\", geslo ali ime podatkovne baze \"%(database)s\" so napačni."
+      ],
+      "The hostname \"%(hostname)s\" cannot be resolved.": [
+        "Imena gostitelja \"%(hostname)s\" ni mogoče razrešiti."
+      ],
+      "Port %(port)s on hostname \"%(hostname)s\" refused the connection.": [
+        "Vrata %(port)s na gostitelju \"%(hostname)s\" niso sprejela povezave."
+      ],
+      "The host \"%(hostname)s\" might be down, and can't be reached on port %(port)s.": [
+        "Gostitelj \"%(hostname)s\" mogoče ne deluje in ga ni mogoče doseči na vratih %(port)s."
+      ],
+      "Either the username \"%(username)s\" or the password is incorrect.": [
+        "Uporabniško ime \"%(username)s\" ali geslo sta napačna."
+      ],
+      "Unknown MySQL server host \"%(hostname)s\".": [
+        "Neznan MySQL strežnik \"%(hostname)s\"."
+      ],
+      "The host \"%(hostname)s\" might be down and can't be reached.": [
+        "Gostitelj \"%(hostname)s\" mogoče ne deluje in ga ni mogoče doseči."
+      ],
+      "Unable to connect to database \"%(database)s\".": [
+        "Povezava s podatkovno bazo \"%(database)s\" ni uspela."
+      ],
+      "The username \"%(username)s\" does not exist.": [
+        "Uporabniško ime \"%(username)s\" ne obstaja."
+      ],
+      "The password provided for username \"%(username)s\" is incorrect.": [
+        "Geslo za uporabniško ime \"%(username)s\" je napačno."
+      ],
+      "Please re-enter the password.": ["Ponovno vpišite geslo."],
+      "We can't seem to resolve the column \"%(column_name)s\" at line %(location)s.": [
+        "Zdi se, da ni mogoče razrešiti stolpca \"%(column_name)s\" v vrstici %(location)s."
+      ],
+      "The table \"%(table_name)s\" does not exist. A valid table must be used to run this query.": [
+        "Tabela \"%(table_name)s\" ne obstaja. V poizvedbi mora biti uporabljena veljavna tabela."
+      ],
+      "The schema \"%(schema_name)s\" does not exist. A valid schema must be used to run this query.": [
+        "Shema \"%(schema_name)s\" ne obstaja. Za poizvedbo mora biti uporabljena veljavna shema."
+      ],
+      "Unable to connect to catalog named \"%(catalog_name)s\".": [
+        "Povezava na katalog \"%(catalog_name)s\" ni uspela."
+      ],
+      "Unknown Presto Error": ["Neznana Presto napaka"],
+      "We were unable to connect to your database named \"%(database)s\". Please verify your database name and try again.": [
+        "Povezava s podatkovno bazo \"%(database)s\" ni uspela. Preverite ime podatkovne baze in poskusite ponovno."
+      ],
+      "Temporal expression not supported for type: %(col_type)s": [
+        "Časovni izraz ni podprt za podatkovne tipe: %(col_type)s"
+      ],
+      "Deleted %(num)d saved query": [
+        "Izbrisana %(num)d shranjena poizvedba",
+        "Izbrisani %(num)d shranjeni poizvedbi",
+        "Izbrisane %(num)d shranjene poizvedbe",
+        "Izbrisanih %(num)d shranjenih poizvedb"
+      ],
+      "Saved queries could not be deleted.": [
+        "Shranjenih poizvedb ni mogoče izbrisati."
+      ],
+      "Saved query not found.": ["Shranjena poizvedba ni najdena."],
+      "Import saved query failed for an unknown reason.": [
+        "Uvoz shranjene poizvedbe ni uspel zaradi neznanega razloga."
+      ],
+      "Saved query parameters are invalid.": [
+        "Parametri shranjene poizvedbe so neveljavni."
+      ],
+      "Deleted %(num)d report schedule": [
+        "Izbrisan %(num)d urnik poročanja",
+        "Izbrisana %(num)d urnika poročanja",
+        "Izbrisani %(num)d urniki poročanja",
+        "Izbrisanih %(num)d urnikov poročanja"
+      ],
+      "Value must be greater than 0": ["Vrednost mora biti večja od 0"],
+      "Alert query returned more then one row. %s rows returned": [
+        "Opozorilna poizvedba je vrnila več kot eno vrstico. Število vrnjenih vrstic: %s"
+      ],
+      "Alert query returned more then one column. %s columns returned": [
+        "Opozorilna poizvedba je vrnila več kot en stolpec. Število vrnjenih stolpcev: %s"
+      ],
+      "Dashboard does not exist": ["Nadzorna plošča ne obstaja"],
+      "Chart does not exist": ["Grafikon ne obstaja"],
+      "Database is required for alerts": [
+        "Podatkovna baza je obvezna za opozorila"
+      ],
+      "Type is required": ["Tip je obvezen"],
+      "Choose a chart or dashboard not both": [
+        "Izberite grafikon ali nadzorno ploščo, ne obojega"
+      ],
+      "Report Schedule parameters are invalid.": [
+        "Parametri urnika poročanja so neveljavni."
+      ],
+      "Report Schedule could not be deleted.": [
+        "Urnika poročanja ni mogoče izbrisati."
+      ],
+      "Report Schedule could not be created.": [
+        "Urnika poročanja ni mogoče ustvariti."
+      ],
+      "Report Schedule could not be updated.": [
+        "Urnika poročanja ni mogoče posodobiti."
+      ],
+      "Report Schedule not found.": ["Urnika poročanja ni najden."],
+      "Report Schedule delete failed.": ["Izbris urnika poročanja ni uspel."],
+      "Report Schedule log prune failed.": [
+        "Krajšanje dnevnika urnika poročanja ni uspelo."
+      ],
+      "Report Schedule execution failed when generating a screenshot.": [
+        "Izvajanje urnika poročanja je bilo neuspešno pri ustvarjanju zaslonske slike."
+      ],
+      "Report Schedule execution failed when generating a csv.": [
+        "Izvajanje urnika poročanja je bilo neuspešno pri ustvarjanju csv."
+      ],
+      "Report Schedule execution got an unexpected error.": [
+        "Pri izvajanju urnika poročanja je prišlo do nepričakovane napake."
+      ],
+      "Report Schedule is still working, refusing to re-compute.": [
+        "Urnik poročanja se še vedno izvaja, ponovni izračun je zavrnjen."
+      ],
+      "Report Schedule reached a working timeout.": [
+        "Urnik poročanja je dosegel mejo časa izvedbe."
+      ],
+      "Alert query returned more then one row.": [
+        "Opozorilna poizvedba je vrnila več kot eno vrstico."
+      ],
+      "Alert validator config error.": [
+        "Napaka nastavitev potrjevalnika opozoril."
+      ],
+      "Alert query returned more then one column.": [
+        "Opozorilna poizvedba je vrnila več kot en stolpec."
+      ],
+      "Alert query returned a non-number value.": [
+        "Opozorilna poizvedba je vrnila neštevilsko vrednost."
+      ],
+      "Alert found an error while executing a query.": [
+        "Opozorilo je našlo napako pri izvajanju poizvedbe."
+      ],
+      "A timeout occurred while executing the query.": [
+        "Pri izvajanju poizvedbe je potekel čas."
+      ],
+      "A timeout occurred while taking a screenshot.": [
+        "Pri ustvarjanju zaslonske slike je potekel čas."
+      ],
+      "A timeout occurred while generating a csv.": [
+        "Pri ustvarjanju csv je potekel čas."
+      ],
+      "Alert fired during grace period.": [
+        "Opozorilo sproženo med obdobjem mirovanja."
+      ],
+      "Alert ended grace period.": ["Opozorilo je končalo obdobje mirovanja."],
+      "Alert on grace period": ["Opozorilo v obdobju mirovanja"],
+      "Report Schedule sellenium user not found": [
+        "Selenium uporabnik za urnik poročanja ni najden"
+      ],
+      "Report Schedule state not found": ["Stanje urnika poročanj ni najdeno"],
+      "Report schedule unexpected error": [
+        "Nepričakovana napaka urnika poročanja"
+      ],
+      "Changing this report is forbidden": [
+        "Spreminjanje tega poročila ni dovoljeno"
+      ],
+      "An error occurred while pruning logs ": [
+        "Pri krajšanju dnevnikov je prišlo do napake "
+      ],
+      "\n            Error: %(text)s\n            ": [
+        "\n            Napaka: %(text)s\n            "
+      ],
+      "\n            <p>%(description)s</p>\n            <b><a href=\"%(url)s\">Explore in Superset</a></b><p></p>\n            %(img_tag)s\n            ": [
+        "\n            <p>%(description)s</p>\n            <b><a href=\"%(url)s\">Razišči v Supersetu</a></b><p></p>\n            %(img_tag)s\n            "
+      ],
+      "%(name)s.csv": ["%(name)s.csv"],
+      "%(prefix)s %(title)s": ["%(prefix)s %(title)s"],
+      "\n            *%(name)s*\n\n            %(description)s\n\n            Error: %(text)s\n            ": [
+        "\n            *%(name)s*\n\n            %(description)s\n\n            Napaka: %(text)s\n            "
+      ],
+      "\n            *%(name)s*\n\n            %(description)s\n\n            <%(url)s|Explore in Superset>\n            ": [
+        "\n            *%(name)s*\n\n            %(description)s\n\n            <%(url)s|Razišči v Supersetu>\n            "
+      ],
+      "%(dialect)s cannot be used as a data source for security reasons.": [
+        "%(dialect)s ni mogoče uporabiti kot podatkovni vir zaradi varnostnih razlogov."
+      ],
+      "\n        *%(name)s*\n\n        <%(url)s|Explore in Superset>\n        ": [
+        "\n        *%(name)s*\n\n        <%(url)s|Razišči v Supersetu>\n        "
+      ],
+      "<b><a href=\"%(url)s\">Explore in Superset</a></b><p></p>": [
+        "<b><a href=\"%(url)s\">Razišči v Supersetu</a></b><p></p>"
+      ],
+      "\n            <b><a href=\"%(url)s\">Explore in Superset</a></b><p></p>\n            <img src=\"cid:%(msgid)s\">\n            ": [
+        "\n            <b><a href=\"%(url)s\">Razišči v Supersetu</a></b><p></p>\n            <img src=\"cid:%(msgid)s\">\n            "
+      ],
+      "\n        *%(slice_name)s*\n\n        <%(slice_url_user_friendly)s|Explore in Superset>\n        ": [
+        "\n        *%(slice_name)s*\n\n        <%(slice_url_user_friendly)s|Razišči v Supersetu>\n        "
+      ],
+      "[Alert] %(label)s": ["[Alert] %(label)s"],
+      "New": ["Nov"],
+      "SQL Query": ["SQL poizvedba"],
+      "Chart": ["Grafikon"],
+      "Dashboard": ["Nadzorna plošča"],
+      "Profile": ["Profil"],
+      "Info": ["Informacije"],
+      "Logout": ["Odjava"],
+      "Login": ["Prijava"],
+      "Record Count": ["Število zapisov"],
+      "No records found": ["Ni zapisov"],
+      "Filter List": ["Seznam filtrov"],
+      "Search": ["Iskanje"],
+      "Refresh": ["Osveži"],
+      "Import dashboards": ["Uvozi nadzorne plošče"],
+      "Import Dashboard(s)": ["Uvozi nadzorne plošče"],
+      "File": ["Datoteka"],
+      "Choose File": ["Izberite datoteko"],
+      "Upload": ["Naloži"],
+      "No Access!": ["Ni dostopa!"],
+      "You do not have permissions to access the datasource(s): %(name)s.": [
+        "Nimate dovoljenj za dostop do podatkovnih virov: %(name)s."
+      ],
+      "Request Permissions": ["Zahtevaj dovoljenja"],
+      "Cancel": ["Prekliči"],
+      "Use the edit buttom to change this field": [
+        "Za spreminjanje tega polja uporabite gumb za urejanje"
+      ],
+      "Test Connection": ["Preizkusi povezavo"],
+      "[Superset] Access to the datasource %(name)s was granted": [
+        "[Superset] dostop do podatkovnega vira %(name)s je odobren"
+      ],
+      "Unable to find such a holiday: [%(holiday)s]": [
+        "Ni mogoče najti takšnega praznika: [%(holiday)s]"
+      ],
+      "Referenced columns not available in DataFrame.": [
+        "Referencirani stolpci niso razpoložljivi v Dataframe-u."
+      ],
+      "Column referenced by aggregate is undefined: %(column)s": [
+        "Stolpec referenciran z agregacijo ni definiran: %(column)s"
+      ],
+      "Operator undefined for aggregator: %(name)s": [
+        "Operand ni definiran za agregatorja: %(name)s"
+      ],
+      "Invalid numpy function: %(operator)s": [
+        "Neveljavna numpy funkcija: %(operator)s"
+      ],
+      "Pivot operation requires at least one index": [
+        "Vrtilna operacija zahteva vsaj en indeks"
+      ],
+      "Pivot operation must include at least one aggregate": [
+        "Vrtilna operacija mora vsebovati vsaj en agregat"
+      ],
+      "Undefined window for rolling operation": [
+        "Nedefinirano okno za drsečo operacijo"
+      ],
+      "Invalid rolling_type: %(type)s": ["Neveljaven rolling_type: %(type)s"],
+      "Invalid options for %(rolling_type)s: %(options)s": [
+        "Neveljavne možnosti za %(rolling_type)s: %(options)s"
+      ],
+      "Invalid cumulative operator: %(operator)s": [
+        "Neveljaven kumulativni operand: %(operator)s"
+      ],
+      "Invalid geohash string": ["Neveljaven niz za geohash"],
+      "Invalid longitude/latitude": ["Neveljavna zemljepisna dolžina/širina"],
+      "Invalid geodetic string": ["Neveljaven geodetski niz"],
+      "Column \"%(column)s\" is not numeric or does not exists in the query results.": [
+        "Stolpec \"%(column)s\" ni numeričen ali ne obstaja v rezultatu poizvedbe."
+      ],
+      "`rename_columns` must have the same length as `columns`.": [
+        "`rename_columns` morajo imeti enako dolžino kot `columns`."
+      ],
+      "`prophet` package not installed": ["Knjižnica `prophet` ni nameščena"],
+      "Time grain missing": ["Časovna granulacija manjka"],
+      "Unsupported time grain: %(time_grain)s": [
+        "Nepodprta časovna granulacija: %(time_grain)s"
+      ],
+      "Periods must be a positive integer value": [
+        "Periode morajo biti pozitivno celo število"
+      ],
+      "Confidence interval must be between 0 and 1 (exclusive)": [
+        "Interval zaupanja mora biti med 0 in 1 (odprt)"
+      ],
+      "DataFrame must include temporal column": [
+        "DataFrame mora vsebovati časovni stolpec"
+      ],
+      "DataFrame include at least one series": [
+        "DataFrame vsebuje vsaj eno serijo"
+      ],
+      "percentiles must be a list or tuple with two numeric values, of which the first is lower than the second value": [
+        "percentili morajo biti tipa list ali tuple z vsaj dvema numeričnima vrednostma, pri čemer je prva manjša od druge"
+      ],
+      "User": ["Uporabnik"],
+      "User Roles": ["Vloge uporabnikov"],
+      "Database URL": ["URL podatkovne baze"],
+      "Roles to grant": ["Vloge za dovoljevanje"],
+      "Created On": ["Ustvarjeno"],
+      "List Observations": ["Naštej opažanja"],
+      "Show Observation": ["Prikaži opažanja"],
+      "Error Message": ["Sporočilo napake"],
+      "Log Retentions (days)": ["Ohranjanje dnevnika (dnevi)"],
+      "A semicolon ';' delimited list of email addresses": [
+        "S podpičjem ';' ločen seznam naslovov e-pošte"
+      ],
+      "How long to keep the logs around for this alert": [
+        "Kako dolgo ohraniti dnevnike za to opozorilo"
+      ],
+      "Once an alert is triggered, how long, in seconds, before Superset nags you again.": [
+        "Kako dolgo naj traja (v sekundah), da vas Superset ponovno opomni, ko je opozorilo sproženo."
+      ],
+      "A SQL statement that defines whether the alert should get triggered or not. The query is expected to return either NULL or a number value.": [
+        "SQL izraz, ki definira ali naj se opozorilo sproži ali ne. Od poizvedbe se pričakuje, da vrne bodisi NULL bodisi številsko vrednost."
+      ],
+      "This feature is deprecated and will be removed on 2.0. Take a look at the replacement feature <a href='https://superset.apache.org/docs/installation/alerts-reports'>Alerts & Reports documentation</a>": [
+        "Ta funkcija je zastarela in bo odstranjena v verziji 2.0. Oglejte si zamenjavo <a href='https://superset.apache.org/docs/installation/alerts-reports'>Dokumentacija za Opozorila & Poročila</a>"
+      ],
+      "annotation start time or end time is required.": [
+        "začetni in končni čas oznake je obvezen."
+      ],
+      "Annotation end time must be no earlier than start time.": [
+        "Končni čas oznake ne sem biti pred začetnim."
+      ],
+      "Annotations": ["Oznake"],
+      "Show Annotation": ["Prikaži oznako"],
+      "Add Annotation": ["Dodaj oznako"],
+      "Edit Annotation": ["Uredi oznako"],
+      "Layer": ["Sloj"],
+      "Label": ["Naziv"],
+      "Start": ["Začetek"],
+      "End": ["Konec"],
+      "JSON Metadata": ["JSON metapodatki"],
+      "Show Annotation Layer": ["Prikaži sloj z oznakami"],
+      "Add Annotation Layer": ["Dodaj sloj z oznakami"],
+      "Edit Annotation Layer": ["Uredi sloj z oznakami"],
+      "Name": ["Ime"],
+      "Table [%{table}s] could not be found, please double check your database connection, schema, and table name, error: {}": [
+        "Tabela [%{table}s] ni najdena. Preverite povezavo, shemo in ime tabele v podatkovni bazi. Napaka: {}"
+      ],
+      "json isn't valid": ["json ni veljaven"],
+      "Export to YAML": ["Izvozi v YAML"],
+      "Export to YAML?": ["Izvozim v YAML?"],
+      "Delete": ["Izbriši"],
+      "Delete all Really?": ["Ali resnično vse izbrišem?"],
+      "Is favorite": ["Je priljubljen"],
+      "The data source seems to have been deleted": [
+        "Zdi se, da je bil podatkovni vir izbrisan"
+      ],
+      "The user seems to have been deleted": [
+        "Zdi se, da je bil uporabnik izbrisan"
+      ],
+      "Access was requested": ["Zahtevan je bil dostop"],
+      "The access requests seem to have been deleted": [
+        "Zdi se, da je bila zahteva za dostop izbrisana"
+      ],
+      "%(user)s was granted the role %(role)s that gives access to the %(datasource)s": [
+        "Uporabniku %(user)s je bila dodeljena vloga %(role)s, ki omogoča dostop do %(datasource)s"
+      ],
+      "Role %(r)s was extended to provide the access to the datasource %(ds)s": [
+        "Vloga %(r)s je bila razširjena za zagotovitev dostopa do podatkovnega vira %(ds)s"
+      ],
+      "You have no permission to approve this request": [
+        "Nimate dovoljenja za odobritev te zahteve"
+      ],
+      "You don't have the rights to ": ["Nimate pravic za "],
+      "download as csv": ["prenos kot csv"],
+      "Cannot import dashboard: %(db_error)s.\nMake sure to create the database before importing the dashboard.": [
+        "Nadzorne plošče ni mogoče uvoziti: %(db_error)s.\nPred uvozom poskrbite za ustvarjenje podatkovne baze."
+      ],
+      "An unknown error occurred. Please contact your Superset administrator": [
+        "Zgodila se je neznana napaka. Kontaktirajte svojega administratorja za Superset"
+      ],
+      "[Missing Dataset]": ["[Manjka podatkovni set]"],
+      "alter this ": ["spreminjanje tega "],
+      "chart": ["grafikona"],
+      "create a ": ["ustvarite "],
+      "Explore - %(table)s": ["Razišči - %(table)s"],
+      "Explore": ["Raziskovanje"],
+      "Chart [{}] has been saved": ["Grafikon [{}] je bil shranjen"],
+      "Chart [{}] has been overwritten": ["Grafikon [{}] je bil prepisan"],
+      "dashboard": ["nadzorna plošča"],
+      "Chart [{}] was added to dashboard [{}]": [
+        "Grafikon [{}] je bil dodan na nadzorno ploščo [{}]"
+      ],
+      "Dashboard [{}] just got created and chart [{}] was added to it": [
+        "Nadzorna plošča [{}] je bila ravno ustvarjena in grafikon [{}] dodan nanjo"
+      ],
+      "This dashboard was changed recently. Please reload dashboard to get latest version.": [
+        "Nadzorna plošča je bila pred kratkim spremenjena. Ponovno jo naložite, da dobite zadnjo verzijo."
+      ],
+      "Could not load database driver: %(driver_name)s": [
+        "Gonilnika podatkovne baze ni mogoče naložiti: %(driver_name)s"
+      ],
+      "Invalid connection string, a valid string usually follows:\n'DRIVER://USER:PASSWORD@DB-HOST/DATABASE-NAME'": [
+        "Neveljaven niz povezave, veljaven niz običajno sledi:\n'DRIVER://USER:PASSWORD@DB-HOST/DATABASE-NAME'"
+      ],
+      "Malformed request. slice_id or table_name and db_name arguments are expected": [
+        "Deformirana zahteva. Pričakovani so argumenti slice_id ali table_name in db_name"
+      ],
+      "Chart %(id)s not found": ["Grafikon %(id)s ni najden"],
+      "Table %(table)s wasn't found in the database %(db)s": [
+        "Tabela %(table)s ni bila najdena v podatkovni bazi %(db)s"
+      ],
+      "Can't find User '%(name)s', please ask your admin to create one.": [
+        "Uporabnika '%(name)s' ni mogoče najti. Prosite administratorja, da ga ustvari."
+      ],
+      "Can't find DruidCluster with cluster_name = '%(name)s'": [
+        "Ni mogoče najti DruidCluster s cluster_name = '%(name)s'"
+      ],
+      "Data could not be deserialized. You may want to re-run the query.": [
+        "Podatkov ni mogoče deserializirati. Poskusite ponovno pognati poizvedbo."
+      ],
+      "%(validator)s was unable to check your query.\nPlease recheck your query.\nException: %(ex)s": [
+        "%(validator)s ni mogel preveriti vaše poizvedbe.\nPonovno preverite poizvedbo.\nIzjema: %(ex)s"
+      ],
+      "Failed to start remote query on a worker. Tell your administrator to verify the availability of the message queue.": [
+        "Zagon daljinske poizvedbe na delavcu ni bil uspešen. Administratorja prosite, da preveri razpoložljivost zaporedja sporočil."
+      ],
+      "Query record was not created as expected.": [
+        "Zapis poizvedbe ni bil ustvarjen, kot je bilo pričakovano."
+      ],
+      "The parameter %(parameters)s in your query is undefined.": [
+        "V vaši poizvedbi ni definiranih naslednjih parametrov: %(parameters)s.",
+        "V vaši poizvedbi ni definiranih naslednjih parametrov: %(parameters)s.",
+        "V vaši poizvedbi ni definiranih naslednjih parametrov: %(parameters)s.",
+        "V vaši poizvedbi ni definiranih naslednjih parametrov: %(parameters)s."
+      ],
+      "%(user)s's profile": ["Profil uporabnika: %(user)s"],
+      "Show CSS Template": ["Prikaži CSS predlogo"],
+      "Add CSS Template": ["Dodaj CSS predlogo"],
+      "Edit CSS Template": ["Uredi CSS predlogo"],
+      "Template Name": ["Ime predloge"],
+      "Request missing data field.": ["Zahtevaj manjkajoča podatkovna polja."],
+      "Duplicate column name(s): %(columns)s": [
+        "Podvojena imena stolpcev: %(columns)s"
+      ],
+      "A human-friendly name": ["Človeku prijazno ime"],
+      "Used internally to identify the plugin. Should be set to the package name from the pluginʼs package.json": [
+        "Uporablja se za interno identifikacijo vtičnika. Naj bo nastavljeno na ime paketa v vtičnikovem package.json"
+      ],
+      "A full URL pointing to the location of the built plugin (could be hosted on a CDN for example)": [
+        "Celoten URL, ki kaže na lokacijo zgrajenega vtičnika (lahko gostuje npr. na CDN)"
+      ],
+      "Custom Plugins": ["Prilagojeni vtičniki"],
+      "Custom Plugin": ["Prilagojeni vtičnik"],
+      "Add a Plugin": ["Dodaj vtičnik"],
+      "Edit Plugin": ["Uredi vtičnik"],
+      "Schedule Email Reports for Dashboards": [
+        "Razporedi e-poštna poročila za nadzorne plošče"
+      ],
+      "Manage Email Reports for Dashboards": [
+        "Upravljaj e-poštna poročila za nadzorne plošče"
+      ],
+      "Changed On": ["Spremenjeno"],
+      "Active": ["Aktiven"],
+      "Crontab": ["Crontab"],
+      "Recipients": ["Prejemniki"],
+      "Slack Channel": ["Slack Channel"],
+      "Deliver As Group": ["Dostavi kot skupino"],
+      "Delivery Type": ["Tip dostave"],
+      "Schedule Email Reports for Charts": [
+        "Razporedi e-poštna poročila za grafikone"
+      ],
+      "Manage Email Reports for Charts": [
+        "Upravljaj e-poštna poročila za grafikone"
+      ],
+      "Email Format": ["Oblika e-pošte"],
+      "List Saved Query": ["Seznam shranjenih poizvedb"],
+      "Show Saved Query": ["Prikaži shranjeno poizvedbo"],
+      "Add Saved Query": ["Dodaj shranjeno poizvedbo"],
+      "Edit Saved Query": ["Uredi shranjeno poizvedbo"],
+      "End Time": ["Končni čas"],
+      "Pop Tab Link": ["Prikaži povezavo zavihka"],
+      "Changed on": ["Spremenjen"],
+      "The dataset associated with this chart no longer exists": [
+        "Podatkovni set, povezan s tem grafikonom, ne obstaja več"
+      ],
+      "Could not determine datasource type": [
+        "Ni mogoče določiti tipa podatkovnega vira"
+      ],
+      "Could not find viz object": [
+        "Ni mogoče najti vizualizacijskega objekta"
+      ],
+      "Show Chart": ["Prikaži grafikon"],
+      "Add Chart": ["Dodaj grafikon"],
+      "Edit Chart": ["Uredi grafikon"],
+      "These parameters are generated dynamically when clicking the save or overwrite button in the explore view. This JSON object is exposed here for reference and for power users who may want to alter specific parameters.": [
+        "Ti parametri se ustvarijo dinamično s klikom gumba Shrani ali Prepiši v raziskovalnem pogledu. Ta JSON objekt je prikazan kot vzorec za napredne uporabnike, ki želijo spreminjati posamezne parametre."
+      ],
+      "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.": [
+        "Časovna veljavnost (v sekundah) predpomnjenja za ta grafikon. Če ni definirana, je uporabljena vrednost za podatkovni vir/tabelo."
+      ],
+      "Last Modified": ["Zadnja sprememba"],
+      "Parameters": ["Parametri"],
+      "Visualization Type": ["Tip vizualizacije"],
+      "Show Dashboard": ["Prikaži nadzorno ploščo"],
+      "Add Dashboard": ["Dodaj nadzorno ploščo"],
+      "Edit Dashboard": ["Uredi nadzorno ploščo"],
+      "This json object describes the positioning of the widgets in the dashboard. It is dynamically generated when adjusting the widgets size and positions by using drag & drop in the dashboard view": [
+        "Ta JSON objekt opisuje postavitev pripomočkov na nadzorni plošči. Ustvari se dinamično, ko prilagajamo velikost in postavitev pripomočkov z uporabo povleci&spusti v pogledu nadzorne plošče"
+      ],
+      "The CSS for individual dashboards can be altered here, or in the dashboard view where changes are immediately visible": [
+        "CSS za posamezne nadzorne plošče lahko spreminjamo tukaj ali pa v pogledu nadzorne plošče, kjer so spremembe vidne takoj"
+      ],
+      "To get a readable URL for your dashboard": [
+        "Za pridobitev berljivega URL-ja za nadzorno ploščo"
+      ],
+      "This JSON object is generated dynamically when clicking the save or overwrite button in the dashboard view. It is exposed here for reference and for power users who may want to alter specific parameters.": [
+        "Ta JSON objekt se ustvari dinamično s klikom gumba Shrani ali Prepiši v pogledu nadzorne plošče. Tukaj je prikazan kot vzorec za napredne uporabnike, ki želijo spreminjati posamezne parametre."
+      ],
+      "Owners is a list of users who can alter the dashboard.": [
+        "\"Lastniki\" je seznam uporabnikov, ki lahko spreminjajo nadzorno ploščo."
+      ],
+      "Roles is a list which defines access to the dashboard. Granting a role access to a dashboard will bypass dataset level checks.If no roles defined then the dashboard is available to all roles.": [
+        "\"Vloge\" je seznam, ki definira dostop do nadzorne plošče. Dodelitev vloge za dostop do nadzorne plošče bo obšlo preverjanje na nivoju podatkovnega seta. Če vloga ni definirana, bo nadzorna plošča dostopna vsem vlogam."
+      ],
+      "Determines whether or not this dashboard is visible in the list of all dashboards": [
+        "Določa ali je nadzorna plošča vidna na seznamu vseh nadzornih plošč"
+      ],
+      "Title": ["Naslov"],
+      "Slug": ["Slug"],
+      "Published": ["Objavljeno"],
+      "Position JSON": ["JSON za postavitev"],
+      "CSS": ["CSS"],
+      "Underlying Tables": ["Temeljne tabele"],
+      "Export": ["Izvoz"],
+      "Export dashboards?": ["Izvozim nadzorne plošče?"],
+      "Name of table to be created from csv data.": [
+        "Ime tabele, ki bo ustvarjena iz CSV podatkov."
+      ],
+      "CSV File": ["CSV datoteka"],
+      "Select a CSV file to be uploaded to a database.": [
+        "Izberite CSV datoteko, ki bo naložena v podatkovno bazo."
+      ],
+      "Only the following file extensions are allowed: %(allowed_extensions)s": [
+        "Dovoljene so le naslednje končnice: %(allowed_extensions)s"
+      ],
+      "Specify a schema (if database flavor supports this).": [
+        "Podajte shemo (če vrsta podatkovne baze to podpira)"
+      ],
+      "Delimiter": ["Ločilnik"],
+      "Delimiter used by CSV file (for whitespace use \\s+).": [
+        "Ločilnik, uporabljen v CSV datoteki (za presledek uporabi \\s+)."
+      ],
+      "Table Exists": ["Tabela obstaja"],
+      "If table exists do one of the following: Fail (do nothing), Replace (drop and recreate table) or Append (insert data).": [
+        "Če tabela obstaja, naredite nekaj od sledečega: Prekini (ne naredi nič), Zamenjaj (zbriši in ponovno ustvari tabelo) ali Dodaj (vstavi podatke)."
+      ],
+      "Fail": ["Prekini"],
+      "Replace": ["Zamenjaj"],
+      "Append": ["Dodaj"],
+      "Header Row": ["Naslovna vrstica"],
+      "Row containing the headers to use as column names (0 is first line of data). Leave empty if there is no header row.": [
+        "Vrstica z naslovi, ki se uporabi za imena stolpcev (0 je prva vrstica podatkov). Pustite prazno, če ni naslovne vrstice."
+      ],
+      "Index Column": ["Indeksni stolpec"],
+      "Column to use as the row labels of the dataframe. Leave empty if no index column.": [
+        "Stolpec, ki se uporabi za naslove vrstic v dataframe-u. Pustite prazno, če ni indeksnega stolpca."
+      ],
+      "Mangle Duplicate Columns": ["Odstrani podvojene stolpce"],
+      "Specify duplicate columns as \"X.0, X.1\".": [
+        "Določite podvojene stolpce kot \"X.0, X.1\"."
+      ],
+      "Skip Initial Space": ["Izpusti začetni presledek"],
+      "Skip spaces after delimiter.": ["Izpusti presledek za ločilnikom."],
+      "Skip Rows": ["Izpusti vrstice"],
+      "Number of rows to skip at start of file.": [
+        "Število vrstic, ki se izpustijo na začetku datoteke."
+      ],
+      "Rows to Read": ["Vrstice za branje"],
+      "Number of rows of file to read.": [
+        "Število vrstic v datoteki za branje."
+      ],
+      "Skip Blank Lines": ["Izpusti prazne vrstice"],
+      "Skip blank lines rather than interpreting them as NaN values.": [
+        "Raje izpusti prazne vrstice, kot pa da so prepoznane kot NaN vrednosti."
+      ],
+      "Parse Dates": ["Prepoznaj datume"],
+      "A comma separated list of columns that should be parsed as dates.": [
+        "Z vejico ločen seznam stolpcev, v katerih bodo prepoznani datumi."
+      ],
+      "Infer Datetime Format": ["Prepoznaj obliko datuma/časa"],
+      "Use Pandas to interpret the datetime format automatically.": [
+        "Uporabi Pandas za samodejno prepoznavo oblike datumov/časov."
+      ],
+      "Decimal Character": ["Decimalno ločilo"],
+      "Character to interpret as decimal point.": [
+        "Znak, ki bo prepoznan kot decimalno ločilo."
+      ],
+      "Dataframe Index": ["Indeks dataframe-a"],
+      "Write dataframe index as a column.": [
+        "Zapiši indeks dataframe-a kot stolpec."
+      ],
+      "Column Label(s)": ["Naslovi stolpcev"],
+      "Column label for index column(s). If None is given and Dataframe Index is True, Index Names are used.": [
+        "Naslovi stolpcev za indeksne stolpce. Če le-ti niso podani in indeksi Dataframe-a obstajajo, se uporabijo imena indeksov."
+      ],
+      "Null values": ["Prazne (Null) vrednosti"],
+      "Json list of the values that should be treated as null. Examples: [\"\"], [\"None\", \"N/A\"], [\"nan\", \"null\"]. Warning: Hive database supports only single value. Use [\"\"] for empty string.": [
+        "JSON seznam vrednosti, ki naj bodo obravnavane kot prazne (Null). Primeri: [\"\"], [\"None\", \"N/A\"], [\"nan\", \"null\"]. Opozorilo: Podatkovna baza Hive podpira le eno vrednost. Uporabite [\"\"] za prazen znakovni niz."
+      ],
+      "Name of table to be created from excel data.": [
+        "Ime tabele, ki bo ustvarjena iz Excel-ovih podatkov."
+      ],
+      "Excel File": ["Excel-ova datoteka"],
+      "Select a Excel file to be uploaded to a database.": [
+        "Izberite Excel-ovo datoteko, ki bo naložena v podatkovno bazo."
+      ],
+      "Sheet Name": ["Ime zvezka"],
+      "Strings used for sheet names (default is the first sheet).": [
+        "Znakovni nizi uporabljeni za imena zvezkov (privzeto je prvi zvezek)."
+      ],
+      "Show Database": ["Prikaži podatkovno bazo"],
+      "Add Database": ["Dodaj podatkovno bazo"],
+      "Edit Database": ["Uredi podatkovno bazo"],
+      "Expose this DB in SQL Lab": [
+        "Uporabi to podatkovno bazo v SQL laboratoriju"
+      ],
+      "Operate the database in asynchronous mode, meaning  that the queries are executed on remote workers as opposed to on the web server itself. This assumes that you have a Celery worker setup as well as a results backend. Refer to the installation docs for more information.": [
+        "Upravljanje podatkovne baze v asinhronem načinu pomeni, da se poizvedbe zaženejo na oddaljenih »delavcih« in ne na samem spletnem strežniku. S tem je predpostavljeno, da imate nastavljenega »delavca« za Celery in zaledni sistem za rezultate. Več informacij je v navodilih za namestitev."
+      ],
+      "Allow CREATE TABLE AS option in SQL Lab": [
+        "Dovoli opcijo CREATE TABLE AS v SQL laboratoriju"
+      ],
+      "Allow CREATE VIEW AS option in SQL Lab": [
+        "Dovoli opcijo CREATE VIEW AS v SQL laboratoriju"
+      ],
+      "Allow users to run non-SELECT statements (UPDATE, DELETE, CREATE, ...) in SQL Lab": [
+        "Dovoli uporabnikom poganjanje ne-SELECT stavkov (UPDATE, DELETE, CREATE, ...) v SQL laboratoriju"
+      ],
+      "When allowing CREATE TABLE AS option in SQL Lab, this option forces the table to be created in this schema": [
+        "Z dovolitvijo opcije CREATE TABLE AS v SQL laboratoriju se tabele ustvarjajo s to shemo"
+      ],
+      "If Presto, all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled, will run the queries as service account, but impersonate the currently logged on user via hive.server2.proxy.user property.": [
+        "V primeru Presto se vse poizvedbe v SQL laboratoriju zaženejo pod trenutno prijavljenim uporabnikom, ki mora imeti pravice za poganjanje.<br/>Če je omogočen Hive in hive.server2.enable.doAs, poizvedbe tečejo pod servisnim računom, vendar je trenutno prijavljen uporabnik predstavljen z lastnostjo hive.server2.proxy.user."
+      ],
+      "Allow SQL Lab to fetch a list of all tables and all views across all database schemas. For large data warehouse with thousands of tables, this can be expensive and put strain on the system.": [
+        "Dovoli SQL laboratoriju, da pridobi seznam vseh tabel in pogledov iz vseh shem podatkovne baze. Pri velikih podatkovnih skladiščih s tisoči tabel je to lahko potratno in obremeni sistem."
+      ],
+      "Duration (in seconds) of the caching timeout for charts of this database. A timeout of 0 indicates that the cache never expires. Note this defaults to the global timeout if undefined.": [
+        "Trajanje (v sekundah) predpomnjenja za grafikon v tej podatkovni bazi. Vrednost 0 označuje, da predpomnilnik nikoli ne poteče. V primeru, da ni definirano, ima globalno nastavitev."
+      ],
+      "If selected, please set the schemas allowed for csv upload in Extra.": [
+        "Če je izbrano, nastavite dovoljene sheme za nalaganje CSV v Dodatno."
+      ],
+      "Expose in SQL Lab": ["Uporabi v SQL laboratoriju"],
+      "Allow CREATE TABLE AS": ["Dovoli CREATE TABLE AS"],
+      "Allow CREATE VIEW AS": ["Dovoli CREATE VIEW AS"],
+      "Allow DML": ["Dovoli DML"],
+      "CTAS Schema": ["CTAS shema"],
+      "SQLAlchemy URI": ["SQLAlchemy URI"],
+      "Chart Cache Timeout": ["Trajanje predpomnilnika grafikona"],
+      "Secure Extra": ["Dodatna varnost"],
+      "Root certificate": ["Korenski certifikat"],
+      "Async Execution": ["Asinhrono izvajanje"],
+      "Impersonate the logged on user": [
+        "Predstavljaj se kot prijavljeni uporabnik"
+      ],
+      "Allow Csv Upload": ["Dovoli nalaganje CSV"],
+      "Allow Multi Schema Metadata Fetch": [
+        "Dovoli pridobivanje metapodatkov z več shemami"
+      ],
+      "Backend": ["Vrsta"],
+      "Extra field cannot be decoded by JSON. %(msg)s": [
+        "Dodatnega polja ni mogoče dekodirati z JSON. %(msg)s"
+      ],
+      "Invalid connection string, a valid string usually follows:'DRIVER://USER:PASSWORD@DB-HOST/DATABASE-NAME'<p>Example:'postgresql://user:password@your-postgres-db/database'</p>": [
+        "Neveljaven niz povezave. Veljaven niz običajno sledi zapisu:'DRIVER://USER:PASSWORD@DB-HOST/DATABASE-NAME'<p>Primer:'postgresql://user:password@your-postgres-db/database'</p>"
+      ],
+      "CSV to Database configuration": [
+        "Nastavitve pretvorbe CSV v podatkovno bazo"
+      ],
+      "Database \"%(database_name)s\" schema \"%(schema_name)s\" is not allowed for csv uploads. Please contact your Superset Admin.": [
+        "Shema \"%(schema_name)s\" podatkovne baze \"%(database_name)s\" ni dovoljena za nalaganje CSV. Kontaktirajte administratorja za Superset."
+      ],
+      "You cannot specify a namespace both in the name of the table: \"%(csv_table.table)s\" and in the schema field: \"%(csv_table.schema)s\". Please remove one": [
+        "Imenskega prostora ni mogoče podati hkrati v tabeli: \"%(csv_table.table)s\" in polju sheme: \"%(csv_table.schema)s\". Odstranite enega"
+      ],
+      "Unable to upload CSV file \"%(filename)s\" to table \"%(table_name)s\" in database \"%(db_name)s\". Error message: %(error_msg)s": [
+        "CSV datoteke \"%(filename)s\" ni mogoče naložiti v tabelo \"%(table_name)s\" v podatkovni bazi \"%(db_name)s\". Sporočilo napake: %(error_msg)s"
+      ],
+      "CSV file \"%(csv_filename)s\" uploaded to table \"%(table_name)s\" in database \"%(db_name)s\"": [
+        "CSV datoteka \"%(csv_filename)s\" naložena v tabelo \"%(table_name)s\" v podatkovni bazi \"%(db_name)s\""
+      ],
+      "Excel to Database configuration": [
+        "Nastavitve pretvorbe Excel v Podatkovno bazo"
+      ],
+      "Database \"%(database_name)s\" schema \"%(schema_name)s\" is not allowed for excel uploads. Please contact your Superset Admin.": [
+        "Shema \"%(schema_name)s\" podatkovne baze \"%(database_name)s\" ni dovoljena za nalaganje Excel datotek. Kontaktirajte administratorja za Superset."
+      ],
+      "You cannot specify a namespace both in the name of the table: \"%(excel_table.table)s\" and in the schema field: \"%(excel_table.schema)s\". Please remove one": [
+        "Imenskega prostora ni mogoče podati hkrati v tabeli: \"%(excel_table.table)s\" in polju sheme: \"%(excel_table.schema)s\". Odstranite enega"
+      ],
+      "Unable to upload Excel file \"%(filename)s\" to table \"%(table_name)s\" in database \"%(db_name)s\". Error message: %(error_msg)s": [
+        "Excel datoteke \"%(filename)s\" ni mogoče naložiti v tabelo \"%(table_name)s\" v podatkovni bazi \"%(db_name)s\". Sporočilo napake: %(error_msg)s"
+      ],
+      "Excel file \"%(excel_filename)s\" uploaded to table \"%(table_name)s\" in database \"%(db_name)s\"": [
+        "Excel datoteka \"%(excel_filename)s\" naložena v tabelo \"%(table_name)s\" v podatkovni bazi \"%(db_name)s\""
+      ],
+      "Logs": ["Dnevniki"],
+      "Show Log": ["Prikaži dnevnik"],
+      "Add Log": ["Dodaj dnevnik"],
+      "Edit Log": ["Uredi dnevnik"],
+      "Action": ["Aktivnost"],
+      "dttm": ["dttm"],
+      "Add item": ["Dodaj"],
+      "The query couldn't be loaded": ["Poizvedbe ni mogoče naložiti"],
+      "Your query has been scheduled. To see details of your query, navigate to Saved queries": [
+        "Vaša poizvedba je v urniku. Za ogled podrobnosti poizvedbe pojdite na shranjene poizvedbe"
+      ],
+      "Your query could not be scheduled": [
+        "Vaše poizvedbe ni mogoče uvrstiti v urnik"
+      ],
+      "Failed at retrieving results": ["Napaka pri pridobivanju rezultatov"],
+      "An error occurred while storing the latest query id in the backend. Please contact your administrator if this problem persists.": [
+        "Pri shranjevanju zadnjega id-ja poizvedbe v sistem je prišlo do napake. Če se težava ponavlja, kontaktirajte administratorja."
+      ],
+      "Unknown error": ["Neznana napaka"],
+      "Query was stopped.": ["Poizvedba je bila ustavljena."],
+      "Unable to migrate table schema state to backend. Superset will retry later. Please contact your administrator if this problem persists.": [
+        "Stanja sheme tabele ni mogoče prenesti v sistem. Superset bo ponovil poskus kasneje. Če se težava ponavlja, kontaktirajte administratorja."
+      ],
+      "Unable to migrate query state to backend. Superset will retry later. Please contact your administrator if this problem persists.": [
+        "Stanja poizvedbe ni mogoče prenesti v sistem. Superset bo ponovil poskus kasneje. Če se težava ponavlja, kontaktirajte administratorja."
+      ],
+      "Unable to migrate query editor state to backend. Superset will retry later. Please contact your administrator if this problem persists.": [
+        "Stanja urejevalnika poizvedb ni mogoče prenesti v sistem. Superset bo ponovil poskus kasneje. Če se težava ponavlja, kontaktirajte administratorja."
+      ],
+      "Unable to add a new tab to the backend. Please contact your administrator.": [
+        "Novega zavihka ni mogoče dodati v sistem. Kontaktirajte administratorja."
+      ],
+      "Copy of %s": ["Kopija %s"],
+      "An error occurred while setting the active tab. Please contact your administrator.": [
+        "Pri določanju aktivnega zavihka je prišlo do napake. Kontaktirajte administratorja."
+      ],
+      "An error occurred while fetching tab state": [
+        "Pri pridobivanju stanja zavihka je prišlo do napake"
+      ],
+      "An error occurred while hiding the left bar. Please contact your administrator.": [
+        "Pri skrivanju leve vrstice je prišlo do napake. Kontaktirajte administratorja."
+      ],
+      "An error occurred while removing tab. Please contact your administrator.": [
+        "Pri odstranjevanju zavihka je prišlo do napake. Kontaktirajte administratorja."
+      ],
+      "An error occurred while removing query. Please contact your administrator.": [
+        "Pri odstranjevanju poizvedbe je prišlo do napake. Kontaktirajte administratorja."
+      ],
+      "An error occurred while setting the tab database ID. Please contact your administrator.": [
+        "Pri določanju ID-ja v podatkovne baze za zavihek je prišlo do napake. Kontaktirajte administratorja."
+      ],
+      "An error occurred while setting the tab schema. Please contact your administrator.": [
+        "Pri določanju sheme zavihka je prišlo do napake. Kontaktirajte administratorja."
+      ],
+      "An error occurred while setting the tab autorun. Please contact your administrator.": [
+        "Pri določanju samodejnega zagona zavihka je prišlo do napake. Kontaktirajte administratorja."
+      ],
+      "An error occurred while setting the tab title. Please contact your administrator.": [
+        "Pri določanju naslova zavihka je prišlo do napake. Kontaktirajte administratorja."
+      ],
+      "Your query was saved": ["Vaša poizvedba je shranjena"],
+      "Your query could not be saved": ["Vaše poizvedbe ni mogoče shraniti"],
+      "Your query was updated": ["Vaša poizvedba je posodobljena"],
+      "Your query could not be updated": [
+        "Vaše poizvedbe ni mogoče posodobiti"
+      ],
+      "An error occurred while storing your query in the backend. To avoid losing your changes, please save your query using the \"Save Query\" button.": [
+        "Pri shranjevanju vaše poizvedbe v sistem je prišlo do napake. Da ne izgubite sprememb, shranite poizvedbo z gumbom \"Shrani poizvedbo\"."
+      ],
+      "An error occurred while setting the tab template parameters. Please contact your administrator.": [
+        "Pri določanju parametrov predloge zavihka je prišlo do napake. Kontaktirajte administratorja."
+      ],
+      "An error occurred while fetching table metadata": [
+        "Pri pridobivanju metapodatkov tabele je prišlo do napake"
+      ],
+      "An error occurred while fetching table metadata. Please contact your administrator.": [
+        "Pri pridobivanju metapodatkov tabele je prišlo do napake. Kontaktirajte administratorja."
+      ],
+      "An error occurred while expanding the table schema. Please contact your administrator.": [
+        "Pri širitvi sheme tabele je prišlo do napake. Kontaktirajte administratorja."
+      ],
+      "An error occurred while collapsing the table schema. Please contact your administrator.": [
+        "Pri krčenju sheme tabele je prišlo do napake. Kontaktirajte administratorja."
+      ],
+      "An error occurred while removing the table schema. Please contact your administrator.": [
+        "Pri odstranjevanju sheme tabele je prišlo do napake. Kontaktirajte administratorja."
+      ],
+      "Shared query": ["Deljene poizvedbe"],
+      "The datasource couldn't be loaded": [
+        "Podatkovnega vira ni mogoče naložiti"
+      ],
+      "An error occurred while creating the data source": [
+        "Pri ustvarjanju podatkovnega vira je prišlo do težave"
+      ],
+      "An error occurred while fetching function names.": [
+        "Pri pridobivanju imen funkcij je prišlo do napake."
+      ],
+      "SQL Lab uses your browser's local storage to store queries and results.\n Currently, you are using ${currentUsage.toFixed(\r\n            2,\r\n          )} KB out of ${LOCALSTORAGE_MAX_USAGE_KB} KB. storage space.\n To keep SQL Lab from crashing, please delete some query tabs.\n You can re-access these queries by using the Save feature before you delete the tab. Note that you will need to close other SQL Lab windows before you do this.": [
+        "SQL laboratorij za shranjevanje poizvedb in rezultatov uporablja brskalnikovo lokalno shrambo.\nTrenutno uporabljate ${currentUsage.toFixed(\r\n            2,\r\n          )} KB od ${LOCALSTORAGE_MAX_USAGE_KB} KB prostora shrambe.\nDa se izognete sesutju SQL laboratorija, izbrišite nekaj zavihkov s poizvedbami.\nTe poizvedbe lahko ponovno uporabite, tako da jih pred izbrisom shranite. Preden storite to, boste morali zapreti druga okna SQL laboratorija."
+      ],
+      "Estimate selected query cost": ["Oceni potratnost izbrane poizvedbe"],
+      "Estimate cost": ["Oceni potratnost"],
+      "Cost estimate": ["Ocena potratnosti"],
+      "Creating a data source and creating a new tab": [
+        "Ustvarjanje podatkovnega vira in novega zavihka"
+      ],
+      "An error occurred": ["Prišlo je do napake"],
+      "Explore the result set in the data exploration view": [
+        "Raziščite rezultate v pogledu raziskovanja podatkov"
+      ],
+      "This query took %s seconds to run, ": [
+        "Trajanje poizvedbe v sekundah: %s, "
+      ],
+      "and the explore view times out at %s seconds ": [
+        "čas izteka raziskovalnega pogleda v sekundah: %s "
+      ],
+      "following this flow will most likely lead to your query timing out. ": [
+        "s takšnim potekom, bo poizvedba najverjetneje potekla. "
+      ],
+      "We recommend your summarize your data further before following that flow. ": [
+        "Priporočamo, da zahtevane podatke pred nadaljevanjem strnete. "
+      ],
+      "If activated you can use the ": ["Če je aktivirana, lahko uporabite "],
+      "feature to store a summarized data set that you can then explore.": [
+        "funkcijo shranjevanja strnjenega podatkovnega seta, ki ga lahko raziščete."
+      ],
+      "Column name(s) ": ["Imena stolpcev "],
+      "cannot be used as a column name. The column name/alias \"__timestamp\"\r\n          is reserved for the main temporal expression, and column aliases ending with\r\n          double underscores followed by a numeric value (e.g. \"my_col__1\") are reserved\r\n          for deduplicating duplicate column names. Please use aliases to rename the\r\n          invalid column names.": [
+        "ni mogoče uporabiti kot imena stolpcev. Ime stolpca \"__timestamp\"\r\n          je rezervirano za glavni časovni izraz. Imena stolpcev, ki se končajo z\r\n          dvojnim podčrtajem, ki mu sledi številska vrednost (npr. \"moj_stolpec__1\" so rezervirana\r\n          za deduplikacijo duplikatov imen stolpcev. Za preimenovanje neustreznih imen\r\n          uporabite psevdonime."
+      ],
+      "Source SQL": ["Izvorni SQL"],
+      "Raw SQL": ["Surovi SQL"],
+      "SQL": ["SQL"],
+      "No query history yet...": ["Zgodovine poizvedb še ni..."],
+      "An error occurred when refreshing queries": [
+        "Pri osveževanju poizvedb je prišlo do napake"
+      ],
+      "It seems you don't have access to any database": [
+        "Zdi se, da nimate dostopa do nobene podatkovne baz"
+      ],
+      "Filter by user": ["Filtriraj po uporabniku"],
+      "Filter by database": ["Filtriraj po podatkovni bazi"],
+      "Query search string": ["Iskalni niz za poizvedbo"],
+      "[From]-": ["[Od]-"],
+      "[To]-": ["[Do]-"],
+      "Filter by status": ["Filtriraj po statusu"],
+      "Edit": ["Urejanje"],
+      "View results": ["Ogled rezultatov"],
+      "Data preview": ["Ogled podatkov"],
+      "Overwrite text in the editor with a query on this table": [
+        "Besedilo v urejevalniku prepišite s poizvedbo na to tabelo"
+      ],
+      "Run query in a new tab": ["Zaženi poizvedbo v novem zavihku"],
+      "Remove query from log": ["Odstrani poizvedbo iz dnevnika"],
+      "An error occurred saving dataset": [
+        "Pri shranjevanju podatkovnega seta je prišlo do napake"
+      ],
+      "Download to CSV": ["Izvozi kot CSV"],
+      "Copy to Clipboard": ["Kopiraj na odložišče"],
+      "Filter results": ["Filtriraj rezultate"],
+      "The number of results displayed is limited to %(rows)d by the configuration DISPLAY_MAX_ROWS. ": [
+        "Število prikazanih rezultatov je omejeno na %(rows)d preko parametra DISPLAY_MAX_ROWS. "
+      ],
+      "Please add additional limits/filters or download to csv to see more rows up to ": [
+        "Dodajte omejitve/filtre ali izvozite csv, če želite videti več vrstic do "
+      ],
+      "the %(limit)d limit.": ["omejitve %(limit)d ."],
+      "The number of results displayed is limited to %(rows)d. ": [
+        "Število prikazanih rezultatov je omejeno na %(rows)d. "
+      ],
+      "Please add additional limits/filters, download to csv, or contact an admin ": [
+        "Dodajte omejitve/filtre ali izvozite csv oz. kontaktirajte administratorja "
+      ],
+      "to see more rows up to the %(limit)d limit.": [
+        "za prikaz več vrstic, kot je omejitev %(limit)d ."
+      ],
+      "The number of rows displayed is limited to %(rows)d by the query": [
+        "Število prikazanih vrstic je omejeno na %(rows)d s poizvedbo"
+      ],
+      "The number of rows displayed is limited to %(rows)d by the limit dropdown.": [
+        "Število prikazanih rezultatov je omejeno na %(rows)d s poizvedbo."
+      ],
+      "The number of rows displayed is limited to %(rows)d by the query and limit dropdown.": [
+        "Število prikazanih vrstic je omejeno na %(rows)d s poizvedbo in spustnim izbirnikom omejitev."
+      ],
+      "%(rows)d rows returned": ["%(rows)d vrnjenih vrstic"],
+      "The number of rows displayed is limited to %s by the dropdown.": [
+        "Število prikazanih vrstic je omejeno na %s s spustnim izbirnikom."
+      ],
+      "Query was stopped": ["Poizvedba je bila ustavljena"],
+      "Database error": ["Napaka podatkovne baze"],
+      "was created": ["ustvarjeno"],
+      "Query in a new tab": ["Poizvedba v novem zavihku"],
+      "The query returned no data": ["Poizvedba ni vrnila podatkov"],
+      "Fetch data preview": ["Pridobi predogled podatkov"],
+      "Refetch results": ["Ponovno pridobi rezultate"],
+      "Track job": ["Sledi opravilom"],
+      "Stop": ["Ustavi"],
+      "Run selection": ["Zaženi izbrano"],
+      "Run": ["Zaženi"],
+      "Stop running (Ctrl + x)": ["Ustavi (Ctrl + x)"],
+      "Run query (Ctrl + Return)": ["Zaženi poizvedbo (Ctrl + Return)"],
+      "Save & Explore": ["Shrani & Razišči"],
+      "Overwrite & Explore": ["Prepiši & Razišči"],
+      "Undefined": ["Ni definirano"],
+      "Save": ["Shrani"],
+      "Save as": ["Shrani kot"],
+      "Save query": ["Shrani poizvedbo"],
+      "Save as new": ["Shrani kot novo"],
+      "Update": ["Posodobi"],
+      "Label for your query": ["Ime vaše poizvedbe"],
+      "Write a description for your query": ["Dodajte opis vaše poizvedbe"],
+      "Schedule query": ["Urnik poizvedb"],
+      "Schedule": ["Urnik"],
+      "There was an error with your request": [
+        "Pri zahtevi je prišlo do napake"
+      ],
+      "Please save the query to enable sharing": [
+        "Shranite poizvedbo za deljenje"
+      ],
+      "Copy query link to your clipboard": [
+        "Kopiraj povezavo do poizvedbe v odložišče"
+      ],
+      "Save the query to enable this feature": [
+        "Za omogočenje te funkcije shranite poizvedbo"
+      ],
+      "Copy link": ["Kopiraj povezavo"],
+      "Run query": ["Zaženi poizvedbo"],
+      "New tab": ["Nov zavihek"],
+      "Untitled query": ["Neimenovana poizvedba"],
+      "Stop query": ["Ustavi poizvedbo"],
+      "Schedule the query periodically": ["Periodično zaganjaj poizvedbo"],
+      "You must run the query successfully first": [
+        "Najprej morate uspešno izvesti poizvedbo"
+      ],
+      "Autocomplete": ["Samodokončaj"],
+      "CREATE TABLE AS": ["CREATE TABLE AS"],
+      "CREATE VIEW AS": ["CREATE VIEW AS"],
+      "Estimate the cost before running a query": [
+        "Oceni potratnost pred zagonom poizvedbe"
+      ],
+      "Reset state": ["Ponastavi stanje"],
+      "Enter a new title for the tab": ["Vnesite novo naslov zavihka"],
+      "Untitled Query %s": ["Neimenovana poizvedba %s"],
+      "Close tab": ["Zapri zavihek"],
+      "Rename tab": ["Preimenuj zavihek"],
+      "Expand tool bar": ["Razširi orodno vrstico"],
+      "Hide tool bar": ["Skrij orodno vrstico"],
+      "Close all other tabs": ["Zapri vse ostale zavihke"],
+      "Duplicate tab": ["Podvoji zavihek"],
+      "New tab (Ctrl + q)": ["Nov zavihek (Ctrl + q)"],
+      "New tab (Ctrl + t)": ["Nov zavihek (Ctrl + t)"],
+      "Copy partition query to clipboard": [
+        "Kopiraj particijsko poizvedbo na odložišče"
+      ],
+      "latest partition:": ["zadnja particija:"],
+      "Keys for table": ["Ključi za tabele"],
+      "View keys & indexes (%s)": ["Ogled ključev in indeksov (%s)"],
+      "Sort columns alphabetically": ["Razvrsti stolpce po abecedi"],
+      "Original table column order": ["Vrstni red stolpcev izvorne tabele"],
+      "Copy SELECT statement to the clipboard": [
+        "Kopiraj stavek SELECT na odložišče"
+      ],
+      "Show CREATE VIEW statement": ["Prikaži CREATE VIEW stavek"],
+      "CREATE VIEW statement": ["CREATE VIEW stavek"],
+      "Remove table preview": ["Odstrani predogled tabele"],
+      "Edit template parameters": ["Uredi parametre predloge"],
+      "Invalid JSON": ["Neveljaven JSON"],
+      "No stored results found, you need to re-run your query": [
+        "Rezultatov še ni shranjenih, ponovno morate zagnati poizvedbo"
+      ],
+      "Run a query to display results here": [
+        "Za prikaz rezultatov morate zagnati poizvedbo"
+      ],
+      "Preview: `%s`": ["Predogled: `%s`"],
+      "Results": ["Rezultati"],
+      "Query history": ["Zgodovina poizvedb"],
+      "Create a new chart": ["Ustvari nov grafikon"],
+      "Choose a dataset": ["Izberite podatkovni set"],
+      "If the dataset you are looking for is not available in the list, follow the instructions on how to add it in the Superset tutorial.": [
+        "Če podatkovnega seta, ki ga iščete, ni na seznamu, sledite navodilom za dodajanje v navodilih za Superset."
+      ],
+      "Choose a visualization type": ["Izberite tip vizualizacije"],
+      "Create new chart": ["Ustvari nov grafikon"],
+      "An error occurred while loading the SQL": [
+        "Pri nalaganju SQL je prišlo do napake"
+      ],
+      "Updating chart was stopped": [
+        "Posodabljanje grafikona je bilo ustavljeno"
+      ],
+      "An error occurred while rendering the visualization: %s": [
+        "Pri prikazovanju vizualizacije je prišlo do napake: %s"
+      ],
+      "Network error.": ["Napaka omrežja."],
+      "Click to see difference": ["Kliknite za prikaz razlike"],
+      "Altered": ["Spremenjeno"],
+      "Chart changes": ["Spremembe grafikona"],
+      "Superset chart": ["Superset grafikon"],
+      "Check out this chart in dashboard:": [
+        "Preizkusite ta grafikon v nadzorni plošči:"
+      ],
+      "Select ...": ["Izberite ..."],
+      "Loaded data cached": ["Podatki so naloženi v predpomnilnik"],
+      "Loaded from cache": ["Naloženo iz predpomnilnika"],
+      "Click to force-refresh": ["Kliknite za prisilno osvežitev"],
+      "cached": ["predpomnjen"],
+      "Certified by %s": ["Certificiral/a %s"],
+      "Copy to clipboard": ["Kopiraj na odložišče"],
+      "Copied to clipboard!": ["Kopirano na odložišče!"],
+      "Sorry, your browser does not support copying. Use Ctrl / Cmd + C!": [
+        "Vaš brskalnik ne podpira kopiranja. Uporabite Ctrl / Cmd + C!"
+      ],
+      "every": ["vsak"],
+      "every month": ["vsak mesec"],
+      "every day of the month": ["vsak dan v mesecu"],
+      "day of the month": ["dan v mesecu"],
+      "every day of the week": ["vsak dan v tednu"],
+      "day of the week": ["dan v tednu"],
+      "every hour": ["vsako uro"],
+      "every minute UTC": ["vsako minuto UTC"],
+      "year": ["leto"],
+      "month": ["mesec"],
+      "week": ["teden"],
+      "day": ["dan"],
+      "hour": ["ura"],
+      "minute": ["minuta"],
+      "reboot": ["ponovni zagon"],
+      "Every": ["Vsak"],
+      "in": ["v"],
+      "on": ["na"],
+      "and": ["in"],
+      "at": ["v"],
+      ":": [":"],
+      "minute(s) UTC": ["minute UTC"],
+      "Invalid cron expression": ["Neveljaven cron izraz"],
+      "Clear": ["Počisti"],
+      "Sunday": ["Nedelja"],
+      "Monday": ["Ponedeljek"],
+      "Tuesday": ["Torek"],
+      "Wednesday": ["Sreda"],
+      "Thursday": ["Četrtek"],
+      "Friday": ["Petek"],
+      "Saturday": ["Sobota"],
+      "January": ["Januar"],
+      "February": ["Februar"],
+      "March": ["Marec"],
+      "April": ["April"],
+      "May": ["Maj"],
+      "June": ["Junij"],
+      "July": ["Julij"],
+      "August": ["Avgust"],
+      "September": ["September"],
+      "October": ["Oktober"],
+      "November": ["November"],
+      "December": ["December"],
+      "SUN": ["NED"],
+      "MON": ["PON"],
+      "TUE": ["TOR"],
+      "WED": ["SRE"],
+      "THU": ["ČET"],
+      "FRI": ["PET"],
+      "SAT": ["SOB"],
+      "JAN": ["JAN"],
+      "FEB": ["FEB"],
+      "MAR": ["MAR"],
+      "APR": ["APR"],
+      "MAY": ["MAJ"],
+      "JUN": ["JUN"],
+      "JUL": ["JUL"],
+      "AUG": ["AVG"],
+      "SEP": ["SEP"],
+      "OCT": ["OKT"],
+      "NOV": ["NOV"],
+      "DEC": ["DEC"],
+      "Error while fetching schema list": [
+        "Napaka pri pridobivanju seznama shem"
+      ],
+      "Error while fetching database list": [
+        "Napaka pri pridobivanju seznama podatkovnih baz"
+      ],
+      "Database:": ["Podatkovna baza:"],
+      "Select a database": ["Izberite podatkovno bazo"],
+      "Force refresh schema list": ["Osveži seznam shem"],
+      "Select a schema (%s)": ["Izberite shemo (%s)"],
+      "Schema:": ["Shema:"],
+      "datasource": ["podatkovni vir"],
+      "schema": ["shema"],
+      "delete": ["izbriši"],
+      "Type \"%s\" to confirm": ["Vnesite \"%s\" za potrditev"],
+      "DELETE": ["IZBRIŠI"],
+      "Click to edit": ["Kliknite za urejanje"],
+      "You don't have the rights to alter this title.": [
+        "Nimate pravic za spreminjanje tega naslova."
+      ],
+      "Unexpected error": ["Nepričakovana napaka"],
+      "This may be triggered by:": ["To je lahko sproženo z/s:"],
+      "Please reach out to the Chart Owner for assistance.": [
+        "Za pomoč se obrnite na lastnika grafikona."
+      ],
+      "Chart Owner: %s": ["Lastnik grafikona: %s"],
+      "%s Error": ["%s napaka"],
+      "See more": ["Oglejte si več"],
+      "See less": ["Oglejte si manj"],
+      "Copy message": ["Kopiraj sporočilo"],
+      "Close": ["Zapri"],
+      "This was triggered by:": ["To je bilo sproženo z/s:"],
+      "Did you mean:": ["Ste mislili:"],
+      "%(suggestion)s instead of \"%(undefinedParameter)s?\"": [
+        "%(suggestion)s namesto \"%(undefinedParameter)s?\""
+      ],
+      "Parameter error": ["Napaka parametra"],
+      "We’re having trouble loading this visualization. Queries are set to timeout after %s second.": [
+        "Težava pri nalaganju vizualizacije. Časovni iztek poizvedb je nastavljen na %s sekund."
+      ],
+      "We’re having trouble loading these results. Queries are set to timeout after %s second.": [
+        "Težava pri nalaganju rezultatov. Časovni iztek poizvedb je nastavljen na %s sekund."
+      ],
+      "Timeout error": ["Napaka pretečenega časa"],
+      "Click to favorite/unfavorite": [
+        "Kliknite za priljubljeno/nepriljubljeno"
+      ],
+      "Cell content": ["Vsebina celice"],
+      "The import was successful": ["Uvoz je uspel"],
+      "OVERWRITE": ["OVERWRITE"],
+      "Overwrite": ["Prepiši"],
+      "Import": ["Uvozi"],
+      "Import %s": ["Uvozi %s"],
+      "Last Updated %s": ["Zadnja posodobitev %s"],
+      "Sort:": ["Razvrščanje:"],
+      "%s Selected": ["Izbranih: %s"],
+      "Deselect all": ["Počisti izbor"],
+      "No Data": ["Ni podatkov"],
+      "%s-%s of %s": ["%s-%s od %s"],
+      "SQL query": ["SQL poizvedba"],
+      "About": ["O programu"],
+      "Documentation": ["Dokumentacija"],
+      "Report a bug": ["Sporočite napako"],
+      "OK": ["OK"],
+      "An error occurred while fetching dashboards": [
+        "Prišlo je do napake pri pridobivanju nadzornih plošč"
+      ],
+      "Error while fetching table list": [
+        "Napaka pri pridobivanju seznama tabel"
+      ],
+      "Select table or type table name": ["Izberite ali vnesite ime tabele"],
+      "Type to search ...": ["Vnesite za iskanje ..."],
+      "Select table ": ["Izberi tabelo "],
+      "Force refresh table list": ["Osveži seznam tabel"],
+      "See table schema": ["Ogled sheme tabele"],
+      "%s%s": ["%s%s"],
+      "There is not enough space for this component. Try decreasing its width, or increasing the destination width.": [
+        "Za to komponento ni dovolj prostora. Poskusite zmanjšati širino ali pa povečati širino cilja."
+      ],
+      "Can not move top level tab into nested tabs": [
+        "Najvišjega zavihka ni mogoče premakniti v gnezdene zavihke"
+      ],
+      "This chart has been moved to a different filter scope.": [
+        "Ta grafikon je bil prestavljen v drug obseg filtrov."
+      ],
+      "There was an issue fetching the favorite status of this dashboard.": [
+        "Pri pridobivanju statusa \"priljubljeno\" za to nadzorno ploščo je prišlo do težave."
+      ],
+      "There was an issue favoriting this dashboard.": [
+        "Pri uvrščanju nadzorne plošče med priljubljene je prišlo do težave."
+      ],
+      "This dashboard is now ${nowPublished}": [
+        "Ta nadzorna plošča je sedaj ${nowPublished}"
+      ],
+      "You do not have permissions to edit this dashboard.": [
+        "Nimate dovoljenj za urejanje te nadzorne plošče."
+      ],
+      "This dashboard was saved successfully.": [
+        "Nadzorna plošča je bila uspešno shranjena."
+      ],
+      "Could not fetch all saved charts": [
+        "Vseh shranjenih grafikonov ni bilo mogoče pridobiti"
+      ],
+      "Sorry there was an error fetching saved charts: ": [
+        "Prišlo je do napake pri pridobivanju shranjenih grafikonov: "
+      ],
+      "Visualization": ["Vizualizacija"],
+      "Data source": ["Podatkovni vir"],
+      "Added": ["Dodano"],
+      "Components": ["Komponente"],
+      "Any color palette selected here will override the colors applied to this dashboard's individual charts": [
+        "Na tem mestu izbrana barvna shema bo nadomestila barve posameznih grafikonov v tej nadzorni plošči"
+      ],
+      "Color scheme": ["Barvna shema"],
+      "You have unsaved changes.": ["Imate neshranjene spremembe."],
+      "There is no chart definition associated with this component, could it have been deleted?": [
+        "S to komponento ni povezana nobena definicija grafikona. Ali je bila izbrisana?"
+      ],
+      "Delete this container and save to remove this message.": [
+        "Izbrišite ta okvir in shranite za odpravo tega sporočila."
+      ],
+      "Don't refresh": ["Ne osvežuj"],
+      "10 seconds": ["10 sekund"],
+      "30 seconds": ["30 sekund"],
+      "1 minute": ["1 minuta"],
+      "5 minutes": ["5 minut"],
+      "30 minutes": ["30 minut"],
+      "1 hour": ["1 ura"],
+      "6 hours": ["6 ur"],
+      "12 hours": ["12 ur"],
+      "24 hours": ["24 ur"],
+      "Refresh interval": ["Interval osveževanja"],
+      "Refresh frequency": ["Frekvenca osveževanja"],
+      "Are you sure you want to proceed?": ["Ali želite nadaljevati?"],
+      "Save for this session": ["Shranite za to sejo"],
+      "You must pick a name for the new dashboard": [
+        "Izbrati morate ime nove nadzorne plošče"
+      ],
+      "Save dashboard": ["Shrani nadzorno ploščo"],
+      "Overwrite Dashboard [%s]": ["Prepiši nadzorno ploščo [%s]"],
+      "Save as:": ["Shrani kot:"],
+      "[dashboard name]": ["[ime nadzorne plošče]"],
+      "also copy (duplicate) charts": ["kopiraj tudi (podvoji) grafikone"],
+      "Filter your charts": ["Filtriraj grafikone"],
+      "Sort by": ["Razvrsti po"],
+      "Cross Filter Scoping": ["Obseg cross-filtra"],
+      "Load a template": ["Naloži predlogo"],
+      "Load a CSS template": ["Naloži CSS predlogo"],
+      "Live CSS editor": ["CSS urejevalnik v živo"],
+      "Applied Cross Filters (%d)": ["Uporabljeni cross-filtri (%d)"],
+      "Applied Filters (%d)": ["Uporabljeni filtri (%d)"],
+      "Incompatible Filters (%d)": ["Neskladni filtri (%d)"],
+      "Unset Filters (%d)": ["Neuporabljeni filtri (%d)"],
+      "This dashboard is currently force refreshing; the next force refresh will be in %s.": [
+        "Nadzorna plošča se trenutno prisilno osvežuje. Naslednja prisilna osvežitev bo v %s."
+      ],
+      "Your dashboard is too large. Please reduce the size before save it.": [
+        "Vaša nadzorna plošča je prevelika. Pred shranjevanjem jo zmanjšajte."
+      ],
+      "Discard changes": ["Zavrzi spremembe"],
+      "Edit dashboard": ["Uredi nadzorno ploščo"],
+      "An error occurred while fetching available CSS templates": [
+        "Pri pridobivanju CSS predlog je prišlo do napake"
+      ],
+      "Superset dashboard": ["Superset nadzorna plošča"],
+      "Check out this dashboard: ": ["Preizkusite to nadzorno ploščo: "],
+      "Copy dashboard URL": ["Kopiraj URL nadzorne plošče"],
+      "Share dashboard by email": ["Deli nadzorno ploščo po e-pošti"],
+      "Refresh dashboard": ["Osveži nadzorno ploščo"],
+      "Set auto-refresh interval": ["Nastavi interval samodejnega osveževanja"],
+      "Set filter mapping": ["Nastavi shemo filtrov"],
+      "Edit dashboard properties": ["Uredi lastnosti nadzorne plošče"],
+      "Edit CSS": ["Uredi CSS"],
+      "Download as image": ["Izvozi kot sliko"],
+      "Toggle fullscreen": ["Preklopi celozaslonski način"],
+      "An error has occurred": ["Prišlo je do napake"],
+      "You do not have permission to edit this dashboard": [
+        "Nimate dovoljenja za urejanje te nadzorne plošče"
+      ],
+      "A valid color scheme is required": [
+        "Zahtevana je veljavna barvna shema"
+      ],
+      "The dashboard has been saved": ["Nadzorna plošča je bila shranjena"],
+      "Access": ["Dostop"],
+      "Owners is a list of users who can alter the dashboard. Searchable by name or username.": [
+        "\"Lastniki\" je seznam uporabnikov, ki lahko spreminjajo nadzorno ploščo. Iskanje je možno po imenu ali uporabniškem imenu."
+      ],
+      "Colors": ["Barve"],
+      "Roles is a list which defines access to the dashboard. Granting a role access to a dashboard will bypass dataset level checks. If no roles defined then the dashboard is available to all roles.": [
+        "\"Vloge\" je seznam, ki definira dostop do nadzorne plošče. Dodelitev vloge za dostop do nadzorne plošče bo obšlo preverjanje na nivoju podatkovnega seta. Če vloga ni definirana, bo nadzorna plošča dostopna vsem vlogam."
+      ],
+      "Apply": ["Uporabi"],
+      "Dashboard properties": ["Lastnosti nadzorne plošče"],
+      "Basic information": ["Osnovne informacije"],
+      "URL slug": ["URL slug"],
+      "A readable URL for your dashboard": [
+        "Berljiv URL za vašo nadzorno ploščo"
+      ],
+      "Advanced": ["Napredno"],
+      "JSON metadata": ["JSON metapodatki"],
+      "This dashboard is not published, it will not show up in the list of dashboards. Click here to publish this dashboard.": [
+        "Ta nadzorna plošča ni objavljena in se ne bo prikazala na seznamu nadzornih plošč. Kliknite tukaj za njeno objavo."
+      ],
+      "This dashboard is not published which means it will not show up in the list of dashboards. Favorite it to see it there or access it by using the URL directly.": [
+        "Ta nadzorna plošča ni objavljena in se ne bo prikazala na seznamu nadzornih plošč. Uvrstite jo med priljubljene, da jo boste videli tam, ali pa uporabite URL za neposredni dostop."
+      ],
+      "This dashboard is published. Click to make it a draft.": [
+        "Ta nadzorna plošča je objavljena. Kliknite, da jo uvrstite med osnutke."
+      ],
+      "Draft": ["Osnutek"],
+      "Annotation layers are still loading.": [
+        "Sloj z oznakami se še vedno nalaga."
+      ],
+      "One ore more annotation layers failed loading.": [
+        "Eden ali več slojev z oznakami se ni naložil."
+      ],
+      "Emitted values": ["Oddane vrednosti"],
+      "Cached %s": ["Predpomnjeno %s"],
+      "Fetched %s": ["Pridobljeno %s"],
+      "Minimize chart": ["Pomanjšaj grafikon"],
+      "Maximize chart": ["Povečaj grafikon"],
+      "Force refresh": ["Osveži"],
+      "Toggle chart description": ["Preklopi opis grafikona"],
+      "View chart in Explore": ["Ogled grafikona v Raziskovalcu"],
+      "View query": ["Ogled poizvedbe"],
+      "Copy chart URL": ["Kopiraj URL grafikona"],
+      "Share chart by email": ["Deli grafikon po e-pošti"],
+      "Check out this chart: ": ["Preizkusite ta grafikon: "],
+      "Export CSV": ["Izvozi CSV"],
+      "Cross-filter scoping": ["Obseg cross-filtra"],
+      "Search...": ["Iskanje ..."],
+      "No filter is selected.": ["Noben filter ni izbran."],
+      "Editing 1 filter:": ["Urejanje enega filtra:"],
+      "Batch editing %d filters:": ["Skupinsko urejanje %d filtrov:"],
+      "Configure filter scopes": ["Nastavi obseg filtrov"],
+      "There are no filters in this dashboard.": [
+        "V nadzorni plošči ni filtrov."
+      ],
+      "Expand all": ["Razširi vse"],
+      "Collapse all": ["Skrči vse"],
+      "This markdown component has an error.": [
+        "Markdown komponenta ima napako."
+      ],
+      "This markdown component has an error. Please revert your recent changes.": [
+        "Markdown komponenta ima napako. Povrnite nedavne spremembe."
+      ],
+      "Delete dashboard tab?": ["Ali izbrišem zavihek nadzorne plošče?"],
+      "Divider": ["Ločilnik"],
+      "Header": ["Glava"],
+      "Row": ["Vrstica"],
+      "Tabs": ["Zavihki"],
+      "Preview": ["Predogled"],
+      "Sorry, your browser does not support copying.": [
+        "Vaš brskalnik ne podpira kopiranja."
+      ],
+      "Sorry, something went wrong. Try again later.": [
+        "Nekaj je šlo narobe. Poskusite ponovno kasneje."
+      ],
+      "All Filters (${filterValues.length})": [
+        "Vsi filtri (${filterValues.length})"
+      ],
+      "Filter Sets (${filterSetFilterValues.length})": [
+        "Nastavljeni filtri (${filterSetFilterValues.length})"
+      ],
+      "Select parent filters": ["Izberi starševske filtre"],
+      "Check configuration": ["Preveri nastavitve"],
+      "Cannot load filter": ["Filtra ni mogoče naložiti"],
+      "Editing filter set:": ["Urejanje seta filtrov:"],
+      "Filter set with this name already exists": [
+        "Set filtrov z enakim imenom že obstaja"
+      ],
+      "Filter set already exists": ["Set filtrov že obstaja"],
+      "This filter set is identical to: \"%s\"": [
+        "Ta set filtrov je enak: \"%s\""
+      ],
+      "Remove invalid filters": ["Odstrani neveljavne filtre"],
+      "Rebuild": ["Obnovi"],
+      "Filters (%d)": ["Filtri (%d)"],
+      "This filter doesn't exist in dashboard. It will not be applied.": [
+        "Ta filter ne obstaja v nadzorni plošči in ne bo uveljavljen."
+      ],
+      "Filter metadata changed in dashboard. It will not be applied.": [
+        "Metapodatki filtra so se spremenili v nadzorni plošči. Ne bo uveljavljen."
+      ],
+      "None": ["Brez"],
+      "Please filter set name": ["Vnesite ime seta filtrov"],
+      "Create": ["Ustvari"],
+      "Create new filter set": ["Ustvarite nov set filtrov"],
+      "New filter set": ["Nov set filtrov"],
+      "Please apply filter changes": ["Potrdite spremembe filtra"],
+      "Unknown value": ["Neznana vrednost"],
+      "Clear all": ["Počisti vse"],
+      "Add filter": ["Dodaj filter"],
+      "(Removed)": ["(Odstranjeno)"],
+      "Undo?": ["Povrni?"],
+      "New filter": ["Nov filter"],
+      "Filters configuration and scoping": ["Nastavitve in obseg filtrov"],
+      "Configuration": ["Nastavitve"],
+      "Scoping": ["Obseg"],
+      "Basic": ["Osnovno"],
+      "Filter name": ["Ime filtra"],
+      "Name is required": ["Zahtevano je ime"],
+      "Filter Type": ["Tip filtra"],
+      "Dataset": ["Podatkovni set"],
+      "Dataset is required": ["Zahtevan je podatkovni set"],
+      "Filter has default value": ["Filter ima privzeto vrednost"],
+      "Default Value": ["Privzeta vrednost"],
+      "Default value is required": ["Zahtevana je privzeta vrednost"],
+      "Fill all required fields to enable \"Default Value\"": [
+        "Izpolnite vsa polja, da omogočite \"Privzeto vrednost\""
+      ],
+      "Apply changes instantly": ["Spremembe uporabi takoj"],
+      "Filter is hierarchical": ["Filter je hierarhičen"],
+      "Parent filter": ["Nadrejeni filter"],
+      "Parent filter is required": ["Zahtevan je nadrejeni filter"],
+      "Pre-filter available values": ["Predfiltriraj razpoložljive vrednosti"],
+      "Adhoc filters is required": ["Zahtevan je ad hoc filter"],
+      "Adhoc filters": ["Adhoc filtri"],
+      "Time range": ["Časovno obdobje"],
+      "Sort filter values": ["Razvrsti vrednosti filtra"],
+      "Sort type": ["Vrsta razvrščanja"],
+      "Sort ascending": ["Razvrsti naraščajoče"],
+      "Sort descending": ["Razvrsti padajoče"],
+      "Sort Metric": ["Mera za razvrščanje"],
+      "You have removed this filter.": ["Odstranili ste ta filter."],
+      "Restore Filter": ["Povrni filter"],
+      "Populate \"Default value\" to enable this control": [
+        "Izpolnite \"Privzeto vrednost\", da omogočite ta kontrolnik"
+      ],
+      "Apply to all panels": ["Uporabi za vse panele"],
+      "Apply to specific panels": ["Uporabi za določene panele"],
+      "Only selected panels will be affected by this filter": [
+        "Ta filter bo vplival le na izbrane panele"
+      ],
+      "All panels with this column will be affected by this filter": [
+        "Ta filter bo vplival na vse panele s tem stolpcem"
+      ],
+      "All panels": ["Vsi paneli"],
+      "Keep editing": ["Nadaljuj z urejanjem"],
+      "Yes, cancel": ["Da, prekini"],
+      "Are you sure you want to cancel?": ["Ali želite prekiniti?"],
+      "will not be saved.": ["ne bo shranjeno."],
+      "Transparent": ["Prozorno"],
+      "White": ["Belo"],
+      "All filters": ["Vsi filtri"],
+      "All charts": ["Vsi grafikoni"],
+      "Small": ["Majhno"],
+      "Medium": ["Srednje"],
+      "Large": ["Veliko"],
+      "Tab title": ["Naslov zavihka"],
+      "Warning! Changing the dataset may break the chart if the metadata does not exist.": [
+        "Opozorilo! Sprememba podatkovnega seta lahko pokvari grafikon, če metapodatki ne obstajajo."
+      ],
+      "Changing the dataset may break the chart if the chart relies on columns or metadata that does not exist in the target dataset": [
+        "Sprememba podatkovnega seta lahko pokvari grafikon, če se le-ta zanaša na stolpce ali metapodatke, ki ne obstajajo v ciljnem podatkovnem nizu"
+      ],
+      "dataset": ["podatkovni set"],
+      "Change dataset": ["Spremeni podatkovni set"],
+      "Warning!": ["Opozorilo!"],
+      "Search / Filter": ["Iskanje / Filter"],
+      "Physical (table or view)": ["Fizičen (tabela ali pogled)"],
+      "Virtual (SQL)": ["Virtualen (SQL)"],
+      "SQL expression": ["SQL izraz"],
+      "Data type": ["Tip podatka"],
+      "Datetime format": ["Oblika datum-časa"],
+      "The pattern of timestamp format. For strings use ": [
+        "Vzorec zapisa časovne značke. Za znakovne nize uporabite "
+      ],
+      "Python datetime string pattern": ["Pythonov vzorec zapisa datum-časa"],
+      " expression which needs to adhere to the ": [" , ki mora upoštevati "],
+      "ISO 8601": ["ISO 8601"],
+      " standard to ensure that the lexicographical ordering\r\n                      coincides with the chronological ordering. If the\r\n                      timestamp format does not adhere to the ISO 8601 standard\r\n                      you will need to define an expression and type for\r\n                      transforming the string into a date or timestamp. Note\r\n                      currently time zones are not supported. If time is stored\r\n                      in epoch format, put `epoch_s` or `epoch_ms`. If no pattern\r\n                      is specified we fall back to using the optional defaults on a per\r\n                      database/column name level via the extra parameter.": [
+        " standard, ki zagotavlja, de se leksikografsko razvrščanje\r\n                      sklada s kronološkim razvrščanjem. Če oblika\r\n                      časovne značke ni v skladu s standardom ISO 8601,\r\n                      boste morali definirati izraz in tip za transformacijo\r\n                      znakovnega niza v datum ali časovno značko.\r\n                      Trenutno časovni pasovi niso podprti.\r\n                      Če je čas shranjen v obliki epohe, dodajte `epoch_s` ali `epoch_ms`.\r\n                      Če ni podan vzorec, se uporabijo privzete vrednosti na podlagi imena\r\n                      podatkovne baze oz. stolpca s pomočjo dodatnega parametra."
+      ],
+      "Is dimension": ["Dimenzija"],
+      "Is filterable": ["Filtriranje"],
+      "Modified columns: %s": ["Spremenjeni stolpci: %s"],
+      "Removed columns: %s": ["Odstranjeni stolpci: %s"],
+      "New columns added: %s": ["Dodani novi stolpci: %s"],
+      "Metadata has been synced": ["Metapodatki so sinhronizirani"],
+      "Column name [%s] is duplicated": ["Ime stolpca [%s] je podvojeno"],
+      "Metric name [%s] is duplicated": ["Ime mere [%s] je podvojeno"],
+      "Calculated column [%s] requires an expression": [
+        "Izračunan stolpec [%s] zahteva izraz"
+      ],
+      "Default URL": ["Privzeti URL"],
+      "Default URL to redirect to when accessing from the dataset list page": [
+        "Privzeti URL za preusmeritev, ko dostopate iz strani s seznamom podatkovnih setov"
+      ],
+      "Autocomplete filters": ["Samodokončaj filtre"],
+      "Whether to populate autocomplete filters options": [
+        "Če želite napolniti možnosti za samodokončanje filtrov"
+      ],
+      "Autocomplete query predicate": ["Predikat za samodokončanje poizvedb"],
+      "When using \"Autocomplete filters\", this can be used to improve performance of the query fetching the values. Use this option to apply a predicate (WHERE clause) to the query selecting the distinct values from the table. Typically the intent would be to limit the scan by applying a relative time filter on a partitioned or indexed time-related field.": [
+        "Ko uporabljate \"Samodokončaj filtre\", lahko s tem izboljšate hitrost pridobivanja rezultatov s poizvedbo. Z uporabo te možnosti dodate predikat (WHERE stavek) k poizvedbi za izbiro različnih vrednosti iz tabele. Običajno je namen omejiti poizvedbo z uporabo filtra za relativni čas na particioniranem ali indeksiranem časovnem polju."
+      ],
+      "Extra data to specify table metadata. Currently supports metadata of the format: `{ \"certification\": { \"certified_by\": \"Data Platform Team\", \"details\": \"This table is the source of truth.\" }, \"warning_markdown\": \"This is a warning.\" }`.": [
+        "Dodatni podatki za tabelo metapodatkov. Trenutno je podprta naslednja oblika zapisa metapodatkov: `{ \"certification\": { \"certified_by\": \"Tim za razvoj\", \"details\": \"Ta tabela je vir resnice.\" }, \"warning_markdown\": \"To je opozorilo.\" }`."
+      ],
+      "Owners of the dataset": ["Lastniki podatkovnega seta"],
+      "Cache timeout": ["Časovna omejitev predpomnilnika"],
+      "The duration of time in seconds before the cache is invalidated": [
+        "Trajanje (v sekundah) do razveljavitve predpomnilnika"
+      ],
+      "Hours offset": ["Urni premik"],
+      "The number of hours, negative or positive, to shift the time column. This can be used to move UTC time to local time.": [
+        "Število ur, negativno ali pozitivno, za zamik časovnega stolpca. Na ta način je mogoče UTC čas prestaviti na lokalni čas."
+      ],
+      "Spatial": ["Prostorski"],
+      "virtual": ["virtualni"],
+      "Dataset name": ["Ime podatkovnega seta"],
+      "When specifying SQL, the datasource acts as a view. Superset will use this statement as a subquery while grouping and filtering on the generated parent queries.": [
+        "Ko podajate SQL, se podatkovni vir obnaša kot pogled (view). Superset bo to izjavo uporabil kot podpoizvedbo, pri čemer bo grupiral in filtriral na podlagi ustvarjenih starševskih poizvedb."
+      ],
+      "The JSON metric or post aggregation definition.": [
+        "JSON mera ali po-agregacijska definicija."
+      ],
+      "Physical": ["Fizičen"],
+      "The pointer to a physical table (or view). Keep in mind that the chart is associated to this Superset logical table, and this logical table points the physical table referenced here.": [
+        "Kazalec na fizično tabelo (ali pogled). Grafikon je povezan s to Supersetovo logično tabelo, ki kaže na tukaj referencirano fizično tabelo."
+      ],
+      "Click the lock to make changes.": [
+        "Kliknite ključavnico, da omogočite spreminjanje."
+      ],
+      "Click the lock to prevent further changes.": [
+        "Kliknite ključavnico, da onemogočite spremembe."
+      ],
+      "D3 format": ["D3 format"],
+      "Certified by": ["Certificiral/a"],
+      "Person or group that has certified this metric": [
+        "Oseba ali skupina, ki je certificirala to mero"
+      ],
+      "Certification details": ["Podrobnosti certifikacije"],
+      "Details of the certification": ["Podrobnosti certifikacije"],
+      "Warning": ["Opozorilo"],
+      "Optional warning about use of this metric": [
+        "Opcijsko opozorilo za uporabo te mere"
+      ],
+      "Be careful.": ["Bodite previdni."],
+      "Changing these settings will affect all charts using this dataset, including charts owned by other people.": [
+        "Spreminjanje teh nastavitev bo vplivalo na vse grafikone, ki uporabljajo ta podatkovni set, vključno z grafikoni v lasti drugih oseb."
+      ],
+      "Source": ["Izvor"],
+      "Sync columns from source": ["Sinhroniziraj stolpce z virom"],
+      "Calculated columns": ["Izračunani stolpci"],
+      "Settings": ["Nastavitve"],
+      "The dataset has been saved": ["Podatkovni set je shranjen"],
+      "The dataset configuration exposed here\r\n                affects all the charts using this dataset.\r\n                Be mindful that changing settings\r\n                here may affect other charts\r\n                in undesirable ways.": [
+        "Tukaj prikazane nastavitve podatkovnega seta\r\n                vpliva na vse grafikone, ki uporabljajo\r\n                ta podatkovni set. Spreminjanje\r\n                nastavitev lahko nezaželeno vpliva\r\n                na druge grafikone."
+      ],
+      "Are you sure you want to save and apply changes?": [
+        "Ali resnično želite shraniti in uporabiti spremembe?"
+      ],
+      "Confirm save": ["Potrdite shranjevanje"],
+      "Edit Dataset ": ["Uredi podatkovni set "],
+      "Use legacy datasource editor": [
+        "Uporabi starejši urejevalnik podatkovnega vira"
+      ],
+      "Time column": ["Časovni stolpec"],
+      "Time grain": ["Granulacija časa"],
+      "Origin": ["Izhodišče"],
+      "Time granularity": ["Granulacija časa"],
+      "A reference to the [Time] configuration, taking granularity into account": [
+        "Sklic na nastavitve za [Čas], ki upošteva granulacijo"
+      ],
+      "Group by": ["Združevanje (Group by)"],
+      "One or many controls to group by": [
+        "En ali več kontrolnikov za združevanje"
+      ],
+      "One or many metrics to display": ["Ena ali več mer za prikaz"],
+      "Visualization type": ["Tip vizualizacije"],
+      "The type of visualization to display": ["Tip vizualizacije za prikaz"],
+      "Fixed color": ["Izbrana barva"],
+      "Use this to define a static color for all circles": [
+        "S tem definirate določeno barvo za vse kroge"
+      ],
+      "Right axis metric": ["Mera desne osi"],
+      "Choose a metric for right axis": ["Izberite mero za desno os"],
+      "Linear color scheme": ["Linearna barvna shema"],
+      "Color metric": ["P"],
+      "A metric to use for color": ["Mera za barvo"],
+      "One or many controls to pivot as columns": [
+        "En ali več kontrolnikov za stolpčno vrtenje"
+      ],
+      "Defines the origin where time buckets start, accepts natural dates as in `now`, `sunday` or `1970-01-01`": [
+        "Določa izhodišče, kadar se začnejo časovni razdelki. Sprejema naravne zapise kot so `zdaj`, `nedelja` ali `1970-01-01`"
+      ],
+      "The time granularity for the visualization. Note that you can type and use simple natural language as in `10 seconds`, `1 day` or `56 weeks`": [
+        "Granulacija časa za vizualizacijo. Uporabite lahko vnos z naravnim jezikom, kot npr. `10 sekund`, `1 dni` ali `56 tednov`"
+      ],
+      "The time column for the visualization. Note that you can define arbitrary expression that return a DATETIME column in the table. Also note that the filter below is applied against this column or expression": [
+        "Časovni stolpec za vizualizacijo. Določite lahko poljuben izraz, ki vrne DATETIME stolpec v tabeli. Spodnji filter se nanaša na ta stolpec ali izraz"
+      ],
+      "The time granularity for the visualization. This applies a date transformation to alter your time column and defines a new time granularity. The options here are defined on a per database engine basis in the Superset source code.": [
+        "Granulacija časa za to vizualizacijo. Izvede transformacijo podatkov, ki spremeni vaš časovni stolpec in določi novo časovno granulacija. Ta možnost je definirana na ravni sistema podatkovne baze v izvorni kodi Superseta."
+      ],
+      "No filter": ["Brez filtra"],
+      "The time range for the visualization. All relative times, e.g. \"Last month\", \"Last 7 days\", \"now\", etc. are evaluated on the server using the server's local time (sans timezone). All tooltips and placeholder times are expressed in UTC (sans timezone). The timestamps are then evaluated by the database using the engine's local timezone. Note one can explicitly set the timezone per the ISO 8601 format if specifying either the start and/or end time.": [
+        "Časovno obdobje za vizualizacijo. Vsi relativni časi, kot npr. \"Zadnji mesec\", Zadnjih 7 dni\", \"Zdaj\" so izračunani na strežniku z njegovim lokalnim časom. Vsi opisi orodij in časi so izraženi v UTC. Časovne značke se nato izračunajo v podatkovni bazi z njenim lokalnim časovnim pasom. Eksplicitno lahko nastavite časovni pas v ISO 8601 formatu, če določite čas začetka ali konca."
+      ],
+      "Row limit": ["Omejitev št. vrstic"],
+      "Series limit": ["Omejitev št. vrst"],
+      "Limits the number of time series that get displayed. A sub query (or an extra phase where sub queries are not supported) is applied to limit the number of time series that get fetched and displayed. This feature is useful when grouping by high cardinality dimension(s).": [
+        "Omeji število časovnih vrst za prikaz. S podpoizvedbo (ali dodatno fazo, kjer podpoizvedbe niso podprte) se omeji število časovnih vrst, ki bodo pridobljene za prikaz. Ta funkcija je uporabna pri združevanju dimenzij z veliko kardinalnostjo."
+      ],
+      "Metric used to define the top series": [
+        "Mera za določanje najvišje podatkovne serije"
+      ],
+      "Series": ["Niz"],
+      "Defines the grouping of entities. Each series is shown as a specific color on the chart and has a legend toggle": [
+        "Določa združevanje entitet. Vsak niz je na grafikonu prikazan z določeno barvo in ima lahko prikazano legendo"
+      ],
+      "Entity": ["Entiteta"],
+      "This defines the element to be plotted on the chart": [
+        "Določa element, ki bo izrisan na grafikonu"
+      ],
+      "X Axis": ["X os"],
+      "Metric assigned to the [X] axis": ["Mera za [X] os"],
+      "Y Axis": ["Y os"],
+      "Metric assigned to the [Y] axis": ["Mera za [Y] os"],
+      "Bubble size": ["Velikost mehurčka"],
+      "Y Axis Format": ["Oblika Y osi"],
+      "When `Calculation type` is set to \"Percentage change\", the Y Axis Format is forced to `.1%`": [
+        "Če je `Vrsta izračuna` nastavljena na \"Procentualna sprememba\", bo oblika Y-osi vsiljena na `.1%`"
+      ],
+      "The color scheme for rendering chart": [
+        "Barvna shema za izris grafikona"
+      ],
+      "Color map": ["Barvna lestvica"],
+      "An error occurred while starring this chart": [
+        "Pri ocenjevanju grafikona je prišlo do napake"
+      ],
+      "description": ["opis"],
+      "bolt": ["vijak"],
+      "Changing this control takes effect instantly": [
+        "Sprememba tega kontrolnika se odrazi takoj"
+      ],
+      "Customize": ["Prilagodi"],
+      "Height": ["Višina"],
+      "Width": ["Širina"],
+      "Copy chart URL to clipboard": ["Kopiraj URL grafikona na odložišče"],
+      "Loading...": ["Nalagam ..."],
+      "Superset Chart": ["Superset grafikon"],
+      "Export to .JSON format": ["Izvozi v .json format"],
+      "Export to .CSV format": ["Izvozi v .csv format"],
+      "%s - untitled": ["%s - neimenovan"],
+      "Edit chart properties": ["Uredi lastnosti grafikona"],
+      "Controls labeled ": ["Kontrolniki imenovani "],
+      "Control labeled ": ["Nastavitev "],
+      "Open Datasource tab": ["Odpri zavihek s podatkovnim virom"],
+      "rows": ["vrstic"],
+      "Limit reached": ["Omejitev dosežena"],
+      "**Select** a dashboard OR **create** a new one": [
+        "**Izberite** nadzorno ploščo ALI **ustvarite** novo"
+      ],
+      "Please enter a chart name": ["Vnesite ime grafikona"],
+      "Save chart": ["Shrani grafikon"],
+      "Save & go to dashboard": ["Shrani in pojdi na nadzorno ploščo"],
+      "Save as new chart": ["Shrani kot nov grafikon"],
+      "Save (Overwrite)": ["Shrani (prepiši)"],
+      "Save as ...": ["Shrani kot ..."],
+      "Chart name": ["Ime grafikona"],
+      "Add to dashboard": ["Dodaj na nadzorno ploščo"],
+      "rows retrieved": ["vrnjenih vrstic"],
+      "Sorry, An error occurred": ["Prišlo je do napake"],
+      "No data": ["Ni podatkov"],
+      "View samples": ["Ogled vzorcev"],
+      "Search Metrics & Columns": ["Iskanje mer in stolpcev"],
+      "Showing %s of %s": ["Prikazanih %s od %s"],
+      "New chart": ["Nov grafikon"],
+      "Edit properties": ["Uredi lastnosti"],
+      "Run in SQL Lab": ["Zaženi v SQL laboratoriju"],
+      "You do not have permission to edit this chart": [
+        "Nimate dovoljenja za urejanje tega grafikona"
+      ],
+      "The description can be displayed as widget headers in the dashboard view. Supports markdown.": [
+        "Opis je lahko prikazan kot glava gradnika in pogledu nadzorne plošče. Podpira markdown."
+      ],
+      "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the dataset's timeout if undefined.": [
+        "Časovna veljavnost (v sekundah) predpomnjenja za ta grafikon. Če ni definirana, je uporabljena vrednost za podatkovni set."
+      ],
+      "A list of users who can alter the chart. Searchable by name or username.": [
+        "Seznam uporabnikov, ki lahko spreminjajo ta grafikon. Možno je iskanje po imenu ali uporabniškem imenu."
+      ],
+      "Min": ["Min"],
+      "Max": ["Max"],
+      "No results found": ["Rezultati niso najdeni"],
+      "%s option(s)": ["Možnosti: %s"],
+      "Invalid lat/long configuration.": [
+        "Neveljavna nastavitev zemljepisne dolžine/širine."
+      ],
+      "Reverse lat/long ": ["Zamenjaj zemljepisno dolžino/širino "],
+      "Longitude & Latitude columns": ["Stolpci zemljepisne dolžine in širine"],
+      "Delimited long & lat single column": [
+        "En stolpec z ločenima zemljepisno dolžino in širino"
+      ],
+      "Multiple formats accepted, look the geopy.points Python library for more details": [
+        "Sprejema različne zapise - podrobnosti najdete v Pythonovi knjižnici geopy.points"
+      ],
+      "Geohash": ["Geohash"],
+      "textarea": ["področje besedila"],
+      "in modal": ["v modalnem"],
+      "Failed to verify select options: %s": [
+        "Preverjanje možnosti izbire ni uspelo: %s"
+      ],
+      "Annotation Slice Configuration": ["Nastavitve rezine z oznakami"],
+      "This section allows you to configure how to use the slice\r\n               to generate annotations.": [
+        "V tem sklopu lahko nastavite način uporabe rezine\r\n               za ustvarjanje oznak."
+      ],
+      "Display configuration": ["Prikaži nastavitve"],
+      "Configure your how you overlay is displayed here.": [
+        "Nastavite kako se tukaj prikazuje vrhnja plast."
+      ],
+      "Style": ["Stil"],
+      "Opacity": ["Prosojnost"],
+      "Color": ["Barva"],
+      "Line width": ["Debelina črte"],
+      "Layer configuration": ["Nastavitve sloja"],
+      "Configure the basics of your Annotation Layer.": [
+        "Osnovne nastavitve sloja z oznakami."
+      ],
+      "Mandatory": ["Obvezno"],
+      "Hide layer": ["Skrij sloj"],
+      "Choose the annotation layer type": ["Izberite tip sloja z oznakami"],
+      "Annotation layer type": ["Tip sloja z oznakami"],
+      "Remove": ["Odstrani"],
+      "Edit annotation layer": ["Uredi sloj z oznakami"],
+      "Add annotation layer": ["Dodaj sloj z oznakami"],
+      "Empty collection": ["Prazen izbor"],
+      "Add an item": ["Dodaj element"],
+      "Remove item": ["Odstrani element"],
+      "Edit dataset": ["Uredi podatkovni set"],
+      "View in SQL Lab": ["Ogled v SQL laboratoriju"],
+      "More dataset related options": ["Več nastavitev za podatkovni set"],
+      "Missing dataset": ["Manjka podatkovni set"],
+      "The dataset linked to this chart may have been deleted.": [
+        "Podatkovni set, povezan s tem grafikonom, je bil izbrisan."
+      ],
+      "RANGE TYPE": ["TIP OBDOBJA"],
+      "Actual time range": ["Dejansko časovno obdobje"],
+      "CANCEL": ["PREKINI"],
+      "APPLY": ["UPORABI"],
+      "Edit time range": ["Uredi časovno obdobje"],
+      "Configure Advanced Time Range ": ["Nastavi napredno časovno obdobje "],
+      "START (INCLUSIVE)": ["ZAČETEK (VKLJUČEN)"],
+      "Start date included in time range": [
+        "Začetni datum je vključen v časovno obdobje"
+      ],
+      "END (EXCLUSIVE)": ["KONEC (NI VKLJUČEN)"],
+      "End date excluded from time range": [
+        "Končni datum ni vključen v časovno obdobje"
+      ],
+      "Configure Time Range: Previous...": [
+        "Nastavi časovno obdobje: Prejšnji ..."
+      ],
+      "Configure Time Range: Last...": ["Nastavi časovno obdobje: Zadnji ..."],
+      "Configure custom time range": ["Nastavi prilagojeno časovno obdobje"],
+      "Relative quantity": ["Relativne vrednosti"],
+      "Anchor to": ["Sidraj na"],
+      "NOW": ["ZDAJ"],
+      "Date/Time": ["Datum/Čas"],
+      "Return to specific datetime.": ["Vrne določen datum-čas."],
+      "Syntax": ["Sintaksa"],
+      "Example": ["Primer"],
+      "Moves the given set of dates by a specified interval.": [
+        "Premakne dani nabor datumov za definirano obdobje."
+      ],
+      "Truncates the specified date to the accuracy specified by the date unit.": [
+        "Zaokroži določen datum, glede na natančnost, definirano s časovno enoto."
+      ],
+      "Get the last date by the date unit.": [
+        "Pridobi zadnji datum glede na časovno enoto."
+      ],
+      "Get the specify date for the holiday": ["Določi datum praznika"],
+      "Last": ["Zadnji"],
+      "Previous": ["Prejšnji"],
+      "Custom": ["Prilagojen"],
+      "last day": ["zadnji dan"],
+      "last week": ["zadnji teden"],
+      "last month": ["zadnji mesec"],
+      "last quarter": ["zadnje četrletje"],
+      "last year": ["zadnje leto"],
+      "previous calendar week": ["prejšnji koledarski teden"],
+      "previous calendar month": ["prejšnji koledarski mesec"],
+      "previous calendar year": ["prejšnje koledarsko leto"],
+      "Before": ["PRED"],
+      "After": ["PO"],
+      "Specific Date/Time": ["Fiksen Datum/Čas"],
+      "Relative Date/Time": ["Relativen Datum/Čas"],
+      "Now": ["Zdaj"],
+      "Midnight": ["Polnoč"],
+      "Drop column": ["Izpusti stolpec"],
+      "Drop columns or metrics": ["Izpusti stolpce ali mere"],
+      "Drop column or metric": ["Izpusti stolpec ali mero"],
+      "Drop columns": ["Izpusti stolpce"],
+      "Default": ["Privzeto"],
+      "(optional) default value for the filter, when using the multiple option, you can use a semicolon-delimited list of options.": [
+        "(opcijsko) privzeta vrednost za filter, če uporabite opcijo izbire večih , lahko uporabite seznam nastavitev ločen s podpičji."
+      ],
+      "Sort metric": ["Mera za razvrščanje"],
+      "Metric to sort the results by": ["Mera za razvrščanje rezultatov"],
+      "Check for sorting ascending": ["Označi za naraščajoče razvrščanje"],
+      "Allow multiple selections": ["Dovoli več izbir"],
+      "Multiple selections allowed, otherwise filter is limited to a single value": [
+        "Lahko izberete več elementov, drugače pa je filter omejen na eno vrednost"
+      ],
+      "Search all filter options": ["PoIšči vse možnosti filtra"],
+      "By default, each filter loads at most 1000 choices at the initial page load. Check this box if you have more than 1000 filter values and want to enable dynamically searching that loads filter values as users type (may add stress to your database).": [
+        "Privzeto vsak filter pri nalaganju začetne strani naloži največ 1000 možnosti. Označite polje, če imate več kot 1000 vrednosti filtra in želite omogočiti dinamično iskanje, ki nalaga vrednosti filtra ko uporabnik tipka (to lahko preobremeni vašo podatkovno bazo)."
+      ],
+      "Required": ["Obvezno"],
+      "User must select a value for this filter": [
+        "Uporabnik mora izbrati vrednost za ta filter"
+      ],
+      "Filter configuration": ["Nastavitve filtra"],
+      "Simple": ["Preprosto"],
+      "Custom SQL": ["Prilagojen SQL"],
+      "No such column found. To filter on a metric, try the Custom SQL tab.": [
+        "Tak stolpec ni najden. Za filtriranje po meri uporabite prilagojen SQL zavihek."
+      ],
+      "%s column(s) and metric(s)": ["Stolpcev in mer: %s"],
+      "%s column(s)": ["Stolpci: %s"],
+      "To filter on a metric, use Custom SQL tab.": [
+        "Za filtriranje po meri uporabite prilagojen SQL zavihek."
+      ],
+      "%s operator(s)": ["Operatorji: %s"],
+      "Type a value here": ["Vnesite vrednost sem"],
+      "Filter value (case sensitive)": [
+        "Vrednost filtra (razlik. velikih/malih črk)"
+      ],
+      "choose WHERE or HAVING...": ["izberite WHERE ali HAVING..."],
+      "Filters by columns": ["Filtrira po stolpcu"],
+      "Filters by metrics": ["Filtrira po merah"],
+      "Fixed": ["Fiksno"],
+      "Based on a metric": ["Osnovan na meri"],
+      "My metric": ["Moja mera"],
+      "Add metric": ["Dodaj mero"],
+      "%s aggregates(s)": ["Agreg. funkcije: %s"],
+      "%s saved metric(s)": ["Shranjene mere: %s"],
+      "Saved": ["Shranjeno"],
+      "Saved metric": ["Shranjena mera"],
+      "column": ["stolpec"],
+      "aggregate": ["agregacija"],
+      "\r\n                This filter was inherited from the dashboard's context.\r\n                It won't be saved when saving the chart.\r\n              ": [
+        "\r\n                Ta filter izvira iz nadzorne plošče.\r\n                Ne bo se shranil pri shranjevanju grafikona.\r\n                "
+      ],
+      "Error while fetching data": ["Napaka pri pridobivanju podatkov"],
+      "Time series columns": ["Stolpci s časovnimi vrstami"],
+      "This visualization type is not supported.": [
+        "Ta tip vizualizacije ni podprt."
+      ],
+      "Click to change visualization type": [
+        "Kliknite za spremembo tipa vizualizacije"
+      ],
+      "Select a visualization type": ["Izberite tip vizualizacije"],
+      "Code": ["Koda"],
+      "Markup type": ["Tip označevanja"],
+      "Pick your favorite markup language": [
+        "Izberite svoj priljubljen označevalni jezik"
+      ],
+      "Put your code here": ["Vstavite svojo kodo sem"],
+      "Query": ["Poizvedba"],
+      "URL": ["URL"],
+      "Templated link, it's possible to include {{ metric }} or other values coming from the controls.": [
+        "Vzorčna povezava, vključiti je mogoče {{ metric }} ali drugo vrednost iz kontrolnikov."
+      ],
+      "Time": ["Čas"],
+      "Time related form attributes": ["S časom povezani atributi prikaza"],
+      "Chart type": ["Tip grafikona"],
+      "Chart ID": ["ID grafikona"],
+      "The id of the active chart": ["Identifikator aktivnega grafikona"],
+      "Cache Timeout (seconds)": ["Trajanje predpomnilnika (sekunde)"],
+      "The number of seconds before expiring the cache": [
+        "Trajanje (v sekundah) do razveljavitve predpomnilnika"
+      ],
+      "URL parameters": ["Parametri URL"],
+      "Extra parameters for use in jinja templated queries": [
+        "Dodatni parametri za poizvedbe z jinja predlogami"
+      ],
+      "Time range endpoints": ["Krajne točke časovnega obdobja"],
+      "Time range endpoints (SIP-15)": [
+        "Krajne točke časovnega obdobja (SIP-15)"
+      ],
+      "Annotations and layers": ["Oznake in sloji"],
+      "Whether to sort descending or ascending": [
+        "Če želite padajoče ali naraščajoče razvrščanje"
+      ],
+      "Contribution": ["Prispevek"],
+      "Compute the contribution to the total": ["Izračunaj prispevek k celoti"],
+      "Advanced analytics": ["Napredna analitika"],
+      "This section contains options that allow for advanced analytical post processing of query results": [
+        "Ta sekcija vsebuje možnosti, ki omogočajo napredno analitično poprocesiranje rezultatov poizvedb"
+      ],
+      "Rolling window": ["Drseče okno"],
+      "Rolling function": ["Drseča funkcija"],
+      "Defines a rolling window function to apply, works along with the [Periods] text box": [
+        "Določi funkcijo drsečega okna. Dela skupaj s tekstovnim okvirjem [Obdobja]"
+      ],
+      "Periods": ["Št. period"],
+      "Defines the size of the rolling window function, relative to the time granularity selected": [
+        "Določi velikost funkcije drsečega okna, glede na izbrano granulacijo časa"
+      ],
+      "Min periods": ["Min. št. period"],
+      "The minimum number of rolling periods required to show a value. For instance if you do a cumulative sum on 7 days you may want your \"Min Period\" to be 7, so that all data points shown are the total of 7 periods. This will hide the \"ramp up\" taking place over the first 7 periods": [
+        "Minimalno število drsečih obdobij, potrebnih za prikaz vrednosti. Če računate kumulativno vsoto 7-dnevnega obdobja, boste nastavili \"Min. št. period\" na 7. Tako bodo vse prikazane točke skupaj obsegale 7 obdobij. To bo prikrilo rampo, ki bi trajala prvih 7 obdobij"
+      ],
+      "Time comparison": ["Časovna primerjava"],
+      "Time shift": ["Časovni zamik"],
+      "Overlay one or more timeseries from a relative time period. Expects relative time deltas in natural language (example:  24 hours, 7 days, 52 weeks, 365 days). Free text is supported.": [
+        "Zamaknite eno ali več časovnih vrst za relativno časovno obdobje. Vnaša se relativne časovne razlike v naravnem jeziku (npr. 24 ur, 7 dni, 52 tednov, 365 dni). Prosto besedilo je podprto."
+      ],
+      "Calculation type": ["Tip izračuna"],
+      "How to display time shifts: as individual lines; as the absolute difference between the main time series and each time shift; as the percentage change; or as the ratio between series and time shifts.": [
+        "Način prikaza časovnih zamikov: kot samostojne črte; kot absolutne razlike med osnovno časovno vrsto in vsakim časovnim zamikom; kot procentualna sprememba; kot razmerje med vrsto in časovnim zamikom."
+      ],
+      "Python functions": ["Pythonove funkcije"],
+      "Rule": ["Pravilo"],
+      "Pandas resample rule": ["Pravilo za prevzorčenje v Pandas"],
+      "Method": ["Metoda"],
+      "Pandas resample method": ["Metoda za prevzorčenje v Pandas"],
+      "No columns": ["Brez stolpcev"],
+      "%s option": ["%s možnost"],
+      "UI Configuration": ["UI nastavitve"],
+      "Multiple select": ["Več izborov"],
+      "Allow selecting multiple values": ["Dovoli izbiro več vrednosti"],
+      "Group By": ["Združevanje (Group by)"],
+      "Group By filter plugin": ["Vtičnik za filter za združevanje"],
+      "Chosen non-numeric column": ["Izbran ne-numeričen stolpec"],
+      "Range filter": ["Filter obdobja"],
+      "Range filter plugin using AntD": [
+        "Vtičnik za filter obdobja z uporabo AntD"
+      ],
+      "User must select a value for this filter when filter is in single select mode. If selection is empty, an always false filter is emitted.": [
+        "Uporabnik mora izbrati vrednost filtra, ko je le-ta v načinu posamičnega izbora. Če je izbor prazen, je oddan vedno napačen (false) filter."
+      ],
+      "Default to first item": ["Privzet prvi element"],
+      "Select first item by default": [
+        "Kot privzeta vrednost je izbran prvi element"
+      ],
+      "Inverse selection": ["Invertiraj izbiro"],
+      "Exclude selected values": ["Izloči izbrane vrednosti"],
+      "Select filter": ["Izbirni filter"],
+      "Select filter plugin using AntD": [
+        "Izberite Vtičnik za filter z uporabo AntD"
+      ],
+      "Time filter": ["Časovni filter"],
+      "Custom time filter plugin": ["Prilagojeni vtičnik za časovni filter"],
+      "No time columns": ["Ni časovnih stolpcev"],
+      "Time column filter plugin": ["Vtičnik za časovni filter"],
+      "Time grain filter plugin": ["Vtičnik za filter časovne granulacije"],
+      "Favorites": ["Priljubljene"],
+      "Created content": ["Ustvarjena vsebina"],
+      "Recent activity": ["Nedavna aktivnost"],
+      "Security & Access": ["Varnost in Dostopi"],
+      "No charts": ["Ni grafikonov"],
+      "No dashboards": ["Ni nadzornih plošč"],
+      "No favorite charts yet, go click on stars!": [
+        "Priljubljenih grafikonov še ni. Kliknite na zvezdice!"
+      ],
+      "No favorite dashboards yet, go click on stars!": [
+        "Priljubljenih nadzornih plošč še ni. Kliknite na zvezdice!"
+      ],
+      "Profile picture provided by Gravatar": [
+        "Profilno sliko je zagotovil Gravatar"
+      ],
+      "joined": ["pridružen"],
+      "id:": ["id:"],
+      "Image download failed, please refresh and try again.": [
+        "Prenos slike ni uspel. Osvežite in poskusite ponovno."
+      ],
+      "Unexpected error: ": ["Nepričakovana napaka: "],
+      "(no description, click to see stack trace)": [
+        "(ni opisa, kliknite za ogled zapisov)"
+      ],
+      "Issue 1000 - The dataset is too large to query.": [
+        "Težava 1000 - podatkovni vir je prevelik za poizvedbo."
+      ],
+      "An error occurred while fetching %s info: %s": [
+        "Napaka pri pridobivanju informacij za %s: %s"
+      ],
+      "An error occurred while fetching %ss: %s": [
+        "Napaka pri pridobivanju informacij za %s: %s"
+      ],
+      "An error occurred while creating %ss: %s": [
+        "Napaka pri ustvarjanju %s: %s"
+      ],
+      "An error occurred while importing %s: %s": [
+        "Napaka pri uvažanju %s: %s"
+      ],
+      "There was an error fetching the favorite status: %s": [
+        "Napaka pri pridobivanju statusa \"Priljubljeno\": %s"
+      ],
+      "There was an error saving the favorite status: %s": [
+        "Napaka pri shranjevanju statusa \"Priljubljeno\": %s"
+      ],
+      "Link Copied!": ["Povezava kopirana!"],
+      "Connection looks good!": ["Povezava izgleda v redu!"],
+      "${t('ERROR: ')}${parsedErrorMessage(errMsg)}": [
+        "${t('NAPAKA: ')}${parsedErrorMessage(errMsg)}"
+      ],
+      "There was an error fetching your recent activity:": [
+        "Pri pridobivanju nedavnih aktivnosti je prišlo do napake:"
+      ],
+      "Deleted: %s": ["Izbrisanih: %s"],
+      "There was an issue deleting: %s": ["Težava pri brisanju: %s"],
+      "There was an issue deleting %s: %s": ["Težava pri brisanju %s: %s"],
+      "report": ["poročilo"],
+      "alert": ["opozorilo"],
+      "reports": ["poročila"],
+      "alerts": ["opozorila"],
+      "There was an issue deleting the selected %s: %s": [
+        "Težava pri brisanju izbranih %s: %s"
+      ],
+      "Last run": ["Zadnji zagon"],
+      "Notification method": ["Način obveščanja"],
+      "Execution log": ["Dnevnik izvajanja"],
+      "Actions": ["Aktivnosti"],
+      "Bulk select": ["Izberi hkrati"],
+      "No %s yet": ["%s še ne obstajajo"],
+      "Created by": ["Ustvaril/a"],
+      "An error occurred while fetching created by values: %s": [
+        "Pri pridobivanju vrednosti \"ustvaril/a\" je prišlo do napake: %s"
+      ],
+      "Status": ["Status"],
+      "${AlertState.success}": ["${AlertState.success}"],
+      "${AlertState.working}": ["${AlertState.working}"],
+      "${AlertState.error}": ["${AlertState.error}"],
+      "${AlertState.noop}": ["${AlertState.noop}"],
+      "${AlertState.grace}": ["${AlertState.grace}"],
+      "Alerts & reports": ["Opozorila in poročila"],
+      "Reports": ["Poročila"],
+      "This action will permanently delete %s.": [
+        "S tem dejanjem boste trajno izbrisali %s."
+      ],
+      "Delete %s?": ["Izbrišem %s?"],
+      "Please confirm": ["Prosim, potrdite"],
+      "Are you sure you want to delete the selected %s?": [
+        "Ali ste prepričani, da želite izbrisati izbrane %s?"
+      ],
+      "< (Smaller than)": ["< (manjše kot)"],
+      "> (Larger than)": ["> (večje kot)"],
+      "<= (Smaller or equal)": ["<= (manjše ali enako)"],
+      ">= (Larger or equal)": [">= (večje ali enako)"],
+      "== (Is equal)": ["== (je enako)"],
+      "!= (Is not equal)": ["!= (ni enako)"],
+      "Not null": ["Ni nič (null)"],
+      "30 days": ["30 dni"],
+      "60 days": ["60 dni"],
+      "90 days": ["90 dni"],
+      "Add notification method": ["Dodajte način obveščanja"],
+      "Add delivery method": ["Dodajte način dostave"],
+      "Add": ["Dodaj"],
+      "Edit ${isReport ? 'Report' : 'Alert'}": [
+        "Uredi ${isReport ? 'Report' : 'Alert'}"
+      ],
+      "Add ${isReport ? 'Report' : 'Alert'}": [
+        "Add ${isReport ? 'Report' : 'Alert'}"
+      ],
+      "Report name": ["Naslov poročila"],
+      "Alert name": ["Naslov opozorila"],
+      "Alert condition": ["Status opozorila"],
+      "Trigger Alert If...": ["Sproži opozorilo v primeru ..."],
+      "Value": ["Vrednost"],
+      "Report schedule": ["Urnik poročanja"],
+      "Alert condition schedule": ["Urnik statusov opozoril"],
+      "Schedule settings": ["Nastavitve urnika"],
+      "Log retention": ["Hranjenje dnevnikov"],
+      "Working timeout": ["Pretek delovanja"],
+      "Time in seconds": ["Čas v sekundah"],
+      "Grace period": ["Obdobje mirovanja"],
+      "Message content": ["Vsebina sporočila"],
+      "Send as PNG": ["Pošlji kot PNG"],
+      "Send as CSV": ["Pošlji kot CSV"],
+      "log": ["dnevnik"],
+      "State": ["Status"],
+      "Execution ID": ["ID izvedbe"],
+      "Scheduled at (UTC)": ["Izvede se ob (UTC)"],
+      "Start at (UTC)": ["Zažene se ob (UTC)"],
+      "Duration": ["Trajanje"],
+      "Error message": ["Sporočilo napake"],
+      "${alertResource?.type}": ["${alertResource?.type}"],
+      "CRON expression": ["Izraz CRON"],
+      "Report sent": ["Poročilo poslano"],
+      "Alert triggered, notification sent": [
+        "Opozorilo sproženo, obvestilo poslano"
+      ],
+      "Report sending": ["Pošiljanje poročila"],
+      "Alert running": ["Opozorilo aktivno"],
+      "Report failed": ["Poročilo ni uspelo"],
+      "Alert failed": ["Opozorilo ni uspelo"],
+      "Nothing triggered": ["Ni ni sproženo"],
+      "Alert Triggered, In Grace Period": [
+        "Opozorilo sproženo, v obdobju mirovanja"
+      ],
+      "Recipients are separated by \",\" or \";\"": [
+        "Prejemniki so ločeni z \",\" ali \";\""
+      ],
+      "${RecipientIconName.email}": ["${RecipientIconName.email}"],
+      "${RecipientIconName.slack}": ["${RecipientIconName.slack}"],
+      "annotation": ["oznaka"],
+      "There was an issue deleting the selected annotations: %s": [
+        "Pri brisanju izbranih oznak je prišlo do težave: %s"
+      ],
+      "Edit annotation": ["Uredi oznako"],
+      "Delete annotation": ["Izbriši oznako"],
+      "Annotation": ["Oznaka"],
+      "No annotation yet": ["Oznak še ni"],
+      "Annotation Layer ${annotationLayerName}": [
+        "Sloj z oznakami ${annotationLayerName}"
+      ],
+      "Are you sure you want to delete ${annotationCurrentlyDeleting?.short_descr}?": [
+        "Ste prepričani, da želite izbrisati ${annotationCurrentlyDeleting?.short_descr}?"
+      ],
+      "Delete Annotation?": ["Izbrišem oznako?"],
+      "Are you sure you want to delete the selected annotations?": [
+        "Ali ste prepričani, da želite izbrisati izbrane oznake?"
+      ],
+      "Add annotation": ["Dodaj oznako"],
+      "Annotation name": ["Ime oznake"],
+      "date": ["datum"],
+      "Additional information": ["Dodatne informacije"],
+      "Description (this can be seen in the list)": [
+        "Opis (lahko je viden na seznamu)"
+      ],
+      "annotation_layer": ["annotation_layer"],
+      "Edit annotation layer properties": ["Uredi lastnosti sloja z oznakami"],
+      "Annotation layer name": ["Ime sloja z oznakami"],
+      "Annotation layers": ["Sloji z oznakami"],
+      "There was an issue deleting the selected layers: %s": [
+        "Pri brisanju izbranih slojev je prišlo do težave: %s"
+      ],
+      "Last modified": ["Zadnja sprememba"],
+      "Created on": ["Ustvarjeno"],
+      "Edit template": ["Uredi predlogo"],
+      "Delete template": ["Izbriši predlogo"],
+      "Annotation layer": ["Sloj z oznakami"],
+      "An error occurred while fetching dataset datasource values: %s": [
+        "Pri pridobivanju vrednosti podatkovnega vira podatkovnega seta je prišlo do napake: %s"
+      ],
+      "No annotation layers yet": ["Slojev z oznakami še ni"],
+      "This action will permanently delete the layer.": [
+        "S tem dejanjem boste trajno izbrisali sloj."
+      ],
+      "Delete Layer?": ["Izbrišem sloj?"],
+      "Are you sure you want to delete the selected layers?": [
+        "Ali ste prepričani, da želite izbrisati izbrane sloje?"
+      ],
+      "Are you sure you want to delete": [
+        "Ali ste prepričani, da želite izbrisati"
+      ],
+      "Last modified %s": ["Zadnja sprememba %s"],
+      "The passwords for the databases below are needed in order to import them together with the charts. Please note that the \"Secure Extra\" and \"Certificate\" sections of the database configuration are not present in export files, and should be added manually after the import if they are needed.": [
+        "Gesla za spodnje podatkovne baze so potrebna za uvoz skupaj z grafikoni. Sekciji \"Dodatna varnost\" in \"Certifikati\" v nastavitvah podatkovne baze nista prisotni v izvoženih datotekah in jih je potrebno dodati ročno po uvozu, če je to potrebno."
+      ],
+      "You are importing one or more charts that already exist. Overwriting might cause you to lose some of your work. Are you sure you want to overwrite?": [
+        "Uvažate enega ali več grafikonov, ki že obstajajo. S prepisom lahko izgubite podatke. Ali ste prepričani, da želite prepisati?"
+      ],
+      "There was an issue deleting the selected charts: %s": [
+        "Pri brisanju izbranih grafikonov je prišlo do težave: %s"
+      ],
+      "Modified by": ["Spremenil/a"],
+      "Favorite": ["Priljubljene"],
+      "Any": ["Katerikoli"],
+      "Yes": ["Da"],
+      "No": ["Ne"],
+      "Owner": ["Lastnik"],
+      "All": ["Vsi"],
+      "An error occurred while fetching chart owners values: %s": [
+        "Pri pridobivanju polja lastnik grafikona je prišlo do napake: %s"
+      ],
+      "An error occurred while fetching chart created by values: %s": [
+        "Pri pridobivanju polja grafikon ustvaril/a je prišlo do napake: %s"
+      ],
+      "Viz type": ["Tip vizualizacije"],
+      "An error occurred while fetching chart dataset values: %s": [
+        "Pri pridobivanju polja podatkovni set za grafikon je prišlo do napake: %s"
+      ],
+      "Alphabetical": ["Po abecedi"],
+      "Recently modified": ["Nedavno spremenjeno"],
+      "Least recently modified": ["Zadnje spremenjeno"],
+      "Import charts": ["Uvozi grafikone"],
+      "Are you sure you want to delete the selected charts?": [
+        "Ali ste prepričani, da želite izbrisati izbrane grafikone?"
+      ],
+      "css_template": ["css_template"],
+      "Edit CSS template properties": ["Uredi lastnosti CSS predloge"],
+      "Add CSS template": ["Dodaj CSS predlogo"],
+      "CSS template name": ["Ime CSS predloge"],
+      "css": ["css"],
+      "CSS templates": ["CSS predloge"],
+      "There was an issue deleting the selected templates: %s": [
+        "Pri brisanju izbranih predlog je prišlo do težave: %s"
+      ],
+      "Last modified by %s": ["Nazadnje spremenil/a %s"],
+      "CSS template": ["CSS predloga"],
+      "This action will permanently delete the template.": [
+        "S tem dejanjem boste trajno izbrisali predlogo."
+      ],
+      "Delete Template?": ["Izbrišem predlogo?"],
+      "Are you sure you want to delete the selected templates?": [
+        "Ali ste prepričani, da želite izbrisati izbrane predloge?"
+      ],
+      "published": ["objavljeno"],
+      "draft": ["osnutek"],
+      "The passwords for the databases below are needed in order to import them together with the dashboards. Please note that the \"Secure Extra\" and \"Certificate\" sections of the database configuration are not present in export files, and should be added manually after the import if they are needed.": [
+        "Gesla za spodnje podatkovne baze so potrebna za uvoz skupaj z nadzornimi ploščami. Sekciji \"Dodatna varnost\" in \"Certifikati\" v nastavitvah podatkovne baze nista prisotni v izvoženih datotekah in jih je potrebno dodati ročno po uvozu, če je to potrebno."
+      ],
+      "You are importing one or more dashboards that already exist. Overwriting might cause you to lose some of your work. Are you sure you want to overwrite?": [
+        "Uvažate eno ali več nadzornih plošč, ki že obstajajo. S prepisom lahko izgubite podatke. Ali ste prepričani, da želite prepisati?"
+      ],
+      "An error occurred while fetching dashboards: %s": [
+        "Prišlo je do napake pri pridobivanju nadzornih plošč: %s"
+      ],
+      "There was an issue deleting the selected dashboards: ": [
+        "Pri brisanju izbranih nadzornih plošč je prišlo do težave: "
+      ],
+      "An error occurred while fetching dashboard owner values: %s": [
+        "Pri pridobivanju polja lastnik nadzorne plošče je prišlo do napake: %s"
+      ],
+      "An error occurred while fetching dashboard created by values: %s": [
+        "Pri pridobivanju polja nadzorno ploščo ustvaril/a je prišlo do napake: %s"
+      ],
+      "Are you sure you want to delete the selected dashboards?": [
+        "Ali ste prepričani, da želite izbrisati izbrane nadzorne plošče?"
+      ],
+      "Saved queries": ["Shranjene poizvedbe"],
+      "SQL Copied!": ["SQL kopiran!"],
+      "The passwords for the databases below are needed in order to import them. Please note that the \"Secure Extra\" and \"Certificate\" sections of the database configuration are not present in export files, and should be added manually after the import if they are needed.": [
+        "Gesla za spodnje podatkovne baze so potrebna za njihov uvoz. Sekciji \"Dodatna varnost\" in \"Certifikati\" v nastavitvah podatkovne baze nista prisotni v izvoženih datotekah in jih je potrebno dodati ročno po uvozu, če je to potrebno."
+      ],
+      "You are importing one or more databases that already exist. Overwriting might cause you to lose some of your work. Are you sure you want to overwrite?": [
+        "Uvažate eno ali več podatkovnih baz, ki že obstajajo. S prepisom lahko izgubite podatke. Ali ste prepričani, da želite prepisati?"
+      ],
+      "database": ["podatkovna baza"],
+      "An error occurred while fetching database related data: %s": [
+        "Pri pridobivanju podatkov iz podatkovne baze je prišlo do napake: %s"
+      ],
+      "Import databases": ["Uvozi podatkovne baze"],
+      "Asynchronous query execution": ["Asinhroni zagon poizvedb"],
+      "AQE": ["AQE"],
+      "Allow data manipulation language": [
+        "Dovoli jezik za manipulacijo podatkov (DML)"
+      ],
+      "DML": ["DML"],
+      "CSV upload": ["Nalaganje CSV"],
+      "Delete database": ["Izbriši podatkovno bazo"],
+      "The database %s is linked to %s charts that appear on %s dashboards. Are you sure you want to continue? Deleting the database will break those objects.": [
+        "Podatkovna baza %s je povezana z grafikoni %s, ki so prisotni na nadzorni plošči %s. Ali želite nadaljevati? Izbris podatkovne baze bo pokvaril te objekte."
+      ],
+      "Delete Database?": ["Izbrišem podatkovno bazo?"],
+      "Allow this database to be queried in SQL Lab": [
+        "Dovoli poizvedbo na to podatkovno bazo v SQL laboratoriju"
+      ],
+      "Allow creation of new tables based on queries": [
+        "Dovoli ustvarjanje novih tabel s poizvedbami"
+      ],
+      "Allow creation of new views based on queries": [
+        "Dovoli ustvarjanje novih pogledov s poizvedbami"
+      ],
+      "CTAS & CVAS SCHEMA": ["CTAS & CVAS SHEMA"],
+      "Search or select schema": ["Poiščite ali izberite shemo"],
+      "When allowing CREATE TABLE AS option in SQL Lab, this option forces the table to be created in this schema.": [
+        "Z dovolitvijo opcije CREATE TABLE AS v SQL laboratoriju se tabele ustvarjajo s to shemo."
+      ],
+      "Allow manipulation of the database using non-SELECT statements such as UPDATE, DELETE, CREATE, etc.": [
+        "Dovoli manipulacije podatkovne baze z uporabo ne-SELECT stavkov, kot so UPDATE, DELETE, CREATE, itd."
+      ],
+      "Allow multi schema metadata fetch": [
+        "Dovoli pridobivanje metapodatkov z več shemami"
+      ],
+      "Chart cache timeout": ["Trajanje predpomnilnika grafikona"],
+      "Operate the database in asynchronous mode, meaning that the queries are executed on remote workers as opposed to on the web server itself. This assumes that you have a Celery worker setup as well as a results backend. Refer to the installation docs for more information.": [
+        "Upravljanje podatkovne baze v asinhronem načinu pomeni, da se poizvedbe zaženejo na oddaljenih »delavcih« in ne na samem spletnem strežniku. S tem je predpostavljeno, da imate nastavljenega »delavca« za Celery in zaledni sistem za rezultate. Več informacij je v navodilih za namestitev."
+      ],
+      "Secure extra": ["Dodatna varnost"],
+      "JSON string containing additional connection configuration.": [
+        "JSON niz vsebuje dodatne nastavitve povezave."
+      ],
+      "This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.": [
+        "S tem pridobite informacije o povezavi za sisteme, kot so Hive, Presto in BigQuery, ki niso skladni s shemo uporabniško_ime:geslo, ki se običajno uporablja v SQLAlchemy."
+      ],
+      "Optional CA_BUNDLE contents to validate HTTPS requests. Only available on certain database engines.": [
+        "Opcijska CA_BUNDLE vsebina, za potrjevanje HTTPS zahtev. Razpoložljivo le na določenih sistemih podatkovnih baz."
+      ],
+      "Impersonate Logged In User (Presto, Hive, and GSheets)": [
+        "Predstavljanje kot prijavljeni uporabnik (Presto, Hive in GSheets)"
+      ],
+      "If Presto, all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them. If Hive and hive.server2.enable.doAs is enabled, will run the queries as service account, but impersonate the currently logged on user via hive.server2.proxy.user property.": [
+        "V Presto se vse poizvedbe v SQL laboratoriju zaženejo pod trenutno prijavljenim uporabnikom, ki mora imeti pravice za poganjanje. Če je omogočen Hive in hive.server2.enable.doAs, poizvedbe tečejo pod servisnim računom, vendar je trenutno prijavljen uporabnik predstavljen z lastnostjo hive.server2.proxy.user."
+      ],
+      "Allow data upload": ["Dovoli nalaganje podatkov"],
+      "If selected, please set the schemas allowed for data upload in Extra.": [
+        "Če je izbrano, nastavite dovoljene sheme za nalaganje podatkov v Dodatno."
+      ],
+      "JSON string containing extra configuration elements.": [
+        "JSON niz, ki vsebuje dodatne nastavitve povezave."
+      ],
+      "1. The engine_params object gets unpacked into the sqlalchemy.create_engine call, while the metadata_params gets unpacked into the sqlalchemy.MetaData call.": [
+        "1. Objekt engine_params se razširi v klic sqlalchemy.create_engine, medtem ko se metadata_params razširijo v sqlalchemy.MetaData call."
+      ],
+      "2. The metadata_cache_timeout is a cache timeout setting in seconds for metadata fetch of this database. Specify it as \"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.": [
+        "2. metadata_cache_timeout je trajanje predpomnilnik v sekundah za pridobivanje metapodatkov za to podatkovno bazo. Definirajte ga kot \"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}. Če ni definirano, predpomnilnik ne bo omogčen pri tej funkciji. Trajanje 0 določa, da se predpomnilnik ne izteče."
+      ],
+      "3. The schemas_allowed_for_csv_upload is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as \"schemas_allowed_for_csv_upload\": [\"public\", \"csv_upload\"]. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty.": [
+        "3. schemas_allowed_for_csv_upload je z vejicami ločen seznam shem, ki jih je dovoljeno nalagati s CSV-ji. Definirajte ga kot \"schemas_allowed_for_csv_upload\": [\"public\", \"csv_upload\"]. Če tip podatkovne baza ne podpira sheme ali pa je dovoljen dostop do vseh shem, pustite seznam prazen."
+      ],
+      "4. The version field is a string specifying this db's version. This should be used with Presto DBs so that the syntax is correct.": [
+        "4. Polje \"version\" je znakovni niz, ki določa verzijo podatkovne baze. Uporabljeno mora biti s Presto bazo, da je sintaksa pravilna."
+      ],
+      "5. The allows_virtual_table_explore field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.": [
+        "5. Polje \"allows_virtual_table_explore\" je binarnega tipa in določa, prikaz gumba \"Razišči\" v rezultatih SQL laboratorija."
+      ],
+      "Display Name": ["Ime za prikaz"],
+      "Name your database": ["Poimenujte podatkovno bazo"],
+      "Pick a name to help you identify this database.": [
+        "Izberite ime za lažjo prepoznavo podatkovne baze."
+      ],
+      "dialect+driver://username:password@host:port/database": [
+        "dialect+driver://username:password@host:port/database"
+      ],
+      "Refer to the": ["Obrnite se na"],
+      "for more information on how to structure your URI.": [
+        "za več informacij o oblikovanju URI."
+      ],
+      "Test connection": ["Preizkus povezave"],
+      "Please enter a SQLAlchemy URI to test": [
+        "Vnesite SQLAlchemy URI za test"
+      ],
+      "Sorry there was an error fetching database information: %s": [
+        "Pri pridobivanju informacij o podatkovni bazi je prišlo do napake: %s"
+      ],
+      "Connect": ["Poveži"],
+      "Edit database": ["Uredi podatkovno bazo"],
+      "Connect a database": ["Poveži se s podatkovno bazo"],
+      "Finish": ["Končaj"],
+      "Add dataset": ["Dodaj podatkovni set"],
+      "The passwords for the databases below are needed in order to import them together with the datasets. Please note that the \"Secure Extra\" and \"Certificate\" sections of the database configuration are not present in export files, and should be added manually after the import if they are needed.": [
+        "Gesla za spodnje podatkovne baze so potrebna za uvoz skupaj s podatkovnimi seti. Sekciji \"Dodatna varnost\" in \"Certifikati\" v nastavitvah podatkovne baze nista prisotni v izvoženih datotekah in jih je potrebno dodati ročno po uvozu, če je to potrebno."
+      ],
+      "You are importing one or more datasets that already exist. Overwriting might cause you to lose some of your work. Are you sure you want to overwrite?": [
+        "Uvažate enega ali več podatkovnih setov, ki že obstajajo. S prepisom lahko izgubite podatke. Ali ste prepričani, da želite prepisati?"
+      ],
+      "An error occurred while fetching dataset related data": [
+        "Napaka pri pridobivanju podatkov iz podatkovnega seta"
+      ],
+      "An error occurred while fetching dataset related data: %s": [
+        "Napaka pri pridobivanju podatkov iz podatkovnega seta: %s"
+      ],
+      "Physical dataset": ["Fizičen podatkovni set"],
+      "Virtual dataset": ["Virtualen podatkovni set"],
+      "An error occurred while fetching dataset owner values: %s": [
+        "Pri pridobivanju polja lastnik podatkovnega seta je prišlo do napake: %s"
+      ],
+      "An error occurred while fetching datasets: %s": [
+        "Prišlo je do napake pri pridobivanju podatkovnih setov: %s"
+      ],
+      "An error occurred while fetching schema values: %s": [
+        "Pri pridobivanju vrednosti shem je prišlo do napake: %s"
+      ],
+      "Import datasets": ["Uvozi podatkovne sete"],
+      "There was an issue deleting the selected datasets: %s": [
+        "Pri brisanju izbranih podatkovnih setov je prišlo do težave: %s"
+      ],
+      "The dataset %s is linked to %s charts that appear on %s dashboards. Are you sure you want to continue? Deleting the dataset will break those objects.": [
+        "Podatkovni set %s je povezan z grafikoni %s, ki so prisotni na nadzorni plošči %s. Ali želite nadaljevati? Izbris podatkovnega seta bo pokvaril te objekte."
+      ],
+      "Delete Dataset?": ["Izbrišem podatkovni set?"],
+      "Are you sure you want to delete the selected datasets?": [
+        "Ali ste prepričani, da želite izbrisati izbrane podatkovne sete?"
+      ],
+      "0 Selected": ["Izbranih: 0"],
+      "%s Selected (Virtual)": ["Izbranih: %s (virtualni)"],
+      "%s Selected (Physical)": ["Izbranih: %s (fizični)"],
+      "%s Selected (%s Physical, %s Virtual)": [
+        "Izbranih: %s (fizični: %s, virtualni: %s)"
+      ],
+      "There was an issue previewing the selected query. %s": [
+        "Pri predogledu izbrane poizvedbe je prišlo do težave. %s"
+      ],
+      "Success": ["Uspelo"],
+      "Failed": ["Ni uspelo"],
+      "Running": ["V teku"],
+      "Offline": ["Offline"],
+      "Scheduled": ["V urniku"],
+      "Duration: %s": ["Trajanje: %s"],
+      "Tab name": ["Naslov zavihka"],
+      "TABLES": ["TABELE"],
+      "Rows": ["Vrstice"],
+      "Open query in SQL Lab": ["Odpri poizvedbo v SQL laboratoriju"],
+      "An error occurred while fetching database values: %s": [
+        "Pri pridobivanju vrednosti podatkovne baze je prišlo do napake: %s"
+      ],
+      "Search by query text": ["Išči z besedilom poizvedbe"],
+      "Query preview": ["Predogled poizvedbe"],
+      "Next": ["Naslednji"],
+      "Open in SQL Lab": ["Odpri v SQL laboratoriju"],
+      "User query": ["Uporabnikova poizvedba"],
+      "Executed query": ["Zagnana poizvedba"],
+      "The passwords for the databases below are needed in order to import them together with the saved queries. Please note that the \"Secure Extra\" and \"Certificate\" sections of the database configuration are not present in export files, and should be added manually after the import if they are needed.": [
+        "Gesla za spodnje podatkovne baze so potrebna za uvoz skupaj s shranjenimi poizvedbami. Sekciji \"Dodatna varnost\" in \"Certifikati\" v nastavitvah podatkovne baze nista prisotni v izvoženih datotekah in jih je potrebno dodati ročno po uvozu, če je to potrebno."
+      ],
+      "You are importing one or more saved queries that already exist. Overwriting might cause you to lose some of your work. Are you sure you want to overwrite?": [
+        "Uvažate eno ali več shranjenih poizvedb, ki že obstajajo. S prepisom lahko izgubite podatke. Ali ste prepričani, da želite prepisati?"
+      ],
+      "There was an issue previewing the selected query %s": [
+        "Do težave je prišlo pri predogledu izbrane poizvedbe %s"
+      ],
+      "Import queries": ["Uvozi poizvedbe"],
+      "There was an issue deleting the selected queries: %s": [
+        "Do težave je prišlo pri brisanju izbranih poizvedb: %s"
+      ],
+      "Edit query": ["Uredi poizvedbo"],
+      "Copy query URL": ["Kopiraj URL poizvedbe"],
+      "Export query": ["Izvozi poizvedbe"],
+      "Delete query": ["Izbriši poizvedbo"],
+      "This action will permanently delete the saved query.": [
+        "S tem dejanjem boste trajno izbrisali shranjeno poizvedbo."
+      ],
+      "Delete Query?": ["Izbrišem poizvedbo?"],
+      "Are you sure you want to delete the selected queries?": [
+        "Ali ste prepričani, da želite izbrisati izbrane poizvedbe?"
+      ],
+      "queries": ["poizvedbe"],
+      "Query name": ["Ime poizvedbe"],
+      "[Untitled]": ["[Neimenovana]"],
+      "Unknown": ["Neznano"],
+      "Edited": ["Urejane"],
+      "Created": ["Ustvarjene"],
+      "Viewed": ["Ogledane"],
+      "Examples": ["Vzorci"],
+      "Mine": ["Moje"],
+      "Recently viewed charts, dashboards, and saved queries will appear here": [
+        "Nedavno ogledani grafikoni, nadzorne plošče in shranjene poizvedbe bodo prikazane tukaj"
+      ],
+      "Recently created charts, dashboards, and saved queries will appear here": [
+        "Nedavno ustvarjeni grafikoni, nadzorne plošče in shranjene poizvedbe bodo prikazane tukaj"
+      ],
+      "Recent example charts, dashboards, and saved queries will appear here": [
+        "Nedavni vzorci grafikonov, nadzornih plošč in shranjenih poizvedb bodo prikazani tukaj"
+      ],
+      "Recently edited charts, dashboards, and saved queries will appear here": [
+        "Nedavno urejani grafikoni, nadzorne plošče in shranjene poizvedbe bodo prikazane tukaj"
+      ],
+      "${tableName\r\n                      .split('')\r\n                      .slice(0, tableName.length - 1)\r\n                      .join('')}\r\n                    ": [
+        "${tableName\r\n                        .split('')\r\n                        .slice(0, tableName.length - 1)\r\n                        .join('')}\r\n                    "
+      ],
+      "You don't have any favorites yet!": ["Priljubljenih še niste izbrali!"],
+      "SQL Lab queries": ["Poizvedbe SQL laboratorija"],
+      "${tableName}": ["${tableName}"],
+      "query": ["poizvedba"],
+      "Share": ["Deljenje"],
+      "Last run %s": ["Zadnji zagon %s"],
+      "There was an issue fetching your recent activity: %s": [
+        "Pri pridobivanju vaše nedavne aktivnosti je prišlo do napake: %s"
+      ],
+      "There was an issues fetching your dashboards: %s": [
+        "Prišlo je do napake pri pridobivanju nadzornih plošč: %s"
+      ],
+      "There was an issues fetching your chart: %s": [
+        "Prišlo je do napake pri pridobivanju grafikona: %s"
+      ],
+      "There was an issues fetching your saved queries: %s": [
+        "Prišlo je do napake pri pridobivanju shranjenih poizvedb: %s"
+      ],
+      "Recents": ["Nedavno"],
+      "Select start and end date": ["Izberite začetni in končni datum"],
+      "Type or Select [%s]": ["Vnesite ali izberite [%s]"],
+      "Filter box": ["Izbirnik za filtriranje"],
+      "Filters configuration": ["Nastavitve filtrov"],
+      "Filter configuration for the filter box": ["Nastavitve za polje filtra"],
+      "Date filter": ["Filter po datumu"],
+      "Whether to include a time filter": [
+        "Če želite vključiti časovni filter"
+      ],
+      "Instant filtering": ["Takojšnje filtriranje"],
+      "Check to apply filters instantly as they change instead of displaying [Apply] button": [
+        "Izberite za takojšnjo uporabo filtrov, ko se spremenijo, brez prikazovanja gumba Uveljavi"
+      ],
+      "Show SQL granularity dropdown": [
+        "Prikaži SQL spustni seznam za granulacijo"
+      ],
+      "Check to include SQL granularity dropdown": [
+        "Izberite za vključitev spustnega seznama za SQL granulacijo"
+      ],
+      "Show SQL time column": ["Prikaži stolpec SQL čas"],
+      "Check to include time column dropdown": [
+        "Izberite za vključitev časovnega stolpca v spustni seznam"
+      ],
+      "Show Druid granularity dropdown": [
+        "Prikaži spustni seznam za Druid granulacijo"
+      ],
+      "Check to include Druid granularity dropdown": [
+        "Izberite za vključitev spustnega seznama za Druid granulacijo"
+      ],
+      "Show Druid time origin": ["Prikaži časovno izhodišče za Druid"],
+      "Check to include time origin dropdown": [
+        "Izberi za vključitev spustnega seznama za časovno izhodišče"
+      ],
+      "Limit selector values": ["Omeji vrednosti izbirnikov"],
+      "These filters apply to the values available in the dropdowns": [
+        "Ti filtri se nanašajo na vrednosti v spustnih seznamih"
+      ],
+      "Time-series Table": ["Tabela s časovno vrsto"],
+      "Time Range": ["Časovno obdobje"],
+      "Time Column": ["Časovni stolpec"],
+      "Time Grain": ["Granulacija časa"],
+      "Time Granularity": ["Granulacija časa"],
+      "Aggregate": ["Agregiraj"],
+      "Raw records": ["Surovi podatki"],
+      "Datasource & Chart Type": ["Tip podatkovnega vira in grafikona"],
+      "URL Parameters": ["Parametri URL"],
+      "Extra url parameters for use in Jinja templated queries": [
+        "Dodatni parametri za poizvedbe z Jinja predlogami"
+      ],
+      "Extra Parameters": ["Dodatni parametri"],
+      "Extra parameters that any plugins can choose to set for use in Jinja templated queries": [
+        "Dodatni parametri, ki jih lahko uporabi kateri koli vtičnik za poizvedbe z Jinja predlogami"
+      ],
+      "Color Scheme": ["Barvna shema"],
+      "Annotations and Layers": ["Oznake in sloji"],
+      "Show info tooltip": ["Prikaži opis orodja"],
+      "One or many columns to group by": [
+        "Eden ali več stolpcev za združevanje"
+      ],
+      "One or many columns to pivot as columns": [
+        "En ali več stolpcev za stolpčno vrtenje"
+      ],
+      "Bubble Size": ["Velikost mehurčka"],
+      "Metric used to calculate bubble size": [
+        "Mera za izračun velikosti mehurčkov"
+      ],
+      "Color Metric": ["Mera za barvo"],
+      "Fixed Color": ["Izbrana barva"],
+      "Right Axis Metric": ["Mera desne osi"],
+      "Linear Color Scheme": ["Linearna barvna shema"],
+      "Sort By": ["Razvrščanje"],
+      "Time format": ["Oblika zapisa časa"],
+      "Color Map": ["Barvna lestvica"],
+      "Show less columns": ["Prikaži manj stolpcev"],
+      "Show all columns": ["Prikaži vse stolpce"],
+      "Fraction digits": ["Število decimalk"],
+      "Number of decimal digits to round numbers to": [
+        "Število decimalnih mest za zaokroževanje števil"
+      ],
+      "Min Width": ["Min. širina"],
+      "Default minimal column width in pixels, actual width may still be larger than this if other columns don't need much space": [
+        "Privzeta min. širina stolpca v pikslih. Dejanska širina bo lahko večja, če drugi stolpci ne potrebujejo veliko prostora"
+      ],
+      "Text align": ["Poravnava besedila"],
+      "Horizontal alignment": ["Vodoravna poravnava"],
+      "Left": ["Levo"],
+      "Center": ["Na sredino"],
+      "Right": ["Desno"],
+      "Show cell bars": ["Prikaži stolp. graf v celicah"],
+      "Whether to display a bar chart background in table columns": [
+        "Če želite omogočiti prikaz manjših stolpčnih grafikonov v ozadju stolpcev tabele"
+      ],
+      "Align +/-": ["Poravnaj +/-"],
+      "Whether to align positive and negative values in cell bar chart at 0": [
+        "Če želite poravnati pozitivne in negativne vrednosti v stolpčnem grafikonu celic pri 0"
+      ],
+      "Color +/-": ["Barva +/-"],
+      "Whether to colorize numeric values by if they are positive or negative": [
+        "Če želite obarvati številske vrednosti, ko so le-te pozitivne ali negativne"
+      ],
+      "Small number format": ["Oblika zapisa majhnih števil"],
+      "D3 number format for numbers between -1.0 and 1.0, useful when you want to have different siginificant digits for small and large numbers": [
+        "D3 oblika zapisa za števila med -1.0 in 1.0. Uporabno, če želite različno število števk za majhna in velika števila"
+      ],
+      "Adaptative formating": ["Adaptivno oblikovanje"],
+      "Duration in ms (66000 => 1m 6s)": ["Trajanje v ms (66000 => 1m 6s)"],
+      "Duration in ms (1.40008 => 1ms 400µs 80ns)": [
+        "Trajanje v ms (1.40008 => 1ms 400µs 80ns)"
+      ],
+      "D3 time format syntax: https://github.com/d3/d3-time-format": [
+        "Sintaksa D3 časovnega formata:: https://github.com/d3/d3-time-format"
+      ],
+      "Found invalid orderby options": [
+        "Najdene so neveljavne možnosti razvrščanja"
+      ],
+      "is expected to be an integer": ["pričakovano je celo število"],
+      "is expected to be a number": ["pričakovano je število"],
+      "cannot be empty": ["ne sme biti prazna"],
+      "haha": ["haha"],
+      "foo": ["foo"],
+      "bar": ["bar"],
+      "yes": ["da"],
+      "second": ["sekunda"],
+      "ox": ["ox"],
+      "Domain": ["Domena"],
+      "The time unit used for the grouping of blocks": [
+        "Časovna enota za združevanje blokov"
+      ],
+      "Subdomain": ["Poddomena"],
+      "The time unit for each block. Should be a smaller unit than domain_granularity. Should be larger or equal to Time Grain": [
+        "Časovna enota za vsak blok. Mora biti manjša enota kot domenska_granulacija. Mora biti večja ali enaka Granulaciji časa"
+      ],
+      "Chart Options": ["Možnosti grafikona"],
+      "Cell Size": ["Velikost celice"],
+      "The size of the square cell, in pixels": [
+        "Velikost kvadratne celice v pikslih"
+      ],
+      "Cell Padding": ["Razmak med celicami"],
+      "The distance between cells, in pixels": [
+        "Razdalja med celicami v pikslih"
+      ],
+      "Cell Radius": ["Polmer celice"],
+      "The pixel radius": ["Polmer piksla"],
+      "Color Steps": ["Barvni koraki"],
+      "The number color \"steps\"": ["Število barvnih korakov"],
+      "Time Format": ["Oblika zapisa časa"],
+      "Legend": ["Legenda"],
+      "Whether to display the legend (toggles)": [
+        "Preklapljanje prikaza legende"
+      ],
+      "Show Values": ["Pokaži vrednosti"],
+      "Whether to display the numerical values within the cells": [
+        "Če želite v celicah prikazati numerične vrednosti"
+      ],
+      "Show Metric Names": ["Pokaži imena mer"],
+      "Whether to display the metric name as a title": [
+        "Če želite prikazati ime mere kot naslov"
+      ],
+      "Number Format": ["Oblika zapisa števila"],
+      "Sort by metric": ["Mera za razvrščanje"],
+      "Whether to sort results by the selected metric in descending order.": [
+        "Če želite padajoče razvrstiti rezultate z izbrano mero."
+      ],
+      "Number format": ["Oblika zapisa števila"],
+      "Choose a number format": ["Izberite obliko zapisa števila"],
+      "Choose a source": ["Izberite vir"],
+      "Target": ["Cilj"],
+      "Choose a target": ["Izberite cilj"],
+      "Chord Diagram": ["Tetivni grafikon"],
+      "Country": ["Država"],
+      "Which country to plot the map for?": [
+        "Za katero državo želite grafikon?"
+      ],
+      "ISO 3166-2 Codes": ["Oznake po ISO 3166-2"],
+      "Column containing ISO 3166-2 codes of region/province/department in your table.": [
+        "Stolpec, ki vsebuje ISO 3166-2 oznake regij/provinc/departmajev v vaši tabeli."
+      ],
+      "Sorry, there appears to be no data": ["Ni podatkov"],
+      "Event definition": ["Definicija dogodka"],
+      "Event Names": ["Imena dogodkov"],
+      "Columns to display": ["Stolpci za prikaz"],
+      "Order by entity id": ["Uredi po ID entitete"],
+      "Important! Select this if the table is not already sorted by entity id, else there is no guarantee that all events for each entity are returned.": [
+        "Pomembno! Izberite, če tabela še ni razvrščena po ID entitete, v nasprotnem primeru ni nujno, da bodo vrnjeni vsi dogodki za posamezno entiteto."
+      ],
+      "Minimum leaf node event count": ["Min. število dogodkov za list"],
+      "Leaf nodes that represent fewer than this number of events will be initially hidden in the visualization": [
+        "Listna vozlišča, ki predstavljajo manjše število dogodkov od te vrednosti, bodo v vizualizaciji skrita"
+      ],
+      "Additional metadata": ["Dodatni metapodatki"],
+      "Metadata": ["Metapodatki"],
+      "Select any columns for metadata inspection": [
+        "Izberite poljubne stolpce za pregled metapodatkov"
+      ],
+      "Entity ID": ["ID entitete"],
+      "e.g., a \"user id\" column": ["t.j. stolpec \"id uporabnika\""],
+      "Max Events": ["Max. dogodkov"],
+      "The maximum number of events to return, equivalent to the number of rows": [
+        "Največje število dogodkov, ki bodo vrnjeni - enako številu vrstic"
+      ],
+      "Event Flow": ["Potek dogodkov"],
+      "Link Length": ["Dolžina povezave"],
+      "Link length in the force layout": ["Dolžina povezave v postavitvi sil"],
+      "Charge": ["Naboj"],
+      "Charge in the force layout": ["Naboj v postavitvi sil"],
+      "Source / Target": ["Izhodišče/Cilj"],
+      "Choose a source and a target": ["Izberite izhodišče in cilj"],
+      "Force-directed Graph": ["Graf usmerjenih sil"],
+      "Axis ascending": ["Naraščajoča os"],
+      "Axis descending": ["Padajoča os"],
+      "Metric ascending": ["Naraščajoča mera"],
+      "Metric descending": ["Padajoča mera"],
+      "Heatmap Options": ["Možnosti toplotnega prikaza"],
+      "XScale Interval": ["Interval X-osi"],
+      "Number of steps to take between ticks when displaying the X scale": [
+        "Število korakov med oznakami pri prikazu X-osi"
+      ],
+      "YScale Interval": ["Interval Y-osi"],
+      "Number of steps to take between ticks when displaying the Y scale": [
+        "Število korakov med oznakami pri prikazu Y-osi"
+      ],
+      "Rendering": ["Izris"],
+      "image-rendering CSS attribute of the canvas object that defines how the browser scales up the image": [
+        "atribut CSS za izris objekta platna, ki določa, kako brskalnik poveča sliko"
+      ],
+      "Normalize Across": ["Normiraj glede na"],
+      "Color will be rendered based on a ratio of the cell against the sum of across this criteria": [
+        "Barva bo prikazana na osnovi razmerja med celico in vsoto glede na ta kriterij"
+      ],
+      "Left Margin": ["Levi rob"],
+      "Left margin, in pixels, allowing for more room for axis labels": [
+        "Levi rob, v pikslih, s katerim povečamo prostor za oznake osi"
+      ],
+      "Bottom Margin": ["Spodnji rob"],
+      "Bottom margin, in pixels, allowing for more room for axis labels": [
+        "Spodnji rob, v pikslih, s katerim povečamo prostor za oznake osi"
+      ],
+      "Value bounds": ["Meje vrednosti"],
+      "Hard value bounds applied for color coding. Is only relevant and applied when the normalization is applied against the whole heatmap.": [
+        "Mejne vrednosti za barvno lestvico. Upošteva se le, če je normiranje uporabljeno glede na celotni toplotni prikaz."
+      ],
+      "Show percentage": ["Prikaži procente"],
+      "Whether to include the percentage in the tooltip": [
+        "Če želite prikaz procentov v opisu orodja"
+      ],
+      "Normalized": ["Normiran"],
+      "Whether to apply a normal distribution based on rank on the color scale": [
+        "Če želite uporabiti normalno porazdelitev glede na stopnjo na barvni lestvici"
+      ],
+      "Sort X Axis": ["Razvrsti X-os"],
+      "Sort Y Axis": ["Razvrsti Y-os"],
+      "Value Format": ["Oblika zapisa vrednosti"],
+      "count": ["število"],
+      "cumulative": ["kumulativno"],
+      "Select the numeric columns to draw the histogram": [
+        "Izberite numerične stolpce za izris histograma"
+      ],
+      "No of Bins": ["Št. razdelkov"],
+      "Select the number of bins for the histogram": [
+        "Izberite število razdelkov za histogram"
+      ],
+      "X Axis Label": ["Naslov X osi"],
+      "Y Axis Label": ["Naslov Y osi"],
+      "Whether to normalize the histogram": ["Če želite normirati histogram"],
+      "Sort Descending": ["Razvrsti padajoče"],
+      "Series Height": ["Višina serije"],
+      "Pixel height of each series": ["Višina vsake serije v pikslih"],
+      "Value Domain": ["Domena vrednosti"],
+      "series: Treat each series independently; overall: All series use the same scale; change: Show changes compared to the first data point in each series": [
+        "serije: Obravnavaj vsako podatkovno serijo neodvisno; skupno: Vse vrste uporabljajo enako skalo; razlika: Pokaži razlike glede na prvo točko vsake serije"
+      ],
+      "Horizon Chart": ["Horizontni grafikon"],
+      "Longitude": ["Dolžina"],
+      "Column containing longitude data": [
+        "Stolpec s podatki zemljepisne dolžine"
+      ],
+      "Latitude": ["Širina"],
+      "Column containing latitude data": [
+        "Stolpec s podatki zemljepisne širine"
+      ],
+      "Clustering Radius": ["Radij gručenja"],
+      "The radius (in pixels) the algorithm uses to define a cluster. Choose 0 to turn off clustering, but beware that a large number of points (>1000) will cause lag.": [
+        "Radij (v pikslih), s katerim algoritem definira gručo. Izberite 0 za izklop gručenja - veliko število točk (>1000) bo povzročilo upočasnitev."
+      ],
+      "Points": ["Točke"],
+      "Point Radius": ["Radij točk"],
+      "The radius of individual points (ones that are not in a cluster). Either a numerical column or `Auto`, which scales the point based on the largest cluster": [
+        "Radij posameznih točk (tistih, ki niso v gruči). Numerični stolpec ali `Auto` (skalira točke na osnovi največje gruče)"
+      ],
+      "Point Radius Unit": ["Enota radija točk"],
+      "The unit of measure for the specified point radius": [
+        "Enota merila za definiran radij točk"
+      ],
+      "Labelling": ["Oznake"],
+      "label": ["oznaka"],
+      "`count` is COUNT(*) if a group by is used. Numerical columns will be aggregated with the aggregator. Non-numerical columns will be used to label points. Leave empty to get a count of points in each cluster.": [
+        "`število` je COUNT(*), če je uporabljeno združevanje (group by). Numerični stolpci bodo agregirani z agregatorjem. Ne-numerični stolpci, bodo uporabljeni za oznake točk. Pustite prazno, da dobite število točk v posamezni gruči."
+      ],
+      "Cluster label aggregator": ["Agregator za oznako gruče"],
+      "Aggregate function applied to the list of points in each cluster to produce the cluster label.": [
+        "Agregacijska funkcija za seznam točk v vsaki gruči, s katero se ustvari oznaka gruče."
+      ],
+      "Visual Tweaks": ["Nastavitve izgleda"],
+      "Live render": ["Sprotni izris"],
+      "Points and clusters will update as the viewport is being changed": [
+        "Točke in gruče se bodo posodabljale, če se bo spremenil pogled"
+      ],
+      "Map Style": ["Slog zemljevida"],
+      "Base layer map style": ["Slog osnovnega sloja zemljevida"],
+      "Opacity of all clusters, points, and labels. Between 0 and 1.": [
+        "Prosojnost vseh gruč, točk in oznak (vrednost med 0 in 1)."
+      ],
+      "RGB Color": ["RGB barva"],
+      "The color for points and clusters in RGB": [
+        "Barva točk in gruč v RGB zapisu"
+      ],
+      "Viewport": ["Pogled"],
+      "Default longitude": ["Privzeta dolžina"],
+      "Longitude of default viewport": ["Dolžina privzetega pogleda"],
+      "Default latitude": ["Privzeta širina"],
+      "Latitude of default viewport": ["Širina privzetega pogleda"],
+      "Zoom": ["Povečava"],
+      "Zoom level of the map": ["Stopnja povečave zemljevida"],
+      "One or many controls to group by. If grouping, latitude and longitude columns must be present.": [
+        "Eden ali več kontrolnikov za združevanje. Pri združevanju morata biti prisotna stolpca širine in dolžine."
+      ],
+      "MapBox": ["MapBox"],
+      "Significance Level": ["Stopnja značilnosti"],
+      "Threshold alpha level for determining significance": [
+        "Mejna vrednost alfa za določanje značilnosti"
+      ],
+      "p-value precision": ["točnost p-vrednosti"],
+      "Number of decimal places with which to display p-values": [
+        "Število decimalnih mest za prikaz p-vrednosti"
+      ],
+      "Lift percent precision": ["Točnost procentualnega dviga"],
+      "Number of decimal places with which to display lift values": [
+        "Število decimalnih mest za prikaz vrednosti dviga"
+      ],
+      "Paired t-test Table": ["Tabela t-testa za odvisne vzorce"],
+      "Options": ["Možnosti"],
+      "Data Table": ["Tabela podatkov"],
+      "Whether to display the interactive data table": [
+        "Če želite prikaz interaktivne podatkovne tabele"
+      ],
+      "Include Series": ["Vključi serijo"],
+      "Include series name as an axis": [
+        "Vključi ime podatkovne serije v naslov osi"
+      ],
+      "Time Series Options": ["Možnosti časovne vrste"],
+      "Not Time Series": ["Ni časovna vrsta"],
+      "Ignore time": ["Ne upoštevaj časa"],
+      "Time Series": ["Časovna vrsta"],
+      "Standard time series": ["Standardna časovna vrsta"],
+      "Aggregate Mean": ["Agregirano povprečje"],
+      "Mean of values over specified period": [
+        "Povprečna vrednost v dani periodi"
+      ],
+      "Aggregate Sum": ["Agregirana vsota"],
+      "Sum of values over specified period": ["Vsota vrednosti v dani periodi"],
+      "Difference": ["Razlika"],
+      "Metric change in value from `since` to `until`": [
+        "Sprememba mere od vrednosti \"OD\" do \"DO\""
+      ],
+      "Percent Change": ["Procentualna sprememba"],
+      "Metric percent change in value from `since` to `until`": [
+        "Procentualna sprememba mere od vrednosti \"OD\" do \"DO\""
+      ],
+      "Factor": ["Faktor"],
+      "Metric factor change from `since` to `until`": [
+        "Sprememba faktorja mere od vrednosti \"OD\" do \"DO\""
+      ],
+      "Advanced Analytics": ["Napredna analitika"],
+      "Use the Advanced Analytics options below": [
+        "Uporabite spodnje možnosti napredne analitike"
+      ],
+      "Settings for time series": ["Nastavitve časovne vrste"],
+      "Date Time Format": ["Oblika zapisa Datum-Časa"],
+      "Partition Limit": ["Omejitev particij"],
+      "The maximum number of subdivisions of each group; lower values are pruned first": [
+        "Največje število podrazdelkov posamezne skupine; nižje vrednosti so zanemarjene prve"
+      ],
+      "Partition Threshold": ["Prag particije"],
+      "Partitions whose height to parent height proportions are below this value are pruned": [
+        "Particije z nižjim razmerjem med njihovo višino in dolžino starša so zanemarjene"
+      ],
+      "Log Scale": ["Logaritemska skala"],
+      "Use a log scale": ["Uporabi logaritemsko skalo"],
+      "Equal Date Sizes": ["Enaki datumi"],
+      "Check to force date partitions to have the same height": [
+        "Če želite, da imajo datumske particije enako višino"
+      ],
+      "Rich Tooltip": ["Podroben opis orodja"],
+      "The rich tooltip shows a list of all series for that point in time": [
+        "Podroben opis orodja prikaže seznam vseh podatkovnih serij za posamezno istočasno točko"
+      ],
+      "Rolling Window": ["Drseče okno"],
+      "Rolling Function": ["Drseča funkcija"],
+      "Min Periods": ["Min. št. period"],
+      "Time Comparison": ["Časovna primerjava"],
+      "Time Shift": ["Časovni zamik"],
+      "Python Functions": ["Pythonove funkcije"],
+      "Partition Chart": ["Grafikon razdelkov"],
+      "Pivot Options": ["Vrtilne možnosti"],
+      "Aggregation function": ["Agregacijska funkcija"],
+      "Aggregate function to apply when pivoting and computing the total rows and columns": [
+        "Agregacijska funkcija za vrtenje in izračun vseh vrstic in stolpcev"
+      ],
+      "Show totals": ["Pokaži vsote"],
+      "Display total row/column": ["Pokaži vsote vrstic/stolpcev"],
+      "Combine Metrics": ["Združuj mere"],
+      "Display metrics side by side within each column, as opposed to each column being displayed side by side for each metric.": [
+        "Prikazuj mere eno ob drugi ob vsakem stolpcu, drugače je vsak stolpec prikazan en ob drugem za vsako mero."
+      ],
+      "Transpose Pivot": ["Transponirano vrtenje"],
+      "Swap Groups and Columns": ["Zamenjaj Skupine in Stolpce"],
+      "Date format": ["Oblika zapisa datuma"],
+      "Use Area Proportions": ["Uporabi razmerje površin"],
+      "Check if the Rose Chart should use segment area instead of segment radius for proportioning": [
+        "Če želite, da grafikon \"Rose\" uporablja površino segmenta namesto radija za proporcioniranje"
+      ],
+      "Nightingale Rose Chart": ["Nightingale Rose grafikon"],
+      "Limiting rows may result in incomplete data and misleading charts. Consider filtering or grouping source/target names instead.": [
+        "Omejitev vrstic lahko povzroči nepopolne podatke in zavajajoč grafikon. Premislite o uporabi filtriranja ali združevanja imen izvorov/ciljev."
+      ],
+      "Sankey Diagram": ["Sankey grafikon"],
+      "Sankey Diagram with Loops": ["Sankey grafikon z zankami"],
+      "Primary Metric": ["Primarna mera"],
+      "The primary metric is used to define the arc segment sizes": [
+        "Primarna mera določa velikost lokov segmentov"
+      ],
+      "Secondary Metric": ["Sekundarna mera"],
+      "[optional] this secondary metric is used to define the color as a ratio against the primary metric. When omitted, the color is categorical and based on labels": [
+        "[opcijsko] sekundarna mera določa barvo kot razmerje do primarne mere. Če je izpuščena, je barva določena kategorično na podlagi oznak"
+      ],
+      "When only a primary metric is provided, a categorical color scale is used.": [
+        "Če je podana samo primarna metrika, je uporabljena kategorična barvna skala."
+      ],
+      "When a secondary metric is provided, a linear color scale is used.": [
+        "Če je podana sekundarna metrika, je uporabljena linearna barvna skala."
+      ],
+      "Hierarchy": ["Hierarhija"],
+      "This defines the level of the hierarchy": ["Določa stopnjo hierarhije"],
+      "Sunburst Chart": ["Večnivojski tortni grafikon"],
+      "Time Series Columns": ["Stolpci s časovnimi vrstami"],
+      "Ratio": ["Razmerje"],
+      "Target aspect ratio for treemap tiles.": [
+        "Ciljno razmerje za razdelke drevesnega grafikona."
+      ],
+      "Country Field Type": ["Tip polja za države"],
+      "The country code standard that Superset should expect to find in the [country] column": [
+        "Standard za oznake držav, ki bodo podane v stolpcu z državami"
+      ],
+      "Show Bubbles": ["Prikaži mehurčke"],
+      "Whether to display bubbles on top of countries": [
+        "Če želite prikaz mehurčkov nad državami"
+      ],
+      "Max Bubble Size": ["Max. velikost mehurčka"],
+      "Country Column": ["Stolpec z državami"],
+      "3 letter code of the country": ["Tričrkovna oznaka države"],
+      "Metric for Color": ["Mera za barvo"],
+      "Metric that defines the color of the country": [
+        "Mera, ki določa barvo države"
+      ],
+      "Metric that defines the size of the bubble": [
+        "Mera, ki določa velikost mehurčka"
+      ],
+      "Bubble Color": ["Barva mehurčka"],
+      "Country Color Scheme": ["Barvna shema držav"],
+      "Big Number Font Size": ["Velikost pisave Velike številke"],
+      "Tiny": ["Drobna"],
+      "Normal": ["Normalna"],
+      "Huge": ["Ogromna"],
+      "Subheader Font Size": ["Velikost pisave podnaslova"],
+      "N/A": ["N/A"],
+      "Last available value seen on %s": [
+        "Zadnja razpoložljiva vrednost na %s"
+      ],
+      "Not up to date": ["Ni posodobljeno"],
+      "No data after filtering or data is NULL for the latest time record": [
+        "Ni podatkov po filtriranju ali pa imajo vrednost NULL za zadnji časovni zapis"
+      ],
+      "Try applying different filters or ensuring your datasource has data": [
+        "Poskusite uporabiti druge filtre oz. zagotovite, da so v podatkovnem viru podatki"
+      ],
+      "Comparison Period Lag": ["Zaostanek obdobja za primerjavo"],
+      "Based on granularity, number of time periods to compare against": [
+        "Na osnovi granulacije, število časovnih obdobij za primerjavo"
+      ],
+      "Comparison suffix": ["Pripona za primerjavo"],
+      "Suffix to apply after the percentage display": [
+        "Pripona za prikaz procenta"
+      ],
+      "Show Trend Line": ["Pokaži trendno črto"],
+      "Whether to display the trend line": ["Če želite prikazati trendno črto"],
+      "Start y-axis at 0": ["Začni y-os z 0"],
+      "Start y-axis at zero. Uncheck to start y-axis at minimum value in the data.": [
+        "Začni y-os z nič. Ne izberite, če želite, da se y-os začne z najmanjšo vrednostjo podatkov."
+      ],
+      "Fix to selected Time Range": ["Nastavi na izbrano časovno obdobje"],
+      "Fix the trend line to the full time range specified in case filtered results do not include the start or end dates": [
+        "Trendno črto nastavite na izbrano obdobje, v primeru, da filtrirani rezultati ne vsebujejo začetnega in/ali končnega datuma"
+      ],
+      "Subheader": ["Podnaslov"],
+      "Description text that shows up below your Big Number": [
+        "Besedilo, ki se prikaže pod veliko številko"
+      ],
+      "Right Axis Format": ["Oblika desne osi"],
+      "Show Markers": ["Prikaži markerje"],
+      "Show data points as circle markers on the lines": [
+        "Pokaži točke kot krožne markerje na krivuljah"
+      ],
+      "Y bounds": ["Y meje"],
+      "Whether to display the min and max values of the Y-axis": [
+        "Če želite prikaz min. in max. vrednosti Y-osi"
+      ],
+      "Y 2 bounds": ["Meje Y 2"],
+      "Line Style": ["Slog črte"],
+      "Line interpolation as defined by d3.js": [
+        "Interpolacija krivulje na osnovi d3.js"
+      ],
+      "Show Range Filter": ["Pokaži filter obdobja"],
+      "Whether to display the time range interactive selector": [
+        "Če želite prikaz interaktivnega izbirnika časovnega obdobja"
+      ],
+      "Extra Controls": ["Dodatni kontrolniki"],
+      "Whether to show extra controls or not. Extra controls include things like making mulitBar charts stacked or side by side.": [
+        "Če želite prikaz dodatnih kontrolnikov. Dodatni kontrolniki vključujejo možnost izdelave večstolpčnih grafikonov, naloženih ali drug ob drugem."
+      ],
+      "X Tick Layout": ["Postavitev oznak na X-osi"],
+      "The way the ticks are laid out on the X-axis": [
+        "Način razporeditve oznak na X-osi"
+      ],
+      "X Axis Format": ["Oblika X-osi"],
+      "Y Log Scale": ["Logaritemska Y-os"],
+      "Use a log scale for the Y-axis": ["Uporabi logaritemsko skalo za Y-os"],
+      "Y Axis Bounds": ["Meje Y-osi"],
+      "Bounds for the Y-axis. When left empty, the bounds are dynamically defined based on the min/max of the data. Note that this feature will only expand the axis range. It won't narrow the data's extent.": [
+        "Meje Y-osi. Če je prazno, se meje nastavijo dinamično na podlagi min./max. vrednosti podatkov. Funkcija omeji le prikaz, obseg podatkov pa ostane enak."
+      ],
+      "Y Axis 2 Bounds": ["Meje Y 2-osi"],
+      "X bounds": ["Meje X-osi"],
+      "Whether to display the min and max values of the X-axis": [
+        "Če želite prikaz min. in max. vrednosti X-osi"
+      ],
+      "Bar Values": ["Vrednosti stolpcev"],
+      "Show the value on top of the bar": [
+        "Prikaži vrednosti na vrhu stolpcev"
+      ],
+      "Stacked Bars": ["Naloženi stolpci"],
+      "Reduce X ticks": ["Manj oznak X-osi"],
+      "Reduces the number of X-axis ticks to be rendered. If true, the x-axis will not overflow and labels may be missing. If false, a minimum width will be applied to columns and the width may overflow into an horizontal scroll.": [
+        "Zmanjša število izrisanih oznak na X-osi. Če je vklopljeno, se x-os ne bo prelila in lahko oznake manjkajo. Če je izklopljeno, bo upoštevana min. širina stolpcev, ki pa se lahko prelije v horizontalni drsnik."
+      ],
+      "You cannot use 45° tick layout along with the time range filter": [
+        "Skupaj s filtriranjem časovnega obdobja ne morete uporabiti oznak pod 45° kotom"
+      ],
+      "Stacked Style": ["Slog nalaganja"],
+      "Area Chart": ["Ploščinski grafikon"],
+      "Time-series Bar Chart": ["Stolpčni grafikon za časovno vrsto"],
+      "Box Plot": ["Box Plot"],
+      "X Log Scale": ["Logaritemska X-os"],
+      "Use a log scale for the X-axis": ["Uporabi logaritemsko skalo za X-os"],
+      "Ranges": ["Razponi"],
+      "Ranges to highlight with shading": ["Razponi za označitev s senčenjem"],
+      "Range labels": ["Oznake razponov"],
+      "Labels for the ranges": ["Oznake za razpone"],
+      "Markers": ["Markerji"],
+      "List of values to mark with triangles": [
+        "Seznam vrednosti, ki bodo markirane s trikotniki"
+      ],
+      "Marker labels": ["Oznake markerjev"],
+      "Labels for the markers": ["Oznake za markerje"],
+      "Marker lines": ["Markirne črtice"],
+      "List of values to mark with lines": [
+        "Seznam vrednosti, ki bodo markirane s črticami"
+      ],
+      "Marker line labels": ["Oznake markirnih črtic"],
+      "Labels for the marker lines": ["Oznake za markirne črtice"],
+      "A line chart component where you can compare the % change over time": [
+        "Komponenta grafikona, kjer lahko primerjate % cpremembo skozi čas"
+      ],
+      "Time-series Percent Change": ["Časovna vrsta - Procentualna sprememba"],
+      "Sort Bars": ["Uredi stolpce"],
+      "Sort bars by x labels.": ["Uredi stolpce po x-oznakah."],
+      "Breakdowns": ["Razčlenitev"],
+      "Defines how each series is broken down": [
+        "Določa, kako se vsaka podatkovna serija razčleni"
+      ],
+      "A bar chart where the x axis is time": [
+        "Stolpčni grafikon, kjer je na x-osi čas"
+      ],
+      "Bar Chart": ["Stolpčni grafikon"],
+      "Y Axis 1": ["Y-os 1"],
+      "Y Axis 2": ["Y-os 2"],
+      "Left Axis Metric": ["Mera za levo os"],
+      "Choose a metric for left axis": ["Izberite mero za levo os"],
+      "Left Axis Format": ["Oblika leve osi"],
+      "Dual Line Chart": ["Grafikon z dvojno krivuljo"],
+      "Propagate": ["Razširi"],
+      "Send range filter events to other charts": [
+        "Pošlji dogodke filtra obdobja na druge grafikone"
+      ],
+      "Line Chart": ["Črtni grafikon"],
+      "Prefix metric name with slice name": ["Imenu mere pripni ime rezine"],
+      "Y Axis Left": ["Y-os levo"],
+      "Left Axis chart(s)": ["Grafikoni leve osi"],
+      "Choose one or more charts for left axis": [
+        "Izberite enega ali več grafikonov za levo os"
+      ],
+      "Select charts": ["Izberi grafikone"],
+      "Error while fetching charts": ["Napaka pri pridobivanju grafikonov"],
+      "Y Axis Right": ["Y-os desno"],
+      "Right Axis chart(s)": ["Grafikoni desne osi"],
+      "Choose one or more charts for right axis": [
+        "Izberite enega ali več grafikonov za desno os"
+      ],
+      "Multiple Line Charts": ["Veččrtni grafikon"],
+      "Label Type": ["Oblika oznake"],
+      "What should be shown on the label?": ["Kaj bo prikazano na oznaki?"],
+      "Donut": ["Kolobar"],
+      "Do you want a donut or a pie?": ["Želite kolobar ali torto?"],
+      "Show Labels": ["Pokaži oznake"],
+      "Whether to display the labels. Note that the label only displays when the the 5% threshold.": [
+        "Če želite prikazati oznake. Oznake so prikazane le pri vsaj 5-odstotnem pragu."
+      ],
+      "Put labels outside": ["Postavi oznake zunaj"],
+      "Put the labels outside the pie?": ["Postavim oznake zunaj torte?"],
+      "Pie Chart": ["Tortni grafikon"],
+      "Frequency": ["Frekvenca"],
+      "The periodicity over which to pivot time. Users can provide\r\n            \"Pandas\" offset alias.\r\n            Click on the info bubble for more details on accepted \"freq\" expressions.": [
+        "Periodičnost za vrtenje časa. Uporabnik lahko poda\n            psevdonim za zamik v \"Pandas\".\n            Kliknite na mehurček za podrobnosti dovoljenih izrazov za \"freq\"."
+      ],
+      "Time-series Period Pivot": ["Časovna serija - Vrtenje periode"],
+      "Show legend": ["Prikaži legendo"],
+      "Whether to display a legend for the chart": [
+        "Če želite prikaz legende za grafikon"
+      ],
+      "Margin": ["Rob"],
+      "Additional padding for legend.": ["Dodatni razmak za legendo."],
+      "Legend type": ["Tip legende"],
+      "Whisker/outlier options": ["Možnosti grafikona kvantilov"],
+      "Determines how whiskers and outliers are calculated.": [
+        "Določa kako so izračunani kvantili in izstopajoče vrednosti."
+      ],
+      "Enable emitting filters": ["Omogoči oddajanje filtrov"],
+      "Enable emmiting filters.": ["Omogoči oddajanje filtrov."],
+      "Categories to group by on the x-axis.": [
+        "Kategorije za združevanje po x-osi."
+      ],
+      "Distribute across": ["Porazdeli glede na"],
+      "Columns to calculate distribution across. Defaults to temporal column if left empty.": [
+        "Stolpci za izračun porazdelitve. Privzeto je izbran časovni stolpec (če je prazno)."
+      ],
+      "Labels": ["Oznake"],
+      "Whether to display the labels.": ["Če želite prikaz oznak."],
+      "Funnel Chart": ["Lijakasti grafikon"],
+      "Columns to group by": ["Stolpci za združevanje"],
+      "General": ["Splošno"],
+      "Minimum value on the gauge axis": ["Najmanjša vrednost na številčnici"],
+      "Maximum value on the gauge axis": ["Največja vrednost na številčnici"],
+      "Start angle": ["Začetni kot"],
+      "Angle at which to start progress axis": [
+        "Kot, pri katerem se začne os območja"
+      ],
+      "End angle": ["Končni kot"],
+      "Angle at which to end progress axis": [
+        "Kot, pri katerem se konča os območja"
+      ],
+      "Font size": ["Velikost pisave"],
+      "Font size for axis labels, detail value and other text elements": [
+        "Velikost pisave za oznake osi, podrobnosti in druge besedilne elemente"
+      ],
+      "Value format": ["Oblika zapisa vrednosti"],
+      "Additional text to add before or after the value, e.g. unit": [
+        "Dodatno besedilo, ki ga dodate pred ali za vrednost, npr. enota"
+      ],
+      "Show pointer": ["Prikaži kazalec"],
+      "Whether to show the pointer": ["Če želite prikazati kazalec"],
+      "Animation": ["Animacija"],
+      "Whether to animate the progress and the value or just display them": [
+        "Če želite animiran prikaz grafikona"
+      ],
+      "Axis": ["Os"],
+      "Show axis line ticks": ["Prikaži oznake na X-osi"],
+      "Whether to show minor ticks on the axis": [
+        "Če želite prikaz manjših oznak na osi"
+      ],
+      "Show split lines": ["Prikaži razdelitvene črte"],
+      "Whether to show the split lines on the axis": [
+        "Če želite prikazati razdelitvene črte na osi"
+      ],
+      "Split number": ["Število razdelitev"],
+      "Number of split segments on the axis": ["Število razdelkov na osi"],
+      "Progress": ["Območje"],
+      "Show progress": ["Prikaži območje"],
+      "Whether to show the progress of gauge chart": [
+        "Prikaži merilno območje števčnega grafikona"
+      ],
+      "Overlap": ["Prekrivanje"],
+      "Whether the progress bar overlaps when there are multiple groups of data": [
+        "Če želite prekrivanje območij, ko imate več skupin podatkov"
+      ],
+      "Round cap": ["Zaobljeni konci"],
+      "Style the ends of the progress bar with a round cap": [
+        "Zaobljena oblika koncev območja"
+      ],
+      "Intervals": ["Intervali"],
+      "Interval bounds": ["Meje intervalov"],
+      "Comma-separated interval bounds, e.g. 2,4,5 for intervals 0-2, 2-4 and 4-5. Last number should match the value provided for MAX.": [
+        "Z vejico ločeni intervali, npr. 2,4,5 za intervale 0-2, 2-4 in 4-5. Zadnja številka naj bo enaka vrednosti za MAX."
+      ],
+      "Interval colors": ["Barve intervalov"],
+      "Comma-separated color picks for the intervals, e.g. 1,2,4. Integers denote colors from the chosen color scheme and are 1-indexed. Length must be matching that of interval bounds.": [
+        "Z vejico ločene barve za intervale, npr. 1,2,4. Cela števila predstavljajo barve iz barvne sheme (začnejo se z 1). Dolžina mora ustrezati mejam intervala."
+      ],
+      "Gauge Chart": ["Števčni grafikon"],
+      "Name of the source nodes": ["Imena izvornih vozlišč"],
+      "Name of the target nodes": ["Imena ciljnih vozlišč"],
+      "Source category": ["Kategorija izvora"],
+      "The category of source nodes used to assign colors. If a node is associated with more than one category, only the first will be used.": [
+        "Kategorija izvornih vozlišč, na podlagi katere je določena barva. Če je vozlišče povezano z več kot eno kategorijo, bo uporabljena samo prva."
+      ],
+      "Target category": ["Kategorija cilja"],
+      "Category of target nodes": ["Kategorija ciljnih vozlišč"],
+      "Chart options": ["Možnosti grafikona"],
+      "Layout": ["Izgled"],
+      "Graph layout": ["Izgled grafikona"],
+      "Force": ["Sila"],
+      "Circular": ["Krožno"],
+      "Layout type of graph": ["Tip izgleda grafikona"],
+      "Edge symbols": ["Simboli povezav"],
+      "Symbol of two ends of edge line": ["Simbol za konca povezave"],
+      "None -> None": ["Brez -> Brez"],
+      "None -> Arrow": ["Brez -> Puščica"],
+      "Circle -> Arrow": ["Krog -> Puščica"],
+      "Circle -> Circle": ["Krog -> Krog"],
+      "Enable node dragging": ["Omogoči premikanje vozlišč"],
+      "Whether to enable node dragging in force layout mode.": [
+        "Če želite omogočiti premikanje vozlišč v načinu vsiljenega prikaza."
+      ],
+      "Enable graph roaming": ["Omogoči preoblikovanje grafikona"],
+      "Disabled": ["Onemogočeno"],
+      "Scale only": ["Samo povečava"],
+      "Move only": ["Samo premikanje"],
+      "Scale and Move": ["Povečava in premikanje"],
+      "Whether to enable changing graph position and scaling.": [
+        "Če želite omogočiti premikanje in povečevanje/zmanjševanje grafikona."
+      ],
+      "Node select mode": ["Način izbire vozlišč"],
+      "Single": ["Posamezno"],
+      "Multiple": ["Več"],
+      "Allow node selections": ["Dovoli izbiro vozlišča"],
+      "Label threshold": ["Prag oznak"],
+      "Minimum value for label to be displayed on graph.": [
+        "Najmanjša vrednost, za katero bo na grafikonu prikazana oznaka."
+      ],
+      "Node size": ["Velikost vozlišča"],
+      "Median node size, the largest node will be 4 times larger than the smallest": [
+        "Mediana velikosti vozlišča. Največje vozlišče bo 4-krat večje od najmanjšega"
+      ],
+      "Edge width": ["Debelina povezave"],
+      "Median edge width, the thickest edge will be 4 times thicker than the thinnest.": [
+        "Mediana debeline povezave. Najdebelejša povezava bo 4-krat debelejša od najtanjše."
+      ],
+      "Edge length": ["Dolžina povezave"],
+      "Edge length between nodes": ["Dolžina povezave med vozlišči"],
+      "Gravity": ["Gravitacija"],
+      "Strength to pull the graph toward center": [
+        "Sila privlačnosti med grafikonom in središčem"
+      ],
+      "Repulsion": ["Odbijanje"],
+      "Repulsion strength between nodes": ["Odbojna sila med vozlišči"],
+      "Friction": ["Trenje"],
+      "Friction between nodes": ["Trenje med vozlišči"],
+      "Graph Chart": ["Graf"],
+      "Series type": ["Tip serije"],
+      "Series chart type (line, bar etc)": [
+        "Tip grafikona za posamezno podatkovno serijo (črtni, stolpčni, ...)"
+      ],
+      "Stack series": ["Nalagaj serije"],
+      "Stack series on top of each other": ["Nalagaj serije eno na drugo"],
+      "Area chart": ["Ploščinski grafikon"],
+      "Draw area under curves. Only applicable for line types.": [
+        "Izriši površino pod krivuljo. Samo za črtne grafikone."
+      ],
+      "Opacity of area chart.": ["Prosojnost ploščinskega grafikona."],
+      "Marker": ["Marker"],
+      "Draw a marker on data points. Only applicable for line types.": [
+        "Nariši markerje na točke grafikona. Samo za črtne grafikone."
+      ],
+      "Marker size": ["Velikost markerja"],
+      "Size of marker. Also applies to forecast observations.": [
+        "Velikost markerja. Upošteva se tudi za napovedi."
+      ],
+      "Primary": ["Primarna"],
+      "Secondary": ["Sekundarna"],
+      "Primary or secondary y-axis": ["Primarna ali sekundarna y-os"],
+      "Query A": ["Poizvedba A"],
+      "Query B": ["Poizvedba B"],
+      "Data Zoom": ["Zoom funkcija"],
+      "Enable data zooming controls": [
+        "Omogoči kontrolnik za povečavo podatkov"
+      ],
+      "Show Min Label": ["Pokaži oznako Min"],
+      "Show Max Label": ["Pokaži oznako Max"],
+      "Rotate x axis label": ["Zavrti oznako x-osi"],
+      "Input field supports custom rotation. e.g. 30 for 30°": [
+        "Vnosno polje omogoča poljubno rotacijo (vnesite 30 za 30°)"
+      ],
+      "Tooltip": ["Opis orodja"],
+      "Rich tooltip": ["Podroben opis orodja"],
+      "Shows a list of all series available at that point in time": [
+        "Prikaže seznam vseh razpoložljivih podatkovnih serij za istočasno točko"
+      ],
+      "Minor Split Line": ["Manjša ločilna črta"],
+      "Draw split lines for minor y-axis ticks": [
+        "Izriši ločilne črte za pomožne oznake y-osi"
+      ],
+      "Truncate Y Axis": ["Prireži Y-os"],
+      "Truncate Y Axis. Can be overridden by specifying a min or max bound.": [
+        "Prireži Y-os. Preprečite, tako da določite spodnjo in zgornjo mejo."
+      ],
+      "Primary y-axis format": ["Oblika primarne y-osi"],
+      "Primary y-axis title": ["Naslov primarne y-osi"],
+      "Title for y-axis": ["Naslov y-osi"],
+      "Logarithmic y-axis": ["Logaritemska y-os"],
+      "Logarithmic scale on primary y-axis": [
+        "Logaritemska skala na primarni y-osi"
+      ],
+      "Secondary y-axis format": ["Oblika sekundarne y-osi"],
+      "Secondary y-axis title": ["Naslov sekundarne y-osi"],
+      "Logarithmic scale on secondary y-axis": [
+        "Logaritemska skala na sekundarni y-osi"
+      ],
+      "Mixed timeseries chart": ["Kombinirani grafikon časovne vrste"],
+      "Percentage threshold": ["Procentualni prag"],
+      "Minimum threshold in percentage points for showing labels.": [
+        "Minimalni prag v odstotnih točkah za prikaz oznak."
+      ],
+      "Put the labels outside of the pie?": ["Postavim oznake zunaj torte?"],
+      "Label Line": ["Črta oznake"],
+      "Draw line from Pie to label when labels outside?": [
+        "Ali želite črto do oznake, ko so le-te zunaj?"
+      ],
+      "Pie shape": ["Oblika torte"],
+      "Outer Radius": ["Zunanji polmer"],
+      "Outer edge of Pie chart": ["Zunanji rob tortnega grafikona"],
+      "Inner Radius": ["Notranji polmer"],
+      "Inner radius of donut hole": ["Notranji polmer kolobarja"],
+      "The maximum value of metrics. It is an optional configuration": [
+        "Največja vrednost mere. To je opcijska nastavitev"
+      ],
+      "Label position": ["Položaj oznake"],
+      "Radar": ["Radar"],
+      "Customize Metrics": ["Prilagodi mere"],
+      "Further customize how to display each metric": [
+        "Dodatne prilagoditve prikaza posameznih mer"
+      ],
+      "Circle radar shape": ["Okrogla oblika radarja"],
+      "Radar render type, whether to display 'circle' shape.": [
+        "Način prikaza radarja - če se prikaže okrogla oblika."
+      ],
+      "Radar Chart": ["Radarski grafikon"],
+      "Contribution Mode": ["Način deležev"],
+      "Calculate contribution per series or total": [
+        "Izračunaj delež za podatkovno serijo ali skupnega"
+      ],
+      "Predictive Analytics": ["Prediktivna analitika"],
+      "Enable forecast": ["Omogoči napoved"],
+      "Enable forecasting": ["Omogoči napovedovanje"],
+      "Forecast periods": ["Obdobja napovedi"],
+      "How many periods into the future do we want to predict": [
+        "Za koliko period v prihodnosti želite napoved"
+      ],
+      "Confidence interval": ["Interval zaupanja"],
+      "Width of the confidence interval. Should be between 0 and 1": [
+        "Širina intervala zaupanja. Mora bit med 0 in 1"
+      ],
+      "Should yearly seasonality be applied. An integer value will specify Fourier order of seasonality.": [
+        "Če želite letno sezonskost. Celo število določa Fourier-jev red sezonskosti."
+      ],
+      "Should weekly seasonality be applied. An integer value will specify Fourier order of seasonality.": [
+        "Če želite tedensko sezonskost. Celo število določa Fourier-jev red sezonskosti."
+      ],
+      "Should daily seasonality be applied. An integer value will specify Fourier order of seasonality.": [
+        "Če želite dnevno sezonskost. Celo število določa Fourier-jev red sezonskosti."
+      ],
+      "Series Style": ["Slog serije"],
+      "Area chart opacity": ["Prosojnost ploščinskega grafikona"],
+      "Opacity of Area Chart. Also applies to confidence band.": [
+        "Prosojnost ploščinskega grafikona. Upošteva se tudi za interval zaupanja."
+      ],
+      "Marker Size": ["Velikost markerja"],
+      "Tooltip time format": ["Oblika zapisa časa v opisu orodja"],
+      "Time-series Chart": ["Grafikon časovne vrste"],
+      "Id": ["Id"],
+      "Name of the id column": ["Naziv id-stolpca"],
+      "Parent": ["Nadrejeni"],
+      "Name of the column containing the id of the parent node": [
+        "Ime stolpca, ki vsebuje id nadrejenega vozlišča"
+      ],
+      "Optional name of the data column.": [
+        "Opcijsko ime podatkovnega stolpca."
+      ],
+      "Root node id": ["Id korenskega vozlišča"],
+      "Id of root node of the tree.": ["Id korenskega vozlišča drevesa."],
+      "Metric for node values": ["Mera za vrednosti vozlišč"],
+      "Tree layout": ["Oblika drevesa"],
+      "Orthogonal": ["Pravokotna"],
+      "Radial": ["Radialna"],
+      "Layout type of tree": ["Način izgleda drevesa"],
+      "Tree orientation": ["Orientacija drevesa"],
+      "Left to Right": ["Iz leve proti desni"],
+      "Right to Left": ["Iz desne proti levi"],
+      "Top to Bottom": ["Iz vrha proti dnu"],
+      "Bottom to Top": ["Iz dna proti vrhu"],
+      "Orientation of tree": ["Orientacija drevesa"],
+      "Node label position": ["Položaj oznake vozlišča"],
+      "left": ["levo"],
+      "top": ["zgoraj"],
+      "right": ["desno"],
+      "bottom": ["spodaj"],
+      "Position of intermidiate node label on tree": [
+        "Položaj vmesne oznake vozlišča na drevesu"
+      ],
+      "Child label position": ["Položaj podrejene oznake"],
+      "Position of child node label on tree": [
+        "Položaj oznake podrejenega vozlišča na drevesu"
+      ],
+      "Emphasis": ["Poudari"],
+      "ancestor": ["nadrejeni"],
+      "descendant": ["podrejeni"],
+      "Which relatives to highlight on hover": [
+        "Kateri element se poudari na prehodu z miško"
+      ],
+      "Symbol": ["Simbol"],
+      "Empty circle": ["Prazen krog"],
+      "Circle": ["Krog"],
+      "Rectangle": ["Pravokotnik"],
+      "Triangle": ["Trikotnik"],
+      "Diamond": ["Karo"],
+      "Pin": ["Žebljiček"],
+      "Arrow": ["Puščica"],
+      "Symbol size": ["Velikost simbola"],
+      "Size of edge symbols": ["Velikost simbola povezave"],
+      "Tree Chart": ["Drevesni grafikon"],
+      "Show Upper Labels": ["Prikaži zgornje oznake"],
+      "Show labels when the node has children.": [
+        "Prikaži oznake, ko ima vozlišče podrejene elemente."
+      ],
+      "Treemap v2": ["Drevesni grafikon s pravokotniki v2"],
+      "Columns to group by on the rows": ["Stolpci za združevanje vrstic"],
+      "Columns to group by on the columns": ["Stolpci za združevanje stolpcev"],
+      "Transpose pivot": ["Transponirano vrtenje"],
+      "Swap rows and columns": ["Zamenjaj vrstice in stolpce"],
+      "Pivot table type": ["Tip vrtilne tabele"],
+      "Table Heatmap": ["Barvanje tabele"],
+      "Table Col Heatmap": ["Barvanje stolpcev tabele"],
+      "Table Row Heatmap": ["Barvanje vrstic tabele"],
+      "Table Barchart": ["Stolpčni grafi po tabeli"],
+      "Table Col Barchart": ["Stolpčni grafi po stolpcih"],
+      "Table Row Barchart": ["Stolpčni grafi po vrsticah"],
+      "The type of pivot table visualization": [
+        "Način za vizualizacijo vrtilne tabele"
+      ],
+      "Rows sort by": ["Razvrsti vrst."],
+      "key a-z": ["a - ž"],
+      "key z-a": ["ž - a"],
+      "value ascending": ["0 - 9"],
+      "value descending": ["9 - 0"],
+      "Order of rows": ["Vrstni red vrstic"],
+      "Cols sort by": ["Razvrsti stolp."],
+      "Order of columns": ["Vrstni red stolpcev"],
+      "Rows subtotals position": ["Položaj vsot vrstic"],
+      "Top": ["Zgoraj"],
+      "Bottom": ["Spodaj"],
+      "Position of row level subtotals": ["Položaj vsot na nivoju vrstic"],
+      "Cols subtotals position": ["Položaj vsot stolp."],
+      "Position of column level subtotals": ["Položaj vsot na nivoju stolpcev"],
+      "Show rows totals": ["Prikaži vsoto vrstic"],
+      "Display row level totals": ["Prikaže vsoto vseh vrstic"],
+      "Show cols totals": ["Prik. vsoto stolpcev"],
+      "Display column level totals": ["Prikaže vsoto vseh stolpcev"],
+      "Whether to apply filter to dashboards when table cells are clicked": [
+        "Če želite uporabiti filter na nadzorni plošči, ko kliknete na celico v tabeli"
+      ],
+      "Pivot Table v2": ["Vrtilna tabela v2"],
+      "search.num_records": ["search.num_records"],
+      "page_size.show": ["page_size.show"],
+      "page_size.entries": ["page_size.entries"],
+      "Totals": ["Vsote"],
+      "page_size.all": ["page_size.all"],
+      "Group By, Metrics or Percentage Metrics must have a value": [
+        "Združevanje, Mera ali Procentualna mera morajo imeti vrednost"
+      ],
+      "Query mode": ["Poizvedbeni način"],
+      "must have a value": ["mora imeti vrednost"],
+      "Percentage metrics": ["Procentualne mere"],
+      "Metrics for which percentage of total are to be displayed. Calculated from only data within the row limit.": [
+        "Mera, za katero je prikazan odstotek od celote. Izračunan je samo iz podatkov znotraj omejitve števila vrstic."
+      ],
+      "Ordering": ["Razvrščanje"],
+      "Order results by selected columns": [
+        "Razvrsti rezultate glede na izbrani stolpec"
+      ],
+      "Server pagination": ["Številčenje strani strežnika"],
+      "Enable server side pagination of results (experimental feature)": [
+        "Omogoči številčenje strani rezultatov na strani strežnika (preizkusna funkcija)"
+      ],
+      "Server Page Length": ["Dolžina strani strežnika"],
+      "Rows per page, 0 means no pagination": [
+        "Vrstic na stran (0 pomeni brez številčenja strani)"
+      ],
+      "Include time": ["Vključi čas"],
+      "Whether to include the time granularity as defined in the time section": [
+        "Če želite vključiti granulacijo časa, ki je določena v sekciji Čas"
+      ],
+      "Show total aggregations of selected metrics. Note that row limit does not apply to the result.": [
+        "Prikaži skupno agregacijo izbrane mere. Omejitev števila vrstic ne vpliva na rezultat."
+      ],
+      "Timestamp format": ["Oblika zapisa časovne značke"],
+      "D3 time format for datetime columns": [
+        "D3 oblika zapisa za časovne stolpce"
+      ],
+      "Page length": ["Dolžina strani"],
+      "Search box": ["Iskalno polje"],
+      "Whether to include a client-side search box": [
+        "Če želite vključiti iskalno polje za uporabnika"
+      ],
+      "Cell bars": ["Stolp. graf v celicah"],
+      "Whether to align background charts with both positive and negative values at 0": [
+        "Če želite poravnati graf v ozadju celic za negativne in pozitivne vrednosti okrog 0"
+      ],
+      "Customize columns": ["Prilagodi stolpce"],
+      "Further customize how to display each column": [
+        "Dodatne prilagoditve prikaza posameznih stolpcev"
+      ],
+      "Word Cloud": ["Oblak besed"],
+      "Minimum Font Size": ["Min. velikost pisave"],
+      "Font size for the smallest value in the list": [
+        "Velikost pisave za najmanjšo vrednost na seznamu"
+      ],
+      "Maximum Font Size": ["Max. velikost pisave"],
+      "Font size for the biggest value in the list": [
+        "Velikost pisave za največjo vrednost na seznamu"
+      ],
+      "Word Rotation": ["Vrtenje besed"],
+      "Rotation to apply to words in the cloud": [
+        "Če želite vrtenje besed v oblaku"
+      ],
+      "Scatter Plot": ["Raztreseni grafikon"],
+      "Hide Mini Map": ["Skrij majhen zemljevid"],
+      "Show Mini Map": ["Prikaži majhen zemljevid"],
+      "Choropleth Map": ["Koroplet zemljevid"],
+      "ChoroplethMap": ["ChoroplethMap"],
+      "Icicle Event Chart": ["Grafikon Icicle dogodkov"],
+      "Map": ["Zemljevid"],
+      "deck.gl charts": ["grafikoni deck.gl"],
+      "Pick a set of deck.gl charts to layer on top of one another": [
+        "Izberite nabor deck.gl grafikonov, ki bodo nanizani en na drugem"
+      ],
+      "deck.gl Multiple Layers": ["deck.gl - Večplastni grafikon"],
+      "Data has no time steps": ["Podatki nimajo časovnih korakov"],
+      "Start Longitude & Latitude": ["Začetna Dolž. in Širina"],
+      "Point to your spatial columns": [
+        "Pokažite na stolpec z lokacijskimi podatki"
+      ],
+      "End Longitude & Latitude": ["Končna Dolž. in Širina"],
+      "Arc": ["Lok"],
+      "Target Color": ["Ciljna barva"],
+      "Color of the target location": ["Barva ciljne lokacije"],
+      "Categorical Color": ["Kategorična barva"],
+      "Pick a dimension from which categorical colors are defined": [
+        "Izberite dimenzijo, ki bo določala kategorične barve"
+      ],
+      "Stroke Width": ["Debelina obrobe"],
+      "deck.gl Arc": ["deck.gl - Lok"],
+      "GeoJson Settings": ["GeoJson nastavitve"],
+      "Point Radius Scale": ["Skaliranje radija točk"],
+      "deck.gl Geojson": ["deck.gl - GeoJSON"],
+      "Metric used to control height": ["Mera za določanje višine"],
+      "deck.gl Grid": ["deck.gl - Mreža"],
+      "deck.gl 3D Hexagon": ["deck.gl - 3D HEX"],
+      "deck.gl Path": ["deck.gl - Poti"],
+      "Polygon Column": ["Stolpec poligonov"],
+      "Polygon Encoding": ["Kodiranje poligonov"],
+      "Elevation": ["Dvig"],
+      "Polygon Settings": ["Nastavitve poligonov"],
+      "Opacity, expects values between 0 and 100": [
+        "Prosojnost, vnesite vrednosti med 0 in 100"
+      ],
+      "Number of buckets to group data": [
+        "Število razdelkov za združevanje podatkov"
+      ],
+      "How many buckets should the data be grouped in.": [
+        "V koliko razdelkov bodo razvrščeni podatki."
+      ],
+      "Bucket break points": ["Točke za razčlenitev razdelkov"],
+      "List of n+1 values for bucketing metric into n buckets.": [
+        "Seznam n+1 vrednosti za mero razvrščanja v n razdelkov."
+      ],
+      "Emit Filter Events": ["Prikaži dogodke filtrov"],
+      "Whether to apply filter when items are clicked": [
+        "Če želite uporabiti filter, ko kliknete na elemente"
+      ],
+      "Multiple filtering": ["Večkratno filtriranje"],
+      "Allow sending multiple polygons as a filter event": [
+        "Dovoli pošiljanje več poligonov kot dogodek filtra"
+      ],
+      "deck.gl Polygon": ["deck.gl - Poligon"],
+      "Point Size": ["Velikost točke"],
+      "Point Unit": ["Enota točke"],
+      "Minimum Radius": ["Min. polmer"],
+      "Minimum radius size of the circle, in pixels. As the zoom level changes, this insures that the circle respects this minimum radius.": [
+        "Minimalni polmer kroga v pikslih. S tem je določen min. polmer kroga, ko se spreminja stopnja povečave."
+      ],
+      "Maximum Radius": ["Max. polmer"],
+      "Maxium radius size of the circle, in pixels. As the zoom level changes, this insures that the circle respects this maximum radius.": [
+        "Maksimalni polmer kroga v pikslih. S tem je določen max. polmer kroga, ko se spreminja stopnja povečave."
+      ],
+      "Point Color": ["Barva točke"],
+      "deck.gl Scatterplot": ["deck.gl - Raztreseni grafikon"],
+      "Grid": ["Mreža"],
+      "Weight": ["Utež"],
+      "Metric used as a weight for the grid's coloring": [
+        "Mera, ki služi kot utež za barvo mreže"
+      ],
+      "deck.gl Screen Grid": ["deck.gl - Mreža"],
+      "For more information about objects are in context in the scope of this function, refer to the": [
+        "Za dodatne informacije o objektih v kontekstu te funkcije si oglejte"
+      ],
+      " source code of Superset's sandboxed parser": [
+        " izvorno kodo za Supersetov \"sandboxed parser\""
+      ],
+      "This functionality is disabled in your environment for security reasons.": [
+        "Ta funkcionalnost je v vašem okolju onemogočena zaradi varnosti."
+      ],
+      "Ignore null locations": ["Izpusti prazne lokacije"],
+      "Whether to ignore locations that are null": [
+        "Če ne želite upoštevati praznih (NULL) lokacij"
+      ],
+      "Auto Zoom": ["Samodejna povečava"],
+      "When checked, the map will zoom to your data after each query": [
+        "Če želite, da se zemljevid prilagodi vašim podatkom po vsaki poizvedbi"
+      ],
+      "Dimension": ["Dimenzija"],
+      "Select a dimension": ["Izberite dimenzijo"],
+      "Extra data for JS": ["Dodatni podatki za JS"],
+      "List of extra columns made available in Javascript functions": [
+        "Seznam dodatnih podatkov, ki so na razpolago v Javascript funkcijah"
+      ],
+      "Javascript data interceptor": ["Javascript prestreznik podatkov"],
+      "Define a javascript function that receives the data array used in the visualization and is expected to return a modified version of that array. This can be used to alter properties of the data, filter, or enrich the array.": [
+        "Določite Javascript funkcijo, ki sprejme podatkovni niz za vizualizacijo in vrne spremenjeno verzijo tega niza. Lahko se uporabi za spreminjanje lastnosti podatkov, filtra ali obogatitve niza."
+      ],
+      "Javascript tooltip generator": ["Javascript generator opisa orodja"],
+      "Define a function that receives the input and outputs the content for a tooltip": [
+        "Določite funkcijo, ki sprejme vhodne podatke in vrne vsebino opisa orodja"
+      ],
+      "Javascript onClick href": ["Javascript onClick href"],
+      "Define a function that returns a URL to navigate to when user clicks": [
+        "Določite funkcijo, ki vrne URL za navigacijo, ko uporabnik klikne"
+      ],
+      "Legend Format": ["Oblika legende"],
+      "Choose the format for legend values": [
+        "Izberite obliko vrednosti legende"
+      ],
+      "Legend Position": ["Položaj legende"],
+      "Choose the position of the legend": ["Izberite položaj legende"],
+      "Lines column": ["Stolpec črt"],
+      "The database columns that contains lines information": [
+        "Stolpec v podatkovni bazi, ki vsebuje podatke črt"
+      ],
+      "The width of the lines": ["Debelina črt"],
+      "Fill Color": ["Barva polnila"],
+      " Set the opacity to 0 if you do not want to override the color specified in the GeoJSON": [
+        " Nastavite prosojnost na 0, če želite obdržati barvo določeno v GeoJSON"
+      ],
+      "Stroke Color": ["Barva obrobe"],
+      "Filled": ["Zapolnjeno"],
+      "Whether to fill the objects": ["Če želite zapolniti objekte"],
+      "Stroked": ["Obrobljeno"],
+      "Whether to display the stroke": ["Če želite prikazati obrobe"],
+      "Extruded": ["Relief"],
+      "Grid Size": ["Velikost mreže"],
+      "Defines the grid size in pixels": ["Določa velikost mreže v pikslih"],
+      "Parameters related to the view and perspective on the map": [
+        "Parametri povezani s pogledom in perspektivo zemljevida"
+      ],
+      "Longitude & Latitude": ["Dolžina in širina"],
+      "Fixed point radius": ["Fiksni radij točk"],
+      "Multiplier": ["Množitelj"],
+      "Factor to multiply the metric by": ["Faktor, s katerim množite mero"],
+      "Lines encoding": ["Kodiranje črt"],
+      "The encoding format of the lines": ["Oblika kodiranja črt"],
+      "Reverse Lat & Long": ["Zamenjaj Dolž. in Širino"],
+      "GeoJson Column": ["GeoJson stolpec"],
+      "Select the geojson column": ["Izberite geojson stolpec"],
+      "Kepler.gl": ["Kepler.gl"],
+      "List Users": ["Seznam uporabnikov"],
+      "List Roles": ["Seznam vlog"],
+      "Your user information": ["Vaše uporabniške informacije"],
+      "User info": ["Informacije o uporabniku"],
+      "User Name": ["Uporabniško ime"],
+      "Is Active?": ["Je aktiven?"],
+      "Login count": ["Število prijav"],
+      "Personal Info": ["Osebne informacije"],
+      "First Name": ["Ime"],
+      "Last Name": ["Priimek"],
+      "Email": ["E-pošta"],
+      "Audit Info": ["Revizijske informacije"],
+      "Last login": ["Zadnja prijava"],
+      "Failed login count": ["Število neuspešnih prijav"],
+      "Changed by": ["Spremenil/a"],
+      "Reset Password": ["Ponastavi geslo"],
+      "Show User": ["Prikaži uporabnika"],
+      "Username valid for authentication on DB or LDAP, unused for OID auth": [
+        "Uporabniško ime za DB ali LDAP avtentikacijo. Ni uporabljeno za OID avtentikacijo"
+      ],
+      "It's not a good policy to remove a user, just make it inactive": [
+        "Izbris uporabnika ni dobra praksa, raje ga deaktivirajte"
+      ],
+      "The user's email, this will also be used for OID auth": [
+        "Uporabnikov e-naslov, uporabljen bo tudi za OID avtentikacijo"
+      ],
+      "The user role on the application, this will associate with a list of permissions": [
+        "Uporabnikova vloga v tej aplikaciji, povezana bo s seznamom dovoljenj"
+      ],
+      "User confirmation needed": ["Potrebna je potrditev s strani uporabnika"],
+      "You sure you want to delete this item?": [
+        "Ste prepričani, da želite izbrisati ta vnos?"
+      ],
+      "Reset my password": ["Ponastavi geslo"],
+      "Reset Password Form": ["Obrazec za ponastavitev gesla"],
+      "Please use a good password policy, this application does not check this for you": [
+        "Uporabite varno geslo. Ta aplikacija tega ne bo preverila"
+      ],
+      "Confirm Password": ["Potrdite geslo"],
+      "Please rewrite the password to confirm": [
+        "Ponovno vpišite geslo za potrditev"
+      ],
+      "Back": ["Nazaj"],
+      "Edit User": ["Uredite uporabnika"],
+      "Edit User Information": ["Uredite informacije o uporabniku"],
+      "Write the user first name or names": ["Vpišite ime uporabnika"],
+      "Write the user last name": ["Vpišite priimek uporabnika"],
+      "Embed code": ["Vstavi kodo"],
+      "creator": ["avtor"],
+      "favorited": ["priljubljeno"],
+      "name": ["ime"],
+      "type": ["tip"],
+      "time": ["čas"],
+      "Toggle SortBy": ["Preklopite razvrščanje"],
+      "Page size": ["Velikost strani"],
+      "Edit record": ["Uredi zapis"],
+      "Delete record": ["Izbriši zapis"],
+      "Show record": ["Pokaži zapis"],
+      "Orientation": ["Postavitev"],
+      "Scroll": ["Drsnik"],
+      "Plain": ["Celotna"]
+    }
+  }
+}

--- a/superset/translations/sl/LC_MESSAGES/messages.po
+++ b/superset/translations/sl/LC_MESSAGES/messages.po
@@ -1,0 +1,13575 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+msgid ""
+msgstr ""
+"Project-Id-Version: Superset\n"
+"Report-Msgid-Bugs-To: dkrat7 @github.com\n"
+"POT-Creation-Date: 2021-05-27 16:46+0200\n"
+"PO-Revision-Date: 2021-05-28 23:11+0200\n"
+"Last-Translator: dkrat7 <dkrat7 @github.com>\n"
+"Language: sl_SI\n"
+"Language-Team: \n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100>=3 && n"
+"%100<=4 ? 2 : 3);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.8.0\n"
+"X-Generator: Poedit 2.3\n"
+
+#: superset/app.py:231
+msgid "Home"
+msgstr "Domov"
+
+#: superset/app.py:238 superset/views/annotations.py:119
+msgid "Annotation Layers"
+msgstr "Sloji z oznakami"
+
+#: superset/app.py:241 superset/app.py:284 superset/app.py:296
+#: superset/app.py:345 superset/app.py:441 superset/app.py:450
+#: superset/app.py:465 superset/app.py:477
+msgid "Manage"
+msgstr "Upravljaj"
+
+#: superset-frontend/src/profile/components/Security.tsx:46
+#: superset-frontend/src/views/CRUD/data/common.ts:26 superset/app.py:247
+#: superset/views/database/mixins.py:33
+msgid "Databases"
+msgstr "Podatkovne baze"
+
+#: superset-frontend/src/explore/components/ControlPanelsContainer.tsx:415
+#: superset-frontend/src/explore/components/DataTablesPane/index.tsx:295
+#: superset-frontend/src/views/CRUD/data/common.ts:22 superset/app.py:250
+#: superset/app.py:259 superset/app.py:381 superset/app.py:399
+#: superset/app.py:504 superset/app.py:514 superset/app.py:527
+#: superset/app.py:540
+msgid "Data"
+msgstr "Podatki"
+
+#: superset-frontend/src/profile/components/Security.tsx:60
+#: superset-frontend/src/views/CRUD/data/common.ts:32 superset/app.py:255
+msgid "Datasets"
+msgstr "Podatkovni seti"
+
+#: superset-frontend/src/dashboard/components/BuilderComponentPane.tsx:77
+#: superset-frontend/src/profile/components/CreatedContent.tsx:76
+#: superset-frontend/src/profile/components/Favorites.tsx:77
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:586
+#: superset-frontend/src/views/CRUD/welcome/Welcome.tsx:242 superset/app.py:266
+#: superset/views/chart/mixin.py:26 superset/views/dashboard/mixin.py:81
+msgid "Charts"
+msgstr "Grafikoni"
+
+#: superset-frontend/src/profile/components/CreatedContent.tsx:73
+#: superset-frontend/src/profile/components/Favorites.tsx:74
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:533
+#: superset-frontend/src/views/CRUD/welcome/Welcome.tsx:219 superset/app.py:274
+#: superset/views/chart/mixin.py:79 superset/views/dashboard/mixin.py:25
+msgid "Dashboards"
+msgstr "Nadzorne plošče"
+
+#: superset/app.py:282
+msgid "Plugins"
+msgstr "Vtičniki"
+
+#: superset/app.py:293 superset/views/css_templates.py:38
+msgid "CSS Templates"
+msgstr "CSS predloge"
+
+#: superset/app.py:302
+msgid "Row level security"
+msgstr "Varnost na nivoju vrstic"
+
+#: superset/app.py:304 superset/app.py:416 superset/app.py:488
+msgid "Security"
+msgstr "Varnost"
+
+#: superset/app.py:341
+msgid "Import Dashboards"
+msgstr "Uvozi nadzorne plošče"
+
+#: superset/app.py:353
+msgid "SQL Editor"
+msgstr "SQL urejevalnik"
+
+#: superset/app.py:358 superset/app.py:373
+msgid "SQL Lab"
+msgstr "SQL laboratorij"
+
+#: superset/app.py:361
+msgid "Saved Queries"
+msgstr "Shranjene poizvedbe"
+
+#: superset/app.py:368
+msgid "Query History"
+msgstr "Zgodovina poizvedb"
+
+#: superset/app.py:377
+msgid "Upload a CSV"
+msgstr "Naloži CSV"
+
+#: superset/app.py:395
+msgid "Upload Excel"
+msgstr "Naloži Excel"
+
+#: superset/app.py:414
+msgid "Action Log"
+msgstr "Dnevnik aktivnosti"
+
+#: superset/app.py:439
+msgid "Dashboard Emails"
+msgstr "E-pošta za nadzorno ploščo"
+
+#: superset/app.py:448
+msgid "Chart Email Schedules"
+msgstr "Urniki za e-pošto grafikonov"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:421 superset/app.py:463
+msgid "Alerts"
+msgstr "Opozorila"
+
+#: superset/app.py:475
+msgid "Alerts & Reports"
+msgstr "Opozorila in poročila"
+
+#: superset/app.py:486
+msgid "Access requests"
+msgstr "Zahteve za dostop"
+
+#: superset/app.py:502 superset/connectors/druid/views.py:274
+msgid "Druid Datasources"
+msgstr "Druid podatkovni viri"
+
+#: superset/app.py:511 superset/connectors/druid/views.py:210
+msgid "Druid Clusters"
+msgstr "Druid gruče"
+
+#: superset/app.py:524
+msgid "Scan New Datasources"
+msgstr "Preišči nove podatkovne vire"
+
+#: superset/app.py:537
+msgid "Refresh Druid Metadata"
+msgstr "Osveži metapodatke za Druid"
+
+#: superset/errors.py:83
+msgid "Issue 1000 - The datasource is too large to query."
+msgstr "Težava 1000 - podatkovni vir je prevelik za poizvedbo."
+
+#: superset-frontend/src/utils/getClientErrorObject.ts:129
+#: superset/errors.py:87
+msgid "Issue 1001 - The database is under an unusual load."
+msgstr "Težava 1001 - podatkovni vir je neobičajno obremenjen."
+
+#: superset/errors.py:93
+msgid "Issue 1002 - The database returned an unexpected error."
+msgstr "Težava 1002 - podatkovna baza je vrnila nepričakovano napako."
+
+#: superset/errors.py:99 superset/errors.py:114 superset/errors.py:129
+msgid ""
+"Issue 1003 - There is a syntax error in the SQL query. Perhaps there was a "
+"misspelling or a typo."
+msgstr ""
+"Težava 1003 - v SQL-poizvedbi je sintaktična napaka. Mogoče ste se zatipkali."
+
+#: superset/errors.py:106
+msgid "Issue 1004 - The column was deleted or renamed in the database."
+msgstr ""
+"Težava 1004 - stolpec je bil izbrisan ali preimenovan v podatkovni bazi."
+
+#: superset/errors.py:121
+msgid "Issue 1005 - The table was deleted or renamed in the database."
+msgstr ""
+"Težava 1005 - tabela je bila izbrisana ali preimenovana v podatkovni bazi."
+
+#: superset/errors.py:136
+msgid "Issue 1005 - The schema was deleted or renamed in the database."
+msgstr ""
+"Težava 1005 - shema je bila izbrisana ali preimenovana v podatkovni bazi."
+
+#: superset/errors.py:144
+msgid "Issue 1006 - One or more parameters specified in the query are missing."
+msgstr "Težava 1006 - en ali več parametrov v SQL-poizvedbi manjka."
+
+#: superset/errors.py:153
+msgid "Issue 1007 - The hostname provided can't be resolved."
+msgstr "Težava 1007 - imena gostitelja ni mogoče razrešiti."
+
+#: superset/errors.py:157
+msgid "Issue 1008 - The port is closed."
+msgstr "Težava 1008 - Vrata so zaprta."
+
+#: superset/errors.py:162
+msgid ""
+"Issue 1009 - The host might be down, and can't be reached on the provided "
+"port."
+msgstr ""
+"Težava 1009 - Gostitelj mogoče ne deluje in ga ni mogoče doseči preko "
+"podanih vrat."
+
+#: superset/errors.py:171
+msgid "Issue 1010 - Superset encountered an error while running a command."
+msgstr "Težava 1010 - Superset je naletel na napako pri izvajanju ukaza."
+
+#: superset/errors.py:179
+msgid "Issue 1011 - Superset encountered an unexpected error."
+msgstr "Težava 1011 - Superset je naletel na nepričakovano napako."
+
+#: superset/errors.py:185
+msgid ""
+"Issue 1012 - The username provided when connecting to a database is not "
+"valid."
+msgstr ""
+"Težava 1012 - Uporabniško ime za povezavo s podatkovno bazo je neveljavno."
+
+#: superset/errors.py:194
+msgid ""
+"Issue 1013 - The password provided when connecting to a database is not "
+"valid."
+msgstr "Težava 1013 - Geslo za povezavo s podatkovno bazo je neveljavno."
+
+#: superset/errors.py:203
+msgid "Issue 1014 - Either the username or the password is wrong."
+msgstr "Težava 1014 - Uporabniško ime ali/in geslo sta napačna."
+
+#: superset/errors.py:207 superset/errors.py:216
+msgid ""
+"Issue 1015 - Either the database is spelled incorrectly or does not exist."
+msgstr ""
+"Težava 1015 - Ime podatkovne baze je zapisano napačno ali pa ne obstaja."
+
+#: superset/errors.py:225
+msgid "Issue 1017 - User doesn't have the proper permissions."
+msgstr "Težava 1017 - Uporabnik nima ustreznih dovoljenj."
+
+#: superset/errors.py:231
+msgid ""
+"Issue 1018 - One or more parameters needed to configure a database are "
+"missing."
+msgstr ""
+"Težava 1018 - Eden ali več parametrov, potrebnih za nastavitev podatkovne "
+"baze, manjka."
+
+#: superset/errors.py:240
+msgid "Issue 1019 - The submitted payload has the incorrect format."
+msgstr "Težava 1019 - Podani podatki so v neustrezni obliki."
+
+#: superset/errors.py:248
+msgid "Issue 1020 - The submitted payload has the incorrect schema."
+msgstr "Težava 1020 - Podani podatki imajo neustrezno shemo."
+
+#: superset/databases/schemas.py:170 superset/exceptions.py:139
+msgid "Invalid certificate"
+msgstr "Neveljaven certifikat"
+
+#: superset/jinja_context.py:328
+#, python-format
+msgid "Unsafe return type for function %(func)s: %(value_type)s"
+msgstr "Nevaren tip rezultata, ki ga vrne funkcija %(func)s: %(value_type)s"
+
+#: superset/jinja_context.py:339
+#, python-format
+msgid "Unsupported return value for method %(name)s"
+msgstr "Nepodprt rezultat vračanja za metodo %(name)s"
+
+#: superset/jinja_context.py:352
+#, python-format
+msgid "Unsafe template value for key %(key)s: %(value_type)s"
+msgstr "Nevaren vzorec za ključ %(key)s: %(value_type)s"
+
+#: superset/jinja_context.py:363
+#, python-format
+msgid "Unsupported template value for key %(key)s"
+msgstr "Nepodprta vrednost vzorca za ključ %(key)s"
+
+#: superset/sql_lab.py:172
+msgid ""
+"SQL Lab timeout. This environment's policy is to kill queries after {} "
+"seconds."
+msgstr ""
+"Iztek časa SQL laboratorija. Nastavitev okolja določa prekinitev poizvedb po "
+"izteku {} sekund."
+
+#: superset/sql_lab.py:204
+msgid "Only `SELECT` statements are allowed against this database"
+msgstr "Za to podatkovno bazo so dovoljeni le `SELECT` stavki"
+
+#: superset/sql_lab.py:371
+msgid ""
+"CTAS (create table as select) can only be run with a query where the last "
+"statement is a SELECT. Please make sure your query has a SELECT as its last "
+"statement. Then, try running your query again."
+msgstr ""
+"CTAS (create table as select) lahko izvajate le v poizvedbah, kjer je zadnji "
+"stavek SELECT. Poskrbite, da bo zadnji stavek v vaši poizvedbi SELECT in "
+"poskusite ponovno zagnati poizvedbo."
+
+#: superset/sql_lab.py:383
+msgid ""
+"CVAS (create view as select) can only be run with a query with a single "
+"SELECT statement. Please make sure your query has only a SELECT statement. "
+"Then, try running your query again."
+msgstr ""
+"CVAS (create view as select) lahko izvajate le v poizvedbah z enim SELECT "
+"stavkom. Poskrbite, da bo v vaši poizvedbi le en SELECT stavek in poskusite "
+"ponovno zagnati poizvedbo."
+
+#: superset/viz.py:131
+msgid "Viz is missing a datasource"
+msgstr "Vizualizaciji manjka podatkovni vir"
+
+#: superset/viz.py:237
+msgid ""
+"Applied rolling window did not return any data. Please make sure the source "
+"query satisfies the minimum periods defined in the rolling window."
+msgstr ""
+"Izbrano drseče okno ni vrnilo podatkov. Poskrbite, da izvorna poizvedba "
+"ustreza minimalni periodi drsečega okna."
+
+#: superset/utils/date_parser.py:264 superset/viz.py:355
+msgid "From date cannot be larger than to date"
+msgstr "Začetni datum ne sme biti večji od končnega datuma"
+
+#: superset/viz.py:522
+msgid "Cached value not found"
+msgstr "Predpomnjena vrednost ni najdena"
+
+#: superset/common/query_context.py:358 superset/viz.py:538
+#, python-format
+msgid "Columns missing in datasource: %(invalid_columns)s"
+msgstr "V podatkovnem viru manjkajo stolpci: %(invalid_columns)s"
+
+#: superset/viz.py:650
+msgid "Table View"
+msgstr "Tabelarični pogled"
+
+#: superset/viz.py:672
+msgid ""
+"You cannot use [Columns] in combination with [Group By]/[Metrics]/"
+"[Percentage Metrics]. Please choose one or the other."
+msgstr ""
+"Ne smete uporabiti [Stolpci] v kombinaciji z [Združevanje]/[Mere]/"
+"[Procentualne mere]. Izberite eno ali drugo."
+
+#: superset/viz.py:709
+msgid "Pick a granularity in the Time section or uncheck 'Include Time'"
+msgstr "Izberite granulacijo v razdelku 'Čas' ali odstranite 'Vključi čas'"
+
+#: superset/viz.py:782
+msgid "Time Table View"
+msgstr "Pogled urnika"
+
+#: superset/viz.py:791 superset/viz.py:1735
+msgid "Pick at least one metric"
+msgstr "Izberite vsaj eno mero"
+
+#: superset/viz.py:795
+msgid "When using 'Group By' you are limited to use a single metric"
+msgstr "Ko uporabljate 'Group By', ste omejeni na uporabo ene mere"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-pivot-table/src/index.js:26
+#: superset/viz.py:824
+msgid "Pivot Table"
+msgstr "Vrtilna tabela"
+
+#: superset/viz.py:841
+msgid "Please choose at least one 'Group by' field "
+msgstr "Izberite vsaj eno 'Group by' polje "
+
+#: superset/viz.py:853
+msgid "Please choose at least one metric"
+msgstr "Izberite vsaj eno mero"
+
+#: superset/viz.py:855
+msgid "Group By' and 'Columns' can't overlap"
+msgstr "'Združevanje' in 'Stolpci' se ne smeta prekrivati"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-treemap/src/index.js:27
+#: superset/viz.py:957
+msgid "Treemap"
+msgstr "Drevesni grafikon s pravokotniki"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-calendar/src/index.js:27
+#: superset/viz.py:1000
+msgid "Calendar Heatmap"
+msgstr "Koledarska barvna lestvica"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bubble/index.js:27
+#: superset/viz.py:1092
+msgid "Bubble Chart"
+msgstr "Mehurčkasti grafikon"
+
+#: superset/viz.py:1114
+msgid "Please use 3 different metric labels"
+msgstr "Uporabite 3 različne oznake mer"
+
+#: superset/viz.py:1116
+msgid "Pick a metric for x, y and size"
+msgstr "Izberite mere za x, y in velikost"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bullet/index.js:27
+#: superset/viz.py:1143
+msgid "Bullet Chart"
+msgstr "'Bullet' grafikon"
+
+#: superset/viz.py:1153
+msgid "Pick a metric to display"
+msgstr "Izberite mero za prikaz"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/index.ts:26
+#: superset/viz.py:1171
+msgid "Big Number with Trendline"
+msgstr "Velika številka s trendno krivuljo"
+
+#: superset/viz.py:1179 superset/viz.py:1213
+msgid "Pick a metric!"
+msgstr "Izberite mero!"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumberTotal/index.ts:29
+#: superset/viz.py:1205
+msgid "Big Number"
+msgstr "Velika številka"
+
+#: superset/viz.py:1227
+msgid "Time Series - Line Chart"
+msgstr "Časovna vrsta - Črtni grafikon"
+
+#: superset/viz.py:1308 superset/viz.py:1574
+msgid "Pick a time granularity for your time series"
+msgstr "Izberite granulacijo časa za časovno vrsto"
+
+#: superset/viz.py:1367
+msgid ""
+"An enclosed time range (both start and end) must be specified when using a "
+"Time Comparison."
+msgstr ""
+"Pri časovni primerjavi mora biti določeno zaprto časovno obdobje (s časom "
+"začetka in konca)."
+
+#: superset/viz.py:1439
+msgid "Time Series - Multiple Line Charts"
+msgstr "Časovna vrsta - Veččrtni grafikon"
+
+#: superset/viz.py:1516
+msgid "Time Series - Dual Axis Line Chart"
+msgstr "Časovna vrsta - Črtni grafikon z dvojno osjo"
+
+#: superset/viz.py:1526
+msgid "Pick a metric for left axis!"
+msgstr "Izberite mero za levo os!"
+
+#: superset/viz.py:1528
+msgid "Pick a metric for right axis!"
+msgstr "Izberite mero za desno os!"
+
+#: superset/viz.py:1531
+msgid "Please choose different metrics on left and right axis"
+msgstr "Izberite različni meri za levo in desno os"
+
+#: superset/viz.py:1591
+msgid "Time Series - Bar Chart"
+msgstr "Časovna vrsta - Stolpčni grafikon"
+
+#: superset/viz.py:1600
+msgid "Time Series - Period Pivot"
+msgstr "Časovna vrsta - Vrtenje period"
+
+#: superset/viz.py:1647
+msgid "Time Series - Percent Change"
+msgstr "Časovna vrsta - Procentualna sprememba"
+
+#: superset/viz.py:1655
+msgid "Time Series - Stacked"
+msgstr "Časovna vrsta - Naložen graf"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-histogram/src/index.js:26
+#: superset/viz.py:1665
+msgid "Histogram"
+msgstr "Histogram"
+
+#: superset/viz.py:1675
+msgid "Must have at least one numeric column specified"
+msgstr "Definiran mora biti vsaj en numerični stolpec"
+
+#: superset/viz.py:1722
+msgid "Distribution - Bar Chart"
+msgstr "Porazdelitev - Stolpčni grafikon"
+
+#: superset/viz.py:1732
+msgid "Can't have overlap between Series and Breakdowns"
+msgstr "Ne sme imeti prekrivanja med podatkovnimi serijami in členitvami"
+
+#: superset/viz.py:1737
+msgid "Pick at least one field for [Series]"
+msgstr "Izberite vsaj eno polje za [Serije]"
+
+#: superset/viz.py:1803
+msgid "Sunburst"
+msgstr "Sunburst"
+
+#: superset/viz.py:1851
+msgid "Sankey"
+msgstr "Sankey"
+
+#: superset/viz.py:1859
+msgid "Pick exactly 2 columns as [Source / Target]"
+msgstr "Izberite natanko dva stolpca za [Izvor / Cilj]"
+
+#: superset/viz.py:1903
+msgid ""
+"There's a loop in your Sankey, please provide a tree. Here's a faulty link: "
+"{}"
+msgstr "V 'Sankey' je zanka, določite drevo. To je okvarjena povezava: {}"
+
+#: superset/viz.py:1916
+msgid "Directed Force Layout"
+msgstr "Izgled usmerjene sile"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-country-map/src/index.js:27
+#: superset/viz.py:1951
+msgid "Country Map"
+msgstr "Zemljevid držav"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-world-map/src/index.js:27
+#: superset/viz.py:1988
+msgid "World Map"
+msgstr "Zemljevid sveta"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx:104
+#: superset-frontend/src/explore/controls.jsx:466
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:72
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:429
+#: superset/viz.py:2048
+msgid "Filters"
+msgstr "Filtri"
+
+#: superset/viz.py:2068
+msgid "Invalid filter configuration, please select a column"
+msgstr "Neveljavna nastavitev filtrov, izberite stolpec"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-parallel-coordinates/src/index.js:27
+#: superset/viz.py:2119
+msgid "Parallel Coordinates"
+msgstr "Vzporedne koordinate"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/index.js:27
+#: superset/viz.py:2148
+msgid "Heatmap"
+msgstr "Toplotni prikaz"
+
+#: superset/viz.py:2208
+msgid "Horizon Charts"
+msgstr "Horizontni grafikon"
+
+#: superset/viz.py:2220
+msgid "Mapbox"
+msgstr "Mapbox"
+
+#: superset/viz.py:2232
+msgid "[Longitude] and [Latitude] must be set"
+msgstr "[Zemljepisna dolžina] in [Zemljepisna širina] morata biti nastavljeni"
+
+#: superset/viz.py:2239
+msgid "Must have a [Group By] column to have 'count' as the [Label]"
+msgstr "Mora imeti stolpec [Združevanje], da ima število (count) kot [Oznaka]"
+
+#: superset/viz.py:2263
+msgid "Choice of [Label] must be present in [Group By]"
+msgstr "Izbira [Oznaka] mora biti prisotna v [Združevanje]"
+
+#: superset/viz.py:2271
+msgid "Choice of [Point Radius] must be present in [Group By]"
+msgstr "Izbran [Point Radius] mora biti prisoten v [Združevanje]"
+
+#: superset/viz.py:2279
+msgid "[Longitude] and [Latitude] columns must be present in [Group By]"
+msgstr ""
+"Stolpca [Zemljepisna dolžina] in [Zemljepisna širina] morata biti prisotna v "
+"[Združevanje]"
+
+#: superset/viz.py:2359
+msgid "Deck.gl - Multiple Layers"
+msgstr "Deck.gl - Večplastni"
+
+#: superset/viz.py:2399 superset/viz.py:2431
+msgid "Bad spatial key"
+msgstr "Neutrezen prostorski ključ"
+
+#: superset/viz.py:2417
+#, python-format
+msgid "Invalid spatial point encountered: %s"
+msgstr "Neustrezna prostorska točka: %s"
+
+#: superset/viz.py:2453
+msgid ""
+"Encountered invalid NULL spatial "
+"entry,                                        please consider filtering "
+"those out"
+msgstr ""
+"Prišlo je do neveljavnega NULL prostorskega "
+"vnosa,                                        poskusite ga izločiti s filtrom"
+
+#: superset/viz.py:2547
+msgid "Deck.gl - Scatter plot"
+msgstr "Deck.gl - Raztreseni graf"
+
+#: superset/viz.py:2596
+msgid "Deck.gl - Screen Grid"
+msgstr "Deck.gl - Mreža"
+
+#: superset/viz.py:2622
+msgid "Deck.gl - 3D Grid"
+msgstr "Deck.gl - 3D mreža"
+
+#: superset/viz.py:2652
+msgid "Deck.gl - Paths"
+msgstr "Deck.gl - Poti"
+
+#: superset/viz.py:2700
+msgid "Deck.gl - Polygon"
+msgstr "Deck.gl - Poligon"
+
+#: superset/viz.py:2729
+msgid "Deck.gl - 3D HEX"
+msgstr "Deck.gl - 3D HEX"
+
+#: superset/viz.py:2748
+msgid "Deck.gl - GeoJSON"
+msgstr "Deck.gl - GeoJSON"
+
+#: superset/viz.py:2767
+msgid "Deck.gl - Arc"
+msgstr "Deck.gl - Arc"
+
+#: superset/viz.py:2802
+msgid "Event flow"
+msgstr "Potek dogodkov"
+
+#: superset/viz.py:2834
+msgid "Time Series - Paired t-test"
+msgstr "Časovna vrsta - t-test za odvisne vzorce"
+
+#: superset/viz.py:2901
+msgid "Time Series - Nightingale Rose Chart"
+msgstr "Časovna vrsta - Nightingale Rose grafikon"
+
+#: superset/viz.py:2936
+msgid "Partition Diagram"
+msgstr "Grafikon s pravokotniki"
+
+#: superset/annotation_layers/api.py:353
+#, python-format
+msgid "Deleted %(num)d annotation layer"
+msgid_plural "Deleted %(num)d annotation layers"
+msgstr[0] "Izbrisan je %(num)d sloj z oznakami"
+msgstr[1] "Izbrisana sta %(num)d sloja z oznakami"
+msgstr[2] "Izbrisanih so %(num)d sloji z oznakami"
+msgstr[3] "Izbrisanih je %(num)d slojev z oznakami"
+
+#: superset/annotation_layers/annotations/filters.py:28
+#: superset/annotation_layers/filters.py:30 superset/charts/filters.py:31
+#: superset/css_templates/filters.py:28
+#: superset/queries/saved_queries/filters.py:31 superset/reports/filters.py:28
+msgid "All Text"
+msgstr "Celotno besedilo"
+
+#: superset/annotation_layers/annotations/api.py:502
+#, python-format
+msgid "Deleted %(num)d annotation"
+msgid_plural "Deleted %(num)d annotations"
+msgstr[0] "Izbrisana je %(num)d oznaka"
+msgstr[1] "Izbrisani sta %(num)d oznaki"
+msgstr[2] "Izbrisane so %(num)d oznake"
+msgstr[3] "Izbrisanih je %(num)d oznak"
+
+#: superset/annotation_layers/annotations/commands/exceptions.py:35
+msgid "End date must be after start date"
+msgstr "Končni datum mora biti za začetnim"
+
+#: superset/annotation_layers/annotations/commands/exceptions.py:46
+msgid "Short description must be unique for this layer"
+msgstr "Kratek opis mora biti za ta sloj unikaten"
+
+#: superset/annotation_layers/annotations/commands/exceptions.py:52
+msgid "Annotations could not be deleted."
+msgstr "Oznak ni mogoče izbrisati."
+
+#: superset/annotation_layers/annotations/commands/exceptions.py:56
+msgid "Annotation not found."
+msgstr "Oznaka ni najdena."
+
+#: superset/annotation_layers/annotations/commands/exceptions.py:60
+msgid "Annotation parameters are invalid."
+msgstr "Parametri oznak so neveljavni."
+
+#: superset/annotation_layers/annotations/commands/exceptions.py:64
+msgid "Annotation could not be created."
+msgstr "Oznake ni mogoče ustvariti."
+
+#: superset/annotation_layers/annotations/commands/exceptions.py:68
+msgid "Annotation could not be updated."
+msgstr "Oznake ni mogoče posodobiti."
+
+#: superset/annotation_layers/annotations/commands/exceptions.py:72
+msgid "Annotation delete failed."
+msgstr "Izbris oznake ni uspel."
+
+#: superset/annotation_layers/commands/exceptions.py:29
+msgid "Annotation layer parameters are invalid."
+msgstr "Parametri sloja z oznakami so neveljavni."
+
+#: superset/annotation_layers/commands/exceptions.py:33
+msgid "Annotation layer could not be deleted."
+msgstr "Sloja z oznakami ni mogoče izbrisati."
+
+#: superset/annotation_layers/commands/exceptions.py:37
+msgid "Annotation layer could not be created."
+msgstr "Sloja z oznakami ni mogoče ustvariti."
+
+#: superset/annotation_layers/commands/exceptions.py:41
+msgid "Annotation layer could not be updated."
+msgstr "Sloja z oznakami ni mogoče posodobiti."
+
+#: superset/annotation_layers/commands/exceptions.py:45
+msgid "Annotation layer not found."
+msgstr "Sloja z oznakami ni mogoče najti."
+
+#: superset/annotation_layers/commands/exceptions.py:49
+msgid "Annotation layer delete failed."
+msgstr "Izbris sloja z oznakami ni uspel."
+
+#: superset/annotation_layers/commands/exceptions.py:53
+#: superset/annotation_layers/commands/exceptions.py:57
+msgid "Annotation layer has associated annotations."
+msgstr "Sloj z oznakami ima povezane oznake."
+
+#: superset/annotation_layers/commands/exceptions.py:66
+#: superset/reports/commands/exceptions.py:137
+msgid "Name must be unique"
+msgstr "Ime mora biti unikatno"
+
+#: superset/charts/api.py:473
+#, python-format
+msgid "Deleted %(num)d chart"
+msgid_plural "Deleted %(num)d charts"
+msgstr[0] "Izbrisan je %(num)d grafikon"
+msgstr[1] "Izbrisana sta %(num)d grafikona"
+msgstr[2] "Izbrisani so %(num)d grafikoni"
+msgstr[3] "Izbrisanih je %(num)d grafikonov"
+
+#: superset/charts/api.py:571
+msgid "Request is not JSON"
+msgstr "Zahtevek ni JSON"
+
+#: superset/charts/api.py:582 superset/charts/api.py:652
+#, python-format
+msgid "Request is incorrect: %(error)s"
+msgstr "Zahtevek je napačen: %(error)s"
+
+#: superset/charts/schemas.py:510
+msgid "`confidence_interval` must be between 0 and 1 (exclusive)"
+msgstr "`confidence_interval` mora biti med 0 in 1 (odprt)"
+
+#: superset/charts/schemas.py:576
+msgid ""
+"lower percentile must be greater than 0 and less than 100. Must be lower "
+"than upper percentile."
+msgstr ""
+"spodnji percentil mora biti večji od 0 in manjši od 100 ter mora biti manjši "
+"od zgornjega percentila."
+
+#: superset/charts/schemas.py:591
+msgid ""
+"upper percentile must be greater than 0 and less than 100. Must be higher "
+"than lower percentile."
+msgstr ""
+"zgornji percentil mora biti večji od 0 in manjši od 100 ter mora biti večji "
+"od spodnjega percentila."
+
+#: superset/charts/schemas.py:871
+msgid "`width` must be greater or equal to 0"
+msgstr "`width` mora biti večja ali enaka 0"
+
+#: superset/charts/schemas.py:986
+msgid "`row_limit` must be greater than or equal to 0"
+msgstr "`row_limit` mora biti večja ali enaka 0"
+
+#: superset/charts/schemas.py:993
+msgid "`row_offset` must be greater than or equal to 0"
+msgstr "`row_offset` mora biti večja ali enaka 1"
+
+#: superset/charts/commands/bulk_delete.py:64
+#: superset/charts/commands/delete.py:68
+#: superset/dashboards/commands/bulk_delete.py:65
+#: superset/dashboards/commands/delete.py:66
+#: superset/databases/commands/delete.py:65
+#, python-format
+msgid "There are associated alerts or reports: %s,"
+msgstr "Prisotna so opozorila in poročila: %s,"
+
+#: superset/charts/commands/exceptions.py:38
+#, python-format
+msgid ""
+"Time string is unclear. Please specify [%(human_readable)s ago] or "
+"[%(human_readable)s later]."
+msgstr ""
+"Časovni izraz je nejasen. Podajte [%(human_readable)s ago] ali "
+"[%(human_readable)s later]."
+
+#: superset/charts/commands/exceptions.py:51
+#, python-format
+msgid "Cannot parse time string [%(human_readable)s]"
+msgstr "Ni mogoče razčleniti časovnega izraza [%(human_readable)s]"
+
+#: superset/charts/commands/exceptions.py:65
+#: superset/datasets/commands/exceptions.py:41
+#: superset/reports/commands/exceptions.py:35
+msgid "Database does not exist"
+msgstr "Podatkovna baza ne obstaja"
+
+#: superset/charts/commands/exceptions.py:74
+msgid "Dashboards do not exist"
+msgstr "Nadzorna plošča ne obstaja"
+
+#: superset/charts/commands/exceptions.py:84
+msgid "Datasource type is required when datasource_id is given"
+msgstr "Ko se podaja datasource_id, je potreben tip podatkovnega vira"
+
+#: superset/charts/commands/exceptions.py:94
+msgid "Chart parameters are invalid."
+msgstr "Parametri grafikona so neveljavni."
+
+#: superset/charts/commands/exceptions.py:98
+msgid "Chart could not be created."
+msgstr "Grafikona ni mogoče ustvariti."
+
+#: superset/charts/commands/exceptions.py:102
+msgid "Chart could not be updated."
+msgstr "Grafikona ni mogoče posodobiti."
+
+#: superset/charts/commands/exceptions.py:106
+msgid "Chart could not be deleted."
+msgstr "Grafikona ni mogoče izbrisati."
+
+#: superset/charts/commands/exceptions.py:110
+#: superset/charts/commands/exceptions.py:130
+#: superset/dashboards/commands/exceptions.py:57
+#: superset/dashboards/commands/exceptions.py:69
+#: superset/databases/commands/exceptions.py:117
+msgid "There are associated alerts or reports"
+msgstr "Prisotna so povezana opozorila in poročila"
+
+#: superset/charts/commands/exceptions.py:114
+msgid "Changing this chart is forbidden"
+msgstr "Spreminjanje tega grafikona ni dovoljeno"
+
+#: superset/charts/commands/exceptions.py:118
+msgid "Charts could not be deleted."
+msgstr "Grafikonov ni mogoče izbrisati."
+
+#: superset/charts/commands/exceptions.py:134
+msgid "Import chart failed for an unknown reason"
+msgstr "Uvoz grafikona ni uspel zaradi neznanega razloga"
+
+#: superset/commands/exceptions.py:85
+#: superset/datasets/commands/exceptions.py:144
+msgid "Owners are invalid"
+msgstr "Lastniki niso veljavni"
+
+#: superset/commands/exceptions.py:92
+msgid "Some roles do not exist"
+msgstr "Nekatere vloge ne obstajajo"
+
+#: superset/commands/exceptions.py:99
+#: superset/datasets/commands/exceptions.py:149
+msgid "Dataset does not exist"
+msgstr "Podatkovni set ne obstaja"
+
+#: superset/common/query_actions.py:183
+msgid "Invalid result type: %(result_type)"
+msgstr "Neveljaven tip rezultata: %(result_type)"
+
+#: superset/common/query_context.py:276
+msgid "The chart does not exist"
+msgstr "Grafikon ne obstaja"
+
+#: superset/common/query_object.py:259
+#, python-format
+msgid ""
+"Duplicate column/metric labels: %(labels)s. Please make sure all columns and "
+"metrics have a unique label."
+msgstr ""
+"Podvojene oznake stolpcev/mer: %(labels)s. Poskrbite, da bodo imeli stolpci "
+"in mere unikatne oznake."
+
+#: superset/common/query_object.py:351
+msgid "`operation` property of post processing object undefined"
+msgstr "Lastnost  `operation` poprocesirnega objekta ni definirana"
+
+#: superset/common/query_object.py:355
+#, python-format
+msgid "Unsupported post processing operation: %(operation)s"
+msgstr "Nepodprta poprocesirna operacija: %(operation)s"
+
+#: superset/connectors/druid/models.py:239
+msgid "Adding new datasource [{}]"
+msgstr "Dodajanje novega podatkovnega vira [{}]"
+
+#: superset/connectors/druid/models.py:242
+msgid "Refreshing datasource [{}]"
+msgstr "Osveževanje podatkovnega vira [{}]"
+
+#: superset/connectors/druid/models.py:1053
+msgid "Metric(s) {} must be aggregations."
+msgstr "Mere {} morajo biti agregacije."
+
+#: superset/connectors/druid/models.py:1471
+msgid "Unsupported extraction function: "
+msgstr "Nepodprta ekstrakcijska funkcija: "
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:1041
+#: superset-frontend/src/explore/components/DatasourcePanel/index.tsx:224
+#: superset-frontend/src/explore/controls.jsx:247
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:45
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:202
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts:31
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:49
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:94
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:117
+#: superset/connectors/druid/views.py:69 superset/connectors/sqla/views.py:65
+msgid "Columns"
+msgstr "Stolpci"
+
+#: superset/connectors/druid/views.py:70
+msgid "Show Druid Column"
+msgstr "Pokaži Druid stolpec"
+
+#: superset/connectors/druid/views.py:71
+msgid "Add Druid Column"
+msgstr "Dodaj Druid stolpec"
+
+#: superset/connectors/druid/views.py:72
+msgid "Edit Druid Column"
+msgstr "Uredi Druid stolpec"
+
+#: superset-frontend/src/dashboard/components/gridComponents/new/NewColumn.jsx:31
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:516
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:228
+#: superset-frontend/src/explore/components/controls/FilterBoxItemControl/index.jsx:139
+#: superset-frontend/src/explore/components/controls/SpatialControl.jsx:193
+#: superset/connectors/druid/views.py:90 superset/connectors/sqla/views.py:136
+msgid "Column"
+msgstr "Stolpec"
+
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:272
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:450
+#: superset/connectors/druid/views.py:91 superset/connectors/druid/views.py:187
+#: superset/connectors/sqla/views.py:145 superset/connectors/sqla/views.py:253
+msgid "Type"
+msgstr "Tip"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:149
+#: superset/connectors/druid/views.py:92 superset/views/access_requests.py:46
+#: superset/views/chart/mixin.py:80
+msgid "Datasource"
+msgstr "Podatkovni vir"
+
+#: superset/connectors/druid/views.py:93 superset/connectors/sqla/views.py:139
+msgid "Groupable"
+msgstr "Združevanje"
+
+#: superset/connectors/druid/views.py:94 superset/connectors/sqla/views.py:140
+msgid "Filterable"
+msgstr "Filtriranje"
+
+#: superset/connectors/druid/views.py:97 superset/connectors/sqla/views.py:100
+msgid ""
+"Whether this column is exposed in the `Filters` section of the explore view."
+msgstr ""
+"Če želite, da je ta stolpec na voljo v sekciji `Filtri` v raziskovalnem "
+"pogledu."
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:1030
+#: superset-frontend/src/explore/components/DatasourcePanel/index.tsx:202
+#: superset-frontend/src/explore/controls.jsx:154
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:89
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:130
+#: superset/connectors/druid/views.py:156 superset/connectors/sqla/views.py:207
+msgid "Metrics"
+msgstr "Mere"
+
+#: superset/connectors/druid/views.py:157
+msgid "Show Druid Metric"
+msgstr "Prikaži Druid mere"
+
+#: superset/connectors/druid/views.py:158
+msgid "Add Druid Metric"
+msgstr "Dodaj Druid mere"
+
+#: superset/connectors/druid/views.py:159
+msgid "Edit Druid Metric"
+msgstr "Uredi Druid mere"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:874
+#: superset-frontend/src/explore/controls.jsx:169
+#: superset-frontend/src/explore/controls.jsx:170
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:102
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:103
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:143
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:144
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-country-map/src/controlPanel.ts:84
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:90
+#: superset/connectors/druid/views.py:184 superset/connectors/sqla/views.py:250
+msgid "Metric"
+msgstr "Mera"
+
+#: superset-frontend/src/SqlLab/components/SaveQuery.tsx:125
+#: superset-frontend/src/SqlLab/components/ScheduleQueryButton.tsx:159
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:175
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:179
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:546
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:888
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:892
+#: superset-frontend/src/explore/components/PropertiesModal/index.tsx:208
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1076
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1082
+#: superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx:153
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx:162
+#: superset/connectors/druid/views.py:185
+#: superset/connectors/druid/views.py:342 superset/connectors/sqla/views.py:138
+#: superset/connectors/sqla/views.py:251 superset/connectors/sqla/views.py:499
+#: superset/views/annotations.py:80 superset/views/annotations.py:128
+#: superset/views/chart/mixin.py:81 superset/views/sql_lab.py:73
+msgid "Description"
+msgstr "Opis"
+
+#: superset/connectors/druid/views.py:186
+#: superset/connectors/druid/views.py:235 superset/connectors/sqla/views.py:137
+#: superset/connectors/sqla/views.py:252
+msgid "Verbose Name"
+msgstr "Podrobno ime"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:772
+#: superset/connectors/druid/views.py:188 superset/views/log/__init__.py:33
+msgid "JSON"
+msgstr "JSON"
+
+#: superset/connectors/druid/views.py:189
+msgid "Druid Datasource"
+msgstr "Podatkovni vir Druid"
+
+#: superset/connectors/druid/views.py:190 superset/connectors/sqla/views.py:258
+msgid "Warning Message"
+msgstr "Opozorilo"
+
+#: superset/connectors/druid/views.py:211
+msgid "Show Druid Cluster"
+msgstr "Pokaži Druid gručo"
+
+#: superset/connectors/druid/views.py:212
+msgid "Add Druid Cluster"
+msgstr "Dodaj Druid gručo"
+
+#: superset/connectors/druid/views.py:213
+msgid "Edit Druid Cluster"
+msgstr "Uredi Druid gručo"
+
+#: superset/connectors/druid/views.py:229
+msgid "Cluster Name"
+msgstr "Ime gruče"
+
+#: superset/connectors/druid/views.py:230
+msgid "Broker Host"
+msgstr "Gostitelj posrednika"
+
+#: superset/connectors/druid/views.py:231
+msgid "Broker Port"
+msgstr "Vrata posrednika"
+
+#: superset/connectors/druid/views.py:232
+msgid "Broker Username"
+msgstr "Uporabniško ime posrednika"
+
+#: superset/connectors/druid/views.py:233
+msgid "Broker Password"
+msgstr "Geslo posrednika"
+
+#: superset/connectors/druid/views.py:234
+msgid "Broker Endpoint"
+msgstr "Končna točka posrednika"
+
+#: superset/connectors/druid/views.py:236
+#: superset/connectors/druid/views.py:348 superset/connectors/sqla/views.py:494
+#: superset/views/chart/mixin.py:77
+msgid "Cache Timeout"
+msgstr "Trajanje predpomnilnika"
+
+#: superset/connectors/druid/views.py:237
+msgid "Metadata Last Refreshed"
+msgstr "Meta-podatki nazadnje osveženi"
+
+#: superset/connectors/druid/views.py:240
+msgid ""
+"Duration (in seconds) of the caching timeout for this cluster. A timeout of "
+"0 indicates that the cache never expires. Note this defaults to the global "
+"timeout if undefined."
+msgstr ""
+"Trajanje (v sekundah) predpomnjenja za to gručo. Vrednost 0 označuje, da "
+"predpomnilnik nikoli ne poteče. V primeru, da ni definirano, ima globalno "
+"nastavitev trajanja."
+
+#: superset/connectors/druid/views.py:245
+#: superset/connectors/druid/views.py:250
+msgid ""
+"Druid supports basic authentication. See [auth](http://druid.io/docs/latest/"
+"design/auth.html) and druid-basic-security extension"
+msgstr ""
+"Druid podpira osnovno avtentikacijo. Glejte [auth](http://druid.io/docs/"
+"latest/design/auth.html) in razširitev druid-basic-security"
+
+#: superset/connectors/druid/views.py:275
+msgid "Show Druid Datasource"
+msgstr "Prikaži podatkovni vir za Druid"
+
+#: superset/connectors/druid/views.py:276
+msgid "Add Druid Datasource"
+msgstr "Dodaj podatkovni vir za Druid"
+
+#: superset/connectors/druid/views.py:277
+msgid "Edit Druid Datasource"
+msgstr "Uredi podatkovni vir za Druid"
+
+#: superset/connectors/druid/views.py:300 superset/connectors/sqla/views.py:426
+msgid ""
+"The list of charts associated with this table. By altering this datasource, "
+"you may change how these associated charts behave. Also note that charts "
+"need to point to a datasource, so this form will fail at saving if removing "
+"charts from a datasource. If you want to change the datasource for a chart, "
+"overwrite the chart from the 'explore view'"
+msgstr ""
+"Seznam grafikonov, povezanih s to tabelo. S spreminjanjem podatkovnega vira "
+"lahko spremenite, kako se povezani grafikoni obnašajo. Poleg tega morajo "
+"biti grafikoni povezani s podatkovnim virom. Če odstranite grafikon s "
+"podatkovnega vira ne bo mogoče shraniti tega vnosa. Če želite spremeniti "
+"podatkovni vir grafikona, prepišite grafikon v raziskovalnem pogledu."
+
+#: superset/connectors/druid/views.py:309 superset/connectors/sqla/views.py:435
+msgid "Timezone offset (in hours) for this datasource"
+msgstr "Razlika časovnega pasu (v urah) za ta podatkovni vir"
+
+#: superset/connectors/druid/views.py:314
+msgid ""
+"Time expression to use as a predicate when retrieving distinct values to "
+"populate the filter component. Only applies when `Enable Filter Select` is "
+"on. If you enter `7 days ago`, the distinct list of values in the filter "
+"will be populated based on the distinct value over the past week"
+msgstr ""
+"Prednastavljeni časovni izraz za pridobitev različnih vrednosti filtrirne "
+"komponente. Upošteva se le v primeru, da je vključeno `Omogoči izbiro "
+"filtra`. Če vnesete `7 days ago`, bo seznam vrednosti filtra napolnjen na "
+"podlagi različnih vrednosti v prejšnjem tednu"
+
+#: superset/connectors/druid/views.py:322 superset/connectors/sqla/views.py:458
+msgid ""
+"Whether to populate the filter's dropdown in the explore view's filter "
+"section with a list of distinct values fetched from the backend on the fly"
+msgstr ""
+"Če želite napolniti spustni seznam filtra v raziskovalnem pogledu filtrske "
+"sekcije z različnimi vrednostmi, pridobljenimi sproti v ozadju"
+
+#: superset/connectors/druid/views.py:327
+msgid ""
+"Redirects to this endpoint when clicking on the datasource from the "
+"datasource list"
+msgstr ""
+"Preusmeri v to končno točko, ko kliknete na podatkovni vir v seznamu "
+"podatkovnih virov"
+
+#: superset/connectors/druid/views.py:331
+msgid ""
+"Duration (in seconds) of the caching timeout for this datasource. A timeout "
+"of 0 indicates that the cache never expires. Note this defaults to the "
+"cluster timeout if undefined."
+msgstr ""
+"Trajanje (v sekundah) predpomnjenja za ta podatkovni vir. Vrednost 0 "
+"označuje, da predpomnilnik nikoli ne poteče. V primeru, da ni definirano, "
+"ima nastavitev trajanja za gručo."
+
+#: superset/connectors/druid/views.py:339 superset/connectors/sqla/views.py:484
+msgid "Associated Charts"
+msgstr "Povezani grafikoni"
+
+#: superset/connectors/druid/views.py:340
+msgid "Data Source"
+msgstr "Podatkovni vir"
+
+#: superset/connectors/druid/views.py:341
+msgid "Cluster"
+msgstr "Gruča"
+
+#: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:337
+#: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:381
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:601
+#: superset-frontend/src/explore/components/PropertiesModal/index.tsx:244
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:267
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1059
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:276
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:318
+#: superset/connectors/druid/views.py:343 superset/connectors/sqla/views.py:497
+#: superset/views/chart/mixin.py:83 superset/views/dashboard/mixin.py:82
+msgid "Owners"
+msgstr "Lastniki"
+
+#: superset/connectors/druid/views.py:344
+msgid "Is Hidden"
+msgstr "Skrito"
+
+#: superset/connectors/druid/views.py:345 superset/connectors/sqla/views.py:490
+msgid "Enable Filter Select"
+msgstr "Omogoči izbiro filtra"
+
+#: superset/connectors/druid/views.py:346 superset/connectors/sqla/views.py:492
+msgid "Default Endpoint"
+msgstr "Privzeta končna točka"
+
+#: superset/connectors/druid/views.py:347
+msgid "Time Offset"
+msgstr "Časovni zamik"
+
+#: superset/connectors/druid/views.py:349
+msgid "Datasource Name"
+msgstr "Ime podatkovnega vira"
+
+#: superset/connectors/druid/views.py:350
+msgid "Fetch Values From"
+msgstr "Pridobi vrednosti iz"
+
+#: superset/connectors/druid/views.py:351 superset/connectors/sqla/views.py:486
+msgid "Changed By"
+msgstr "Spremenil/a"
+
+#: superset-frontend/src/dashboard/components/AddSliceCard.jsx:128
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:254
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:293
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:351
+#: superset/connectors/druid/views.py:352 superset/connectors/sqla/views.py:368
+#: superset/connectors/sqla/views.py:503 superset/views/dashboard/mixin.py:86
+#: superset/views/dashboard/views.py:148 superset/views/database/mixins.py:202
+#: superset/views/sql_lab.py:74
+msgid "Modified"
+msgstr "Sprememba"
+
+#: superset/connectors/druid/views.py:417
+msgid "Refreshed metadata from cluster [{}]"
+msgstr "Osveženi meta-podatki iz gruče [{}]"
+
+#: superset/connectors/sqla/models.py:645
+msgid "Only `SELECT` statements are allowed"
+msgstr "Dovoljeni so le `SELECT` stavki"
+
+#: superset/connectors/sqla/models.py:654
+msgid "Only single queries supported"
+msgstr "Podprte so le enojne poizvedbe"
+
+#: superset/connectors/sqla/models.py:738
+#, python-format
+msgid "Error in jinja expression in fetch values predicate: %(msg)s"
+msgstr "Napaka v jinja izrazu za pridobivanje vrednosti predikatov: %(msg)s"
+
+#: superset/connectors/sqla/models.py:820
+msgid "Virtual dataset query must be read-only"
+msgstr "Poizvedba na virtualnem podatkovnem setu mora biti samo za branje"
+
+#: superset/connectors/sqla/models.py:837
+#, python-format
+msgid "Error while rendering virtual dataset query: %(msg)s"
+msgstr "Napaka pri izvajanju poizvedbe virtualnega podatkovnega seta: %(msg)s"
+
+#: superset/connectors/sqla/models.py:844
+msgid "Virtual dataset query cannot be empty"
+msgstr "Poizvedba na virtualnem podatkovnem setu ne sme biti prazna"
+
+#: superset/connectors/sqla/models.py:847
+msgid "Virtual dataset query cannot consist of multiple statements"
+msgstr ""
+"Poizvedba na virtualnem podatkovnem setu ne sme biti sestavljena iz več "
+"stavkov"
+
+#: superset/connectors/sqla/models.py:948
+#, python-format
+msgid "Error in jinja expression in RLS filters: %(msg)s"
+msgstr "Napaka v jinja izrazu RLS filtrov: %(msg)s"
+
+#: superset/connectors/sqla/models.py:1013
+msgid ""
+"Datetime column not provided as part table configuration and is required by "
+"this type of chart"
+msgstr ""
+"Stolpec datum-čas ni podan kot del tabele, čeprav mora biti za ta tip "
+"grafikona"
+
+#: superset/connectors/sqla/models.py:1019
+msgid "Empty query?"
+msgstr "Prazna poizvedba?"
+
+#: superset/connectors/sqla/models.py:1030
+#: superset/connectors/sqla/models.py:1423
+#, python-format
+msgid "Metric '%(metric)s' does not exist"
+msgstr "Mera '%(metric)s' ne obstaja"
+
+#: superset/connectors/sqla/models.py:1070
+#, python-format
+msgid "Unknown column used in orderby: %(col)s"
+msgstr "Za razvrščanje je uporabljen neznan stolpec: %(col)s"
+
+#: superset/connectors/sqla/models.py:1112
+#, python-format
+msgid "Time column \"%(col)s\" does not exist in dataset"
+msgstr "Časovni stolpec \"%(col)s\" ne obstaja v podatkovnem setu"
+
+#: superset/connectors/sqla/models.py:1199
+msgid "Filter value list cannot be empty"
+msgstr "Seznam vrednosti filtra ne sme biti prazen"
+
+#: superset/connectors/sqla/models.py:1224
+msgid "Must specify a value for filters with comparison operators"
+msgstr "Potrebno je podati vrednost za filter s primerjalnim operandom"
+
+#: superset/connectors/sqla/models.py:1247
+#, python-format
+msgid "Invalid filter operation type: %(op)s"
+msgstr "Neveljaven tip operacije filtra: %(op)s"
+
+#: superset/connectors/sqla/models.py:1258
+#, python-format
+msgid "Error in jinja expression in WHERE clause: %(msg)s"
+msgstr "Napaka v jinja izrazu WHERE stavka: %(msg)s"
+
+#: superset/connectors/sqla/models.py:1270
+#, python-format
+msgid "Error in jinja expression in HAVING clause: %(msg)s"
+msgstr "Napaka v jinja izrazu HAVING stavka: %(msg)s"
+
+#: superset/connectors/sqla/models.py:1393
+msgid "Database does not support subqueries"
+msgstr "Podatkovna baza ne podpira podpoizvedb"
+
+#: superset/connectors/sqla/models.py:1468
+msgid "Db engine did not return all queried columns"
+msgstr "Sitem podatkovne baze ni vrnil vse stolpcev poizvedbe"
+
+#: superset/connectors/sqla/views.py:66
+msgid "Show Column"
+msgstr "Pokaži stolpec"
+
+#: superset/connectors/sqla/views.py:67
+msgid "Add Column"
+msgstr "Dodaj stolpec"
+
+#: superset/connectors/sqla/views.py:68
+msgid "Edit Column"
+msgstr "Uredi stolpec"
+
+#: superset/connectors/sqla/views.py:95
+msgid ""
+"Whether to make this column available as a [Time Granularity] option, column "
+"has to be DATETIME or DATETIME-like"
+msgstr ""
+"Če želite, da bo ta stolpec na razpolago kot možnost [Granulacija časa]. "
+"Stolpec mora biti tipa DATETIME ali DATETIME-like"
+
+#: superset/connectors/sqla/views.py:104
+msgid ""
+"The data type that was inferred by the database. It may be necessary to "
+"input a type manually for expression-defined columns in some cases. In most "
+"case users should not need to alter this."
+msgstr ""
+"Podatkovni tip, ki izvira iz podatkovne baze. V nekaterih primerih je "
+"potrebno ročno vnesti tip za stolpce, ki temeljijo na izrazih. V večini "
+"primerov uporabniku tega ni potrebno spreminjati."
+
+#: superset-frontend/src/components/TableSelector/index.tsx:405
+#: superset-ui/superset-ui-plugins/packages/superset-ui-plugin-chart-table/src/createMetadata.ts:9
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:148
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/index.ts:35
+#: superset-ui/superset-ui/temporary-plugins/hold-potentially-deprecate/superset-ui-plugin-chart-table/src/createMetadata.ts:8
+#: superset/connectors/sqla/views.py:141 superset/connectors/sqla/views.py:255
+#: superset/connectors/sqla/views.py:485 superset/views/chart/mixin.py:87
+msgid "Table"
+msgstr "Tabela"
+
+#: superset/connectors/sqla/views.py:142
+msgid "Expression"
+msgstr "Izraz"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:231
+#: superset/connectors/sqla/views.py:143
+msgid "Is temporal"
+msgstr "Časoven"
+
+#: superset/connectors/sqla/views.py:144
+msgid "Datetime Format"
+msgstr "Oblika zapisa datuma,časa"
+
+#: superset/connectors/sqla/views.py:161 superset/datasets/schemas.py:39
+msgid "Invalid date/timestamp format"
+msgstr "Neveljaven zapis datuma/časa"
+
+#: superset/connectors/sqla/views.py:208
+msgid "Show Metric"
+msgstr "Pokaži mero"
+
+#: superset/connectors/sqla/views.py:209
+msgid "Add Metric"
+msgstr "Dodaj mero"
+
+#: superset/connectors/sqla/views.py:210
+msgid "Edit Metric"
+msgstr "Uredi mero"
+
+#: superset/connectors/sqla/views.py:254
+msgid "SQL Expression"
+msgstr "SQL izraz"
+
+#: superset/connectors/sqla/views.py:256
+msgid "D3 Format"
+msgstr "D3 zapis"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:583
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:326
+#: superset/connectors/sqla/views.py:257 superset/connectors/sqla/views.py:502
+#: superset/views/database/mixins.py:196
+msgid "Extra"
+msgstr "Dodatno"
+
+#: superset/connectors/sqla/views.py:311
+msgid "Row level security filter"
+msgstr "Filter za varnost na nivoju vrstic"
+
+#: superset/connectors/sqla/views.py:312
+msgid "Show Row level security filter"
+msgstr "Prikaži filter za varnost na nivoju vrstic"
+
+#: superset/connectors/sqla/views.py:313
+msgid "Add Row level security filter"
+msgstr "Dodaj filter za varnost na nivoju vrstic"
+
+#: superset/connectors/sqla/views.py:314
+msgid "Edit Row level security filter"
+msgstr "Uredi filter za varnost na nivoju vrstic"
+
+#: superset/connectors/sqla/views.py:332
+msgid ""
+"Regular filters add where clauses to queries if a user belongs to a role "
+"referenced in the filter. Base filters apply filters to all queries except "
+"the roles defined in the filter, and can be used to define what users can "
+"see if no RLS filters within a filter group apply to them."
+msgstr ""
+"Navadni filtri dodajo WHERE stavek v poizvedbe, če ima uporabnik vlogo "
+"podano v filtru. Osnovni filtri filtrirajo vse poizvedbe, razen vlog, "
+"definiranih v filtru, in jih je mogoče uporabiti za nastavitev tega kaj "
+"uporabnik vidi, če v skupini filtrov ni RLS-filtrov, ki bi se nanašali nanje."
+
+#: superset/connectors/sqla/views.py:338
+msgid "These are the tables this filter will be applied to."
+msgstr "To so tabele, na katere se nanaša ta filter."
+
+#: superset/connectors/sqla/views.py:339
+msgid ""
+"For regular filters, these are the roles this filter will be applied to. For "
+"base filters, these are the roles that the filter DOES NOT apply to, e.g. "
+"Admin if admin should see all data."
+msgstr ""
+"Za regularne filtre so te vloge tiste, ki bodo filtrirane. Za osnovne "
+"filtre, so te vloge tiste, ki NE bodo filtrirane, npr. Admin, če naj "
+"administrator vidi vse podatke."
+
+#: superset/connectors/sqla/views.py:345
+msgid ""
+"Filters with the same group key will be ORed together within the group, "
+"while different filter groups will be ANDed together. Undefined group keys "
+"are treated as unique groups, i.e. are not grouped together. For example, if "
+"a table has three filters, of which two are for departments Finance and "
+"Marketing (group key = 'department'), and one refers to the region Europe "
+"(group key = 'region'), the filter clause would apply the filter (department "
+"= 'Finance' OR department = 'Marketing') AND (region = 'Europe')."
+msgstr ""
+"Filtri z enakim skupinskim ključem bodo znotraj skupine združeni z OR "
+"funkcijo, medtem ko bodo različne skupine združene z AND funkcijo. "
+"Nedefinirani skupinski ključi so obravnavani kot unikatne skupine in niso "
+"združeni v svojo skupino. Npr., če ima tabela tri filtre, pri čemer sta dva "
+"za oddelka marketinga in financ (skupinski ključ = 'oddelek') tretji pa se "
+"nanaša na regijo Evropa (skupinski ključ = 'regija'), bo filtrski izraz "
+"(oddelek = 'Finance' OR oddelek = 'Marketing') AND (regija = 'Evropa')."
+
+#: superset/connectors/sqla/views.py:355
+msgid ""
+"This is the condition that will be added to the WHERE clause. For example, "
+"to only return rows for a particular client, you might define a regular "
+"filter with the clause `client_id = 9`. To display no rows unless a user "
+"belongs to a RLS filter role, a base filter can be created with the clause "
+"`1 = 0` (always false)."
+msgstr ""
+"To je pogoj, ki bo dodan WHERE stavku. Npr., če želite dobiti vrstice za "
+"določeno stranko, lahko definirate regularni filter z izrazom 'id_stranke = "
+"9'. Če ne želimo prikazati vrstic, razen če uporabnik pripada RLS vlogi, "
+"lahko filter ustvarimo z izrazom `1 = 0` (vedno neresnično)."
+
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:278
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:316
+#: superset/connectors/sqla/views.py:364 superset/connectors/sqla/views.py:392
+msgid "Tables"
+msgstr "Tabele"
+
+#: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:403
+#: superset-frontend/src/profile/components/Security.tsx:35
+#: superset/connectors/sqla/views.py:365 superset/views/dashboard/mixin.py:83
+msgid "Roles"
+msgstr "Vloge"
+
+#: superset/connectors/sqla/views.py:366
+msgid "Clause"
+msgstr "Stavek"
+
+#: superset/connectors/sqla/views.py:367 superset/views/chart/mixin.py:78
+#: superset/views/dashboard/mixin.py:85 superset/views/dashboard/views.py:147
+#: superset/views/database/mixins.py:192
+msgid "Creator"
+msgstr "Avtor"
+
+#: superset/connectors/sqla/views.py:393
+msgid "Show Table"
+msgstr "Prikaži tabelo"
+
+#: superset/connectors/sqla/views.py:394
+msgid "Import a table definition"
+msgstr "Uvozi definicijo tabele"
+
+#: superset/connectors/sqla/views.py:395
+msgid "Edit Table"
+msgstr "Uredi tabelo"
+
+#: superset/connectors/sqla/views.py:436
+msgid "Name of the table that exists in the source database"
+msgstr "Ime tabele, ki obstaja v izvorni podatkovni bazi"
+
+#: superset/connectors/sqla/views.py:437
+msgid "Schema, as used only in some databases like Postgres, Redshift and DB2"
+msgstr ""
+"Shema, ki se uporablja pri nekaterih podatkovnih bazah, kot so Postgres, "
+"Redshift in DB2"
+
+#: superset/connectors/sqla/views.py:444
+msgid ""
+"This fields acts a Superset view, meaning that Superset will run a query "
+"against this string as a subquery."
+msgstr ""
+"To polje se obnaša kot Supersetov pogled, kar pomeni, da bo Superset izvedel "
+"poizvedbo za ta niz kot podpoizvedbo."
+
+#: superset/connectors/sqla/views.py:448
+msgid ""
+"Predicate applied when fetching distinct value to populate the filter "
+"control component. Supports jinja template syntax. Applies only when `Enable "
+"Filter Select` is on."
+msgstr ""
+"Privzeta vrednost za pridobivanje različnih vrednost pri oblikovanju "
+"filtrov. Podpira sintakso za jinja predloge. Potrebno le, ko je vključeno "
+"`Omogoči izbiro filtra`."
+
+#: superset/connectors/sqla/views.py:454
+msgid ""
+"Redirects to this endpoint when clicking on the table from the table list"
+msgstr "Preusmeri v to končno točko, ko kliknete na tabelo v seznamu tabel"
+
+#: superset/connectors/sqla/views.py:463
+msgid "Whether the table was generated by the 'Visualize' flow in SQL Lab"
+msgstr ""
+"Če želite, da je tabela ustvarjena s postopkom 'Vizualizacija' v SQL "
+"laboratoriju"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:649
+#: superset/connectors/sqla/views.py:466
+msgid ""
+"A set of parameters that become available in the query using Jinja "
+"templating syntax"
+msgstr ""
+"Nabor parametrov, ki postanejo razpoložljivi za poizvedbo z uporabo sintakse "
+"za Jinja predloge"
+
+#: superset/connectors/sqla/views.py:470
+msgid ""
+"Duration (in seconds) of the caching timeout for this table. A timeout of 0 "
+"indicates that the cache never expires. Note this defaults to the database "
+"timeout if undefined."
+msgstr ""
+"Trajanje (v sekundah) predpomnjenja za to tabelo. Vrednost 0 označuje, da "
+"predpomnilnik nikoli ne poteče. V primeru, da ni definirano, ima nastavitev "
+"trajanja za podatkovno bazo."
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:178
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:218
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:420
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:232
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:340
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:269
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:416
+#: superset/connectors/sqla/views.py:487 superset/connectors/sqla/views.py:488
+#: superset/templates/superset/import_dashboards.html:53
+#: superset/views/database/forms.py:112 superset/views/database/forms.py:309
+#: superset/views/database/mixins.py:191 superset/views/sql_lab.py:72
+msgid "Database"
+msgstr "Podatkovna baza"
+
+#: superset/connectors/sqla/views.py:489 superset/views/database/mixins.py:193
+msgid "Last Changed"
+msgstr "Zadnja sprememba"
+
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:283
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:435
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:241
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:279
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:436
+#: superset/connectors/sqla/views.py:491 superset/views/database/forms.py:118
+#: superset/views/database/forms.py:315
+msgid "Schema"
+msgstr "Shema"
+
+#: superset/connectors/sqla/views.py:493
+msgid "Offset"
+msgstr "Odmik"
+
+#: superset/connectors/sqla/views.py:495 superset/views/database/forms.py:87
+#: superset/views/database/forms.py:276
+msgid "Table Name"
+msgstr "Ime tabele"
+
+#: superset/connectors/sqla/views.py:496
+msgid "Fetch Values Predicate"
+msgstr "Pridobi vrednosti predikatov"
+
+#: superset/connectors/sqla/views.py:498
+msgid "Main Datetime Column"
+msgstr "Glavni stolpec Datum-Čas"
+
+#: superset/connectors/sqla/views.py:500
+msgid "SQL Lab View"
+msgstr "Pogled SQL laboratorija"
+
+#: superset-frontend/src/SqlLab/components/TemplateParamsEditor.tsx:94
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:648
+#: superset/connectors/sqla/views.py:501
+msgid "Template parameters"
+msgstr "Parametri predlog"
+
+#: superset/connectors/sqla/views.py:537
+msgid ""
+"The table was created. As part of this two-phase configuration process, you "
+"should now click the edit button by the new table to configure it."
+msgstr ""
+"Tabela je ustvarjena. Sedaj morate v tem dvodelnem postopku klikniti gumb za "
+"urejanje nove tabele."
+
+#: superset/connectors/sqla/views.py:562
+msgid "Refresh Metadata"
+msgstr "Osveži metapodatke"
+
+#: superset/connectors/sqla/views.py:562
+msgid "Refresh column metadata"
+msgstr "Osveži metapodatke stolpca"
+
+#: superset/connectors/sqla/views.py:599
+#, python-format
+msgid "Metadata refreshed for the following table(s): %(tables)s"
+msgstr "Metapodatki osveženi za naslednje tabele: %(tables)s"
+
+#: superset/connectors/sqla/views.py:609
+#, python-format
+msgid "The following tables added new columns: %(tables)s"
+msgstr "Nove stolpce so dodale naslednje tabele: %(tables)s"
+
+#: superset/connectors/sqla/views.py:620
+#, python-format
+msgid "The following tables removed columns: %(tables)s"
+msgstr "Stolpce so odstranile naslednje tabele: %(tables)s"
+
+#: superset/connectors/sqla/views.py:631
+#, python-format
+msgid "The following tables update column metadata: %(tables)s"
+msgstr "Metapodatke stolpcev so posodobile naslednje tabele: %(tables)s"
+
+#: superset/connectors/sqla/views.py:638
+#, python-format
+msgid "Unable to refresh metadata for the following table(s): %(tables)s"
+msgstr "Ni mogoče osvežiti metapodatkov za naslednje tabele: %(tables)s"
+
+#: superset/css_templates/api.py:137
+#, python-format
+msgid "Deleted %(num)d css template"
+msgid_plural "Deleted %(num)d css templates"
+msgstr[0] "Izbrisana %(num)d css predloga"
+msgstr[1] "Izbrisani %(num)d css predlogi"
+msgstr[2] "Izbrisane %(num)d css predloge"
+msgstr[3] "Izbrisanih %(num)d css predlog"
+
+#: superset/css_templates/commands/exceptions.py:23
+msgid "CSS template could not be deleted."
+msgstr "CSS predloge ni mogoče izbrisati."
+
+#: superset/css_templates/commands/exceptions.py:27
+msgid "CSS template not found."
+msgstr "CSS predloga ni najdena."
+
+#: superset/dashboards/api.py:657
+#, python-format
+msgid "Deleted %(num)d dashboard"
+msgid_plural "Deleted %(num)d dashboards"
+msgstr[0] "Izbrisana je %(num)d nadzorna plošča"
+msgstr[1] "Izbrisani sta %(num)d nadzorni plošči"
+msgstr[2] "Izbrisane so %(num)d nadzorne plošče"
+msgstr[3] "Izbrisanih je %(num)d nadzornih plošč"
+
+#: superset/dashboards/filters.py:35
+msgid "Title or Slug"
+msgstr "Naslov ali `Slug`"
+
+#: superset/dashboards/filters.py:153
+msgid "Role"
+msgstr "Vloga"
+
+#: superset/dashboards/commands/exceptions.py:37
+msgid "Must be unique"
+msgstr "Mora biti unikaten"
+
+#: superset/dashboards/commands/exceptions.py:41
+msgid "Dashboard parameters are invalid."
+msgstr "Parametri nadzorne plošče so neveljavni."
+
+#: superset/dashboards/commands/exceptions.py:45
+msgid "Dashboard not found."
+msgstr "Nadzorna plošča ni najdena."
+
+#: superset/dashboards/commands/exceptions.py:49
+msgid "Dashboard could not be created."
+msgstr "Nadzorne plošče ni mogoče ustvariti."
+
+#: superset/dashboards/commands/exceptions.py:53
+msgid "Dashboards could not be deleted."
+msgstr "Nadzornih plošč ni mogoče izbrisati."
+
+#: superset/dashboards/commands/exceptions.py:61
+msgid "Dashboard could not be updated."
+msgstr "Nadzorne plošče ni mogoče posodobiti."
+
+#: superset/dashboards/commands/exceptions.py:65
+msgid "Dashboard could not be deleted."
+msgstr "Nadzorne plošče ni mogoče izbrisati."
+
+#: superset/dashboards/commands/exceptions.py:73
+msgid "Changing this Dashboard is forbidden"
+msgstr "Spreminjanje te nadzorne plošče ni dovoljeno"
+
+#: superset/dashboards/commands/exceptions.py:77
+msgid "Import dashboard failed for an unknown reason"
+msgstr "Uvoz nadzorne plošče ni uspel zaradi neznanega razloga"
+
+#: superset/dashboards/commands/exceptions.py:81
+msgid "You don't have access to this dashboard."
+msgstr "Nimate dostopa do te nadzorne plošče."
+
+#: superset/dashboards/commands/importers/v0.py:303
+msgid "No data in file"
+msgstr "V datoteki ni podatkov"
+
+#: superset/databases/decorators.py:46
+msgid "Table name undefined"
+msgstr "Ime tabele ni definirano"
+
+#: superset/databases/schemas.py:148
+msgid ""
+"Invalid connection string, a valid string usually follows: driver://user:"
+"password@database-host/database-name"
+msgstr ""
+"Neveljaven niz povezave - veljaven niz običajno sledi: driver://user:"
+"password@database-host/database-name"
+
+#: superset/databases/schemas.py:183 superset/databases/schemas.py:198
+#, python-format
+msgid "Field cannot be decoded by JSON. %(msg)s"
+msgstr "Polja ni mogoče dekodirati z JSON. %(msg)s"
+
+#: superset/databases/schemas.py:206
+#, python-format
+msgid ""
+"The metadata_params in Extra field is not configured correctly. The key "
+"%(key)s is invalid."
+msgstr ""
+"Metadata_params v polju Dodatno niso pravilno nastavljeni. Ključ %(key)s je "
+"neveljaven."
+
+#: superset/databases/schemas.py:266
+msgid ""
+"An engine must be specified when passing individual parameters to a database."
+msgstr ""
+"Pri podajanju posameznih parametrov podatkovne baze mora biti podan njen tip."
+
+#: superset/databases/commands/validate.py:51 superset/databases/schemas.py:275
+#, python-format
+msgid "Engine \"%(engine)s\" is not a valid engine."
+msgstr "\"%(engine)s\" ni veljaven tip podatkovne baze."
+
+#: superset/databases/schemas.py:282
+msgid ""
+"Engine spec \"InvalidEngine\" does not support being configured via "
+"individual parameters."
+msgstr ""
+"Specifikacija baze \"InvalidEngine\" ne podpira konfiguracije s posameznimi "
+"parametri."
+
+#: superset/databases/commands/exceptions.py:32
+msgid "Database parameters are invalid."
+msgstr "Parametri podatkovne baze so neveljavni."
+
+#: superset/databases/commands/exceptions.py:42
+msgid "A database with the same name already exists"
+msgstr "Podatkovna baza z enakim imenom že obstaja"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:518
+#: superset/databases/commands/exceptions.py:50
+msgid "Field is required"
+msgstr "Polje je obvezno"
+
+#: superset/databases/commands/exceptions.py:62
+msgid "Field cannot be decoded by JSON.  %{json_error}s"
+msgstr "Polja ni mogoče dekodirati z JSON.  %{json_error}s"
+
+#: superset/databases/commands/exceptions.py:79
+#: superset/views/database/mixins.py:252
+msgid ""
+"The metadata_params in Extra field is not configured correctly. The key "
+"%{key}s is invalid."
+msgstr ""
+"Metadata_params v polju Dodatno niso pravilno nastavljeni. Ključ %{key}s je "
+"neveljaven."
+
+#: superset/databases/commands/exceptions.py:91
+msgid "Database not found."
+msgstr "Podatkovna baza ni najdena."
+
+#: superset/databases/commands/exceptions.py:95
+msgid "Database could not be created."
+msgstr "Podatkovne baze ni mogoče ustvariti."
+
+#: superset/databases/commands/exceptions.py:99
+msgid "Database could not be updated."
+msgstr "Podatkovne baze ni mogoče posodobiti."
+
+#: superset/databases/commands/exceptions.py:105
+#: superset/databases/commands/exceptions.py:122 superset/views/core.py:1317
+msgid "Connection failed, please check your connection settings"
+msgstr "Povezava neuspešna. Preverite nastavitve povezave"
+
+#: superset/databases/commands/exceptions.py:109
+msgid "Cannot delete a database that has tables attached"
+msgstr "Podatkovne baze s povezanimi tabelami ni mogoče izbrisati"
+
+#: superset/databases/commands/exceptions.py:113
+msgid "Database could not be deleted."
+msgstr "Podatkovne baze ni mogoče izbrisati."
+
+#: superset/databases/commands/exceptions.py:126
+msgid "Stopped an unsafe database connection"
+msgstr "Nevarna povezava s podatkovno bazo je bila ustavljena"
+
+#: superset/databases/commands/exceptions.py:130
+msgid "Could not load database driver"
+msgstr "Ni mogoče naložiti gonilnika podatkovne baze"
+
+#: superset/databases/commands/exceptions.py:135 superset/views/core.py:1325
+msgid "Unexpected error occurred, please check your logs for details"
+msgstr "Zgodila se je nepričakovana napaka. Podrobnosti preverite v dnevnikih"
+
+#: superset/databases/commands/exceptions.py:139
+msgid "Import database failed for an unknown reason"
+msgstr "Uvoz podatkovne baze ni uspel zaradi neznanega razloga"
+
+#: superset/databases/commands/test_connection.py:95
+msgid "Could not load database driver: {}"
+msgstr "Ni mogoče naložiti gonilnika podatkovne baze: {}"
+
+#: superset/databases/commands/validate.py:63
+#, python-format
+msgid "Engine \"%(engine)s\" cannot be configured through parameters."
+msgstr ""
+"Podatkovne baze tipa \"%(engine)s\" ni mogoče konfigurirati s parametri."
+
+#: superset/databases/commands/validate.py:126
+msgid "Database is offline."
+msgstr "Podatkovna baza ni povezana."
+
+#: superset/datasets/api.py:646
+#, python-format
+msgid "Deleted %(num)d dataset"
+msgid_plural "Deleted %(num)d datasets"
+msgstr[0] "Izbrisan %(num)d podatkovni set"
+msgstr[1] "Izbrisana %(num)d podatkovna niza"
+msgstr[2] "Izbrisani %(num)d podatkovni nizi"
+msgstr[3] "Izbrisanih %(num)d podatkovnih nizov"
+
+#: superset/datasets/filters.py:26
+msgid "Null or Empty"
+msgstr "Nič (NULL) ali prazen"
+
+#: superset/datasets/columns/commands/exceptions.py:23
+msgid "Dataset column not found."
+msgstr "Stolpec podatkovnega seta ni najden."
+
+#: superset/datasets/columns/commands/exceptions.py:27
+msgid "Dataset column delete failed."
+msgstr "Brisanje stolpca podatkovnega seta neuspešno."
+
+#: superset/datasets/columns/commands/exceptions.py:31
+#: superset/datasets/metrics/commands/exceptions.py:31
+msgid "Changing this dataset is forbidden."
+msgstr "Spreminjanje tega podatkovnega seta ni dovoljeno."
+
+#: superset/datasets/commands/exceptions.py:32
+#, python-format
+msgid "Dataset %(name)s already exists"
+msgstr "Podatkovni set %(name)s že obstaja"
+
+#: superset/datasets/commands/exceptions.py:50
+msgid "Database not allowed to change"
+msgstr "Podatkovne baze ni dovoljeno spreminjati"
+
+#: superset/datasets/commands/exceptions.py:70
+msgid "One or more columns do not exist"
+msgstr "En ali več stolpcev ne obstaja"
+
+#: superset/datasets/commands/exceptions.py:80
+msgid "One or more columns are duplicated"
+msgstr "En ali več stolpcev je podvojenih"
+
+#: superset/datasets/commands/exceptions.py:90
+msgid "One or more columns already exist"
+msgstr "En ali več stolpcev že obstaja"
+
+#: superset/datasets/commands/exceptions.py:99
+msgid "One or more metrics do not exist"
+msgstr "Ena ali več mer ne obstaja"
+
+#: superset/datasets/commands/exceptions.py:109
+msgid "One or more metrics are duplicated"
+msgstr "Ena ali več mer je podvojenih"
+
+#: superset/datasets/commands/exceptions.py:119
+msgid "One or more metrics already exist"
+msgstr "Ena ali več mer že obstaja"
+
+#: superset/datasets/commands/exceptions.py:130
+#, python-format
+msgid ""
+"Table [%(table_name)s] could not be found, please double check your database "
+"connection, schema, and table name"
+msgstr ""
+"Tabele [%(table_name)s] ni mogoče najti. Preverite povezavo, shemo in ime "
+"podatkovne baze"
+
+#: superset/datasets/commands/exceptions.py:153
+msgid "Dataset parameters are invalid."
+msgstr "Parametri podatkovnega seta so neveljavni."
+
+#: superset/datasets/commands/exceptions.py:157
+msgid "Dataset could not be created."
+msgstr "Podatkovnega niza ni mogoče ustvariti."
+
+#: superset/datasets/commands/exceptions.py:161
+#: superset/datasets/commands/exceptions.py:173
+msgid "Dataset could not be updated."
+msgstr "Podatkovnega niza ni mogoče posodobiti."
+
+#: superset/datasets/commands/exceptions.py:165
+msgid "Dataset could not be deleted."
+msgstr "Podatkovnega niza ni mogoče izbrisati."
+
+#: superset/datasets/commands/exceptions.py:169
+msgid "Dataset(s) could not be bulk deleted."
+msgstr "Podatkovnih nizov ni mogoče množično izbrisati."
+
+#: superset/datasets/commands/exceptions.py:177
+msgid "Changing this dataset is forbidden"
+msgstr "Spreminjanje tega podatkovnega seta ni dovoljeno"
+
+#: superset/datasets/commands/exceptions.py:181
+msgid "Import dataset failed for an unknown reason"
+msgstr "Uvoz podatkovnega seta ni uspel zaradi neznanega razloga"
+
+#: superset/datasets/metrics/commands/exceptions.py:23
+msgid "Dataset metric not found."
+msgstr "Mer podatkovnega seta ni najdena."
+
+#: superset/datasets/metrics/commands/exceptions.py:27
+msgid "Dataset metric delete failed."
+msgstr "Brisanje mere podatkovnega seta ni uspelo."
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:29
+#: superset/db_engine_specs/base.py:86
+msgid "Original value"
+msgstr "Izvorna vrednost"
+
+#: superset/db_engine_specs/base.py:87
+msgid "Second"
+msgstr "Sekunda"
+
+#: superset/db_engine_specs/base.py:88
+msgid "Minute"
+msgstr "Minuta"
+
+#: superset/db_engine_specs/base.py:89
+msgid "5 minute"
+msgstr "5 minut"
+
+#: superset/db_engine_specs/base.py:90
+msgid "10 minute"
+msgstr "10 minut"
+
+#: superset/db_engine_specs/base.py:91
+msgid "15 minute"
+msgstr "15 minut"
+
+#: superset/db_engine_specs/base.py:92
+msgid "Half hour"
+msgstr "Pol ure"
+
+#: superset/db_engine_specs/base.py:93
+msgid "Hour"
+msgstr "Ura"
+
+#: superset/db_engine_specs/base.py:94
+msgid "Day"
+msgstr "Dan"
+
+#: superset/db_engine_specs/base.py:95
+msgid "Week"
+msgstr "Teden"
+
+#: superset/db_engine_specs/base.py:96
+msgid "Month"
+msgstr "Mesec"
+
+#: superset/db_engine_specs/base.py:97
+msgid "Quarter"
+msgstr "Četrtletje"
+
+#: superset/db_engine_specs/base.py:98
+msgid "Year"
+msgstr "Leto"
+
+#: superset/db_engine_specs/base.py:99
+msgid "Week starting sunday"
+msgstr "Teden z začetkom v nedeljo"
+
+#: superset/db_engine_specs/base.py:100
+msgid "Week starting monday"
+msgstr "Teden z začetkom v ponedeljek"
+
+#: superset/db_engine_specs/base.py:101
+msgid "Week ending saturday"
+msgstr "Teden s koncem v soboto"
+
+#: superset/db_engine_specs/base.py:102
+msgid "Week_ending sunday"
+msgstr "Teden s koncem v nedeljo"
+
+#: superset/db_engine_specs/base.py:1299
+msgid "Username"
+msgstr "Uporabniško ime"
+
+#: superset/db_engine_specs/base.py:1300
+msgid "Password"
+msgstr "Geslo"
+
+#: superset/db_engine_specs/base.py:1301
+msgid "Hostname or IP address"
+msgstr "Ime gostitelja ali IP naslov"
+
+#: superset/db_engine_specs/base.py:1302
+msgid "Database port"
+msgstr "Vrata podatkovne baze"
+
+#: superset/db_engine_specs/base.py:1303
+msgid "Database name"
+msgstr "Ime podatkovne baze"
+
+#: superset/db_engine_specs/base.py:1305
+msgid "Additional parameters"
+msgstr "Dodatni parametri"
+
+#: superset/db_engine_specs/base.py:1308
+msgid "Use an encrypted connection to the database"
+msgstr "Uporabite šifrirano povezavo s podatkovno bazo"
+
+#: superset/db_engine_specs/bigquery.py:122
+msgid ""
+"We were unable to connect to your database. Please confirm that your service "
+"account has the Viewer and Job User roles on the project."
+msgstr ""
+"Povezava s podatkovno bazo ni uspela. Preverite, da ima vaš dostop dodeljeni "
+"vlogi Viewer in Job User."
+
+#: superset/db_engine_specs/mssql.py:69
+#, python-format
+msgid ""
+"Either the username \"%(username)s\", password, or database name "
+"\"%(database)s\" is incorrect."
+msgstr ""
+"Uporabniško ime \"%(username)s\", geslo ali ime podatkovne baze "
+"\"%(database)s\" so napačni."
+
+#: superset/db_engine_specs/mssql.py:77
+#: superset/db_engine_specs/postgres.py:120
+#: superset/db_engine_specs/presto.py:199
+#: superset/db_engine_specs/redshift.py:67
+#, python-format
+msgid "The hostname \"%(hostname)s\" cannot be resolved."
+msgstr "Imena gostitelja \"%(hostname)s\" ni mogoče razrešiti."
+
+#: superset/db_engine_specs/mssql.py:82
+#: superset/db_engine_specs/postgres.py:125
+#: superset/db_engine_specs/presto.py:212
+#: superset/db_engine_specs/redshift.py:72
+#, python-format
+msgid "Port %(port)s on hostname \"%(hostname)s\" refused the connection."
+msgstr "Vrata %(port)s na gostitelju \"%(hostname)s\" niso sprejela povezave."
+
+#: superset/db_engine_specs/mssql.py:87
+#: superset/db_engine_specs/postgres.py:130
+#: superset/db_engine_specs/presto.py:204
+#: superset/db_engine_specs/redshift.py:77
+#, python-format
+msgid ""
+"The host \"%(hostname)s\" might be down, and can't be reached on port "
+"%(port)s."
+msgstr ""
+"Gostitelj \"%(hostname)s\" mogoče ne deluje in ga ni mogoče doseči na vratih "
+"%(port)s."
+
+#: superset/db_engine_specs/mysql.py:118 superset/db_engine_specs/presto.py:194
+#: superset/db_engine_specs/redshift.py:62
+#, python-format
+msgid "Either the username \"%(username)s\" or the password is incorrect."
+msgstr "Uporabniško ime \"%(username)s\" ali geslo sta napačna."
+
+#: superset/db_engine_specs/mysql.py:123
+#, python-format
+msgid "Unknown MySQL server host \"%(hostname)s\"."
+msgstr "Neznan MySQL strežnik \"%(hostname)s\"."
+
+#: superset/db_engine_specs/mysql.py:128
+#, python-format
+msgid "The host \"%(hostname)s\" might be down and can't be reached."
+msgstr "Gostitelj \"%(hostname)s\" mogoče ne deluje in ga ni mogoče doseči."
+
+#: superset/db_engine_specs/mysql.py:133
+#: superset/db_engine_specs/postgres.py:138
+#, python-format
+msgid "Unable to connect to database \"%(database)s\"."
+msgstr "Povezava s podatkovno bazo \"%(database)s\" ni uspela."
+
+#: superset/db_engine_specs/postgres.py:105
+#, python-format
+msgid "The username \"%(username)s\" does not exist."
+msgstr "Uporabniško ime \"%(username)s\" ne obstaja."
+
+#: superset/db_engine_specs/postgres.py:110
+#, python-format
+msgid "The password provided for username \"%(username)s\" is incorrect."
+msgstr "Geslo za uporabniško ime \"%(username)s\" je napačno."
+
+#: superset/db_engine_specs/postgres.py:115
+msgid "Please re-enter the password."
+msgstr "Ponovno vpišite geslo."
+
+#: superset/db_engine_specs/presto.py:170
+#, python-format
+msgid ""
+"We can't seem to resolve the column \"%(column_name)s\" at line %(location)s."
+msgstr ""
+"Zdi se, da ni mogoče razrešiti stolpca \"%(column_name)s\" v vrstici "
+"%(location)s."
+
+#: superset/db_engine_specs/presto.py:178
+#, python-format
+msgid ""
+"The table \"%(table_name)s\" does not exist. A valid table must be used to "
+"run this query."
+msgstr ""
+"Tabela \"%(table_name)s\" ne obstaja. V poizvedbi mora biti uporabljena "
+"veljavna tabela."
+
+#: superset/db_engine_specs/presto.py:186
+#, python-format
+msgid ""
+"The schema \"%(schema_name)s\" does not exist. A valid schema must be used "
+"to run this query."
+msgstr ""
+"Shema \"%(schema_name)s\" ne obstaja. Za poizvedbo mora biti uporabljena "
+"veljavna shema."
+
+#: superset/db_engine_specs/presto.py:217
+#, python-format
+msgid "Unable to connect to catalog named \"%(catalog_name)s\"."
+msgstr "Povezava na katalog \"%(catalog_name)s\" ni uspela."
+
+#: superset/db_engine_specs/presto.py:1005
+msgid "Unknown Presto Error"
+msgstr "Neznana Presto napaka"
+
+#: superset/db_engine_specs/redshift.py:85
+#, python-format
+msgid ""
+"We were unable to connect to your database named \"%(database)s\". Please "
+"verify your database name and try again."
+msgstr ""
+"Povezava s podatkovno bazo \"%(database)s\" ni uspela. Preverite ime "
+"podatkovne baze in poskusite ponovno."
+
+#: superset/models/sql_types/base.py:50
+#, python-format
+msgid "Temporal expression not supported for type: %(col_type)s"
+msgstr "Časovni izraz ni podprt za podatkovne tipe: %(col_type)s"
+
+#: superset/queries/saved_queries/api.py:197
+#, python-format
+msgid "Deleted %(num)d saved query"
+msgid_plural "Deleted %(num)d saved queries"
+msgstr[0] "Izbrisana %(num)d shranjena poizvedba"
+msgstr[1] "Izbrisani %(num)d shranjeni poizvedbi"
+msgstr[2] "Izbrisane %(num)d shranjene poizvedbe"
+msgstr[3] "Izbrisanih %(num)d shranjenih poizvedb"
+
+#: superset/queries/saved_queries/commands/exceptions.py:28
+msgid "Saved queries could not be deleted."
+msgstr "Shranjenih poizvedb ni mogoče izbrisati."
+
+#: superset/queries/saved_queries/commands/exceptions.py:32
+msgid "Saved query not found."
+msgstr "Shranjena poizvedba ni najdena."
+
+#: superset/queries/saved_queries/commands/exceptions.py:36
+msgid "Import saved query failed for an unknown reason."
+msgstr "Uvoz shranjene poizvedbe ni uspel zaradi neznanega razloga."
+
+#: superset/queries/saved_queries/commands/exceptions.py:40
+msgid "Saved query parameters are invalid."
+msgstr "Parametri shranjene poizvedbe so neveljavni."
+
+#: superset/reports/api.py:435
+#, python-format
+msgid "Deleted %(num)d report schedule"
+msgid_plural "Deleted %(num)d report schedules"
+msgstr[0] "Izbrisan %(num)d urnik poročanja"
+msgstr[1] "Izbrisana %(num)d urnika poročanja"
+msgstr[2] "Izbrisani %(num)d urniki poročanja"
+msgstr[3] "Izbrisanih %(num)d urnikov poročanja"
+
+#: superset/reports/schemas.py:166 superset/reports/schemas.py:172
+#: superset/reports/schemas.py:178 superset/reports/schemas.py:245
+#: superset/reports/schemas.py:251 superset/reports/schemas.py:258
+msgid "Value must be greater than 0"
+msgstr "Vrednost mora biti večja od 0"
+
+#: superset/reports/commands/alert.py:96
+#, python-format
+msgid "Alert query returned more then one row. %s rows returned"
+msgstr ""
+"Opozorilna poizvedba je vrnila več kot eno vrstico. Število vrnjenih vrstic: "
+"%s"
+
+#: superset/reports/commands/alert.py:105
+#, python-format
+msgid "Alert query returned more then one column. %s columns returned"
+msgstr ""
+"Opozorilna poizvedba je vrnila več kot en stolpec. Število vrnjenih "
+"stolpcev: %s"
+
+#: superset/reports/commands/exceptions.py:44
+msgid "Dashboard does not exist"
+msgstr "Nadzorna plošča ne obstaja"
+
+#: superset/reports/commands/exceptions.py:53
+msgid "Chart does not exist"
+msgstr "Grafikon ne obstaja"
+
+#: superset/reports/commands/exceptions.py:62
+msgid "Database is required for alerts"
+msgstr "Podatkovna baza je obvezna za opozorila"
+
+#: superset/reports/commands/exceptions.py:71
+msgid "Type is required"
+msgstr "Tip je obvezen"
+
+#: superset/reports/commands/exceptions.py:80
+msgid "Choose a chart or dashboard not both"
+msgstr "Izberite grafikon ali nadzorno ploščo, ne obojega"
+
+#: superset/reports/commands/exceptions.py:84
+msgid "Report Schedule parameters are invalid."
+msgstr "Parametri urnika poročanja so neveljavni."
+
+#: superset/reports/commands/exceptions.py:88
+msgid "Report Schedule could not be deleted."
+msgstr "Urnika poročanja ni mogoče izbrisati."
+
+#: superset/reports/commands/exceptions.py:92
+msgid "Report Schedule could not be created."
+msgstr "Urnika poročanja ni mogoče ustvariti."
+
+#: superset/reports/commands/exceptions.py:96
+msgid "Report Schedule could not be updated."
+msgstr "Urnika poročanja ni mogoče posodobiti."
+
+#: superset/reports/commands/exceptions.py:100
+msgid "Report Schedule not found."
+msgstr "Urnika poročanja ni najden."
+
+#: superset/reports/commands/exceptions.py:104
+msgid "Report Schedule delete failed."
+msgstr "Izbris urnika poročanja ni uspel."
+
+#: superset/reports/commands/exceptions.py:108
+msgid "Report Schedule log prune failed."
+msgstr "Krajšanje dnevnika urnika poročanja ni uspelo."
+
+#: superset/reports/commands/exceptions.py:112
+msgid "Report Schedule execution failed when generating a screenshot."
+msgstr ""
+"Izvajanje urnika poročanja je bilo neuspešno pri ustvarjanju zaslonske slike."
+
+#: superset/reports/commands/exceptions.py:116
+msgid "Report Schedule execution failed when generating a csv."
+msgstr "Izvajanje urnika poročanja je bilo neuspešno pri ustvarjanju csv."
+
+#: superset/reports/commands/exceptions.py:120
+msgid "Report Schedule execution got an unexpected error."
+msgstr "Pri izvajanju urnika poročanja je prišlo do nepričakovane napake."
+
+#: superset/reports/commands/exceptions.py:124
+msgid "Report Schedule is still working, refusing to re-compute."
+msgstr "Urnik poročanja se še vedno izvaja, ponovni izračun je zavrnjen."
+
+#: superset/reports/commands/exceptions.py:128
+msgid "Report Schedule reached a working timeout."
+msgstr "Urnik poročanja je dosegel mejo časa izvedbe."
+
+#: superset/reports/commands/exceptions.py:142
+msgid "Alert query returned more then one row."
+msgstr "Opozorilna poizvedba je vrnila več kot eno vrstico."
+
+#: superset/reports/commands/exceptions.py:147
+msgid "Alert validator config error."
+msgstr "Napaka nastavitev potrjevalnika opozoril."
+
+#: superset/reports/commands/exceptions.py:151
+msgid "Alert query returned more then one column."
+msgstr "Opozorilna poizvedba je vrnila več kot en stolpec."
+
+#: superset/reports/commands/exceptions.py:155
+msgid "Alert query returned a non-number value."
+msgstr "Opozorilna poizvedba je vrnila neštevilsko vrednost."
+
+#: superset/reports/commands/exceptions.py:159
+msgid "Alert found an error while executing a query."
+msgstr "Opozorilo je našlo napako pri izvajanju poizvedbe."
+
+#: superset/reports/commands/exceptions.py:163
+msgid "A timeout occurred while executing the query."
+msgstr "Pri izvajanju poizvedbe je potekel čas."
+
+#: superset/reports/commands/exceptions.py:167
+msgid "A timeout occurred while taking a screenshot."
+msgstr "Pri ustvarjanju zaslonske slike je potekel čas."
+
+#: superset/reports/commands/exceptions.py:171
+msgid "A timeout occurred while generating a csv."
+msgstr "Pri ustvarjanju csv je potekel čas."
+
+#: superset/reports/commands/exceptions.py:175
+msgid "Alert fired during grace period."
+msgstr "Opozorilo sproženo med obdobjem mirovanja."
+
+#: superset/reports/commands/exceptions.py:179
+msgid "Alert ended grace period."
+msgstr "Opozorilo je končalo obdobje mirovanja."
+
+#: superset/reports/commands/exceptions.py:183
+msgid "Alert on grace period"
+msgstr "Opozorilo v obdobju mirovanja"
+
+#: superset/reports/commands/exceptions.py:187
+msgid "Report Schedule sellenium user not found"
+msgstr "Selenium uporabnik za urnik poročanja ni najden"
+
+#: superset/reports/commands/exceptions.py:191
+msgid "Report Schedule state not found"
+msgstr "Stanje urnika poročanj ni najdeno"
+
+#: superset/reports/commands/exceptions.py:195
+msgid "Report schedule unexpected error"
+msgstr "Nepričakovana napaka urnika poročanja"
+
+#: superset/reports/commands/exceptions.py:199
+msgid "Changing this report is forbidden"
+msgstr "Spreminjanje tega poročila ni dovoljeno"
+
+#: superset/reports/commands/exceptions.py:203
+msgid "An error occurred while pruning logs "
+msgstr "Pri krajšanju dnevnikov je prišlo do napake "
+
+#: superset/reports/notifications/email.py:55
+#, python-format
+msgid ""
+"\n"
+"            Error: %(text)s\n"
+"            "
+msgstr ""
+"\n"
+"            Napaka: %(text)s\n"
+"            "
+
+#: superset/reports/notifications/email.py:79
+#, python-format
+msgid ""
+"\n"
+"            <p>%(description)s</p>\n"
+"            <b><a href=\"%(url)s\">Explore in Superset</a></b><p></p>\n"
+"            %(img_tag)s\n"
+"            "
+msgstr ""
+"\n"
+"            <p>%(description)s</p>\n"
+"            <b><a href=\"%(url)s\">Razišči v Supersetu</a></b><p></p>\n"
+"            %(img_tag)s\n"
+"            "
+
+#: superset/reports/notifications/email.py:86 superset/tasks/schedules.py:362
+#, python-format
+msgid "%(name)s.csv"
+msgstr "%(name)s.csv"
+
+#: superset/reports/notifications/email.py:90 superset/tasks/schedules.py:294
+#: superset/tasks/schedules.py:463
+#, python-format
+msgid "%(prefix)s %(title)s"
+msgstr "%(prefix)s %(title)s"
+
+#: superset/reports/notifications/slack.py:48
+#, python-format
+msgid ""
+"\n"
+"            *%(name)s*\n"
+"\n"
+"            %(description)s\n"
+"\n"
+"            Error: %(text)s\n"
+"            "
+msgstr ""
+"\n"
+"            *%(name)s*\n"
+"\n"
+"            %(description)s\n"
+"\n"
+"            Napaka: %(text)s\n"
+"            "
+
+#: superset/reports/notifications/slack.py:64
+#, python-format
+msgid ""
+"\n"
+"            *%(name)s*\n"
+"\n"
+"            %(description)s\n"
+"\n"
+"            <%(url)s|Explore in Superset>\n"
+"            "
+msgstr ""
+"\n"
+"            *%(name)s*\n"
+"\n"
+"            %(description)s\n"
+"\n"
+"            <%(url)s|Razišči v Supersetu>\n"
+"            "
+
+#: superset/security/analytics_db_safety.py:44
+#, python-format
+msgid "%(dialect)s cannot be used as a data source for security reasons."
+msgstr ""
+"%(dialect)s ni mogoče uporabiti kot podatkovni vir zaradi varnostnih "
+"razlogov."
+
+#: superset/tasks/schedules.py:160
+#, python-format
+msgid ""
+"\n"
+"        *%(name)s*\n"
+"\n"
+"        <%(url)s|Explore in Superset>\n"
+"        "
+msgstr ""
+"\n"
+"        *%(name)s*\n"
+"\n"
+"        <%(url)s|Razišči v Supersetu>\n"
+"        "
+
+#: superset/tasks/schedules.py:172 superset/tasks/schedules.py:363
+#, python-format
+msgid "<b><a href=\"%(url)s\">Explore in Superset</a></b><p></p>"
+msgstr "<b><a href=\"%(url)s\">Razišči v Supersetu</a></b><p></p>"
+
+#: superset/tasks/schedules.py:185
+#, python-format
+msgid ""
+"\n"
+"            <b><a href=\"%(url)s\">Explore in Superset</a></b><p></p>\n"
+"            <img src=\"cid:%(msgid)s\">\n"
+"            "
+msgstr ""
+"\n"
+"            <b><a href=\"%(url)s\">Razišči v Supersetu</a></b><p></p>\n"
+"            <img src=\"cid:%(msgid)s\">\n"
+"            "
+
+#: superset/tasks/schedules.py:370
+#, python-format
+msgid ""
+"\n"
+"        *%(slice_name)s*\n"
+"\n"
+"        <%(slice_url_user_friendly)s|Explore in Superset>\n"
+"        "
+msgstr ""
+"\n"
+"        *%(slice_name)s*\n"
+"\n"
+"        <%(slice_url_user_friendly)s|Razišči v Supersetu>\n"
+"        "
+
+#: superset/tasks/schedules.py:656
+#, python-format
+msgid "[Alert] %(label)s"
+msgstr "[Alert] %(label)s"
+
+#: superset/templates/appbuilder/navbar_right.html:35
+msgid "New"
+msgstr "Nov"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1127
+#: superset/templates/appbuilder/navbar_right.html:38
+msgid "SQL Query"
+msgstr "SQL poizvedba"
+
+#: superset-frontend/src/components/Menu/MenuRight.tsx:34
+#: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:408
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1275
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:232
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:560
+#: superset-frontend/src/views/CRUD/welcome/ChartTable.tsx:174
+#: superset/templates/appbuilder/navbar_right.html:39
+#: superset/views/chart/mixin.py:85 superset/views/chart/views.py:117
+#: superset/views/schedules.py:318
+msgid "Chart"
+msgstr "Grafikon"
+
+#: superset-frontend/src/components/Menu/MenuRight.tsx:39
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1274
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:507
+#: superset/templates/appbuilder/navbar_right.html:40
+#: superset/views/dashboard/mixin.py:78 superset/views/dashboard/views.py:145
+#: superset/views/schedules.py:238
+msgid "Dashboard"
+msgstr "Nadzorna plošča"
+
+#: superset-frontend/src/components/Menu/MenuRight.tsx:133
+#: superset/templates/appbuilder/navbar_right.html:109
+msgid "Profile"
+msgstr "Profil"
+
+#: superset-frontend/src/components/Menu/MenuRight.tsx:137
+#: superset/templates/appbuilder/navbar_right.html:110
+msgid "Info"
+msgstr "Informacije"
+
+#: superset-frontend/src/components/Menu/MenuRight.tsx:140
+#: superset/templates/appbuilder/navbar_right.html:111
+msgid "Logout"
+msgstr "Odjava"
+
+#: superset-frontend/src/components/Menu/MenuRight.tsx:193
+#: superset/templates/appbuilder/navbar_right.html:126
+msgid "Login"
+msgstr "Prijava"
+
+#: superset/templates/appbuilder/general/widgets/base_list.html:55
+msgid "Record Count"
+msgstr "Število zapisov"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/TableChart.tsx:416
+#: superset/templates/appbuilder/general/widgets/base_list.html:64
+msgid "No records found"
+msgstr "Ni zapisov"
+
+#: superset/templates/appbuilder/general/widgets/search.html:24
+msgid "Filter List"
+msgstr "Seznam filtrov"
+
+#: superset-frontend/src/SqlLab/components/QuerySearch.tsx:257
+#: superset-frontend/src/explore/components/DataTableControl/index.tsx:76
+#: superset-frontend/src/explore/components/controls/VizTypeControl/index.jsx:224
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:404
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx:310
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:496
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx:295
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:442
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:411
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:461
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:453
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/TableChart.tsx:108
+#: superset/templates/appbuilder/general/widgets/search.html:40
+msgid "Search"
+msgstr "Iskanje"
+
+#: superset/templates/appbuilder/general/widgets/search.html:57
+msgid "Refresh"
+msgstr "Osveži"
+
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:521
+#: superset/templates/superset/import_dashboards.html:21
+msgid "Import dashboards"
+msgstr "Uvozi nadzorne plošče"
+
+#: superset/templates/superset/import_dashboards.html:26
+msgid "Import Dashboard(s)"
+msgstr "Uvozi nadzorne plošče"
+
+#: superset-frontend/src/components/ImportModal/index.tsx:277
+#: superset/templates/superset/import_dashboards.html:37
+msgid "File"
+msgstr "Datoteka"
+
+#: superset/templates/superset/import_dashboards.html:47
+msgid "Choose File"
+msgstr "Izberite datoteko"
+
+#: superset/templates/superset/import_dashboards.html:63
+msgid "Upload"
+msgstr "Naloži"
+
+#: superset/templates/superset/request_access.html:20
+msgid "No Access!"
+msgstr "Ni dostopa!"
+
+#: superset/templates/superset/request_access.html:25
+#, python-format
+msgid "You do not have permissions to access the datasource(s): %(name)s."
+msgstr "Nimate dovoljenj za dostop do podatkovnih virov: %(name)s."
+
+#: superset/templates/superset/request_access.html:31
+msgid "Request Permissions"
+msgstr "Zahtevaj dovoljenja"
+
+#: superset-frontend/src/SqlLab/components/SaveQuery.tsx:172
+#: superset-frontend/src/components/Modal/Modal.tsx:146
+#: superset-frontend/src/dashboard/components/CrossFilterScopingModal/CrossFilterScopingModal.tsx:80
+#: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:458
+#: superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx:151
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/EditSection.tsx:142
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/Footer.tsx:76
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/Footer/Footer.tsx:83
+#: superset-frontend/src/datasource/DatasourceModal.tsx:208
+#: superset-frontend/src/explore/components/PropertiesModal/index.tsx:173
+#: superset-frontend/src/explore/components/SaveModal.tsx:180
+#: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:797
+#: superset/templates/superset/request_access.html:34
+msgid "Cancel"
+msgstr "Prekliči"
+
+#: superset/templates/superset/fab_overrides/list_with_checkboxes.html:82
+msgid "Use the edit buttom to change this field"
+msgstr "Za spreminjanje tega polja uporabite gumb za urejanje"
+
+#: superset/templates/superset/models/database/macros.html:22
+msgid "Test Connection"
+msgstr "Preizkusi povezavo"
+
+#: superset/utils/core.py:881
+#, python-format
+msgid "[Superset] Access to the datasource %(name)s was granted"
+msgstr "[Superset] dostop do podatkovnega vira %(name)s je odobren"
+
+#: superset/utils/date_parser.py:386
+#, python-format
+msgid "Unable to find such a holiday: [%(holiday)s]"
+msgstr "Ni mogoče najti takšnega praznika: [%(holiday)s]"
+
+#: superset/utils/pandas_postprocessing.py:138
+msgid "Referenced columns not available in DataFrame."
+msgstr "Referencirani stolpci niso razpoložljivi v Dataframe-u."
+
+#: superset/utils/pandas_postprocessing.py:163
+#, python-format
+msgid "Column referenced by aggregate is undefined: %(column)s"
+msgstr "Stolpec referenciran z agregacijo ni definiran: %(column)s"
+
+#: superset/utils/pandas_postprocessing.py:170
+#, python-format
+msgid "Operator undefined for aggregator: %(name)s"
+msgstr "Operand ni definiran za agregatorja: %(name)s"
+
+#: superset/utils/pandas_postprocessing.py:179
+#, python-format
+msgid "Invalid numpy function: %(operator)s"
+msgstr "Neveljavna numpy funkcija: %(operator)s"
+
+#: superset/utils/pandas_postprocessing.py:249
+msgid "Pivot operation requires at least one index"
+msgstr "Vrtilna operacija zahteva vsaj en indeks"
+
+#: superset/utils/pandas_postprocessing.py:253
+msgid "Pivot operation must include at least one aggregate"
+msgstr "Vrtilna operacija mora vsebovati vsaj en agregat"
+
+#: superset/utils/pandas_postprocessing.py:361
+msgid "Undefined window for rolling operation"
+msgstr "Nedefinirano okno za drsečo operacijo"
+
+#: superset/utils/pandas_postprocessing.py:376
+#, python-format
+msgid "Invalid rolling_type: %(type)s"
+msgstr "Neveljaven rolling_type: %(type)s"
+
+#: superset/utils/pandas_postprocessing.py:382
+#, python-format
+msgid "Invalid options for %(rolling_type)s: %(options)s"
+msgstr "Neveljavne možnosti za %(rolling_type)s: %(options)s"
+
+#: superset/utils/pandas_postprocessing.py:467
+#, python-format
+msgid "Invalid cumulative operator: %(operator)s"
+msgstr "Neveljaven kumulativni operand: %(operator)s"
+
+#: superset/utils/pandas_postprocessing.py:493
+msgid "Invalid geohash string"
+msgstr "Neveljaven niz za geohash"
+
+#: superset/utils/pandas_postprocessing.py:516
+msgid "Invalid longitude/latitude"
+msgstr "Neveljavna zemljepisna dolžina/širina"
+
+#: superset/utils/pandas_postprocessing.py:558
+msgid "Invalid geodetic string"
+msgstr "Neveljaven geodetski niz"
+
+#: superset/utils/pandas_postprocessing.py:591
+#, python-format
+msgid ""
+"Column \"%(column)s\" is not numeric or does not exists in the query results."
+msgstr ""
+"Stolpec \"%(column)s\" ni numeričen ali ne obstaja v rezultatu poizvedbe."
+
+#: superset/utils/pandas_postprocessing.py:601
+msgid "`rename_columns` must have the same length as `columns`."
+msgstr "`rename_columns` morajo imeti enako dolžino kot `columns`."
+
+#: superset/utils/pandas_postprocessing.py:644
+msgid "`prophet` package not installed"
+msgstr "Knjižnica `prophet` ni nameščena"
+
+#: superset/utils/pandas_postprocessing.py:695
+msgid "Time grain missing"
+msgstr "Časovna granulacija manjka"
+
+#: superset/utils/pandas_postprocessing.py:698
+#, python-format
+msgid "Unsupported time grain: %(time_grain)s"
+msgstr "Nepodprta časovna granulacija: %(time_grain)s"
+
+#: superset/utils/pandas_postprocessing.py:704
+msgid "Periods must be a positive integer value"
+msgstr "Periode morajo biti pozitivno celo število"
+
+#: superset/utils/pandas_postprocessing.py:707
+msgid "Confidence interval must be between 0 and 1 (exclusive)"
+msgstr "Interval zaupanja mora biti med 0 in 1 (odprt)"
+
+#: superset/utils/pandas_postprocessing.py:710
+msgid "DataFrame must include temporal column"
+msgstr "DataFrame mora vsebovati časovni stolpec"
+
+#: superset/utils/pandas_postprocessing.py:712
+msgid "DataFrame include at least one series"
+msgstr "DataFrame vsebuje vsaj eno serijo"
+
+#: superset/utils/pandas_postprocessing.py:801
+msgid ""
+"percentiles must be a list or tuple with two numeric values, of which the "
+"first is lower than the second value"
+msgstr ""
+"percentili morajo biti tipa list ali tuple z vsaj dvema numeričnima "
+"vrednostma, pri čemer je prva manjša od druge"
+
+#: superset-frontend/src/components/Menu/MenuRight.tsx:130
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:284
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:374
+#: superset/views/access_requests.py:43 superset/views/log/__init__.py:30
+#: superset/views/schedules.py:241 superset/views/schedules.py:321
+#: superset/views/sql_lab.py:71
+msgid "User"
+msgstr "Uporabnik"
+
+#: superset/views/access_requests.py:44
+msgid "User Roles"
+msgstr "Vloge uporabnikov"
+
+#: superset/views/access_requests.py:45
+msgid "Database URL"
+msgstr "URL podatkovne baze"
+
+#: superset/views/access_requests.py:47
+msgid "Roles to grant"
+msgstr "Vloge za dovoljevanje"
+
+#: superset/views/access_requests.py:48 superset/views/schedules.py:239
+#: superset/views/schedules.py:319
+msgid "Created On"
+msgstr "Ustvarjeno"
+
+#: superset/views/alerts.py:75
+msgid "List Observations"
+msgstr "Naštej opažanja"
+
+#: superset/views/alerts.py:76
+msgid "Show Observation"
+msgstr "Prikaži opažanja"
+
+#: superset/views/alerts.py:83
+msgid "Error Message"
+msgstr "Sporočilo napake"
+
+#: superset/views/alerts.py:182
+msgid "Log Retentions (days)"
+msgstr "Ohranjanje dnevnika (dnevi)"
+
+#: superset/views/alerts.py:191
+msgid "A semicolon ';' delimited list of email addresses"
+msgstr "S podpičjem ';' ločen seznam naslovov e-pošte"
+
+#: superset/views/alerts.py:192
+msgid "How long to keep the logs around for this alert"
+msgstr "Kako dolgo ohraniti dnevnike za to opozorilo"
+
+#: superset/views/alerts.py:193
+msgid ""
+"Once an alert is triggered, how long, in seconds, before Superset nags you "
+"again."
+msgstr ""
+"Kako dolgo naj traja (v sekundah), da vas Superset ponovno opomni, ko je "
+"opozorilo sproženo."
+
+#: superset/views/alerts.py:197
+msgid ""
+"A SQL statement that defines whether the alert should get triggered or not. "
+"The query is expected to return either NULL or a number value."
+msgstr ""
+"SQL izraz, ki definira ali naj se opozorilo sproži ali ne. Od poizvedbe se "
+"pričakuje, da vrne bodisi NULL bodisi številsko vrednost."
+
+#: superset/views/alerts.py:234 superset/views/schedules.py:255
+#: superset/views/schedules.py:336
+msgid ""
+"This feature is deprecated and will be removed on 2.0. Take a look at the "
+"replacement feature <a href='https://superset.apache.org/docs/installation/"
+"alerts-reports'>Alerts & Reports documentation</a>"
+msgstr ""
+"Ta funkcija je zastarela in bo odstranjena v verziji 2.0. Oglejte si "
+"zamenjavo <a href='https://superset.apache.org/docs/installation/alerts-"
+"reports'>Dokumentacija za Opozorila & Poročila</a>"
+
+#: superset/views/annotations.py:40
+msgid "annotation start time or end time is required."
+msgstr "začetni in končni čas oznake je obvezen."
+
+#: superset/views/annotations.py:47
+msgid "Annotation end time must be no earlier than start time."
+msgstr "Končni čas oznake ne sem biti pred začetnim."
+
+#: superset/views/annotations.py:60
+msgid "Annotations"
+msgstr "Oznake"
+
+#: superset/views/annotations.py:61
+msgid "Show Annotation"
+msgstr "Prikaži oznako"
+
+#: superset/views/annotations.py:62
+msgid "Add Annotation"
+msgstr "Dodaj oznako"
+
+#: superset/views/annotations.py:63
+msgid "Edit Annotation"
+msgstr "Uredi oznako"
+
+#: superset/views/annotations.py:78
+msgid "Layer"
+msgstr "Sloj"
+
+#: superset-frontend/src/SqlLab/components/ScheduleQueryButton.tsx:145
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:165
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:169
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:875
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:883
+#: superset-frontend/src/explore/components/controls/FilterBoxItemControl/index.jsx:159
+#: superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx:149
+#: superset/views/annotations.py:79 superset/views/sql_lab.py:70
+msgid "Label"
+msgstr "Naziv"
+
+#: superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx:161
+#: superset/views/annotations.py:81
+msgid "Start"
+msgstr "Začetek"
+
+#: superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx:170
+#: superset/views/annotations.py:82
+msgid "End"
+msgstr "Konec"
+
+#: superset/views/annotations.py:83 superset/views/dashboard/mixin.py:89
+msgid "JSON Metadata"
+msgstr "JSON metapodatki"
+
+#: superset/views/annotations.py:120
+msgid "Show Annotation Layer"
+msgstr "Prikaži sloj z oznakami"
+
+#: superset/views/annotations.py:121
+msgid "Add Annotation Layer"
+msgstr "Dodaj sloj z oznakami"
+
+#: superset/views/annotations.py:122
+msgid "Edit Annotation Layer"
+msgstr "Uredi sloj z oznakami"
+
+#: superset-frontend/src/SqlLab/components/SaveQuery.tsx:117
+#: superset-frontend/src/explore/components/PropertiesModal/index.tsx:197
+#: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:748
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:224
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx:135
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx:134
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:263
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:265
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:66
+#: superset/views/annotations.py:128 superset/views/chart/mixin.py:86
+msgid "Name"
+msgstr "Ime"
+
+#: superset/views/base.py:247
+msgid ""
+"Table [%{table}s] could not be found, please double check your database "
+"connection, schema, and table name, error: {}"
+msgstr ""
+"Tabela [%{table}s] ni najdena. Preverite povezavo, shemo in ime tabele v "
+"podatkovni bazi. Napaka: {}"
+
+#: superset/views/base.py:493
+msgid "json isn't valid"
+msgstr "json ni veljaven"
+
+#: superset/views/base.py:504
+msgid "Export to YAML"
+msgstr "Izvozi v YAML"
+
+#: superset/views/base.py:504
+msgid "Export to YAML?"
+msgstr "Izvozim v YAML?"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/FilterSetUnit.tsx:82
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:316
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:481
+#: superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx:316
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx:379
+#: superset-frontend/src/views/CRUD/chart/ChartCard.tsx:101
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:330
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:605
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx:339
+#: superset-frontend/src/views/CRUD/dashboard/DashboardCard.tsx:132
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:309
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:546
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:341
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:611
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:500
+#: superset-frontend/src/views/CRUD/welcome/SavedQueries.tsx:233
+#: superset/views/base.py:561
+msgid "Delete"
+msgstr "Izbriši"
+
+#: superset/views/base.py:561
+msgid "Delete all Really?"
+msgstr "Ali resnično vse izbrišem?"
+
+#: superset/views/base_api.py:107
+msgid "Is favorite"
+msgstr "Je priljubljen"
+
+#: superset/views/core.py:163
+msgid "The data source seems to have been deleted"
+msgstr "Zdi se, da je bil podatkovni vir izbrisan"
+
+#: superset/views/core.py:164
+msgid "The user seems to have been deleted"
+msgstr "Zdi se, da je bil uporabnik izbrisan"
+
+#: superset/views/core.py:279
+msgid "Access was requested"
+msgstr "Zahtevan je bil dostop"
+
+#: superset/views/core.py:333
+msgid "The access requests seem to have been deleted"
+msgstr "Zdi se, da je bila zahteva za dostop izbrisana"
+
+#: superset/views/core.py:345
+#, python-format
+msgid ""
+"%(user)s was granted the role %(role)s that gives access to the "
+"%(datasource)s"
+msgstr ""
+"Uporabniku %(user)s je bila dodeljena vloga %(role)s, ki omogoča dostop do "
+"%(datasource)s"
+
+#: superset/views/core.py:368
+#, python-format
+msgid "Role %(r)s was extended to provide the access to the datasource %(ds)s"
+msgstr ""
+"Vloga %(r)s je bila razširjena za zagotovitev dostopa do podatkovnega vira "
+"%(ds)s"
+
+#: superset/views/core.py:385
+msgid "You have no permission to approve this request"
+msgstr "Nimate dovoljenja za odobritev te zahteve"
+
+#: superset/views/core.py:593 superset/views/core.py:776
+#: superset/views/core.py:782 superset/views/core.py:943
+#: superset/views/core.py:961
+msgid "You don't have the rights to "
+msgstr "Nimate pravic za "
+
+#: superset/views/core.py:593
+msgid "download as csv"
+msgstr "prenos kot csv"
+
+#: superset/views/core.py:653
+#, python-format
+msgid ""
+"Cannot import dashboard: %(db_error)s.\n"
+"Make sure to create the database before importing the dashboard."
+msgstr ""
+"Nadzorne plošče ni mogoče uvoziti: %(db_error)s.\n"
+"Pred uvozom poskrbite za ustvarjenje podatkovne baze."
+
+#: superset/views/core.py:664
+msgid "An unknown error occurred. Please contact your Superset administrator"
+msgstr ""
+"Zgodila se je neznana napaka. Kontaktirajte svojega administratorja za "
+"Superset"
+
+#: superset/views/core.py:736
+msgid "[Missing Dataset]"
+msgstr "[Manjka podatkovni set]"
+
+#: superset/views/core.py:776 superset/views/core.py:944
+msgid "alter this "
+msgstr "spreminjanje tega "
+
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:142
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:646
+#: superset-frontend/src/views/CRUD/welcome/ChartTable.tsx:70
+#: superset/views/core.py:776 superset/views/core.py:782
+msgid "chart"
+msgstr "grafikona"
+
+#: superset/views/core.py:782 superset/views/core.py:962
+msgid "create a "
+msgstr "ustvarite "
+
+#: superset/views/core.py:832
+#, python-format
+msgid "Explore - %(table)s"
+msgstr "Razišči - %(table)s"
+
+#: superset-frontend/src/SqlLab/components/ExploreCtasResultsButton.jsx:100
+#: superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx:172
+#: superset/views/core.py:834
+msgid "Explore"
+msgstr "Raziskovanje"
+
+#: superset/views/core.py:919
+msgid "Chart [{}] has been saved"
+msgstr "Grafikon [{}] je bil shranjen"
+
+#: superset/views/core.py:923
+msgid "Chart [{}] has been overwritten"
+msgstr "Grafikon [{}] je bil prepisan"
+
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:110
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:597
+#: superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx:60
+#: superset/views/core.py:945 superset/views/core.py:963
+msgid "dashboard"
+msgstr "nadzorna plošča"
+
+#: superset/views/core.py:950
+msgid "Chart [{}] was added to dashboard [{}]"
+msgstr "Grafikon [{}] je bil dodan na nadzorno ploščo [{}]"
+
+#: superset/views/core.py:972
+msgid "Dashboard [{}] just got created and chart [{}] was added to it"
+msgstr ""
+"Nadzorna plošča [{}] je bila ravno ustvarjena in grafikon [{}] dodan nanjo"
+
+#: superset/views/core.py:1205
+msgid ""
+"This dashboard was changed recently. Please reload dashboard to get latest "
+"version."
+msgstr ""
+"Nadzorna plošča je bila pred kratkim spremenjena. Ponovno jo naložite, da "
+"dobite zadnjo verzijo."
+
+#: superset/views/core.py:1300
+#, python-format
+msgid "Could not load database driver: %(driver_name)s"
+msgstr "Gonilnika podatkovne baze ni mogoče naložiti: %(driver_name)s"
+
+#: superset/views/core.py:1309
+msgid ""
+"Invalid connection string, a valid string usually follows:\n"
+"'DRIVER://USER:PASSWORD@DB-HOST/DATABASE-NAME'"
+msgstr ""
+"Neveljaven niz povezave, veljaven niz običajno sledi:\n"
+"'DRIVER://USER:PASSWORD@DB-HOST/DATABASE-NAME'"
+
+#: superset/views/core.py:1672
+msgid ""
+"Malformed request. slice_id or table_name and db_name arguments are expected"
+msgstr ""
+"Deformirana zahteva. Pričakovani so argumenti slice_id ali table_name in "
+"db_name"
+
+#: superset/views/core.py:1682
+#, python-format
+msgid "Chart %(id)s not found"
+msgstr "Grafikon %(id)s ni najden"
+
+#: superset/views/core.py:1695
+#, python-format
+msgid "Table %(table)s wasn't found in the database %(db)s"
+msgstr "Tabela %(table)s ni bila najdena v podatkovni bazi %(db)s"
+
+#: superset/views/core.py:1931
+#, python-format
+msgid "Can't find User '%(name)s', please ask your admin to create one."
+msgstr ""
+"Uporabnika '%(name)s' ni mogoče najti. Prosite administratorja, da ga "
+"ustvari."
+
+#: superset/views/core.py:1943
+#, python-format
+msgid "Can't find DruidCluster with cluster_name = '%(name)s'"
+msgstr "Ni mogoče najti DruidCluster s cluster_name = '%(name)s'"
+
+#: superset/views/core.py:2186
+msgid "Data could not be deserialized. You may want to re-run the query."
+msgstr ""
+"Podatkov ni mogoče deserializirati. Poskusite ponovno pognati poizvedbo."
+
+#: superset/views/core.py:2293
+#, python-format
+msgid ""
+"%(validator)s was unable to check your query.\n"
+"Please recheck your query.\n"
+"Exception: %(ex)s"
+msgstr ""
+"%(validator)s ni mogel preveriti vaše poizvedbe.\n"
+"Ponovno preverite poizvedbo.\n"
+"Izjema: %(ex)s"
+
+#: superset/views/core.py:2349
+msgid ""
+"Failed to start remote query on a worker. Tell your administrator to verify "
+"the availability of the message queue."
+msgstr ""
+"Zagon daljinske poizvedbe na delavcu ni bil uspešen. Administratorja "
+"prosite, da preveri razpoložljivost zaporedja sporočil."
+
+#: superset/views/core.py:2516 superset/views/core.py:2518
+msgid "Query record was not created as expected."
+msgstr "Zapis poizvedbe ni bil ustvarjen, kot je bilo pričakovano."
+
+#: superset/views/core.py:2555
+#, python-format
+msgid "The parameter %(parameters)s in your query is undefined."
+msgid_plural ""
+"The following parameters in your query are undefined: %(parameters)s."
+msgstr[0] ""
+"V vaši poizvedbi ni definiranih naslednjih parametrov: %(parameters)s."
+msgstr[1] ""
+"V vaši poizvedbi ni definiranih naslednjih parametrov: %(parameters)s."
+msgstr[2] ""
+"V vaši poizvedbi ni definiranih naslednjih parametrov: %(parameters)s."
+msgstr[3] ""
+"V vaši poizvedbi ni definiranih naslednjih parametrov: %(parameters)s."
+
+#: superset/views/core.py:2840
+#, python-format
+msgid "%(user)s's profile"
+msgstr "Profil uporabnika: %(user)s"
+
+#: superset/views/css_templates.py:39
+msgid "Show CSS Template"
+msgstr "Prikaži CSS predlogo"
+
+#: superset/views/css_templates.py:40
+msgid "Add CSS Template"
+msgstr "Dodaj CSS predlogo"
+
+#: superset/views/css_templates.py:41
+msgid "Edit CSS Template"
+msgstr "Uredi CSS predlogo"
+
+#: superset/views/css_templates.py:46
+msgid "Template Name"
+msgstr "Ime predloge"
+
+#: superset/views/datasource.py:49
+msgid "Request missing data field."
+msgstr "Zahtevaj manjkajoča podatkovna polja."
+
+#: superset/views/datasource.py:85
+#, python-format
+msgid "Duplicate column name(s): %(columns)s"
+msgstr "Podvojena imena stolpcev: %(columns)s"
+
+#: superset/views/dynamic_plugins.py:47
+msgid "A human-friendly name"
+msgstr "Človeku prijazno ime"
+
+#: superset/views/dynamic_plugins.py:48
+msgid ""
+"Used internally to identify the plugin. Should be set to the package name "
+"from the pluginʼs package.json"
+msgstr ""
+"Uporablja se za interno identifikacijo vtičnika. Naj bo nastavljeno na ime "
+"paketa v vtičnikovem package.json"
+
+#: superset/views/dynamic_plugins.py:52
+msgid ""
+"A full URL pointing to the location of the built plugin (could be hosted on "
+"a CDN for example)"
+msgstr ""
+"Celoten URL, ki kaže na lokacijo zgrajenega vtičnika (lahko gostuje npr. na "
+"CDN)"
+
+#: superset/views/dynamic_plugins.py:58
+msgid "Custom Plugins"
+msgstr "Prilagojeni vtičniki"
+
+#: superset/views/dynamic_plugins.py:59
+msgid "Custom Plugin"
+msgstr "Prilagojeni vtičnik"
+
+#: superset/views/dynamic_plugins.py:60
+msgid "Add a Plugin"
+msgstr "Dodaj vtičnik"
+
+#: superset/views/dynamic_plugins.py:61
+msgid "Edit Plugin"
+msgstr "Uredi vtičnik"
+
+#: superset/views/schedules.py:198
+msgid "Schedule Email Reports for Dashboards"
+msgstr "Razporedi e-poštna poročila za nadzorne plošče"
+
+#: superset/views/schedules.py:200
+msgid "Manage Email Reports for Dashboards"
+msgstr "Upravljaj e-poštna poročila za nadzorne plošče"
+
+#: superset/views/schedules.py:240 superset/views/schedules.py:320
+msgid "Changed On"
+msgstr "Spremenjeno"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:281
+#: superset/views/schedules.py:242 superset/views/schedules.py:322
+msgid "Active"
+msgstr "Aktiven"
+
+#: superset/views/schedules.py:243 superset/views/schedules.py:323
+msgid "Crontab"
+msgstr "Crontab"
+
+#: superset/views/schedules.py:244 superset/views/schedules.py:324
+msgid "Recipients"
+msgstr "Prejemniki"
+
+#: superset/views/schedules.py:245 superset/views/schedules.py:325
+msgid "Slack Channel"
+msgstr "Slack Channel"
+
+#: superset/views/schedules.py:246 superset/views/schedules.py:326
+msgid "Deliver As Group"
+msgstr "Dostavi kot skupino"
+
+#: superset/views/schedules.py:247 superset/views/schedules.py:327
+msgid "Delivery Type"
+msgstr "Tip dostave"
+
+#: superset/views/schedules.py:276
+msgid "Schedule Email Reports for Charts"
+msgstr "Razporedi e-poštna poročila za grafikone"
+
+#: superset/views/schedules.py:278
+msgid "Manage Email Reports for Charts"
+msgstr "Upravljaj e-poštna poročila za grafikone"
+
+#: superset/views/schedules.py:328
+msgid "Email Format"
+msgstr "Oblika e-pošte"
+
+#: superset/views/sql_lab.py:41
+msgid "List Saved Query"
+msgstr "Seznam shranjenih poizvedb"
+
+#: superset/views/sql_lab.py:42
+msgid "Show Saved Query"
+msgstr "Prikaži shranjeno poizvedbo"
+
+#: superset/views/sql_lab.py:43
+msgid "Add Saved Query"
+msgstr "Dodaj shranjeno poizvedbo"
+
+#: superset/views/sql_lab.py:44
+msgid "Edit Saved Query"
+msgstr "Uredi shranjeno poizvedbo"
+
+#: superset/views/sql_lab.py:75
+msgid "End Time"
+msgstr "Končni čas"
+
+#: superset/views/sql_lab.py:76
+msgid "Pop Tab Link"
+msgstr "Prikaži povezavo zavihka"
+
+#: superset/views/sql_lab.py:77
+msgid "Changed on"
+msgstr "Spremenjen"
+
+#: superset/views/utils.py:227
+msgid "The dataset associated with this chart no longer exists"
+msgstr "Podatkovni set, povezan s tem grafikonom, ne obstaja več"
+
+#: superset/views/utils.py:506
+msgid "Could not determine datasource type"
+msgstr "Ni mogoče določiti tipa podatkovnega vira"
+
+#: superset/views/utils.py:522
+msgid "Could not find viz object"
+msgstr "Ni mogoče najti vizualizacijskega objekta"
+
+#: superset/views/chart/mixin.py:27
+msgid "Show Chart"
+msgstr "Prikaži grafikon"
+
+#: superset/views/chart/mixin.py:28
+msgid "Add Chart"
+msgstr "Dodaj grafikon"
+
+#: superset/views/chart/mixin.py:29
+msgid "Edit Chart"
+msgstr "Uredi grafikon"
+
+#: superset/views/chart/mixin.py:64
+msgid ""
+"These parameters are generated dynamically when clicking the save or "
+"overwrite button in the explore view. This JSON object is exposed here for "
+"reference and for power users who may want to alter specific parameters."
+msgstr ""
+"Ti parametri se ustvarijo dinamično s klikom gumba Shrani ali Prepiši v "
+"raziskovalnem pogledu. Ta JSON objekt je prikazan kot vzorec za napredne "
+"uporabnike, ki želijo spreminjati posamezne parametre."
+
+#: superset/views/chart/mixin.py:70
+msgid ""
+"Duration (in seconds) of the caching timeout for this chart. Note this "
+"defaults to the datasource/table timeout if undefined."
+msgstr ""
+"Časovna veljavnost (v sekundah) predpomnjenja za ta grafikon. Če ni "
+"definirana, je uporabljena vrednost za podatkovni vir/tabelo."
+
+#: superset/views/chart/mixin.py:82
+msgid "Last Modified"
+msgstr "Zadnja sprememba"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts:64
+#: superset/views/chart/mixin.py:84
+msgid "Parameters"
+msgstr "Parametri"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:159
+#: superset/views/chart/mixin.py:88
+msgid "Visualization Type"
+msgstr "Tip vizualizacije"
+
+#: superset/views/dashboard/mixin.py:26
+msgid "Show Dashboard"
+msgstr "Prikaži nadzorno ploščo"
+
+#: superset/views/dashboard/mixin.py:27
+msgid "Add Dashboard"
+msgstr "Dodaj nadzorno ploščo"
+
+#: superset/views/dashboard/mixin.py:28
+msgid "Edit Dashboard"
+msgstr "Uredi nadzorno ploščo"
+
+#: superset/views/dashboard/mixin.py:47
+msgid ""
+"This json object describes the positioning of the widgets in the dashboard. "
+"It is dynamically generated when adjusting the widgets size and positions by "
+"using drag & drop in the dashboard view"
+msgstr ""
+"Ta JSON objekt opisuje postavitev pripomočkov na nadzorni plošči. Ustvari se "
+"dinamično, ko prilagajamo velikost in postavitev pripomočkov z uporabo "
+"povleci&spusti v pogledu nadzorne plošče"
+
+#: superset/views/dashboard/mixin.py:53
+msgid ""
+"The CSS for individual dashboards can be altered here, or in the dashboard "
+"view where changes are immediately visible"
+msgstr ""
+"CSS za posamezne nadzorne plošče lahko spreminjamo tukaj ali pa v pogledu "
+"nadzorne plošče, kjer so spremembe vidne takoj"
+
+#: superset/views/dashboard/mixin.py:58
+msgid "To get a readable URL for your dashboard"
+msgstr "Za pridobitev berljivega URL-ja za nadzorno ploščo"
+
+#: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:542
+#: superset/views/dashboard/mixin.py:59
+msgid ""
+"This JSON object is generated dynamically when clicking the save or "
+"overwrite button in the dashboard view. It is exposed here for reference and "
+"for power users who may want to alter specific parameters."
+msgstr ""
+"Ta JSON objekt se ustvari dinamično s klikom gumba Shrani ali Prepiši v "
+"pogledu nadzorne plošče. Tukaj je prikazan kot vzorec za napredne "
+"uporabnike, ki želijo spreminjati posamezne parametre."
+
+#: superset/views/dashboard/mixin.py:65
+msgid "Owners is a list of users who can alter the dashboard."
+msgstr ""
+"\"Lastniki\" je seznam uporabnikov, ki lahko spreminjajo nadzorno ploščo."
+
+#: superset/views/dashboard/mixin.py:66
+msgid ""
+"Roles is a list which defines access to the dashboard. Granting a role "
+"access to a dashboard will bypass dataset level checks.If no roles defined "
+"then the dashboard is available to all roles."
+msgstr ""
+"\"Vloge\" je seznam, ki definira dostop do nadzorne plošče. Dodelitev vloge "
+"za dostop do nadzorne plošče bo obšlo preverjanje na nivoju podatkovnega "
+"seta. Če vloga ni definirana, bo nadzorna plošča dostopna vsem vlogam."
+
+#: superset/views/dashboard/mixin.py:71
+msgid ""
+"Determines whether or not this dashboard is visible in the list of all "
+"dashboards"
+msgstr "Določa ali je nadzorna plošča vidna na seznamu vseh nadzornih plošč"
+
+#: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:486
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:220
+#: superset/views/dashboard/mixin.py:79 superset/views/dashboard/views.py:146
+msgid "Title"
+msgstr "Naslov"
+
+#: superset/views/dashboard/mixin.py:80
+msgid "Slug"
+msgstr "Slug"
+
+#: superset-frontend/src/dashboard/components/PublishedStatus/index.jsx:104
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:243
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:436
+#: superset/views/dashboard/mixin.py:84
+msgid "Published"
+msgstr "Objavljeno"
+
+#: superset/views/dashboard/mixin.py:87
+msgid "Position JSON"
+msgstr "JSON za postavitev"
+
+#: superset-frontend/src/dashboard/components/CssEditor/index.jsx:82
+#: superset/views/dashboard/mixin.py:88
+msgid "CSS"
+msgstr "CSS"
+
+#: superset/views/dashboard/mixin.py:90
+msgid "Underlying Tables"
+msgstr "Temeljne tabele"
+
+#: superset-frontend/src/views/CRUD/chart/ChartCard.tsx:114
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:349
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:613
+#: superset-frontend/src/views/CRUD/dashboard/DashboardCard.tsx:99
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:327
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:554
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:336
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:357
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:619
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:508
+#: superset/views/dashboard/views.py:66
+msgid "Export"
+msgstr "Izvoz"
+
+#: superset/views/dashboard/views.py:66
+msgid "Export dashboards?"
+msgstr "Izvozim nadzorne plošče?"
+
+#: superset/views/database/forms.py:88
+msgid "Name of table to be created from csv data."
+msgstr "Ime tabele, ki bo ustvarjena iz CSV podatkov."
+
+#: superset/views/database/forms.py:93
+msgid "CSV File"
+msgstr "CSV datoteka"
+
+#: superset/views/database/forms.py:94
+msgid "Select a CSV file to be uploaded to a database."
+msgstr "Izberite CSV datoteko, ki bo naložena v podatkovno bazo."
+
+#: superset/views/database/forms.py:103 superset/views/database/forms.py:292
+#, python-format
+msgid "Only the following file extensions are allowed: %(allowed_extensions)s"
+msgstr "Dovoljene so le naslednje končnice: %(allowed_extensions)s"
+
+#: superset/views/database/forms.py:119 superset/views/database/forms.py:316
+msgid "Specify a schema (if database flavor supports this)."
+msgstr "Podajte shemo (če vrsta podatkovne baze to podpira)"
+
+#: superset/views/database/forms.py:124
+msgid "Delimiter"
+msgstr "Ločilnik"
+
+#: superset/views/database/forms.py:125
+msgid "Delimiter used by CSV file (for whitespace use \\s+)."
+msgstr "Ločilnik, uporabljen v CSV datoteki (za presledek uporabi \\s+)."
+
+#: superset/views/database/forms.py:130 superset/views/database/forms.py:321
+msgid "Table Exists"
+msgstr "Tabela obstaja"
+
+#: superset/views/database/forms.py:131 superset/views/database/forms.py:322
+msgid ""
+"If table exists do one of the following: Fail (do nothing), Replace (drop "
+"and recreate table) or Append (insert data)."
+msgstr ""
+"Če tabela obstaja, naredite nekaj od sledečega: Prekini (ne naredi nič), "
+"Zamenjaj (zbriši in ponovno ustvari tabelo) ali Dodaj (vstavi podatke)."
+
+#: superset/views/database/forms.py:137 superset/views/database/forms.py:328
+msgid "Fail"
+msgstr "Prekini"
+
+#: superset/views/database/forms.py:138 superset/views/database/forms.py:329
+msgid "Replace"
+msgstr "Zamenjaj"
+
+#: superset/views/database/forms.py:139 superset/views/database/forms.py:330
+msgid "Append"
+msgstr "Dodaj"
+
+#: superset/views/database/forms.py:144 superset/views/database/forms.py:335
+msgid "Header Row"
+msgstr "Naslovna vrstica"
+
+#: superset/views/database/forms.py:145 superset/views/database/forms.py:336
+msgid ""
+"Row containing the headers to use as column names (0 is first line of data). "
+"Leave empty if there is no header row."
+msgstr ""
+"Vrstica z naslovi, ki se uporabi za imena stolpcev (0 je prva vrstica "
+"podatkov). Pustite prazno, če ni naslovne vrstice."
+
+#: superset/views/database/forms.py:154 superset/views/database/forms.py:345
+msgid "Index Column"
+msgstr "Indeksni stolpec"
+
+#: superset/views/database/forms.py:155 superset/views/database/forms.py:346
+msgid ""
+"Column to use as the row labels of the dataframe. Leave empty if no index "
+"column."
+msgstr ""
+"Stolpec, ki se uporabi za naslove vrstic v dataframe-u. Pustite prazno, če "
+"ni indeksnega stolpca."
+
+#: superset/views/database/forms.py:163 superset/views/database/forms.py:354
+msgid "Mangle Duplicate Columns"
+msgstr "Odstrani podvojene stolpce"
+
+#: superset/views/database/forms.py:164 superset/views/database/forms.py:355
+msgid "Specify duplicate columns as \"X.0, X.1\"."
+msgstr "Določite podvojene stolpce kot \"X.0, X.1\"."
+
+#: superset/views/database/forms.py:167
+msgid "Skip Initial Space"
+msgstr "Izpusti začetni presledek"
+
+#: superset/views/database/forms.py:167
+msgid "Skip spaces after delimiter."
+msgstr "Izpusti presledek za ločilnikom."
+
+#: superset/views/database/forms.py:170 superset/views/database/forms.py:358
+msgid "Skip Rows"
+msgstr "Izpusti vrstice"
+
+#: superset/views/database/forms.py:171 superset/views/database/forms.py:359
+msgid "Number of rows to skip at start of file."
+msgstr "Število vrstic, ki se izpustijo na začetku datoteke."
+
+#: superset/views/database/forms.py:176 superset/views/database/forms.py:364
+msgid "Rows to Read"
+msgstr "Vrstice za branje"
+
+#: superset/views/database/forms.py:177 superset/views/database/forms.py:365
+msgid "Number of rows of file to read."
+msgstr "Število vrstic v datoteki za branje."
+
+#: superset/views/database/forms.py:182
+msgid "Skip Blank Lines"
+msgstr "Izpusti prazne vrstice"
+
+#: superset/views/database/forms.py:183
+msgid "Skip blank lines rather than interpreting them as NaN values."
+msgstr ""
+"Raje izpusti prazne vrstice, kot pa da so prepoznane kot NaN vrednosti."
+
+#: superset/views/database/forms.py:186 superset/views/database/forms.py:370
+msgid "Parse Dates"
+msgstr "Prepoznaj datume"
+
+#: superset/views/database/forms.py:187 superset/views/database/forms.py:371
+msgid "A comma separated list of columns that should be parsed as dates."
+msgstr "Z vejico ločen seznam stolpcev, v katerih bodo prepoznani datumi."
+
+#: superset/views/database/forms.py:193
+msgid "Infer Datetime Format"
+msgstr "Prepoznaj obliko datuma/časa"
+
+#: superset/views/database/forms.py:194
+msgid "Use Pandas to interpret the datetime format automatically."
+msgstr "Uporabi Pandas za samodejno prepoznavo oblike datumov/časov."
+
+#: superset/views/database/forms.py:197 superset/views/database/forms.py:377
+msgid "Decimal Character"
+msgstr "Decimalno ločilo"
+
+#: superset/views/database/forms.py:199 superset/views/database/forms.py:379
+msgid "Character to interpret as decimal point."
+msgstr "Znak, ki bo prepoznan kot decimalno ločilo."
+
+#: superset/views/database/forms.py:204 superset/views/database/forms.py:384
+msgid "Dataframe Index"
+msgstr "Indeks dataframe-a"
+
+#: superset/views/database/forms.py:204 superset/views/database/forms.py:384
+msgid "Write dataframe index as a column."
+msgstr "Zapiši indeks dataframe-a kot stolpec."
+
+#: superset/views/database/forms.py:207 superset/views/database/forms.py:387
+msgid "Column Label(s)"
+msgstr "Naslovi stolpcev"
+
+#: superset/views/database/forms.py:208 superset/views/database/forms.py:388
+msgid ""
+"Column label for index column(s). If None is given and Dataframe Index is "
+"True, Index Names are used."
+msgstr ""
+"Naslovi stolpcev za indeksne stolpce. Če le-ti niso podani in indeksi "
+"Dataframe-a obstajajo, se uporabijo imena indeksov."
+
+#: superset/views/database/forms.py:216 superset/views/database/forms.py:396
+msgid "Null values"
+msgstr "Prazne (Null) vrednosti"
+
+#: superset/views/database/forms.py:218 superset/views/database/forms.py:398
+msgid ""
+"Json list of the values that should be treated as null. Examples: [\"\"], "
+"[\"None\", \"N/A\"], [\"nan\", \"null\"]. Warning: Hive database supports "
+"only single value. Use [\"\"] for empty string."
+msgstr ""
+"JSON seznam vrednosti, ki naj bodo obravnavane kot prazne (Null). Primeri: "
+"[\"\"], [\"None\", \"N/A\"], [\"nan\", \"null\"]. Opozorilo: Podatkovna baza "
+"Hive podpira le eno vrednost. Uporabite [\"\"] za prazen znakovni niz."
+
+#: superset/views/database/forms.py:277
+msgid "Name of table to be created from excel data."
+msgstr "Ime tabele, ki bo ustvarjena iz Excel-ovih podatkov."
+
+#: superset/views/database/forms.py:282
+msgid "Excel File"
+msgstr "Excel-ova datoteka"
+
+#: superset/views/database/forms.py:283
+msgid "Select a Excel file to be uploaded to a database."
+msgstr "Izberite Excel-ovo datoteko, ki bo naložena v podatkovno bazo."
+
+#: superset/views/database/forms.py:302
+msgid "Sheet Name"
+msgstr "Ime zvezka"
+
+#: superset/views/database/forms.py:303
+msgid "Strings used for sheet names (default is the first sheet)."
+msgstr "Znakovni nizi uporabljeni za imena zvezkov (privzeto je prvi zvezek)."
+
+#: superset/views/database/mixins.py:34
+msgid "Show Database"
+msgstr "Prikaži podatkovno bazo"
+
+#: superset/views/database/mixins.py:35
+msgid "Add Database"
+msgstr "Dodaj podatkovno bazo"
+
+#: superset/views/database/mixins.py:36
+msgid "Edit Database"
+msgstr "Uredi podatkovno bazo"
+
+#: superset/views/database/mixins.py:104
+msgid "Expose this DB in SQL Lab"
+msgstr "Uporabi to podatkovno bazo v SQL laboratoriju"
+
+#: superset/views/database/mixins.py:105
+msgid ""
+"Operate the database in asynchronous mode, meaning  that the queries are "
+"executed on remote workers as opposed to on the web server itself. This "
+"assumes that you have a Celery worker setup as well as a results backend. "
+"Refer to the installation docs for more information."
+msgstr ""
+"Upravljanje podatkovne baze v asinhronem načinu pomeni, da se poizvedbe "
+"zaženejo na oddaljenih »delavcih« in ne na samem spletnem strežniku. S tem "
+"je predpostavljeno, da imate nastavljenega »delavca« za Celery in zaledni "
+"sistem za rezultate. Več informacij je v navodilih za namestitev."
+
+#: superset/views/database/mixins.py:113
+msgid "Allow CREATE TABLE AS option in SQL Lab"
+msgstr "Dovoli opcijo CREATE TABLE AS v SQL laboratoriju"
+
+#: superset/views/database/mixins.py:114
+msgid "Allow CREATE VIEW AS option in SQL Lab"
+msgstr "Dovoli opcijo CREATE VIEW AS v SQL laboratoriju"
+
+#: superset/views/database/mixins.py:115
+msgid ""
+"Allow users to run non-SELECT statements (UPDATE, DELETE, CREATE, ...) in "
+"SQL Lab"
+msgstr ""
+"Dovoli uporabnikom poganjanje ne-SELECT stavkov (UPDATE, DELETE, "
+"CREATE, ...) v SQL laboratoriju"
+
+#: superset/views/database/mixins.py:120
+msgid ""
+"When allowing CREATE TABLE AS option in SQL Lab, this option forces the "
+"table to be created in this schema"
+msgstr ""
+"Z dovolitvijo opcije CREATE TABLE AS v SQL laboratoriju se tabele ustvarjajo "
+"s to shemo"
+
+#: superset/views/database/mixins.py:163
+msgid ""
+"If Presto, all the queries in SQL Lab are going to be executed as the "
+"currently logged on user who must have permission to run them.<br/>If Hive "
+"and hive.server2.enable.doAs is enabled, will run the queries as service "
+"account, but impersonate the currently logged on user via hive.server2.proxy."
+"user property."
+msgstr ""
+"V primeru Presto se vse poizvedbe v SQL laboratoriju zaženejo pod trenutno "
+"prijavljenim uporabnikom, ki mora imeti pravice za poganjanje.<br/>Če je "
+"omogočen Hive in hive.server2.enable.doAs, poizvedbe tečejo pod servisnim "
+"računom, vendar je trenutno prijavljen uporabnik predstavljen z lastnostjo "
+"hive.server2.proxy.user."
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:161
+#: superset/views/database/mixins.py:170
+msgid ""
+"Allow SQL Lab to fetch a list of all tables and all views across all "
+"database schemas. For large data warehouse with thousands of tables, this "
+"can be expensive and put strain on the system."
+msgstr ""
+"Dovoli SQL laboratoriju, da pridobi seznam vseh tabel in pogledov iz vseh "
+"shem podatkovne baze. Pri velikih podatkovnih skladiščih s tisoči tabel je "
+"to lahko potratno in obremeni sistem."
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:195
+#: superset/views/database/mixins.py:175
+msgid ""
+"Duration (in seconds) of the caching timeout for charts of this database. A "
+"timeout of 0 indicates that the cache never expires. Note this defaults to "
+"the global timeout if undefined."
+msgstr ""
+"Trajanje (v sekundah) predpomnjenja za grafikon v tej podatkovni bazi. "
+"Vrednost 0 označuje, da predpomnilnik nikoli ne poteče. V primeru, da ni "
+"definirano, ima globalno nastavitev."
+
+#: superset/views/database/mixins.py:180
+msgid "If selected, please set the schemas allowed for csv upload in Extra."
+msgstr "Če je izbrano, nastavite dovoljene sheme za nalaganje CSV v Dodatno."
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:275
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:381
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:75
+#: superset/views/database/mixins.py:186
+msgid "Expose in SQL Lab"
+msgstr "Uporabi v SQL laboratoriju"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:94
+#: superset/views/database/mixins.py:187
+msgid "Allow CREATE TABLE AS"
+msgstr "Dovoli CREATE TABLE AS"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:108
+#: superset/views/database/mixins.py:188
+msgid "Allow CREATE VIEW AS"
+msgstr "Dovoli CREATE VIEW AS"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:142
+#: superset/views/database/mixins.py:189
+msgid "Allow DML"
+msgstr "Dovoli DML"
+
+#: superset/views/database/mixins.py:190
+msgid "CTAS Schema"
+msgstr "CTAS shema"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/SqlAlchemyForm.tsx:59
+#: superset/views/database/mixins.py:194
+msgid "SQLAlchemy URI"
+msgstr "SQLAlchemy URI"
+
+#: superset/views/database/mixins.py:195
+msgid "Chart Cache Timeout"
+msgstr "Trajanje predpomnilnika grafikona"
+
+#: superset/views/database/mixins.py:197
+msgid "Secure Extra"
+msgstr "Dodatna varnost"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:261
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:266
+#: superset/views/database/mixins.py:198
+msgid "Root certificate"
+msgstr "Korenski certifikat"
+
+#: superset/views/database/mixins.py:199
+msgid "Async Execution"
+msgstr "Asinhrono izvajanje"
+
+#: superset/views/database/mixins.py:200
+msgid "Impersonate the logged on user"
+msgstr "Predstavljaj se kot prijavljeni uporabnik"
+
+#: superset/views/database/mixins.py:201
+msgid "Allow Csv Upload"
+msgstr "Dovoli nalaganje CSV"
+
+#: superset/views/database/mixins.py:203
+msgid "Allow Multi Schema Metadata Fetch"
+msgstr "Dovoli pridobivanje metapodatkov z več shemami"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:222
+#: superset/views/database/mixins.py:204
+msgid "Backend"
+msgstr "Vrsta"
+
+#: superset/views/database/mixins.py:244 superset/views/database/mixins.py:268
+#, python-format
+msgid "Extra field cannot be decoded by JSON. %(msg)s"
+msgstr "Dodatnega polja ni mogoče dekodirati z JSON. %(msg)s"
+
+#: superset/views/database/validators.py:40
+msgid ""
+"Invalid connection string, a valid string usually follows:'DRIVER://USER:"
+"PASSWORD@DB-HOST/DATABASE-NAME'<p>Example:'postgresql://user:password@your-"
+"postgres-db/database'</p>"
+msgstr ""
+"Neveljaven niz povezave. Veljaven niz običajno sledi zapisu:'DRIVER://USER:"
+"PASSWORD@DB-HOST/DATABASE-NAME'<p>Primer:'postgresql://user:password@your-"
+"postgres-db/database'</p>"
+
+#: superset/views/database/views.py:115
+msgid "CSV to Database configuration"
+msgstr "Nastavitve pretvorbe CSV v podatkovno bazo"
+
+#: superset/views/database/views.py:133
+#, python-format
+msgid ""
+"Database \"%(database_name)s\" schema \"%(schema_name)s\" is not allowed for "
+"csv uploads. Please contact your Superset Admin."
+msgstr ""
+"Shema \"%(schema_name)s\" podatkovne baze \"%(database_name)s\" ni dovoljena "
+"za nalaganje CSV. Kontaktirajte administratorja za Superset."
+
+#: superset/views/database/views.py:143
+msgid ""
+"You cannot specify a namespace both in the name of the table: \"%(csv_table."
+"table)s\" and in the schema field: \"%(csv_table.schema)s\". Please remove "
+"one"
+msgstr ""
+"Imenskega prostora ni mogoče podati hkrati v tabeli: \"%(csv_table.table)s\" "
+"in polju sheme: \"%(csv_table.schema)s\". Odstranite enega"
+
+#: superset/views/database/views.py:236
+#, python-format
+msgid ""
+"Unable to upload CSV file \"%(filename)s\" to table \"%(table_name)s\" in "
+"database \"%(db_name)s\". Error message: %(error_msg)s"
+msgstr ""
+"CSV datoteke \"%(filename)s\" ni mogoče naložiti v tabelo \"%(table_name)s\" "
+"v podatkovni bazi \"%(db_name)s\". Sporočilo napake: %(error_msg)s"
+
+#: superset/views/database/views.py:248
+#, python-format
+msgid ""
+"CSV file \"%(csv_filename)s\" uploaded to table \"%(table_name)s\" in "
+"database \"%(db_name)s\""
+msgstr ""
+"CSV datoteka \"%(csv_filename)s\" naložena v tabelo \"%(table_name)s\" v "
+"podatkovni bazi \"%(db_name)s\""
+
+#: superset/views/database/views.py:259
+msgid "Excel to Database configuration"
+msgstr "Nastavitve pretvorbe Excel v Podatkovno bazo"
+
+#: superset/views/database/views.py:274
+#, python-format
+msgid ""
+"Database \"%(database_name)s\" schema \"%(schema_name)s\" is not allowed for "
+"excel uploads. Please contact your Superset Admin."
+msgstr ""
+"Shema \"%(schema_name)s\" podatkovne baze \"%(database_name)s\" ni dovoljena "
+"za nalaganje Excel datotek. Kontaktirajte administratorja za Superset."
+
+#: superset/views/database/views.py:284
+msgid ""
+"You cannot specify a namespace both in the name of the table: "
+"\"%(excel_table.table)s\" and in the schema field: \"%(excel_table.schema)s"
+"\". Please remove one"
+msgstr ""
+"Imenskega prostora ni mogoče podati hkrati v tabeli: \"%(excel_table.table)s"
+"\" in polju sheme: \"%(excel_table.schema)s\". Odstranite enega"
+
+#: superset/views/database/views.py:377
+#, python-format
+msgid ""
+"Unable to upload Excel file \"%(filename)s\" to table \"%(table_name)s\" in "
+"database \"%(db_name)s\". Error message: %(error_msg)s"
+msgstr ""
+"Excel datoteke \"%(filename)s\" ni mogoče naložiti v tabelo \"%(table_name)s"
+"\" v podatkovni bazi \"%(db_name)s\". Sporočilo napake: %(error_msg)s"
+
+#: superset/views/database/views.py:389
+#, python-format
+msgid ""
+"Excel file \"%(excel_filename)s\" uploaded to table \"%(table_name)s\" in "
+"database \"%(db_name)s\""
+msgstr ""
+"Excel datoteka \"%(excel_filename)s\" naložena v tabelo \"%(table_name)s\" v "
+"podatkovni bazi \"%(db_name)s\""
+
+#: superset/views/log/__init__.py:21
+msgid "Logs"
+msgstr "Dnevniki"
+
+#: superset/views/log/__init__.py:22
+msgid "Show Log"
+msgstr "Prikaži dnevnik"
+
+#: superset/views/log/__init__.py:23
+msgid "Add Log"
+msgstr "Dodaj dnevnik"
+
+#: superset/views/log/__init__.py:24
+msgid "Edit Log"
+msgstr "Uredi dnevnik"
+
+#: superset/views/log/__init__.py:31
+msgid "Action"
+msgstr "Aktivnost"
+
+#: superset/views/log/__init__.py:32
+msgid "dttm"
+msgstr "dttm"
+
+#: superset-frontend/src/CRUD/CollectionTable.tsx:324
+msgid "Add item"
+msgstr "Dodaj"
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:106
+msgid "The query couldn't be loaded"
+msgstr "Poizvedbe ni mogoče naložiti"
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:163
+msgid ""
+"Your query has been scheduled. To see details of your query, navigate to "
+"Saved queries"
+msgstr ""
+"Vaša poizvedba je v urniku. Za ogled podrobnosti poizvedbe pojdite na "
+"shranjene poizvedbe"
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:170
+msgid "Your query could not be scheduled"
+msgstr "Vaše poizvedbe ni mogoče uvrstiti v urnik"
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:198
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:305
+msgid "Failed at retrieving results"
+msgstr "Napaka pri pridobivanju rezultatov"
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:236
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:262
+msgid ""
+"An error occurred while storing the latest query id in the backend. Please "
+"contact your administrator if this problem persists."
+msgstr ""
+"Pri shranjevanju zadnjega id-ja poizvedbe v sistem je prišlo do napake. Če "
+"se težava ponavlja, kontaktirajte administratorja."
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:349
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:390
+msgid "Unknown error"
+msgstr "Neznana napaka"
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:408
+msgid "Query was stopped."
+msgstr "Poizvedba je bila ustavljena."
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:437
+msgid ""
+"Unable to migrate table schema state to backend. Superset will retry later. "
+"Please contact your administrator if this problem persists."
+msgstr ""
+"Stanja sheme tabele ni mogoče prenesti v sistem. Superset bo ponovil poskus "
+"kasneje. Če se težava ponavlja, kontaktirajte administratorja."
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:455
+msgid ""
+"Unable to migrate query state to backend. Superset will retry later. Please "
+"contact your administrator if this problem persists."
+msgstr ""
+"Stanja poizvedbe ni mogoče prenesti v sistem. Superset bo ponovil poskus "
+"kasneje. Če se težava ponavlja, kontaktirajte administratorja."
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:501
+msgid ""
+"Unable to migrate query editor state to backend. Superset will retry later. "
+"Please contact your administrator if this problem persists."
+msgstr ""
+"Stanja urejevalnika poizvedb ni mogoče prenesti v sistem. Superset bo "
+"ponovil poskus kasneje. Če se težava ponavlja, kontaktirajte administratorja."
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:534
+msgid ""
+"Unable to add a new tab to the backend. Please contact your administrator."
+msgstr ""
+"Novega zavihka ni mogoče dodati v sistem. Kontaktirajte administratorja."
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:551
+#: superset-frontend/src/SqlLab/reducers/sqlLab.js:74
+#, python-format
+msgid "Copy of %s"
+msgstr "Kopija %s"
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:578
+msgid ""
+"An error occurred while setting the active tab. Please contact your "
+"administrator."
+msgstr ""
+"Pri določanju aktivnega zavihka je prišlo do napake. Kontaktirajte "
+"administratorja."
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:665
+msgid "An error occurred while fetching tab state"
+msgstr "Pri pridobivanju stanja zavihka je prišlo do napake"
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:701
+msgid ""
+"An error occurred while hiding the left bar. Please contact your "
+"administrator."
+msgstr ""
+"Pri skrivanju leve vrstice je prišlo do napake. Kontaktirajte "
+"administratorja."
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:723
+msgid ""
+"An error occurred while removing tab. Please contact your administrator."
+msgstr ""
+"Pri odstranjevanju zavihka je prišlo do napake. Kontaktirajte "
+"administratorja."
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:747
+msgid ""
+"An error occurred while removing query. Please contact your administrator."
+msgstr ""
+"Pri odstranjevanju poizvedbe je prišlo do napake. Kontaktirajte "
+"administratorja."
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:770
+msgid ""
+"An error occurred while setting the tab database ID. Please contact your "
+"administrator."
+msgstr ""
+"Pri določanju ID-ja v podatkovne baze za zavihek je prišlo do napake. "
+"Kontaktirajte administratorja."
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:795
+msgid ""
+"An error occurred while setting the tab schema. Please contact your "
+"administrator."
+msgstr ""
+"Pri določanju sheme zavihka je prišlo do napake. Kontaktirajte "
+"administratorja."
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:828
+msgid ""
+"An error occurred while setting the tab autorun. Please contact your "
+"administrator."
+msgstr ""
+"Pri določanju samodejnega zagona zavihka je prišlo do napake. Kontaktirajte "
+"administratorja."
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:853
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:945
+msgid ""
+"An error occurred while setting the tab title. Please contact your "
+"administrator."
+msgstr ""
+"Pri določanju naslova zavihka je prišlo do napake. Kontaktirajte "
+"administratorja."
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:875
+msgid "Your query was saved"
+msgstr "Vaša poizvedba je shranjena"
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:879
+msgid "Your query could not be saved"
+msgstr "Vaše poizvedbe ni mogoče shraniti"
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:891
+msgid "Your query was updated"
+msgstr "Vaša poizvedba je posodobljena"
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:895
+msgid "Your query could not be updated"
+msgstr "Vaše poizvedbe ni mogoče posodobiti"
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:914
+msgid ""
+"An error occurred while storing your query in the backend. To avoid losing "
+"your changes, please save your query using the \"Save Query\" button."
+msgstr ""
+"Pri shranjevanju vaše poizvedbe v sistem je prišlo do napake. Da ne izgubite "
+"sprememb, shranite poizvedbo z gumbom \"Shrani poizvedbo\"."
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:974
+msgid ""
+"An error occurred while setting the tab template parameters. Please contact "
+"your administrator."
+msgstr ""
+"Pri določanju parametrov predloge zavihka je prišlo do napake. Kontaktirajte "
+"administratorja."
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:1036
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:1061
+msgid "An error occurred while fetching table metadata"
+msgstr "Pri pridobivanju metapodatkov tabele je prišlo do napake"
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:1102
+msgid ""
+"An error occurred while fetching table metadata. Please contact your "
+"administrator."
+msgstr ""
+"Pri pridobivanju metapodatkov tabele je prišlo do napake. Kontaktirajte "
+"administratorja."
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:1150
+msgid ""
+"An error occurred while expanding the table schema. Please contact your "
+"administrator."
+msgstr ""
+"Pri širitvi sheme tabele je prišlo do napake. Kontaktirajte administratorja."
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:1174
+msgid ""
+"An error occurred while collapsing the table schema. Please contact your "
+"administrator."
+msgstr ""
+"Pri krčenju sheme tabele je prišlo do napake. Kontaktirajte administratorja."
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:1197
+msgid ""
+"An error occurred while removing the table schema. Please contact your "
+"administrator."
+msgstr ""
+"Pri odstranjevanju sheme tabele je prišlo do napake. Kontaktirajte "
+"administratorja."
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:1230
+msgid "Shared query"
+msgstr "Deljene poizvedbe"
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:1292
+msgid "The datasource couldn't be loaded"
+msgstr "Podatkovnega vira ni mogoče naložiti"
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:1322
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:1344
+msgid "An error occurred while creating the data source"
+msgstr "Pri ustvarjanju podatkovnega vira je prišlo do težave"
+
+#: superset-frontend/src/SqlLab/actions/sqlLab.js:1365
+msgid "An error occurred while fetching function names."
+msgstr "Pri pridobivanju imen funkcij je prišlo do napake."
+
+#: superset-frontend/src/SqlLab/components/App.jsx:76
+msgid ""
+"SQL Lab uses your browser's local storage to store queries and results.\n"
+" Currently, you are using ${currentUsage.toFixed(\r\n"
+"            2,\r\n"
+"          )} KB out of ${LOCALSTORAGE_MAX_USAGE_KB} KB. storage space.\n"
+" To keep SQL Lab from crashing, please delete some query tabs.\n"
+" You can re-access these queries by using the Save feature before you delete "
+"the tab. Note that you will need to close other SQL Lab windows before you "
+"do this."
+msgstr ""
+"SQL laboratorij za shranjevanje poizvedb in rezultatov uporablja "
+"brskalnikovo lokalno shrambo.\n"
+"Trenutno uporabljate ${currentUsage.toFixed(\r\n"
+"            2,\r\n"
+"          )} KB od ${LOCALSTORAGE_MAX_USAGE_KB} KB prostora shrambe.\n"
+"Da se izognete sesutju SQL laboratorija, izbrišite nekaj zavihkov s "
+"poizvedbami.\n"
+"Te poizvedbe lahko ponovno uporabite, tako da jih pred izbrisom shranite. "
+"Preden storite to, boste morali zapreti druga okna SQL laboratorija."
+
+#: superset-frontend/src/SqlLab/components/EstimateQueryCostButton.jsx:87
+msgid "Estimate selected query cost"
+msgstr "Oceni potratnost izbrane poizvedbe"
+
+#: superset-frontend/src/SqlLab/components/EstimateQueryCostButton.jsx:88
+msgid "Estimate cost"
+msgstr "Oceni potratnost"
+
+#: superset-frontend/src/SqlLab/components/EstimateQueryCostButton.jsx:92
+msgid "Cost estimate"
+msgstr "Ocena potratnosti"
+
+#: superset-frontend/src/SqlLab/components/ExploreCtasResultsButton.jsx:73
+msgid "Creating a data source and creating a new tab"
+msgstr "Ustvarjanje podatkovnega vira in novega zavihka"
+
+#: superset-frontend/src/SqlLab/components/ExploreCtasResultsButton.jsx:82
+#: superset-frontend/src/components/TableLoader/index.tsx:48
+#: superset-frontend/src/utils/getClientErrorObject.ts:148
+msgid "An error occurred"
+msgstr "Prišlo je do napake"
+
+#: superset-frontend/src/SqlLab/components/ExploreCtasResultsButton.jsx:93
+#: superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx:165
+msgid "Explore the result set in the data exploration view"
+msgstr "Raziščite rezultate v pogledu raziskovanja podatkov"
+
+#: superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx:113
+#, python-format
+msgid "This query took %s seconds to run, "
+msgstr "Trajanje poizvedbe v sekundah: %s, "
+
+#: superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx:115
+#, python-format
+msgid "and the explore view times out at %s seconds "
+msgstr "čas izteka raziskovalnega pogleda v sekundah: %s "
+
+#: superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx:119
+msgid "following this flow will most likely lead to your query timing out. "
+msgstr "s takšnim potekom, bo poizvedba najverjetneje potekla. "
+
+#: superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx:122
+msgid ""
+"We recommend your summarize your data further before following that flow. "
+msgstr "Priporočamo, da zahtevane podatke pred nadaljevanjem strnete. "
+
+#: superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx:125
+msgid "If activated you can use the "
+msgstr "Če je aktivirana, lahko uporabite "
+
+#: superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx:127
+msgid "feature to store a summarized data set that you can then explore."
+msgstr ""
+"funkcijo shranjevanja strnjenega podatkovnega seta, ki ga lahko raziščete."
+
+#: superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx:143
+msgid "Column name(s) "
+msgstr "Imena stolpcev "
+
+#: superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx:147
+msgid ""
+"cannot be used as a column name. The column name/alias \"__timestamp\"\r\n"
+"          is reserved for the main temporal expression, and column aliases "
+"ending with\r\n"
+"          double underscores followed by a numeric value (e.g. "
+"\"my_col__1\") are reserved\r\n"
+"          for deduplicating duplicate column names. Please use aliases to "
+"rename the\r\n"
+"          invalid column names."
+msgstr ""
+"ni mogoče uporabiti kot imena stolpcev. Ime stolpca \"__timestamp\"\r\n"
+"          je rezervirano za glavni časovni izraz. Imena stolpcev, ki se "
+"končajo z\r\n"
+"          dvojnim podčrtajem, ki mu sledi številska vrednost (npr. "
+"\"moj_stolpec__1\" so rezervirana\r\n"
+"          za deduplikacijo duplikatov imen stolpcev. Za preimenovanje "
+"neustreznih imen\r\n"
+"          uporabite psevdonime."
+
+#: superset-frontend/src/SqlLab/components/HighlightedSql.tsx:77
+msgid "Source SQL"
+msgstr "Izvorni SQL"
+
+#: superset-frontend/src/SqlLab/components/HighlightedSql.tsx:83
+msgid "Raw SQL"
+msgstr "Surovi SQL"
+
+#: superset-frontend/src/SqlLab/components/HighlightedSql.tsx:102
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:751
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:303
+msgid "SQL"
+msgstr "SQL"
+
+#: superset-frontend/src/SqlLab/components/QueryHistory.tsx:50
+msgid "No query history yet..."
+msgstr "Zgodovine poizvedb še ni..."
+
+#: superset-frontend/src/SqlLab/components/QuerySearch.tsx:132
+msgid "An error occurred when refreshing queries"
+msgstr "Pri osveževanju poizvedb je prišlo do napake"
+
+#: superset-frontend/src/SqlLab/components/QuerySearch.tsx:181
+#: superset-frontend/src/SqlLab/components/SqlEditorLeftBar.jsx:117
+#: superset-frontend/src/components/DatabaseSelector/index.tsx:156
+msgid "It seems you don't have access to any database"
+msgstr "Zdi se, da nimate dostopa do nobene podatkovne baz"
+
+#: superset-frontend/src/SqlLab/components/QuerySearch.tsx:196
+msgid "Filter by user"
+msgstr "Filtriraj po uporabniku"
+
+#: superset-frontend/src/SqlLab/components/QuerySearch.tsx:205
+msgid "Filter by database"
+msgstr "Filtriraj po podatkovni bazi"
+
+#: superset-frontend/src/SqlLab/components/QuerySearch.tsx:214
+msgid "Query search string"
+msgstr "Iskalni niz za poizvedbo"
+
+#: superset-frontend/src/SqlLab/components/QuerySearch.tsx:220
+msgid "[From]-"
+msgstr "[Od]-"
+
+#: superset-frontend/src/SqlLab/components/QuerySearch.tsx:232
+msgid "[To]-"
+msgstr "[Do]-"
+
+#: superset-frontend/src/SqlLab/components/QuerySearch.tsx:241
+msgid "Filter by status"
+msgstr "Filtriraj po statusu"
+
+#: superset-frontend/src/SqlLab/components/QueryTable.jsx:134
+#: superset-frontend/src/dashboard/components/menu/MarkdownModeDropdown.tsx:35
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/FilterSetUnit.tsx:75
+#: superset-frontend/src/explore/components/controls/TextAreaControl.jsx:132
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:307
+#: superset-frontend/src/views/CRUD/chart/ChartCard.tsx:126
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:365
+#: superset-frontend/src/views/CRUD/dashboard/DashboardCard.tsx:86
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:343
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:352
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:373
+#: superset-frontend/src/views/CRUD/welcome/SavedQueries.tsx:214
+msgid "Edit"
+msgstr "Urejanje"
+
+#: superset-frontend/src/SqlLab/components/QueryTable.jsx:153
+#: superset-frontend/src/explore/components/DataTablesPane/index.tsx:303
+msgid "View results"
+msgstr "Ogled rezultatov"
+
+#: superset-frontend/src/SqlLab/components/QueryTable.jsx:156
+msgid "Data preview"
+msgstr "Ogled podatkov"
+
+#: superset-frontend/src/SqlLab/components/QueryTable.jsx:203
+msgid "Overwrite text in the editor with a query on this table"
+msgstr "Besedilo v urejevalniku prepišite s poizvedbo na to tabelo"
+
+#: superset-frontend/src/SqlLab/components/QueryTable.jsx:211
+msgid "Run query in a new tab"
+msgstr "Zaženi poizvedbo v novem zavihku"
+
+#: superset-frontend/src/SqlLab/components/QueryTable.jsx:216
+msgid "Remove query from log"
+msgstr "Odstrani poizvedbo iz dnevnika"
+
+#: superset-frontend/src/SqlLab/components/ResultSet.tsx:304
+msgid "An error occurred saving dataset"
+msgstr "Pri shranjevanju podatkovnega seta je prišlo do napake"
+
+#: superset-frontend/src/SqlLab/components/ResultSet.tsx:502
+msgid "Download to CSV"
+msgstr "Izvozi kot CSV"
+
+#: superset-frontend/src/SqlLab/components/ResultSet.tsx:511
+msgid "Copy to Clipboard"
+msgstr "Kopiraj na odložišče"
+
+#: superset-frontend/src/SqlLab/components/ResultSet.tsx:522
+msgid "Filter results"
+msgstr "Filtriraj rezultate"
+
+#: superset-frontend/src/SqlLab/components/ResultSet.tsx:542
+#, python-format
+msgid ""
+"The number of results displayed is limited to %(rows)d by the configuration "
+"DISPLAY_MAX_ROWS. "
+msgstr ""
+"Število prikazanih rezultatov je omejeno na %(rows)d preko parametra "
+"DISPLAY_MAX_ROWS. "
+
+#: superset-frontend/src/SqlLab/components/ResultSet.tsx:546
+msgid ""
+"Please add additional limits/filters or download to csv to see more rows up "
+"to "
+msgstr ""
+"Dodajte omejitve/filtre ali izvozite csv, če želite videti več vrstic do "
+
+#: superset-frontend/src/SqlLab/components/ResultSet.tsx:549
+#, python-format
+msgid "the %(limit)d limit."
+msgstr "omejitve %(limit)d ."
+
+#: superset-frontend/src/SqlLab/components/ResultSet.tsx:551
+#, python-format
+msgid "The number of results displayed is limited to %(rows)d. "
+msgstr "Število prikazanih rezultatov je omejeno na %(rows)d. "
+
+#: superset-frontend/src/SqlLab/components/ResultSet.tsx:555
+msgid ""
+"Please add additional limits/filters, download to csv, or contact an admin "
+msgstr ""
+"Dodajte omejitve/filtre ali izvozite csv oz. kontaktirajte administratorja "
+
+#: superset-frontend/src/SqlLab/components/ResultSet.tsx:558
+#, python-format
+msgid "to see more rows up to the %(limit)d limit."
+msgstr "za prikaz več vrstic, kot je omejitev %(limit)d ."
+
+#: superset-frontend/src/SqlLab/components/ResultSet.tsx:570
+#, python-format
+msgid "The number of rows displayed is limited to %(rows)d by the query"
+msgstr "Število prikazanih vrstic je omejeno na %(rows)d s poizvedbo"
+
+#: superset-frontend/src/SqlLab/components/ResultSet.tsx:582
+#, python-format
+msgid ""
+"The number of rows displayed is limited to %(rows)d by the limit dropdown."
+msgstr "Število prikazanih rezultatov je omejeno na %(rows)d s poizvedbo."
+
+#: superset-frontend/src/SqlLab/components/ResultSet.tsx:591
+#, python-format
+msgid ""
+"The number of rows displayed is limited to %(rows)d by the query and limit "
+"dropdown."
+msgstr ""
+"Število prikazanih vrstic je omejeno na %(rows)d s poizvedbo in spustnim "
+"izbirnikom omejitev."
+
+#: superset-frontend/src/SqlLab/components/ResultSet.tsx:602
+#: superset-frontend/src/SqlLab/components/ResultSet.tsx:609
+#: superset-frontend/src/SqlLab/components/ResultSet.tsx:623
+#, python-format
+msgid "%(rows)d rows returned"
+msgstr "%(rows)d vrnjenih vrstic"
+
+#: superset-frontend/src/SqlLab/components/ResultSet.tsx:611
+#, python-format
+msgid "The number of rows displayed is limited to %s by the dropdown."
+msgstr "Število prikazanih vrstic je omejeno na %s s spustnim izbirnikom."
+
+#: superset-frontend/src/SqlLab/components/ResultSet.tsx:649
+msgid "Query was stopped"
+msgstr "Poizvedba je bila ustavljena"
+
+#: superset-frontend/src/SqlLab/components/ResultSet.tsx:655
+msgid "Database error"
+msgstr "Napaka podatkovne baze"
+
+#: superset-frontend/src/SqlLab/components/ResultSet.tsx:682
+msgid "was created"
+msgstr "ustvarjeno"
+
+#: superset-frontend/src/SqlLab/components/ResultSet.tsx:689
+msgid "Query in a new tab"
+msgstr "Poizvedba v novem zavihku"
+
+#: superset-frontend/src/SqlLab/components/ResultSet.tsx:739
+msgid "The query returned no data"
+msgstr "Poizvedba ni vrnila podatkov"
+
+#: superset-frontend/src/SqlLab/components/ResultSet.tsx:756
+msgid "Fetch data preview"
+msgstr "Pridobi predogled podatkov"
+
+#: superset-frontend/src/SqlLab/components/ResultSet.tsx:767
+msgid "Refetch results"
+msgstr "Ponovno pridobi rezultate"
+
+#: superset-frontend/src/SqlLab/components/ResultSet.tsx:788
+msgid "Track job"
+msgstr "Sledi opravilom"
+
+#: superset-frontend/src/SqlLab/components/RunQueryActionButton.tsx:49
+#: superset-frontend/src/explore/components/QueryAndSaveBtns.jsx:66
+msgid "Stop"
+msgstr "Ustavi"
+
+#: superset-frontend/src/SqlLab/components/RunQueryActionButton.tsx:54
+msgid "Run selection"
+msgstr "Zaženi izbrano"
+
+#: superset-frontend/src/SqlLab/components/RunQueryActionButton.tsx:56
+#: superset-frontend/src/explore/components/QueryAndSaveBtns.jsx:76
+msgid "Run"
+msgstr "Zaženi"
+
+#: superset-frontend/src/SqlLab/components/RunQueryActionButton.tsx:111
+msgid "Stop running (Ctrl + x)"
+msgstr "Ustavi (Ctrl + x)"
+
+#: superset-frontend/src/SqlLab/components/RunQueryActionButton.tsx:112
+msgid "Run query (Ctrl + Return)"
+msgstr "Zaženi poizvedbo (Ctrl + Return)"
+
+#: superset-frontend/src/SqlLab/components/SaveDatasetModal.tsx:109
+msgid "Save & Explore"
+msgstr "Shrani & Razišči"
+
+#: superset-frontend/src/SqlLab/components/SaveDatasetModal.tsx:121
+msgid "Overwrite & Explore"
+msgstr "Prepiši & Razišči"
+
+#: superset-frontend/src/SqlLab/components/SaveQuery.tsx:69
+#: superset-frontend/src/SqlLab/components/ScheduleQueryButton.tsx:110
+msgid "Undefined"
+msgstr "Ni definirano"
+
+#: superset-frontend/src/SqlLab/components/SaveQuery.tsx:159
+#: superset-frontend/src/SqlLab/components/SaveQuery.tsx:165
+#: superset-frontend/src/SqlLab/components/SaveQuery.tsx:180
+#: superset-frontend/src/dashboard/components/CrossFilterScopingModal/CrossFilterScopingModal.tsx:88
+#: superset-frontend/src/dashboard/components/Header/index.jsx:476
+#: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:442
+#: superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx:148
+#: superset-frontend/src/dashboard/components/SaveModal.tsx:226
+#: superset-frontend/src/dashboard/components/filterscope/FilterScopeSelector.jsx:564
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/EditSection.tsx:162
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/Footer/Footer.tsx:91
+#: superset-frontend/src/datasource/DatasourceModal.tsx:217
+#: superset-frontend/src/explore/components/PropertiesModal/index.tsx:186
+#: superset-frontend/src/explore/components/QueryAndSaveBtns.jsx:112
+#: superset-frontend/src/explore/components/SaveModal.tsx:203
+#: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.jsx:254
+#: superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx:460
+#: superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/index.jsx:345
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1023
+#: superset-frontend/src/views/CRUD/annotation/AnnotationModal.tsx:289
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayerModal.tsx:241
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplateModal.tsx:232
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx:370
+msgid "Save"
+msgstr "Shrani"
+
+#: superset-frontend/src/SqlLab/components/SaveQuery.tsx:159
+#: superset-frontend/src/SqlLab/components/SaveQuery.tsx:165
+#: superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx:242
+msgid "Save as"
+msgstr "Shrani kot"
+
+#: superset-frontend/src/SqlLab/components/SaveQuery.tsx:168
+msgid "Save query"
+msgstr "Shrani poizvedbo"
+
+#: superset-frontend/src/SqlLab/components/SaveQuery.tsx:180
+msgid "Save as new"
+msgstr "Shrani kot novo"
+
+#: superset-frontend/src/SqlLab/components/SaveQuery.tsx:189
+msgid "Update"
+msgstr "Posodobi"
+
+#: superset-frontend/src/SqlLab/components/ScheduleQueryButton.tsx:148
+msgid "Label for your query"
+msgstr "Ime vaše poizvedbe"
+
+#: superset-frontend/src/SqlLab/components/ScheduleQueryButton.tsx:162
+msgid "Write a description for your query"
+msgstr "Dodajte opis vaše poizvedbe"
+
+#: superset-frontend/src/SqlLab/components/ScheduleQueryButton.tsx:207
+msgid "Schedule query"
+msgstr "Urnik poizvedb"
+
+#: superset-frontend/src/SqlLab/components/ScheduleQueryButton.tsx:217
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:228
+msgid "Schedule"
+msgstr "Urnik"
+
+#: superset-frontend/src/SqlLab/components/ShareSqlLabQuery.tsx:58
+msgid "There was an error with your request"
+msgstr "Pri zahtevi je prišlo do napake"
+
+#: superset-frontend/src/SqlLab/components/ShareSqlLabQuery.tsx:72
+msgid "Please save the query to enable sharing"
+msgstr "Shranite poizvedbo za deljenje"
+
+#: superset-frontend/src/SqlLab/components/ShareSqlLabQuery.tsx:85
+msgid "Copy query link to your clipboard"
+msgstr "Kopiraj povezavo do poizvedbe v odložišče"
+
+#: superset-frontend/src/SqlLab/components/ShareSqlLabQuery.tsx:86
+msgid "Save the query to enable this feature"
+msgstr "Za omogočenje te funkcije shranite poizvedbo"
+
+#: superset-frontend/src/SqlLab/components/ShareSqlLabQuery.tsx:97
+msgid "Copy link"
+msgstr "Kopiraj povezavo"
+
+#: superset-frontend/src/SqlLab/components/SqlEditor.jsx:295
+#: superset-frontend/src/SqlLab/components/SqlEditor.jsx:305
+#: superset-frontend/src/chart/Chart.jsx:242
+msgid "Run query"
+msgstr "Zaženi poizvedbo"
+
+#: superset-frontend/src/SqlLab/components/SqlEditor.jsx:315
+msgid "New tab"
+msgstr "Nov zavihek"
+
+#: superset-frontend/src/SqlLab/components/SqlEditor.jsx:319
+#: superset-frontend/src/SqlLab/reducers/getInitialState.js:44
+msgid "Untitled query"
+msgstr "Neimenovana poizvedba"
+
+#: superset-frontend/src/SqlLab/components/SqlEditor.jsx:327
+msgid "Stop query"
+msgstr "Ustavi poizvedbo"
+
+#: superset-frontend/src/SqlLab/components/SqlEditor.jsx:510
+msgid "Schedule the query periodically"
+msgstr "Periodično zaganjaj poizvedbo"
+
+#: superset-frontend/src/SqlLab/components/SqlEditor.jsx:511
+msgid "You must run the query successfully first"
+msgstr "Najprej morate uspešno izvesti poizvedbo"
+
+#: superset-frontend/src/SqlLab/components/SqlEditor.jsx:516
+msgid "Autocomplete"
+msgstr "Samodokončaj"
+
+#: superset-frontend/src/SqlLab/components/SqlEditor.jsx:595
+msgid "CREATE TABLE AS"
+msgstr "CREATE TABLE AS"
+
+#: superset-frontend/src/SqlLab/components/SqlEditor.jsx:608
+msgid "CREATE VIEW AS"
+msgstr "CREATE VIEW AS"
+
+#: superset-frontend/src/SqlLab/components/SqlEditor.jsx:642
+msgid "Estimate the cost before running a query"
+msgstr "Oceni potratnost pred zagonom poizvedbe"
+
+#: superset-frontend/src/SqlLab/components/SqlEditorLeftBar.jsx:205
+msgid "Reset state"
+msgstr "Ponastavi stanje"
+
+#: superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx:251
+msgid "Enter a new title for the tab"
+msgstr "Vnesite novo naslov zavihka"
+
+#: superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx:277
+#, python-format
+msgid "Untitled Query %s"
+msgstr "Neimenovana poizvedba %s"
+
+#: superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx:352
+msgid "Close tab"
+msgstr "Zapri zavihek"
+
+#: superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx:358
+msgid "Rename tab"
+msgstr "Preimenuj zavihek"
+
+#: superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx:364
+msgid "Expand tool bar"
+msgstr "Razširi orodno vrstico"
+
+#: superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx:364
+msgid "Hide tool bar"
+msgstr "Skrij orodno vrstico"
+
+#: superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx:373
+msgid "Close all other tabs"
+msgstr "Zapri vse ostale zavihke"
+
+#: superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx:379
+msgid "Duplicate tab"
+msgstr "Podvoji zavihek"
+
+#: superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx:434
+msgid "New tab (Ctrl + q)"
+msgstr "Nov zavihek (Ctrl + q)"
+
+#: superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx:435
+msgid "New tab (Ctrl + t)"
+msgstr "Nov zavihek (Ctrl + t)"
+
+#: superset-frontend/src/SqlLab/components/TableElement.jsx:103
+msgid "Copy partition query to clipboard"
+msgstr "Kopiraj particijsko poizvedbo na odložišče"
+
+#: superset-frontend/src/SqlLab/components/TableElement.jsx:121
+msgid "latest partition:"
+msgstr "zadnja particija:"
+
+#: superset-frontend/src/SqlLab/components/TableElement.jsx:139
+msgid "Keys for table"
+msgstr "Ključi za tabele"
+
+#: superset-frontend/src/SqlLab/components/TableElement.jsx:148
+#, python-format
+msgid "View keys & indexes (%s)"
+msgstr "Ogled ključev in indeksov (%s)"
+
+#: superset-frontend/src/SqlLab/components/TableElement.jsx:165
+msgid "Sort columns alphabetically"
+msgstr "Razvrsti stolpce po abecedi"
+
+#: superset-frontend/src/SqlLab/components/TableElement.jsx:166
+msgid "Original table column order"
+msgstr "Vrstni red stolpcev izvorne tabele"
+
+#: superset-frontend/src/SqlLab/components/TableElement.jsx:178
+msgid "Copy SELECT statement to the clipboard"
+msgstr "Kopiraj stavek SELECT na odložišče"
+
+#: superset-frontend/src/SqlLab/components/TableElement.jsx:184
+msgid "Show CREATE VIEW statement"
+msgstr "Prikaži CREATE VIEW stavek"
+
+#: superset-frontend/src/SqlLab/components/TableElement.jsx:185
+msgid "CREATE VIEW statement"
+msgstr "CREATE VIEW stavek"
+
+#: superset-frontend/src/SqlLab/components/TableElement.jsx:191
+msgid "Remove table preview"
+msgstr "Odstrani predogled tabele"
+
+#: superset-frontend/src/SqlLab/components/TemplateParamsEditor.tsx:99
+msgid "Edit template parameters"
+msgstr "Uredi parametre predloge"
+
+#: superset-frontend/src/SqlLab/components/TemplateParamsEditor.tsx:109
+msgid "Invalid JSON"
+msgstr "Neveljaven JSON"
+
+#: superset-frontend/src/SqlLab/components/SouthPane/SouthPane.tsx:131
+msgid "No stored results found, you need to re-run your query"
+msgstr "Rezultatov še ni shranjenih, ponovno morate zagnati poizvedbo"
+
+#: superset-frontend/src/SqlLab/components/SouthPane/SouthPane.tsx:155
+msgid "Run a query to display results here"
+msgstr "Za prikaz rezultatov morate zagnati poizvedbo"
+
+#: superset-frontend/src/SqlLab/components/SouthPane/SouthPane.tsx:164
+#, python-format
+msgid "Preview: `%s`"
+msgstr "Predogled: `%s`"
+
+#: superset-frontend/src/SqlLab/components/SouthPane/SouthPane.tsx:192
+msgid "Results"
+msgstr "Rezultati"
+
+#: superset-frontend/src/SqlLab/components/SouthPane/SouthPane.tsx:195
+#: superset-frontend/src/views/CRUD/data/common.ts:44
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:102
+msgid "Query history"
+msgstr "Zgodovina poizvedb"
+
+#: superset-frontend/src/addSlice/AddSliceContainer.tsx:99
+msgid "Create a new chart"
+msgstr "Ustvari nov grafikon"
+
+#: superset-frontend/src/addSlice/AddSliceContainer.tsx:101
+#: superset-frontend/src/addSlice/AddSliceContainer.tsx:109
+msgid "Choose a dataset"
+msgstr "Izberite podatkovni set"
+
+#: superset-frontend/src/addSlice/AddSliceContainer.tsx:121
+msgid ""
+"If the dataset you are looking for is not available in the list, follow the "
+"instructions on how to add it in the Superset tutorial."
+msgstr ""
+"Če podatkovnega seta, ki ga iščete, ni na seznamu, sledite navodilom za "
+"dodajanje v navodilih za Superset."
+
+#: superset-frontend/src/addSlice/AddSliceContainer.tsx:135
+msgid "Choose a visualization type"
+msgstr "Izberite tip vizualizacije"
+
+#: superset-frontend/src/addSlice/AddSliceContainer.tsx:150
+msgid "Create new chart"
+msgstr "Ustvari nov grafikon"
+
+#: superset-frontend/src/chart/chartAction.js:564
+msgid "An error occurred while loading the SQL"
+msgstr "Pri nalaganju SQL je prišlo do napake"
+
+#: superset-frontend/src/chart/chartReducer.ts:81
+msgid "Updating chart was stopped"
+msgstr "Posodabljanje grafikona je bilo ustavljeno"
+
+#: superset-frontend/src/chart/chartReducer.ts:93
+#, python-format
+msgid "An error occurred while rendering the visualization: %s"
+msgstr "Pri prikazovanju vizualizacije je prišlo do napake: %s"
+
+#: superset-frontend/src/chart/chartReducer.ts:105
+#: superset-frontend/src/chart/chartReducer.ts:169
+msgid "Network error."
+msgstr "Napaka omrežja."
+
+#: superset-frontend/src/components/AlteredSliceTag/index.jsx:184
+msgid "Click to see difference"
+msgstr "Kliknite za prikaz razlike"
+
+#: superset-frontend/src/components/AlteredSliceTag/index.jsx:189
+msgid "Altered"
+msgstr "Spremenjeno"
+
+#: superset-frontend/src/components/AlteredSliceTag/index.jsx:210
+msgid "Chart changes"
+msgstr "Spremembe grafikona"
+
+#: superset-frontend/src/components/AnchorLink/index.jsx:88
+#: superset-frontend/src/dashboard/components/SliceHeaderControls/index.jsx:290
+msgid "Superset chart"
+msgstr "Superset grafikon"
+
+#: superset-frontend/src/components/AnchorLink/index.jsx:89
+msgid "Check out this chart in dashboard:"
+msgstr "Preizkusite ta grafikon v nadzorni plošči:"
+
+#: superset-frontend/src/components/AsyncSelect/index.jsx:42
+#: superset-frontend/src/explore/components/controls/SelectAsyncControl/index.jsx:47
+msgid "Select ..."
+msgstr "Izberite ..."
+
+#: superset-frontend/src/components/CachedLabel/TooltipContent.tsx:30
+msgid "Loaded data cached"
+msgstr "Podatki so naloženi v predpomnilnik"
+
+#: superset-frontend/src/components/CachedLabel/TooltipContent.tsx:34
+msgid "Loaded from cache"
+msgstr "Naloženo iz predpomnilnika"
+
+#: superset-frontend/src/components/CachedLabel/TooltipContent.tsx:39
+msgid "Click to force-refresh"
+msgstr "Kliknite za prisilno osvežitev"
+
+#: superset-frontend/src/components/CachedLabel/index.tsx:51
+msgid "cached"
+msgstr "predpomnjen"
+
+#: superset-frontend/src/components/CertifiedIcon/index.tsx:42
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/components/CertifiedIconWithTooltip.tsx:45
+#, python-format
+msgid "Certified by %s"
+msgstr "Certificiral/a %s"
+
+#: superset-frontend/src/components/CopyToClipboard/index.jsx:43
+#: superset-frontend/src/components/URLShortLinkButton/index.jsx:65
+#: superset-frontend/src/explore/components/EmbedCodeButton.jsx:106
+msgid "Copy to clipboard"
+msgstr "Kopiraj na odložišče"
+
+#: superset-frontend/src/components/CopyToClipboard/index.jsx:76
+#: superset-frontend/src/dashboard/components/menu/ShareMenuItems/index.tsx:53
+#: superset-frontend/src/explore/components/ExploreActionButtons.tsx:107
+msgid "Copied to clipboard!"
+msgstr "Kopirano na odložišče!"
+
+#: superset-frontend/src/components/CopyToClipboard/index.jsx:80
+msgid "Sorry, your browser does not support copying. Use Ctrl / Cmd + C!"
+msgstr "Vaš brskalnik ne podpira kopiranja. Uporabite Ctrl / Cmd + C!"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:27
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:35
+msgid "every"
+msgstr "vsak"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:28
+msgid "every month"
+msgstr "vsak mesec"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:29
+msgid "every day of the month"
+msgstr "vsak dan v mesecu"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:30
+msgid "day of the month"
+msgstr "dan v mesecu"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:31
+msgid "every day of the week"
+msgstr "vsak dan v tednu"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:32
+msgid "day of the week"
+msgstr "dan v tednu"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:33
+msgid "every hour"
+msgstr "vsako uro"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:34
+msgid "every minute UTC"
+msgstr "vsako minuto UTC"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:36
+msgid "year"
+msgstr "leto"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:37
+msgid "month"
+msgstr "mesec"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:38
+msgid "week"
+msgstr "teden"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:39
+msgid "day"
+msgstr "dan"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:40
+msgid "hour"
+msgstr "ura"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:41
+msgid "minute"
+msgstr "minuta"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:42
+msgid "reboot"
+msgstr "ponovni zagon"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:43
+msgid "Every"
+msgstr "Vsak"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:44
+msgid "in"
+msgstr "v"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:45
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:46
+msgid "on"
+msgstr "na"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:47
+msgid "and"
+msgstr "in"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:48
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:50
+msgid "at"
+msgstr "v"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:49
+msgid ":"
+msgstr ":"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:51
+msgid "minute(s) UTC"
+msgstr "minute UTC"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:52
+msgid "Invalid cron expression"
+msgstr "Neveljaven cron izraz"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:53
+msgid "Clear"
+msgstr "Počisti"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:57
+msgid "Sunday"
+msgstr "Nedelja"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:59
+msgid "Monday"
+msgstr "Ponedeljek"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:60
+msgid "Tuesday"
+msgstr "Torek"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:61
+msgid "Wednesday"
+msgstr "Sreda"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:62
+msgid "Thursday"
+msgstr "Četrtek"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:63
+msgid "Friday"
+msgstr "Petek"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:64
+msgid "Saturday"
+msgstr "Sobota"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:69
+msgid "January"
+msgstr "Januar"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:70
+msgid "February"
+msgstr "Februar"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:71
+msgid "March"
+msgstr "Marec"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:72
+msgid "April"
+msgstr "April"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:73
+msgid "May"
+msgstr "Maj"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:74
+msgid "June"
+msgstr "Junij"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:75
+msgid "July"
+msgstr "Julij"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:76
+msgid "August"
+msgstr "Avgust"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:77
+msgid "September"
+msgstr "September"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:78
+msgid "October"
+msgstr "Oktober"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:79
+msgid "November"
+msgstr "November"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:80
+msgid "December"
+msgstr "December"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:85
+msgid "SUN"
+msgstr "NED"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:87
+msgid "MON"
+msgstr "PON"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:88
+msgid "TUE"
+msgstr "TOR"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:89
+msgid "WED"
+msgstr "SRE"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:90
+msgid "THU"
+msgstr "ČET"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:91
+msgid "FRI"
+msgstr "PET"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:92
+msgid "SAT"
+msgstr "SOB"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:97
+msgid "JAN"
+msgstr "JAN"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:98
+msgid "FEB"
+msgstr "FEB"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:99
+msgid "MAR"
+msgstr "MAR"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:100
+msgid "APR"
+msgstr "APR"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:101
+msgid "MAY"
+msgstr "MAJ"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:102
+msgid "JUN"
+msgstr "JUN"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:103
+msgid "JUL"
+msgstr "JUL"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:104
+msgid "AUG"
+msgstr "AVG"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:105
+msgid "SEP"
+msgstr "SEP"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:106
+msgid "OCT"
+msgstr "OKT"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:107
+msgid "NOV"
+msgstr "NOV"
+
+#: superset-frontend/src/components/CronPicker/CronPicker.tsx:108
+msgid "DEC"
+msgstr "DEC"
+
+#: superset-frontend/src/components/DatabaseSelector/index.tsx:131
+msgid "Error while fetching schema list"
+msgstr "Napaka pri pridobivanju seznama shem"
+
+#: superset-frontend/src/components/DatabaseSelector/index.tsx:233
+msgid "Error while fetching database list"
+msgstr "Napaka pri pridobivanju seznama podatkovnih baz"
+
+#: superset-frontend/src/components/DatabaseSelector/index.tsx:240
+msgid "Database:"
+msgstr "Podatkovna baza:"
+
+#: superset-frontend/src/components/DatabaseSelector/index.tsx:246
+msgid "Select a database"
+msgstr "Izberite podatkovno bazo"
+
+#: superset-frontend/src/components/DatabaseSelector/index.tsx:259
+msgid "Force refresh schema list"
+msgstr "Osveži seznam shem"
+
+#: superset-frontend/src/components/DatabaseSelector/index.tsx:266
+#, python-format
+msgid "Select a schema (%s)"
+msgstr "Izberite shemo (%s)"
+
+#: superset-frontend/src/components/DatabaseSelector/index.tsx:271
+msgid "Schema:"
+msgstr "Shema:"
+
+#: superset-frontend/src/components/DatabaseSelector/index.tsx:285
+msgid "datasource"
+msgstr "podatkovni vir"
+
+#: superset-frontend/src/components/DatabaseSelector/index.tsx:287
+msgid "schema"
+msgstr "shema"
+
+#: superset-frontend/src/components/DeleteModal/index.tsx:61
+msgid "delete"
+msgstr "izbriši"
+
+#: superset-frontend/src/components/DeleteModal/index.tsx:69
+#: superset-frontend/src/components/ImportModal/index.tsx:240
+#, python-format
+msgid "Type \"%s\" to confirm"
+msgstr "Vnesite \"%s\" za potrditev"
+
+#: superset-frontend/src/components/DeleteModal/index.tsx:78
+msgid "DELETE"
+msgstr "IZBRIŠI"
+
+#: superset-frontend/src/components/EditableTitle/index.tsx:203
+msgid "Click to edit"
+msgstr "Kliknite za urejanje"
+
+#: superset-frontend/src/components/EditableTitle/index.tsx:205
+msgid "You don't have the rights to alter this title."
+msgstr "Nimate pravic za spreminjanje tega naslova."
+
+#: superset-frontend/src/components/ErrorBoundary/index.jsx:51
+#: superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx:26
+msgid "Unexpected error"
+msgstr "Nepričakovana napaka"
+
+#: superset-frontend/src/components/ErrorMessage/DatabaseErrorMessage.tsx:46
+#: superset-frontend/src/components/ErrorMessage/TimeoutErrorMessage.tsx:63
+msgid "This may be triggered by:"
+msgstr "To je lahko sproženo z/s:"
+
+#: superset-frontend/src/components/ErrorMessage/DatabaseErrorMessage.tsx:58
+#: superset-frontend/src/components/ErrorMessage/TimeoutErrorMessage.tsx:73
+msgid "Please reach out to the Chart Owner for assistance."
+msgstr "Za pomoč se obrnite na lastnika grafikona."
+
+#: superset-frontend/src/components/ErrorMessage/DatabaseErrorMessage.tsx:69
+#: superset-frontend/src/components/ErrorMessage/TimeoutErrorMessage.tsx:84
+#, python-format
+msgid "Chart Owner: %s"
+msgstr "Lastnik grafikona: %s"
+
+#: superset-frontend/src/components/ErrorMessage/DatabaseErrorMessage.tsx:83
+#, python-format
+msgid "%s Error"
+msgstr "%s napaka"
+
+#: superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx:123
+#: superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx:139
+msgid "See more"
+msgstr "Oglejte si več"
+
+#: superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx:152
+msgid "See less"
+msgstr "Oglejte si manj"
+
+#: superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx:181
+msgid "Copy message"
+msgstr "Kopiraj sporočilo"
+
+#: superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx:189
+#: superset-frontend/src/dashboard/components/filterscope/FilterScopeSelector.jsx:556
+#: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.jsx:241
+#: superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx:448
+#: superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/index.jsx:337
+msgid "Close"
+msgstr "Zapri"
+
+#: superset-frontend/src/components/ErrorMessage/ParameterErrorMessage.tsx:60
+msgid "This was triggered by:"
+msgstr "To je bilo sproženo z/s:"
+
+#: superset-frontend/src/components/ErrorMessage/ParameterErrorMessage.tsx:76
+msgid "Did you mean:"
+msgstr "Ste mislili:"
+
+#: superset-frontend/src/components/ErrorMessage/ParameterErrorMessage.tsx:87
+#, python-format
+msgid "%(suggestion)s instead of \"%(undefinedParameter)s?\""
+msgstr "%(suggestion)s namesto \"%(undefinedParameter)s?\""
+
+#: superset-frontend/src/components/ErrorMessage/ParameterErrorMessage.tsx:114
+msgid "Parameter error"
+msgstr "Napaka parametra"
+
+#: superset-frontend/src/components/ErrorMessage/TimeoutErrorMessage.tsx:47
+#, python-format
+msgid ""
+"We’re having trouble loading this visualization. Queries are set to timeout "
+"after %s second."
+msgstr ""
+"Težava pri nalaganju vizualizacije. Časovni iztek poizvedb je nastavljen na "
+"%s sekund."
+
+#: superset-frontend/src/components/ErrorMessage/TimeoutErrorMessage.tsx:53
+#, python-format
+msgid ""
+"We’re having trouble loading these results. Queries are set to timeout after "
+"%s second."
+msgstr ""
+"Težava pri nalaganju rezultatov. Časovni iztek poizvedb je nastavljen na %s "
+"sekund."
+
+#: superset-frontend/src/components/ErrorMessage/TimeoutErrorMessage.tsx:98
+msgid "Timeout error"
+msgstr "Napaka pretečenega časa"
+
+#: superset-frontend/src/components/FaveStar/index.tsx:77
+msgid "Click to favorite/unfavorite"
+msgstr "Kliknite za priljubljeno/nepriljubljeno"
+
+#: superset-frontend/src/components/FilterableTable/FilterableTable.tsx:328
+msgid "Cell content"
+msgstr "Vsebina celice"
+
+#: superset-frontend/src/components/ImportModal/index.tsx:183
+msgid "The import was successful"
+msgstr "Uvoz je uspel"
+
+#: superset-frontend/src/components/ImportModal/index.tsx:197
+msgid "OVERWRITE"
+msgstr "OVERWRITE"
+
+#: superset-frontend/src/components/ImportModal/index.tsx:268
+msgid "Overwrite"
+msgstr "Prepiši"
+
+#: superset-frontend/src/components/ImportModal/index.tsx:268
+msgid "Import"
+msgstr "Uvozi"
+
+#: superset-frontend/src/components/ImportModal/index.tsx:272
+#, python-format
+msgid "Import %s"
+msgstr "Uvozi %s"
+
+#: superset-frontend/src/components/LastUpdated/index.tsx:76
+#, python-format
+msgid "Last Updated %s"
+msgstr "Zadnja posodobitev %s"
+
+#: superset-frontend/src/components/ListView/CardSortSelect.tsx:103
+msgid "Sort:"
+msgstr "Razvrščanje:"
+
+#: superset-frontend/src/components/ListView/ListView.tsx:239
+#, python-format
+msgid "%s Selected"
+msgstr "Izbranih: %s"
+
+#: superset-frontend/src/components/ListView/ListView.tsx:345
+msgid "Deselect all"
+msgstr "Počisti izbor"
+
+#: superset-frontend/src/components/ListView/ListView.tsx:394
+msgid "No Data"
+msgstr "Ni podatkov"
+
+#: superset-frontend/src/components/ListView/ListView.tsx:415
+#: superset-frontend/src/components/TableView/TableView.tsx:183
+#, python-format
+msgid "%s-%s of %s"
+msgstr "%s-%s od %s"
+
+#: superset-frontend/src/components/Menu/MenuRight.tsx:29
+#: superset-frontend/src/views/CRUD/welcome/EmptyState.tsx:112
+msgid "SQL query"
+msgstr "SQL poizvedba"
+
+#: superset-frontend/src/components/Menu/MenuRight.tsx:146
+msgid "About"
+msgstr "O programu"
+
+#: superset-frontend/src/components/Menu/MenuRight.tsx:174
+msgid "Documentation"
+msgstr "Dokumentacija"
+
+#: superset-frontend/src/components/Menu/MenuRight.tsx:185
+msgid "Report a bug"
+msgstr "Sporočite napako"
+
+#: superset-frontend/src/components/Modal/Modal.tsx:129
+#: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:819
+msgid "OK"
+msgstr "OK"
+
+#: superset-frontend/src/components/OmniContainer/getDashboards.ts:50
+msgid "An error occurred while fetching dashboards"
+msgstr "Prišlo je do napake pri pridobivanju nadzornih plošč"
+
+#: superset-frontend/src/components/TableSelector/index.tsx:172
+msgid "Error while fetching table list"
+msgstr "Napaka pri pridobivanju seznama tabel"
+
+#: superset-frontend/src/components/TableSelector/index.tsx:321
+#: superset-frontend/src/components/TableSelector/index.tsx:339
+msgid "Select table or type table name"
+msgstr "Izberite ali vnesite ime tabele"
+
+#: superset-frontend/src/components/TableSelector/index.tsx:355
+msgid "Type to search ..."
+msgstr "Vnesite za iskanje ..."
+
+#: superset-frontend/src/components/TableSelector/index.tsx:357
+msgid "Select table "
+msgstr "Izberi tabelo "
+
+#: superset-frontend/src/components/TableSelector/index.tsx:378
+msgid "Force refresh table list"
+msgstr "Osveži seznam tabel"
+
+#: superset-frontend/src/components/TableSelector/index.tsx:388
+msgid "See table schema"
+msgstr "Ogled sheme tabele"
+
+#: superset-frontend/src/components/URLShortLinkButton/index.jsx:59
+#: superset-frontend/src/explore/components/ExploreActionButtons.tsx:117
+#, python-format
+msgid "%s%s"
+msgstr "%s%s"
+
+#: superset-frontend/src/dashboard/actions/dashboardLayout.js:190
+msgid ""
+"There is not enough space for this component. Try decreasing its width, or "
+"increasing the destination width."
+msgstr ""
+"Za to komponento ni dovolj prostora. Poskusite zmanjšati širino ali pa "
+"povečati širino cilja."
+
+#: superset-frontend/src/dashboard/actions/dashboardLayout.js:227
+msgid "Can not move top level tab into nested tabs"
+msgstr "Najvišjega zavihka ni mogoče premakniti v gnezdene zavihke"
+
+#: superset-frontend/src/dashboard/actions/dashboardLayout.js:279
+msgid "This chart has been moved to a different filter scope."
+msgstr "Ta grafikon je bil prestavljen v drug obseg filtrov."
+
+#: superset-frontend/src/dashboard/actions/dashboardState.js:80
+msgid "There was an issue fetching the favorite status of this dashboard."
+msgstr ""
+"Pri pridobivanju statusa \"priljubljeno\" za to nadzorno ploščo je prišlo do "
+"težave."
+
+#: superset-frontend/src/dashboard/actions/dashboardState.js:101
+msgid "There was an issue favoriting this dashboard."
+msgstr "Pri uvrščanju nadzorne plošče med priljubljene je prišlo do težave."
+
+#: superset-frontend/src/dashboard/actions/dashboardState.js:123
+msgid "This dashboard is now ${nowPublished}"
+msgstr "Ta nadzorna plošča je sedaj ${nowPublished}"
+
+#: superset-frontend/src/dashboard/actions/dashboardState.js:129
+msgid "You do not have permissions to edit this dashboard."
+msgstr "Nimate dovoljenj za urejanje te nadzorne plošče."
+
+#: superset-frontend/src/dashboard/actions/dashboardState.js:231
+msgid "This dashboard was saved successfully."
+msgstr "Nadzorna plošča je bila uspešno shranjena."
+
+#: superset-frontend/src/dashboard/actions/sliceEntities.js:112
+#: superset-frontend/src/dashboard/reducers/sliceEntities.js:65
+msgid "Could not fetch all saved charts"
+msgstr "Vseh shranjenih grafikonov ni bilo mogoče pridobiti"
+
+#: superset-frontend/src/dashboard/actions/sliceEntities.js:117
+msgid "Sorry there was an error fetching saved charts: "
+msgstr "Prišlo je do napake pri pridobivanju shranjenih grafikonov: "
+
+#: superset-frontend/src/dashboard/components/AddSliceCard.jsx:132
+msgid "Visualization"
+msgstr "Vizualizacija"
+
+#: superset-frontend/src/dashboard/components/AddSliceCard.jsx:136
+msgid "Data source"
+msgstr "Podatkovni vir"
+
+#: superset-frontend/src/dashboard/components/AddSliceCard.jsx:141
+msgid "Added"
+msgstr "Dodano"
+
+#: superset-frontend/src/dashboard/components/BuilderComponentPane.tsx:67
+msgid "Components"
+msgstr "Komponente"
+
+#: superset-frontend/src/dashboard/components/ColorSchemeControlWrapper.jsx:54
+msgid ""
+"Any color palette selected here will override the colors applied to this "
+"dashboard's individual charts"
+msgstr ""
+"Na tem mestu izbrana barvna shema bo nadomestila barve posameznih grafikonov "
+"v tej nadzorni plošči"
+
+#: superset-frontend/src/dashboard/components/ColorSchemeControlWrapper.jsx:57
+#: superset-frontend/src/explore/controlPanels/sections.tsx:79
+#: superset-frontend/src/explore/controls.jsx:480
+msgid "Color scheme"
+msgstr "Barvna shema"
+
+#: superset-frontend/src/dashboard/components/Dashboard.jsx:87
+msgid "You have unsaved changes."
+msgstr "Imate neshranjene spremembe."
+
+#: superset-frontend/src/dashboard/components/MissingChart.jsx:31
+msgid ""
+"There is no chart definition associated with this component, could it have "
+"been deleted?"
+msgstr ""
+"S to komponento ni povezana nobena definicija grafikona. Ali je bila "
+"izbrisana?"
+
+#: superset-frontend/src/dashboard/components/MissingChart.jsx:36
+msgid "Delete this container and save to remove this message."
+msgstr "Izbrišite ta okvir in shranite za odpravo tega sporočila."
+
+#: superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx:29
+msgid "Don't refresh"
+msgstr "Ne osvežuj"
+
+#: superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx:30
+msgid "10 seconds"
+msgstr "10 sekund"
+
+#: superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx:31
+msgid "30 seconds"
+msgstr "30 sekund"
+
+#: superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx:32
+msgid "1 minute"
+msgstr "1 minuta"
+
+#: superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx:33
+msgid "5 minutes"
+msgstr "5 minut"
+
+#: superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx:34
+msgid "30 minutes"
+msgstr "30 minut"
+
+#: superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx:35
+msgid "1 hour"
+msgstr "1 ura"
+
+#: superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx:36
+msgid "6 hours"
+msgstr "6 ur"
+
+#: superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx:37
+msgid "12 hours"
+msgstr "12 ur"
+
+#: superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx:38
+msgid "24 hours"
+msgstr "24 ur"
+
+#: superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx:115
+msgid "Refresh interval"
+msgstr "Interval osveževanja"
+
+#: superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx:118
+msgid "Refresh frequency"
+msgstr "Frekvenca osveževanja"
+
+#: superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx:133
+msgid "Are you sure you want to proceed?"
+msgstr "Ali želite nadaljevati?"
+
+#: superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx:148
+msgid "Save for this session"
+msgstr "Shranite za to sejo"
+
+#: superset-frontend/src/dashboard/components/SaveModal.tsx:162
+msgid "You must pick a name for the new dashboard"
+msgstr "Izbrati morate ime nove nadzorne plošče"
+
+#: superset-frontend/src/dashboard/components/SaveModal.tsx:184
+msgid "Save dashboard"
+msgstr "Shrani nadzorno ploščo"
+
+#: superset-frontend/src/dashboard/components/SaveModal.tsx:193
+#, python-format
+msgid "Overwrite Dashboard [%s]"
+msgstr "Prepiši nadzorno ploščo [%s]"
+
+#: superset-frontend/src/dashboard/components/SaveModal.tsx:201
+msgid "Save as:"
+msgstr "Shrani kot:"
+
+#: superset-frontend/src/dashboard/components/SaveModal.tsx:205
+msgid "[dashboard name]"
+msgstr "[ime nadzorne plošče]"
+
+#: superset-frontend/src/dashboard/components/SaveModal.tsx:215
+msgid "also copy (duplicate) charts"
+msgstr "kopiraj tudi (podvoji) grafikone"
+
+#: superset-frontend/src/dashboard/components/SliceAdder.jsx:242
+msgid "Filter your charts"
+msgstr "Filtriraj grafikone"
+
+#: superset-frontend/src/dashboard/components/SliceAdder.jsx:256
+#: superset-frontend/src/explore/controls.jsx:387
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:108
+msgid "Sort by"
+msgstr "Razvrsti po"
+
+#: superset-frontend/src/dashboard/components/CrossFilterScopingModal/CrossFilterScopingModal.tsx:65
+msgid "Cross Filter Scoping"
+msgstr "Obseg cross-filtra"
+
+#: superset-frontend/src/dashboard/components/CssEditor/index.jsx:66
+msgid "Load a template"
+msgstr "Naloži predlogo"
+
+#: superset-frontend/src/dashboard/components/CssEditor/index.jsx:69
+msgid "Load a CSS template"
+msgstr "Naloži CSS predlogo"
+
+#: superset-frontend/src/dashboard/components/CssEditor/index.jsx:87
+msgid "Live CSS editor"
+msgstr "CSS urejevalnik v živo"
+
+#: superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel/index.tsx:166
+#, python-format
+msgid "Applied Cross Filters (%d)"
+msgstr "Uporabljeni cross-filtri (%d)"
+
+#: superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel/index.tsx:190
+#, python-format
+msgid "Applied Filters (%d)"
+msgstr "Uporabljeni filtri (%d)"
+
+#: superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel/index.tsx:211
+#, python-format
+msgid "Incompatible Filters (%d)"
+msgstr "Neskladni filtri (%d)"
+
+#: superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel/index.tsx:235
+#, python-format
+msgid "Unset Filters (%d)"
+msgstr "Neuporabljeni filtri (%d)"
+
+#: superset-frontend/src/dashboard/components/Header/index.jsx:250
+#, python-format
+msgid ""
+"This dashboard is currently force refreshing; the next force refresh will be "
+"in %s."
+msgstr ""
+"Nadzorna plošča se trenutno prisilno osvežuje. Naslednja prisilna osvežitev "
+"bo v %s."
+
+#: superset-frontend/src/dashboard/components/Header/index.jsx:336
+msgid "Your dashboard is too large. Please reduce the size before save it."
+msgstr "Vaša nadzorna plošča je prevelika. Pred shranjevanjem jo zmanjšajte."
+
+#: superset-frontend/src/dashboard/components/Header/index.jsx:467
+msgid "Discard changes"
+msgstr "Zavrzi spremembe"
+
+#: superset-frontend/src/dashboard/components/Header/index.jsx:493
+msgid "Edit dashboard"
+msgstr "Uredi nadzorno ploščo"
+
+#: superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx:125
+msgid "An error occurred while fetching available CSS templates"
+msgstr "Pri pridobivanju CSS predlog je prišlo do napake"
+
+#: superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx:208
+msgid "Superset dashboard"
+msgstr "Superset nadzorna plošča"
+
+#: superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx:210
+msgid "Check out this dashboard: "
+msgstr "Preizkusite to nadzorno ploščo: "
+
+#: superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx:251
+msgid "Copy dashboard URL"
+msgstr "Kopiraj URL nadzorne plošče"
+
+#: superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx:252
+msgid "Share dashboard by email"
+msgstr "Deli nadzorno ploščo po e-pošti"
+
+#: superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx:264
+msgid "Refresh dashboard"
+msgstr "Osveži nadzorno ploščo"
+
+#: superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx:274
+msgid "Set auto-refresh interval"
+msgstr "Nastavi interval samodejnega osveževanja"
+
+#: superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx:282
+msgid "Set filter mapping"
+msgstr "Nastavi shemo filtrov"
+
+#: superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx:289
+msgid "Edit dashboard properties"
+msgstr "Uredi lastnosti nadzorne plošče"
+
+#: superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx:296
+msgid "Edit CSS"
+msgstr "Uredi CSS"
+
+#: superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx:306
+#: superset-frontend/src/dashboard/components/SliceHeaderControls/index.jsx:300
+#: superset-frontend/src/explore/components/ExploreAdditionalActionsMenu/index.jsx:104
+msgid "Download as image"
+msgstr "Izvozi kot sliko"
+
+#: superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx:312
+msgid "Toggle fullscreen"
+msgstr "Preklopi celozaslonski način"
+
+#: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:71
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.tsx:89
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:382
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:478
+#: superset-frontend/src/datasource/DatasourceModal.tsx:130
+#: superset-frontend/src/explore/components/PropertiesModal/index.tsx:61
+msgid "An error has occurred"
+msgstr "Prišlo je do napake"
+
+#: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:79
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.tsx:91
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:384
+msgid "You do not have permission to edit this dashboard"
+msgstr "Nimate dovoljenja za urejanje te nadzorne plošče"
+
+#: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:150
+msgid "A valid color scheme is required"
+msgstr "Zahtevana je veljavna barvna shema"
+
+#: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:316
+msgid "The dashboard has been saved"
+msgstr "Nadzorna plošča je bila shranjena"
+
+#: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:336
+#: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:376
+#: superset-frontend/src/explore/components/PropertiesModal/index.tsx:243
+msgid "Access"
+msgstr "Dostop"
+
+#: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:352
+#: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:396
+msgid ""
+"Owners is a list of users who can alter the dashboard. Searchable by name or "
+"username."
+msgstr ""
+"\"Lastniki\" je seznam uporabnikov, ki lahko spreminjajo nadzorno ploščo. "
+"Iskanje je možno po imenu ali uporabniškem imenu."
+
+#: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:359
+msgid "Colors"
+msgstr "Barve"
+
+#: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:418
+msgid ""
+"Roles is a list which defines access to the dashboard. Granting a role "
+"access to a dashboard will bypass dataset level checks. If no roles defined "
+"then the dashboard is available to all roles."
+msgstr ""
+"\"Vloge\" je seznam, ki definira dostop do nadzorne plošče. Dodelitev vloge "
+"za dostop do nadzorne plošče bo obšlo preverjanje na nivoju podatkovnega "
+"seta. Če vloga ni definirana, bo nadzorna plošča dostopna vsem vlogam."
+
+#: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:442
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx:137
+#: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:810
+#: superset-frontend/src/visualizations/FilterBox/FilterBox.jsx:445
+msgid "Apply"
+msgstr "Uporabi"
+
+#: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:448
+msgid "Dashboard properties"
+msgstr "Lastnosti nadzorne plošče"
+
+#: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:481
+#: superset-frontend/src/explore/components/PropertiesModal/index.tsx:196
+#: superset-frontend/src/views/CRUD/annotation/AnnotationModal.tsx:304
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayerModal.tsx:258
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplateModal.tsx:249
+msgid "Basic information"
+msgstr "Osnovne informacije"
+
+#: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:498
+msgid "URL slug"
+msgstr "URL slug"
+
+#: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:507
+msgid "A readable URL for your dashboard"
+msgstr "Berljiv URL za vašo nadzorno ploščo"
+
+#: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:525
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:187
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:625
+#: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:34
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx:447
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Arc/controlPanel.js:128
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Geojson/controlPanel.js:82
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Grid/controlPanel.js:52
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Hex/controlPanel.js:82
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Path/controlPanel.js:72
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Polygon/controlPanel.js:178
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Scatter/controlPanel.js:142
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Screengrid/controlPanel.js:56
+msgid "Advanced"
+msgstr "Napredno"
+
+#: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:529
+#: superset-frontend/src/views/CRUD/annotation/AnnotationModal.tsx:352
+msgid "JSON metadata"
+msgstr "JSON metapodatki"
+
+#: superset-frontend/src/dashboard/components/PublishedStatus/index.jsx:33
+msgid ""
+"This dashboard is not published, it will not show up in the list of "
+"dashboards. Click here to publish this dashboard."
+msgstr ""
+"Ta nadzorna plošča ni objavljena in se ne bo prikazala na seznamu nadzornih "
+"plošč. Kliknite tukaj za njeno objavo."
+
+#: superset-frontend/src/dashboard/components/PublishedStatus/index.jsx:38
+msgid ""
+"This dashboard is not published which means it will not show up in the list "
+"of dashboards. Favorite it to see it there or access it by using the URL "
+"directly."
+msgstr ""
+"Ta nadzorna plošča ni objavljena in se ne bo prikazala na seznamu nadzornih "
+"plošč. Uvrstite jo med priljubljene, da jo boste videli tam, ali pa "
+"uporabite URL za neposredni dostop."
+
+#: superset-frontend/src/dashboard/components/PublishedStatus/index.jsx:43
+msgid "This dashboard is published. Click to make it a draft."
+msgstr ""
+"Ta nadzorna plošča je objavljena. Kliknite, da jo uvrstite med osnutke."
+
+#: superset-frontend/src/dashboard/components/PublishedStatus/index.jsx:74
+#: superset-frontend/src/dashboard/components/PublishedStatus/index.jsx:85
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:243
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:437
+msgid "Draft"
+msgstr "Osnutek"
+
+#: superset-frontend/src/dashboard/components/SliceHeader/index.tsx:62
+msgid "Annotation layers are still loading."
+msgstr "Sloj z oznakami se še vedno nalaga."
+
+#: superset-frontend/src/dashboard/components/SliceHeader/index.tsx:63
+msgid "One ore more annotation layers failed loading."
+msgstr "Eden ali več slojev z oznakami se ni naložil."
+
+#: superset-frontend/src/dashboard/components/SliceHeader/index.tsx:160
+msgid "Emitted values"
+msgstr "Oddane vrednosti"
+
+#: superset-frontend/src/dashboard/components/SliceHeaderControls/index.jsx:215
+#, python-format
+msgid "Cached %s"
+msgstr "Predpomnjeno %s"
+
+#: superset-frontend/src/dashboard/components/SliceHeaderControls/index.jsx:218
+#, python-format
+msgid "Fetched %s"
+msgstr "Pridobljeno %s"
+
+#: superset-frontend/src/dashboard/components/SliceHeaderControls/index.jsx:233
+msgid "Minimize chart"
+msgstr "Pomanjšaj grafikon"
+
+#: superset-frontend/src/dashboard/components/SliceHeaderControls/index.jsx:233
+msgid "Maximize chart"
+msgstr "Povečaj grafikon"
+
+#: superset-frontend/src/dashboard/components/SliceHeaderControls/index.jsx:246
+msgid "Force refresh"
+msgstr "Osveži"
+
+#: superset-frontend/src/dashboard/components/SliceHeaderControls/index.jsx:256
+msgid "Toggle chart description"
+msgstr "Preklopi opis grafikona"
+
+#: superset-frontend/src/dashboard/components/SliceHeaderControls/index.jsx:262
+msgid "View chart in Explore"
+msgstr "Ogled grafikona v Raziskovalcu"
+
+#: superset-frontend/src/dashboard/components/SliceHeaderControls/index.jsx:270
+#: superset-frontend/src/dashboard/components/SliceHeaderControls/index.jsx:272
+#: superset-frontend/src/explore/components/ExploreAdditionalActionsMenu/index.jsx:87
+#: superset-frontend/src/explore/components/ExploreAdditionalActionsMenu/index.jsx:89
+msgid "View query"
+msgstr "Ogled poizvedbe"
+
+#: superset-frontend/src/dashboard/components/SliceHeaderControls/index.jsx:288
+msgid "Copy chart URL"
+msgstr "Kopiraj URL grafikona"
+
+#: superset-frontend/src/dashboard/components/SliceHeaderControls/index.jsx:289
+#: superset-frontend/src/explore/components/ExploreActionButtons.tsx:161
+msgid "Share chart by email"
+msgstr "Deli grafikon po e-pošti"
+
+#: superset-frontend/src/dashboard/components/SliceHeaderControls/index.jsx:291
+msgid "Check out this chart: "
+msgstr "Preizkusite ta grafikon: "
+
+#: superset-frontend/src/dashboard/components/SliceHeaderControls/index.jsx:304
+msgid "Export CSV"
+msgstr "Izvozi CSV"
+
+#: superset-frontend/src/dashboard/components/SliceHeaderControls/index.jsx:309
+msgid "Cross-filter scoping"
+msgstr "Obseg cross-filtra"
+
+#: superset-frontend/src/dashboard/components/filterscope/FilterScopeSelector.jsx:483
+msgid "Search..."
+msgstr "Iskanje ..."
+
+#: superset-frontend/src/dashboard/components/filterscope/FilterScopeSelector.jsx:516
+msgid "No filter is selected."
+msgstr "Noben filter ni izbran."
+
+#: superset-frontend/src/dashboard/components/filterscope/FilterScopeSelector.jsx:517
+msgid "Editing 1 filter:"
+msgstr "Urejanje enega filtra:"
+
+#: superset-frontend/src/dashboard/components/filterscope/FilterScopeSelector.jsx:519
+#, python-format
+msgid "Batch editing %d filters:"
+msgstr "Skupinsko urejanje %d filtrov:"
+
+#: superset-frontend/src/dashboard/components/filterscope/FilterScopeSelector.jsx:533
+msgid "Configure filter scopes"
+msgstr "Nastavi obseg filtrov"
+
+#: superset-frontend/src/dashboard/components/filterscope/FilterScopeSelector.jsx:540
+msgid "There are no filters in this dashboard."
+msgstr "V nadzorni plošči ni filtrov."
+
+#: superset-frontend/src/dashboard/components/filterscope/treeIcons.jsx:36
+msgid "Expand all"
+msgstr "Razširi vse"
+
+#: superset-frontend/src/dashboard/components/filterscope/treeIcons.jsx:39
+msgid "Collapse all"
+msgstr "Skrči vse"
+
+#: superset-frontend/src/dashboard/components/gridComponents/Markdown.jsx:81
+msgid "This markdown component has an error."
+msgstr "Markdown komponenta ima napako."
+
+#: superset-frontend/src/dashboard/components/gridComponents/Markdown.jsx:175
+msgid ""
+"This markdown component has an error. Please revert your recent changes."
+msgstr "Markdown komponenta ima napako. Povrnite nedavne spremembe."
+
+#: superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx:178
+msgid "Delete dashboard tab?"
+msgstr "Ali izbrišem zavihek nadzorne plošče?"
+
+#: superset-frontend/src/dashboard/components/gridComponents/new/NewDivider.jsx:31
+msgid "Divider"
+msgstr "Ločilnik"
+
+#: superset-frontend/src/dashboard/components/gridComponents/new/NewHeader.jsx:31
+msgid "Header"
+msgstr "Glava"
+
+#: superset-frontend/src/dashboard/components/gridComponents/new/NewRow.jsx:31
+msgid "Row"
+msgstr "Vrstica"
+
+#: superset-frontend/src/dashboard/components/gridComponents/new/NewTabs.jsx:31
+msgid "Tabs"
+msgstr "Zavihki"
+
+#: superset-frontend/src/dashboard/components/menu/MarkdownModeDropdown.tsx:39
+msgid "Preview"
+msgstr "Predogled"
+
+#: superset-frontend/src/dashboard/components/menu/ShareMenuItems/index.tsx:55
+#: superset-frontend/src/explore/components/ExploreActionButtons.tsx:109
+#: superset-frontend/src/views/CRUD/data/components/SyntaxHighlighterCopy/index.tsx:75
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:221
+#: superset-frontend/src/views/CRUD/hooks.ts:635
+msgid "Sorry, your browser does not support copying."
+msgstr "Vaš brskalnik ne podpira kopiranja."
+
+#: superset-frontend/src/dashboard/components/menu/ShareMenuItems/index.tsx:65
+#: superset-frontend/src/explore/components/ExploreActionButtons.tsx:120
+msgid "Sorry, something went wrong. Try again later."
+msgstr "Nekaj je šlo narobe. Poskusite ponovno kasneje."
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx:264
+msgid "All Filters (${filterValues.length})"
+msgstr "Vsi filtri (${filterValues.length})"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx:283
+msgid "Filter Sets (${filterSetFilterValues.length})"
+msgstr "Nastavljeni filtri (${filterSetFilterValues.length})"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CascadeFilters/CascadePopover/index.tsx:164
+msgid "Select parent filters"
+msgstr "Izberi starševske filtre"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx:118
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:340
+msgid "Check configuration"
+msgstr "Preveri nastavitve"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx:165
+msgid "Cannot load filter"
+msgstr "Filtra ni mogoče naložiti"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/EditSection.tsx:124
+msgid "Editing filter set:"
+msgstr "Urejanje seta filtrov:"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/EditSection.tsx:148
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/Footer.tsx:83
+msgid "Filter set with this name already exists"
+msgstr "Set filtrov z enakim imenom že obstaja"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/EditSection.tsx:149
+msgid "Filter set already exists"
+msgstr "Set filtrov že obstaja"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/EditSection.tsx:170
+#, python-format
+msgid "This filter set is identical to: \"%s\""
+msgstr "Ta set filtrov je enak: \"%s\""
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/FilterSetUnit.tsx:77
+msgid "Remove invalid filters"
+msgstr "Odstrani neveljavne filtre"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/FilterSetUnit.tsx:78
+msgid "Rebuild"
+msgstr "Obnovi"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/FiltersHeader.tsx:75
+#, python-format
+msgid "Filters (%d)"
+msgstr "Filtri (%d)"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/FiltersHeader.tsx:92
+msgid "This filter doesn't exist in dashboard. It will not be applied."
+msgstr "Ta filter ne obstaja v nadzorni plošči in ne bo uveljavljen."
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/FiltersHeader.tsx:96
+msgid "Filter metadata changed in dashboard. It will not be applied."
+msgstr ""
+"Metapodatki filtra so se spremenili v nadzorni plošči. Ne bo uveljavljen."
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/FiltersHeader.tsx:107
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:657
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:99
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:235
+msgid "None"
+msgstr "Brez"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/Footer.tsx:81
+msgid "Please filter set name"
+msgstr "Vnesite ime seta filtrov"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/Footer.tsx:96
+msgid "Create"
+msgstr "Ustvari"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/Footer.tsx:111
+msgid "Create new filter set"
+msgstr "Ustvarite nov set filtrov"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/index.tsx:76
+msgid "New filter set"
+msgstr "Nov set filtrov"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/utils/index.ts:28
+msgid "Please apply filter changes"
+msgstr "Potrdite spremembe filtra"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/utils/index.ts:45
+msgid "Unknown value"
+msgstr "Neznana vrednost"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx:127
+msgid "Clear all"
+msgstr "Počisti vse"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTabs.tsx:172
+#: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl/index.jsx:363
+msgid "Add filter"
+msgstr "Dodaj filter"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTabs.tsx:182
+msgid "(Removed)"
+msgstr "(Odstranjeno)"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTabs.tsx:191
+msgid "Undo?"
+msgstr "Povrni?"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx:197
+msgid "New filter"
+msgstr "Nov filter"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx:251
+msgid "Filters configuration and scoping"
+msgstr "Nastavitve in obseg filtrov"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:172
+#: superset-frontend/src/explore/components/PropertiesModal/index.tsx:226
+msgid "Configuration"
+msgstr "Nastavitve"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:176
+msgid "Scoping"
+msgstr "Obseg"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:183
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:540
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx:405
+msgid "Basic"
+msgstr "Osnovno"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:444
+msgid "Filter name"
+msgstr "Ime filtra"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:446
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:452
+msgid "Name is required"
+msgstr "Zahtevano je ime"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:454
+msgid "Filter Type"
+msgstr "Tip filtra"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:479
+#: superset-frontend/src/explore/components/ExploreViewContainer.jsx:492
+#: superset-frontend/src/explore/controls.jsx:191
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:254
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:477
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:489
+msgid "Dataset"
+msgstr "Podatkovni set"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:481
+msgid "Dataset is required"
+msgstr "Zahtevan je podatkovni set"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:557
+msgid "Filter has default value"
+msgstr "Filter ima privzeto vrednost"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:565
+msgid "Default Value"
+msgstr "Privzeta vrednost"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:578
+msgid "Default value is required"
+msgstr "Zahtevana je privzeta vrednost"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:602
+msgid "Fill all required fields to enable \"Default Value\""
+msgstr "Izpolnite vsa polja, da omogočite \"Privzeto vrednost\""
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:616
+msgid "Apply changes instantly"
+msgstr "Spremembe uporabi takoj"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:627
+msgid "Filter is hierarchical"
+msgstr "Filter je hierarhičen"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:645
+msgid "Parent filter"
+msgstr "Nadrejeni filter"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:652
+msgid "Parent filter is required"
+msgstr "Zahtevan je nadrejeni filter"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:669
+msgid "Pre-filter available values"
+msgstr "Predfiltriraj razpoložljive vrednosti"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:695
+msgid "Adhoc filters is required"
+msgstr "Zahtevan je ad hoc filter"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:716
+msgid "Adhoc filters"
+msgstr "Adhoc filtri"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:723
+#: superset-frontend/src/explore/constants.ts:85
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:391
+msgid "Time range"
+msgstr "Časovno obdobje"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:739
+msgid "Sort filter values"
+msgstr "Razvrsti vrednosti filtra"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:755
+msgid "Sort type"
+msgstr "Vrsta razvrščanja"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:764
+#: superset-frontend/src/explore/components/controls/FilterBoxItemControl/index.jsx:206
+#: superset-frontend/src/filters/components/Select/controlPanel.ts:52
+msgid "Sort ascending"
+msgstr "Razvrsti naraščajoče"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:768
+#: superset-frontend/src/explore/controlPanels/sections.tsx:125
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:315
+msgid "Sort descending"
+msgstr "Razvrsti padajoče"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:780
+msgid "Sort Metric"
+msgstr "Mera za razvrščanje"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/RemovedFilter.tsx:39
+msgid "You have removed this filter."
+msgstr "Odstranili ste ta filter."
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/RemovedFilter.tsx:46
+msgid "Restore Filter"
+msgstr "Povrni filter"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/getControlItemsMap.tsx:69
+msgid "Populate \"Default value\" to enable this control"
+msgstr "Izpolnite \"Privzeto vrednost\", da omogočite ta kontrolnik"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.tsx:82
+msgid "Apply to all panels"
+msgstr "Uporabi za vse panele"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.tsx:84
+msgid "Apply to specific panels"
+msgstr "Uporabi za določene panele"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.tsx:90
+msgid "Only selected panels will be affected by this filter"
+msgstr "Ta filter bo vplival le na izbrane panele"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.tsx:91
+msgid "All panels with this column will be affected by this filter"
+msgstr "Ta filter bo vplival na vse panele s tem stolpcem"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/state.ts:48
+msgid "All panels"
+msgstr "Vsi paneli"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/Footer/CancelConfirmationAlert.tsx:56
+msgid "Keep editing"
+msgstr "Nadaljuj z urejanjem"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/Footer/CancelConfirmationAlert.tsx:64
+msgid "Yes, cancel"
+msgstr "Da, prekini"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/Footer/Footer.tsx:69
+msgid "Are you sure you want to cancel?"
+msgstr "Ali želite prekiniti?"
+
+#: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/Footer/Footer.tsx:70
+msgid "will not be saved."
+msgstr "ne bo shranjeno."
+
+#: superset-frontend/src/dashboard/util/backgroundStyleOptions.ts:25
+msgid "Transparent"
+msgstr "Prozorno"
+
+#: superset-frontend/src/dashboard/util/backgroundStyleOptions.ts:30
+msgid "White"
+msgstr "Belo"
+
+#: superset-frontend/src/dashboard/util/getFilterFieldNodesTree.js:44
+msgid "All filters"
+msgstr "Vsi filtri"
+
+#: superset-frontend/src/dashboard/util/getFilterScopeNodesTree.js:85
+msgid "All charts"
+msgstr "Vsi grafikoni"
+
+#: superset-frontend/src/dashboard/util/headerStyleOptions.ts:25
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/sharedControls.ts:41
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/sharedControls.ts:76
+msgid "Small"
+msgstr "Majhno"
+
+#: superset-frontend/src/dashboard/util/headerStyleOptions.ts:30
+msgid "Medium"
+msgstr "Srednje"
+
+#: superset-frontend/src/dashboard/util/headerStyleOptions.ts:35
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/sharedControls.ts:49
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/sharedControls.ts:84
+msgid "Large"
+msgstr "Veliko"
+
+#: superset-frontend/src/dashboard/util/newComponentFactory.js:56
+#: superset-frontend/src/dashboard/util/newComponentFactory.js:57
+msgid "Tab title"
+msgstr "Naslov zavihka"
+
+#: superset-frontend/src/datasource/ChangeDatasourceModal.tsx:39
+msgid ""
+"Warning! Changing the dataset may break the chart if the metadata does not "
+"exist."
+msgstr ""
+"Opozorilo! Sprememba podatkovnega seta lahko pokvari grafikon, če "
+"metapodatki ne obstajajo."
+
+#: superset-frontend/src/datasource/ChangeDatasourceModal.tsx:43
+msgid ""
+"Changing the dataset may break the chart if the chart relies on columns or "
+"metadata that does not exist in the target dataset"
+msgstr ""
+"Sprememba podatkovnega seta lahko pokvari grafikon, če se le-ta zanaša na "
+"stolpce ali metapodatke, ki ne obstajajo v ciljnem podatkovnem nizu"
+
+#: superset-frontend/src/datasource/ChangeDatasourceModal.tsx:115
+#: superset-frontend/src/views/CRUD/data/dataset/AddDatasetModal.tsx:64
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:125
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:682
+msgid "dataset"
+msgstr "podatkovni set"
+
+#: superset-frontend/src/datasource/ChangeDatasourceModal.tsx:216
+#: superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx:174
+#: superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx:253
+msgid "Change dataset"
+msgstr "Spremeni podatkovni set"
+
+#: superset-frontend/src/datasource/ChangeDatasourceModal.tsx:248
+msgid "Warning!"
+msgstr "Opozorilo!"
+
+#: superset-frontend/src/datasource/ChangeDatasourceModal.tsx:256
+msgid "Search / Filter"
+msgstr "Iskanje / Filter"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:110
+msgid "Physical (table or view)"
+msgstr "Fizičen (tabela ali pogled)"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:111
+msgid "Virtual (SQL)"
+msgstr "Virtualen (SQL)"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:154
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:876
+msgid "SQL expression"
+msgstr "SQL izraz"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:186
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:229
+msgid "Data type"
+msgstr "Tip podatka"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:194
+msgid "Datetime format"
+msgstr "Oblika datum-časa"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:198
+msgid "The pattern of timestamp format. For strings use "
+msgstr "Vzorec zapisa časovne značke. Za znakovne nize uporabite "
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:200
+msgid "Python datetime string pattern"
+msgstr "Pythonov vzorec zapisa datum-časa"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:202
+msgid " expression which needs to adhere to the "
+msgstr " , ki mora upoštevati "
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:204
+msgid "ISO 8601"
+msgstr "ISO 8601"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:206
+msgid ""
+" standard to ensure that the lexicographical ordering\r\n"
+"                      coincides with the chronological ordering. If the\r\n"
+"                      timestamp format does not adhere to the ISO 8601 "
+"standard\r\n"
+"                      you will need to define an expression and type for\r\n"
+"                      transforming the string into a date or timestamp. Note"
+"\r\n"
+"                      currently time zones are not supported. If time is "
+"stored\r\n"
+"                      in epoch format, put `epoch_s` or `epoch_ms`. If no "
+"pattern\r\n"
+"                      is specified we fall back to using the optional "
+"defaults on a per\r\n"
+"                      database/column name level via the extra parameter."
+msgstr ""
+" standard, ki zagotavlja, de se leksikografsko razvrščanje\r\n"
+"                      sklada s kronološkim razvrščanjem. Če oblika\r\n"
+"                      časovne značke ni v skladu s standardom ISO 8601,\r\n"
+"                      boste morali definirati izraz in tip za transformacijo"
+"\r\n"
+"                      znakovnega niza v datum ali časovno značko.\r\n"
+"                      Trenutno časovni pasovi niso podprti.\r\n"
+"                      Če je čas shranjen v obliki epohe, dodajte `epoch_s` "
+"ali `epoch_ms`.\r\n"
+"                      Če ni podan vzorec, se uporabijo privzete vrednosti na "
+"podlagi imena\r\n"
+"                      podatkovne baze oz. stolpca s pomočjo dodatnega "
+"parametra."
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:230
+msgid "Is dimension"
+msgstr "Dimenzija"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:232
+msgid "Is filterable"
+msgstr "Filtriranje"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:459
+#, python-format
+msgid "Modified columns: %s"
+msgstr "Spremenjeni stolpci: %s"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:464
+#, python-format
+msgid "Removed columns: %s"
+msgstr "Odstranjeni stolpci: %s"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:469
+#, python-format
+msgid "New columns added: %s"
+msgstr "Dodani novi stolpci: %s"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:472
+msgid "Metadata has been synced"
+msgstr "Metapodatki so sinhronizirani"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:508
+#, python-format
+msgid "Column name [%s] is duplicated"
+msgstr "Ime stolpca [%s] je podvojeno"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:515
+#, python-format
+msgid "Metric name [%s] is duplicated"
+msgstr "Ime mere [%s] je podvojeno"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:525
+#, python-format
+msgid "Calculated column [%s] requires an expression"
+msgstr "Izračunan stolpec [%s] zahteva izraz"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:553
+msgid "Default URL"
+msgstr "Privzeti URL"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:554
+msgid "Default URL to redirect to when accessing from the dataset list page"
+msgstr ""
+"Privzeti URL za preusmeritev, ko dostopate iz strani s seznamom podatkovnih "
+"setov"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:562
+msgid "Autocomplete filters"
+msgstr "Samodokončaj filtre"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:563
+msgid "Whether to populate autocomplete filters options"
+msgstr "Če želite napolniti možnosti za samodokončanje filtrov"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:569
+msgid "Autocomplete query predicate"
+msgstr "Predikat za samodokončanje poizvedb"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:570
+msgid ""
+"When using \"Autocomplete filters\", this can be used to improve performance "
+"of the query fetching the values. Use this option to apply a predicate "
+"(WHERE clause) to the query selecting the distinct values from the table. "
+"Typically the intent would be to limit the scan by applying a relative time "
+"filter on a partitioned or indexed time-related field."
+msgstr ""
+"Ko uporabljate \"Samodokončaj filtre\", lahko s tem izboljšate hitrost "
+"pridobivanja rezultatov s poizvedbo. Z uporabo te možnosti dodate predikat "
+"(WHERE stavek) k poizvedbi za izbiro različnih vrednosti iz tabele. Običajno "
+"je namen omejiti poizvedbo z uporabo filtra za relativni čas na "
+"particioniranem ali indeksiranem časovnem polju."
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:584
+msgid ""
+"Extra data to specify table metadata. Currently supports metadata of the "
+"format: `{ \"certification\": { \"certified_by\": \"Data Platform Team\", "
+"\"details\": \"This table is the source of truth.\" }, \"warning_markdown\": "
+"\"This is a warning.\" }`."
+msgstr ""
+"Dodatni podatki za tabelo metapodatkov. Trenutno je podprta naslednja oblika "
+"zapisa metapodatkov: `{ \"certification\": { \"certified_by\": \"Tim za "
+"razvoj\", \"details\": \"Ta tabela je vir resnice.\" }, \"warning_markdown"
+"\": \"To je opozorilo.\" }`."
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:602
+msgid "Owners of the dataset"
+msgstr "Lastniki podatkovnega seta"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:631
+#: superset-frontend/src/explore/components/PropertiesModal/index.tsx:227
+msgid "Cache timeout"
+msgstr "Časovna omejitev predpomnilnika"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:632
+msgid "The duration of time in seconds before the cache is invalidated"
+msgstr "Trajanje (v sekundah) do razveljavitve predpomnilnika"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:639
+msgid "Hours offset"
+msgstr "Urni premik"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:641
+msgid ""
+"The number of hours, negative or positive, to shift the time column. This "
+"can be used to move UTC time to local time."
+msgstr ""
+"Število ur, negativno ali pozitivno, za zamik časovnega stolpca. Na ta način "
+"je mogoče UTC čas prestaviti na lokalni čas."
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:664
+msgid "Spatial"
+msgstr "Prostorski"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:716
+msgid "virtual"
+msgstr "virtualni"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:737
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:744
+msgid "Dataset name"
+msgstr "Ime podatkovnega seta"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:752
+msgid ""
+"When specifying SQL, the datasource acts as a view. Superset will use this "
+"statement as a subquery while grouping and filtering on the generated parent "
+"queries."
+msgstr ""
+"Ko podajate SQL, se podatkovni vir obnaša kot pogled (view). Superset bo to "
+"izjavo uporabil kot podpoizvedbo, pri čemer bo grupiral in filtriral na "
+"podlagi ustvarjenih starševskih poizvedb."
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:775
+msgid "The JSON metric or post aggregation definition."
+msgstr "JSON mera ali po-agregacijska definicija."
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:790
+msgid "Physical"
+msgstr "Fizičen"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:820
+msgid ""
+"The pointer to a physical table (or view). Keep in mind that the chart is "
+"associated to this Superset logical table, and this logical table points the "
+"physical table referenced here."
+msgstr ""
+"Kazalec na fizično tabelo (ali pogled). Grafikon je povezan s to Supersetovo "
+"logično tabelo, ki kaže na tukaj referencirano fizično tabelo."
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:839
+msgid "Click the lock to make changes."
+msgstr "Kliknite ključavnico, da omogočite spreminjanje."
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:842
+msgid "Click the lock to prevent further changes."
+msgstr "Kliknite ključavnico, da onemogočite spremembe."
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:898
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:44
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:55
+msgid "D3 format"
+msgstr "D3 format"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:904
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:912
+msgid "Certified by"
+msgstr "Certificiral/a"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:906
+msgid "Person or group that has certified this metric"
+msgstr "Oseba ali skupina, ki je certificirala to mero"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:917
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:923
+msgid "Certification details"
+msgstr "Podrobnosti certifikacije"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:919
+msgid "Details of the certification"
+msgstr "Podrobnosti certifikacije"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:928
+msgid "Warning"
+msgstr "Opozorilo"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:930
+msgid "Optional warning about use of this metric"
+msgstr "Opcijsko opozorilo za uporabo te mere"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:1009
+msgid "Be careful."
+msgstr "Bodite previdni."
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:1010
+msgid ""
+"Changing these settings will affect all charts using this dataset, including "
+"charts owned by other people."
+msgstr ""
+"Spreminjanje teh nastavitev bo vplivalo na vse grafikone, ki uporabljajo ta "
+"podatkovni set, vključno z grafikoni v lasti drugih oseb."
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:1023
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1103
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:278
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-chord/src/controlPanel.ts:61
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:48
+msgid "Source"
+msgstr "Izvor"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:1056
+msgid "Sync columns from source"
+msgstr "Sinhroniziraj stolpce z virom"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:1074
+msgid "Calculated columns"
+msgstr "Izračunani stolpci"
+
+#: superset-frontend/src/datasource/DatasourceEditor.jsx:1097
+msgid "Settings"
+msgstr "Nastavitve"
+
+#: superset-frontend/src/datasource/DatasourceModal.tsx:121
+#: superset-frontend/src/views/CRUD/data/dataset/AddDatasetModal.tsx:96
+msgid "The dataset has been saved"
+msgstr "Podatkovni set je shranjen"
+
+#: superset-frontend/src/datasource/DatasourceModal.tsx:157
+msgid ""
+"The dataset configuration exposed here\r\n"
+"                affects all the charts using this dataset.\r\n"
+"                Be mindful that changing settings\r\n"
+"                here may affect other charts\r\n"
+"                in undesirable ways."
+msgstr ""
+"Tukaj prikazane nastavitve podatkovnega seta\r\n"
+"                vpliva na vse grafikone, ki uporabljajo\r\n"
+"                ta podatkovni set. Spreminjanje\r\n"
+"                nastavitev lahko nezaželeno vpliva\r\n"
+"                na druge grafikone."
+
+#: superset-frontend/src/datasource/DatasourceModal.tsx:163
+msgid "Are you sure you want to save and apply changes?"
+msgstr "Ali resnično želite shraniti in uporabiti spremembe?"
+
+#: superset-frontend/src/datasource/DatasourceModal.tsx:169
+msgid "Confirm save"
+msgstr "Potrdite shranjevanje"
+
+#: superset-frontend/src/datasource/DatasourceModal.tsx:182
+msgid "Edit Dataset "
+msgstr "Uredi podatkovni set "
+
+#: superset-frontend/src/datasource/DatasourceModal.tsx:199
+msgid "Use legacy datasource editor"
+msgstr "Uporabi starejši urejevalnik podatkovnega vira"
+
+#: superset-frontend/src/explore/constants.ts:86
+#: superset-frontend/src/filters/components/TimeColumn/index.ts:28
+msgid "Time column"
+msgstr "Časovni stolpec"
+
+#: superset-frontend/src/explore/constants.ts:87
+#: superset-frontend/src/filters/components/TimeGrain/index.ts:28
+msgid "Time grain"
+msgstr "Granulacija časa"
+
+#: superset-frontend/src/explore/constants.ts:88
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/constants.ts:28
+msgid "Origin"
+msgstr "Izhodišče"
+
+#: superset-frontend/src/explore/constants.ts:89
+msgid "Time granularity"
+msgstr "Granulacija časa"
+
+#: superset-frontend/src/explore/controls.jsx:114
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/constants.ts:40
+msgid ""
+"A reference to the [Time] configuration, taking granularity into account"
+msgstr "Sklic na nastavitve za [Čas], ki upošteva granulacijo"
+
+#: superset-frontend/src/explore/controls.jsx:124
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:26
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:97
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:41
+msgid "Group by"
+msgstr "Združevanje (Group by)"
+
+#: superset-frontend/src/explore/controls.jsx:127
+msgid "One or many controls to group by"
+msgstr "En ali več kontrolnikov za združevanje"
+
+#: superset-frontend/src/explore/controls.jsx:164
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:96
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:137
+msgid "One or many metrics to display"
+msgstr "Ena ali več mer za prikaz"
+
+#: superset-frontend/src/explore/controls.jsx:202
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:241
+msgid "Visualization type"
+msgstr "Tip vizualizacije"
+
+#: superset-frontend/src/explore/controls.jsx:204
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:161
+msgid "The type of visualization to display"
+msgstr "Tip vizualizacije za prikaz"
+
+#: superset-frontend/src/explore/controls.jsx:208
+msgid "Fixed color"
+msgstr "Izbrana barva"
+
+#: superset-frontend/src/explore/controls.jsx:209
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:167
+msgid "Use this to define a static color for all circles"
+msgstr "S tem definirate določeno barvo za vse kroge"
+
+#: superset-frontend/src/explore/controls.jsx:217
+msgid "Right axis metric"
+msgstr "Mera desne osi"
+
+#: superset-frontend/src/explore/controls.jsx:219
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:176
+msgid "Choose a metric for right axis"
+msgstr "Izberite mero za desno os"
+
+#: superset-frontend/src/explore/controls.jsx:224
+msgid "Linear color scheme"
+msgstr "Linearna barvna shema"
+
+#: superset-frontend/src/explore/controls.jsx:237
+msgid "Color metric"
+msgstr "P"
+
+#: superset-frontend/src/explore/controls.jsx:240
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:140
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:197
+msgid "A metric to use for color"
+msgstr "Mera za barvo"
+
+#: superset-frontend/src/explore/controls.jsx:248
+msgid "One or many controls to pivot as columns"
+msgstr "En ali več kontrolnikov za stolpčno vrtenje"
+
+#: superset-frontend/src/explore/controls.jsx:260
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:215
+msgid ""
+"Defines the origin where time buckets start, accepts natural dates as in "
+"`now`, `sunday` or `1970-01-01`"
+msgstr ""
+"Določa izhodišče, kadar se začnejo časovni razdelki. Sprejema naravne zapise "
+"kot so `zdaj`, `nedelja` ali `1970-01-01`"
+
+#: superset-frontend/src/explore/controls.jsx:289
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:244
+msgid ""
+"The time granularity for the visualization. Note that you can type and use "
+"simple natural language as in `10 seconds`, `1 day` or `56 weeks`"
+msgstr ""
+"Granulacija časa za vizualizacijo. Uporabite lahko vnos z naravnim jezikom, "
+"kot npr. `10 sekund`, `1 dni` ali `56 tednov`"
+
+#: superset-frontend/src/explore/controls.jsx:299
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:254
+msgid ""
+"The time column for the visualization. Note that you can define arbitrary "
+"expression that return a DATETIME column in the table. Also note that the "
+"filter below is applied against this column or expression"
+msgstr ""
+"Časovni stolpec za vizualizacijo. Določite lahko poljuben izraz, ki vrne "
+"DATETIME stolpec v tabeli. Spodnji filter se nanaša na ta stolpec ali izraz"
+
+#: superset-frontend/src/explore/controls.jsx:329
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:285
+msgid ""
+"The time granularity for the visualization. This applies a date "
+"transformation to alter your time column and defines a new time granularity. "
+"The options here are defined on a per database engine basis in the Superset "
+"source code."
+msgstr ""
+"Granulacija časa za to vizualizacijo. Izvede transformacijo podatkov, ki "
+"spremeni vaš časovni stolpec in določi novo časovno granulacija. Ta možnost "
+"je definirana na ravni sistema podatkovne baze v izvorni kodi Superseta."
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:35
+#: superset-frontend/src/explore/controls.jsx:345
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:301
+msgid "No filter"
+msgstr "Brez filtra"
+
+#: superset-frontend/src/explore/controls.jsx:347
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:303
+msgid ""
+"The time range for the visualization. All relative times, e.g. \"Last month"
+"\", \"Last 7 days\", \"now\", etc. are evaluated on the server using the "
+"server's local time (sans timezone). All tooltips and placeholder times are "
+"expressed in UTC (sans timezone). The timestamps are then evaluated by the "
+"database using the engine's local timezone. Note one can explicitly set the "
+"timezone per the ISO 8601 format if specifying either the start and/or end "
+"time."
+msgstr ""
+"Časovno obdobje za vizualizacijo. Vsi relativni časi, kot npr. \"Zadnji mesec"
+"\", Zadnjih 7 dni\", \"Zdaj\" so izračunani na strežniku z njegovim lokalnim "
+"časom. Vsi opisi orodij in časi so izraženi v UTC. Časovne značke se nato "
+"izračunajo v podatkovni bazi z njenim lokalnim časovnim pasom. Eksplicitno "
+"lahko nastavite časovni pas v ISO 8601 formatu, če določite čas začetka ali "
+"konca."
+
+#: superset-frontend/src/explore/controls.jsx:365
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:320
+msgid "Row limit"
+msgstr "Omejitev št. vrstic"
+
+#: superset-frontend/src/explore/controls.jsx:374
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:329
+msgid "Series limit"
+msgstr "Omejitev št. vrst"
+
+#: superset-frontend/src/explore/controls.jsx:377
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:333
+msgid ""
+"Limits the number of time series that get displayed. A sub query (or an "
+"extra phase where sub queries are not supported) is applied to limit the "
+"number of time series that get fetched and displayed. This feature is useful "
+"when grouping by high cardinality dimension(s)."
+msgstr ""
+"Omeji število časovnih vrst za prikaz. S podpoizvedbo (ali dodatno fazo, "
+"kjer podpoizvedbe niso podprte) se omeji število časovnih vrst, ki bodo "
+"pridobljene za prikaz. Ta funkcija je uporabna pri združevanju dimenzij z "
+"veliko kardinalnostjo."
+
+#: superset-frontend/src/explore/controls.jsx:390
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:110
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:345
+msgid "Metric used to define the top series"
+msgstr "Mera za določanje najvišje podatkovne serije"
+
+#: superset-frontend/src/explore/controls.jsx:400
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:51
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:355
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts:108
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts:131
+msgid "Series"
+msgstr "Niz"
+
+#: superset-frontend/src/explore/controls.jsx:403
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:54
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:358
+msgid ""
+"Defines the grouping of entities. Each series is shown as a specific color "
+"on the chart and has a legend toggle"
+msgstr ""
+"Določa združevanje entitet. Vsak niz je na grafikonu prikazan z določeno "
+"barvo in ima lahko prikazano legendo"
+
+#: superset-frontend/src/explore/controls.jsx:412
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:63
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:367
+msgid "Entity"
+msgstr "Entiteta"
+
+#: superset-frontend/src/explore/controls.jsx:416
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:67
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:371
+msgid "This defines the element to be plotted on the chart"
+msgstr "Določa element, ki bo izrisan na grafikonu"
+
+#: superset-frontend/src/explore/controls.jsx:421
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:126
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:376
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Area/controlPanel.ts:69
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bar/controlPanel.ts:64
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bubble/controlPanel.ts:77
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Compare/controlPanel.ts:45
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts:101
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Line/controlPanel.ts:70
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:77
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/TimePivot/controlPanel.ts:82
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:261
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:324
+msgid "X Axis"
+msgstr "X os"
+
+#: superset-frontend/src/explore/controls.jsx:422
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:127
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:377
+msgid "Metric assigned to the [X] axis"
+msgstr "Mera za [X] os"
+
+#: superset-frontend/src/explore/controls.jsx:428
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:132
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:383
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Area/controlPanel.ts:79
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bar/controlPanel.ts:76
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bubble/controlPanel.ts:109
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Compare/controlPanel.ts:54
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Line/controlPanel.ts:81
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/TimePivot/controlPanel.ts:101
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:205
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:322
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:407
+msgid "Y Axis"
+msgstr "Y os"
+
+#: superset-frontend/src/explore/controls.jsx:430
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:133
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:385
+msgid "Metric assigned to the [Y] axis"
+msgstr "Mera za [Y] os"
+
+#: superset-frontend/src/explore/controls.jsx:435
+msgid "Bubble size"
+msgstr "Velikost mehurčka"
+
+#: superset-frontend/src/explore/controls.jsx:442
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:398
+msgid "Y Axis Format"
+msgstr "Oblika Y osi"
+
+#: superset-frontend/src/explore/controls.jsx:454
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:407
+msgid ""
+"When `Calculation type` is set to \"Percentage change\", the Y Axis Format "
+"is forced to `.1%`"
+msgstr ""
+"Če je `Vrsta izračuna` nastavljena na \"Procentualna sprememba\", bo oblika "
+"Y-osi vsiljena na `.1%`"
+
+#: superset-frontend/src/explore/controls.jsx:484
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:448
+msgid "The color scheme for rendering chart"
+msgstr "Barvna shema za izris grafikona"
+
+#: superset-frontend/src/explore/controls.jsx:490
+#: superset-frontend/src/utils/getControlsForVizType.test.js:86
+msgid "Color map"
+msgstr "Barvna lestvica"
+
+#: superset-frontend/src/explore/actions/exploreActions.ts:92
+msgid "An error occurred while starring this chart"
+msgstr "Pri ocenjevanju grafikona je prišlo do napake"
+
+#: superset-frontend/src/explore/components/ControlHeader.jsx:65
+#: superset-frontend/src/views/CRUD/annotation/AnnotationModal.tsx:343
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayerModal.tsx:273
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/components/ControlHeader.tsx:64
+msgid "description"
+msgstr "opis"
+
+#: superset-frontend/src/explore/components/ControlHeader.jsx:75
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/components/ControlHeader.tsx:74
+msgid "bolt"
+msgstr "vijak"
+
+#: superset-frontend/src/explore/components/ControlHeader.jsx:76
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/components/ControlHeader.tsx:75
+msgid "Changing this control takes effect instantly"
+msgstr "Sprememba tega kontrolnika se odrazi takoj"
+
+#: superset-frontend/src/explore/components/ControlPanelsContainer.tsx:431
+msgid "Customize"
+msgstr "Prilagodi"
+
+#: superset-frontend/src/explore/components/EmbedCodeButton.jsx:116
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Grid/controlPanel.js:58
+msgid "Height"
+msgstr "Višina"
+
+#: superset-frontend/src/explore/components/EmbedCodeButton.jsx:130
+msgid "Width"
+msgstr "Širina"
+
+#: superset-frontend/src/explore/components/ExploreActionButtons.tsx:97
+msgid "Copy chart URL to clipboard"
+msgstr "Kopiraj URL grafikona na odložišče"
+
+#: superset-frontend/src/explore/components/ExploreActionButtons.tsx:104
+msgid "Loading..."
+msgstr "Nalagam ..."
+
+#: superset-frontend/src/explore/components/ExploreActionButtons.tsx:115
+msgid "Superset Chart"
+msgstr "Superset grafikon"
+
+#: superset-frontend/src/explore/components/ExploreActionButtons.tsx:168
+msgid "Export to .JSON format"
+msgstr "Izvozi v .json format"
+
+#: superset-frontend/src/explore/components/ExploreActionButtons.tsx:174
+msgid "Export to .CSV format"
+msgstr "Izvozi v .csv format"
+
+#: superset-frontend/src/explore/components/ExploreChartHeader.jsx:101
+#, python-format
+msgid "%s - untitled"
+msgstr "%s - neimenovan"
+
+#: superset-frontend/src/explore/components/ExploreChartHeader.jsx:169
+msgid "Edit chart properties"
+msgstr "Uredi lastnosti grafikona"
+
+#: superset-frontend/src/explore/components/ExploreViewContainer.jsx:402
+msgid "Controls labeled "
+msgstr "Kontrolniki imenovani "
+
+#: superset-frontend/src/explore/components/ExploreViewContainer.jsx:402
+msgid "Control labeled "
+msgstr "Nastavitev "
+
+#: superset-frontend/src/explore/components/ExploreViewContainer.jsx:521
+msgid "Open Datasource tab"
+msgstr "Odpri zavihek s podatkovnim virom"
+
+#: superset-frontend/src/explore/components/RowCountLabel.jsx:35
+msgid "rows"
+msgstr "vrstic"
+
+#: superset-frontend/src/explore/components/RowCountLabel.jsx:45
+msgid "Limit reached"
+msgstr "Omejitev dosežena"
+
+#: superset-frontend/src/explore/components/SaveModal.tsx:35
+msgid "**Select** a dashboard OR **create** a new one"
+msgstr "**Izberite** nadzorno ploščo ALI **ustvarite** novo"
+
+#: superset-frontend/src/explore/components/SaveModal.tsx:130
+msgid "Please enter a chart name"
+msgstr "Vnesite ime grafikona"
+
+#: superset-frontend/src/explore/components/SaveModal.tsx:172
+msgid "Save chart"
+msgstr "Shrani grafikon"
+
+#: superset-frontend/src/explore/components/SaveModal.tsx:191
+msgid "Save & go to dashboard"
+msgstr "Shrani in pojdi na nadzorno ploščo"
+
+#: superset-frontend/src/explore/components/SaveModal.tsx:202
+msgid "Save as new chart"
+msgstr "Shrani kot nov grafikon"
+
+#: superset-frontend/src/explore/components/SaveModal.tsx:235
+msgid "Save (Overwrite)"
+msgstr "Shrani (prepiši)"
+
+#: superset-frontend/src/explore/components/SaveModal.tsx:244
+msgid "Save as ..."
+msgstr "Shrani kot ..."
+
+#: superset-frontend/src/explore/components/SaveModal.tsx:248
+msgid "Chart name"
+msgstr "Ime grafikona"
+
+#: superset-frontend/src/explore/components/SaveModal.tsx:259
+msgid "Add to dashboard"
+msgstr "Dodaj na nadzorno ploščo"
+
+#: superset-frontend/src/explore/components/DataTableControl/index.tsx:95
+msgid "rows retrieved"
+msgstr "vrnjenih vrstic"
+
+#: superset-frontend/src/explore/components/DataTablesPane/index.tsx:168
+#: superset-frontend/src/explore/components/controls/ViewQueryModal.tsx:76
+msgid "Sorry, An error occurred"
+msgstr "Prišlo je do napake"
+
+#: superset-frontend/src/explore/components/DataTablesPane/index.tsx:258
+#: superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx:245
+#: superset-frontend/src/filters/components/TimeGrain/TimeGrainFilterPlugin.tsx:81
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/BigNumber.tsx:148
+msgid "No data"
+msgstr "Ni podatkov"
+
+#: superset-frontend/src/explore/components/DataTablesPane/index.tsx:309
+msgid "View samples"
+msgstr "Ogled vzorcev"
+
+#: superset-frontend/src/explore/components/DatasourcePanel/index.tsx:192
+msgid "Search Metrics & Columns"
+msgstr "Iskanje mer in stolpcev"
+
+#: superset-frontend/src/explore/components/DatasourcePanel/index.tsx:206
+#: superset-frontend/src/explore/components/DatasourcePanel/index.tsx:228
+#, python-format
+msgid "Showing %s of %s"
+msgstr "Prikazanih %s od %s"
+
+#: superset-frontend/src/explore/components/ExploreAdditionalActionsMenu/index.jsx:62
+msgid "New chart"
+msgstr "Nov grafikon"
+
+#: superset-frontend/src/explore/components/ExploreAdditionalActionsMenu/index.jsx:81
+msgid "Edit properties"
+msgstr "Uredi lastnosti"
+
+#: superset-frontend/src/explore/components/ExploreAdditionalActionsMenu/index.jsx:100
+msgid "Run in SQL Lab"
+msgstr "Zaženi v SQL laboratoriju"
+
+#: superset-frontend/src/explore/components/PropertiesModal/index.tsx:63
+msgid "You do not have permission to edit this chart"
+msgstr "Nimate dovoljenja za urejanje tega grafikona"
+
+#: superset-frontend/src/explore/components/PropertiesModal/index.tsx:219
+msgid ""
+"The description can be displayed as widget headers in the dashboard view. "
+"Supports markdown."
+msgstr ""
+"Opis je lahko prikazan kot glava gradnika in pogledu nadzorne plošče. "
+"Podpira markdown."
+
+#: superset-frontend/src/explore/components/PropertiesModal/index.tsx:238
+msgid ""
+"Duration (in seconds) of the caching timeout for this chart. Note this "
+"defaults to the dataset's timeout if undefined."
+msgstr ""
+"Časovna veljavnost (v sekundah) predpomnjenja za ta grafikon. Če ni "
+"definirana, je uporabljena vrednost za podatkovni set."
+
+#: superset-frontend/src/explore/components/PropertiesModal/index.tsx:259
+msgid ""
+"A list of users who can alter the chart. Searchable by name or username."
+msgstr ""
+"Seznam uporabnikov, ki lahko spreminjajo ta grafikon. Možno je iskanje po "
+"imenu ali uporabniškem imenu."
+
+#: superset-frontend/src/explore/components/controls/BoundsControl.jsx:112
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:84
+msgid "Min"
+msgstr "Min"
+
+#: superset-frontend/src/explore/components/controls/BoundsControl.jsx:118
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:96
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx:55
+msgid "Max"
+msgstr "Max"
+
+#: superset-frontend/src/explore/components/controls/SelectControl.jsx:76
+#: superset-frontend/src/visualizations/FilterBox/FilterBox.jsx:412
+msgid "No results found"
+msgstr "Rezultati niso najdeni"
+
+#: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.jsx:301
+#: superset-frontend/src/explore/components/controls/SelectControl.jsx:252
+#, python-format
+msgid "%s option(s)"
+msgstr "Možnosti: %s"
+
+#: superset-frontend/src/explore/components/controls/SpatialControl.jsx:82
+msgid "Invalid lat/long configuration."
+msgstr "Neveljavna nastavitev zemljepisne dolžine/širine."
+
+#: superset-frontend/src/explore/components/controls/SpatialControl.jsx:154
+msgid "Reverse lat/long "
+msgstr "Zamenjaj zemljepisno dolžino/širino "
+
+#: superset-frontend/src/explore/components/controls/SpatialControl.jsx:167
+msgid "Longitude & Latitude columns"
+msgstr "Stolpci zemljepisne dolžine in širine"
+
+#: superset-frontend/src/explore/components/controls/SpatialControl.jsx:183
+msgid "Delimited long & lat single column"
+msgstr "En stolpec z ločenima zemljepisno dolžino in širino"
+
+#: superset-frontend/src/explore/components/controls/SpatialControl.jsx:184
+msgid ""
+"Multiple formats accepted, look the geopy.points Python library for more "
+"details"
+msgstr ""
+"Sprejema različne zapise - podrobnosti najdete v Pythonovi knjižnici geopy."
+"points"
+
+#: superset-frontend/src/explore/components/controls/SpatialControl.jsx:202
+msgid "Geohash"
+msgstr "Geohash"
+
+#: superset-frontend/src/explore/components/controls/TextAreaControl.jsx:103
+msgid "textarea"
+msgstr "področje besedila"
+
+#: superset-frontend/src/explore/components/controls/TextAreaControl.jsx:133
+msgid "in modal"
+msgstr "v modalnem"
+
+#: superset-frontend/src/explore/components/controls/withAsyncVerification.tsx:208
+#, python-format
+msgid "Failed to verify select options: %s"
+msgstr "Preverjanje možnosti izbire ni uspelo: %s"
+
+#: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:485
+msgid "Annotation Slice Configuration"
+msgstr "Nastavitve rezine z oznakami"
+
+#: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:486
+msgid ""
+"This section allows you to configure how to use the slice\r\n"
+"               to generate annotations."
+msgstr ""
+"V tem sklopu lahko nastavite način uporabe rezine\r\n"
+"               za ustvarjanje oznak."
+
+#: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:638
+msgid "Display configuration"
+msgstr "Prikaži nastavitve"
+
+#: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:639
+msgid "Configure your how you overlay is displayed here."
+msgstr "Nastavite kako se tukaj prikazuje vrhnja plast."
+
+#: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:643
+msgid "Style"
+msgstr "Stil"
+
+#: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:658
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Polygon/controlPanel.js:115
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:220
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:164
+msgid "Opacity"
+msgstr "Prosojnost"
+
+#: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:675
+msgid "Color"
+msgstr "Barva"
+
+#: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:694
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:194
+msgid "Line width"
+msgstr "Debelina črte"
+
+#: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:743
+msgid "Layer configuration"
+msgstr "Nastavitve sloja"
+
+#: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:744
+msgid "Configure the basics of your Annotation Layer."
+msgstr "Osnovne nastavitve sloja z oznakami."
+
+#: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:752
+#: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:785
+msgid "Mandatory"
+msgstr "Obvezno"
+
+#: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:756
+msgid "Hide layer"
+msgstr "Skrij sloj"
+
+#: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:762
+msgid "Choose the annotation layer type"
+msgstr "Izberite tip sloja z oznakami"
+
+#: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:763
+msgid "Annotation layer type"
+msgstr "Tip sloja z oznakami"
+
+#: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:801
+msgid "Remove"
+msgstr "Odstrani"
+
+#: superset-frontend/src/explore/components/controls/AnnotationLayerControl/index.jsx:185
+msgid "Edit annotation layer"
+msgstr "Uredi sloj z oznakami"
+
+#: superset-frontend/src/explore/components/controls/AnnotationLayerControl/index.jsx:216
+#: superset-frontend/src/explore/components/controls/AnnotationLayerControl/index.jsx:228
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayerModal.tsx:253
+msgid "Add annotation layer"
+msgstr "Dodaj sloj z oznakami"
+
+#: superset-frontend/src/explore/components/controls/CollectionControl/index.jsx:59
+msgid "Empty collection"
+msgstr "Prazen izbor"
+
+#: superset-frontend/src/explore/components/controls/CollectionControl/index.jsx:63
+msgid "Add an item"
+msgstr "Dodaj element"
+
+#: superset-frontend/src/explore/components/controls/CollectionControl/index.jsx:142
+msgid "Remove item"
+msgstr "Odstrani element"
+
+#: superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx:171
+msgid "Edit dataset"
+msgstr "Uredi podatkovni set"
+
+#: superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx:176
+msgid "View in SQL Lab"
+msgstr "Ogled v SQL laboratoriju"
+
+#: superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx:223
+msgid "More dataset related options"
+msgstr "Več nastavitev za podatkovni set"
+
+#: superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx:237
+msgid "Missing dataset"
+msgstr "Manjka podatkovni set"
+
+#: superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx:242
+msgid "The dataset linked to this chart may have been deleted."
+msgstr "Podatkovni set, povezan s tem grafikonom, je bil izbrisan."
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx:279
+msgid "RANGE TYPE"
+msgstr "TIP OBDOBJA"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx:302
+msgid "Actual time range"
+msgstr "Dejansko časovno obdobje"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx:323
+msgid "CANCEL"
+msgstr "PREKINI"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx:333
+msgid "APPLY"
+msgstr "UPORABI"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx:342
+msgid "Edit time range"
+msgstr "Uredi časovno obdobje"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/AdvancedFrame.tsx:58
+msgid "Configure Advanced Time Range "
+msgstr "Nastavi napredno časovno obdobje "
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/AdvancedFrame.tsx:64
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx:115
+msgid "START (INCLUSIVE)"
+msgstr "ZAČETEK (VKLJUČEN)"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/AdvancedFrame.tsx:66
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx:117
+msgid "Start date included in time range"
+msgstr "Začetni datum je vključen v časovno obdobje"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/AdvancedFrame.tsx:76
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx:173
+msgid "END (EXCLUSIVE)"
+msgstr "KONEC (NI VKLJUČEN)"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/AdvancedFrame.tsx:78
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx:175
+msgid "End date excluded from time range"
+msgstr "Končni datum ni vključen v časovno obdobje"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/CalendarFrame.tsx:43
+msgid "Configure Time Range: Previous..."
+msgstr "Nastavi časovno obdobje: Prejšnji ..."
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/CommonFrame.tsx:41
+msgid "Configure Time Range: Last..."
+msgstr "Nastavi časovno obdobje: Zadnji ..."
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx:111
+msgid "Configure custom time range"
+msgstr "Nastavi prilagojeno časovno obdobje"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx:147
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx:204
+msgid "Relative quantity"
+msgstr "Relativne vrednosti"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx:231
+msgid "Anchor to"
+msgstr "Sidraj na"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx:240
+msgid "NOW"
+msgstr "ZDAJ"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx:243
+msgid "Date/Time"
+msgstr "Datum/Čas"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/DateFunctionTooltip.tsx:29
+msgid "Return to specific datetime."
+msgstr "Vrne določen datum-čas."
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/DateFunctionTooltip.tsx:30
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/DateFunctionTooltip.tsx:44
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/DateFunctionTooltip.tsx:62
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/DateFunctionTooltip.tsx:76
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/DateFunctionTooltip.tsx:89
+msgid "Syntax"
+msgstr "Sintaksa"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/DateFunctionTooltip.tsx:34
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/DateFunctionTooltip.tsx:49
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/DateFunctionTooltip.tsx:67
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/DateFunctionTooltip.tsx:81
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/DateFunctionTooltip.tsx:95
+msgid "Example"
+msgstr "Primer"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/DateFunctionTooltip.tsx:43
+msgid "Moves the given set of dates by a specified interval."
+msgstr "Premakne dani nabor datumov za definirano obdobje."
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/DateFunctionTooltip.tsx:58
+msgid ""
+"Truncates the specified date to the accuracy specified by the date unit."
+msgstr ""
+"Zaokroži določen datum, glede na natančnost, definirano s časovno enoto."
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/DateFunctionTooltip.tsx:75
+msgid "Get the last date by the date unit."
+msgstr "Pridobi zadnji datum glede na časovno enoto."
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/components/DateFunctionTooltip.tsx:88
+msgid "Get the specify date for the holiday"
+msgstr "Določi datum praznika"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:31
+msgid "Last"
+msgstr "Zadnji"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:32
+#: superset-frontend/src/views/CRUD/data/query/QueryPreviewModal.tsx:127
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryPreviewModal.tsx:106
+msgid "Previous"
+msgstr "Prejšnji"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:33
+msgid "Custom"
+msgstr "Prilagojen"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:39
+msgid "last day"
+msgstr "zadnji dan"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:40
+msgid "last week"
+msgstr "zadnji teden"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:41
+msgid "last month"
+msgstr "zadnji mesec"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:42
+msgid "last quarter"
+msgstr "zadnje četrletje"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:43
+msgid "last year"
+msgstr "zadnje leto"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:50
+msgid "previous calendar week"
+msgstr "prejšnji koledarski teden"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:51
+msgid "previous calendar month"
+msgstr "prejšnji koledarski mesec"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:52
+msgid "previous calendar year"
+msgstr "prejšnje koledarsko leto"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:72
+msgid "Before"
+msgstr "PRED"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:79
+msgid "After"
+msgstr "PO"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:84
+msgid "Specific Date/Time"
+msgstr "Fiksen Datum/Čas"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:85
+msgid "Relative Date/Time"
+msgstr "Relativen Datum/Čas"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:86
+msgid "Now"
+msgstr "Zdaj"
+
+#: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:87
+msgid "Midnight"
+msgstr "Polnoč"
+
+#: superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx:83
+msgid "Drop column"
+msgstr "Izpusti stolpec"
+
+#: superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx:324
+msgid "Drop columns or metrics"
+msgstr "Izpusti stolpce ali mere"
+
+#: superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx:280
+msgid "Drop column or metric"
+msgstr "Izpusti stolpec ali mero"
+
+#: superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx:58
+msgid "Drop columns"
+msgstr "Izpusti stolpce"
+
+#: superset-frontend/src/explore/components/controls/FilterBoxItemControl/index.jsx:169
+msgid "Default"
+msgstr "Privzeto"
+
+#: superset-frontend/src/explore/components/controls/FilterBoxItemControl/index.jsx:170
+msgid ""
+"(optional) default value for the filter, when using the multiple option, you "
+"can use a semicolon-delimited list of options."
+msgstr ""
+"(opcijsko) privzeta vrednost za filter, če uporabite opcijo izbire večih , "
+"lahko uporabite seznam nastavitev ločen s podpičji."
+
+#: superset-frontend/src/explore/components/controls/FilterBoxItemControl/index.jsx:186
+msgid "Sort metric"
+msgstr "Mera za razvrščanje"
+
+#: superset-frontend/src/explore/components/controls/FilterBoxItemControl/index.jsx:187
+msgid "Metric to sort the results by"
+msgstr "Mera za razvrščanje rezultatov"
+
+#: superset-frontend/src/explore/components/controls/FilterBoxItemControl/index.jsx:207
+#: superset-frontend/src/filters/components/Select/controlPanel.ts:54
+msgid "Check for sorting ascending"
+msgstr "Označi za naraščajoče razvrščanje"
+
+#: superset-frontend/src/explore/components/controls/FilterBoxItemControl/index.jsx:217
+msgid "Allow multiple selections"
+msgstr "Dovoli več izbir"
+
+#: superset-frontend/src/explore/components/controls/FilterBoxItemControl/index.jsx:219
+msgid ""
+"Multiple selections allowed, otherwise filter is limited to a single value"
+msgstr ""
+"Lahko izberete več elementov, drugače pa je filter omejen na eno vrednost"
+
+#: superset-frontend/src/explore/components/controls/FilterBoxItemControl/index.jsx:233
+#: superset-frontend/src/filters/components/Select/controlPanel.ts:121
+msgid "Search all filter options"
+msgstr "PoIšči vse možnosti filtra"
+
+#: superset-frontend/src/explore/components/controls/FilterBoxItemControl/index.jsx:234
+#: superset-frontend/src/filters/components/Select/controlPanel.ts:123
+msgid ""
+"By default, each filter loads at most 1000 choices at the initial page load. "
+"Check this box if you have more than 1000 filter values and want to enable "
+"dynamically searching that loads filter values as users type (may add stress "
+"to your database)."
+msgstr ""
+"Privzeto vsak filter pri nalaganju začetne strani naloži največ 1000 "
+"možnosti. Označite polje, če imate več kot 1000 vrednosti filtra in želite "
+"omogočiti dinamično iskanje, ki nalaga vrednosti filtra ko uporabnik tipka "
+"(to lahko preobremeni vašo podatkovno bazo)."
+
+#: superset-frontend/src/explore/components/controls/FilterBoxItemControl/index.jsx:253
+#: superset-frontend/src/filters/components/Select/controlPanel.ts:77
+msgid "Required"
+msgstr "Obvezno"
+
+#: superset-frontend/src/explore/components/controls/FilterBoxItemControl/index.jsx:254
+msgid "User must select a value for this filter"
+msgstr "Uporabnik mora izbrati vrednost za ta filter"
+
+#: superset-frontend/src/explore/components/controls/FilterBoxItemControl/index.jsx:283
+msgid "Filter configuration"
+msgstr "Nastavitve filtra"
+
+#: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.jsx:202
+#: superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx:379
+msgid "Simple"
+msgstr "Preprosto"
+
+#: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.jsx:219
+#: superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx:413
+msgid "Custom SQL"
+msgstr "Prilagojen SQL"
+
+#: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.jsx:321
+msgid "No such column found. To filter on a metric, try the Custom SQL tab."
+msgstr ""
+"Tak stolpec ni najden. Za filtriranje po meri uporabite prilagojen SQL "
+"zavihek."
+
+#: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.jsx:330
+#, python-format
+msgid "%s column(s) and metric(s)"
+msgstr "Stolpcev in mer: %s"
+
+#: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.jsx:343
+#: superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx:296
+#, python-format
+msgid "%s column(s)"
+msgstr "Stolpci: %s"
+
+#: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.jsx:344
+msgid "To filter on a metric, use Custom SQL tab."
+msgstr "Za filtriranje po meri uporabite prilagojen SQL zavihek."
+
+#: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.jsx:351
+#, python-format
+msgid "%s operator(s)"
+msgstr "Operatorji: %s"
+
+#: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.jsx:373
+msgid "Type a value here"
+msgstr "Vnesite vrednost sem"
+
+#: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.jsx:452
+msgid "Filter value (case sensitive)"
+msgstr "Vrednost filtra (razlik. velikih/malih črk)"
+
+#: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSqlTabContent/index.jsx:95
+msgid "choose WHERE or HAVING..."
+msgstr "izberite WHERE ali HAVING..."
+
+#: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSqlTabContent/index.jsx:131
+msgid "Filters by columns"
+msgstr "Filtrira po stolpcu"
+
+#: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSqlTabContent/index.jsx:133
+msgid "Filters by metrics"
+msgstr "Filtrira po merah"
+
+#: superset-frontend/src/explore/components/controls/FixedOrMetricControl/index.jsx:149
+msgid "Fixed"
+msgstr "Fiksno"
+
+#: superset-frontend/src/explore/components/controls/FixedOrMetricControl/index.jsx:165
+msgid "Based on a metric"
+msgstr "Osnovan na meri"
+
+#: superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopoverTitle.jsx:73
+msgid "My metric"
+msgstr "Moja mera"
+
+#: superset-frontend/src/explore/components/controls/MetricControl/MetricsControl.jsx:415
+msgid "Add metric"
+msgstr "Dodaj mero"
+
+#: superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx:307
+#, python-format
+msgid "%s aggregates(s)"
+msgstr "Agreg. funkcije: %s"
+
+#: superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx:316
+#, python-format
+msgid "%s saved metric(s)"
+msgstr "Shranjene mere: %s"
+
+#: superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx:357
+msgid "Saved"
+msgstr "Shranjeno"
+
+#: superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx:358
+msgid "Saved metric"
+msgstr "Shranjena mera"
+
+#: superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx:380
+msgid "column"
+msgstr "stolpec"
+
+#: superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx:397
+msgid "aggregate"
+msgstr "agregacija"
+
+#: superset-frontend/src/explore/components/controls/OptionControls/index.tsx:301
+msgid ""
+"\r\n"
+"                This filter was inherited from the dashboard's context.\r\n"
+"                It won't be saved when saving the chart.\r\n"
+"              "
+msgstr ""
+"\r\n"
+"                Ta filter izvira iz nadzorne plošče.\r\n"
+"                Ne bo se shranil pri shranjevanju grafikona.\r\n"
+"                "
+
+#: superset-frontend/src/explore/components/controls/SelectAsyncControl/index.jsx:45
+msgid "Error while fetching data"
+msgstr "Napaka pri pridobivanju podatkov"
+
+#: superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/index.jsx:48
+#: superset-frontend/src/explore/controlPanels/TimeTable.js:38
+msgid "Time series columns"
+msgstr "Stolpci s časovnimi vrstami"
+
+#: superset-frontend/src/explore/components/controls/VizTypeControl/index.jsx:106
+msgid "This visualization type is not supported."
+msgstr "Ta tip vizualizacije ni podprt."
+
+#: superset-frontend/src/explore/components/controls/VizTypeControl/index.jsx:198
+msgid "Click to change visualization type"
+msgstr "Kliknite za spremembo tipa vizualizacije"
+
+#: superset-frontend/src/explore/components/controls/VizTypeControl/index.jsx:214
+msgid "Select a visualization type"
+msgstr "Izberite tip vizualizacije"
+
+#: superset-frontend/src/explore/controlPanels/Separator.js:25
+#: superset-frontend/src/explore/controlPanels/Separator.js:46
+msgid "Code"
+msgstr "Koda"
+
+#: superset-frontend/src/explore/controlPanels/Separator.js:32
+msgid "Markup type"
+msgstr "Tip označevanja"
+
+#: superset-frontend/src/explore/controlPanels/Separator.js:37
+msgid "Pick your favorite markup language"
+msgstr "Izberite svoj priljubljen označevalni jezik"
+
+#: superset-frontend/src/explore/controlPanels/Separator.js:47
+msgid "Put your code here"
+msgstr "Vstavite svojo kodo sem"
+
+#: superset-frontend/src/explore/controlPanels/TimeTable.js:26
+#: superset-frontend/src/explore/controlPanels/sections.tsx:113
+#: superset-frontend/src/filters/components/Range/controlPanel.ts:30
+#: superset-frontend/src/filters/components/Select/controlPanel.ts:38
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:179
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/Multi/controlPanel.js:60
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Arc/controlPanel.js:44
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Geojson/controlPanel.js:47
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Grid/controlPanel.js:39
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Hex/controlPanel.js:47
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Path/controlPanel.js:41
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Polygon/controlPanel.js:56
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Scatter/controlPanel.js:54
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Screengrid/controlPanel.js:39
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:32
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-chord/src/controlPanel.ts:26
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-country-map/src/controlPanel.ts:32
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-event-flow/src/controlPanel.tsx:90
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-force-directed/src/controlPanel.ts:26
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:60
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts:55
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-horizon/src/controlPanel.ts:26
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:45
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts:26
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-parallel-coordinates/src/controlPanel.ts:26
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:36
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.ts:33
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:34
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sankey-loop/src/controlPanel.ts:26
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sankey/src/controlPanel.ts:26
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts:26
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-time-table/src/controlPanel.ts:26
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-treemap/src/controlPanel.ts:31
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:26
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx:28
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumberTotal/controlPanel.ts:27
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bubble/controlPanel.ts:43
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:26
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts:39
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/DualLine/controlPanel.ts:50
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:156
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:335
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Pie/controlPanel.ts:26
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/TimePivot/controlPanel.ts:39
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts:35
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Funnel/controlPanel.tsx:40
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:33
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:40
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:48
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx:68
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:66
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:38
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Treemap/controlPanel.tsx:43
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:31
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:169
+#: superset-ui/superset-ui/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.ts:26
+#: superset-ui/superset-ui/plugins/preset-chart-xy/src/BoxPlot/controlPanel.ts:26
+msgid "Query"
+msgstr "Poizvedba"
+
+#: superset-frontend/src/explore/controlPanels/TimeTable.js:50
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-time-table/src/controlPanel.ts:49
+msgid "URL"
+msgstr "URL"
+
+#: superset-frontend/src/explore/controlPanels/TimeTable.js:51
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-time-table/src/controlPanel.ts:50
+msgid ""
+"Templated link, it's possible to include {{ metric }} or other values coming "
+"from the controls."
+msgstr ""
+"Vzorčna povezava, vključiti je mogoče {{ metric }} ali drugo vrednost iz "
+"kontrolnikov."
+
+# SUPERSET UI
+#: superset-frontend/src/explore/controlPanels/sections.tsx:25
+#: superset-frontend/src/explore/controlPanels/sections.tsx:84
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:191
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/constants.ts:33
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/sections.tsx:28
+msgid "Time"
+msgstr "Čas"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:27
+#: superset-frontend/src/explore/controlPanels/sections.tsx:85
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/sections.tsx:30
+msgid "Time related form attributes"
+msgstr "S časom povezani atributi prikaza"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:32
+msgid "Chart type"
+msgstr "Tip grafikona"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:42
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/sections.tsx:60
+msgid "Chart ID"
+msgstr "ID grafikona"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:44
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/sections.tsx:62
+msgid "The id of the active chart"
+msgstr "Identifikator aktivnega grafikona"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:51
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/sections.tsx:69
+msgid "Cache Timeout (seconds)"
+msgstr "Trajanje predpomnilnika (sekunde)"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:53
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/sections.tsx:71
+msgid "The number of seconds before expiring the cache"
+msgstr "Trajanje (v sekundah) do razveljavitve predpomnilnika"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:60
+msgid "URL parameters"
+msgstr "Parametri URL"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:62
+msgid "Extra parameters for use in jinja templated queries"
+msgstr "Dodatni parametri za poizvedbe z jinja predlogami"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:69
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/sections.tsx:98
+msgid "Time range endpoints"
+msgstr "Krajne točke časovnega obdobja"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:71
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/sections.tsx:100
+msgid "Time range endpoints (SIP-15)"
+msgstr "Krajne točke časovnega obdobja (SIP-15)"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:91
+msgid "Annotations and layers"
+msgstr "Oznake in sloji"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:127
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-horizon/src/controlPanel.ts:40
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts:47
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-parallel-coordinates/src/controlPanel.ts:42
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:50
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.ts:49
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:48
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-treemap/src/controlPanel.ts:46
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts:55
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:350
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:94
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:97
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:317
+msgid "Whether to sort descending or ascending"
+msgstr "Če želite padajoče ali naraščajoče razvrščanje"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:134
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-horizon/src/controlPanel.ts:47
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts:54
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:57
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:55
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts:64
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:359
+msgid "Contribution"
+msgstr "Prispevek"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:136
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-horizon/src/controlPanel.ts:49
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts:56
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:59
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:57
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts:66
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:361
+msgid "Compute the contribution to the total"
+msgstr "Izračunaj prispevek k celoti"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:144
+msgid "Advanced analytics"
+msgstr "Napredna analitika"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:146
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:230
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:125
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:371
+msgid ""
+"This section contains options that allow for advanced analytical post "
+"processing of query results"
+msgstr ""
+"Ta sekcija vsebuje možnosti, ki omogočajo napredno analitično poprocesiranje "
+"rezultatov poizvedb"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:152
+msgid "Rolling window"
+msgstr "Drseče okno"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:158
+msgid "Rolling function"
+msgstr "Drseča funkcija"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:167
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:247
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:142
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx:126
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:386
+msgid ""
+"Defines a rolling window function to apply, works along with the [Periods] "
+"text box"
+msgstr ""
+"Določi funkcijo drsečega okna. Dela skupaj s tekstovnim okvirjem [Obdobja]"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:177
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:259
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:154
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx:138
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:398
+msgid "Periods"
+msgstr "Št. period"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:179
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:261
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:156
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx:140
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:400
+msgid ""
+"Defines the size of the rolling window function, relative to the time "
+"granularity selected"
+msgstr ""
+"Določi velikost funkcije drsečega okna, glede na izbrano granulacijo časa"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:189
+msgid "Min periods"
+msgstr "Min. št. period"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:191
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:273
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:168
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx:154
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:414
+msgid ""
+"The minimum number of rolling periods required to show a value. For instance "
+"if you do a cumulative sum on 7 days you may want your \"Min Period\" to be "
+"7, so that all data points shown are the total of 7 periods. This will hide "
+"the \"ramp up\" taking place over the first 7 periods"
+msgstr ""
+"Minimalno število drsečih obdobij, potrebnih za prikaz vrednosti. Če "
+"računate kumulativno vsoto 7-dnevnega obdobja, boste nastavili \"Min. št. "
+"period\" na 7. Tako bodo vse prikazane točke skupaj obsegale 7 obdobij. To "
+"bo prikrilo rampo, ki bi trajala prvih 7 obdobij"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:201
+msgid "Time comparison"
+msgstr "Časovna primerjava"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:209
+msgid "Time shift"
+msgstr "Časovni zamik"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:220
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:304
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:199
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:443
+msgid ""
+"Overlay one or more timeseries from a relative time period. Expects relative "
+"time deltas in natural language (example:  24 hours, 7 days, 52 weeks, 365 "
+"days). Free text is supported."
+msgstr ""
+"Zamaknite eno ali več časovnih vrst za relativno časovno obdobje. Vnaša se "
+"relativne časovne razlike v naravnem jeziku (npr. 24 ur, 7 dni, 52 tednov, "
+"365 dni). Prosto besedilo je podprto."
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:232
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:316
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:211
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:457
+msgid "Calculation type"
+msgstr "Tip izračuna"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:240
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:324
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:219
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:465
+msgid ""
+"How to display time shifts: as individual lines; as the absolute difference "
+"between the main time series and each time shift; as the percentage change; "
+"or as the ratio between series and time shifts."
+msgstr ""
+"Način prikaza časovnih zamikov: kot samostojne črte; kot absolutne razlike "
+"med osnovno časovno vrsto in vsakim časovnim zamikom; kot procentualna "
+"sprememba; kot razmerje med vrsto in časovnim zamikom."
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:248
+msgid "Python functions"
+msgstr "Pythonove funkcije"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:258
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:344
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:239
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:481
+msgid "Rule"
+msgstr "Pravilo"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:261
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:347
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:242
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:484
+msgid "Pandas resample rule"
+msgstr "Pravilo za prevzorčenje v Pandas"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:269
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:355
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:250
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:494
+msgid "Method"
+msgstr "Metoda"
+
+#: superset-frontend/src/explore/controlPanels/sections.tsx:279
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:358
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:253
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:497
+msgid "Pandas resample method"
+msgstr "Metoda za prevzorčenje v Pandas"
+
+#: superset-frontend/src/filters/components/GroupBy/GroupByFilterPlugin.tsx:71
+msgid "No columns"
+msgstr "Brez stolpcev"
+
+#: superset-frontend/src/filters/components/GroupBy/GroupByFilterPlugin.tsx:72
+#: superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx:246
+#: superset-frontend/src/filters/components/TimeColumn/TimeColumnFilterPlugin.tsx:85
+#: superset-frontend/src/filters/components/TimeGrain/TimeGrainFilterPlugin.tsx:82
+#, python-format
+msgid "%s option"
+msgstr "%s možnost"
+
+#: superset-frontend/src/filters/components/GroupBy/controlPanel.ts:31
+#: superset-frontend/src/filters/components/Select/controlPanel.ts:43
+msgid "UI Configuration"
+msgstr "UI nastavitve"
+
+#: superset-frontend/src/filters/components/GroupBy/controlPanel.ts:39
+#: superset-frontend/src/filters/components/Select/controlPanel.ts:63
+msgid "Multiple select"
+msgstr "Več izborov"
+
+#: superset-frontend/src/filters/components/GroupBy/controlPanel.ts:44
+#: superset-frontend/src/filters/components/Select/controlPanel.ts:68
+msgid "Allow selecting multiple values"
+msgstr "Dovoli izbiro več vrednosti"
+
+#: superset-frontend/src/filters/components/GroupBy/index.ts:28
+msgid "Group By"
+msgstr "Združevanje (Group by)"
+
+#: superset-frontend/src/filters/components/GroupBy/index.ts:29
+msgid "Group By filter plugin"
+msgstr "Vtičnik za filter za združevanje"
+
+#: superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx:79
+msgid "Chosen non-numeric column"
+msgstr "Izbran ne-numeričen stolpec"
+
+#: superset-frontend/src/filters/components/Range/index.ts:28
+msgid "Range filter"
+msgstr "Filter obdobja"
+
+#: superset-frontend/src/filters/components/Range/index.ts:29
+msgid "Range filter plugin using AntD"
+msgstr "Vtičnik za filter obdobja z uporabo AntD"
+
+#: superset-frontend/src/filters/components/Select/controlPanel.ts:80
+msgid ""
+"User must select a value for this filter when filter is in single select "
+"mode. If selection is empty, an always false filter is emitted."
+msgstr ""
+"Uporabnik mora izbrati vrednost filtra, ko je le-ta v načinu posamičnega "
+"izbora. Če je izbor prazen, je oddan vedno napačen (false) filter."
+
+#: superset-frontend/src/filters/components/Select/controlPanel.ts:92
+msgid "Default to first item"
+msgstr "Privzet prvi element"
+
+#: superset-frontend/src/filters/components/Select/controlPanel.ts:97
+msgid "Select first item by default"
+msgstr "Kot privzeta vrednost je izbran prvi element"
+
+#: superset-frontend/src/filters/components/Select/controlPanel.ts:108
+msgid "Inverse selection"
+msgstr "Invertiraj izbiro"
+
+#: superset-frontend/src/filters/components/Select/controlPanel.ts:110
+msgid "Exclude selected values"
+msgstr "Izloči izbrane vrednosti"
+
+#: superset-frontend/src/filters/components/Select/index.ts:28
+msgid "Select filter"
+msgstr "Izbirni filter"
+
+#: superset-frontend/src/filters/components/Select/index.ts:29
+msgid "Select filter plugin using AntD"
+msgstr "Izberite Vtičnik za filter z uporabo AntD"
+
+#: superset-frontend/src/filters/components/Time/index.ts:27
+msgid "Time filter"
+msgstr "Časovni filter"
+
+#: superset-frontend/src/filters/components/Time/index.ts:28
+msgid "Custom time filter plugin"
+msgstr "Prilagojeni vtičnik za časovni filter"
+
+#: superset-frontend/src/filters/components/TimeColumn/TimeColumnFilterPlugin.tsx:84
+msgid "No time columns"
+msgstr "Ni časovnih stolpcev"
+
+#: superset-frontend/src/filters/components/TimeColumn/index.ts:29
+msgid "Time column filter plugin"
+msgstr "Vtičnik za časovni filter"
+
+#: superset-frontend/src/filters/components/TimeGrain/index.ts:29
+msgid "Time grain filter plugin"
+msgstr "Vtičnik za filter časovne granulacije"
+
+#: superset-frontend/src/profile/components/App.tsx:52
+msgid "Favorites"
+msgstr "Priljubljene"
+
+#: superset-frontend/src/profile/components/App.tsx:62
+msgid "Created content"
+msgstr "Ustvarjena vsebina"
+
+#: superset-frontend/src/profile/components/App.tsx:72
+msgid "Recent activity"
+msgstr "Nedavna aktivnost"
+
+#: superset-frontend/src/profile/components/App.tsx:82
+msgid "Security & Access"
+msgstr "Varnost in Dostopi"
+
+#: superset-frontend/src/profile/components/CreatedContent.tsx:45
+msgid "No charts"
+msgstr "Ni grafikonov"
+
+#: superset-frontend/src/profile/components/CreatedContent.tsx:63
+msgid "No dashboards"
+msgstr "Ni nadzornih plošč"
+
+#: superset-frontend/src/profile/components/Favorites.tsx:46
+msgid "No favorite charts yet, go click on stars!"
+msgstr "Priljubljenih grafikonov še ni. Kliknite na zvezdice!"
+
+#: superset-frontend/src/profile/components/Favorites.tsx:64
+msgid "No favorite dashboards yet, go click on stars!"
+msgstr "Priljubljenih nadzornih plošč še ni. Kliknite na zvezdice!"
+
+#: superset-frontend/src/profile/components/UserInfo.tsx:44
+msgid "Profile picture provided by Gravatar"
+msgstr "Profilno sliko je zagotovil Gravatar"
+
+#: superset-frontend/src/profile/components/UserInfo.tsx:63
+msgid "joined"
+msgstr "pridružen"
+
+#: superset-frontend/src/profile/components/UserInfo.tsx:75
+msgid "id:"
+msgstr "id:"
+
+#: superset-frontend/src/utils/downloadAsImage.ts:63
+msgid "Image download failed, please refresh and try again."
+msgstr "Prenos slike ni uspel. Osvežite in poskusite ponovno."
+
+#: superset-frontend/src/utils/getClientErrorObject.ts:60
+msgid "Unexpected error: "
+msgstr "Nepričakovana napaka: "
+
+#: superset-frontend/src/utils/getClientErrorObject.ts:61
+msgid "(no description, click to see stack trace)"
+msgstr "(ni opisa, kliknite za ogled zapisov)"
+
+#: superset-frontend/src/utils/getClientErrorObject.ts:123
+msgid "Issue 1000 - The dataset is too large to query."
+msgstr "Težava 1000 - podatkovni vir je prevelik za poizvedbo."
+
+#: superset-frontend/src/views/CRUD/hooks.ts:99
+#, python-format
+msgid "An error occurred while fetching %s info: %s"
+msgstr "Napaka pri pridobivanju informacij za %s: %s"
+
+#: superset-frontend/src/views/CRUD/hooks.ts:165
+#: superset-frontend/src/views/CRUD/hooks.ts:255
+#: superset-frontend/src/views/CRUD/hooks.ts:339
+#, python-format
+msgid "An error occurred while fetching %ss: %s"
+msgstr "Napaka pri pridobivanju informacij za %s: %s"
+
+#: superset-frontend/src/views/CRUD/hooks.ts:297
+#, python-format
+msgid "An error occurred while creating %ss: %s"
+msgstr "Napaka pri ustvarjanju %s: %s"
+
+#: superset-frontend/src/views/CRUD/hooks.ts:471
+#: superset-frontend/src/views/CRUD/hooks.ts:481
+#, python-format
+msgid "An error occurred while importing %s: %s"
+msgstr "Napaka pri uvažanju %s: %s"
+
+#: superset-frontend/src/views/CRUD/hooks.ts:552
+#, python-format
+msgid "There was an error fetching the favorite status: %s"
+msgstr "Napaka pri pridobivanju statusa \"Priljubljeno\": %s"
+
+#: superset-frontend/src/views/CRUD/hooks.ts:573
+#, python-format
+msgid "There was an error saving the favorite status: %s"
+msgstr "Napaka pri shranjevanju statusa \"Priljubljeno\": %s"
+
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:218
+#: superset-frontend/src/views/CRUD/hooks.ts:632
+msgid "Link Copied!"
+msgstr "Povezava kopirana!"
+
+#: superset-frontend/src/views/CRUD/hooks.ts:650
+msgid "Connection looks good!"
+msgstr "Povezava izgleda v redu!"
+
+#: superset-frontend/src/views/CRUD/hooks.ts:653
+msgid "${t('ERROR: ')}${parsedErrorMessage(errMsg)}"
+msgstr "${t('NAPAKA: ')}${parsedErrorMessage(errMsg)}"
+
+#: superset-frontend/src/views/CRUD/utils.tsx:146
+msgid "There was an error fetching your recent activity:"
+msgstr "Pri pridobivanju nedavnih aktivnosti je prišlo do napake:"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:153
+#: superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx:108
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx:95
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx:96
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:139
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:530
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:234
+#: superset-frontend/src/views/CRUD/utils.tsx:216
+#: superset-frontend/src/views/CRUD/utils.tsx:281
+#: superset-frontend/src/views/CRUD/welcome/SavedQueries.tsx:167
+#, python-format
+msgid "Deleted: %s"
+msgstr "Izbrisanih: %s"
+
+#: superset-frontend/src/views/CRUD/utils.tsx:219
+#, python-format
+msgid "There was an issue deleting: %s"
+msgstr "Težava pri brisanju: %s"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:156
+#: superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx:112
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx:98
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx:100
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:146
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:534
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:237
+#: superset-frontend/src/views/CRUD/utils.tsx:285
+#: superset-frontend/src/views/CRUD/welcome/SavedQueries.tsx:170
+#, python-format
+msgid "There was an issue deleting %s: %s"
+msgstr "Težava pri brisanju %s: %s"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:80
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:473
+msgid "report"
+msgstr "poročilo"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:80
+msgid "alert"
+msgstr "opozorilo"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:81
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:107
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:116
+#: superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx:72
+msgid "reports"
+msgstr "poročila"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:81
+msgid "alerts"
+msgstr "opozorila"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:171
+#, python-format
+msgid "There was an issue deleting the selected %s: %s"
+msgstr "Težava pri brisanju izbranih %s: %s"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:219
+msgid "Last run"
+msgstr "Zadnji zagon"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:251
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1331
+msgid "Notification method"
+msgstr "Način obveščanja"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:298
+msgid "Execution log"
+msgstr "Dnevnik izvajanja"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:326
+#: superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx:195
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx:254
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:381
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx:232
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:359
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:369
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:389
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:318
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:405
+msgid "Actions"
+msgstr "Aktivnosti"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:353
+#: superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx:218
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx:282
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:550
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx:265
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:497
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:479
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:170
+msgid "Bulk select"
+msgstr "Izberi hkrati"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:367
+#, python-format
+msgid "No %s yet"
+msgstr "%s še ne obstajajo"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:374
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx:217
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx:291
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:294
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:431
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx:195
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx:276
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:265
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:409
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:286
+msgid "Created by"
+msgstr "Ustvaril/a"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:383
+#, python-format
+msgid "An error occurred while fetching created by values: %s"
+msgstr "Pri pridobivanju vrednosti \"ustvaril/a\" je prišlo do napake: %s"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:390
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:244
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:430
+msgid "Status"
+msgstr "Status"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:396
+msgid "${AlertState.success}"
+msgstr "${AlertState.success}"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:397
+msgid "${AlertState.working}"
+msgstr "${AlertState.working}"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:398
+msgid "${AlertState.error}"
+msgstr "${AlertState.error}"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:399
+msgid "${AlertState.noop}"
+msgstr "${AlertState.noop}"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:400
+msgid "${AlertState.grace}"
+msgstr "${AlertState.grace}"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:417
+msgid "Alerts & reports"
+msgstr "Opozorila in poročila"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:428
+msgid "Reports"
+msgstr "Poročila"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:454
+#, python-format
+msgid "This action will permanently delete %s."
+msgstr "S tem dejanjem boste trajno izbrisali %s."
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:465
+#, python-format
+msgid "Delete %s?"
+msgstr "Izbrišem %s?"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:469
+#: superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx:306
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx:370
+#: superset-frontend/src/views/CRUD/chart/ChartCard.tsx:75
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:318
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:596
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx:328
+#: superset-frontend/src/views/CRUD/dashboard/DashboardCard.tsx:106
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:297
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:535
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:600
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:491
+msgid "Please confirm"
+msgstr "Prosim, potrdite"
+
+#: superset-frontend/src/views/CRUD/alert/AlertList.tsx:470
+#, python-format
+msgid "Are you sure you want to delete the selected %s?"
+msgstr "Ali ste prepričani, da želite izbrisati izbrane %s?"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:68
+msgid "< (Smaller than)"
+msgstr "< (manjše kot)"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:72
+msgid "> (Larger than)"
+msgstr "> (večje kot)"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:76
+msgid "<= (Smaller or equal)"
+msgstr "<= (manjše ali enako)"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:80
+msgid ">= (Larger or equal)"
+msgstr ">= (večje ali enako)"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:84
+msgid "== (Is equal)"
+msgstr "== (je enako)"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:88
+msgid "!= (Is not equal)"
+msgstr "!= (ni enako)"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:92
+msgid "Not null"
+msgstr "Ni nič (null)"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:103
+msgid "30 days"
+msgstr "30 dni"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:107
+msgid "60 days"
+msgstr "60 dni"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:111
+msgid "90 days"
+msgstr "90 dni"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:375
+msgid "Add notification method"
+msgstr "Dodajte način obveščanja"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:376
+msgid "Add delivery method"
+msgstr "Dodajte način dostave"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1023
+#: superset-frontend/src/views/CRUD/annotation/AnnotationModal.tsx:289
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayerModal.tsx:241
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplateModal.tsx:232
+#: superset-frontend/src/views/CRUD/data/dataset/AddDatasetModal.tsx:106
+msgid "Add"
+msgstr "Dodaj"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1035
+msgid "Edit ${isReport ? 'Report' : 'Alert'}"
+msgstr "Uredi ${isReport ? 'Report' : 'Alert'}"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1036
+msgid "Add ${isReport ? 'Report' : 'Alert'}"
+msgstr "Add ${isReport ? 'Report' : 'Alert'}"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1044
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1052
+msgid "Report name"
+msgstr "Naslov poročila"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1044
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1052
+msgid "Alert name"
+msgstr "Naslov opozorila"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1099
+msgid "Alert condition"
+msgstr "Status opozorila"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1144
+msgid "Trigger Alert If..."
+msgstr "Sproži opozorilo v primeru ..."
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1168
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1184
+#: superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx:140
+msgid "Value"
+msgstr "Vrednost"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1196
+msgid "Report schedule"
+msgstr "Urnik poročanja"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1197
+msgid "Alert condition schedule"
+msgstr "Urnik statusov opozoril"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1208
+msgid "Schedule settings"
+msgstr "Nastavitve urnika"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1212
+msgid "Log retention"
+msgstr "Hranjenje dnevnikov"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1236
+msgid "Working timeout"
+msgstr "Pretek delovanja"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1245
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1260
+msgid "Time in seconds"
+msgstr "Čas v sekundah"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1253
+msgid "Grace period"
+msgstr "Obdobje mirovanja"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1270
+msgid "Message content"
+msgstr "Vsebina sporočila"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1283
+msgid "Send as PNG"
+msgstr "Pošlji kot PNG"
+
+#: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1284
+msgid "Send as CSV"
+msgstr "Pošlji kot CSV"
+
+#: superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx:63
+msgid "log"
+msgstr "dnevnik"
+
+#: superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx:94
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:357
+msgid "State"
+msgstr "Status"
+
+#: superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx:105
+msgid "Execution ID"
+msgstr "ID izvedbe"
+
+#: superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx:117
+msgid "Scheduled at (UTC)"
+msgstr "Izvede se ob (UTC)"
+
+#: superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx:125
+msgid "Start at (UTC)"
+msgstr "Zažene se ob (UTC)"
+
+#: superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx:135
+msgid "Duration"
+msgstr "Trajanje"
+
+#: superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx:144
+msgid "Error message"
+msgstr "Sporočilo napake"
+
+#: superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx:156
+msgid "${alertResource?.type}"
+msgstr "${alertResource?.type}"
+
+#: superset-frontend/src/views/CRUD/alert/components/AlertReportCronScheduler.tsx:77
+msgid "CRON expression"
+msgstr "Izraz CRON"
+
+#: superset-frontend/src/views/CRUD/alert/components/AlertStatusIcon.tsx:67
+msgid "Report sent"
+msgstr "Poročilo poslano"
+
+#: superset-frontend/src/views/CRUD/alert/components/AlertStatusIcon.tsx:68
+msgid "Alert triggered, notification sent"
+msgstr "Opozorilo sproženo, obvestilo poslano"
+
+#: superset-frontend/src/views/CRUD/alert/components/AlertStatusIcon.tsx:74
+msgid "Report sending"
+msgstr "Pošiljanje poročila"
+
+#: superset-frontend/src/views/CRUD/alert/components/AlertStatusIcon.tsx:75
+msgid "Alert running"
+msgstr "Opozorilo aktivno"
+
+#: superset-frontend/src/views/CRUD/alert/components/AlertStatusIcon.tsx:81
+msgid "Report failed"
+msgstr "Poročilo ni uspelo"
+
+#: superset-frontend/src/views/CRUD/alert/components/AlertStatusIcon.tsx:82
+msgid "Alert failed"
+msgstr "Opozorilo ni uspelo"
+
+#: superset-frontend/src/views/CRUD/alert/components/AlertStatusIcon.tsx:87
+#: superset-frontend/src/views/CRUD/alert/components/AlertStatusIcon.tsx:97
+msgid "Nothing triggered"
+msgstr "Ni ni sproženo"
+
+#: superset-frontend/src/views/CRUD/alert/components/AlertStatusIcon.tsx:92
+msgid "Alert Triggered, In Grace Period"
+msgstr "Opozorilo sproženo, v obdobju mirovanja"
+
+#: superset-frontend/src/views/CRUD/alert/components/NotificationMethod.tsx:164
+msgid "Recipients are separated by \",\" or \";\""
+msgstr "Prejemniki so ločeni z \",\" ali \";\""
+
+#: superset-frontend/src/views/CRUD/alert/components/RecipientIcon.tsx:38
+msgid "${RecipientIconName.email}"
+msgstr "${RecipientIconName.email}"
+
+#: superset-frontend/src/views/CRUD/alert/components/RecipientIcon.tsx:42
+msgid "${RecipientIconName.slack}"
+msgstr "${RecipientIconName.slack}"
+
+#: superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx:64
+#: superset-frontend/src/views/CRUD/annotation/AnnotationModal.tsx:111
+msgid "annotation"
+msgstr "oznaka"
+
+#: superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx:132
+#, python-format
+msgid "There was an issue deleting the selected annotations: %s"
+msgstr "Pri brisanju izbranih oznak je prišlo do težave: %s"
+
+#: superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx:180
+#: superset-frontend/src/views/CRUD/annotation/AnnotationModal.tsx:299
+msgid "Edit annotation"
+msgstr "Uredi oznako"
+
+#: superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx:187
+msgid "Delete annotation"
+msgstr "Izbriši oznako"
+
+#: superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx:208
+#: superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx:255
+msgid "Annotation"
+msgstr "Oznaka"
+
+#: superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx:261
+msgid "No annotation yet"
+msgstr "Oznak še ni"
+
+#: superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx:270
+msgid "Annotation Layer ${annotationLayerName}"
+msgstr "Sloj z oznakami ${annotationLayerName}"
+
+#: superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx:292
+msgid ""
+"Are you sure you want to delete ${annotationCurrentlyDeleting?.short_descr}?"
+msgstr ""
+"Ste prepričani, da želite izbrisati ${annotationCurrentlyDeleting?."
+"short_descr}?"
+
+#: superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx:302
+msgid "Delete Annotation?"
+msgstr "Izbrišem oznako?"
+
+#: superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx:307
+msgid "Are you sure you want to delete the selected annotations?"
+msgstr "Ali ste prepričani, da želite izbrisati izbrane oznake?"
+
+#: superset-frontend/src/views/CRUD/annotation/AnnotationModal.tsx:299
+msgid "Add annotation"
+msgstr "Dodaj oznako"
+
+#: superset-frontend/src/views/CRUD/annotation/AnnotationModal.tsx:308
+msgid "Annotation name"
+msgstr "Ime oznake"
+
+#: superset-frontend/src/views/CRUD/annotation/AnnotationModal.tsx:320
+msgid "date"
+msgstr "datum"
+
+#: superset-frontend/src/views/CRUD/annotation/AnnotationModal.tsx:340
+msgid "Additional information"
+msgstr "Dodatne informacije"
+
+#: superset-frontend/src/views/CRUD/annotation/AnnotationModal.tsx:347
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayerModal.tsx:277
+msgid "Description (this can be seen in the list)"
+msgstr "Opis (lahko je viden na seznamu)"
+
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayerModal.tsx:108
+msgid "annotation_layer"
+msgstr "annotation_layer"
+
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayerModal.tsx:252
+msgid "Edit annotation layer properties"
+msgstr "Uredi lastnosti sloja z oznakami"
+
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayerModal.tsx:262
+msgid "Annotation layer name"
+msgstr "Ime sloja z oznakami"
+
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx:70
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx:348
+msgid "Annotation layers"
+msgstr "Sloji z oznakami"
+
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx:115
+#, python-format
+msgid "There was an issue deleting the selected layers: %s"
+msgstr "Pri brisanju izbranih slojev je prišlo do težave: %s"
+
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx:185
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:278
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx:161
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:301
+msgid "Last modified"
+msgstr "Zadnja sprememba"
+
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx:210
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx:187
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:341
+msgid "Created on"
+msgstr "Ustvarjeno"
+
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx:235
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx:213
+msgid "Edit template"
+msgstr "Uredi predlogo"
+
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx:244
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx:222
+msgid "Delete template"
+msgstr "Izbriši predlogo"
+
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx:270
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx:327
+msgid "Annotation layer"
+msgstr "Sloj z oznakami"
+
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx:300
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx:285
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:426
+#, python-format
+msgid "An error occurred while fetching dataset datasource values: %s"
+msgstr ""
+"Pri pridobivanju vrednosti podatkovnega vira podatkovnega seta je prišlo do "
+"napake: %s"
+
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx:333
+msgid "No annotation layers yet"
+msgstr "Slojev z oznakami še ni"
+
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx:358
+msgid "This action will permanently delete the layer."
+msgstr "S tem dejanjem boste trajno izbrisali sloj."
+
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx:366
+msgid "Delete Layer?"
+msgstr "Izbrišem sloj?"
+
+#: superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx:371
+msgid "Are you sure you want to delete the selected layers?"
+msgstr "Ali ste prepričani, da želite izbrisati izbrane sloje?"
+
+#: superset-frontend/src/views/CRUD/chart/ChartCard.tsx:78
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:321
+#: superset-frontend/src/views/CRUD/dashboard/DashboardCard.tsx:109
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:300
+msgid "Are you sure you want to delete"
+msgstr "Ali ste prepričani, da želite izbrisati"
+
+#: superset-frontend/src/views/CRUD/chart/ChartCard.tsx:151
+#: superset-frontend/src/views/CRUD/dashboard/DashboardCard.tsx:163
+#, python-format
+msgid "Last modified %s"
+msgstr "Zadnja sprememba %s"
+
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:61
+msgid ""
+"The passwords for the databases below are needed in order to import them "
+"together with the charts. Please note that the \"Secure Extra\" and "
+"\"Certificate\" sections of the database configuration are not present in "
+"export files, and should be added manually after the import if they are "
+"needed."
+msgstr ""
+"Gesla za spodnje podatkovne baze so potrebna za uvoz skupaj z grafikoni. "
+"Sekciji \"Dodatna varnost\" in \"Certifikati\" v nastavitvah podatkovne baze "
+"nista prisotni v izvoženih datotekah in jih je potrebno dodati ročno po "
+"uvozu, če je to potrebno."
+
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:68
+msgid ""
+"You are importing one or more charts that already exist. Overwriting might "
+"cause you to lose some of your work. Are you sure you want to overwrite?"
+msgstr ""
+"Uvažate enega ali več grafikonov, ki že obstajajo. S prepisom lahko izgubite "
+"podatke. Ali ste prepričani, da želite prepisati?"
+
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:193
+#, python-format
+msgid "There was an issue deleting the selected charts: %s"
+msgstr "Pri brisanju izbranih grafikonov je prišlo do težave: %s"
+
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:268
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:233
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:303
+msgid "Modified by"
+msgstr "Spremenil/a"
+
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:396
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:374
+#: superset-frontend/src/views/CRUD/welcome/ChartTable.tsx:152
+#: superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx:125
+#: superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx:151
+msgid "Favorite"
+msgstr "Priljubljene"
+
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:401
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:379
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:434
+msgid "Any"
+msgstr "Katerikoli"
+
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:403
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:381
+msgid "Yes"
+msgstr "Da"
+
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:404
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:382
+msgid "No"
+msgstr "Ne"
+
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:410
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:388
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:401
+msgid "Owner"
+msgstr "Lastnik"
+
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:414
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:435
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:456
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:481
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:392
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:413
+msgid "All"
+msgstr "Vsi"
+
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:420
+#, python-format
+msgid "An error occurred while fetching chart owners values: %s"
+msgstr "Pri pridobivanju polja lastnik grafikona je prišlo do napake: %s"
+
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:441
+#, python-format
+msgid "An error occurred while fetching chart created by values: %s"
+msgstr "Pri pridobivanju polja grafikon ustvaril/a je prišlo do napake: %s"
+
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:452
+msgid "Viz type"
+msgstr "Tip vizualizacije"
+
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:485
+#, python-format
+msgid "An error occurred while fetching chart dataset values: %s"
+msgstr ""
+"Pri pridobivanju polja podatkovni set za grafikon je prišlo do napake: %s"
+
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:507
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:453
+msgid "Alphabetical"
+msgstr "Po abecedi"
+
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:513
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:459
+msgid "Recently modified"
+msgstr "Nedavno spremenjeno"
+
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:519
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:465
+msgid "Least recently modified"
+msgstr "Zadnje spremenjeno"
+
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:574
+msgid "Import charts"
+msgstr "Uvozi grafikone"
+
+#: superset-frontend/src/views/CRUD/chart/ChartList.tsx:597
+msgid "Are you sure you want to delete the selected charts?"
+msgstr "Ali ste prepričani, da želite izbrisati izbrane grafikone?"
+
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplateModal.tsx:97
+msgid "css_template"
+msgstr "css_template"
+
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplateModal.tsx:243
+msgid "Edit CSS template properties"
+msgstr "Uredi lastnosti CSS predloge"
+
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplateModal.tsx:244
+msgid "Add CSS template"
+msgstr "Dodaj CSS predlogo"
+
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplateModal.tsx:253
+msgid "CSS template name"
+msgstr "Ime CSS predloge"
+
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplateModal.tsx:265
+msgid "css"
+msgstr "css"
+
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx:69
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx:243
+msgid "CSS templates"
+msgstr "CSS predloge"
+
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx:118
+#, python-format
+msgid "There was an issue deleting the selected templates: %s"
+msgstr "Pri brisanju izbranih predlog je prišlo do težave: %s"
+
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx:154
+#, python-format
+msgid "Last modified by %s"
+msgstr "Nazadnje spremenil/a %s"
+
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx:252
+msgid "CSS template"
+msgstr "CSS predloga"
+
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx:316
+msgid "This action will permanently delete the template."
+msgstr "S tem dejanjem boste trajno izbrisali predlogo."
+
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx:324
+msgid "Delete Template?"
+msgstr "Izbrišem predlogo?"
+
+#: superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx:329
+msgid "Are you sure you want to delete the selected templates?"
+msgstr "Ali ste prepričani, da želite izbrisati izbrane predloge?"
+
+#: superset-frontend/src/views/CRUD/dashboard/DashboardCard.tsx:152
+msgid "published"
+msgstr "objavljeno"
+
+#: superset-frontend/src/views/CRUD/dashboard/DashboardCard.tsx:152
+msgid "draft"
+msgstr "osnutek"
+
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:54
+msgid ""
+"The passwords for the databases below are needed in order to import them "
+"together with the dashboards. Please note that the \"Secure Extra\" and "
+"\"Certificate\" sections of the database configuration are not present in "
+"export files, and should be added manually after the import if they are "
+"needed."
+msgstr ""
+"Gesla za spodnje podatkovne baze so potrebna za uvoz skupaj z nadzornimi "
+"ploščami. Sekciji \"Dodatna varnost\" in \"Certifikati\" v nastavitvah "
+"podatkovne baze nista prisotni v izvoženih datotekah in jih je potrebno "
+"dodati ročno po uvozu, če je to potrebno."
+
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:61
+msgid ""
+"You are importing one or more dashboards that already exist. Overwriting "
+"might cause you to lose some of your work. Are you sure you want to "
+"overwrite?"
+msgstr ""
+"Uvažate eno ali več nadzornih plošč, ki že obstajajo. S prepisom lahko "
+"izgubite podatke. Ali ste prepričani, da želite prepisati?"
+
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:167
+#: superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx:99
+#, python-format
+msgid "An error occurred while fetching dashboards: %s"
+msgstr "Prišlo je do napake pri pridobivanju nadzornih plošč: %s"
+
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:185
+msgid "There was an issue deleting the selected dashboards: "
+msgstr "Pri brisanju izbranih nadzornih plošč je prišlo do težave: "
+
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:398
+#, python-format
+msgid "An error occurred while fetching dashboard owner values: %s"
+msgstr "Pri pridobivanju polja lastnik nadzorne plošče je prišlo do napake: %s"
+
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:419
+#, python-format
+msgid "An error occurred while fetching dashboard created by values: %s"
+msgstr ""
+"Pri pridobivanju polja nadzorno ploščo ustvaril/a je prišlo do napake: %s"
+
+#: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:536
+msgid "Are you sure you want to delete the selected dashboards?"
+msgstr "Ali ste prepričani, da želite izbrisati izbrane nadzorne plošče?"
+
+#: superset-frontend/src/views/CRUD/data/common.ts:38
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:107
+#: superset-frontend/src/views/CRUD/welcome/Welcome.tsx:230
+msgid "Saved queries"
+msgstr "Shranjene poizvedbe"
+
+#: superset-frontend/src/views/CRUD/data/components/SyntaxHighlighterCopy/index.tsx:70
+msgid "SQL Copied!"
+msgstr "SQL kopiran!"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:37
+msgid ""
+"The passwords for the databases below are needed in order to import them. "
+"Please note that the \"Secure Extra\" and \"Certificate\" sections of the "
+"database configuration are not present in export files, and should be added "
+"manually after the import if they are needed."
+msgstr ""
+"Gesla za spodnje podatkovne baze so potrebna za njihov uvoz. Sekciji "
+"\"Dodatna varnost\" in \"Certifikati\" v nastavitvah podatkovne baze nista "
+"prisotni v izvoženih datotekah in jih je potrebno dodati ročno po uvozu, če "
+"je to potrebno."
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:43
+msgid ""
+"You are importing one or more databases that already exist. Overwriting "
+"might cause you to lose some of your work. Are you sure you want to "
+"overwrite?"
+msgstr ""
+"Uvažate eno ali več podatkovnih baz, ki že obstajajo. S prepisom lahko "
+"izgubite podatke. Ali ste prepričani, da želite prepisati?"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:86
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:464
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx:217
+msgid "database"
+msgstr "podatkovna baza"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:126
+#, python-format
+msgid "An error occurred while fetching database related data: %s"
+msgstr "Pri pridobivanju podatkov iz podatkovne baze je prišlo do napake: %s"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:195
+msgid "Import databases"
+msgstr "Uvozi podatkovne baze"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:232
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:395
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:209
+msgid "Asynchronous query execution"
+msgstr "Asinhroni zagon poizvedb"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:235
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:398
+msgid "AQE"
+msgstr "AQE"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:250
+msgid "Allow data manipulation language"
+msgstr "Dovoli jezik za manipulacijo podatkov (DML)"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:253
+msgid "DML"
+msgstr "DML"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:265
+msgid "CSV upload"
+msgstr "Nalaganje CSV"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:326
+msgid "Delete database"
+msgstr "Izbriši podatkovno bazo"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:433
+#, python-format
+msgid ""
+"The database %s is linked to %s charts that appear on %s dashboards. Are you "
+"sure you want to continue? Deleting the database will break those objects."
+msgstr ""
+"Podatkovna baza %s je povezana z grafikoni %s, ki so prisotni na nadzorni "
+"plošči %s. Ali želite nadaljevati? Izbris podatkovne baze bo pokvaril te "
+"objekte."
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx:446
+msgid "Delete Database?"
+msgstr "Izbrišem podatkovno bazo?"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:78
+msgid "Allow this database to be queried in SQL Lab"
+msgstr "Dovoli poizvedbo na to podatkovno bazo v SQL laboratoriju"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:97
+msgid "Allow creation of new tables based on queries"
+msgstr "Dovoli ustvarjanje novih tabel s poizvedbami"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:111
+msgid "Allow creation of new views based on queries"
+msgstr "Dovoli ustvarjanje novih pogledov s poizvedbami"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:117
+msgid "CTAS & CVAS SCHEMA"
+msgstr "CTAS & CVAS SHEMA"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:123
+msgid "Search or select schema"
+msgstr "Poiščite ali izberite shemo"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:128
+msgid ""
+"When allowing CREATE TABLE AS option in SQL Lab, this option forces the "
+"table to be created in this schema."
+msgstr ""
+"Z dovolitvijo opcije CREATE TABLE AS v SQL laboratoriju se tabele ustvarjajo "
+"s to shemo."
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:145
+msgid ""
+"Allow manipulation of the database using non-SELECT statements such as "
+"UPDATE, DELETE, CREATE, etc."
+msgstr ""
+"Dovoli manipulacije podatkovne baze z uporabo ne-SELECT stavkov, kot so "
+"UPDATE, DELETE, CREATE, itd."
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:158
+msgid "Allow multi schema metadata fetch"
+msgstr "Dovoli pridobivanje metapodatkov z več shemami"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:184
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:190
+msgid "Chart cache timeout"
+msgstr "Trajanje predpomnilnika grafikona"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:212
+msgid ""
+"Operate the database in asynchronous mode, meaning that the queries are "
+"executed on remote workers as opposed to on the web server itself. This "
+"assumes that you have a Celery worker setup as well as a results backend. "
+"Refer to the installation docs for more information."
+msgstr ""
+"Upravljanje podatkovne baze v asinhronem načinu pomeni, da se poizvedbe "
+"zaženejo na oddaljenih »delavcih« in ne na samem spletnem strežniku. S tem "
+"je predpostavljeno, da imate nastavljenega »delavca« za Celery in zaledni "
+"sistem za rezultate. Več informacij je v navodilih za namestitev."
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:234
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:239
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:331
+msgid "Secure extra"
+msgstr "Dodatna varnost"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:249
+msgid "JSON string containing additional connection configuration."
+msgstr "JSON niz vsebuje dodatne nastavitve povezave."
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:252
+msgid ""
+"This is used to provide connection information for systems like Hive, "
+"Presto, and BigQuery, which do not conform to the username:password syntax "
+"normally used by SQLAlchemy."
+msgstr ""
+"S tem pridobite informacije o povezavi za sisteme, kot so Hive, Presto in "
+"BigQuery, ki niso skladni s shemo uporabniško_ime:geslo, ki se običajno "
+"uporablja v SQLAlchemy."
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:271
+msgid ""
+"Optional CA_BUNDLE contents to validate HTTPS requests. Only available on "
+"certain database engines."
+msgstr ""
+"Opcijska CA_BUNDLE vsebina, za potrjevanje HTTPS zahtev. Razpoložljivo le na "
+"določenih sistemih podatkovnih baz."
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:294
+msgid "Impersonate Logged In User (Presto, Hive, and GSheets)"
+msgstr "Predstavljanje kot prijavljeni uporabnik (Presto, Hive in GSheets)"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:299
+msgid ""
+"If Presto, all the queries in SQL Lab are going to be executed as the "
+"currently logged on user who must have permission to run them. If Hive and "
+"hive.server2.enable.doAs is enabled, will run the queries as service "
+"account, but impersonate the currently logged on user via hive.server2.proxy."
+"user property."
+msgstr ""
+"V Presto se vse poizvedbe v SQL laboratoriju zaženejo pod trenutno "
+"prijavljenim uporabnikom, ki mora imeti pravice za poganjanje. Če je "
+"omogočen Hive in hive.server2.enable.doAs, poizvedbe tečejo pod servisnim "
+"računom, vendar je trenutno prijavljen uporabnik predstavljen z lastnostjo "
+"hive.server2.proxy.user."
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:316
+msgid "Allow data upload"
+msgstr "Dovoli nalaganje podatkov"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:319
+msgid "If selected, please set the schemas allowed for data upload in Extra."
+msgstr ""
+"Če je izbrano, nastavite dovoljene sheme za nalaganje podatkov v Dodatno."
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:341
+msgid "JSON string containing extra configuration elements."
+msgstr "JSON niz, ki vsebuje dodatne nastavitve povezave."
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:344
+msgid ""
+"1. The engine_params object gets unpacked into the sqlalchemy.create_engine "
+"call, while the metadata_params gets unpacked into the sqlalchemy.MetaData "
+"call."
+msgstr ""
+"1. Objekt engine_params se razširi v klic sqlalchemy.create_engine, medtem "
+"ko se metadata_params razširijo v sqlalchemy.MetaData call."
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:351
+msgid ""
+"2. The metadata_cache_timeout is a cache timeout setting in seconds for "
+"metadata fetch of this database. Specify it as \"metadata_cache_timeout\": "
+"{\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}. If unset, "
+"cache will not be enabled for the functionality. A timeout of 0 indicates "
+"that the cache never expires."
+msgstr ""
+"2. metadata_cache_timeout je trajanje predpomnilnik v sekundah za "
+"pridobivanje metapodatkov za to podatkovno bazo. Definirajte ga kot "
+"\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, "
+"\"table_cache_timeout\": 600}. Če ni definirano, predpomnilnik ne bo omogčen "
+"pri tej funkciji. Trajanje 0 določa, da se predpomnilnik ne izteče."
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:360
+msgid ""
+"3. The schemas_allowed_for_csv_upload is a comma separated list of schemas "
+"that CSVs are allowed to upload to. Specify it as "
+"\"schemas_allowed_for_csv_upload\": [\"public\", \"csv_upload\"]. If "
+"database flavor does not support schema or any schema is allowed to be "
+"accessed, just leave the list empty."
+msgstr ""
+"3. schemas_allowed_for_csv_upload je z vejicami ločen seznam shem, ki jih je "
+"dovoljeno nalagati s CSV-ji. Definirajte ga kot "
+"\"schemas_allowed_for_csv_upload\": [\"public\", \"csv_upload\"]. Če tip "
+"podatkovne baza ne podpira sheme ali pa je dovoljen dostop do vseh shem, "
+"pustite seznam prazen."
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:369
+msgid ""
+"4. The version field is a string specifying this db's version. This should "
+"be used with Presto DBs so that the syntax is correct."
+msgstr ""
+"4. Polje \"version\" je znakovni niz, ki določa verzijo podatkovne baze. "
+"Uporabljeno mora biti s Presto bazo, da je sintaksa pravilna."
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:375
+msgid ""
+"5. The allows_virtual_table_explore field is a boolean specifying whether or "
+"not the Explore button in SQL Lab results is shown."
+msgstr ""
+"5. Polje \"allows_virtual_table_explore\" je binarnega tipa in določa, "
+"prikaz gumba \"Razišči\" v rezultatih SQL laboratorija."
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/SqlAlchemyForm.tsx:40
+msgid "Display Name"
+msgstr "Ime za prikaz"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/SqlAlchemyForm.tsx:49
+msgid "Name your database"
+msgstr "Poimenujte podatkovno bazo"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/SqlAlchemyForm.tsx:54
+msgid "Pick a name to help you identify this database."
+msgstr "Izberite ime za lažjo prepoznavo podatkovne baze."
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/SqlAlchemyForm.tsx:69
+msgid "dialect+driver://username:password@host:port/database"
+msgstr "dialect+driver://username:password@host:port/database"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/SqlAlchemyForm.tsx:76
+msgid "Refer to the"
+msgstr "Obrnite se na"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/SqlAlchemyForm.tsx:84
+msgid "for more information on how to structure your URI."
+msgstr "za več informacij o oblikovanju URI."
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/SqlAlchemyForm.tsx:93
+msgid "Test connection"
+msgstr "Preizkus povezave"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx:225
+msgid "Please enter a SQLAlchemy URI to test"
+msgstr "Vnesite SQLAlchemy URI za test"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx:296
+#, python-format
+msgid "Sorry there was an error fetching database information: %s"
+msgstr "Pri pridobivanju informacij o podatkovni bazi je prišlo do napake: %s"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx:370
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx:484
+msgid "Connect"
+msgstr "Poveži"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx:374
+msgid "Edit database"
+msgstr "Uredi podatkovno bazo"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx:374
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx:487
+msgid "Connect a database"
+msgstr "Poveži se s podatkovno bazo"
+
+#: superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx:484
+msgid "Finish"
+msgstr "Končaj"
+
+#: superset-frontend/src/views/CRUD/data/dataset/AddDatasetModal.tsx:111
+msgid "Add dataset"
+msgstr "Dodaj podatkovni set"
+
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:58
+msgid ""
+"The passwords for the databases below are needed in order to import them "
+"together with the datasets. Please note that the \"Secure Extra\" and "
+"\"Certificate\" sections of the database configuration are not present in "
+"export files, and should be added manually after the import if they are "
+"needed."
+msgstr ""
+"Gesla za spodnje podatkovne baze so potrebna za uvoz skupaj s podatkovnimi "
+"seti. Sekciji \"Dodatna varnost\" in \"Certifikati\" v nastavitvah "
+"podatkovne baze nista prisotni v izvoženih datotekah in jih je potrebno "
+"dodati ročno po uvozu, če je to potrebno."
+
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:65
+msgid ""
+"You are importing one or more datasets that already exist. Overwriting might "
+"cause you to lose some of your work. Are you sure you want to overwrite?"
+msgstr ""
+"Uvažate enega ali več podatkovnih setov, ki že obstajajo. S prepisom lahko "
+"izgubite podatke. Ali ste prepričani, da želite prepisati?"
+
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:174
+msgid "An error occurred while fetching dataset related data"
+msgstr "Napaka pri pridobivanju podatkov iz podatkovnega seta"
+
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:194
+#, python-format
+msgid "An error occurred while fetching dataset related data: %s"
+msgstr "Napaka pri pridobivanju podatkov iz podatkovnega seta: %s"
+
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:213
+msgid "Physical dataset"
+msgstr "Fizičen podatkovni set"
+
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:221
+msgid "Virtual dataset"
+msgstr "Virtualen podatkovni set"
+
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:410
+#, python-format
+msgid "An error occurred while fetching dataset owner values: %s"
+msgstr ""
+"Pri pridobivanju polja lastnik podatkovnega seta je prišlo do napake: %s"
+
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:429
+#, python-format
+msgid "An error occurred while fetching datasets: %s"
+msgstr "Prišlo je do napake pri pridobivanju podatkovnih setov: %s"
+
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:444
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:367
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:446
+#, python-format
+msgid "An error occurred while fetching schema values: %s"
+msgstr "Pri pridobivanju vrednosti shem je prišlo do napake: %s"
+
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:502
+msgid "Import datasets"
+msgstr "Uvozi podatkovne sete"
+
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:552
+#, python-format
+msgid "There was an issue deleting the selected datasets: %s"
+msgstr "Pri brisanju izbranih podatkovnih setov je prišlo do težave: %s"
+
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:575
+#, python-format
+msgid ""
+"The dataset %s is linked to %s charts that appear on %s dashboards. Are you "
+"sure you want to continue? Deleting the dataset will break those objects."
+msgstr ""
+"Podatkovni set %s je povezan z grafikoni %s, ki so prisotni na nadzorni "
+"plošči %s. Ali želite nadaljevati? Izbris podatkovnega seta bo pokvaril te "
+"objekte."
+
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:588
+msgid "Delete Dataset?"
+msgstr "Izbrišem podatkovni set?"
+
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:601
+msgid "Are you sure you want to delete the selected datasets?"
+msgstr "Ali ste prepričani, da želite izbrisati izbrane podatkovne sete?"
+
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:651
+msgid "0 Selected"
+msgstr "Izbranih: 0"
+
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:654
+#, python-format
+msgid "%s Selected (Virtual)"
+msgstr "Izbranih: %s (virtualni)"
+
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:661
+#, python-format
+msgid "%s Selected (Physical)"
+msgstr "Izbranih: %s (fizični)"
+
+#: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:668
+#, python-format
+msgid "%s Selected (%s Physical, %s Virtual)"
+msgstr "Izbranih: %s (fizični: %s, virtualni: %s)"
+
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:122
+#, python-format
+msgid "There was an issue previewing the selected query. %s"
+msgstr "Pri predogledu izbrane poizvedbe je prišlo do težave. %s"
+
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:151
+msgid "Success"
+msgstr "Uspelo"
+
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:156
+msgid "Failed"
+msgstr "Ni uspelo"
+
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:161
+msgid "Running"
+msgstr "V teku"
+
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:166
+msgid "Offline"
+msgstr "Offline"
+
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:171
+msgid "Scheduled"
+msgstr "V urniku"
+
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:214
+#, python-format
+msgid "Duration: %s"
+msgstr "Trajanje: %s"
+
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:227
+#: superset-frontend/src/views/CRUD/data/query/QueryPreviewModal.tsx:147
+msgid "Tab name"
+msgstr "Naslov zavihka"
+
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:259
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:297
+msgid "TABLES"
+msgstr "TABELE"
+
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:298
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:39
+msgid "Rows"
+msgstr "Vrstice"
+
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:326
+msgid "Open query in SQL Lab"
+msgstr "Odpri poizvedbo v SQL laboratoriju"
+
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:350
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:384
+#, python-format
+msgid "An error occurred while fetching database values: %s"
+msgstr "Pri pridobivanju vrednosti podatkovne baze je prišlo do napake: %s"
+
+#: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:397
+msgid "Search by query text"
+msgstr "Išči z besedilom poizvedbe"
+
+#: superset-frontend/src/views/CRUD/data/query/QueryPreviewModal.tsx:119
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:368
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryPreviewModal.tsx:98
+msgid "Query preview"
+msgstr "Predogled poizvedbe"
+
+#: superset-frontend/src/views/CRUD/data/query/QueryPreviewModal.tsx:135
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryPreviewModal.tsx:114
+msgid "Next"
+msgstr "Naslednji"
+
+#: superset-frontend/src/views/CRUD/data/query/QueryPreviewModal.tsx:143
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryPreviewModal.tsx:122
+msgid "Open in SQL Lab"
+msgstr "Odpri v SQL laboratoriju"
+
+#: superset-frontend/src/views/CRUD/data/query/QueryPreviewModal.tsx:156
+msgid "User query"
+msgstr "Uporabnikova poizvedba"
+
+#: superset-frontend/src/views/CRUD/data/query/QueryPreviewModal.tsx:164
+msgid "Executed query"
+msgstr "Zagnana poizvedba"
+
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:55
+msgid ""
+"The passwords for the databases below are needed in order to import them "
+"together with the saved queries. Please note that the \"Secure Extra\" and "
+"\"Certificate\" sections of the database configuration are not present in "
+"export files, and should be added manually after the import if they are "
+"needed."
+msgstr ""
+"Gesla za spodnje podatkovne baze so potrebna za uvoz skupaj s shranjenimi "
+"poizvedbami. Sekciji \"Dodatna varnost\" in \"Certifikati\" v nastavitvah "
+"podatkovne baze nista prisotni v izvoženih datotekah in jih je potrebno "
+"dodati ročno po uvozu, če je to potrebno."
+
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:62
+msgid ""
+"You are importing one or more saved queries that already exist. Overwriting "
+"might cause you to lose some of your work. Are you sure you want to "
+"overwrite?"
+msgstr ""
+"Uvažate eno ali več shranjenih poizvedb, ki že obstajajo. S prepisom lahko "
+"izgubite podatke. Ali ste prepričani, da želite prepisati?"
+
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:153
+#, python-format
+msgid "There was an issue previewing the selected query %s"
+msgstr "Do težave je prišlo pri predogledu izbrane poizvedbe %s"
+
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:191
+msgid "Import queries"
+msgstr "Uvozi poizvedbe"
+
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:254
+#, python-format
+msgid "There was an issue deleting the selected queries: %s"
+msgstr "Do težave je prišlo pri brisanju izbranih poizvedb: %s"
+
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:375
+msgid "Edit query"
+msgstr "Uredi poizvedbo"
+
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:382
+msgid "Copy query URL"
+msgstr "Kopiraj URL poizvedbe"
+
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:389
+msgid "Export query"
+msgstr "Izvozi poizvedbe"
+
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:396
+msgid "Delete query"
+msgstr "Izbriši poizvedbo"
+
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:467
+#: superset-frontend/src/views/CRUD/welcome/SavedQueries.tsx:244
+msgid "This action will permanently delete the saved query."
+msgstr "S tem dejanjem boste trajno izbrisali shranjeno poizvedbo."
+
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:477
+#: superset-frontend/src/views/CRUD/welcome/SavedQueries.tsx:256
+msgid "Delete Query?"
+msgstr "Izbrišem poizvedbo?"
+
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:492
+msgid "Are you sure you want to delete the selected queries?"
+msgstr "Ali ste prepričani, da želite izbrisati izbrane poizvedbe?"
+
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:535
+msgid "queries"
+msgstr "poizvedbe"
+
+#: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryPreviewModal.tsx:126
+msgid "Query name"
+msgstr "Ime poizvedbe"
+
+#: superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx:101
+msgid "[Untitled]"
+msgstr "[Neimenovana]"
+
+#: superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx:102
+msgid "Unknown"
+msgstr "Neznano"
+
+#: superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx:191
+msgid "Edited"
+msgstr "Urejane"
+
+#: superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx:200
+msgid "Created"
+msgstr "Ustvarjene"
+
+#: superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx:211
+msgid "Viewed"
+msgstr "Ogledane"
+
+#: superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx:220
+msgid "Examples"
+msgstr "Vzorci"
+
+#: superset-frontend/src/views/CRUD/welcome/ChartTable.tsx:161
+#: superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx:161
+#: superset-frontend/src/views/CRUD/welcome/SavedQueries.tsx:273
+msgid "Mine"
+msgstr "Moje"
+
+#: superset-frontend/src/views/CRUD/welcome/EmptyState.tsx:70
+msgid "Recently viewed charts, dashboards, and saved queries will appear here"
+msgstr ""
+"Nedavno ogledani grafikoni, nadzorne plošče in shranjene poizvedbe bodo "
+"prikazane tukaj"
+
+#: superset-frontend/src/views/CRUD/welcome/EmptyState.tsx:75
+msgid "Recently created charts, dashboards, and saved queries will appear here"
+msgstr ""
+"Nedavno ustvarjeni grafikoni, nadzorne plošče in shranjene poizvedbe bodo "
+"prikazane tukaj"
+
+#: superset-frontend/src/views/CRUD/welcome/EmptyState.tsx:80
+msgid "Recent example charts, dashboards, and saved queries will appear here"
+msgstr ""
+"Nedavni vzorci grafikonov, nadzornih plošč in shranjenih poizvedb bodo "
+"prikazani tukaj"
+
+#: superset-frontend/src/views/CRUD/welcome/EmptyState.tsx:85
+msgid "Recently edited charts, dashboards, and saved queries will appear here"
+msgstr ""
+"Nedavno urejani grafikoni, nadzorne plošče in shranjene poizvedbe bodo "
+"prikazane tukaj"
+
+#: superset-frontend/src/views/CRUD/welcome/EmptyState.tsx:113
+msgid ""
+"${tableName\r\n"
+"                      .split('')\r\n"
+"                      .slice(0, tableName.length - 1)\r\n"
+"                      .join('')}\r\n"
+"                    "
+msgstr ""
+"${tableName\r\n"
+"                        .split('')\r\n"
+"                        .slice(0, tableName.length - 1)\r\n"
+"                        .join('')}\r\n"
+"                    "
+
+#: superset-frontend/src/views/CRUD/welcome/EmptyState.tsx:133
+msgid "You don't have any favorites yet!"
+msgstr "Priljubljenih še niste izbrali!"
+
+#: superset-frontend/src/views/CRUD/welcome/EmptyState.tsx:145
+msgid "SQL Lab queries"
+msgstr "Poizvedbe SQL laboratorija"
+
+#: superset-frontend/src/views/CRUD/welcome/EmptyState.tsx:146
+msgid "${tableName}"
+msgstr "${tableName}"
+
+#: superset-frontend/src/views/CRUD/welcome/SavedQueries.tsx:125
+msgid "query"
+msgstr "poizvedba"
+
+#: superset-frontend/src/views/CRUD/welcome/SavedQueries.tsx:224
+msgid "Share"
+msgstr "Deljenje"
+
+#: superset-frontend/src/views/CRUD/welcome/SavedQueries.tsx:313
+#, python-format
+msgid "Last run %s"
+msgstr "Zadnji zagon %s"
+
+#: superset-frontend/src/views/CRUD/welcome/Welcome.tsx:142
+#, python-format
+msgid "There was an issue fetching your recent activity: %s"
+msgstr "Pri pridobivanju vaše nedavne aktivnosti je prišlo do napake: %s"
+
+#: superset-frontend/src/views/CRUD/welcome/Welcome.tsx:156
+#, python-format
+msgid "There was an issues fetching your dashboards: %s"
+msgstr "Prišlo je do napake pri pridobivanju nadzornih plošč: %s"
+
+#: superset-frontend/src/views/CRUD/welcome/Welcome.tsx:165
+#, python-format
+msgid "There was an issues fetching your chart: %s"
+msgstr "Prišlo je do napake pri pridobivanju grafikona: %s"
+
+#: superset-frontend/src/views/CRUD/welcome/Welcome.tsx:174
+#, python-format
+msgid "There was an issues fetching your saved queries: %s"
+msgstr "Prišlo je do napake pri pridobivanju shranjenih poizvedb: %s"
+
+#: superset-frontend/src/views/CRUD/welcome/Welcome.tsx:207
+msgid "Recents"
+msgstr "Nedavno"
+
+#: superset-frontend/src/visualizations/FilterBox/FilterBox.jsx:277
+msgid "Select start and end date"
+msgstr "Izberite začetni in končni datum"
+
+#: superset-frontend/src/visualizations/FilterBox/FilterBox.jsx:388
+#, python-format
+msgid "Type or Select [%s]"
+msgstr "Vnesite ali izberite [%s]"
+
+#: superset-frontend/src/visualizations/FilterBox/FilterBoxChartPlugin.js:25
+msgid "Filter box"
+msgstr "Izbirnik za filtriranje"
+
+#: superset-frontend/src/visualizations/FilterBox/controlPanel.jsx:27
+msgid "Filters configuration"
+msgstr "Nastavitve filtrov"
+
+#: superset-frontend/src/visualizations/FilterBox/controlPanel.jsx:36
+msgid "Filter configuration for the filter box"
+msgstr "Nastavitve za polje filtra"
+
+#: superset-frontend/src/visualizations/FilterBox/controlPanel.jsx:49
+msgid "Date filter"
+msgstr "Filter po datumu"
+
+#: superset-frontend/src/visualizations/FilterBox/controlPanel.jsx:51
+msgid "Whether to include a time filter"
+msgstr "Če želite vključiti časovni filter"
+
+#: superset-frontend/src/visualizations/FilterBox/controlPanel.jsx:58
+msgid "Instant filtering"
+msgstr "Takojšnje filtriranje"
+
+#: superset-frontend/src/visualizations/FilterBox/controlPanel.jsx:61
+msgid ""
+"Check to apply filters instantly as they change instead of displaying "
+"[Apply] button"
+msgstr ""
+"Izberite za takojšnjo uporabo filtrov, ko se spremenijo, brez prikazovanja "
+"gumba Uveljavi"
+
+#: superset-frontend/src/visualizations/FilterBox/controlPanel.jsx:72
+msgid "Show SQL granularity dropdown"
+msgstr "Prikaži SQL spustni seznam za granulacijo"
+
+#: superset-frontend/src/visualizations/FilterBox/controlPanel.jsx:74
+msgid "Check to include SQL granularity dropdown"
+msgstr "Izberite za vključitev spustnega seznama za SQL granulacijo"
+
+#: superset-frontend/src/visualizations/FilterBox/controlPanel.jsx:81
+msgid "Show SQL time column"
+msgstr "Prikaži stolpec SQL čas"
+
+#: superset-frontend/src/visualizations/FilterBox/controlPanel.jsx:83
+msgid "Check to include time column dropdown"
+msgstr "Izberite za vključitev časovnega stolpca v spustni seznam"
+
+#: superset-frontend/src/visualizations/FilterBox/controlPanel.jsx:92
+msgid "Show Druid granularity dropdown"
+msgstr "Prikaži spustni seznam za Druid granulacijo"
+
+#: superset-frontend/src/visualizations/FilterBox/controlPanel.jsx:94
+msgid "Check to include Druid granularity dropdown"
+msgstr "Izberite za vključitev spustnega seznama za Druid granulacijo"
+
+#: superset-frontend/src/visualizations/FilterBox/controlPanel.jsx:101
+msgid "Show Druid time origin"
+msgstr "Prikaži časovno izhodišče za Druid"
+
+#: superset-frontend/src/visualizations/FilterBox/controlPanel.jsx:103
+msgid "Check to include time origin dropdown"
+msgstr "Izberi za vključitev spustnega seznama za časovno izhodišče"
+
+#: superset-frontend/src/visualizations/FilterBox/controlPanel.jsx:113
+msgid "Limit selector values"
+msgstr "Omeji vrednosti izbirnikov"
+
+#: superset-frontend/src/visualizations/FilterBox/controlPanel.jsx:114
+msgid "These filters apply to the values available in the dropdowns"
+msgstr "Ti filtri se nanašajo na vrednosti v spustnih seznamih"
+
+#: superset-frontend/src/visualizations/TimeTable/TimeTableChartPlugin.js:24
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-time-table/src/TimeTableChartPlugin.ts:24
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-time-table/src/index.ts:25
+msgid "Time-series Table"
+msgstr "Tabela s časovno vrsto"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/constants.ts:25
+msgid "Time Range"
+msgstr "Časovno obdobje"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/constants.ts:26
+msgid "Time Column"
+msgstr "Časovni stolpec"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/constants.ts:27
+msgid "Time Grain"
+msgstr "Granulacija časa"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/constants.ts:29
+msgid "Time Granularity"
+msgstr "Granulacija časa"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/constants.ts:44
+msgid "Aggregate"
+msgstr "Agregiraj"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/constants.ts:45
+msgid "Raw records"
+msgstr "Surovi podatki"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/sections.tsx:50
+msgid "Datasource & Chart Type"
+msgstr "Tip podatkovnega vira in grafikona"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/sections.tsx:78
+msgid "URL Parameters"
+msgstr "Parametri URL"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/sections.tsx:80
+msgid "Extra url parameters for use in Jinja templated queries"
+msgstr "Dodatni parametri za poizvedbe z Jinja predlogami"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/sections.tsx:87
+msgid "Extra Parameters"
+msgstr "Dodatni parametri"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/sections.tsx:89
+msgid ""
+"Extra parameters that any plugins can choose to set for use in Jinja "
+"templated queries"
+msgstr ""
+"Dodatni parametri, ki jih lahko uporabi kateri koli vtičnik za poizvedbe z "
+"Jinja predlogami"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/sections.tsx:108
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:444
+msgid "Color Scheme"
+msgstr "Barvna shema"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/sections.tsx:113
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:225
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:105
+msgid "Annotations and Layers"
+msgstr "Oznake in sloji"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/components/InfoTooltipWithTrigger.tsx:48
+msgid "Show info tooltip"
+msgstr "Prikaži opis orodja"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:28
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:103
+msgid "One or many columns to group by"
+msgstr "Eden ali več stolpcev za združevanje"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:46
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:203
+msgid "One or many columns to pivot as columns"
+msgstr "En ali več stolpcev za stolpčno vrtenje"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:120
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:390
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:109
+msgid "Bubble Size"
+msgstr "Velikost mehurčka"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:121
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:391
+msgid "Metric used to calculate bubble size"
+msgstr "Mera za izračun velikosti mehurčkov"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:138
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:194
+msgid "Color Metric"
+msgstr "Mera za barvo"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:166
+msgid "Fixed Color"
+msgstr "Izbrana barva"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:174
+msgid "Right Axis Metric"
+msgstr "Mera desne osi"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:181
+msgid "Linear Color Scheme"
+msgstr "Linearna barvna shema"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:343
+msgid "Sort By"
+msgstr "Razvrščanje"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:420
+msgid "Time format"
+msgstr "Oblika zapisa časa"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:454
+msgid "Color Map"
+msgstr "Barvna lestvica"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/ColumnConfigControl.tsx:139
+msgid "Show less columns"
+msgstr "Prikaži manj stolpcev"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/ColumnConfigControl.tsx:144
+msgid "Show all columns"
+msgstr "Prikaži vse stolpce"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:66
+msgid "Fraction digits"
+msgstr "Število decimalk"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:67
+msgid "Number of decimal digits to round numbers to"
+msgstr "Število decimalnih mest za zaokroževanje števil"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:76
+msgid "Min Width"
+msgstr "Min. širina"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:77
+msgid ""
+"Default minimal column width in pixels, actual width may still be larger "
+"than this if other columns don't need much space"
+msgstr ""
+"Privzeta min. širina stolpca v pikslih. Dejanska širina bo lahko večja, če "
+"drugi stolpci ne potrebujejo veliko prostora"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:91
+msgid "Text align"
+msgstr "Poravnava besedila"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:92
+msgid "Horizontal alignment"
+msgstr "Vodoravna poravnava"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:97
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:225
+msgid "Left"
+msgstr "Levo"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:98
+msgid "Center"
+msgstr "Na sredino"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:99
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:226
+msgid "Right"
+msgstr "Desno"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:105
+msgid "Show cell bars"
+msgstr "Prikaži stolp. graf v celicah"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:106
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:393
+msgid "Whether to display a bar chart background in table columns"
+msgstr ""
+"Če želite omogočiti prikaz manjših stolpčnih grafikonov v ozadju stolpcev "
+"tabele"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:113
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:402
+msgid "Align +/-"
+msgstr "Poravnaj +/-"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:114
+msgid "Whether to align positive and negative values in cell bar chart at 0"
+msgstr ""
+"Če želite poravnati pozitivne in negativne vrednosti v stolpčnem grafikonu "
+"celic pri 0"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:121
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:414
+msgid "Color +/-"
+msgstr "Barva +/-"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:122
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:417
+msgid "Whether to colorize numeric values by if they are positive or negative"
+msgstr ""
+"Če želite obarvati številske vrednosti, ko so le-te pozitivne ali negativne"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:134
+msgid "Small number format"
+msgstr "Oblika zapisa majhnih števil"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:135
+msgid ""
+"D3 number format for numbers between -1.0 and 1.0, useful when you want to "
+"have different siginificant digits for small and large numbers"
+msgstr ""
+"D3 oblika zapisa za števila med -1.0 in 1.0. Uporabno, če želite različno "
+"število števk za majhna in velika števila"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:28
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:46
+msgid "Adaptative formating"
+msgstr "Adaptivno oblikovanje"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:39
+msgid "Duration in ms (66000 => 1m 6s)"
+msgstr "Trajanje v ms (66000 => 1m 6s)"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:40
+msgid "Duration in ms (1.40008 => 1ms 400µs 80ns)"
+msgstr "Trajanje v ms (1.40008 => 1ms 400µs 80ns)"
+
+#: superset-ui/superset-ui/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:43
+msgid "D3 time format syntax: https://github.com/d3/d3-time-format"
+msgstr "Sintaksa D3 časovnega formata:: https://github.com/d3/d3-time-format"
+
+#: superset-ui/superset-ui/packages/superset-ui-core/src/query/extractQueryFields.ts:129
+msgid "Found invalid orderby options"
+msgstr "Najdene so neveljavne možnosti razvrščanja"
+
+#: superset-ui/superset-ui/packages/superset-ui-core/src/validator/legacyValidateInteger.ts:9
+#: superset-ui/superset-ui/packages/superset-ui-core/src/validator/validateInteger.ts:11
+msgid "is expected to be an integer"
+msgstr "pričakovano je celo število"
+
+#: superset-ui/superset-ui/packages/superset-ui-core/src/validator/legacyValidateNumber.ts:9
+#: superset-ui/superset-ui/packages/superset-ui-core/src/validator/validateNumber.ts:11
+msgid "is expected to be a number"
+msgstr "pričakovano je število"
+
+#: superset-ui/superset-ui/packages/superset-ui-core/src/validator/validateNonEmpty.ts:5
+msgid "cannot be empty"
+msgstr "ne sme biti prazna"
+
+#: superset-ui/superset-ui/packages/superset-ui-core/test/translation/Translator.test.ts:90
+#: superset-ui/superset-ui/packages/superset-ui-core/test/translation/Translator.test.ts:102
+#: superset-ui/superset-ui/packages/superset-ui-core/test/translation/Translator.test.ts:119
+msgid "haha"
+msgstr "haha"
+
+#: superset-ui/superset-ui/packages/superset-ui-core/test/translation/Translator.test.ts:105
+#: superset-ui/superset-ui/packages/superset-ui-core/test/translation/Translator.test.ts:106
+msgid "foo"
+msgstr "foo"
+
+#: superset-ui/superset-ui/packages/superset-ui-core/test/translation/Translator.test.ts:107
+#: superset-ui/superset-ui/packages/superset-ui-core/test/translation/Translator.test.ts:111
+msgid "bar"
+msgstr "bar"
+
+#: superset-ui/superset-ui/packages/superset-ui-core/test/translation/Translator.test.ts:130
+#: superset-ui/superset-ui/packages/superset-ui-core/test/translation/Translator.test.ts:154
+msgid "yes"
+msgstr "da"
+
+#: superset-ui/superset-ui/packages/superset-ui-core/test/translation/TranslatorSingleton.test.ts:14
+#: superset-ui/superset-ui/packages/superset-ui-core/test/translation/TranslatorSingleton.test.ts:39
+msgid "second"
+msgstr "sekunda"
+
+#: superset-ui/superset-ui/packages/superset-ui-core/test/translation/TranslatorSingleton.test.ts:22
+#: superset-ui/superset-ui/packages/superset-ui-core/test/translation/TranslatorSingleton.test.ts:47
+msgid "ox"
+msgstr "ox"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:40
+msgid "Domain"
+msgstr "Domena"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:43
+msgid "The time unit used for the grouping of blocks"
+msgstr "Časovna enota za združevanje blokov"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:50
+msgid "Subdomain"
+msgstr "Poddomena"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:53
+msgid ""
+"The time unit for each block. Should be a smaller unit than "
+"domain_granularity. Should be larger or equal to Time Grain"
+msgstr ""
+"Časovna enota za vsak blok. Mora biti manjša enota kot domenska_granulacija. "
+"Mora biti večja ali enaka Granulaciji časa"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:65
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-chord/src/controlPanel.ts:47
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-country-map/src/controlPanel.ts:54
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-force-directed/src/controlPanel.ts:46
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts:70
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-horizon/src/controlPanel.ts:57
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:130
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:65
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sankey-loop/src/controlPanel.ts:31
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sankey/src/controlPanel.ts:63
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts:47
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-treemap/src/controlPanel.ts:53
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx:107
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumberTotal/controlPanel.ts:49
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Area/controlPanel.ts:42
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bar/controlPanel.ts:48
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bubble/controlPanel.ts:68
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:31
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Compare/controlPanel.ts:40
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts:73
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/DualLine/controlPanel.ts:35
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Line/controlPanel.ts:45
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:54
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Pie/controlPanel.ts:31
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/TimePivot/controlPanel.ts:77
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts:64
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Funnel/controlPanel.tsx:69
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:71
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:242
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:69
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx:87
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:217
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Treemap/controlPanel.tsx:63
+#: superset-ui/superset-ui/plugins/preset-chart-xy/src/BoxPlot/controlPanel.ts:31
+msgid "Chart Options"
+msgstr "Možnosti grafikona"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:79
+msgid "Cell Size"
+msgstr "Velikost celice"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:80
+msgid "The size of the square cell, in pixels"
+msgstr "Velikost kvadratne celice v pikslih"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:91
+msgid "Cell Padding"
+msgstr "Razmak med celicami"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:92
+msgid "The distance between cells, in pixels"
+msgstr "Razdalja med celicami v pikslih"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:105
+msgid "Cell Radius"
+msgstr "Polmer celice"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:106
+msgid "The pixel radius"
+msgstr "Polmer piksla"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:117
+msgid "Color Steps"
+msgstr "Barvni koraki"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:118
+msgid "The number color \"steps\""
+msgstr "Število barvnih korakov"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:129
+msgid "Time Format"
+msgstr "Oblika zapisa časa"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:142
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:214
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts:79
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:147
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx:91
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/controls.tsx:90
+msgid "Legend"
+msgstr "Legenda"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:145
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:217
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts:82
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:150
+msgid "Whether to display the legend (toggles)"
+msgstr "Preklapljanje prikaza legende"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:152
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:236
+msgid "Show Values"
+msgstr "Pokaži vrednosti"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:155
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:239
+msgid "Whether to display the numerical values within the cells"
+msgstr "Če želite v celicah prikazati numerične vrednosti"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:164
+msgid "Show Metric Names"
+msgstr "Pokaži imena mer"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:167
+msgid "Whether to display the metric name as a title"
+msgstr "Če želite prikazati ime mere kot naslov"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:177
+msgid "Number Format"
+msgstr "Oblika zapisa števila"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-chord/src/controlPanel.ts:39
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-force-directed/src/controlPanel.ts:38
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:89
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sankey/src/controlPanel.ts:55
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts:39
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:58
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Funnel/controlPanel.tsx:61
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:63
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:61
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Treemap/controlPanel.tsx:54
+#: superset-ui/superset-ui/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.ts:38
+msgid "Sort by metric"
+msgstr "Mera za razvrščanje"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-chord/src/controlPanel.ts:40
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-force-directed/src/controlPanel.ts:39
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:90
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sankey/src/controlPanel.ts:56
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts:40
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:59
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Funnel/controlPanel.tsx:62
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:64
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:62
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Treemap/controlPanel.tsx:55
+#: superset-ui/superset-ui/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.ts:39
+msgid "Whether to sort results by the selected metric in descending order."
+msgstr "Če želite padajoče razvrstiti rezultate z izbrano mero."
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-chord/src/controlPanel.ts:57
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-country-map/src/controlPanel.ts:64
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:141
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.ts:121
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:75
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-treemap/src/controlPanel.ts:78
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx:169
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumberTotal/controlPanel.ts:56
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Pie/controlPanel.ts:58
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts:102
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Funnel/controlPanel.tsx:117
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:143
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:130
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx:156
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Treemap/controlPanel.tsx:129
+msgid "Number format"
+msgstr "Oblika zapisa števila"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-chord/src/controlPanel.ts:58
+msgid "Choose a number format"
+msgstr "Izberite obliko zapisa števila"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-chord/src/controlPanel.ts:64
+msgid "Choose a source"
+msgstr "Izberite vir"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-chord/src/controlPanel.ts:67
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:58
+msgid "Target"
+msgstr "Cilj"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-chord/src/controlPanel.ts:70
+msgid "Choose a target"
+msgstr "Izberite cilj"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-chord/src/index.js:27
+msgid "Chord Diagram"
+msgstr "Tetivni grafikon"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-country-map/src/controlPanel.ts:40
+msgid "Country"
+msgstr "Država"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-country-map/src/controlPanel.ts:43
+msgid "Which country to plot the map for?"
+msgstr "Za katero državo želite grafikon?"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-country-map/src/controlPanel.ts:78
+msgid "ISO 3166-2 Codes"
+msgstr "Oznake po ISO 3166-2"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-country-map/src/controlPanel.ts:79
+msgid ""
+"Column containing ISO 3166-2 codes of region/province/department in your "
+"table."
+msgstr ""
+"Stolpec, ki vsebuje ISO 3166-2 oznake regij/provinc/departmajev v vaši "
+"tabeli."
+
+#: superset-ui/superset-ui-plugins/packages/superset-ui-legacy-plugin-chart-event-flow/src/EventFlow.jsx:54
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-event-flow/src/EventFlow.tsx:50
+msgid "Sorry, there appears to be no data"
+msgstr "Ni podatkov"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-event-flow/src/controlPanel.tsx:35
+msgid "Event definition"
+msgstr "Definicija dogodka"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-event-flow/src/controlPanel.tsx:43
+msgid "Event Names"
+msgstr "Imena dogodkov"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-event-flow/src/controlPanel.tsx:44
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:40
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:49
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:95
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:118
+msgid "Columns to display"
+msgstr "Stolpci za prikaz"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-event-flow/src/controlPanel.tsx:62
+msgid "Order by entity id"
+msgstr "Uredi po ID entitete"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-event-flow/src/controlPanel.tsx:63
+msgid ""
+"Important! Select this if the table is not already sorted by entity id, else "
+"there is no guarantee that all events for each entity are returned."
+msgstr ""
+"Pomembno! Izberite, če tabela še ni razvrščena po ID entitete, v nasprotnem "
+"primeru ni nujno, da bodo vrnjeni vsi dogodki za posamezno entiteto."
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-event-flow/src/controlPanel.tsx:77
+msgid "Minimum leaf node event count"
+msgstr "Min. število dogodkov za list"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-event-flow/src/controlPanel.tsx:80
+msgid ""
+"Leaf nodes that represent fewer than this number of events will be initially "
+"hidden in the visualization"
+msgstr ""
+"Listna vozlišča, ki predstavljajo manjše število dogodkov od te vrednosti, "
+"bodo v vizualizaciji skrita"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-event-flow/src/controlPanel.tsx:95
+msgid "Additional metadata"
+msgstr "Dodatni metapodatki"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-event-flow/src/controlPanel.tsx:105
+msgid "Metadata"
+msgstr "Metapodatki"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-event-flow/src/controlPanel.tsx:107
+msgid "Select any columns for metadata inspection"
+msgstr "Izberite poljubne stolpce za pregled metapodatkov"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-event-flow/src/controlPanel.tsx:125
+msgid "Entity ID"
+msgstr "ID entitete"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-event-flow/src/controlPanel.tsx:126
+msgid "e.g., a \"user id\" column"
+msgstr "t.j. stolpec \"id uporabnika\""
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-event-flow/src/controlPanel.tsx:129
+msgid "Max Events"
+msgstr "Max. dogodkov"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-event-flow/src/controlPanel.tsx:130
+msgid ""
+"The maximum number of events to return, equivalent to the number of rows"
+msgstr "Največje število dogodkov, ki bodo vrnjeni - enako številu vrstic"
+
+#: superset-ui/superset-ui-plugins/packages/superset-ui-legacy-plugin-chart-event-flow/src/index.js:26
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-event-flow/src/index.ts:26
+msgid "Event Flow"
+msgstr "Potek dogodkov"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-force-directed/src/controlPanel.ts:56
+msgid "Link Length"
+msgstr "Dolžina povezave"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-force-directed/src/controlPanel.ts:59
+msgid "Link length in the force layout"
+msgstr "Dolžina povezave v postavitvi sil"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-force-directed/src/controlPanel.ts:70
+msgid "Charge"
+msgstr "Naboj"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-force-directed/src/controlPanel.ts:84
+msgid "Charge in the force layout"
+msgstr "Naboj v postavitvi sil"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-force-directed/src/controlPanel.ts:93
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sankey-loop/src/controlPanel.ts:38
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sankey/src/controlPanel.ts:33
+msgid "Source / Target"
+msgstr "Izhodišče/Cilj"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-force-directed/src/controlPanel.ts:94
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sankey-loop/src/controlPanel.ts:39
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sankey/src/controlPanel.ts:34
+msgid "Choose a source and a target"
+msgstr "Izberite izhodišče in cilj"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-force-directed/src/index.js:27
+msgid "Force-directed Graph"
+msgstr "Graf usmerjenih sil"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:31
+msgid "Axis ascending"
+msgstr "Naraščajoča os"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:32
+msgid "Axis descending"
+msgstr "Padajoča os"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:33
+msgid "Metric ascending"
+msgstr "Naraščajoča mera"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:34
+msgid "Metric descending"
+msgstr "Padajoča mera"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:97
+msgid "Heatmap Options"
+msgstr "Možnosti toplotnega prikaza"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:107
+msgid "XScale Interval"
+msgstr "Interval X-osi"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:112
+msgid "Number of steps to take between ticks when displaying the X scale"
+msgstr "Število korakov med oznakami pri prikazu X-osi"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:119
+msgid "YScale Interval"
+msgstr "Interval Y-osi"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:124
+msgid "Number of steps to take between ticks when displaying the Y scale"
+msgstr "Število korakov med oznakami pri prikazu Y-osi"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:133
+msgid "Rendering"
+msgstr "Izris"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:140
+msgid ""
+"image-rendering CSS attribute of the canvas object that defines how the "
+"browser scales up the image"
+msgstr ""
+"atribut CSS za izris objekta platna, ki določa, kako brskalnik poveča sliko"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:150
+msgid "Normalize Across"
+msgstr "Normiraj glede na"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:157
+msgid ""
+"Color will be rendered based on a ratio of the cell against the sum of "
+"across this criteria"
+msgstr ""
+"Barva bo prikazana na osnovi razmerja med celico in vsoto glede na ta "
+"kriterij"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:172
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:77
+msgid "Left Margin"
+msgstr "Levi rob"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:176
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:81
+msgid "Left margin, in pixels, allowing for more room for axis labels"
+msgstr "Levi rob, v pikslih, s katerim povečamo prostor za oznake osi"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:185
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:185
+msgid "Bottom Margin"
+msgstr "Spodnji rob"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:189
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:189
+msgid "Bottom margin, in pixels, allowing for more room for axis labels"
+msgstr "Spodnji rob, v pikslih, s katerim povečamo prostor za oznake osi"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:198
+msgid "Value bounds"
+msgstr "Meje vrednosti"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:201
+msgid ""
+"Hard value bounds applied for color coding. Is only relevant and applied "
+"when the normalization is applied against the whole heatmap."
+msgstr ""
+"Mejne vrednosti za barvno lestvico. Upošteva se le, če je normiranje "
+"uporabljeno glede na celotni toplotni prikaz."
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:224
+msgid "Show percentage"
+msgstr "Prikaži procente"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:226
+msgid "Whether to include the percentage in the tooltip"
+msgstr "Če želite prikaz procentov v opisu orodja"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:246
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts:125
+msgid "Normalized"
+msgstr "Normiran"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:248
+msgid "Whether to apply a normal distribution based on rank on the color scale"
+msgstr ""
+"Če želite uporabiti normalno porazdelitev glede na stopnjo na barvni lestvici"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:260
+msgid "Sort X Axis"
+msgstr "Razvrsti X-os"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:270
+msgid "Sort Y Axis"
+msgstr "Razvrsti Y-os"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:282
+msgid "Value Format"
+msgstr "Oblika zapisa vrednosti"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-histogram/src/Histogram.jsx:112
+msgid "count"
+msgstr "število"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-histogram/src/Histogram.jsx:116
+msgid "cumulative"
+msgstr "kumulativno"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts:33
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts:43
+msgid "Select the numeric columns to draw the histogram"
+msgstr "Izberite numerične stolpce za izris histograma"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts:93
+msgid "No of Bins"
+msgstr "Št. razdelkov"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts:96
+msgid "Select the number of bins for the histogram"
+msgstr "Izberite število razdelkov za histogram"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts:105
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:173
+msgid "X Axis Label"
+msgstr "Naslov X osi"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts:114
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:327
+msgid "Y Axis Label"
+msgstr "Naslov Y osi"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts:127
+msgid "Whether to normalize the histogram"
+msgstr "Če želite normirati histogram"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-horizon/src/controlPanel.ts:38
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts:45
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-parallel-coordinates/src/controlPanel.ts:40
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:48
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.ts:47
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:46
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-treemap/src/controlPanel.ts:44
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts:53
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:348
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:92
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:95
+msgid "Sort Descending"
+msgstr "Razvrsti padajoče"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-horizon/src/controlPanel.ts:67
+msgid "Series Height"
+msgstr "Višina serije"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-horizon/src/controlPanel.ts:70
+msgid "Pixel height of each series"
+msgstr "Višina vsake serije v pikslih"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-horizon/src/controlPanel.ts:78
+msgid "Value Domain"
+msgstr "Domena vrednosti"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-horizon/src/controlPanel.ts:85
+msgid ""
+"series: Treat each series independently; overall: All series use the same "
+"scale; change: Show changes compared to the first data point in each series"
+msgstr ""
+"serije: Obravnavaj vsako podatkovno serijo neodvisno; skupno: Vse vrste "
+"uporabljajo enako skalo; razlika: Pokaži razlike glede na prvo točko vsake "
+"serije"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-horizon/src/index.js:27
+msgid "Horizon Chart"
+msgstr "Horizontni grafikon"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:53
+msgid "Longitude"
+msgstr "Dolžina"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:54
+msgid "Column containing longitude data"
+msgstr "Stolpec s podatki zemljepisne dolžine"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:63
+msgid "Latitude"
+msgstr "Širina"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:64
+msgid "Column containing latitude data"
+msgstr "Stolpec s podatki zemljepisne širine"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:74
+msgid "Clustering Radius"
+msgstr "Radij gručenja"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:87
+msgid ""
+"The radius (in pixels) the algorithm uses to define a cluster. Choose 0 to "
+"turn off clustering, but beware that a large number of points (>1000) will "
+"cause lag."
+msgstr ""
+"Radij (v pikslih), s katerim algoritem definira gručo. Izberite 0 za izklop "
+"gručenja - veliko število točk (>1000) bo povzročilo upočasnitev."
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:101
+msgid "Points"
+msgstr "Točke"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:108
+msgid "Point Radius"
+msgstr "Radij točk"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:110
+msgid ""
+"The radius of individual points (ones that are not in a cluster). Either a "
+"numerical column or `Auto`, which scales the point based on the largest "
+"cluster"
+msgstr ""
+"Radij posameznih točk (tistih, ki niso v gruči). Numerični stolpec ali "
+"`Auto` (skalira točke na osnovi največje gruče)"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:130
+msgid "Point Radius Unit"
+msgstr "Enota radija točk"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Scatter/controlPanel.js:86
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:133
+msgid "The unit of measure for the specified point radius"
+msgstr "Enota merila za definiran radij točk"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:140
+msgid "Labelling"
+msgstr "Oznake"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:148
+msgid "label"
+msgstr "oznaka"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:150
+msgid ""
+"`count` is COUNT(*) if a group by is used. Numerical columns will be "
+"aggregated with the aggregator. Non-numerical columns will be used to label "
+"points. Leave empty to get a count of points in each cluster."
+msgstr ""
+"`število` je COUNT(*), če je uporabljeno združevanje (group by). Numerični "
+"stolpci bodo agregirani z agregatorjem. Ne-numerični stolpci, bodo "
+"uporabljeni za oznake točk. Pustite prazno, da dobite število točk v "
+"posamezni gruči."
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:167
+msgid "Cluster label aggregator"
+msgstr "Agregator za oznako gruče"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:171
+msgid ""
+"Aggregate function applied to the list of points in each cluster to produce "
+"the cluster label."
+msgstr ""
+"Agregacijska funkcija za seznam točk v vsaki gruči, s katero se ustvari "
+"oznaka gruče."
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:181
+msgid "Visual Tweaks"
+msgstr "Nastavitve izgleda"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:188
+msgid "Live render"
+msgstr "Sprotni izris"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:190
+msgid "Points and clusters will update as the viewport is being changed"
+msgstr "Točke in gruče se bodo posodabljale, če se bo spremenil pogled"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:356
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:199
+msgid "Map Style"
+msgstr "Slog zemljevida"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:368
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:211
+msgid "Base layer map style"
+msgstr "Slog osnovnega sloja zemljevida"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:223
+msgid "Opacity of all clusters, points, and labels. Between 0 and 1."
+msgstr "Prosojnost vseh gruč, točk in oznak (vrednost med 0 in 1)."
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:233
+msgid "RGB Color"
+msgstr "RGB barva"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:243
+msgid "The color for points and clusters in RGB"
+msgstr "Barva točk in gruč v RGB zapisu"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:277
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:250
+msgid "Viewport"
+msgstr "Pogled"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:258
+msgid "Default longitude"
+msgstr "Privzeta dolžina"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:262
+msgid "Longitude of default viewport"
+msgstr "Dolžina privzetega pogleda"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:273
+msgid "Default latitude"
+msgstr "Privzeta širina"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:277
+msgid "Latitude of default viewport"
+msgstr "Širina privzetega pogleda"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:290
+msgid "Zoom"
+msgstr "Povečava"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:294
+msgid "Zoom level of the map"
+msgstr "Stopnja povečave zemljevida"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:308
+msgid ""
+"One or many controls to group by. If grouping, latitude and longitude "
+"columns must be present."
+msgstr ""
+"Eden ali več kontrolnikov za združevanje. Pri združevanju morata biti "
+"prisotna stolpca širine in dolžine."
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-map-box/src/index.js:26
+msgid "MapBox"
+msgstr "MapBox"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts:72
+msgid "Significance Level"
+msgstr "Stopnja značilnosti"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts:74
+msgid "Threshold alpha level for determining significance"
+msgstr "Mejna vrednost alfa za določanje značilnosti"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts:83
+msgid "p-value precision"
+msgstr "točnost p-vrednosti"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts:85
+msgid "Number of decimal places with which to display p-values"
+msgstr "Število decimalnih mest za prikaz p-vrednosti"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts:94
+msgid "Lift percent precision"
+msgstr "Točnost procentualnega dviga"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts:96
+msgid "Number of decimal places with which to display lift values"
+msgstr "Število decimalnih mest za prikaz vrednosti dviga"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-paired-t-test/src/index.js:26
+msgid "Paired t-test Table"
+msgstr "Tabela t-testa za odvisne vzorce"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-parallel-coordinates/src/controlPanel.ts:49
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:75
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.ts:112
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:66
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx:33
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumberTotal/controlPanel.ts:32
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:75
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:129
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:340
+#: superset-ui/superset-ui/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.ts:46
+msgid "Options"
+msgstr "Možnosti"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-parallel-coordinates/src/controlPanel.ts:57
+msgid "Data Table"
+msgstr "Tabela podatkov"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-parallel-coordinates/src/controlPanel.ts:60
+msgid "Whether to display the interactive data table"
+msgstr "Če želite prikaz interaktivne podatkovne tabele"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-parallel-coordinates/src/controlPanel.ts:67
+msgid "Include Series"
+msgstr "Vključi serijo"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-parallel-coordinates/src/controlPanel.ts:70
+msgid "Include series name as an axis"
+msgstr "Vključi ime podatkovne serije v naslov osi"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:67
+msgid "Time Series Options"
+msgstr "Možnosti časovne vrste"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:81
+msgid "Not Time Series"
+msgstr "Ni časovna vrsta"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:83
+msgid "Ignore time"
+msgstr "Ne upoštevaj časa"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:86
+msgid "Time Series"
+msgstr "Časovna vrsta"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:88
+msgid "Standard time series"
+msgstr "Standardna časovna vrsta"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:91
+msgid "Aggregate Mean"
+msgstr "Agregirano povprečje"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:93
+msgid "Mean of values over specified period"
+msgstr "Povprečna vrednost v dani periodi"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:96
+msgid "Aggregate Sum"
+msgstr "Agregirana vsota"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:98
+msgid "Sum of values over specified period"
+msgstr "Vsota vrednosti v dani periodi"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:101
+msgid "Difference"
+msgstr "Razlika"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:103
+msgid "Metric change in value from `since` to `until`"
+msgstr "Sprememba mere od vrednosti \"OD\" do \"DO\""
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:106
+msgid "Percent Change"
+msgstr "Procentualna sprememba"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:108
+msgid "Metric percent change in value from `since` to `until`"
+msgstr "Procentualna sprememba mere od vrednosti \"OD\" do \"DO\""
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:111
+msgid "Factor"
+msgstr "Faktor"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:113
+msgid "Metric factor change from `since` to `until`"
+msgstr "Sprememba faktorja mere od vrednosti \"OD\" do \"DO\""
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:116
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:228
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:123
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx:112
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:369
+msgid "Advanced Analytics"
+msgstr "Napredna analitika"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:118
+msgid "Use the Advanced Analytics options below"
+msgstr "Uporabite spodnje možnosti napredne analitike"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:123
+msgid "Settings for time series"
+msgstr "Nastavitve časovne vrste"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:153
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:87
+msgid "Date Time Format"
+msgstr "Oblika zapisa Datum-Časa"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:166
+msgid "Partition Limit"
+msgstr "Omejitev particij"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:169
+msgid ""
+"The maximum number of subdivisions of each group; lower values are pruned "
+"first"
+msgstr ""
+"Največje število podrazdelkov posamezne skupine; nižje vrednosti so "
+"zanemarjene prve"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:179
+msgid "Partition Threshold"
+msgstr "Prag particije"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:182
+msgid ""
+"Partitions whose height to parent height proportions are below this value "
+"are pruned"
+msgstr ""
+"Particije z nižjim razmerjem med njihovo višino in dolžino starša so "
+"zanemarjene"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:194
+msgid "Log Scale"
+msgstr "Logaritemska skala"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:197
+msgid "Use a log scale"
+msgstr "Uporabi logaritemsko skalo"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:206
+msgid "Equal Date Sizes"
+msgstr "Enaki datumi"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:209
+msgid "Check to force date partitions to have the same height"
+msgstr "Če želite, da imajo datumske particije enako višino"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:218
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:100
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:277
+msgid "Rich Tooltip"
+msgstr "Podroben opis orodja"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:221
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:103
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:280
+msgid "The rich tooltip shows a list of all series for that point in time"
+msgstr ""
+"Podroben opis orodja prikaže seznam vseh podatkovnih serij za posamezno "
+"istočasno točko"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:238
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:133
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx:117
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:377
+msgid "Rolling Window"
+msgstr "Drseče okno"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:244
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:139
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx:123
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:383
+msgid "Rolling Function"
+msgstr "Drseča funkcija"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:271
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:166
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx:152
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:412
+msgid "Min Periods"
+msgstr "Min. št. period"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:285
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:180
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:424
+msgid "Time Comparison"
+msgstr "Časovna primerjava"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:293
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:188
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:432
+msgid "Time Shift"
+msgstr "Časovni zamik"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:334
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:229
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:473
+msgid "Python Functions"
+msgstr "Pythonove funkcije"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-partition/src/index.js:26
+msgid "Partition Chart"
+msgstr "Grafikon razdelkov"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.ts:56
+msgid "Pivot Options"
+msgstr "Vrtilne možnosti"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.ts:63
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:84
+msgid "Aggregation function"
+msgstr "Agregacijska funkcija"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.ts:67
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:107
+msgid ""
+"Aggregate function to apply when pivoting and computing the total rows and "
+"columns"
+msgstr "Agregacijska funkcija za vrtenje in izračun vseh vrstic in stolpcev"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.ts:80
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:327
+msgid "Show totals"
+msgstr "Pokaži vsote"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.ts:82
+msgid "Display total row/column"
+msgstr "Pokaži vsote vrstic/stolpcev"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.ts:89
+msgid "Combine Metrics"
+msgstr "Združuj mere"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.ts:91
+msgid ""
+"Display metrics side by side within each column, as opposed to each column "
+"being displayed side by side for each metric."
+msgstr ""
+"Prikazuj mere eno ob drugi ob vsakem stolpcu, drugače je vsak stolpec "
+"prikazan en ob drugem za vsako mero."
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.ts:103
+msgid "Transpose Pivot"
+msgstr "Transponirano vrtenje"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.ts:105
+msgid "Swap Groups and Columns"
+msgstr "Zamenjaj Skupine in Stolpce"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.ts:135
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts:118
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:146
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx:172
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Treemap/controlPanel.tsx:145
+msgid "Date format"
+msgstr "Oblika zapisa datuma"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:110
+msgid "Use Area Proportions"
+msgstr "Uporabi razmerje površin"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:111
+msgid ""
+"Check if the Rose Chart should use segment area instead of segment radius "
+"for proportioning"
+msgstr ""
+"Če želite, da grafikon \"Rose\" uporablja površino segmenta namesto radija "
+"za proporcioniranje"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-rose/src/index.js:26
+msgid "Nightingale Rose Chart"
+msgstr "Nightingale Rose grafikon"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sankey/src/controlPanel.ts:44
+msgid ""
+"Limiting rows may result in incomplete data and misleading charts. Consider "
+"filtering or grouping source/target names instead."
+msgstr ""
+"Omejitev vrstic lahko povzroči nepopolne podatke in zavajajoč grafikon. "
+"Premislite o uporabi filtriranja ali združevanja imen izvorov/ciljev."
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sankey/src/index.js:27
+msgid "Sankey Diagram"
+msgstr "Sankey grafikon"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sankey-loop/src/index.js:27
+msgid "Sankey Diagram with Loops"
+msgstr "Sankey grafikon z zankami"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts:54
+msgid "Primary Metric"
+msgstr "Primarna mera"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts:55
+msgid "The primary metric is used to define the arc segment sizes"
+msgstr "Primarna mera določa velikost lokov segmentov"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts:58
+msgid "Secondary Metric"
+msgstr "Sekundarna mera"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts:60
+msgid ""
+"[optional] this secondary metric is used to define the color as a ratio "
+"against the primary metric. When omitted, the color is categorical and based "
+"on labels"
+msgstr ""
+"[opcijsko] sekundarna mera določa barvo kot razmerje do primarne mere. Če je "
+"izpuščena, je barva določena kategorično na podlagi oznak"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts:67
+msgid ""
+"When only a primary metric is provided, a categorical color scale is used."
+msgstr ""
+"Če je podana samo primarna metrika, je uporabljena kategorična barvna skala."
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts:70
+msgid "When a secondary metric is provided, a linear color scale is used."
+msgstr "Če je podana sekundarna metrika, je uporabljena linearna barvna skala."
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts:73
+msgid "Hierarchy"
+msgstr "Hierarhija"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts:74
+msgid "This defines the level of the hierarchy"
+msgstr "Določa stopnjo hierarhije"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-sunburst/src/index.js:27
+msgid "Sunburst Chart"
+msgstr "Večnivojski tortni grafikon"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-time-table/src/controlPanel.ts:38
+msgid "Time Series Columns"
+msgstr "Stolpci s časovnimi vrstami"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-treemap/src/controlPanel.ts:63
+msgid "Ratio"
+msgstr "Razmerje"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-treemap/src/controlPanel.ts:68
+msgid "Target aspect ratio for treemap tiles."
+msgstr "Ciljno razmerje za razdelke drevesnega grafikona."
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:35
+msgid "Country Field Type"
+msgstr "Tip polja za države"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:43
+msgid ""
+"The country code standard that Superset should expect to find in the "
+"[country] column"
+msgstr "Standard za oznake držav, ki bodo podane v stolpcu z državami"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:74
+msgid "Show Bubbles"
+msgstr "Prikaži mehurčke"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:77
+msgid "Whether to display bubbles on top of countries"
+msgstr "Če želite prikaz mehurčkov nad državami"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:88
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bubble/controlPanel.ts:58
+msgid "Max Bubble Size"
+msgstr "Max. velikost mehurčka"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:101
+msgid "Country Column"
+msgstr "Stolpec z državami"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:102
+msgid "3 letter code of the country"
+msgstr "Tričrkovna oznaka države"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:105
+msgid "Metric for Color"
+msgstr "Mera za barvo"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:106
+msgid "Metric that defines the color of the country"
+msgstr "Mera, ki določa barvo države"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:110
+msgid "Metric that defines the size of the bubble"
+msgstr "Mera, ki določa velikost mehurčka"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:113
+msgid "Bubble Color"
+msgstr "Barva mehurčka"
+
+#: superset-ui/superset-ui/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:116
+msgid "Country Color Scheme"
+msgstr "Barvna shema držav"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/sharedControls.ts:29
+msgid "Big Number Font Size"
+msgstr "Velikost pisave Velike številke"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/sharedControls.ts:37
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/sharedControls.ts:72
+msgid "Tiny"
+msgstr "Drobna"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/sharedControls.ts:45
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/sharedControls.ts:80
+msgid "Normal"
+msgstr "Normalna"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/sharedControls.ts:53
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/sharedControls.ts:88
+msgid "Huge"
+msgstr "Ogromna"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/sharedControls.ts:64
+msgid "Subheader Font Size"
+msgstr "Velikost pisave podnaslova"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/BigNumber.tsx:71
+msgid "N/A"
+msgstr "N/A"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/BigNumber.tsx:139
+#, python-format
+msgid "Last available value seen on %s"
+msgstr "Zadnja razpoložljiva vrednost na %s"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/BigNumber.tsx:141
+msgid "Not up to date"
+msgstr "Ni posodobljeno"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/BigNumber.tsx:178
+msgid "No data after filtering or data is NULL for the latest time record"
+msgstr ""
+"Ni podatkov po filtriranju ali pa imajo vrednost NULL za zadnji časovni zapis"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/BigNumber.tsx:181
+msgid "Try applying different filters or ensuring your datasource has data"
+msgstr ""
+"Poskusite uporabiti druge filtre oz. zagotovite, da so v podatkovnem viru "
+"podatki"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx:42
+msgid "Comparison Period Lag"
+msgstr "Zaostanek obdobja za primerjavo"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx:44
+msgid "Based on granularity, number of time periods to compare against"
+msgstr "Na osnovi granulacije, število časovnih obdobij za primerjavo"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx:53
+msgid "Comparison suffix"
+msgstr "Pripona za primerjavo"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx:54
+msgid "Suffix to apply after the percentage display"
+msgstr "Pripona za prikaz procenta"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx:64
+msgid "Show Trend Line"
+msgstr "Pokaži trendno črto"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx:67
+msgid "Whether to display the trend line"
+msgstr "Če želite prikazati trendno črto"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx:76
+msgid "Start y-axis at 0"
+msgstr "Začni y-os z 0"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx:79
+msgid ""
+"Start y-axis at zero. Uncheck to start y-axis at minimum value in the data."
+msgstr ""
+"Začni y-os z nič. Ne izberite, če želite, da se y-os začne z najmanjšo "
+"vrednostjo podatkov."
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx:90
+msgid "Fix to selected Time Range"
+msgstr "Nastavi na izbrano časovno obdobje"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx:91
+msgid ""
+"Fix the trend line to the full time range specified in case filtered results "
+"do not include the start or end dates"
+msgstr ""
+"Trendno črto nastavite na izbrano obdobje, v primeru, da filtrirani "
+"rezultati ne vsebujejo začetnega in/ali končnega datuma"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumberTotal/controlPanel.ts:40
+msgid "Subheader"
+msgstr "Podnaslov"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-big-number/src/BigNumberTotal/controlPanel.ts:41
+msgid "Description text that shows up below your Big Number"
+msgstr "Besedilo, ki se prikaže pod veliko številko"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:53
+msgid "Right Axis Format"
+msgstr "Oblika desne osi"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:64
+msgid "Show Markers"
+msgstr "Prikaži markerje"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:67
+msgid "Show data points as circle markers on the lines"
+msgstr "Pokaži točke kot krožne markerje na krivuljah"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:89
+msgid "Y bounds"
+msgstr "Y meje"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:92
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:103
+msgid "Whether to display the min and max values of the Y-axis"
+msgstr "Če želite prikaz min. in max. vrednosti Y-osi"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:100
+msgid "Y 2 bounds"
+msgstr "Meje Y 2"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:111
+msgid "Line Style"
+msgstr "Slog črte"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:122
+msgid "Line interpolation as defined by d3.js"
+msgstr "Interpolacija krivulje na osnovi d3.js"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:130
+msgid "Show Range Filter"
+msgstr "Pokaži filter obdobja"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:139
+msgid "Whether to display the time range interactive selector"
+msgstr "Če želite prikaz interaktivnega izbirnika časovnega obdobja"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:158
+msgid "Extra Controls"
+msgstr "Dodatni kontrolniki"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:161
+msgid ""
+"Whether to show extra controls or not. Extra controls include things like "
+"making mulitBar charts stacked or side by side."
+msgstr ""
+"Če želite prikaz dodatnih kontrolnikov. Dodatni kontrolniki vključujejo "
+"možnost izdelave večstolpčnih grafikonov, naloženih ali drug ob drugem."
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:197
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts:87
+#: superset-ui/superset-ui/plugins/preset-chart-xy/src/BoxPlot/controlPanel.ts:56
+msgid "X Tick Layout"
+msgstr "Postavitev oznak na X-osi"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:202
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts:92
+#: superset-ui/superset-ui/plugins/preset-chart-xy/src/BoxPlot/controlPanel.ts:61
+msgid "The way the ticks are laid out on the X-axis"
+msgstr "Način razporeditve oznak na X-osi"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:211
+msgid "X Axis Format"
+msgstr "Oblika X-osi"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:223
+msgid "Y Log Scale"
+msgstr "Logaritemska Y-os"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:226
+msgid "Use a log scale for the Y-axis"
+msgstr "Uporabi logaritemsko skalo za Y-os"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:234
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:354
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:464
+msgid "Y Axis Bounds"
+msgstr "Meje Y-osi"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:237
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:253
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:357
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:467
+msgid ""
+"Bounds for the Y-axis. When left empty, the bounds are dynamically defined "
+"based on the min/max of the data. Note that this feature will only expand "
+"the axis range. It won't narrow the data's extent."
+msgstr ""
+"Meje Y-osi. Če je prazno, se meje nastavijo dinamično na podlagi min./max. "
+"vrednosti podatkov. Funkcija omeji le prikaz, obseg podatkov pa ostane enak."
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:250
+msgid "Y Axis 2 Bounds"
+msgstr "Meje Y 2-osi"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:266
+msgid "X bounds"
+msgstr "Meje X-osi"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:269
+msgid "Whether to display the min and max values of the X-axis"
+msgstr "Če želite prikaz min. in max. vrednosti X-osi"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:288
+msgid "Bar Values"
+msgstr "Vrednosti stolpcev"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:291
+msgid "Show the value on top of the bar"
+msgstr "Prikaži vrednosti na vrhu stolpcev"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:299
+msgid "Stacked Bars"
+msgstr "Naloženi stolpci"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:310
+msgid "Reduce X ticks"
+msgstr "Manj oznak X-osi"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:313
+msgid ""
+"Reduces the number of X-axis ticks to be rendered. If true, the x-axis will "
+"not overflow and labels may be missing. If false, a minimum width will be "
+"applied to columns and the width may overflow into an horizontal scroll."
+msgstr ""
+"Zmanjša število izrisanih oznak na X-osi. Če je vklopljeno, se x-os ne bo "
+"prelila in lahko oznake manjkajo. Če je izklopljeno, bo upoštevana min. "
+"širina stolpcev, ki pa se lahko prelije v horizontalni drsnik."
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js:369
+msgid "You cannot use 45° tick layout along with the time range filter"
+msgstr ""
+"Skupaj s filtriranjem časovnega obdobja ne morete uporabiti oznak pod 45° "
+"kotom"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Area/controlPanel.ts:52
+msgid "Stacked Style"
+msgstr "Slog nalaganja"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Area/index.js:28
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:259
+msgid "Area Chart"
+msgstr "Ploščinski grafikon"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bar/index.js:28
+msgid "Time-series Bar Chart"
+msgstr "Stolpčni grafikon za časovno vrsto"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/BoxPlot/index.js:26
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/BoxPlot/index.ts:49
+#: superset-ui/superset-ui/plugins/preset-chart-xy/src/BoxPlot/createMetadata.ts:7
+msgid "Box Plot"
+msgstr "Box Plot"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bubble/controlPanel.ts:98
+msgid "X Log Scale"
+msgstr "Logaritemska X-os"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bubble/controlPanel.ts:101
+msgid "Use a log scale for the X-axis"
+msgstr "Uporabi logaritemsko skalo za X-os"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:39
+msgid "Ranges"
+msgstr "Razponi"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:41
+msgid "Ranges to highlight with shading"
+msgstr "Razponi za označitev s senčenjem"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:48
+msgid "Range labels"
+msgstr "Oznake razponov"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:50
+msgid "Labels for the ranges"
+msgstr "Oznake za razpone"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:59
+msgid "Markers"
+msgstr "Markerji"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:61
+msgid "List of values to mark with triangles"
+msgstr "Seznam vrednosti, ki bodo markirane s trikotniki"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:68
+msgid "Marker labels"
+msgstr "Oznake markerjev"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:70
+msgid "Labels for the markers"
+msgstr "Oznake za markerje"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:79
+msgid "Marker lines"
+msgstr "Markirne črtice"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:81
+msgid "List of values to mark with lines"
+msgstr "Seznam vrednosti, ki bodo markirane s črticami"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:88
+msgid "Marker line labels"
+msgstr "Oznake markirnih črtic"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:90
+msgid "Labels for the marker lines"
+msgstr "Oznake za markirne črtice"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Compare/index.js:26
+#, python-format
+msgid "A line chart component where you can compare the % change over time"
+msgstr "Komponenta grafikona, kjer lahko primerjate % cpremembo skozi čas"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Compare/index.js:27
+msgid "Time-series Percent Change"
+msgstr "Časovna vrsta - Procentualna sprememba"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts:86
+msgid "Sort Bars"
+msgstr "Uredi stolpce"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts:89
+msgid "Sort bars by x labels."
+msgstr "Uredi stolpce po x-oznakah."
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts:112
+msgid "Breakdowns"
+msgstr "Razčlenitev"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts:113
+msgid "Defines how each series is broken down"
+msgstr "Določa, kako se vsaka podatkovna serija razčleni"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js:26
+msgid "A bar chart where the x axis is time"
+msgstr "Stolpčni grafikon, kjer je na x-osi čas"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js:27
+msgid "Bar Chart"
+msgstr "Stolpčni grafikon"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/DualLine/controlPanel.ts:40
+msgid "Y Axis 1"
+msgstr "Y-os 1"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/DualLine/controlPanel.ts:45
+msgid "Y Axis 2"
+msgstr "Y-os 2"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/DualLine/controlPanel.ts:58
+msgid "Left Axis Metric"
+msgstr "Mera za levo os"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/DualLine/controlPanel.ts:59
+msgid "Choose a metric for left axis"
+msgstr "Izberite mero za levo os"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/DualLine/controlPanel.ts:62
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:164
+msgid "Left Axis Format"
+msgstr "Oblika leve osi"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/DualLine/index.js:27
+msgid "Dual Line Chart"
+msgstr "Grafikon z dvojno krivuljo"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Line/controlPanel.ts:56
+msgid "Propagate"
+msgstr "Razširi"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Line/controlPanel.ts:59
+msgid "Send range filter events to other charts"
+msgstr "Pošlji dogodke filtra obdobja na druge grafikone"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Line/index.js:29
+#: superset-ui/superset-ui/plugins/preset-chart-xy/src/Line/createMetadata.ts:7
+msgid "Line Chart"
+msgstr "Črtni grafikon"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:64
+msgid "Prefix metric name with slice name"
+msgstr "Imenu mere pripni ime rezine"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:88
+msgid "Y Axis Left"
+msgstr "Y-os levo"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:97
+msgid "Left Axis chart(s)"
+msgstr "Grafikoni leve osi"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:100
+msgid "Choose one or more charts for left axis"
+msgstr "Izberite enega ali več grafikonov za levo os"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/Multi/controlPanel.js:42
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:102
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:136
+msgid "Select charts"
+msgstr "Izberi grafikone"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/Multi/controlPanel.js:43
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:103
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:137
+msgid "Error while fetching charts"
+msgstr "Napaka pri pridobivanju grafikonov"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:122
+msgid "Y Axis Right"
+msgstr "Y-os desno"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:131
+msgid "Right Axis chart(s)"
+msgstr "Grafikoni desne osi"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:134
+msgid "Choose one or more charts for right axis"
+msgstr "Izberite enega ali več grafikonov za desno os"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/LineMulti/index.js:27
+msgid "Multiple Line Charts"
+msgstr "Veččrtni grafikon"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Pie/controlPanel.ts:39
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Funnel/controlPanel.tsx:96
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:109
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx:125
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Treemap/controlPanel.tsx:111
+msgid "Label Type"
+msgstr "Oblika oznake"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Pie/controlPanel.ts:50
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Funnel/controlPanel.tsx:107
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:120
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx:132
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Treemap/controlPanel.tsx:119
+msgid "What should be shown on the label?"
+msgstr "Kaj bo prikazano na oznaki?"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Pie/controlPanel.ts:73
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:217
+msgid "Donut"
+msgstr "Kolobar"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Pie/controlPanel.ts:76
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:220
+msgid "Do you want a donut or a pie?"
+msgstr "Želite kolobar ali torto?"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Pie/controlPanel.ts:86
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Funnel/controlPanel.tsx:132
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:159
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx:113
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Treemap/controlPanel.tsx:87
+msgid "Show Labels"
+msgstr "Pokaži oznake"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Pie/controlPanel.ts:89
+msgid ""
+"Whether to display the labels. Note that the label only displays when the "
+"the 5% threshold."
+msgstr ""
+"Če želite prikazati oznake. Oznake so prikazane le pri vsaj 5-odstotnem "
+"pragu."
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Pie/controlPanel.ts:99
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:171
+msgid "Put labels outside"
+msgstr "Postavi oznake zunaj"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Pie/controlPanel.ts:102
+msgid "Put the labels outside the pie?"
+msgstr "Postavim oznake zunaj torte?"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/Pie/index.js:27
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/index.ts:49
+msgid "Pie Chart"
+msgstr "Tortni grafikon"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/TimePivot/controlPanel.ts:49
+msgid "Frequency"
+msgstr "Frekvenca"
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/TimePivot/controlPanel.ts:61
+msgid ""
+"The periodicity over which to pivot time. Users can provide\r\n"
+"            \"Pandas\" offset alias.\r\n"
+"            Click on the info bubble for more details on accepted \"freq\" "
+"expressions."
+msgstr ""
+"Periodičnost za vrtenje časa. Uporabnik lahko poda\n"
+"            psevdonim za zamik v \"Pandas\".\n"
+"            Kliknite na mehurček za podrobnosti dovoljenih izrazov za \"freq"
+"\"."
+
+#: superset-ui/superset-ui/plugins/legacy-preset-chart-nvd3/src/TimePivot/index.js:27
+msgid "Time-series Period Pivot"
+msgstr "Časovna serija - Vrtenje periode"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/controls.tsx:30
+msgid "Show legend"
+msgstr "Prikaži legendo"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/controls.tsx:33
+msgid "Whether to display a legend for the chart"
+msgstr "Če želite prikaz legende za grafikon"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/controls.tsx:41
+msgid "Margin"
+msgstr "Rob"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/controls.tsx:45
+msgid "Additional padding for legend."
+msgstr "Dodatni razmak za legendo."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/controls.tsx:63
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/controls.tsx:83
+msgid "Legend type"
+msgstr "Tip legende"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts:49
+#: superset-ui/superset-ui/plugins/preset-chart-xy/src/BoxPlot/controlPanel.ts:41
+msgid "Whisker/outlier options"
+msgstr "Možnosti grafikona kvantilov"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts:51
+#: superset-ui/superset-ui/plugins/preset-chart-xy/src/BoxPlot/controlPanel.ts:43
+msgid "Determines how whiskers and outliers are calculated."
+msgstr "Določa kako so izračunani kvantili in izstopajoče vrednosti."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts:74
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Funnel/controlPanel.tsx:79
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:92
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx:98
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Treemap/controlPanel.tsx:73
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:261
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:429
+msgid "Enable emitting filters"
+msgstr "Omogoči oddajanje filtrov"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts:77
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Funnel/controlPanel.tsx:82
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:95
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx:101
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Treemap/controlPanel.tsx:76
+msgid "Enable emmiting filters."
+msgstr "Omogoči oddajanje filtrov."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts:132
+msgid "Categories to group by on the x-axis."
+msgstr "Kategorije za združevanje po x-osi."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts:135
+msgid "Distribute across"
+msgstr "Porazdeli glede na"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts:137
+msgid ""
+"Columns to calculate distribution across. Defaults to temporal column if "
+"left empty."
+msgstr ""
+"Stolpci za izračun porazdelitve. Privzeto je izbran časovni stolpec (če je "
+"prazno)."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Funnel/controlPanel.tsx:90
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:103
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx:107
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Treemap/controlPanel.tsx:81
+msgid "Labels"
+msgstr "Oznake"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Funnel/controlPanel.tsx:135
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:162
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx:116
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Treemap/controlPanel.tsx:90
+msgid "Whether to display the labels."
+msgstr "Če želite prikaz oznak."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Funnel/index.ts:49
+msgid "Funnel Chart"
+msgstr "Lijakasti grafikon"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:42
+msgid "Columns to group by"
+msgstr "Stolpci za združevanje"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:74
+msgid "General"
+msgstr "Splošno"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:85
+msgid "Minimum value on the gauge axis"
+msgstr "Najmanjša vrednost na številčnici"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:97
+msgid "Maximum value on the gauge axis"
+msgstr "Največja vrednost na številčnici"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:106
+msgid "Start angle"
+msgstr "Začetni kot"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:107
+msgid "Angle at which to start progress axis"
+msgstr "Kot, pri katerem se začne os območja"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:116
+msgid "End angle"
+msgstr "Končni kot"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:117
+msgid "Angle at which to end progress axis"
+msgstr "Kot, pri katerem se konča os območja"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:129
+msgid "Font size"
+msgstr "Velikost pisave"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:130
+msgid "Font size for axis labels, detail value and other text elements"
+msgstr "Velikost pisave za oznake osi, podrobnosti in druge besedilne elemente"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:157
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:135
+msgid "Value format"
+msgstr "Oblika zapisa vrednosti"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:158
+msgid "Additional text to add before or after the value, e.g. unit"
+msgstr "Dodatno besedilo, ki ga dodate pred ali za vrednost, npr. enota"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:169
+msgid "Show pointer"
+msgstr "Prikaži kazalec"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:170
+msgid "Whether to show the pointer"
+msgstr "Če želite prikazati kazalec"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:181
+msgid "Animation"
+msgstr "Animacija"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:182
+msgid "Whether to animate the progress and the value or just display them"
+msgstr "Če želite animiran prikaz grafikona"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:188
+msgid "Axis"
+msgstr "Os"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:194
+msgid "Show axis line ticks"
+msgstr "Prikaži oznake na X-osi"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:195
+msgid "Whether to show minor ticks on the axis"
+msgstr "Če želite prikaz manjših oznak na osi"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:206
+msgid "Show split lines"
+msgstr "Prikaži razdelitvene črte"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:207
+msgid "Whether to show the split lines on the axis"
+msgstr "Če želite prikazati razdelitvene črte na osi"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:218
+msgid "Split number"
+msgstr "Število razdelitev"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:219
+msgid "Number of split segments on the axis"
+msgstr "Število razdelkov na osi"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:227
+msgid "Progress"
+msgstr "Območje"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:233
+msgid "Show progress"
+msgstr "Prikaži območje"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:234
+msgid "Whether to show the progress of gauge chart"
+msgstr "Prikaži merilno območje števčnega grafikona"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:245
+msgid "Overlap"
+msgstr "Prekrivanje"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:246
+msgid ""
+"Whether the progress bar overlaps when there are multiple groups of data"
+msgstr "Če želite prekrivanje območij, ko imate več skupin podatkov"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:259
+msgid "Round cap"
+msgstr "Zaobljeni konci"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:260
+msgid "Style the ends of the progress bar with a round cap"
+msgstr "Zaobljena oblika koncev območja"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:266
+msgid "Intervals"
+msgstr "Intervali"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:272
+msgid "Interval bounds"
+msgstr "Meje intervalov"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:273
+msgid ""
+"Comma-separated interval bounds, e.g. 2,4,5 for intervals 0-2, 2-4 and 4-5. "
+"Last number should match the value provided for MAX."
+msgstr ""
+"Z vejico ločeni intervali, npr. 2,4,5 za intervale 0-2, 2-4 in 4-5. Zadnja "
+"številka naj bo enaka vrednosti za MAX."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:286
+msgid "Interval colors"
+msgstr "Barve intervalov"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:287
+msgid ""
+"Comma-separated color picks for the intervals, e.g. 1,2,4. Integers denote "
+"colors from the chosen color scheme and are 1-indexed. Length must be "
+"matching that of interval bounds."
+msgstr ""
+"Z vejico ločene barve za intervale, npr. 1,2,4. Cela števila predstavljajo "
+"barve iz barvne sheme (začnejo se z 1). Dolžina mora ustrezati mejam "
+"intervala."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Gauge/index.ts:33
+msgid "Gauge Chart"
+msgstr "Števčni grafikon"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:49
+msgid "Name of the source nodes"
+msgstr "Imena izvornih vozlišč"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:59
+msgid "Name of the target nodes"
+msgstr "Imena ciljnih vozlišč"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:69
+msgid "Source category"
+msgstr "Kategorija izvora"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:70
+msgid ""
+"The category of source nodes used to assign colors. If a node is associated "
+"with more than one category, only the first will be used."
+msgstr ""
+"Kategorija izvornih vozlišč, na podlagi katere je določena barva. Če je "
+"vozlišče povezano z več kot eno kategorijo, bo uporabljena samo prva."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:82
+msgid "Target category"
+msgstr "Kategorija cilja"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:83
+msgid "Category of target nodes"
+msgstr "Kategorija ciljnih vozlišč"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:92
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:100
+msgid "Chart options"
+msgstr "Možnosti grafikona"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:97
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:103
+msgid "Layout"
+msgstr "Izgled"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:104
+msgid "Graph layout"
+msgstr "Izgled grafikona"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:107
+msgid "Force"
+msgstr "Sila"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:108
+msgid "Circular"
+msgstr "Krožno"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:110
+msgid "Layout type of graph"
+msgstr "Tip izgleda grafikona"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:120
+msgid "Edge symbols"
+msgstr "Simboli povezav"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:121
+msgid "Symbol of two ends of edge line"
+msgstr "Simbol za konca povezave"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:124
+msgid "None -> None"
+msgstr "Brez -> Brez"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:125
+msgid "None -> Arrow"
+msgstr "Brez -> Puščica"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:126
+msgid "Circle -> Arrow"
+msgstr "Krog -> Puščica"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:127
+msgid "Circle -> Circle"
+msgstr "Krog -> Krog"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:137
+msgid "Enable node dragging"
+msgstr "Omogoči premikanje vozlišč"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:140
+msgid "Whether to enable node dragging in force layout mode."
+msgstr "Če želite omogočiti premikanje vozlišč v načinu vsiljenega prikaza."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:152
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:263
+msgid "Enable graph roaming"
+msgstr "Omogoči preoblikovanje grafikona"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:156
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:174
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:267
+msgid "Disabled"
+msgstr "Onemogočeno"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:157
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:268
+msgid "Scale only"
+msgstr "Samo povečava"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:158
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:269
+msgid "Move only"
+msgstr "Samo premikanje"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:159
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:270
+msgid "Scale and Move"
+msgstr "Povečava in premikanje"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:161
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:272
+msgid "Whether to enable changing graph position and scaling."
+msgstr "Če želite omogočiti premikanje in povečevanje/zmanjševanje grafikona."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:171
+msgid "Node select mode"
+msgstr "Način izbire vozlišč"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:175
+msgid "Single"
+msgstr "Posamezno"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:176
+msgid "Multiple"
+msgstr "Več"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:178
+msgid "Allow node selections"
+msgstr "Dovoli izbiro vozlišča"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:187
+msgid "Label threshold"
+msgstr "Prag oznak"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:191
+msgid "Minimum value for label to be displayed on graph."
+msgstr "Najmanjša vrednost, za katero bo na grafikonu prikazana oznaka."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:200
+msgid "Node size"
+msgstr "Velikost vozlišča"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:204
+msgid ""
+"Median node size, the largest node will be 4 times larger than the smallest"
+msgstr ""
+"Mediana velikosti vozlišča. Največje vozlišče bo 4-krat večje od najmanjšega"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:213
+msgid "Edge width"
+msgstr "Debelina povezave"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:217
+msgid ""
+"Median edge width, the thickest edge will be 4 times thicker than the "
+"thinnest."
+msgstr ""
+"Mediana debeline povezave. Najdebelejša povezava bo 4-krat debelejša od "
+"najtanjše."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:228
+msgid "Edge length"
+msgstr "Dolžina povezave"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:234
+msgid "Edge length between nodes"
+msgstr "Dolžina povezave med vozlišči"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:246
+msgid "Gravity"
+msgstr "Gravitacija"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:252
+msgid "Strength to pull the graph toward center"
+msgstr "Sila privlačnosti med grafikonom in središčem"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:264
+msgid "Repulsion"
+msgstr "Odbijanje"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:270
+msgid "Repulsion strength between nodes"
+msgstr "Odbojna sila med vozlišči"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:282
+msgid "Friction"
+msgstr "Trenje"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:288
+msgid "Friction between nodes"
+msgstr "Trenje med vozlišči"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Graph/index.ts:33
+msgid "Graph Chart"
+msgstr "Graf"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:119
+msgid "Series type"
+msgstr "Tip serije"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:131
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:238
+msgid "Series chart type (line, bar etc)"
+msgstr "Tip grafikona za posamezno podatkovno serijo (črtni, stolpčni, ...)"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:140
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:247
+msgid "Stack series"
+msgstr "Nalagaj serije"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:143
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:250
+msgid "Stack series on top of each other"
+msgstr "Nalagaj serije eno na drugo"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:152
+msgid "Area chart"
+msgstr "Ploščinski grafikon"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:155
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:262
+msgid "Draw area under curves. Only applicable for line types."
+msgstr "Izriši površino pod krivuljo. Samo za črtne grafikone."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:170
+msgid "Opacity of area chart."
+msgstr "Prosojnost ploščinskega grafikona."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:179
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:288
+msgid "Marker"
+msgstr "Marker"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:182
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:291
+msgid "Draw a marker on data points. Only applicable for line types."
+msgstr "Nariši markerje na točke grafikona. Samo za črtne grafikone."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:191
+msgid "Marker size"
+msgstr "Velikost markerja"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:196
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:305
+msgid "Size of marker. Also applies to forecast observations."
+msgstr "Velikost markerja. Upošteva se tudi za napovedi."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:207
+msgid "Primary"
+msgstr "Primarna"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:208
+msgid "Secondary"
+msgstr "Sekundarna"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:212
+msgid "Primary or secondary y-axis"
+msgstr "Primarna ali sekundarna y-os"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:222
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:246
+msgid "Query A"
+msgstr "Poizvedba A"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:223
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:247
+msgid "Query B"
+msgstr "Poizvedba B"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:253
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:316
+msgid "Data Zoom"
+msgstr "Zoom funkcija"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:256
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:319
+msgid "Enable data zooming controls"
+msgstr "Omogoči kontrolnik za povečavo podatkov"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:268
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:271
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:342
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:345
+msgid "Show Min Label"
+msgstr "Pokaži oznako Min"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:280
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:283
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:354
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:357
+msgid "Show Max Label"
+msgstr "Pokaži oznako Max"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:294
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:368
+msgid "Rotate x axis label"
+msgstr "Zavrti oznako x-osi"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:301
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:375
+msgid "Input field supports custom rotation. e.g. 30 for 30°"
+msgstr "Vnosno polje omogoča poljubno rotacijo (vnesite 30 za 30°)"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:307
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:381
+msgid "Tooltip"
+msgstr "Opis orodja"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:313
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:387
+msgid "Rich tooltip"
+msgstr "Podroben opis orodja"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:316
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:390
+msgid "Shows a list of all series available at that point in time"
+msgstr ""
+"Prikaže seznam vseh razpoložljivih podatkovnih serij za istočasno točko"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:328
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:426
+msgid "Minor Split Line"
+msgstr "Manjša ločilna črta"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:331
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:429
+msgid "Draw split lines for minor y-axis ticks"
+msgstr "Izriši ločilne črte za pomožne oznake y-osi"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:340
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:450
+msgid "Truncate Y Axis"
+msgstr "Prireži Y-os"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:343
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:453
+msgid "Truncate Y Axis. Can be overridden by specifying a min or max bound."
+msgstr "Prireži Y-os. Preprečite, tako da določite spodnjo in zgornjo mejo."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:371
+msgid "Primary y-axis format"
+msgstr "Oblika primarne y-osi"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:380
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:438
+msgid "Primary y-axis title"
+msgstr "Naslov primarne y-osi"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:383
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:441
+msgid "Title for y-axis"
+msgstr "Naslov y-osi"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:392
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:416
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:425
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:414
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:417
+msgid "Logarithmic y-axis"
+msgstr "Logaritemska y-os"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:395
+msgid "Logarithmic scale on primary y-axis"
+msgstr "Logaritemska skala na primarni y-osi"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:404
+msgid "Secondary y-axis format"
+msgstr "Oblika sekundarne y-osi"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:413
+msgid "Secondary y-axis title"
+msgstr "Naslov sekundarne y-osi"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:428
+msgid "Logarithmic scale on secondary y-axis"
+msgstr "Logaritemska skala na sekundarni y-osi"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/MixedTimeseries/index.ts:50
+msgid "Mixed timeseries chart"
+msgstr "Kombinirani grafikon časovne vrste"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:78
+msgid "Percentage threshold"
+msgstr "Procentualni prag"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:82
+msgid "Minimum threshold in percentage points for showing labels."
+msgstr "Minimalni prag v odstotnih točkah za prikaz oznak."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:174
+msgid "Put the labels outside of the pie?"
+msgstr "Postavim oznake zunaj torte?"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:185
+msgid "Label Line"
+msgstr "Črta oznake"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:188
+msgid "Draw line from Pie to label when labels outside?"
+msgstr "Ali želite črto do oznake, ko so le-te zunaj?"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:196
+msgid "Pie shape"
+msgstr "Oblika torte"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:202
+msgid "Outer Radius"
+msgstr "Zunanji polmer"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:208
+msgid "Outer edge of Pie chart"
+msgstr "Zunanji rob tortnega grafikona"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:229
+msgid "Inner Radius"
+msgstr "Notranji polmer"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:235
+msgid "Inner radius of donut hole"
+msgstr "Notranji polmer kolobarja"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx:56
+msgid "The maximum value of metrics. It is an optional configuration"
+msgstr "Največja vrednost mere. To je opcijska nastavitev"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx:142
+msgid "Label position"
+msgstr "Položaj oznake"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx:180
+msgid "Radar"
+msgstr "Radar"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx:186
+msgid "Customize Metrics"
+msgstr "Prilagodi mere"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx:187
+msgid "Further customize how to display each metric"
+msgstr "Dodatne prilagoditve prikaza posameznih mer"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx:213
+msgid "Circle radar shape"
+msgstr "Okrogla oblika radarja"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx:216
+msgid "Radar render type, whether to display 'circle' shape."
+msgstr "Način prikaza radarja - če se prikaže okrogla oblika."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Radar/index.ts:50
+msgid "Radar Chart"
+msgstr "Radarski grafikon"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:76
+msgid "Contribution Mode"
+msgstr "Način deležev"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:83
+msgid "Calculate contribution per series or total"
+msgstr "Izračunaj delež za podatkovno serijo ali skupnega"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:122
+msgid "Predictive Analytics"
+msgstr "Prediktivna analitika"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:130
+msgid "Enable forecast"
+msgstr "Omogoči napoved"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:133
+msgid "Enable forecasting"
+msgstr "Omogoči napovedovanje"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:142
+msgid "Forecast periods"
+msgstr "Obdobja napovedi"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:145
+msgid "How many periods into the future do we want to predict"
+msgstr "Za koliko period v prihodnosti želite napoved"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:154
+msgid "Confidence interval"
+msgstr "Interval zaupanja"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:157
+msgid "Width of the confidence interval. Should be between 0 and 1"
+msgstr "Širina intervala zaupanja. Mora bit med 0 in 1"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:172
+msgid ""
+"Should yearly seasonality be applied. An integer value will specify Fourier "
+"order of seasonality."
+msgstr ""
+"Če želite letno sezonskost. Celo število določa Fourier-jev red sezonskosti."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:191
+msgid ""
+"Should weekly seasonality be applied. An integer value will specify Fourier "
+"order of seasonality."
+msgstr ""
+"Če želite tedensko sezonskost. Celo število določa Fourier-jev red "
+"sezonskosti."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:208
+msgid ""
+"Should daily seasonality be applied. An integer value will specify Fourier "
+"order of seasonality."
+msgstr ""
+"Če želite dnevno sezonskost. Celo število določa Fourier-jev red sezonskosti."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:226
+msgid "Series Style"
+msgstr "Slog serije"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:271
+msgid "Area chart opacity"
+msgstr "Prosojnost ploščinskega grafikona"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:277
+msgid "Opacity of Area Chart. Also applies to confidence band."
+msgstr ""
+"Prosojnost ploščinskega grafikona. Upošteva se tudi za interval zaupanja."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:300
+msgid "Marker Size"
+msgstr "Velikost markerja"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:399
+msgid "Tooltip time format"
+msgstr "Oblika zapisa časa v opisu orodja"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Timeseries/index.ts:50
+msgid "Time-series Chart"
+msgstr "Grafikon časovne vrste"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:46
+msgid "Id"
+msgstr "Id"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:47
+msgid "Name of the id column"
+msgstr "Naziv id-stolpca"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:56
+msgid "Parent"
+msgstr "Nadrejeni"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:57
+msgid "Name of the column containing the id of the parent node"
+msgstr "Ime stolpca, ki vsebuje id nadrejenega vozlišča"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:67
+msgid "Optional name of the data column."
+msgstr "Opcijsko ime podatkovnega stolpca."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:79
+msgid "Root node id"
+msgstr "Id korenskega vozlišča"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:80
+msgid "Id of root node of the tree."
+msgstr "Id korenskega vozlišča drevesa."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:91
+msgid "Metric for node values"
+msgstr "Mera za vrednosti vozlišč"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:110
+msgid "Tree layout"
+msgstr "Oblika drevesa"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:113
+msgid "Orthogonal"
+msgstr "Pravokotna"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:114
+msgid "Radial"
+msgstr "Radialna"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:116
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:239
+msgid "Layout type of tree"
+msgstr "Način izgleda drevesa"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:127
+msgid "Tree orientation"
+msgstr "Orientacija drevesa"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:130
+msgid "Left to Right"
+msgstr "Iz leve proti desni"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:131
+msgid "Right to Left"
+msgstr "Iz desne proti levi"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:132
+msgid "Top to Bottom"
+msgstr "Iz vrha proti dnu"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:133
+msgid "Bottom to Top"
+msgstr "Iz dna proti vrhu"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:135
+msgid "Orientation of tree"
+msgstr "Orientacija drevesa"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:148
+msgid "Node label position"
+msgstr "Položaj oznake vozlišča"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:151
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:169
+msgid "left"
+msgstr "levo"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:152
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:170
+msgid "top"
+msgstr "zgoraj"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:153
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:171
+msgid "right"
+msgstr "desno"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:154
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:172
+msgid "bottom"
+msgstr "spodaj"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:156
+msgid "Position of intermidiate node label on tree"
+msgstr "Položaj vmesne oznake vozlišča na drevesu"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:166
+msgid "Child label position"
+msgstr "Položaj podrejene oznake"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:174
+msgid "Position of child node label on tree"
+msgstr "Položaj oznake podrejenega vozlišča na drevesu"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:184
+msgid "Emphasis"
+msgstr "Poudari"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:187
+msgid "ancestor"
+msgstr "nadrejeni"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:188
+msgid "descendant"
+msgstr "podrejeni"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:190
+msgid "Which relatives to highlight on hover"
+msgstr "Kateri element se poudari na prehodu z miško"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:203
+msgid "Symbol"
+msgstr "Simbol"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:207
+msgid "Empty circle"
+msgstr "Prazen krog"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:211
+msgid "Circle"
+msgstr "Krog"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:215
+msgid "Rectangle"
+msgstr "Pravokotnik"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:219
+msgid "Triangle"
+msgstr "Trikotnik"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:223
+msgid "Diamond"
+msgstr "Karo"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:227
+msgid "Pin"
+msgstr "Žebljiček"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:231
+msgid "Arrow"
+msgstr "Puščica"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:248
+msgid "Symbol size"
+msgstr "Velikost simbola"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:254
+msgid "Size of edge symbols"
+msgstr "Velikost simbola povezave"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Tree/index.ts:33
+msgid "Tree Chart"
+msgstr "Drevesni grafikon"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Treemap/controlPanel.tsx:99
+msgid "Show Upper Labels"
+msgstr "Prikaži zgornje oznake"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Treemap/controlPanel.tsx:102
+msgid "Show labels when the node has children."
+msgstr "Prikaži oznake, ko ima vozlišče podrejene elemente."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/Treemap/index.ts:50
+msgid "Treemap v2"
+msgstr "Drevesni grafikon s pravokotniki v2"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:40
+msgid "Columns to group by on the rows"
+msgstr "Stolpci za združevanje vrstic"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:50
+msgid "Columns to group by on the columns"
+msgstr "Stolpci za združevanje stolpcev"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:119
+msgid "Transpose pivot"
+msgstr "Transponirano vrtenje"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:121
+msgid "Swap rows and columns"
+msgstr "Zamenjaj vrstice in stolpce"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:143
+msgid "Pivot table type"
+msgstr "Tip vrtilne tabele"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:149
+msgid "Table Heatmap"
+msgstr "Barvanje tabele"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:150
+msgid "Table Col Heatmap"
+msgstr "Barvanje stolpcev tabele"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:151
+msgid "Table Row Heatmap"
+msgstr "Barvanje vrstic tabele"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:152
+msgid "Table Barchart"
+msgstr "Stolpčni grafi po tabeli"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:153
+msgid "Table Col Barchart"
+msgstr "Stolpčni grafi po stolpcih"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:154
+msgid "Table Row Barchart"
+msgstr "Stolpčni grafi po vrsticah"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:157
+msgid "The type of pivot table visualization"
+msgstr "Način za vizualizacijo vrtilne tabele"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:166
+msgid "Rows sort by"
+msgstr "Razvrsti vrst."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:171
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:189
+msgid "key a-z"
+msgstr "a - ž"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:172
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:190
+msgid "key z-a"
+msgstr "ž - a"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:173
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:191
+msgid "value ascending"
+msgstr "0 - 9"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:174
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:192
+msgid "value descending"
+msgstr "9 - 0"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:177
+msgid "Order of rows"
+msgstr "Vrstni red vrstic"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:184
+msgid "Cols sort by"
+msgstr "Razvrsti stolp."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:195
+msgid "Order of columns"
+msgstr "Vrstni red stolpcev"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:204
+msgid "Rows subtotals position"
+msgstr "Položaj vsot vrstic"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:209
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/controls.ts:72
+msgid "Top"
+msgstr "Zgoraj"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:210
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/controls.ts:73
+msgid "Bottom"
+msgstr "Spodaj"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:213
+msgid "Position of row level subtotals"
+msgstr "Položaj vsot na nivoju vrstic"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:220
+msgid "Cols subtotals position"
+msgstr "Položaj vsot stolp."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:229
+msgid "Position of column level subtotals"
+msgstr "Položaj vsot na nivoju stolpcev"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:238
+msgid "Show rows totals"
+msgstr "Prikaži vsoto vrstic"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:241
+msgid "Display row level totals"
+msgstr "Prikaže vsoto vseh vrstic"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:248
+msgid "Show cols totals"
+msgstr "Prik. vsoto stolpcev"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:251
+msgid "Display column level totals"
+msgstr "Prikaže vsoto vseh stolpcev"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts:264
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:432
+msgid "Whether to apply filter to dashboards when table cells are clicked"
+msgstr ""
+"Če želite uporabiti filter na nadzorni plošči, ko kliknete na celico v tabeli"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-pivot-table/src/plugin/index.ts:41
+msgid "Pivot Table v2"
+msgstr "Vrtilna tabela v2"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/TableChart.tsx:111
+msgid "search.num_records"
+msgstr "search.num_records"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/TableChart.tsx:122
+msgid "page_size.show"
+msgstr "page_size.show"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/TableChart.tsx:140
+msgid "page_size.entries"
+msgstr "page_size.entries"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/TableChart.tsx:368
+msgid "Totals"
+msgstr "Vsote"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/consts.ts:26
+msgid "page_size.all"
+msgstr "page_size.all"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:76
+msgid "Group By, Metrics or Percentage Metrics must have a value"
+msgstr "Združevanje, Mera ali Procentualna mera morajo imeti vrednost"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:82
+msgid "Query mode"
+msgstr "Poizvedbeni način"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:109
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:129
+msgid "must have a value"
+msgstr "mora imeti vrednost"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:138
+msgid "Percentage metrics"
+msgstr "Procentualne mere"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:139
+msgid ""
+"Metrics for which percentage of total are to be displayed. Calculated from "
+"only data within the row limit."
+msgstr ""
+"Mera, za katero je prikazan odstotek od celote. Izračunan je samo iz "
+"podatkov znotraj omejitve števila vrstic."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:254
+msgid "Ordering"
+msgstr "Razvrščanje"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:255
+msgid "Order results by selected columns"
+msgstr "Razvrsti rezultate glede na izbrani stolpec"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:270
+msgid "Server pagination"
+msgstr "Številčenje strani strežnika"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:271
+msgid "Enable server side pagination of results (experimental feature)"
+msgstr ""
+"Omogoči številčenje strani rezultatov na strani strežnika (preizkusna "
+"funkcija)"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:289
+msgid "Server Page Length"
+msgstr "Dolžina strani strežnika"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:292
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:368
+msgid "Rows per page, 0 means no pagination"
+msgstr "Vrstic na stran (0 pomeni brez številčenja strani)"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:303
+msgid "Include time"
+msgstr "Vključi čas"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:304
+msgid "Whether to include the time granularity as defined in the time section"
+msgstr "Če želite vključiti granulacijo časa, ki je določena v sekciji Čas"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:329
+msgid ""
+"Show total aggregations of selected metrics. Note that row limit does not "
+"apply to the result."
+msgstr ""
+"Prikaži skupno agregacijo izbrane mere. Omejitev števila vrstic ne vpliva na "
+"rezultat."
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:349
+msgid "Timestamp format"
+msgstr "Oblika zapisa časovne značke"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:354
+msgid "D3 time format for datetime columns"
+msgstr "D3 oblika zapisa za časovne stolpce"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:365
+msgid "Page length"
+msgstr "Dolžina strani"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:380
+msgid "Search box"
+msgstr "Iskalno polje"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:383
+msgid "Whether to include a client-side search box"
+msgstr "Če želite vključiti iskalno polje za uporabnika"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:390
+msgid "Cell bars"
+msgstr "Stolp. graf v celicah"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:405
+msgid ""
+"Whether to align background charts with both positive and negative values at "
+"0"
+msgstr ""
+"Če želite poravnati graf v ozadju celic za negativne in pozitivne vrednosti "
+"okrog 0"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:444
+msgid "Customize columns"
+msgstr "Prilagodi stolpce"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-table/src/controlPanel.tsx:445
+msgid "Further customize how to display each column"
+msgstr "Dodatne prilagoditve prikaza posameznih stolpcev"
+
+#: superset-ui/superset-ui-plugins/packages/superset-ui-legacy-plugin-chart-word-cloud/src/index.js:27
+#: superset-ui/superset-ui/plugins/plugin-chart-word-cloud/src/legacyPlugin/index.ts:10
+#: superset-ui/superset-ui/plugins/plugin-chart-word-cloud/src/plugin/index.ts:14
+#: superset-ui/superset-ui/temporary-plugins/hold-potentially-deprecate/superset-ui-legacy-plugin-chart-word-cloud/src/index.js:26
+msgid "Word Cloud"
+msgstr "Oblak besed"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.ts:55
+msgid "Minimum Font Size"
+msgstr "Min. velikost pisave"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.ts:58
+msgid "Font size for the smallest value in the list"
+msgstr "Velikost pisave za najmanjšo vrednost na seznamu"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.ts:66
+msgid "Maximum Font Size"
+msgstr "Max. velikost pisave"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.ts:69
+msgid "Font size for the biggest value in the list"
+msgstr "Velikost pisave za največjo vrednost na seznamu"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.ts:78
+msgid "Word Rotation"
+msgstr "Vrtenje besed"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.ts:87
+msgid "Rotation to apply to words in the cloud"
+msgstr "Če želite vrtenje besed v oblaku"
+
+#: superset-ui/superset-ui/plugins/preset-chart-xy/src/ScatterPlot/createMetadata.ts:7
+msgid "Scatter Plot"
+msgstr "Raztreseni grafikon"
+
+#: superset-ui/superset-ui/temporary-plugins/plugin-chart-choropleth-map/src/chart/ChoroplethMap.tsx:309
+msgid "Hide Mini Map"
+msgstr "Skrij majhen zemljevid"
+
+#: superset-ui/superset-ui/temporary-plugins/plugin-chart-choropleth-map/src/chart/ChoroplethMap.tsx:309
+msgid "Show Mini Map"
+msgstr "Prikaži majhen zemljevid"
+
+#: superset-ui/superset-ui/temporary-plugins/plugin-chart-choropleth-map/src/plugin/index.ts:24
+msgid "Choropleth Map"
+msgstr "Koroplet zemljevid"
+
+#: superset-ui/superset-ui/temporary-plugins/plugin-chart-choropleth-map/src/plugin/index.ts:25
+msgid "ChoroplethMap"
+msgstr "ChoroplethMap"
+
+#: superset-ui/superset-ui-plugins/packages/superset-ui-plugin-chart-icicle-event/src/createMetadata.ts:26
+msgid "Icicle Event Chart"
+msgstr "Grafikon Icicle dogodkov"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/Multi/controlPanel.js:27
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Arc/controlPanel.js:78
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Geojson/controlPanel.js:52
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Grid/controlPanel.js:44
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Hex/controlPanel.js:52
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Path/controlPanel.js:63
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Polygon/controlPanel.js:94
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Scatter/controlPanel.js:59
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Screengrid/controlPanel.js:44
+msgid "Map"
+msgstr "Zemljevid"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/Multi/controlPanel.js:37
+msgid "deck.gl charts"
+msgstr "grafikoni deck.gl"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/Multi/controlPanel.js:40
+msgid "Pick a set of deck.gl charts to layer on top of one another"
+msgstr "Izberite nabor deck.gl grafikonov, ki bodo nanizani en na drugem"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/Multi/index.js:27
+msgid "deck.gl Multiple Layers"
+msgstr "deck.gl - Večplastni grafikon"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/components/PlaySlider.jsx:147
+msgid "Data has no time steps"
+msgstr "Podatki nimajo časovnih korakov"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Arc/controlPanel.js:52
+msgid "Start Longitude & Latitude"
+msgstr "Začetna Dolž. in Širina"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Arc/controlPanel.js:54
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Arc/controlPanel.js:66
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:295
+msgid "Point to your spatial columns"
+msgstr "Pokažite na stolpec z lokacijskimi podatki"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Arc/controlPanel.js:64
+msgid "End Longitude & Latitude"
+msgstr "Končna Dolž. in Širina"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Arc/controlPanel.js:85
+msgid "Arc"
+msgstr "Lok"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Arc/controlPanel.js:92
+msgid "Target Color"
+msgstr "Ciljna barva"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Arc/controlPanel.js:93
+msgid "Color of the target location"
+msgstr "Barva ciljne lokacije"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Arc/controlPanel.js:103
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Scatter/controlPanel.js:133
+msgid "Categorical Color"
+msgstr "Kategorična barva"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Arc/controlPanel.js:104
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Scatter/controlPanel.js:134
+msgid "Pick a dimension from which categorical colors are defined"
+msgstr "Izberite dimenzijo, ki bo določala kategorične barve"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Arc/controlPanel.js:115
+msgid "Stroke Width"
+msgstr "Debelina obrobe"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Arc/index.js:27
+msgid "deck.gl Arc"
+msgstr "deck.gl - Lok"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Geojson/controlPanel.js:60
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Hex/controlPanel.js:60
+msgid "GeoJson Settings"
+msgstr "GeoJson nastavitve"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Geojson/controlPanel.js:71
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Hex/controlPanel.js:71
+msgid "Point Radius Scale"
+msgstr "Skaliranje radija točk"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Geojson/index.js:27
+msgid "deck.gl Geojson"
+msgstr "deck.gl - GeoJSON"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Grid/controlPanel.js:59
+msgid "Metric used to control height"
+msgstr "Mera za določanje višine"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Grid/index.js:27
+msgid "deck.gl Grid"
+msgstr "deck.gl - Mreža"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Hex/index.js:27
+msgid "deck.gl 3D Hexagon"
+msgstr "deck.gl - 3D HEX"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Path/index.js:27
+msgid "deck.gl Path"
+msgstr "deck.gl - Poti"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Polygon/controlPanel.js:64
+msgid "Polygon Column"
+msgstr "Stolpec poligonov"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Polygon/controlPanel.js:73
+msgid "Polygon Encoding"
+msgstr "Kodiranje poligonov"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Polygon/controlPanel.js:84
+msgid "Elevation"
+msgstr "Dvig"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Polygon/controlPanel.js:102
+msgid "Polygon Settings"
+msgstr "Nastavitve poligonov"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Polygon/controlPanel.js:121
+msgid "Opacity, expects values between 0 and 100"
+msgstr "Prosojnost, vnesite vrednosti med 0 in 100"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Polygon/controlPanel.js:132
+msgid "Number of buckets to group data"
+msgstr "Število razdelkov za združevanje podatkov"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Polygon/controlPanel.js:135
+msgid "How many buckets should the data be grouped in."
+msgstr "V koliko razdelkov bodo razvrščeni podatki."
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Polygon/controlPanel.js:145
+msgid "Bucket break points"
+msgstr "Točke za razčlenitev razdelkov"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Polygon/controlPanel.js:147
+msgid "List of n+1 values for bucketing metric into n buckets."
+msgstr "Seznam n+1 vrednosti za mero razvrščanja v n razdelkov."
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Polygon/controlPanel.js:157
+msgid "Emit Filter Events"
+msgstr "Prikaži dogodke filtrov"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Polygon/controlPanel.js:160
+msgid "Whether to apply filter when items are clicked"
+msgstr "Če želite uporabiti filter, ko kliknete na elemente"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Polygon/controlPanel.js:167
+msgid "Multiple filtering"
+msgstr "Večkratno filtriranje"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Polygon/controlPanel.js:170
+msgid "Allow sending multiple polygons as a filter event"
+msgstr "Dovoli pošiljanje več poligonov kot dogodek filtra"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Polygon/index.js:27
+msgid "deck.gl Polygon"
+msgstr "deck.gl - Poligon"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Scatter/controlPanel.js:67
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:306
+msgid "Point Size"
+msgstr "Velikost točke"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Scatter/controlPanel.js:75
+msgid "Point Unit"
+msgstr "Enota točke"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Scatter/controlPanel.js:95
+msgid "Minimum Radius"
+msgstr "Min. polmer"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Scatter/controlPanel.js:100
+msgid ""
+"Minimum radius size of the circle, in pixels. As the zoom level changes, "
+"this insures that the circle respects this minimum radius."
+msgstr ""
+"Minimalni polmer kroga v pikslih. S tem je določen min. polmer kroga, ko se "
+"spreminja stopnja povečave."
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Scatter/controlPanel.js:110
+msgid "Maximum Radius"
+msgstr "Max. polmer"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Scatter/controlPanel.js:115
+msgid ""
+"Maxium radius size of the circle, in pixels. As the zoom level changes, this "
+"insures that the circle respects this maximum radius."
+msgstr ""
+"Maksimalni polmer kroga v pikslih. S tem je določen max. polmer kroga, ko se "
+"spreminja stopnja povečave."
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Scatter/controlPanel.js:126
+msgid "Point Color"
+msgstr "Barva točke"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Scatter/index.js:27
+msgid "deck.gl Scatterplot"
+msgstr "deck.gl - Raztreseni grafikon"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Screengrid/controlPanel.js:51
+msgid "Grid"
+msgstr "Mreža"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Screengrid/controlPanel.js:62
+msgid "Weight"
+msgstr "Utež"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Screengrid/controlPanel.js:63
+msgid "Metric used as a weight for the grid's coloring"
+msgstr "Mera, ki služi kot utež za barvo mreže"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Screengrid/index.js:27
+msgid "deck.gl Screen Grid"
+msgstr "deck.gl - Mreža"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:41
+msgid ""
+"For more information about objects are in context in the scope of this "
+"function, refer to the"
+msgstr "Za dodatne informacije o objektih v kontekstu te funkcije si oglejte"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:44
+msgid " source code of Superset's sandboxed parser"
+msgstr " izvorno kodo za Supersetov \"sandboxed parser\""
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:67
+msgid ""
+"This functionality is disabled in your environment for security reasons."
+msgstr "Ta funkcionalnost je v vašem okolju onemogočena zaradi varnosti."
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:78
+msgid "Ignore null locations"
+msgstr "Izpusti prazne lokacije"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:80
+msgid "Whether to ignore locations that are null"
+msgstr "Če ne želite upoštevati praznih (NULL) lokacij"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:88
+msgid "Auto Zoom"
+msgstr "Samodejna povečava"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:91
+msgid "When checked, the map will zoom to your data after each query"
+msgstr "Če želite, da se zemljevid prilagodi vašim podatkom po vsaki poizvedbi"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:99
+msgid "Dimension"
+msgstr "Dimenzija"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:100
+msgid "Select a dimension"
+msgstr "Izberite dimenzijo"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:110
+msgid "Extra data for JS"
+msgstr "Dodatni podatki za JS"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:112
+msgid "List of extra columns made available in Javascript functions"
+msgstr "Seznam dodatnih podatkov, ki so na razpolago v Javascript funkcijah"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:119
+msgid "Javascript data interceptor"
+msgstr "Javascript prestreznik podatkov"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:120
+msgid ""
+"Define a javascript function that receives the data array used in the "
+"visualization and is expected to return a modified version of that array. "
+"This can be used to alter properties of the data, filter, or enrich the "
+"array."
+msgstr ""
+"Določite Javascript funkcijo, ki sprejme podatkovni niz za vizualizacijo in "
+"vrne spremenjeno verzijo tega niza. Lahko se uporabi za spreminjanje "
+"lastnosti podatkov, filtra ali obogatitve niza."
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:131
+msgid "Javascript tooltip generator"
+msgstr "Javascript generator opisa orodja"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:132
+msgid ""
+"Define a function that receives the input and outputs the content for a "
+"tooltip"
+msgstr ""
+"Določite funkcijo, ki sprejme vhodne podatke in vrne vsebino opisa orodja"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:139
+msgid "Javascript onClick href"
+msgstr "Javascript onClick href"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:140
+msgid "Define a function that returns a URL to navigate to when user clicks"
+msgstr "Določite funkcijo, ki vrne URL za navigacijo, ko uporabnik klikne"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:147
+msgid "Legend Format"
+msgstr "Oblika legende"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:148
+msgid "Choose the format for legend values"
+msgstr "Izberite obliko vrednosti legende"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:160
+msgid "Legend Position"
+msgstr "Položaj legende"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:161
+msgid "Choose the position of the legend"
+msgstr "Izberite položaj legende"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:180
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/sharedDndControls.jsx:27
+msgid "Lines column"
+msgstr "Stolpec črt"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:182
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/sharedDndControls.jsx:28
+msgid "The database columns that contains lines information"
+msgstr "Stolpec v podatkovni bazi, ki vsebuje podatke črt"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:198
+msgid "The width of the lines"
+msgstr "Debelina črt"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:205
+msgid "Fill Color"
+msgstr "Barva polnila"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:206
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:219
+msgid ""
+" Set the opacity to 0 if you do not want to override the color specified in "
+"the GeoJSON"
+msgstr ""
+" Nastavite prosojnost na 0, če želite obdržati barvo določeno v GeoJSON"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:218
+msgid "Stroke Color"
+msgstr "Barva obrobe"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:232
+msgid "Filled"
+msgstr "Zapolnjeno"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:234
+msgid "Whether to fill the objects"
+msgstr "Če želite zapolniti objekte"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:243
+msgid "Stroked"
+msgstr "Obrobljeno"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:245
+msgid "Whether to display the stroke"
+msgstr "Če želite prikazati obrobe"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:254
+msgid "Extruded"
+msgstr "Relief"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:265
+msgid "Grid Size"
+msgstr "Velikost mreže"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:269
+msgid "Defines the grid size in pixels"
+msgstr "Določa velikost mreže v pikslih"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:279
+msgid "Parameters related to the view and perspective on the map"
+msgstr "Parametri povezani s pogledom in perspektivo zemljevida"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:293
+msgid "Longitude & Latitude"
+msgstr "Dolžina in širina"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:308
+msgid "Fixed point radius"
+msgstr "Fiksni radij točk"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:319
+msgid "Multiplier"
+msgstr "Množitelj"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:323
+msgid "Factor to multiply the metric by"
+msgstr "Faktor, s katerim množite mero"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:331
+msgid "Lines encoding"
+msgstr "Kodiranje črt"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:334
+msgid "The encoding format of the lines"
+msgstr "Oblika kodiranja črt"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:347
+msgid "Reverse Lat & Long"
+msgstr "Zamenjaj Dolž. in Širino"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:376
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/sharedDndControls.jsx:36
+msgid "GeoJson Column"
+msgstr "GeoJson stolpec"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx:378
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/sharedDndControls.jsx:37
+msgid "Select the geojson column"
+msgstr "Izberite geojson stolpec"
+
+#: superset-ui/superset-ui-plugins-deckgl/packages/superset-ui-legacy-preset-chart-kepler/src/KeplerChartPlugin.js:24
+msgid "Kepler.gl"
+msgstr "Kepler.gl"
+
+# ROCNI VNOS
+msgid "List Users"
+msgstr "Seznam uporabnikov"
+
+msgid "List Roles"
+msgstr "Seznam vlog"
+
+msgid "Your user information"
+msgstr "Vaše uporabniške informacije"
+
+msgid "User info"
+msgstr "Informacije o uporabniku"
+
+msgid "User Name"
+msgstr "Uporabniško ime"
+
+msgid "Is Active?"
+msgstr "Je aktiven?"
+
+msgid "Login count"
+msgstr "Število prijav"
+
+msgid "Personal Info"
+msgstr "Osebne informacije"
+
+msgid "First Name"
+msgstr "Ime"
+
+msgid "Last Name"
+msgstr "Priimek"
+
+msgid "Email"
+msgstr "E-pošta"
+
+msgid "Audit Info"
+msgstr "Revizijske informacije"
+
+msgid "Last login"
+msgstr "Zadnja prijava"
+
+msgid "Failed login count"
+msgstr "Število neuspešnih prijav"
+
+msgid "Changed by"
+msgstr "Spremenil/a"
+
+msgid "Reset Password"
+msgstr "Ponastavi geslo"
+
+msgid "Show User"
+msgstr "Prikaži uporabnika"
+
+msgid "Username valid for authentication on DB or LDAP, unused for OID auth"
+msgstr ""
+"Uporabniško ime za DB ali LDAP avtentikacijo. Ni uporabljeno za OID "
+"avtentikacijo"
+
+msgid "It's not a good policy to remove a user, just make it inactive"
+msgstr "Izbris uporabnika ni dobra praksa, raje ga deaktivirajte"
+
+msgid "The user's email, this will also be used for OID auth"
+msgstr "Uporabnikov e-naslov, uporabljen bo tudi za OID avtentikacijo"
+
+msgid ""
+"The user role on the application, this will associate with a list of "
+"permissions"
+msgstr "Uporabnikova vloga v tej aplikaciji, povezana bo s seznamom dovoljenj"
+
+msgid "User confirmation needed"
+msgstr "Potrebna je potrditev s strani uporabnika"
+
+msgid "You sure you want to delete this item?"
+msgstr "Ste prepričani, da želite izbrisati ta vnos?"
+
+msgid "Reset my password"
+msgstr "Ponastavi geslo"
+
+msgid "Reset Password Form"
+msgstr "Obrazec za ponastavitev gesla"
+
+msgid ""
+"Please use a good password policy, this application does not check this for "
+"you"
+msgstr "Uporabite varno geslo. Ta aplikacija tega ne bo preverila"
+
+msgid "Confirm Password"
+msgstr "Potrdite geslo"
+
+msgid "Please rewrite the password to confirm"
+msgstr "Ponovno vpišite geslo za potrditev"
+
+msgid "Back"
+msgstr "Nazaj"
+
+msgid "Edit User"
+msgstr "Uredite uporabnika"
+
+msgid "Edit User Information"
+msgstr "Uredite informacije o uporabniku"
+
+msgid "Write the user first name or names"
+msgstr "Vpišite ime uporabnika"
+
+msgid "Write the user last name"
+msgstr "Vpišite priimek uporabnika"
+
+msgid "Embed code"
+msgstr "Vstavi kodo"
+
+msgid "creator"
+msgstr "avtor"
+
+msgid "favorited"
+msgstr "priljubljeno"
+
+msgid "name"
+msgstr "ime"
+
+msgid "type"
+msgstr "tip"
+
+msgid "time"
+msgstr "čas"
+
+msgid "Toggle SortBy"
+msgstr "Preklopite razvrščanje"
+
+msgid "Page size"
+msgstr "Velikost strani"
+
+msgid "Edit record"
+msgstr "Uredi zapis"
+
+msgid "Delete record"
+msgstr "Izbriši zapis"
+
+msgid "Show record"
+msgstr "Pokaži zapis"
+
+#: superset-ui/superset-ui/plugins/plugin-chart-echarts/src/controls.ts:70
+msgid "Orientation"
+msgstr "Postavitev"
+
+msgid "Scroll"
+msgstr "Drsnik"
+
+msgid "Plain"
+msgstr "Celotna"


### PR DESCRIPTION
### SUMMARY
New translation for superset UI is added - Slovenian (sl_SI).
I also extracted strings from the superset-ui repos and manually added some strings which are not extracted by the "pybabel extract".

P.S.
This is revision of my previous PR ( https://github.com/apache/superset/pull/13558 ), which was closed by me. There was an issue with wrong language code (si -> sl) and translations were outdated (this translation fits latest Superset state).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![110685658-cd2e0480-81de-11eb-8913-9ed147fa0312](https://user-images.githubusercontent.com/9586713/120043660-a973a100-c00c-11eb-96e3-b88a481e7449.png)


### TESTING INSTRUCTIONS
Change language, inspect translations.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
