### PR TITLE
fix(dashboard): custom css should be removed on unmount

### DIFF
--- a/superset-frontend/src/dashboard/containers/DashboardPage.tsx
+++ b/superset-frontend/src/dashboard/containers/DashboardPage.tsx
@@ -26,7 +26,6 @@ import {
   useDashboardDatasets,
 } from 'src/common/hooks/apiResources';
 import { ResourceStatus } from 'src/common/hooks/apiResources/apiResources';
-import { usePrevious } from 'src/common/hooks/usePrevious';
 import { hydrateDashboard } from 'src/dashboard/actions/hydrate';
 import injectCustomCss from 'src/dashboard/util/injectCustomCss';
 
@@ -42,14 +41,10 @@ const DashboardContainer = React.lazy(
 const DashboardPage: FC = () => {
   const dispatch = useDispatch();
   const { idOrSlug } = useParams<{ idOrSlug: string }>();
-  const [isLoaded, setLoaded] = useState(false);
+  const [isHydrated, setHydrated] = useState(false);
   const dashboardResource = useDashboard(idOrSlug);
   const chartsResource = useDashboardCharts(idOrSlug);
   const datasetsResource = useDashboardDatasets(idOrSlug);
-  const isLoading = [dashboardResource, chartsResource, datasetsResource].some(
-    resource => resource.status === ResourceStatus.LOADING,
-  );
-  const wasLoading = usePrevious(isLoading);
   const error = [dashboardResource, chartsResource, datasetsResource].find(
     resource => resource.status === ResourceStatus.ERROR,
   )?.error;
@@ -57,16 +52,21 @@ const DashboardPage: FC = () => {
   useEffect(() => {
     if (dashboardResource.result) {
       document.title = dashboardResource.result.dashboard_title;
+      if (dashboardResource.result.css) {
+        // cleans up custom css when dashboardpage unmounts or result changes
+        return injectCustomCss(dashboardResource.result.css);
+      }
     }
+    return () => {};
   }, [dashboardResource.result]);
 
+  const shouldBeHydrated =
+    dashboardResource.status === ResourceStatus.COMPLETE &&
+    chartsResource.status === ResourceStatus.COMPLETE &&
+    datasetsResource.status === ResourceStatus.COMPLETE;
+
   useEffect(() => {
-    if (
-      wasLoading &&
-      dashboardResource.status === ResourceStatus.COMPLETE &&
-      chartsResource.status === ResourceStatus.COMPLETE &&
-      datasetsResource.status === ResourceStatus.COMPLETE
-    ) {
+    if (shouldBeHydrated) {
       dispatch(
         hydrateDashboard(
           dashboardResource.result,
@@ -74,20 +74,13 @@ const DashboardPage: FC = () => {
           datasetsResource.result,
         ),
       );
-      injectCustomCss(dashboardResource.result.css);
-      setLoaded(true);
+      setHydrated(true);
     }
-  }, [
-    dispatch,
-    wasLoading,
-    dashboardResource,
-    chartsResource,
-    datasetsResource,
-  ]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldBeHydrated]);
 
   if (error) throw error; // caught in error boundary
-
-  if (!isLoaded) return <Loading />;
+  if (!isHydrated) return <Loading />;
   return <DashboardContainer />;
 };
 

--- a/superset-frontend/src/dashboard/containers/DashboardPage.tsx
+++ b/superset-frontend/src/dashboard/containers/DashboardPage.tsx
@@ -53,7 +53,8 @@ const DashboardPage: FC = () => {
     if (dashboardResource.result) {
       document.title = dashboardResource.result.dashboard_title;
       if (dashboardResource.result.css) {
-        // cleans up custom css when dashboardpage unmounts or result changes
+        // returning will clean up custom css
+        // when dashboard unmounts or changes
         return injectCustomCss(dashboardResource.result.css);
       }
     }

--- a/superset-frontend/src/dashboard/util/injectCustomCss.ts
+++ b/superset-frontend/src/dashboard/util/injectCustomCss.ts
@@ -16,19 +16,32 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-export default function injectCustomCss(css) {
+
+function createStyleElement(className: string) {
+  const style = document.createElement('style');
+  style.className = className;
+  style.type = 'text/css';
+  return style;
+}
+
+export default function injectCustomCss(css: string) {
   const className = 'CssEditor-css';
   const head = document.head || document.getElementsByTagName('head')[0];
-  let style = document.querySelector(`.${className}`);
+  const style: HTMLStyleElement =
+    (document.querySelector(`.${className}`) as any) ||
+    createStyleElement(className);
 
-  if (!style) {
-    style = document.createElement('style');
-    style.className = className;
-    style.type = 'text/css';
-  }
-
-  if (style.styleSheet) {
-    style.styleSheet.cssText = css;
+  if ('styleSheet' in style) {
+    // The original, non-typescript code referenced `style.styleSheet`.
+    // I can't find what sort of element would have a styleSheet property,
+    // and don't know in what situation this condition would be true,
+    // so have created this type to satisfy TS without changing behavior.
+    type MysteryStyleElement = {
+      styleSheet: {
+        cssText: string;
+      };
+    };
+    (style as MysteryStyleElement).styleSheet.cssText = css;
   } else {
     style.innerHTML = css;
   }
@@ -45,4 +58,8 @@ export default function injectCustomCss(css) {
    */
 
   head.appendChild(style);
+
+  return function removeCustomCSS() {
+    style.remove();
+  };
 }

--- a/superset-frontend/src/dashboard/util/injectCustomCss.ts
+++ b/superset-frontend/src/dashboard/util/injectCustomCss.ts
@@ -28,8 +28,7 @@ export default function injectCustomCss(css: string) {
   const className = 'CssEditor-css';
   const head = document.head || document.getElementsByTagName('head')[0];
   const style: HTMLStyleElement =
-    (document.querySelector(`.${className}`) as any) ||
-    createStyleElement(className);
+    document.querySelector(`.${className}`) || createStyleElement(className);
 
   if ('styleSheet' in style) {
     // The original, non-typescript code referenced `style.styleSheet`.

--- a/superset-frontend/src/dashboard/util/injectCustomCss.ts
+++ b/superset-frontend/src/dashboard/util/injectCustomCss.ts
@@ -24,6 +24,15 @@ function createStyleElement(className: string) {
   return style;
 }
 
+// The original, non-typescript code referenced `style.styleSheet`.
+// I can't find what sort of element would have a styleSheet property,
+// so have created this type to satisfy TS without changing behavior.
+type MysteryStyleElement = {
+  styleSheet: {
+    cssText: string;
+  };
+};
+
 export default function injectCustomCss(css: string) {
   const className = 'CssEditor-css';
   const head = document.head || document.getElementsByTagName('head')[0];
@@ -31,15 +40,6 @@ export default function injectCustomCss(css: string) {
     document.querySelector(`.${className}`) || createStyleElement(className);
 
   if ('styleSheet' in style) {
-    // The original, non-typescript code referenced `style.styleSheet`.
-    // I can't find what sort of element would have a styleSheet property,
-    // and don't know in what situation this condition would be true,
-    // so have created this type to satisfy TS without changing behavior.
-    type MysteryStyleElement = {
-      styleSheet: {
-        cssText: string;
-      };
-    };
     (style as MysteryStyleElement).styleSheet.cssText = css;
   } else {
     style.innerHTML = css;


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Unmounts custom dashboard css when the dashboard page unmounts

Cleaned up the `DashboardPage` logic a bit to be clearer

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

before (after viewing a dashboard that sets `span { background: pink }`):

<img width="1007" alt="Screen Shot 2021-06-07 at 12 40 12 PM" src="https://user-images.githubusercontent.com/1858430/121079037-81afd600-c78e-11eb-8fb1-b14410a133e3.png">

after:

<img width="1009" alt="Screen Shot 2021-06-07 at 12 41 20 PM" src="https://user-images.githubusercontent.com/1858430/121079115-9ab88700-c78e-11eb-9caa-b835e941b479.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Turn React Crud View on
2. Navigate to a dashboard with custom css that could effect several pages
3. Navigate to any other SPA page (currently list views or homepage)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #14681 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
