### PR TITLE
fix(native-filters): cascading filters not rendering in tab

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -72,6 +72,7 @@ const FilterControls: FC<FilterControlsProps> = ({
     }));
     return buildCascadeFiltersTree(filtersWithValue);
   }, [filterValues, dataMaskSelected]);
+  const cascadeFilterIds = new Set(cascadeFilters.map(item => item.id));
 
   let filtersInScope: CascadeFilter[] = [];
   const filtersOutOfScope: CascadeFilter[] = [];
@@ -93,23 +94,25 @@ const FilterControls: FC<FilterControlsProps> = ({
 
   return (
     <Wrapper>
-      {portalNodes.map((node, index) => (
-        <portals.InPortal node={node}>
-          <CascadePopover
-            data-test="cascade-filters-control"
-            key={cascadeFilters[index].id}
-            visible={visiblePopoverId === cascadeFilters[index].id}
-            onVisibleChange={visible =>
-              setVisiblePopoverId(visible ? cascadeFilters[index].id : null)
-            }
-            filter={cascadeFilters[index]}
-            onFilterSelectionChange={onFilterSelectionChange}
-            directPathToChild={directPathToChild}
-          />
-        </portals.InPortal>
-      ))}
+      {portalNodes
+        .filter((node, index) => cascadeFilterIds.has(filterValues[index].id))
+        .map((node, index) => (
+          <portals.InPortal node={node}>
+            <CascadePopover
+              data-test="cascade-filters-control"
+              key={cascadeFilters[index].id}
+              visible={visiblePopoverId === cascadeFilters[index].id}
+              onVisibleChange={visible =>
+                setVisiblePopoverId(visible ? cascadeFilters[index].id : null)
+              }
+              filter={cascadeFilters[index]}
+              onFilterSelectionChange={onFilterSelectionChange}
+              directPathToChild={directPathToChild}
+            />
+          </portals.InPortal>
+        ))}
       {filtersInScope.map(filter => {
-        const index = cascadeFilters.findIndex(f => f.id === filter.id);
+        const index = filterValues.findIndex(f => f.id === filter.id);
         return <portals.OutPortal node={portalNodes[index]} />;
       })}
       {showCollapsePanel && (


### PR DESCRIPTION
### SUMMARY
#14933 caused a regression for cascading filters. This was caused by the fact that filters with a parent aren't rendered in the filter tab, causing index referencing to the array of nodes in the portal to fall out of sync. This PR does the following:
- does not attempt to render a cascading popover for nodes that have a parent (these will be rendered within the parent's popover)
- checks the index for the in scope filters from the unfiltered filter array, as the portal node needs to be referenced by this (not the filtered cascading filter array).

### BEFORE
Cascading filters caused an error when rendering the filter tab due to the index being referenced on the unfiltered portal node array didn't exist on the cascade filters array:
![image](https://user-images.githubusercontent.com/33317356/120609338-bfdd8a80-c45a-11eb-9d9e-df6b4c50ab1d.png)

### AFTER
Now cascading filters show up as expected ("Continent" is the parent of "Country", while "Country code" is unhierarchical):
![image](https://user-images.githubusercontent.com/33317356/120609415-d1269700-c45a-11eb-8727-16f24ff8aa89.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
