### PR TITLE
fix(native-filters): remove implied fetch predicate

### DIFF
--- a/superset-frontend/src/filters/components/Range/buildQuery.ts
+++ b/superset-frontend/src/filters/components/Range/buildQuery.ts
@@ -43,7 +43,6 @@ export default function buildQuery(formData: QueryFormData) {
   return buildQueryContext(formData, baseQueryObject => [
     {
       ...baseQueryObject,
-      apply_fetch_values_predicate: true,
       columns: [],
       groupby: [],
       metrics: [

--- a/superset-frontend/src/filters/components/Select/buildQuery.test.ts
+++ b/superset-frontend/src/filters/components/Select/buildQuery.test.ts
@@ -44,7 +44,6 @@ describe('Select buildQuery', () => {
     expect(query.groupby).toEqual(['my_col']);
     expect(query.filters).toEqual([{ col: 'my_col', op: 'IS NOT NULL' }]);
     expect(query.metrics).toEqual([]);
-    expect(query.apply_fetch_values_predicate).toEqual(true);
     expect(query.orderby).toEqual([]);
   });
 

--- a/superset-frontend/src/filters/components/Select/buildQuery.ts
+++ b/superset-frontend/src/filters/components/Select/buildQuery.ts
@@ -61,7 +61,6 @@ const buildQuery: BuildQuery<PluginFilterSelectQueryFormData> = (
     const query: QueryObject[] = [
       {
         ...baseQueryObject,
-        apply_fetch_values_predicate: true,
         groupby: columns,
         metrics: sortMetric ? [sortMetric] : [],
         filters: filters.concat(extra_filters),


### PR DESCRIPTION
### SUMMARY
Currently both the Range and Select filters automatically apply the fetch values predicate from the dataset to the query. A PR was opened to add functionality for making the predicate optional (#14264), but this became largely obsolete with the introduction of adhoc and time filters that were made available in the filter config modal (#14313). In addition, as Filter Box doesn't apply the predicate, native filters probably shouldn't, either.

Therefore this PR removes the implicit fetch values predicate (can be added as an optional control later if needed).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
