### PR TITLE
fix(native-filters): Fix "undefined" error after editing a filter

### DIFF
--- a/superset-frontend/src/dashboard/actions/nativeFilters.ts
+++ b/superset-frontend/src/dashboard/actions/nativeFilters.ts
@@ -92,7 +92,7 @@ export const setFilterConfiguration = (
     }
     return { ...oldFilter, ...filter };
   });
-  console.log({ filterConfig, oldFilters, mergedFilterConfig });
+
   try {
     const response = await updateDashboard({
       json_metadata: JSON.stringify({

--- a/superset-frontend/src/dashboard/actions/nativeFilters.ts
+++ b/superset-frontend/src/dashboard/actions/nativeFilters.ts
@@ -85,11 +85,19 @@ export const setFilterConfiguration = (
     endpoint: `/api/v1/dashboard/${id}`,
   });
 
+  const mergedFilterConfig = filterConfig.map(filter => {
+    const oldFilter = oldFilters[filter.id];
+    if (!oldFilter) {
+      return filter;
+    }
+    return { ...oldFilter, ...filter };
+  });
+  console.log({ filterConfig, oldFilters, mergedFilterConfig });
   try {
     const response = await updateDashboard({
       json_metadata: JSON.stringify({
         ...metadata,
-        native_filter_configuration: filterConfig,
+        native_filter_configuration: mergedFilterConfig,
       }),
     });
     dispatch(
@@ -99,12 +107,20 @@ export const setFilterConfiguration = (
     );
     dispatch({
       type: SET_FILTER_CONFIG_COMPLETE,
-      filterConfig,
+      filterConfig: mergedFilterConfig,
     });
-    dispatch(setDataMaskForFilterConfigComplete(filterConfig, oldFilters));
+    dispatch(
+      setDataMaskForFilterConfigComplete(mergedFilterConfig, oldFilters),
+    );
   } catch (err) {
-    dispatch({ type: SET_FILTER_CONFIG_FAIL, filterConfig });
-    dispatch({ type: SET_DATA_MASK_FOR_FILTER_CONFIG_FAIL, filterConfig });
+    dispatch({
+      type: SET_FILTER_CONFIG_FAIL,
+      filterConfig: mergedFilterConfig,
+    });
+    dispatch({
+      type: SET_DATA_MASK_FOR_FILTER_CONFIG_FAIL,
+      filterConfig: mergedFilterConfig,
+    });
   }
 };
 


### PR DESCRIPTION
### SUMMARY
We calculate `chartsInScope` and `tabsInScope` of native filters on first render and recalculate them only when filter's scope or dashboard's layout changes. When user edited a filter without changing it's scope, `chartsInScope` and `tabsInScope` were being set to undefined, which was causing an caused an error described in https://github.com/apache/superset/issues/14975.
This PR fixes it by merging edited filter into the old filter rather than overriding it. Since the edited filter object has exactly the same fields as the old filter except `chartsInScope` and `tabsInScope`, what really happens is that we override the old filter and add `chartsInScope` and `tabsInScope` fields.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: See linked issue
After:
https://user-images.githubusercontent.com/15073128/120797636-97c65800-c53c-11eb-96ac-8c34f35bb801.mov

### TESTING INSTRUCTIONS
0. Enable `DASHBOARD_NATIVE_FILTERS` feature flag
1. Add a native filter
2. Click on the filter and verify that tabs and charts in scope get highlighted
3. Edit the filter without changing it's scope
4. Verify that charts and tabs still get highlighted when you focus on the filter

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #14975
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc @villebro 