### PR TITLE
chore: Improves the native filters UI/UX - iteration 6

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTabs.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTabs.tsx
@@ -24,7 +24,7 @@ import Icon from 'src/components/Icon';
 import { FilterRemoval } from './types';
 import { REMOVAL_DELAY_SECS } from './utils';
 
-export const FILTER_WIDTH = 200;
+export const FILTER_WIDTH = 180;
 
 export const StyledSpan = styled.span`
   cursor: pointer;
@@ -115,6 +115,7 @@ const FilterTabsContainer = styled(LineEditableTabs)`
       padding-right: ${theme.gridUnit}px;
       padding-bottom: ${theme.gridUnit * 3}px;
       padding-left: ${theme.gridUnit * 3}px;
+      width: 270px;
     }
 
     // extra selector specificity:
@@ -185,6 +186,8 @@ const FilterTabs: FC<FilterTabsProps> = ({
   children,
 }) => (
   <FilterTabsContainer
+    id="native-filters-tabs"
+    type="editable-card"
     tabPosition="left"
     onChange={onChange}
     activeKey={currentFilterId}
@@ -193,7 +196,20 @@ const FilterTabs: FC<FilterTabsProps> = ({
     tabBarExtraContent={{
       left: <StyledHeader>{t('Filters')}</StyledHeader>,
       right: (
-        <StyledAddFilterBox onClick={() => onEdit('', 'add')}>
+        <StyledAddFilterBox
+          onClick={() => {
+            onEdit('', 'add');
+            setTimeout(() => {
+              const element = document.getElementById('native-filters-tabs');
+              if (element) {
+                const navList = element.getElementsByClassName(
+                  'ant-tabs-nav-list',
+                )[0];
+                navList.scrollTop = navList.scrollHeight;
+              }
+            }, 0);
+          }}
+        >
           <PlusOutlined />{' '}
           <span data-test="add-filter-button" aria-label="Add filter">
             {t('Add filter')}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/getControlItemsMap.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/getControlItemsMap.test.tsx
@@ -83,8 +83,12 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-function renderControlItems(controlItemsMap: {}): any {
-  return render(<>{Object.values(controlItemsMap).map(value => value)}</>);
+function renderControlItems(
+  controlItemsMap: ReturnType<typeof getControlItemsMap>,
+) {
+  return render(
+    <>{Object.values(controlItemsMap).map(value => value.element)}</>,
+  );
 }
 
 test('Should render null when has no "formFilter"', () => {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/getControlItemsMap.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/getControlItemsMap.tsx
@@ -50,7 +50,10 @@ export default function getControlItemsMap({
   const controlPanelRegistry = getChartControlPanelRegistry();
   const controlItems =
     getControlItems(controlPanelRegistry.get(filterType)) ?? [];
-  const map = {};
+  const map: Record<
+    string,
+    { element: React.ReactNode; checked: boolean }
+  > = {};
 
   controlItems
     .filter(
@@ -59,6 +62,9 @@ export default function getControlItemsMap({
         controlItem.name !== 'sortAscending',
     )
     .forEach(controlItem => {
+      const initialValue =
+        filterToEdit?.controlValues?.[controlItem.name] ??
+        controlItem?.config?.default;
       const element = (
         <Tooltip
           key={controlItem.name}
@@ -72,10 +78,7 @@ export default function getControlItemsMap({
           <StyledRowFormItem
             key={controlItem.name}
             name={['filters', filterId, 'controlValues', controlItem.name]}
-            initialValue={
-              filterToEdit?.controlValues?.[controlItem.name] ??
-              controlItem?.config?.default
-            }
+            initialValue={initialValue}
             valuePropName="checked"
             colon={false}
           >
@@ -104,7 +107,7 @@ export default function getControlItemsMap({
           </StyledRowFormItem>
         </Tooltip>
       );
-      map[controlItem.name] = element;
+      map[controlItem.name] = { element, checked: initialValue };
     });
   return map;
 }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
@@ -183,7 +183,11 @@ export function FiltersConfigModal({
     filterIds
       .filter(filterId => filterId !== id && !removedFilters[filterId])
       .filter(filterId =>
-        CASCADING_FILTERS.includes(formValues.filters[filterId]?.filterType),
+        CASCADING_FILTERS.includes(
+          formValues.filters[filterId]
+            ? formValues.filters[filterId].filterType
+            : filterConfigMap[filterId]?.filterType,
+        ),
       )
       .map(id => ({
         id,


### PR DESCRIPTION
### SUMMARY
Improves the native filters UI/UX - iteration 6.
- Removes the sort option for the numeric range filter type
- When the left panel vertical scroll is enabled, automatically scrolls down when adding a new item
- Adds a TODO to rename the filter plugins
- Fixes a bug where the parent filter disappeared after refreshing the dashboard
- Sets a min-width for the left panel to deal with the case when we don't have any filter
- Opens the Advanced section if any of its options are checked

This work is part of the [Native dashboard filter project](https://github.com/apache/superset/projects/12)

The items below will be handled in the next iterations:
- Remove horizontal scroll when the column select is too wide
- Unify the select components to use the AntD one. Currently, we have different selects with different themes and interactions.

The iterations below are optional but recommended:
- Split the FiltersConfigForm into smaller components to make it easier to read and remove react warnings

@villebro @rusackas @junlincc

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/70410625/120341882-a8bd6200-c2cd-11eb-8679-543253fe1216.mp4

https://user-images.githubusercontent.com/70410625/120341125-00a79900-c2cd-11eb-9291-70df122b268c.mp4

### TESTING INSTRUCTIONS
Check the before and after videos to see all the problems and fixes.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
