### PR TITLE
fix: show custom errors in SQL Lab

### DIFF
--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -82,7 +82,7 @@ CONNECTION_UNKNOWN_DATABASE_REGEX = re.compile(
 )
 COLUMN_DOES_NOT_EXIST_REGEX = re.compile(
     r'postgresql error: column "(?P<column_name>.+?)" '
-    "does not exist\s+LINE (?P<location>\d+?)"
+    r"does not exist\s+LINE (?P<location>\d+?)"
 )
 
 

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -81,7 +81,8 @@ CONNECTION_UNKNOWN_DATABASE_REGEX = re.compile(
     'database "(?P<database>.*?)" does not exist'
 )
 COLUMN_DOES_NOT_EXIST_REGEX = re.compile(
-    'postgresql error: column "(?P<column_name>.+?)" does not exist\s+LINE (?P<location>\d+?)',
+    r'postgresql error: column "(?P<column_name>.+?)" '
+    "does not exist\s+LINE (?P<location>\d+?)"
 )
 
 

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -80,6 +80,9 @@ CONNECTION_HOST_DOWN_REGEX = re.compile(
 CONNECTION_UNKNOWN_DATABASE_REGEX = re.compile(
     'database "(?P<database>.*?)" does not exist'
 )
+COLUMN_DOES_NOT_EXIST_REGEX = re.compile(
+    'postgresql error: column "(?P<column_name>.+?)" does not exist\s+LINE (?P<location>\d+?)',
+)
 
 
 class PostgresBaseEngineSpec(BaseEngineSpec):
@@ -100,7 +103,7 @@ class PostgresBaseEngineSpec(BaseEngineSpec):
         "P1Y": "DATE_TRUNC('year', {col})",
     }
 
-    custom_errors = {
+    custom_errors: Dict[Pattern[str], Tuple[str, SupersetErrorType, Dict[str, Any]]] = {
         CONNECTION_INVALID_USERNAME_REGEX: (
             __('The username "%(username)s" does not exist.'),
             SupersetErrorType.CONNECTION_INVALID_USERNAME_ERROR,
@@ -138,6 +141,14 @@ class PostgresBaseEngineSpec(BaseEngineSpec):
             __('Unable to connect to database "%(database)s".'),
             SupersetErrorType.CONNECTION_UNKNOWN_DATABASE_ERROR,
             {"invalid": ["database"]},
+        ),
+        COLUMN_DOES_NOT_EXIST_REGEX: (
+            __(
+                'We can\'t seem to resolve the column "%(column_name)s" at '
+                "line %(location)s.",
+            ),
+            SupersetErrorType.COLUMN_DOES_NOT_EXIST_ERROR,
+            {},
         ),
     }
 

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -207,6 +207,9 @@ def handle_api_exception(
             return json_errors_response(
                 errors=[ex.error], status=ex.status, payload=ex.payload
             )
+        except SupersetErrorsException as ex:
+            logger.warning(ex)
+            return json_errors_response(errors=ex.errors, status=ex.status)
         except SupersetErrorException as ex:
             logger.warning(ex)
             return json_errors_response(errors=[ex.error], status=ex.status)

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -208,7 +208,7 @@ def handle_api_exception(
                 errors=[ex.error], status=ex.status, payload=ex.payload
             )
         except SupersetErrorsException as ex:
-            logger.warning(ex)
+            logger.warning(ex, exc_info=True)
             return json_errors_response(errors=ex.errors, status=ex.status)
         except SupersetErrorException as ex:
             logger.warning(ex)

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -78,6 +78,7 @@ from superset.exceptions import (
     CertificateException,
     DatabaseNotFound,
     SerializationError,
+    SupersetErrorsException,
     SupersetException,
     SupersetGenericDBErrorException,
     SupersetSecurityException,
@@ -2426,7 +2427,14 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             raise SupersetGenericDBErrorException(utils.error_msg_from_exception(ex))
 
         if data.get("status") == QueryStatus.FAILED:
-            raise SupersetGenericDBErrorException(data["error"])
+            msg = data["error"]
+            query = _session.query(Query).filter_by(id=query_id).one()
+            database = query.database
+            db_engine_spec = database.db_engine_spec
+            errors = db_engine_spec.extract_errors(msg)
+            if errors:
+                raise SupersetErrorsException(errors)
+            raise SupersetGenericDBErrorException(msg)
         return json_success(payload)
 
     @has_access_api

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2432,6 +2432,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             database = query.database
             db_engine_spec = database.db_engine_spec
             errors = db_engine_spec.extract_errors(msg)
+            _session.close()
             if errors:
                 raise SupersetErrorsException(errors)
             raise SupersetGenericDBErrorException(msg)

--- a/tests/celery_tests.py
+++ b/tests/celery_tests.py
@@ -141,6 +141,8 @@ def get_select_star(table: str, schema: Optional[str] = None):
 
 @pytest.mark.parametrize("ctas_method", [CtasMethod.TABLE, CtasMethod.VIEW])
 def test_run_sync_query_dont_exist(setup_sqllab, ctas_method):
+    examples_db = get_example_database()
+    engine_name = examples_db.db_engine_spec.engine_name
     sql_dont_exist = "SELECT name FROM table_dont_exist"
     result = run_sql(sql_dont_exist, cta=True, ctas_method=ctas_method)
     if backend() == "sqlite" and ctas_method == CtasMethod.VIEW:
@@ -157,7 +159,8 @@ def test_run_sync_query_dont_exist(setup_sqllab, ctas_method):
                     "code": 1002,
                     "message": "Issue 1002 - The database returned an unexpected error.",
                 }
-            ]
+            ],
+            "engine_name": engine_name,
         }
 
 

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -75,6 +75,9 @@ class TestSqlLab(SupersetTestCase):
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_sql_json(self):
+        examples_db = get_example_database()
+        engine_name = examples_db.db_engine_spec.engine_name
+
         self.login("admin")
 
         data = self.run_sql("SELECT * FROM birth_names LIMIT 10", "1")
@@ -91,7 +94,8 @@ class TestSqlLab(SupersetTestCase):
                     "code": 1002,
                     "message": "Issue 1002 - The database returned an unexpected error.",
                 }
-            ]
+            ],
+            "engine_name": engine_name,
         }
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -84,7 +84,6 @@ class TestSqlLab(SupersetTestCase):
         self.assertLess(0, len(data["data"]))
 
         data = self.run_sql("SELECT * FROM unexistant_table", "2")
-        print(data)
         assert (
             data["errors"][0]["error_type"] == SupersetErrorType.GENERIC_DB_ENGINE_ERROR
         )

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -84,6 +84,7 @@ class TestSqlLab(SupersetTestCase):
         self.assertLess(0, len(data["data"]))
 
         data = self.run_sql("SELECT * FROM unexistant_table", "2")
+        print(data)
         assert (
             data["errors"][0]["error_type"] == SupersetErrorType.GENERIC_DB_ENGINE_ERROR
         )


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

There was a regression and SQL Lab is no longer showing custom errors like invalid column. I discovered this while adding the custom `COLUMN_DOES_NOT_EXIST_ERROR` for Postgres, and fixed the problem.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

We were getting a generic DB error:

![Screenshot_2021-06-02 Superset(2)](https://user-images.githubusercontent.com/1534870/120573188-076c0400-c3d2-11eb-8da3-6a55202cf804.png)

With the change, Presto now shows custom error messages:

![Screenshot_2021-06-02 Superset](https://user-images.githubusercontent.com/1534870/120573217-118e0280-c3d2-11eb-98f6-66879ac666c6.png)

Same for Postgres, which was added in this PR:

![Screenshot_2021-06-02 Superset(1)](https://user-images.githubusercontent.com/1534870/120573204-0d61e500-c3d2-11eb-9e12-a4d7b617b944.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Manual testing. Update unit test.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
