### PR TITLE
fix(explore): Long labels should wrap to new line

### DIFF
--- a/superset-frontend/src/explore/components/ControlHeader.jsx
+++ b/superset-frontend/src/explore/components/ControlHeader.jsx
@@ -98,7 +98,6 @@ export default class ControlHeader extends React.Component {
             css={{
               marginBottom: 0,
               position: 'relative',
-              whiteSpace: 'nowrap',
             }}
           >
             {this.props.leftNode && <span>{this.props.leftNode}</span>}


### PR DESCRIPTION
### SUMMARY
It removes a `nowrap` style rule to make sure that the label text can wrap to a new line.

### BEFORE
<img width="1788" alt="119867353-aa081c80-bed2-11eb-889c-574a6609961e" src="https://user-images.githubusercontent.com/60598000/120537019-77d44e80-c3ed-11eb-8104-e9450fa32348.png">

### AFTER
![Screen Shot 2021-06-02 at 21 53 41](https://user-images.githubusercontent.com/60598000/120537062-83277a00-c3ed-11eb-879d-6484e5c15853.png)

### TESTING INSTRUCTIONS
1. Open a deck.gl Arc chart in Explore
2. Observe the long labels and make sure they are wrapping to a new line

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #14877
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
