### PR TITLE
fix(native-filters): show error if default value query failed

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -333,6 +333,20 @@ const FiltersConfigForm = (
 
   useBackendFormUpdate(form, filterId);
 
+  const setNativeFilterFieldValuesWrapper = (values: object) => {
+    setNativeFilterFieldValues(form, filterId, values);
+    setError('');
+    forceUpdate();
+  };
+
+  const setErrorWrapper = (error: string) => {
+    setNativeFilterFieldValues(form, filterId, {
+      defaultValueQueriesData: null,
+    });
+    setError(error);
+    forceUpdate();
+  };
+
   const refreshHandler = useCallback(() => {
     if (!hasDataset || !formFilter?.dataset?.value) {
       forceUpdate();
@@ -343,12 +357,10 @@ const FiltersConfigForm = (
       groupby: formFilter?.column,
       ...formFilter,
     });
-    setNativeFilterFieldValues(form, filterId, {
+    setNativeFilterFieldValuesWrapper({
       defaultValueQueriesData: null,
       isDataDirty: false,
     });
-    setError('');
-    forceUpdate();
     getChartDataRequest({
       formData,
       force: false,
@@ -360,11 +372,9 @@ const FiltersConfigForm = (
           const result = 'result' in response ? response.result[0] : response;
           waitForAsyncData(result)
             .then((asyncResult: ChartDataResponseResult[]) => {
-              setNativeFilterFieldValues(form, filterId, {
+              setNativeFilterFieldValuesWrapper({
                 defaultValueQueriesData: asyncResult,
               });
-              setError('');
-              forceUpdate();
             })
             .catch((error: ClientErrorObject) => {
               setError(
@@ -372,16 +382,14 @@ const FiltersConfigForm = (
               );
             });
         } else {
-          setNativeFilterFieldValues(form, filterId, {
+          setNativeFilterFieldValuesWrapper({
             defaultValueQueriesData: response.result,
           });
-          setError('');
-          forceUpdate();
         }
       })
       .catch((error: Response) => {
         error.json().then(body => {
-          setError(
+          setErrorWrapper(
             body.message || error.statusText || t('Check configuration'),
           );
         });


### PR DESCRIPTION
### SUMMARY
Currently the default value picker will show an eternal spinner if the query errors out.
Closes https://github.com/apache/superset/issues/14937 

### BEFORE
Previously the spinner would spin forever if the query returned an error:
![image](https://user-images.githubusercontent.com/33317356/120888561-8d21c680-c601-11eb-821e-67d4dd9ce576.png)

### AFTER
Now a proper error is shown:
![image](https://user-images.githubusercontent.com/33317356/120888548-7aa78d00-c601-11eb-9838-068e78fb503b.png)


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
