### PR TITLE
fix: font regression in SQL Lab

### DIFF
--- a/superset-frontend/src/components/ErrorMessage/DatabaseErrorMessage.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/DatabaseErrorMessage.test.tsx
@@ -44,6 +44,7 @@ const mockedProps = {
     message: 'Error message',
   },
   source: 'dashboard' as ErrorSource,
+  subtitle: 'Error message',
 };
 
 test('should render', () => {

--- a/superset-frontend/src/components/ErrorMessage/DatabaseErrorMessage.tsx
+++ b/superset-frontend/src/components/ErrorMessage/DatabaseErrorMessage.tsx
@@ -35,6 +35,7 @@ interface DatabaseErrorExtra {
 function DatabaseErrorMessage({
   error,
   source = 'dashboard',
+  subtitle,
 }: ErrorMessageComponentProps<DatabaseErrorExtra>) {
   const { extra, level, message } = error;
 
@@ -81,7 +82,7 @@ ${extra.issue_codes.map(issueCode => issueCode.message).join('\n')}`;
   return (
     <ErrorAlert
       title={t('%s Error', extra.engine_name || t('DB engine'))}
-      subtitle={message}
+      subtitle={subtitle}
       level={level}
       source={source}
       copyText={copyText}

--- a/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
@@ -50,7 +50,13 @@ export default function ErrorMessageWithStackTrace({
       error.error_type,
     );
     if (ErrorMessageComponent) {
-      return <ErrorMessageComponent error={error} source={source} />;
+      return (
+        <ErrorMessageComponent
+          error={error}
+          source={source}
+          subtitle={subtitle}
+        />
+      );
     }
   }
 

--- a/superset-frontend/src/components/ErrorMessage/ParameterErrorMessage.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ParameterErrorMessage.test.tsx
@@ -44,6 +44,7 @@ const mockedProps = {
     message: 'Error message',
   },
   source: 'dashboard' as ErrorSource,
+  subtitle: 'Error message',
 };
 
 test('should render', () => {

--- a/superset-frontend/src/components/ErrorMessage/ParameterErrorMessage.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ParameterErrorMessage.tsx
@@ -54,6 +54,7 @@ const findMatches = (undefinedParameters: string[], templateKeys: string[]) => {
 function ParameterErrorMessage({
   error,
   source = 'sqllab',
+  subtitle,
 }: ErrorMessageComponentProps<ParameterErrorExtra>) {
   const { extra, level, message } = error;
 
@@ -112,7 +113,7 @@ ${extra.issue_codes.map(issueCode => issueCode.message).join('\n')}`;
   return (
     <ErrorAlert
       title={t('Parameter error')}
-      subtitle={message}
+      subtitle={subtitle}
       level={level}
       source={source}
       copyText={copyText}

--- a/superset-frontend/src/components/ErrorMessage/types.ts
+++ b/superset-frontend/src/components/ErrorMessage/types.ts
@@ -88,6 +88,7 @@ export type ErrorMessageComponentProps<
 > = {
   error: SupersetError<ExtraType>;
   source?: ErrorSource;
+  subtitle?: React.ReactNode;
 };
 
 export type ErrorMessageComponent = React.ComponentType<ErrorMessageComponentProps>;


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

In SQL Lab we wrap the error message in a `<MonospaceDiv>` to show the error messages with a monospaced font. But this is being dropped if there's a custom error component registered for the error.

I fixed it by passing the monospaced error (`subtitle`) to the custom error component.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

![Screenshot_2021-06-02 Superset(4)](https://user-images.githubusercontent.com/1534870/120580184-96324e00-c3dd-11eb-9fe4-7482a8820736.png)

After:

![Screenshot_2021-06-02 Superset(3)](https://user-images.githubusercontent.com/1534870/120580021-4d7a9500-c3dd-11eb-9aab-f743f9202c87.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
