### PR TITLE
fix: time parser truncate to first day of year/month

### DIFF
--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -79,7 +79,8 @@ def parse_human_datetime(human_readable: str) -> datetime:
     if re.search(x_periods, human_readable, re.IGNORECASE):
         raise TimeRangeUnclearError(human_readable)
     try:
-        dttm = parse(human_readable)
+        default = datetime(year=datetime.now().year, month=1, day=1)
+        dttm = parse(human_readable, default=default)
     except (ValueError, OverflowError) as ex:
         cal = parsedatetime.Calendar()
         parsed_dttm, parsed_flags = cal.parseDT(human_readable)

--- a/tests/utils/date_parser_tests.py
+++ b/tests/utils/date_parser_tests.py
@@ -35,6 +35,10 @@ from tests.base_tests import SupersetTestCase
 def mock_parse_human_datetime(s):
     if s == "now":
         return datetime(2016, 11, 7, 9, 30, 10)
+    elif s == "2018":
+        return datetime(2018, 1, 1)
+    elif s == "2018-9":
+        return datetime(2018, 9, 1)
     elif s == "today":
         return datetime(2016, 11, 7)
     elif s == "yesterday":
@@ -151,6 +155,14 @@ class TestDateParser(SupersetTestCase):
 
         result = datetime_eval("datetime('today'  )")
         expected = datetime(2016, 11, 7)
+        self.assertEqual(result, expected)
+
+        result = datetime_eval("datetime('2018')")
+        expected = datetime(2018, 1, 1)
+        self.assertEqual(result, expected)
+
+        result = datetime_eval("datetime('2018-9')")
+        expected = datetime(2018, 9, 1)
         self.assertEqual(result, expected)
 
         # Parse compact arguments spelling


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Superset uses the `dateutil.parser` library parses a string to the date object. The current behavior will use the `now` as the "conversion anchor". for instance(now is 2017-06-02 CST):

```Python
>>> from dateutil.parser import parse
>>> parse("2017")
datetime.datetime(2017, 6, 2, 0, 0)
```

The new behavior will use the first day of the year(01 Jan) for this "conversion anchor"

```Python
>>> from datetime import datetime
>>> default = datetime(year=datetime.now().year, month=1, day=1)
>>> parse('2017', default=default)
datetime.datetime(2017, 1, 1, 0, 0)
>>> parse('2017-9', default=default)
datetime.datetime(2017, 9, 1, 0, 0)
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### Before
####
![image](https://user-images.githubusercontent.com/2016594/120464395-7562fc00-c3cf-11eb-999d-9827bf8e27d5.png)




#### After

![image](https://user-images.githubusercontent.com/2016594/120464174-38970500-c3cf-11eb-8fd6-fa0320819e58.png)





### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
