### PR TITLE
fix(docker/helm): Make webserver query timeout adjustable

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -27,7 +27,7 @@ else
         --workers 1 \
         --worker-class gthread \
         --threads 20 \
-        --timeout 60 \
+        --timeout ${GUNICORN_TIMEOUT:-60} \
         --limit-request-line 0 \
         --limit-request-field_size 0 \
         "${FLASK_APP}"

--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
   - name: craig-rueda
     email: craig@craigrueda.com
     url: https://github.com/craig-rueda
-version: 0.1.3
+version: 0.1.4
 dependencies:
 - name: postgresql
   version: 10.2.0

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -129,7 +129,7 @@ ingress:
     ## Extend timeout to allow long running queries.
     # nginx.ingress.kubernetes.io/proxy-connect-timeout: "300"
     # nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
-    # nginx.ingress.kubernetes.io/proxy-send-timeout: "300"    
+    # nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
   path: /
   hosts:
     - chart-example.local

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -129,8 +129,7 @@ ingress:
     ## Extend timeout to allow long running queries.
     # nginx.ingress.kubernetes.io/proxy-connect-timeout: "300"
     # nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
-    # nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
-    
+    # nginx.ingress.kubernetes.io/proxy-send-timeout: "300"    
   path: /
   hosts:
     - chart-example.local

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -48,6 +48,8 @@ envFromSecret: '{{ template "superset.fullname" . }}-env'
 ## Extra environment variables that will be passed into pods
 ##
 extraEnv: {}
+  # Extend timeout to allow long running queries.
+  # GUNICORN_TIMEOUT: 300
 
 ## Extra environment variables to pass as secrets
 ##
@@ -76,6 +78,9 @@ extraSecrets: {}
 # A dictionary of overrides to append at the end of superset_config.py - the name does not matter
 # WARNING: the order is not guaranteed
 configOverrides: {}
+  #  extend_timeout: |
+  #    # Extend timeout to allow long running queries.
+  #    SUPERSET_WEBSERVER_TIMEOUT = ...
   # enable_oauth: |
   #   from flask_appbuilder.security.manager import AUTH_DB
   #   AUTH_TYPE = AUTH_OAUTH
@@ -121,6 +126,11 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+    ## Extend timeout to allow long running queries.
+    # nginx.ingress.kubernetes.io/proxy-connect-timeout: "300"
+    # nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    # nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+    
   path: /
   hosts:
     - chart-example.local


### PR DESCRIPTION
### SUMMARY
We have long running dashboard queries (2-3 minutes) which were getting tripped up by the 60 second timeout with 504 Gateway Timeout.

I modified the dockerfile to keep the default 60 second timeout on gunicorn, but allow GUNICORN_TIMEOUT env to override.

I also modified the values.yml to provide the needed placeholders to implementing a longer timeout at gunicorn, superset_webserver_timeout, and the nginx proxy timeout. 

Note: This change is non-disruptive, no end user will be impacted unless they turn on settings in the values.yaml.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Run a query on a dashboard that takes longer than 60 seconds, watch it time out.
2. Apply patch, enable new helm lines, do same query, watch it work.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
