### PR TITLE
fix(native-filters): avoid double load on select initialization

### DIFF
--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -30,7 +30,7 @@ const selectMultipleProps = {
     enableEmptyFilter: true,
     defaultToFirstItem: false,
     inverseSelection: false,
-    searchAllOptions: true,
+    searchAllOptions: false,
     datasource: '3__table',
     groupby: ['gender'],
     adhocFilters: [],
@@ -48,7 +48,7 @@ const selectMultipleProps = {
   },
   height: 20,
   hooks: {},
-  ownState: { coltypeMap: { gender: 1 }, search: null },
+  ownState: {},
   filterState: { value: ['boy'] },
   queriesData: [
     {
@@ -91,11 +91,6 @@ describe('SelectFilterPlugin', () => {
       filterState: {
         value: ['boy'],
       },
-      ownState: {
-        coltypeMap: {
-          gender: 1,
-        },
-      },
     });
     expect(setDataMask).toHaveBeenCalledWith({
       extraFormData: {
@@ -110,11 +105,6 @@ describe('SelectFilterPlugin', () => {
       filterState: {
         label: 'boy',
         value: ['boy'],
-      },
-      ownState: {
-        coltypeMap: {
-          gender: 1,
-        },
       },
     });
     userEvent.click(screen.getByRole('combobox'));
@@ -132,12 +122,6 @@ describe('SelectFilterPlugin', () => {
       filterState: {
         label: 'boy, girl',
         value: ['boy', 'girl'],
-      },
-      ownState: {
-        coltypeMap: {
-          gender: 1,
-        },
-        search: null,
       },
     });
   });
@@ -159,11 +143,6 @@ describe('SelectFilterPlugin', () => {
         label: '',
         value: null,
       },
-      ownState: {
-        coltypeMap: {
-          gender: 1,
-        },
-      },
     });
   });
 
@@ -175,11 +154,6 @@ describe('SelectFilterPlugin', () => {
       filterState: {
         label: '',
         value: null,
-      },
-      ownState: {
-        coltypeMap: {
-          gender: 1,
-        },
       },
     });
   });
@@ -200,6 +174,27 @@ describe('SelectFilterPlugin', () => {
       },
       filterState: {
         label: 'girl (excluded)',
+        value: ['girl'],
+      },
+    });
+  });
+
+  it('Add ownState with column types when search all options', () => {
+    getWrapper({ searchAllOptions: true, multiSelect: false });
+    userEvent.click(screen.getByRole('combobox'));
+    userEvent.click(screen.getByTitle('girl'));
+    expect(setDataMask).toHaveBeenCalledWith({
+      extraFormData: {
+        filters: [
+          {
+            col: 'gender',
+            op: 'IN',
+            val: ['girl'],
+          },
+        ],
+      },
+      filterState: {
+        label: 'girl',
         value: ['girl'],
       },
       ownState: {

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -109,6 +109,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
   } = formData;
   const groupby = ensureIsArray<string>(formData.groupby);
   const [col] = groupby;
+  const [initialColtypeMap] = useState(coltypeMap);
   const [selectedValues, setSelectedValues] = useState<SelectValue>(
     filterState.value,
   );
@@ -129,9 +130,6 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
   const [currentSuggestionSearch, setCurrentSuggestionSearch] = useState('');
   const [dataMask, dispatchDataMask] = useReducer<DataMaskReducer>(reducer, {
     filterState,
-    ownState: {
-      coltypeMap,
-    },
   });
   const updateDataMask = (values: SelectValue) => {
     const emptyFilter =
@@ -169,6 +167,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
       dispatchDataMask({
         type: 'ownState',
         ownState: {
+          coltypeMap: initialColtypeMap,
           search: val,
         },
       });
@@ -189,6 +188,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
       dispatchDataMask({
         type: 'ownState',
         ownState: {
+          coltypeMap: initialColtypeMap,
           search: null,
         },
       });


### PR DESCRIPTION
### SUMMARY
Currently select filters make two requests for data upon initialization. This is due to the filter adding column type mappings to `ownState` on initialization. Since these are only needed when "Search all options" is enabled, the initial column type mappings are stored on initialization, and are added to `ownState` only when needed.

### BEFORE
Currently the "Continent" filter generates two requests (the last two requests to "data"); the first with `ownState: {}` and the second with `ownState: { colTypeMap: region: 1 }`. Note that the request is the same, due to `ownState` not changing the generated query in `buildQuery`:
![image](https://user-images.githubusercontent.com/33317356/120992544-61cae300-c78b-11eb-82a4-917ada9cf81b.png)

### AFTER
Now loading the Filter Tab only causes one single request on initialization, both when "Search all options" is enabled and disabled (`ownState` is added to `dataMask` when the first update happens):
![image](https://user-images.githubusercontent.com/33317356/120992416-41028d80-c78b-11eb-9b37-e0c2034036ab.png)

 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
Updated tests + added new test to ensure that `ownState` is populated correctly when `searchAllOptions` is `true`.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
