### PR TITLE
feat(native-filters): add markers and number formatter to range filter

### DIFF
--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.stories.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.stories.tsx
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+import {
+  SuperChart,
+  getChartTransformPropsRegistry,
+  GenericDataType,
+} from '@superset-ui/core';
+import RangeFilterPlugin from './index';
+import transformProps from './transformProps';
+
+new RangeFilterPlugin().configure({ key: 'filter_range' }).register();
+
+getChartTransformPropsRegistry().registerValue('filter_range', transformProps);
+
+export default {
+  title: 'Filter Plugins',
+};
+
+export const range = ({ width, height }: { width: number; height: number }) => (
+  <SuperChart
+    chartType="filter_range"
+    width={width}
+    height={height}
+    queriesData={[{ data: [{ min: 10, max: 100 }] }]}
+    filterState={{ value: [10, 70] }}
+    formData={{
+      groupby: ['SP_POP_TOTL'],
+      adhoc_filters: [],
+      extra_filters: [],
+      viz_type: 'filter_range',
+      metrics: [
+        {
+          aggregate: 'MIN',
+          column: {
+            column_name: 'SP_POP_TOTL',
+            id: 1,
+            type_generic: GenericDataType.NUMERIC,
+          },
+          expressionType: 'SIMPLE',
+          hasCustomLabel: true,
+          label: 'min',
+        },
+        {
+          aggregate: 'MAX',
+          column: {
+            column_name: 'SP_POP_TOTL',
+            id: 2,
+            type_generic: GenericDataType.NUMERIC,
+          },
+          expressionType: 'SIMPLE',
+          hasCustomLabel: true,
+          label: 'max',
+        },
+      ],
+    }}
+    hooks={{
+      setDataMask: action('setDataMask'),
+    }}
+  />
+);

--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { AppSection, GenericDataType } from '@superset-ui/core';
+import React from 'react';
+import { render } from 'spec/helpers/testing-library';
+import RangeFilterPlugin from './RangeFilterPlugin';
+import transformProps from './transformProps';
+
+const rangeProps = {
+  formData: {
+    datasource: '3__table',
+    groupby: ['SP_POP_TOTL'],
+    adhocFilters: [],
+    extraFilters: [],
+    extraFormData: {},
+    granularitySqla: 'ds',
+    metrics: [
+      {
+        aggregate: 'MIN',
+        column: {
+          column_name: 'SP_POP_TOTL',
+          id: 1,
+          type_generic: GenericDataType.NUMERIC,
+        },
+        expressionType: 'SIMPLE',
+        hasCustomLabel: true,
+        label: 'min',
+      },
+      {
+        aggregate: 'MAX',
+        column: {
+          column_name: 'SP_POP_TOTL',
+          id: 2,
+          type_generic: GenericDataType.NUMERIC,
+        },
+        expressionType: 'SIMPLE',
+        hasCustomLabel: true,
+        label: 'max',
+      },
+    ],
+    rowLimit: 1000,
+    showSearch: true,
+    defaultValue: [10, 70],
+    timeRangeEndpoints: ['inclusive', 'exclusive'],
+    urlParams: {},
+    vizType: 'filter_range',
+    inputRef: { current: null },
+  },
+  height: 20,
+  hooks: {},
+  filterState: { value: [10, 70] },
+  queriesData: [
+    {
+      rowcount: 1,
+      colnames: ['min', 'max'],
+      coltypes: [GenericDataType.NUMERIC, GenericDataType.NUMERIC],
+      data: [{ min: 10, max: 100 }],
+      applied_filters: [],
+      rejected_filters: [],
+    },
+  ],
+  width: 220,
+  behaviors: ['NATIVE_FILTER'],
+  isRefreshing: false,
+  appSection: AppSection.DASHBOARD,
+};
+
+describe('RangeFilterPlugin', () => {
+  const setDataMask = jest.fn();
+  const getWrapper = (props = {}) =>
+    render(
+      // @ts-ignore
+      <RangeFilterPlugin
+        // @ts-ignore
+        {...transformProps({
+          ...rangeProps,
+          formData: { ...rangeProps.formData, ...props },
+        })}
+        setDataMask={setDataMask}
+      />,
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call setDataMask with correct filter', () => {
+    getWrapper();
+    expect(setDataMask).toHaveBeenCalledWith({
+      extraFormData: {
+        filters: [
+          {
+            col: 'SP_POP_TOTL',
+            op: '<=',
+            val: 70,
+          },
+        ],
+      },
+      filterState: {
+        label: 'x ≤ 70',
+        value: [10, 70],
+      },
+    });
+  });
+});


### PR DESCRIPTION
### SUMMARY
Small improvements to range filter:
- Add smart number formatter to make ranges more legible.
- When lower and upper bounds are at min/max, assume no filter should be emitted. Also when either lower or upper bound is greater/smaller than min/max, only emit single filter.
- Add custom label using formatter.
- Add markers that indicate when lower/upper bound is being applied (also using number formatter).

Also:
- Added story book entry
- Added simple test case

(both story and test cases can be expanded later)

### BEFORE
https://user-images.githubusercontent.com/33317356/120781403-bbd06c00-c531-11eb-898f-5992927ea952.mp4

### AFTER
https://user-images.githubusercontent.com/33317356/120781204-80ce3880-c531-11eb-9675-3c18bbd2b32f.mp4

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
