### PR TITLE
refactor: Convert TableElement to TypeScript

### DIFF
--- a/superset-frontend/spec/javascripts/sqllab/TableElement_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/TableElement_spec.jsx
@@ -55,7 +55,7 @@ describe('TableElement', () => {
         },
       },
     );
-    expect(wrapper.find(IconTooltip)).toHaveLength(5);
+    expect(wrapper.find(IconTooltip)).toHaveLength(4);
   });
   it('has 14 columns', () => {
     const wrapper = shallow(<TableElement {...mockedProps} />);
@@ -112,20 +112,20 @@ describe('TableElement', () => {
       },
     );
     expect(
-      wrapper.find(IconTooltip).at(2).hasClass('fa-sort-alpha-asc'),
+      wrapper.find(IconTooltip).at(1).hasClass('fa-sort-alpha-asc'),
     ).toEqual(true);
     expect(
-      wrapper.find(IconTooltip).at(2).hasClass('fa-sort-numeric-asc'),
+      wrapper.find(IconTooltip).at(1).hasClass('fa-sort-numeric-asc'),
     ).toEqual(false);
     wrapper.find('.header-container').hostNodes().simulate('click');
     expect(wrapper.find(ColumnElement).first().props().column.name).toBe('id');
     wrapper.find('.header-container').simulate('mouseEnter');
     wrapper.find('.sort-cols').hostNodes().simulate('click');
     expect(
-      wrapper.find(IconTooltip).at(2).hasClass('fa-sort-numeric-asc'),
+      wrapper.find(IconTooltip).at(1).hasClass('fa-sort-numeric-asc'),
     ).toEqual(true);
     expect(
-      wrapper.find(IconTooltip).at(2).hasClass('fa-sort-alpha-asc'),
+      wrapper.find(IconTooltip).at(1).hasClass('fa-sort-alpha-asc'),
     ).toEqual(false);
     expect(wrapper.find(ColumnElement).first().props().column.name).toBe(
       'active',

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar.jsx
@@ -138,13 +138,17 @@ export default class SqlEditorLeftBar extends React.PureComponent {
 
   renderExpandIconWithTooltip = ({ isActive }) => (
     <IconTooltip
-      style={{ transform: 'rotate(90deg)' }}
+      css={css`
+        transform: rotate(90deg);
+      `}
       aria-label="Collapse"
       tooltip={t(`${isActive ? 'Collapse' : 'Expand'} table preview`)}
     >
       <Icons.RightOutlined
         iconSize="s"
-        style={{ transform: isActive ? 'rotateY(180deg)' : '' }}
+        css={css`
+          transform: ${isActive ? 'rotateY(180deg)' : ''};
+        `}
       />
     </IconTooltip>
   );

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar.jsx
@@ -23,6 +23,8 @@ import { t, styled, css } from '@superset-ui/core';
 import Collapse from 'src/components/Collapse';
 import TableElement from './TableElement';
 import TableSelector from '../../components/TableSelector';
+import Icons from 'src/components/Icons';
+import { IconTooltip } from '../../components/IconTooltip';
 
 const propTypes = {
   queryEditor: PropTypes.object.isRequired,
@@ -134,6 +136,19 @@ export default class SqlEditorLeftBar extends React.PureComponent {
     this.props.actions.addTable(this.props.queryEditor, tableName, schemaName);
   }
 
+  renderExpandIconWithTooltip = ({ isActive }) => (
+    <IconTooltip
+      style={{ transform: 'rotate(90deg)' }}
+      aria-label="Collapse"
+      tooltip={t(`${isActive ? 'Collapse' : 'Expand'} table preview`)}
+    >
+      <Icons.RightOutlined
+        iconSize="s"
+        style={{ transform: isActive ? 'rotateY(180deg)' : '' }}
+      />
+    </IconTooltip>
+  );
+
   render() {
     const shouldShowReset = window.location.search === '?reset=1';
     const tableMetaDataHeight = this.props.height - 130; // 130 is the height of the selects above
@@ -184,6 +199,7 @@ export default class SqlEditorLeftBar extends React.PureComponent {
               expandIconPosition="right"
               ghost
               onChange={this.onToggleTable}
+              expandIcon={this.renderExpandIconWithTooltip}
             >
               {this.props.tables.map(table => (
                 <TableElement

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar.jsx
@@ -21,9 +21,9 @@ import PropTypes from 'prop-types';
 import Button from 'src/components/Button';
 import { t, styled, css } from '@superset-ui/core';
 import Collapse from 'src/components/Collapse';
+import Icons from 'src/components/Icons';
 import TableElement from './TableElement';
 import TableSelector from '../../components/TableSelector';
-import Icons from 'src/components/Icons';
 import { IconTooltip } from '../../components/IconTooltip';
 
 const propTypes = {

--- a/superset-frontend/src/SqlLab/components/TableElement.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.tsx
@@ -32,7 +32,7 @@ import ModalTrigger from '../../components/ModalTrigger';
 import Loading from '../../components/Loading';
 
 // I don't think this makes sense to have
-// Shouldn't be rendering component if table and actions are passed in
+// Shouldn't be rendering component if table and actions are'nt passed in
 // ----------------------
 // const defaultProps = {
 //   actions: {},
@@ -40,7 +40,13 @@ import Loading from '../../components/Loading';
 // };
 // ----------------------
 
-interface tableType {
+interface Column {
+  name: string;
+  keys?: { type: ColumnKeyTypeType }[];
+  type: string;
+}
+
+interface Table {
   name: string;
   partitions?: {
     partitionQuery: string;
@@ -51,20 +57,14 @@ interface tableType {
   view: string;
   isMetadataLoading: boolean;
   isExtraMetadataLoading: boolean;
-  columns: columnType[];
-}
-
-interface columnType {
-  name: string;
-  keys?: { type: ColumnKeyTypeType }[];
-  type: string;
+  columns: Column[];
 }
 
 interface TableElementProps {
-  table: tableType;
+  table: Table;
   actions: {
-    removeDataPreview(table: tableType): void;
-    removeTable(table: tableType): void;
+    removeDataPreview(table: Table): void;
+    removeTable(table: Table): void;
   };
   isActive: boolean;
   key: string | number;
@@ -243,7 +243,7 @@ const TableElement = (props: TableElementProps) => {
     if (table.columns) {
       cols = table.columns.slice();
       if (sortColumns) {
-        cols.sort((a: columnType, b: columnType) => {
+        cols.sort((a: Column, b: Column) => {
           const colA = a.name.toUpperCase();
           const colB = b.name.toUpperCase();
           return colA < colB ? -1 : colA > colB ? 1 : 0;

--- a/superset-frontend/src/SqlLab/components/TableElement.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.tsx
@@ -38,6 +38,7 @@ interface Column {
 }
 
 interface Table {
+  id: string;
   name: string;
   partitions?: {
     partitionQuery: string;
@@ -57,7 +58,6 @@ interface TableElementProps {
     removeDataPreview: (table: Table) => void;
     removeTable: (table: Table) => void;
   };
-  key: string | number;
 }
 
 const StyledSpan = styled.span`
@@ -73,7 +73,14 @@ const Fade = styled.div`
   opacity: ${(props: { hovered: boolean }) => (props.hovered ? 1 : 0)};
 `;
 
-const TableElement = ({ table, actions, key, ...props }: TableElementProps) => {
+// Note about TableElement props:
+// The antd Collapse component is expecting its children to be `Collapse.Panel`s and
+// is quietly passing extra props that need to be on the panels for them to work correctly.
+// These props are not defined in their TypeScript type for Panel though because
+// this logic is happening in the Collapse component itself. We have gotten around the TypeScript
+// errors by using the rest and spread operators to pass the necessary extra props to the Panels.
+
+const TableElement = ({ table, actions, ...props }: TableElementProps) => {
   const [sortColumns, setSortColumns] = useState(false);
   const [hovered, setHovered] = useState(false);
 
@@ -259,7 +266,7 @@ const TableElement = ({ table, actions, key, ...props }: TableElementProps) => {
   return (
     <Collapse.Panel
       {...props}
-      key={key}
+      key={table.id}
       header={renderHeader()}
       className="TableElement"
       forceRender

--- a/superset-frontend/src/SqlLab/components/TableElement.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.tsx
@@ -43,9 +43,9 @@ interface Table {
     partitionQuery: string;
     latest: object[];
   };
-  indexes: object[];
-  selectStar: string;
-  view: string;
+  indexes?: object[];
+  selectStar?: string;
+  view?: string;
   isMetadataLoading: boolean;
   isExtraMetadataLoading: boolean;
   columns: Column[];
@@ -54,11 +54,14 @@ interface Table {
 interface TableElementProps {
   table: Table;
   actions: {
-    removeDataPreview(table: Table): void;
-    removeTable(table: Table): void;
+    removeDataPreview: (table: Table) => void;
+    removeTable: (table: Table) => void;
   };
   isActive: boolean;
-  key: string | number;
+  panelKey: string | number;
+  expandIcon: any;
+  onItemClick: any;
+  openMotion: any;
 }
 
 const StyledSpan = styled.span`
@@ -74,11 +77,17 @@ const Fade = styled.div`
   opacity: ${(props: { hovered: boolean }) => (props.hovered ? 1 : 0)};
 `;
 
-const TableElement = (props: TableElementProps) => {
+const TableElement = ({
+  table,
+  actions,
+  isActive,
+  expandIcon,
+  onItemClick,
+  openMotion,
+  panelKey,
+}: TableElementProps) => {
   const [sortColumns, setSortColumns] = useState(false);
   const [hovered, setHovered] = useState(false);
-
-  const { table, actions } = props;
 
   const setHover = (hovered: boolean) => {
     debounce(() => setHovered(hovered), 100)();
@@ -261,10 +270,14 @@ const TableElement = (props: TableElementProps) => {
 
   return (
     <Collapse.Panel
-      {...props}
       header={renderHeader()}
       className="TableElement"
       forceRender
+      isActive={isActive}
+      expandIcon={expandIcon}
+      onItemClick={onItemClick}
+      openMotion={openMotion}
+      panelKey={panelKey}
     >
       {renderBody()}
     </Collapse.Panel>

--- a/superset-frontend/src/SqlLab/components/TableElement.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.tsx
@@ -31,15 +31,6 @@ import ShowSQL from './ShowSQL';
 import ModalTrigger from '../../components/ModalTrigger';
 import Loading from '../../components/Loading';
 
-// I don't think this makes sense to have
-// Shouldn't be rendering component if table and actions are'nt passed in
-// ----------------------
-// const defaultProps = {
-//   actions: {},
-//   table: null,
-// };
-// ----------------------
-
 interface Column {
   name: string;
   keys?: { type: ColumnKeyTypeType }[];
@@ -279,7 +270,5 @@ const TableElement = (props: TableElementProps) => {
     </Collapse.Panel>
   );
 };
-
-// TableElement.defaultProps = defaultProps;
 
 export default TableElement;

--- a/superset-frontend/src/SqlLab/components/TableElement.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.tsx
@@ -17,7 +17,6 @@
  * under the License.
  */
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
 import Collapse from 'src/components/Collapse';
 import Card from 'src/components/Card';
 import ButtonGroup from 'src/components/ButtonGroup';
@@ -25,23 +24,51 @@ import { t, styled } from '@superset-ui/core';
 import { debounce } from 'lodash';
 
 import { Tooltip } from 'src/components/Tooltip';
-import Icons from 'src/components/Icons';
 import CopyToClipboard from '../../components/CopyToClipboard';
 import { IconTooltip } from '../../components/IconTooltip';
-import ColumnElement from './ColumnElement';
+import ColumnElement, { ColumnKeyTypeType } from './ColumnElement';
 import ShowSQL from './ShowSQL';
 import ModalTrigger from '../../components/ModalTrigger';
 import Loading from '../../components/Loading';
 
-const propTypes = {
-  table: PropTypes.object,
-  actions: PropTypes.object,
-};
+// I don't think this makes sense to have
+// Shouldn't be rendering component if table and actions are passed in
+// ----------------------
+// const defaultProps = {
+//   actions: {},
+//   table: null,
+// };
+// ----------------------
 
-const defaultProps = {
-  actions: {},
-  table: null,
-};
+interface tableType {
+  name: string;
+  partitions?: {
+    partitionQuery: string;
+    latest: object[];
+  };
+  indexes: object[];
+  selectStar: string;
+  view: string;
+  isMetadataLoading: boolean;
+  isExtraMetadataLoading: boolean;
+  columns: columnType[];
+}
+
+interface columnType {
+  name: string;
+  keys?: { type: ColumnKeyTypeType }[];
+  type: string;
+}
+
+interface TableElementProps {
+  table: tableType;
+  actions: {
+    removeDataPreview(table: tableType): void;
+    removeTable(table: tableType): void;
+  };
+  isActive: boolean;
+  key: string | number;
+}
 
 const StyledSpan = styled.span`
   color: ${({ theme }) => theme.colors.primary.dark1};
@@ -53,16 +80,16 @@ const StyledSpan = styled.span`
 
 const Fade = styled.div`
   transition: all ${({ theme }) => theme.transitionTiming}s;
-  opacity: ${props => (props.hovered ? 1 : 0)};
+  opacity: ${(props: { hovered: boolean }) => (props.hovered ? 1 : 0)};
 `;
 
-const TableElement = props => {
+const TableElement = (props: TableElementProps) => {
   const [sortColumns, setSortColumns] = useState(false);
   const [hovered, setHovered] = useState(false);
 
-  const { table, actions, isActive } = props;
+  const { table, actions } = props;
 
-  const setHover = hovered => {
+  const setHover = (hovered: boolean) => {
     debounce(() => setHovered(hovered), 100)();
   };
 
@@ -92,15 +119,15 @@ const TableElement = props => {
           />
         );
       }
-      let latest = Object.entries(table.partitions?.latest || []).map(
+      const latest = Object.entries(table.partitions?.latest || []).map(
         ([key, value]) => `${key}=${value}`,
       );
-      latest = latest.join('/');
+      const latestString: string = latest.join('/');
       header = (
         <Card size="small">
           <div>
             <small>
-              {t('latest partition:')} {latest}
+              {t('latest partition:')} {latestString}
             </small>{' '}
             {partitionClipBoard}
           </div>
@@ -142,9 +169,9 @@ const TableElement = props => {
           }
           onClick={toggleSortColumns}
           tooltip={
-            !sortColumns
-              ? t('Sort columns alphabetically')
-              : t('Original table column order')
+            sortColumns
+              ? t('Original table column order')
+              : t('Sort columns alphabetically')
           }
         />
         {table.selectStar && (
@@ -216,16 +243,10 @@ const TableElement = props => {
     if (table.columns) {
       cols = table.columns.slice();
       if (sortColumns) {
-        cols.sort((a, b) => {
+        cols.sort((a: columnType, b: columnType) => {
           const colA = a.name.toUpperCase();
           const colB = b.name.toUpperCase();
-          if (colA < colB) {
-            return -1;
-          }
-          if (colA > colB) {
-            return 1;
-          }
-          return 0;
+          return colA < colB ? -1 : colA > colB ? 1 : 0;
         });
       }
     }
@@ -247,41 +268,18 @@ const TableElement = props => {
     return metadata;
   };
 
-  const collapseExpandIcon = () => (
-    <IconTooltip
-      style={{
-        position: 'fixed',
-        right: '16px',
-        left: 'auto',
-        fontSize: '12px',
-        transform: 'rotate(90deg)',
-        display: 'flex',
-        alignItems: 'center',
-      }}
-      aria-label="Collapse"
-      tooltip={t(`${isActive ? 'Collapse' : 'Expand'} table preview`)}
-    >
-      <Icons.RightOutlined
-        iconSize="s"
-        style={isActive ? { transform: 'rotateY(180deg)' } : null}
-      />
-    </IconTooltip>
-  );
-
   return (
     <Collapse.Panel
       {...props}
       header={renderHeader()}
       className="TableElement"
       forceRender
-      expandIcon={collapseExpandIcon}
     >
       {renderBody()}
     </Collapse.Panel>
   );
 };
 
-TableElement.propTypes = propTypes;
-TableElement.defaultProps = defaultProps;
+// TableElement.defaultProps = defaultProps;
 
 export default TableElement;

--- a/superset-frontend/src/SqlLab/components/TableElement.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.tsx
@@ -73,13 +73,6 @@ const Fade = styled.div`
   opacity: ${(props: { hovered: boolean }) => (props.hovered ? 1 : 0)};
 `;
 
-// Note about TableElement props:
-// The antd Collapse component is expecting its children to be `Collapse.Panel`s and
-// is quietly passing extra props that need to be on the panels for them to work correctly.
-// These props are not defined in their TypeScript type for Panel though because
-// this logic is happening in the Collapse component itself. We have gotten around the TypeScript
-// errors by using the rest and spread operators to pass the necessary extra props to the Panels.
-
 const TableElement = ({ table, actions, ...props }: TableElementProps) => {
   const [sortColumns, setSortColumns] = useState(false);
   const [hovered, setHovered] = useState(false);
@@ -114,15 +107,15 @@ const TableElement = ({ table, actions, ...props }: TableElementProps) => {
           />
         );
       }
-      const latest = Object.entries(table.partitions?.latest || []).map(
-        ([key, value]) => `${key}=${value}`,
-      );
-      const latestString: string = latest.join('/');
+      const latest = Object.entries(table.partitions?.latest || [])
+        .map(([key, value]) => `${key}=${value}`)
+        .join('/');
+
       header = (
         <Card size="small">
           <div>
             <small>
-              {t('latest partition:')} {latestString}
+              {t('latest partition:')} {latest}
             </small>{' '}
             {partitionClipBoard}
           </div>

--- a/superset-frontend/src/SqlLab/components/TableElement.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.tsx
@@ -57,11 +57,7 @@ interface TableElementProps {
     removeDataPreview: (table: Table) => void;
     removeTable: (table: Table) => void;
   };
-  isActive: boolean;
-  panelKey: string | number;
-  expandIcon: any;
-  onItemClick: any;
-  openMotion: any;
+  key: string | number;
 }
 
 const StyledSpan = styled.span`
@@ -77,15 +73,7 @@ const Fade = styled.div`
   opacity: ${(props: { hovered: boolean }) => (props.hovered ? 1 : 0)};
 `;
 
-const TableElement = ({
-  table,
-  actions,
-  isActive,
-  expandIcon,
-  onItemClick,
-  openMotion,
-  panelKey,
-}: TableElementProps) => {
+const TableElement = ({ table, actions, key, ...props }: TableElementProps) => {
   const [sortColumns, setSortColumns] = useState(false);
   const [hovered, setHovered] = useState(false);
 
@@ -270,14 +258,11 @@ const TableElement = ({
 
   return (
     <Collapse.Panel
+      {...props}
+      key={key}
       header={renderHeader()}
       className="TableElement"
       forceRender
-      isActive={isActive}
-      expandIcon={expandIcon}
-      onItemClick={onItemClick}
-      openMotion={openMotion}
-      panelKey={panelKey}
     >
       {renderBody()}
     </Collapse.Panel>


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Converted TableElement to TypeScript.

Required me to move the expand icon with tooltip off the Collapse.Panel component on to the Collapse parent component where it was supposed to be. Allowed me to remove most of the inline styling in the expand icon because the styles are now being inherited correctly.

Made code more concise and readable wherever I could.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Should look and behave the same

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- To test TableElement navigate to the route superset/sqllab
- On the left towards the bottom there should be a drop-down saying Select table or type table name
- Use the drop-down and select some tables and below the drop-down, some TableElement components should appear
- Check them out

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
