### PR TITLE
fix(explore): Datepicker glitch on hover outside the modal

### DIFF
--- a/superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx
@@ -130,7 +130,7 @@ export function CustomFrame(props: FrameComponentProps) {
             <Row>
               <DatePicker
                 showTime
-                value={dttmToMoment(sinceDatetime)}
+                defaultValue={dttmToMoment(sinceDatetime)}
                 onChange={(datetime: Moment) =>
                   onChange('sinceDatetime', datetime.format(MOMENT_FORMAT))
                 }
@@ -188,7 +188,7 @@ export function CustomFrame(props: FrameComponentProps) {
             <Row>
               <DatePicker
                 showTime
-                value={dttmToMoment(untilDatetime)}
+                defaultValue={dttmToMoment(untilDatetime)}
                 onChange={(datetime: Moment) =>
                   onChange('untilDatetime', datetime.format(MOMENT_FORMAT))
                 }
@@ -247,7 +247,7 @@ export function CustomFrame(props: FrameComponentProps) {
               <Col>
                 <DatePicker
                   showTime
-                  value={dttmToMoment(anchorValue)}
+                  defaultValue={dttmToMoment(anchorValue)}
                   onChange={(datetime: Moment) =>
                     onChange('anchorValue', datetime.format(MOMENT_FORMAT))
                   }


### PR DESCRIPTION
### SUMMARY
When user selects a date in antd datepicker and hovers outside of Modal before saving the changes, the date gets reverted to it's initial value. I fixed it by passing initial date to datepicker with `defaultValue` prop instead of `value`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see linked issue
After:
https://user-images.githubusercontent.com/15073128/121126292-3ba75080-c828-11eb-9a7e-475012c4c6db.mov


### TESTING INSTRUCTIONS
1. Open time selection modal in "Time range" section in Explore.
2. Select "Range type: Custom" and "Start/End: Specific Date/Time".
3. Open a datepicker and select some date.
4. Before you save, hover outside of time range modal and verify that the date didn't reset to the initial value.
5. Save and verify that the date has changed correctly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes https://github.com/apache/superset/issues/15028
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc @zhaoyongjie @villebro 