### PR TITLE
fix: upgrade celery to 5.1.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ aiohttp==3.7.2
     # via slackclient
 alembic==1.4.3
     # via flask-migrate
-amqp==2.6.1
+amqp==5.0.6
     # via kombu
 apispec[yaml]==3.3.2
     # via flask-appbuilder
@@ -25,23 +25,35 @@ babel==2.8.0
     # via flask-babel
 backoff==1.10.0
     # via apache-superset
-billiard==3.6.3.0
+billiard==3.6.4.0
     # via celery
 bleach==3.3.0
     # via apache-superset
 brotli==1.0.9
     # via flask-compress
+cached-property==1.5.2
+    # via kombu
 cachelib==0.1.1
     # via apache-superset
-celery==4.4.7
+celery==5.1.0
     # via apache-superset
 cffi==1.14.3
     # via cryptography
 chardet==3.0.4
     # via aiohttp
+click-didyoumean==0.0.3
+    # via celery
+click-plugins==1.1.1
+    # via celery
+click-repl==0.2.0
+    # via celery
 click==7.1.2
     # via
     #   apache-superset
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
     #   flask
     #   flask-appbuilder
 colorama==0.4.4
@@ -139,7 +151,7 @@ jinja2==2.11.3
     #   flask-babel
 jsonschema==3.2.0
     # via flask-appbuilder
-kombu==4.6.11
+kombu==5.1.0
     # via celery
 korean-lunar-calendar==0.2.1
     # via holidays
@@ -187,6 +199,8 @@ polyline==1.4.0
     # via apache-superset
 prison==0.1.3
     # via flask-appbuilder
+prompt-toolkit==3.0.18
+    # via click-repl
 py==1.9.0
     # via retry
 pyarrow==3.0.0
@@ -246,6 +260,7 @@ simplejson==3.17.2
 six==1.15.0
     # via
     #   bleach
+    #   click-repl
     #   cryptography
     #   flask-jwt-extended
     #   flask-talisman
@@ -283,10 +298,13 @@ typing-extensions==3.7.4.3
     #   yarl
 urllib3==1.25.11
     # via selenium
-vine==1.3.0
+vine==5.0.0
     # via
     #   amqp
     #   celery
+    #   kombu
+wcwidth==0.2.5
+    # via prompt-toolkit
 webencodings==0.5.1
     # via bleach
 werkzeug==1.0.1

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -14,8 +14,6 @@ botocore==1.19.10
     # via
     #   boto3
     #   s3transfer
-cached-property==1.5.2
-    # via tableschema
 certifi==2020.6.20
     # via requests
 deprecated==1.2.11

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -9,8 +9,6 @@
 -r integration.txt
 -e file:.
     # via -r requirements/base.in
-appnope==0.1.0
-    # via ipython
 astroid==2.4.2
     # via pylint
 backcall==0.2.0
@@ -51,8 +49,6 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-prompt-toolkit==3.0.8
-    # via ipython
 ptyprocess==0.6.0
     # via pexpect
 pyfakefs==4.4.0
@@ -77,8 +73,6 @@ traitlets==5.0.5
     # via ipython
 typed-ast==1.4.3
     # via astroid
-wcwidth==0.2.5
-    # via prompt-toolkit
 websocket-client==0.57.0
     # via docker
 

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         "backoff>=1.8.0",
         "bleach>=3.0.2, <4.0.0",
         "cachelib>=0.1.1,<0.2",
-        "celery>=4.3.0, <5.0.0, !=4.4.1",
+        "celery>=5.1.0",
         "click<8",
         "colorama",
         "contextlib2",


### PR DESCRIPTION
### SUMMARY
Upgrade celery to 5.1.0 to pick up fix of https://github.com/celery/celery/issues/6422 (So that it can connect to Redis 6 with username/pass authentication)

Based on the official guide [Upgrading from Celery 4.x](https://docs.celeryproject.org/en/stable/history/whatsnew-5.0.html#upgrading-from-celery-4-x), here are the 5 steps:

1. [x] Step 1: Adjust your command line invocation - #15053
2. [x] Step 2: Update your configuration with the new setting names - #12560
3. [ ] Step 3: Read the [important notes](https://docs.celeryproject.org/en/stable/history/whatsnew-5.0.html#v500-important) in this document
    - <strike>drops support for python 2.7 & 3.5</strike>
4. <strike>[ ] Step 4: Migrate your code to Python 3</strike>
5. [ ] Step 5: Upgrade to Celery 5.0 - This PR

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
See #14925 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #14925 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
