### PR TITLE
fix: Adds left padding to dashboard edit mode when filter bar is closed

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -57,7 +57,10 @@ const HEADER_HEIGHT = 67;
 
 type DashboardBuilderProps = {};
 
-const StyledDashboardContent = styled.div<{ dashboardFiltersOpen: boolean }>`
+const StyledDashboardContent = styled.div<{
+  dashboardFiltersOpen: boolean;
+  editMode: boolean;
+}>`
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
@@ -75,13 +78,15 @@ const StyledDashboardContent = styled.div<{ dashboardFiltersOpen: boolean }>`
     width: 100%;
     flex-grow: 1;
     position: relative;
-    margin: ${({ theme }) => theme.gridUnit * 6}px
-      ${({ theme }) => theme.gridUnit * 8}px
-      ${({ theme }) => theme.gridUnit * 6}px
-      ${({ theme, dashboardFiltersOpen }) => {
-        if (dashboardFiltersOpen) return theme.gridUnit * 8;
+    margin-top: ${({ theme }) => theme.gridUnit * 6}px;
+    margin-right: ${({ theme }) => theme.gridUnit * 8}px;
+    margin-bottom: ${({ theme }) => theme.gridUnit * 6}px;
+    margin-left: ${({ theme, dashboardFiltersOpen, editMode }) => {
+      if (!dashboardFiltersOpen && !editMode) {
         return 0;
-      }}px;
+      }
+      return theme.gridUnit * 8;
+    }}px;
   }
 
   .dashboard-component-chart-holder {
@@ -204,6 +209,7 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
       <StyledDashboardContent
         className="dashboard-content"
         dashboardFiltersOpen={dashboardFiltersOpen}
+        editMode={editMode}
       >
         {nativeFiltersEnabled && !editMode && (
           <StickyVerticalBar


### PR DESCRIPTION
### SUMMARY
Fixes #14992, fixes #14728

@junlincc @rusackas 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/121077656-47563100-c7ae-11eb-9ef7-89132fb3faa5.mov

https://user-images.githubusercontent.com/70410625/121077595-30afda00-c7ae-11eb-84e2-3645522a1647.mov

### TESTING INSTRUCTIONS
See before/after videos.

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
