### PR TITLE
fix: adding additional configs and colors for queryHistory

### DIFF
--- a/superset-frontend/src/SqlLab/components/QueryTable/index.jsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/index.jsx
@@ -88,6 +88,14 @@ const statusAttributes = {
       status: 'running',
     },
   },
+  fetching: {
+    color: ({ theme }) => theme.colors.primary.base,
+    config: {
+      name: 'fetching',
+      label: t('fetching'),
+      status: 'fetching',
+    },
+  },
   timed_out: {
     color: ({ theme }) => theme.colors.grayscale.light1,
     config: {
@@ -97,14 +105,20 @@ const statusAttributes = {
     },
   },
   scheduled: {
-    name: 'queued',
-    label: t('Scheduled'),
-    status: 'queued',
+    color: ({ theme }) => theme.colors.greyscale.base,
+    config: {
+      name: 'queued',
+      label: t('Scheduled'),
+      status: 'queued',
+    },
   },
   pending: {
-    name: 'queued',
-    label: t('Scheduled'),
-    status: 'queued',
+    color: ({ theme }) => theme.colors.greyscale.base,
+    config: {
+      name: 'queued',
+      label: t('Scheduled'),
+      status: 'queued',
+    },
   },
 };
 

--- a/superset-frontend/src/SqlLab/components/QueryTable/index.jsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/index.jsx
@@ -273,12 +273,10 @@ const QueryTable = props => {
             placement="bottom"
           >
             <span>
-              {q.state && (
-                <StatusIcon
-                  name={statusAttributes[q.state].config.name}
-                  status={statusAttributes[q.state].config.status}
-                />
-              
+              <StatusIcon
+                name={statusAttributes[q.state].config.name}
+                status={statusAttributes[q.state].config.status}
+              />
             </span>
           </Tooltip>
         );

--- a/superset-frontend/src/SqlLab/components/QueryTable/index.jsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/index.jsx
@@ -91,7 +91,7 @@ const statusAttributes = {
   fetching: {
     color: ({ theme }) => theme.colors.primary.base,
     config: {
-      name: 'fetching',
+      name: 'queued',
       label: t('fetching'),
       status: 'fetching',
     },
@@ -273,10 +273,12 @@ const QueryTable = props => {
             placement="bottom"
           >
             <span>
-              <StatusIcon
-                name={statusAttributes[q.state].config.name}
-                status={statusAttributes[q.state].config.status}
-              />
+              {q.state && (
+                <StatusIcon
+                  name={statusAttributes[q.state].config.name}
+                  status={statusAttributes[q.state].config.status}
+                />
+              )}
             </span>
           </Tooltip>
         );

--- a/superset-frontend/src/SqlLab/components/QueryTable/index.jsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/index.jsx
@@ -278,7 +278,7 @@ const QueryTable = props => {
                   name={statusAttributes[q.state].config.name}
                   status={statusAttributes[q.state].config.status}
                 />
-              )}
+              
             </span>
           </Tooltip>
         );


### PR DESCRIPTION
### SUMMARY
Some of the statuses in Query History did not have the proper configs and colors, this PR fixes that. Changes were suggested in: 
https://github.com/apache/superset/pull/14885

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Should be like: 
![image](https://user-images.githubusercontent.com/48933336/120856394-cb5dae00-c54d-11eb-9a3f-8e60e345a42b.png)

### TESTING INSTRUCTIONS
Go to the QueryHistory tab in sql lab, make sure that 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
