### PR TITLE
fix: display all metric results in editor

### DIFF
--- a/superset-frontend/spec/fixtures/mockDatasource.js
+++ b/superset-frontend/spec/fixtures/mockDatasource.js
@@ -45,6 +45,8 @@ export default {
         verbose_name: 'sum__num',
         metric_name: 'sum__num',
         description: null,
+        extra:
+          '{"certification":{"details":"foo", "certified_by":"someone"},"warning_markdown":"bar"}',
       },
       {
         expression: 'AVG(birth_names.num)',

--- a/superset-frontend/spec/javascripts/datasource/DatasourceEditor_spec.jsx
+++ b/superset-frontend/spec/javascripts/datasource/DatasourceEditor_spec.jsx
@@ -21,6 +21,9 @@ import { shallow } from 'enzyme';
 import configureStore from 'redux-mock-store';
 import fetchMock from 'fetch-mock';
 import thunk from 'redux-thunk';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from 'spec/helpers/testing-library';
+
 import { Radio } from 'src/components/Radio';
 
 import Icon from 'src/components/Icon';
@@ -54,6 +57,10 @@ describe('DatasourceEditor', () => {
     el = <DatasourceEditor {...props} store={store} />;
     wrapper = shallow(el).dive();
     inst = wrapper.instance();
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
   });
 
   it('is valid', () => {
@@ -204,5 +211,23 @@ describe('DatasourceEditor', () => {
     expect(icon).toHaveLength(0);
 
     isFeatureEnabledMock.mockRestore();
+  });
+});
+
+describe('DatasourceEditor RTL', () => {
+  it('properly renders the metric information', async () => {
+    render(<DatasourceEditor {...props} />, { useRedux: true });
+    const metricButton = screen.getByTestId('collection-tab-Metrics');
+    userEvent.click(metricButton);
+    const expandToggle = await screen.findAllByLabelText(/toggle expand/i);
+    userEvent.click(expandToggle[0]);
+    const certificationDetails = await screen.findByPlaceholderText(
+      /certification details/i,
+    );
+    expect(certificationDetails.value).toEqual('foo');
+    const warningMarkdown = await await screen.findByPlaceholderText(
+      /certified by/i,
+    );
+    expect(warningMarkdown.value).toEqual('someone');
   });
 });

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -930,7 +930,18 @@ class DatasourceEditor extends React.PureComponent {
             </Fieldset>
           </FormContainer>
         }
-        collection={this.state.datasource.metrics}
+        collection={this.state.datasource.metrics?.map(metric => {
+          const {
+            certification: { details, certified_by: certifiedBy } = {},
+            warning_markdown: warningMarkdown,
+          } = JSON.parse(metric.extra || '{}') || {};
+          return {
+            ...metric,
+            certification_details: details || '',
+            warning_markdown: warningMarkdown || '',
+            certified_by: certifiedBy,
+          };
+        })}
         allowAddItem
         onChange={this.onDatasourcePropChange.bind(this, 'metrics')}
         itemGenerator={() => ({


### PR DESCRIPTION
### SUMMARY
In the dataset editor, the certified_by, certification_details, and warning fields weren't populated with the saved values. 
This fixes that issue, adds the values into the proper fields and ensures that the warning properly shows up. 


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before: 
<img width="794" alt="Screenshot_6_7_21__5_51_PM" src="https://user-images.githubusercontent.com/5186919/121105652-58586f80-c7b9-11eb-8336-ff8737544ecf.png">
Fields were empty even though we had previously saved values there. 


after: 
Fields are now populated and the warning is displayed:
<img width="801" alt="_DEV__Superset" src="https://user-images.githubusercontent.com/5186919/121105714-758d3e00-c7b9-11eb-873f-bd747d5cd60d.png">

<img width="867" alt="_DEV__Superset" src="https://user-images.githubusercontent.com/5186919/121105696-6e663000-c7b9-11eb-8bb6-85170bf03492.png">


### TESTING INSTRUCTIONS
Open the dataset edit modal, select a metric, expand the field and add some values to certified_by, certification_details, and warning fields. Save, and reopen the edit dialogue. The values should be there and the warning should show up next to the row.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
