### PR TITLE
feat(dashboard/native-filters): Hide filters out of scope of current tab

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard_list/filter.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard_list/filter.test.ts
@@ -61,7 +61,6 @@ describe('dashboard filters card view', () => {
     cy.get('.Select__menu').contains('Published').click({ timeout: 5000 });
     cy.get('[data-test="styled-card"]').should('have.length', 2);
     cy.get('[data-test="styled-card"]')
-      .first()
       .contains('USA Births Names')
       .should('be.visible');
     cy.get('.Select__control').eq(1).click();

--- a/superset-frontend/cypress-base/cypress/integration/dashboard_list/filter.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard_list/filter.test.ts
@@ -106,13 +106,12 @@ describe('dashboard filters list view', () => {
     cy.get('[data-test="table-row"]').should('not.exist');
   });
 
-  xit('should filter by published correctly', () => {
+  it('should filter by published correctly', () => {
     // filter by published
     cy.get('.Select__control').eq(2).click();
     cy.get('.Select__menu').contains('Published').click();
     cy.get('[data-test="table-row"]').should('have.length', 2);
     cy.get('[data-test="table-row"]')
-      .first()
       .contains('USA Births Names')
       .should('be.visible');
     cy.get('.Select__control').eq(2).click();

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -102,6 +102,7 @@
         "react-markdown": "^4.3.1",
         "react-redux": "^7.2.0",
         "react-resize-detector": "^6.0.1-rc.1",
+        "react-reverse-portal": "^2.0.1",
         "react-router-dom": "^5.1.2",
         "react-search-input": "^0.11.3",
         "react-select": "^3.1.0",
@@ -44735,6 +44736,15 @@
         "lodash.throttle": "^4.1.1",
         "raf-schd": "^4.0.2",
         "resize-observer-polyfill": "^1.5.1"
+      }
+    },
+    "node_modules/react-reverse-portal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/react-reverse-portal/-/react-reverse-portal-2.0.1.tgz",
+      "integrity": "sha512-sj/D9nSHspqV8i8hWkTSZ5Ohnrqk2A5fkDKw4Xe/zV4OfF1UYwmbzrxLdmNRdKkWgQwnXIxaa2E3FC7QYdZAeA==",
+      "peerDependencies": {
+        "react": "^16.0.0",
+        "react-dom": "^16.0.0"
       }
     },
     "node_modules/react-router": {
@@ -92327,6 +92337,12 @@
         "raf-schd": "^4.0.2",
         "resize-observer-polyfill": "^1.5.1"
       }
+    },
+    "react-reverse-portal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/react-reverse-portal/-/react-reverse-portal-2.0.1.tgz",
+      "integrity": "sha512-sj/D9nSHspqV8i8hWkTSZ5Ohnrqk2A5fkDKw4Xe/zV4OfF1UYwmbzrxLdmNRdKkWgQwnXIxaa2E3FC7QYdZAeA==",
+      "requires": {}
     },
     "react-router": {
       "version": "5.1.2",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -154,6 +154,7 @@
     "react-markdown": "^4.3.1",
     "react-redux": "^7.2.0",
     "react-resize-detector": "^6.0.1-rc.1",
+    "react-reverse-portal": "^2.0.1",
     "react-router-dom": "^5.1.2",
     "react-search-input": "^0.11.3",
     "react-select": "^3.1.0",

--- a/superset-frontend/spec/javascripts/dashboard/components/DashboardBuilder_spec.jsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/DashboardBuilder_spec.jsx
@@ -50,16 +50,21 @@ jest.mock('src/dashboard/actions/dashboardState');
 
 describe('DashboardBuilder', () => {
   let favStarStub;
+  let focusedTabStub;
 
   beforeAll(() => {
     // this is invoked on mount, so we stub it instead of making a request
     favStarStub = sinon
       .stub(dashboardStateActions, 'fetchFaveStar')
       .returns({ type: 'mock-action' });
+    focusedTabStub = sinon
+      .stub(dashboardStateActions, 'setLastFocusedTab')
+      .returns({ type: 'mock-action' });
   });
 
   afterAll(() => {
     favStarStub.restore();
+    focusedTabStub.restore();
   });
 
   function setup(overrideState = {}, overrideStore) {

--- a/superset-frontend/spec/javascripts/dashboard/components/gridComponents/ChartHolder_spec.jsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/gridComponents/ChartHolder_spec.jsx
@@ -36,6 +36,7 @@ import { sliceId } from 'spec/fixtures/mockChartQueries';
 import dashboardInfo from 'spec/fixtures/mockDashboardInfo';
 import { dashboardLayout as mockLayout } from 'spec/fixtures/mockDashboardLayout';
 import { sliceEntitiesForChart } from 'spec/fixtures/mockSliceEntities';
+import { nativeFiltersInfo } from '../../fixtures/mockNativeFilters';
 
 describe('ChartHolder', () => {
   const props = {
@@ -55,6 +56,7 @@ describe('ChartHolder', () => {
     handleComponentDrop() {},
     updateComponents() {},
     deleteComponent() {},
+    nativeFilters: nativeFiltersInfo.filters,
   };
 
   function setup(overrideProps) {

--- a/superset-frontend/spec/javascripts/dashboard/components/gridComponents/Tabs_spec.jsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/gridComponents/Tabs_spec.jsx
@@ -33,8 +33,10 @@ import HoverMenu from 'src/dashboard/components/menu/HoverMenu';
 import DragDroppable from 'src/dashboard/components/dnd/DragDroppable';
 import Tabs from 'src/dashboard/components/gridComponents/Tabs';
 import { DASHBOARD_ROOT_ID } from 'src/dashboard/util/constants';
+import emptyDashboardLayout from 'src/dashboard/fixtures/emptyDashboardLayout';
 import { dashboardLayoutWithTabs } from 'spec/fixtures/mockDashboardLayout';
 import { mockStoreWithTabs } from 'spec/fixtures/mockStore';
+import { nativeFilters } from 'spec/fixtures/mockNativeFilters';
 
 describe('Tabs', () => {
   fetchMock.post('glob:*/r/shortner/', {});
@@ -59,6 +61,8 @@ describe('Tabs', () => {
     deleteComponent() {},
     updateComponents() {},
     logEvent() {},
+    dashboardLayout: emptyDashboardLayout,
+    nativeFilters: nativeFilters.filters,
   };
 
   function setup(overrideProps) {

--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -344,6 +344,11 @@ export function setDirectPathToChild(path) {
   return { type: SET_DIRECT_PATH, path };
 }
 
+export const SET_LAST_FOCUSED_TAB = 'SET_LAST_FOCUSED_TAB';
+export function setLastFocusedTab(tabId) {
+  return { type: SET_LAST_FOCUSED_TAB, tabId };
+}
+
 export const SET_FOCUSED_FILTER_FIELD = 'SET_FOCUSED_FILTER_FIELD';
 export function setFocusedFilterField(chartId, column) {
   return { type: SET_FOCUSED_FILTER_FIELD, chartId, column };

--- a/superset-frontend/src/dashboard/actions/hydrate.js
+++ b/superset-frontend/src/dashboard/actions/hydrate.js
@@ -377,6 +377,7 @@ export const hydrateDashboard = (dashboardData, chartData, datasourcesData) => (
         hasUnsavedChanges: false,
         maxUndoHistoryExceeded: false,
         lastModifiedTime: dashboardData.changed_on,
+        lastFocusedTabId: null,
       },
       dashboardLayout,
     },

--- a/superset-frontend/src/dashboard/components/gridComponents/ChartHolder.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/ChartHolder.test.tsx
@@ -18,12 +18,13 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { waitFor } from '@testing-library/react';
 import { render, screen } from 'spec/helpers/testing-library';
 import mockState from 'spec/fixtures/mockState';
 import { sliceId as chartId } from 'spec/fixtures/mockChartQueries';
+import { nativeFiltersInfo } from 'spec/javascripts/dashboard/fixtures/mockNativeFilters';
 import newComponentFactory from 'src/dashboard/util/newComponentFactory';
-import userEvent from '@testing-library/user-event';
-import { waitFor } from '@testing-library/react';
 import { ChartHolder } from './index';
 import { CHART_TYPE, ROW_TYPE } from '../../util/componentTypes';
 
@@ -60,6 +61,7 @@ describe('ChartHolder', () => {
     editMode: false,
     isComponentVisible: true,
     dashboardId: 123,
+    nativeFilters: nativeFiltersInfo.filters,
   };
 
   const renderWrapper = (props = defaultProps, state = mockState) =>

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -31,7 +31,11 @@ import findTabIndexByComponentId from '../../util/findTabIndexByComponentId';
 import getDirectPathToTabIndex from '../../util/getDirectPathToTabIndex';
 import getLeafComponentIdFromPath from '../../util/getLeafComponentIdFromPath';
 import { componentShape } from '../../util/propShapes';
-import { NEW_TAB_ID, DASHBOARD_ROOT_ID } from '../../util/constants';
+import {
+  NEW_TAB_ID,
+  DASHBOARD_ROOT_ID,
+  DASHBOARD_GRID_ID,
+} from '../../util/constants';
 import { RENDER_TAB, RENDER_TAB_CONTENT } from './Tab';
 import { TAB_TYPE } from '../../util/componentTypes';
 
@@ -269,10 +273,21 @@ class Tabs extends React.PureComponent {
       isComponentVisible: isCurrentTabVisible,
       editMode,
       nativeFilters,
+      dashboardLayout,
+      lastFocusedTabId,
+      setLastFocusedTab,
     } = this.props;
 
     const { children: tabIds } = tabsComponent;
     const { tabIndex: selectedTabIndex, activeKey } = this.state;
+
+    // On dashboards with top level tabs, set initial focus to the active top level tab
+    const dashboardRoot = dashboardLayout[DASHBOARD_ROOT_ID];
+    const rootChildId = dashboardRoot.children[0];
+    const isTopLevelTabs = rootChildId !== DASHBOARD_GRID_ID;
+    if (isTopLevelTabs && !lastFocusedTabId) {
+      setLastFocusedTab(activeKey);
+    }
 
     let tabsToHighlight;
     if (nativeFilters.focusedFilterId) {
@@ -313,6 +328,7 @@ class Tabs extends React.PureComponent {
               onEdit={this.handleEdit}
               data-test="nav-list"
               type={editMode ? 'editable-card' : 'card'}
+              onTabClick={setLastFocusedTab}
             >
               {tabIds.map((tabId, tabIndex) => (
                 <LineEditableTabs.TabPane

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.test.tsx
@@ -20,11 +20,12 @@
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { render, screen, waitFor } from 'spec/helpers/testing-library';
+import { nativeFiltersInfo } from 'spec/javascripts/dashboard/fixtures/mockNativeFilters';
 import DashboardComponent from 'src/dashboard/containers/DashboardComponent';
 import DragDroppable from 'src/dashboard/components/dnd/DragDroppable';
 import DeleteComponentButton from 'src/dashboard/components/DeleteComponentButton';
 import getLeafComponentIdFromPath from 'src/dashboard/util/getLeafComponentIdFromPath';
-
+import emptyDashboardLayout from 'src/dashboard/fixtures/emptyDashboardLayout';
 import Tabs from './Tabs';
 
 jest.mock('src/dashboard/containers/DashboardComponent', () =>
@@ -110,6 +111,8 @@ const createProps = () => ({
   onChangeTab: jest.fn(),
   deleteComponent: jest.fn(),
   updateComponents: jest.fn(),
+  dashboardLayout: emptyDashboardLayout,
+  nativeFilters: nativeFiltersInfo.filters,
 });
 
 beforeEach(() => {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -19,10 +19,12 @@
 import React, { FC, useMemo, useState } from 'react';
 import { DataMask, styled, t } from '@superset-ui/core';
 import { css } from '@emotion/react';
+import { useSelector } from 'react-redux';
 import * as portals from 'react-reverse-portal';
 import { DataMaskState } from 'src/dataMask/types';
 import { Collapse } from 'src/common/components';
 import { TAB_TYPE } from 'src/dashboard/util/componentTypes';
+import { RootState } from 'src/dashboard/types';
 import CascadePopover from '../CascadeFilters/CascadePopover';
 import { buildCascadeFiltersTree } from './utils';
 import { useFilters } from '../state';
@@ -51,6 +53,9 @@ const FilterControls: FC<FilterControlsProps> = ({
   const [visiblePopoverId, setVisiblePopoverId] = useState<string | null>(null);
   const filters = useFilters();
   const dashboardLayout = useDashboardLayout();
+  const lastFocusedTabId = useSelector<RootState, string | null>(
+    state => state.dashboardState?.lastFocusedTabId,
+  );
   const filterValues = Object.values<Filter>(filters);
   const portalNodes = React.useMemo(() => {
     const nodes = new Array(filterValues.length);
@@ -74,19 +79,11 @@ const FilterControls: FC<FilterControlsProps> = ({
     element => element.type === TAB_TYPE,
   );
   const showCollapsePanel = dashboardHasTabs && cascadeFilters.length > 0;
-  if (
-    !directPathToChild ||
-    directPathToChild.length === 0 ||
-    !dashboardHasTabs
-  ) {
+  if (!lastFocusedTabId || !dashboardHasTabs) {
     filtersInScope = cascadeFilters;
   } else {
     cascadeFilters.forEach((filter, index) => {
-      if (
-        cascadeFilters[index].tabsInScope?.includes(
-          directPathToChild[directPathToChild.length - 1],
-        )
-      ) {
+      if (cascadeFilters[index].tabsInScope?.includes(lastFocusedTabId)) {
         filtersInScope.push(filter);
       } else {
         filtersOutOfScope.push(filter);

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -17,12 +17,18 @@
  * under the License.
  */
 import React, { FC, useMemo, useState } from 'react';
+import { DataMask, styled, t } from '@superset-ui/core';
+import { css } from '@emotion/react';
+import * as portals from 'react-reverse-portal';
 import { DataMaskState } from 'src/dataMask/types';
-import { DataMask, styled } from '@superset-ui/core';
+import { Collapse } from 'src/common/components';
+import { TAB_TYPE } from 'src/dashboard/util/componentTypes';
 import CascadePopover from '../CascadeFilters/CascadePopover';
 import { buildCascadeFiltersTree } from './utils';
 import { useFilters } from '../state';
 import { Filter } from '../../types';
+import { CascadeFilter } from '../CascadeFilters/types';
+import { useDashboardLayout } from '../../state';
 
 const Wrapper = styled.div`
   padding: ${({ theme }) => theme.gridUnit * 4}px;
@@ -44,7 +50,15 @@ const FilterControls: FC<FilterControlsProps> = ({
 }) => {
   const [visiblePopoverId, setVisiblePopoverId] = useState<string | null>(null);
   const filters = useFilters();
+  const dashboardLayout = useDashboardLayout();
   const filterValues = Object.values<Filter>(filters);
+  const portalNodes = React.useMemo(() => {
+    const nodes = new Array(filterValues.length);
+    for (let i = 0; i < filterValues.length; i += 1) {
+      nodes[i] = portals.createHtmlPortalNode();
+    }
+    return nodes;
+  }, [filterValues.length]);
 
   const cascadeFilters = useMemo(() => {
     const filtersWithValue = filterValues.map(filter => ({
@@ -54,21 +68,94 @@ const FilterControls: FC<FilterControlsProps> = ({
     return buildCascadeFiltersTree(filtersWithValue);
   }, [filterValues, dataMaskSelected]);
 
+  let filtersInScope: CascadeFilter[] = [];
+  const filtersOutOfScope: CascadeFilter[] = [];
+  const dashboardHasTabs = Object.values(dashboardLayout).some(
+    element => element.type === TAB_TYPE,
+  );
+  const showCollapsePanel = dashboardHasTabs && cascadeFilters.length > 0;
+  if (
+    !directPathToChild ||
+    directPathToChild.length === 0 ||
+    !dashboardHasTabs
+  ) {
+    filtersInScope = cascadeFilters;
+  } else {
+    cascadeFilters.forEach((filter, index) => {
+      if (
+        cascadeFilters[index].tabsInScope?.includes(
+          directPathToChild[directPathToChild.length - 1],
+        )
+      ) {
+        filtersInScope.push(filter);
+      } else {
+        filtersOutOfScope.push(filter);
+      }
+    });
+  }
+
   return (
     <Wrapper>
-      {cascadeFilters.map(filter => (
-        <CascadePopover
-          data-test="cascade-filters-control"
-          key={filter.id}
-          visible={visiblePopoverId === filter.id}
-          onVisibleChange={visible =>
-            setVisiblePopoverId(visible ? filter.id : null)
-          }
-          filter={filter}
-          onFilterSelectionChange={onFilterSelectionChange}
-          directPathToChild={directPathToChild}
-        />
+      {portalNodes.map((node, index) => (
+        <portals.InPortal node={node}>
+          <CascadePopover
+            data-test="cascade-filters-control"
+            key={cascadeFilters[index].id}
+            visible={visiblePopoverId === cascadeFilters[index].id}
+            onVisibleChange={visible =>
+              setVisiblePopoverId(visible ? cascadeFilters[index].id : null)
+            }
+            filter={cascadeFilters[index]}
+            onFilterSelectionChange={onFilterSelectionChange}
+            directPathToChild={directPathToChild}
+          />
+        </portals.InPortal>
       ))}
+      {filtersInScope.map(filter => {
+        const index = cascadeFilters.findIndex(f => f.id === filter.id);
+        return <portals.OutPortal node={portalNodes[index]} />;
+      })}
+      {showCollapsePanel && (
+        <Collapse
+          ghost
+          bordered
+          expandIconPosition="right"
+          collapsible={filtersOutOfScope.length === 0 ? 'disabled' : undefined}
+          css={theme => css`
+            &.ant-collapse {
+              margin-top: ${filtersInScope.length > 0
+                ? theme.gridUnit * 6
+                : 0}px;
+              & > .ant-collapse-item {
+                & > .ant-collapse-header {
+                  padding-left: 0;
+                  padding-bottom: ${theme.gridUnit * 2}px;
+
+                  & > .ant-collapse-arrow {
+                    right: ${theme.gridUnit}px;
+                  }
+                }
+
+                & .ant-collapse-content-box {
+                  padding: ${theme.gridUnit * 4}px 0 0;
+                }
+              }
+            }
+          `}
+        >
+          <Collapse.Panel
+            header={`${t('Filters out of scope')} (${
+              filtersOutOfScope.length
+            })`}
+            key="1"
+          >
+            {filtersOutOfScope.map(filter => {
+              const index = cascadeFilters.findIndex(f => f.id === filter.id);
+              return <portals.OutPortal node={portalNodes[index]} />;
+            })}
+          </Collapse.Panel>
+        </Collapse>
+      )}
     </Wrapper>
   );
 };

--- a/superset-frontend/src/dashboard/components/nativeFilters/state.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/state.ts
@@ -19,6 +19,7 @@
 import { useSelector } from 'react-redux';
 import { useMemo } from 'react';
 import { Filter, FilterConfiguration } from './types';
+import { DashboardLayout } from '../../types';
 
 const defaultFilterConfiguration: Filter[] = [];
 
@@ -43,5 +44,11 @@ export function useFilterConfigMap() {
         return acc;
       }, {} as Record<string, Filter>),
     [filterConfig],
+  );
+}
+
+export function useDashboardLayout() {
+  return useSelector<any, DashboardLayout>(
+    state => state.dashboardLayout?.present,
   );
 }

--- a/superset-frontend/src/dashboard/components/nativeFilters/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/types.ts
@@ -56,6 +56,8 @@ export interface Filter {
   sortMetric?: string | null;
   adhoc_filters?: AdhocFilter[];
   time_range?: string;
+  tabsInScope?: string[];
+  chartsInScope?: number[];
 }
 
 export type FilterConfiguration = Filter[];

--- a/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
+++ b/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
@@ -79,19 +79,6 @@ function selectFocusedFilterScope(dashboardState, dashboardFilters) {
   };
 }
 
-function selectFocusedNativeFilterScope(nativeFilters) {
-  if (!nativeFilters.focusedFilterId) return null;
-  const id = nativeFilters.focusedFilterId;
-  const focusedFilterScope = nativeFilters.filters[id].scope;
-  return {
-    chartId: id,
-    scope: {
-      scope: focusedFilterScope.rootPath,
-      immune: focusedFilterScope.excluded,
-    },
-  };
-}
-
 function mapStateToProps(
   {
     dashboardLayout: undoableLayout,
@@ -116,9 +103,11 @@ function mapStateToProps(
     directPathToChild: dashboardState.directPathToChild,
     directPathLastUpdated: dashboardState.directPathLastUpdated,
     dashboardId: dashboardInfo.id,
-    focusedFilterScope:
-      selectFocusedFilterScope(dashboardState, dashboardFilters) ||
-      selectFocusedNativeFilterScope(nativeFilters),
+    nativeFilters,
+    focusedFilterScope: selectFocusedFilterScope(
+      dashboardState,
+      dashboardFilters,
+    ),
   };
 
   // rows and columns need more data about their child dimensions

--- a/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
+++ b/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
@@ -35,7 +35,10 @@ import {
   updateComponents,
   handleComponentDrop,
 } from '../actions/dashboardLayout';
-import { setDirectPathToChild } from '../actions/dashboardState';
+import {
+  setDirectPathToChild,
+  setLastFocusedTab,
+} from '../actions/dashboardState';
 
 const propTypes = {
   id: PropTypes.string,
@@ -101,6 +104,7 @@ function mapStateToProps(
     redoLength: undoableLayout.future.length,
     filters: getActiveFilters(),
     directPathToChild: dashboardState.directPathToChild,
+    lastFocusedTabId: dashboardState.lastFocusedTabId,
     directPathLastUpdated: dashboardState.directPathLastUpdated,
     dashboardId: dashboardInfo.id,
     nativeFilters,
@@ -137,6 +141,7 @@ function mapDispatchToProps(dispatch) {
       updateComponents,
       handleComponentDrop,
       setDirectPathToChild,
+      setLastFocusedTab,
       logEvent,
     },
     dispatch,

--- a/superset-frontend/src/dashboard/reducers/dashboardState.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.js
@@ -35,6 +35,7 @@ import {
   SET_DIRECT_PATH,
   SET_FOCUSED_FILTER_FIELD,
   UNSET_FOCUSED_FILTER_FIELD,
+  SET_LAST_FOCUSED_TAB,
 } from '../actions/dashboardState';
 import { HYDRATE_DASHBOARD } from '../actions/hydrate';
 
@@ -131,6 +132,12 @@ export default function dashboardStateReducer(state = {}, action) {
         ...state,
         directPathToChild: action.path,
         directPathLastUpdated: Date.now(),
+      };
+    },
+    [SET_LAST_FOCUSED_TAB]() {
+      return {
+        ...state,
+        lastFocusedTabId: action.tabId,
       };
     },
     [SET_FOCUSED_FILTER_FIELD]() {

--- a/superset-frontend/src/dashboard/types.ts
+++ b/superset-frontend/src/dashboard/types.ts
@@ -43,7 +43,11 @@ export type Chart = ChartState & {
 
 export type DashboardLayout = { [key: string]: LayoutItem };
 export type DashboardLayoutState = { present: DashboardLayout };
-export type DashboardState = { editMode: boolean; directPathToChild: string[] };
+export type DashboardState = {
+  editMode: boolean;
+  directPathToChild: string[];
+  lastFocusedTabId: string | null;
+};
 export type DashboardInfo = {
   common: {
     flash_messages: string[];


### PR DESCRIPTION
### SUMMARY
On dashboards with tabs, native filters that are out of scope of currently focused tab should be hidden.
When user opens a dashboard with top level tabs, the active top level tab is used as an initially focused tab. For dashboards without top level tabs, initially every filter is considered to be in scope, until the user clicks on a tab.
Hidden filters are moved to a new collapsible section in the native filters panel. In order to prevent expensive rerendering of native filters when they are moved in and out of collapsible, I used `react-reverse-portal` library, which utilizes React portals to perform reparenting without unmounting and remounting the child. In our case, it was essential, as each native filter sends a request to backend on mount - if a user had many native filters with narrow scopes, we'd risk having lots of redundant API calls on each tab change.
Moreover, I optimized finding charts and tabs in scope for each native filter. Before, functions that traverse the whole component tree in search for charts and tabs were called every time a native filter was focused. Now, they are called once for each filter when the filters are initialized (and then again when filter's scope or dashboard layout changes).

In case of dashboards without any tabs, there are no visible changes.

Potential improvements:
1. Show currently focused tab's name. I'd love some **design input** on that, as I'm not sure where to put tab's name on the filter panel and how to make it consistent with the rest of the design. I believe that would improve user experience a lot, as it might be confusing for the user why some filters are marked as "out of scope".
2. Currently for dashboards without top level tabs, we start with every filter being considered to be in scope. After a user focuses on some tab, there is no way to return to the initial state. It might be problematic in cases when there are charts not attached to any tab group - after some tab has been focused, we can never return to the state where a chart outside of any tab group is "in scope".

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/15073128/120353413-f0f67780-c301-11eb-8f5f-e4b0b9fd2167.mov

### TESTING INSTRUCTIONS
0. Set `DASHBOARD_NATIVE_FILTERS` feature flag to True.
1. Create a dashboard with tabs (try both top level tabs + grid level tabs and only grid level tabs) and add some native filters with different scopes.
2. Verify that when you change tabs, filters that are out of scope of current tab are moved to collapsed section.
3. Verify that native filters are not rerendered - when you switch tabs, there shouldn't be any new api calls related to native filters.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc @villebro 