### PR TITLE
fix: renamed sqllab filters to _filters

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1271,10 +1271,11 @@ There is a special ``_filters`` parameter which can be used to test filters used
 
 .. code-block:: JSON
     {
-        "_filters": {
+        "_filters": [ {
             "col": "action_type",
             "op": "IN",
             "val": ["sell", "buy"]
+            } ]
     }
 
 .. code-block:: python

--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -280,7 +280,8 @@ export default class ResultSet extends React.PureComponent<
     // before saving the dataset.
     if (templateParams) {
       const p = JSON.parse(templateParams);
-      if (p.filters) {
+        /* eslint-disable-next-line no-underscore-dangle */
+      if (p._filters) {
         /* eslint-disable-next-line no-underscore-dangle */
         delete p._filters;
         templateParams = JSON.stringify(p);

--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -280,7 +280,7 @@ export default class ResultSet extends React.PureComponent<
     // before saving the dataset.
     if (templateParams) {
       const p = JSON.parse(templateParams);
-        /* eslint-disable-next-line no-underscore-dangle */
+      /* eslint-disable-next-line no-underscore-dangle */
       if (p._filters) {
         /* eslint-disable-next-line no-underscore-dangle */
         delete p._filters;

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -212,7 +212,7 @@ def add_sqllab_custom_filters(form_data: Dict[Any, Any]) -> Any:
             if isinstance(params_str, str):
                 params = json.loads(params_str)
                 if isinstance(params, dict):
-                    filters = params.get("filters")
+                    filters = params.get("_filters")
                     if filters:
                         form_data.update({"filters": filters})
     except (TypeError, json.JSONDecodeError):


### PR DESCRIPTION
### SUMMARY
Fixing previous commit. Ville suggested renaming filters to _filters in sqllab template parameters.
 
