### PR TITLE
refactor: Add "is_select_query" method to base engine spec to unlock non-SQL dialects

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1255,6 +1255,14 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         )
 
     @classmethod
+    def is_select_query(cls, parsed_query: ParsedQuery) -> bool:
+        """
+        Determine if the statement should be considered as SELECT statement.
+        Some query dialects do not contain "SELECT" word in queries (eg. Kusto)
+        """
+        return parsed_query.is_select()
+
+    @classmethod
     @utils.memoized
     def get_column_spec(
         cls,

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -217,7 +217,7 @@ def execute_sql_statement(
         query.select_as_cta_used = True
 
     # Do not apply limit to the CTA queries when SQLLAB_CTAS_NO_LIMIT is set to true
-    if parsed_query.is_select() and not (
+    if db_engine_spec.is_select_query(parsed_query) and not (
         query.select_as_cta_used and SQLLAB_CTAS_NO_LIMIT
     ):
         if SQL_MAX_ROW and (not query.limit or query.limit > SQL_MAX_ROW):


### PR DESCRIPTION
### SUMMARY
We add `is_select_query` method to the `superset/db_engine_specs/base.py` to allow override it in the inherited specs.

Reason:
We are working on the SQLAlchemy Kusto dialect (Azure Data Explorer) and want to propose the support of this dialect in Superset. The current problem is that KQL (Kusto Query Language) doesn't use "SELECT" keyword for queries, it is started from the table name instead. If we want to allow SQLLabs limits UI component to working properly, we need to have the ability to define which query is essentially the SELECT-query in our db engine spec file.

More details in the issue: #15011

### TESTING INSTRUCTIONS
The functionality is still the same. Actually, you may just run any query in the SQLLab and verify that the limit (UI component) is still applying.


### ADDITIONAL INFORMATION
- [x] Has associated issue: #15011
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
