### PR TITLE
fix: apply template_params on external_metadata

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -638,7 +638,9 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
         db_engine_spec = self.db_engine_spec
         if self.sql:
             engine = self.database.get_sqla_engine(schema=self.schema)
-            sql = self.get_template_processor().process_template(self.sql)
+            sql = self.get_template_processor().process_template(
+                self.sql, **self.template_params_dict
+            )
             parsed_query = ParsedQuery(sql)
             if not db_engine_spec.is_readonly_query(parsed_query):
                 raise SupersetSecurityException(

--- a/tests/datasource_tests.py
+++ b/tests/datasource_tests.py
@@ -79,7 +79,7 @@ class TestDatasource(SupersetTestCase):
         table = SqlaTable(
             table_name="dummy_sql_table_with_template_params",
             database=get_example_database(),
-            sql="select {{ foo }}",
+            sql="select {{ foo }} as intcol",
             template_params=json.dumps({"foo": "123"}),
         )
         session.add(table)
@@ -88,7 +88,7 @@ class TestDatasource(SupersetTestCase):
         table = self.get_table_by_name("dummy_sql_table_with_template_params")
         url = f"/datasource/external_metadata/table/{table.id}/"
         resp = self.get_json_resp(url)
-        assert {o.get("name") for o in resp} == {"123"}
+        assert {o.get("name") for o in resp} == {"intcol"}
         session.delete(table)
         session.commit()
 

--- a/tests/datasource_tests.py
+++ b/tests/datasource_tests.py
@@ -73,6 +73,25 @@ class TestDatasource(SupersetTestCase):
         session.delete(table)
         session.commit()
 
+    def test_external_metadata_for_virtual_table_template_params(self):
+        self.login(username="admin")
+        session = db.session
+        table = SqlaTable(
+            table_name="dummy_sql_table_with_template_params",
+            database=get_example_database(),
+            sql="select {{ foo }}",
+            template_params=json.dumps({"foo": "123"}),
+        )
+        session.add(table)
+        session.commit()
+
+        table = self.get_table_by_name("dummy_sql_table_with_template_params")
+        url = f"/datasource/external_metadata/table/{table.id}/"
+        resp = self.get_json_resp(url)
+        assert {o.get("name") for o in resp} == {"123"}
+        session.delete(table)
+        session.commit()
+
     def test_external_metadata_for_malicious_virtual_table(self):
         self.login(username="admin")
         table = SqlaTable(


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Apply templates when syncing columns on a virtual dataset.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

![Screen Shot 2021-06-04 at 3 28 54 PM](https://user-images.githubusercontent.com/1534870/120868779-9fd8c480-c549-11eb-8f3e-852f042d403c.png)

After:

![Screen Shot 2021-06-04 at 3 27 54 PM](https://user-images.githubusercontent.com/1534870/120868787-a5360f00-c549-11eb-86dd-446cf243ea09.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Tested manually (screenshots), added unit test.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
