### PR TITLE
build(webpack): use [contenthash] instead of [chunkhash]

### DIFF
--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -59,11 +59,11 @@ if (isDevMode) {
   output.filename = '[name].[hash:8].entry.js';
   output.chunkFilename = '[name].[hash:8].chunk.js';
 } else if (nameChunks) {
-  output.filename = '[name].[chunkhash].entry.js';
-  output.chunkFilename = '[name].[chunkhash].chunk.js';
+  output.filename = '[name].[contenthash].entry.js';
+  output.chunkFilename = '[name].[contenthash].chunk.js';
 } else {
-  output.filename = '[name].[chunkhash].entry.js';
-  output.chunkFilename = '[chunkhash].chunk.js';
+  output.filename = '[name].[contenthash].entry.js';
+  output.chunkFilename = '[contenthash].chunk.js';
 }
 
 const plugins = [

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -155,8 +155,8 @@ if (!isDevMode) {
   // text loading (webpack 4+)
   plugins.push(
     new MiniCssExtractPlugin({
-      filename: '[name].[chunkhash].entry.css',
-      chunkFilename: '[name].[chunkhash].chunk.css',
+      filename: '[name].[contenthash].entry.css',
+      chunkFilename: '[name].[contenthash].chunk.css',
     }),
   );
   plugins.push(new OptimizeCSSAssetsPlugin());


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Webpack's `chunkhash` is not reliable and produces different hashes for builds of the same assets. Using `contenthash` is far more reliable for caching dependencies based on content.  

More info available in this issue https://github.com/webpack/webpack/issues/7179


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- `npm run build` produces a working prod build 


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
