### PR TITLE
fix(native-filters): update cascaded filter state on change

### DIFF
--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -158,6 +158,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
     if (!isDropdownVisible) {
       setSelectedValues(filterState.value);
     }
+    updateDataMask(filterState.value);
   }, [JSON.stringify(filterState.value)]);
 
   const isDisabled =


### PR DESCRIPTION
### SUMMARY
When the same native filter is visible both the popover and the filter tab, making changes to one doesn't update the datamask in the other, causing trouble when checking for changes in the `useEffect` hook for `dataMask`.

### BEFORE
https://user-images.githubusercontent.com/33317356/120746724-751a4c00-c508-11eb-97e3-36bea187e69c.mp4

### AFTER
https://user-images.githubusercontent.com/33317356/120746745-7e0b1d80-c508-11eb-93c6-fd7924d2bd58.mp4

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
