### PR TITLE
fix(native-filters): show overridden chart name on scoping tree

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.ts
@@ -45,7 +45,11 @@ export const buildTree = (
   ) {
     const currentTreeItem = {
       key: node.id,
-      title: node.meta.sliceName || node.meta.text || node.id.toString(),
+      title:
+        node.meta.sliceNameOverride ||
+        node.meta.sliceName ||
+        node.meta.text ||
+        node.id.toString(),
       children: [],
     };
     treeItem.children.push(currentTreeItem);

--- a/superset-frontend/src/dashboard/types.ts
+++ b/superset-frontend/src/dashboard/types.ts
@@ -93,6 +93,7 @@ export type LayoutItem = {
     chartId: number;
     height: number;
     sliceName?: string;
+    sliceNameOverride?: string;
     text?: string;
     uuid: string;
     width: number;


### PR DESCRIPTION
### SUMMARY
Currently the scoping tree is showing the original chart name, even if a chart name has been overridden on the dashboard level.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
On the Covid example dashboard, many chart names have been overridden. For instance, we expect to see the following chart names on the scoping tree:
![image](https://user-images.githubusercontent.com/33317356/121176925-75e31300-c865-11eb-9ad8-6e8b71cf7611.png)

However, the scoping tree is showing the original names:
![image](https://user-images.githubusercontent.com/33317356/121176774-47fdce80-c865-11eb-99da-c8fea1ee3449.png)

### AFTER
Now the overridden chart names are displayed where available:
![image](https://user-images.githubusercontent.com/33317356/121176657-243a8880-c865-11eb-90a2-c9f3d4557300.png)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #14859
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
