### PR TITLE
fix: remove unused time column when update dataset

### DIFF
--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -123,14 +124,18 @@ class DatasourceControl extends React.PureComponent {
 
   onDatasourceSave(datasource) {
     this.props.actions.setDatasource(datasource);
-    // remove time column in the form_data
-    const timeCol = this.props.form_data?.granularity_sqla; // eslint-disable-line camelcase
+    const timeCol = this.props.form_data?.granularity_sqla;
     const { columns } = this.props.datasource;
+    const firstDttmCol = columns.find(column => column.is_dttm);
     if (
       datasource.type === 'table' &&
-      !columns.find(({ column_name }) => column_name === timeCol)?.is_dttm // eslint-disable-line camelcase
+      !columns.find(({ column_name }) => column_name === timeCol)?.is_dttm
     ) {
-      this.props.actions.setControlValue('granularity_sqla', null);
+      // set `granularity_sqla` to first datatime column name or null
+      this.props.actions.setControlValue(
+        'granularity_sqla',
+        firstDttmCol ? firstDttmCol.column_name : null,
+      );
     }
     if (this.props.onDatasourceSave) {
       this.props.onDatasourceSave(datasource);
@@ -221,9 +226,9 @@ class DatasourceControl extends React.PureComponent {
               <Icons.AlertSolid iconColor={supersetTheme.colors.warning.base} />
             </Tooltip>
           )}
-          {extra?.warning_markdown && ( // eslint-disable-line camelcase
+          {extra?.warning_markdown && (
             <WarningIconWithTooltip
-              warningMarkdown={extra.warning_markdown} // eslint-disable-line camelcase
+              warningMarkdown={extra.warning_markdown}
               size={30}
             />
           )}

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -35,6 +35,7 @@ const propTypes = {
   onChange: PropTypes.func,
   value: PropTypes.string,
   datasource: PropTypes.object.isRequired,
+  form_data: PropTypes.object.isRequired,
   isEditable: PropTypes.bool,
   onDatasourceSave: PropTypes.func,
 };
@@ -122,6 +123,15 @@ class DatasourceControl extends React.PureComponent {
 
   onDatasourceSave(datasource) {
     this.props.actions.setDatasource(datasource);
+    // remove time column in the form_data
+    const timeCol = this.props.form_data?.granularity_sqla;
+    const { columns } = this.props.datasource;
+    if (
+      datasource.type === 'table' &&
+      !columns.find(({ column_name }) => column_name === timeCol)?.is_dttm
+    ) {
+      this.props.actions.setControlValue('granularity_sqla', null);
+    }
     if (this.props.onDatasourceSave) {
       this.props.onDatasourceSave(datasource);
     }

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -124,11 +124,11 @@ class DatasourceControl extends React.PureComponent {
   onDatasourceSave(datasource) {
     this.props.actions.setDatasource(datasource);
     // remove time column in the form_data
-    const timeCol = this.props.form_data?.granularity_sqla;
+    const timeCol = this.props.form_data?.granularity_sqla; // eslint-disable-line camelcase
     const { columns } = this.props.datasource;
     if (
       datasource.type === 'table' &&
-      !columns.find(({ column_name }) => column_name === timeCol)?.is_dttm
+      !columns.find(({ column_name }) => column_name === timeCol)?.is_dttm // eslint-disable-line camelcase
     ) {
       this.props.actions.setControlValue('granularity_sqla', null);
     }

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1032,7 +1032,7 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
         metrics = metrics or []
 
         # For backward compatibility
-        if granularity not in self.dttm_cols:
+        if granularity not in self.dttm_cols and granularity is not None:
             granularity = self.main_dttm_col
 
         # Database spec supports join-free timeslot grouping


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
closes: https://github.com/apache/superset/issues/14683
superset-ui related PR: https://github.com/apache-superset/superset-ui/pull/1148

Since the early Superset TableSource references to Druid table structure, there was always a time dimension(time partition column) in all tables(as known as, datasource or dataset). But this concept is not suitable for other data warehouses or databases. 

There is a `main_dttm_col` field in the superset dataset, service time dimension. Now if a time column is not passed to superset backend, the `main_dttm_col` will be used in the time column. 

This change 
- allows Superset to receive null time column
- force user update time column value when user changed existing time column type(for instance: uncheck is_temporal)




### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

#### Before

https://user-images.githubusercontent.com/2016594/120643352-a3683f00-c4a8-11eb-9ed7-b9f3713236c9.mp4




#### After

https://user-images.githubusercontent.com/2016594/120643003-2b017e00-c4a8-11eb-9b11-59aac1384351.mp4




### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/14683 https://github.com/apache/superset/issues/14754
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
