### PR TITLE
feat: create translation function for superset text overrides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1012,7 +1012,7 @@ LANGUAGES = {
 ### Extracting new strings for translation
 
 ```bash
-pybabel extract -F superset/translations/babel.cfg -o superset/translations/messages.pot -k _ -k __ -k t -k tn -k tct .
+pybabel extract -F superset/translations/babel.cfg -o superset/translations/messages.pot -k _ -k __ -k t -k tn -k tct -k st .
 ```
 
 This will update the template file `superset/translations/messages.pot` with current application strings. Do not forget to update

--- a/Makefile
+++ b/Makefile
@@ -74,3 +74,8 @@ py-format: pre-commit
 
 js-format:
 	cd superset-frontend; npm run prettier
+
+translate:
+	pybabel extract -F superset/translations/babel.cfg -o superset/translations/messages.pot -k _ -k __ -k t -k tn -k tct -k st .
+	pybabel update -i superset/translations/messages.pot -d superset/translations --ignore-obsolete
+	./scripts/po2json.sh

--- a/superset-frontend/src/utils/textUtils.ts
+++ b/superset-frontend/src/utils/textUtils.ts
@@ -17,6 +17,8 @@
  */
 
 /* eslint-disable global-require */
+import { t } from '@superset-ui/core';
+
 const loadModule = () => {
   let module;
   try {
@@ -29,5 +31,28 @@ const loadModule = () => {
 };
 
 const supersetText = loadModule();
+
+// if the translation is the same as the string passed in
+// then the translation doesn't exist, so return the value
+// To use this properly, you should pass in an already translated string
+// as the value. i.e.,
+// const docsText = t('SQLAlchemy docs');
+// return (
+//  st(
+//   'DATABASE_MODAL.SQLALCHEMY_DISPLAY_TEXT',
+//    SQLALCHEMY_DISPLAY_TEXT,
+//    docsText,
+//  )
+// )
+// params: overwrite key, overwrite value, default value
+export const st = (oKey: string, oValue: string | undefined, dValue: string) =>
+  t(oKey) === oKey ? oValue || dValue : t(oKey);
+
+export type SupersetTextType = {
+  DATABASE_MODAL?: {
+    SQLALCHEMY_DISPLAY_TEXT?: string;
+    SQLALCHEMY_DOCS_URL?: string;
+  };
+};
 
 export default supersetText;

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/SqlAlchemyForm.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/SqlAlchemyForm.tsx
@@ -19,6 +19,7 @@
 import React, { EventHandler, ChangeEvent, MouseEvent } from 'react';
 import { t, SupersetTheme } from '@superset-ui/core';
 import Button from 'src/components/Button';
+import SupersetText, { SupersetTextType, st } from 'src/utils/textUtils';
 import { StyledInputContainer, wideButton } from './styles';
 
 import { DatabaseObject } from '../types';
@@ -27,74 +28,83 @@ const SqlAlchemyTab = ({
   db,
   onInputChange,
   testConnection,
-  conf,
-  isEditMode = false,
 }: {
   db: DatabaseObject | null;
   onInputChange: EventHandler<ChangeEvent<HTMLInputElement>>;
   testConnection: EventHandler<MouseEvent<HTMLElement>>;
-  conf: { SQLALCHEMY_DOCS_URL: string; SQLALCHEMY_DISPLAY_TEXT: string };
-  isEditMode?: boolean;
-}) => (
-  <>
-    <StyledInputContainer>
-      <div className="control-label">
-        {t('Display Name')}
-        <span className="required">*</span>
-      </div>
-      <div className="input-container">
-        <input
-          type="text"
-          name="database_name"
-          data-test="database-name-input"
-          value={db?.database_name || ''}
-          placeholder={t('Name your database')}
-          onChange={onInputChange}
-        />
-      </div>
-      <div className="helper">
-        {t('Pick a name to help you identify this database.')}
-      </div>
-    </StyledInputContainer>
-    <StyledInputContainer>
-      <div className="control-label">
-        {t('SQLAlchemy URI')}
-        <span className="required">*</span>
-      </div>
-      <div className="input-container">
-        <input
-          type="text"
-          name="sqlalchemy_uri"
-          data-test="sqlalchemy-uri-input"
-          value={db?.sqlalchemy_uri || ''}
-          autoComplete="off"
-          placeholder={t(
-            'dialect+driver://username:password@host:port/database',
-          )}
-          onChange={onInputChange}
-        />
-      </div>
-      <div className="helper">
-        {t('Refer to the')}{' '}
-        <a
-          href={conf?.SQLALCHEMY_DOCS_URL ?? ''}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {conf?.SQLALCHEMY_DISPLAY_TEXT ?? ''}
-        </a>{' '}
-        {t('for more information on how to structure your URI.')}
-      </div>
-    </StyledInputContainer>
-    <Button
-      onClick={testConnection}
-      cta
-      buttonStyle="link"
-      css={(theme: SupersetTheme) => wideButton(theme)}
-    >
-      {t('Test connection')}
-    </Button>
-  </>
-);
+}) => {
+  const {
+    DATABASE_MODAL: { SQLALCHEMY_DISPLAY_TEXT, SQLALCHEMY_DOCS_URL } = {},
+  }: SupersetTextType = SupersetText;
+  const docsText = t('SQLAlchemy docs');
+  return (
+    <>
+      <StyledInputContainer>
+        <div className="control-label">
+          {t('Display Name')}
+          <span className="required">*</span>
+        </div>
+        <div className="input-container">
+          <input
+            type="text"
+            name="database_name"
+            data-test="database-name-input"
+            value={db?.database_name || ''}
+            placeholder={t('Name your database')}
+            onChange={onInputChange}
+          />
+        </div>
+        <div className="helper">
+          {t('Pick a name to help you identify this database.')}
+        </div>
+      </StyledInputContainer>
+      <StyledInputContainer>
+        <div className="control-label">
+          {t('SQLAlchemy URI')}
+          <span className="required">*</span>
+        </div>
+        <div className="input-container">
+          <input
+            type="text"
+            name="sqlalchemy_uri"
+            data-test="sqlalchemy-uri-input"
+            value={db?.sqlalchemy_uri || ''}
+            autoComplete="off"
+            placeholder={t(
+              'dialect+driver://username:password@host:port/database',
+            )}
+            onChange={onInputChange}
+          />
+        </div>
+        <div className="helper">
+          {t('Refer to the')}{' '}
+          <a
+            href={
+              SQLALCHEMY_DOCS_URL ??
+              'https://docs.sqlalchemy.org/en/13/core/engines.html'
+            }
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {st(
+              'DATABASE_MODAL.SQLALCHEMY_DISPLAY_TEXT',
+              SQLALCHEMY_DISPLAY_TEXT,
+              docsText,
+            )}
+          </a>{' '}
+          {t('for more information on how to structure your URI.')}
+        </div>
+      </StyledInputContainer>
+      <Button
+        onClick={testConnection}
+        cta
+        buttonStyle="link"
+        css={(theme: SupersetTheme) => wideButton(theme)}
+      >
+        {t('Test connection')}
+      </Button>
+    </>
+  );
+};
 
 export default SqlAlchemyTab;

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -45,7 +45,6 @@ import {
   getDatabaseImages,
   getConnectionAlert,
 } from 'src/views/CRUD/hooks';
-import { useCommonConf } from 'src/views/CRUD/data/database/state';
 import {
   DatabaseObject,
   DatabaseForm,
@@ -338,7 +337,6 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
   const [dbName, setDbName] = useState('');
   const [editNewDb, setEditNewDb] = useState<boolean>(false);
   const [isLoading, setLoading] = useState<boolean>(false);
-  const conf = useCommonConf();
   const dbImages = getDatabaseImages();
   const connectionAlert = getConnectionAlert();
   const isEditMode = !!databaseId;
@@ -877,7 +875,6 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
                     value: target.value,
                   })
                 }
-                conf={conf}
                 testConnection={testConnection}
                 isEditMode={isEditMode}
               />

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -166,16 +166,9 @@ export function createErrorHandler(
     const parsedError = await getClientErrorObject(e);
     // Taking the first error returned from the API
     // @ts-ignore
-    const errorsArray = parsedError?.errors;
-    const config = await SupersetText;
-    if (
-      errorsArray &&
-      errorsArray.length &&
-      config &&
-      config.ERRORS &&
-      errorsArray[0].error_type in config.ERRORS
-    ) {
-      parsedError.message = config.ERRORS[errorsArray[0].error_type];
+    const errorType = parsedError?.errors?.[0].error_type;
+    if (errorType && SupersetText.ERRORS && errorType in SupersetText.ERRORS) {
+      parsedError.message = SupersetText.ERRORS[errorType];
     }
     logging.error(e);
     handleErrorFunc(parsedError.message || parsedError.error);

--- a/superset/config.py
+++ b/superset/config.py
@@ -1221,6 +1221,7 @@ GLOBAL_ASYNC_QUERIES_WEBSOCKET_URL = "ws://127.0.0.1:8080/"
 #
 DATASET_HEALTH_CHECK: Optional[Callable[["SqlaTable"], str]] = None
 
+# TODO: this is deprecated. Remove in next major release
 # SQLalchemy link doc reference
 SQLALCHEMY_DOCS_URL = "https://docs.sqlalchemy.org/en/13/core/engines.html"
 SQLALCHEMY_DISPLAY_TEXT = "SQLAlchemy docs"


### PR DESCRIPTION
### SUMMARY
After the recent addition of the superset_text.yml file that allows us to add specific text overwrites, there was an ask to make this text translatable. This change adds a key to the translation files that matches the key in the superset_text.yml file. It is up to the admin of the application to add their specific translation to that file on their local working system. I did not provide a way for people to overwrite that key, just exposed the key into the file. Any other suggestions to that end welcome.

I also added a make command for running translations on development

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
With no overwrite or translation:
<img width="490" alt="_DEV__Superset" src="https://user-images.githubusercontent.com/5186919/120567886-958ebd00-c3c7-11eb-937d-3cf3dd20f192.png">

With only translation:
<img width="489" alt="_DEV__Superset" src="https://user-images.githubusercontent.com/5186919/120567781-5d877a00-c3c7-11eb-8726-3bafa54c3799.png">


With overwrite text and translation: 
<img width="499" alt="_DEV__Superset" src="https://user-images.githubusercontent.com/5186919/120567571-fe296a00-c3c6-11eb-8eac-9e1216f4e975.png">

### TESTING INSTRUCTIONS
Most importantly we should test that this change didn't introduce regressions. Open the database modal window. The text should match the first screenshot in this ticket. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
