### PR TITLE
fix: import metrics with extra

### DIFF
--- a/superset/datasets/commands/importers/v1/utils.py
+++ b/superset/datasets/commands/importers/v1/utils.py
@@ -98,11 +98,12 @@ def import_dataset(
             except TypeError:
                 logger.info("Unable to encode `%s` field: %s", key, config[key])
     for metric in config.get("metrics", []):
-        if metric.get("extra"):
+        if metric.get("extra") is not None:
             try:
                 metric["extra"] = json.dumps(metric["extra"])
             except TypeError:
                 logger.info("Unable to encode `extra` field: %s", metric["extra"])
+                metric["extra"] = None
 
     # should we delete columns and metrics not present in the current import?
     sync = ["columns", "metrics"] if overwrite else []

--- a/tests/datasets/commands_tests.py
+++ b/tests/datasets/commands_tests.py
@@ -328,7 +328,7 @@ class TestImportDatasetsCommand(SupersetTestCase):
         assert metric.expression == "count(1)"
         assert metric.description is None
         assert metric.d3format is None
-        assert metric.extra is None
+        assert metric.extra == "{}"
         assert metric.warning_text is None
 
         assert len(dataset.columns) == 1

--- a/tests/fixtures/importexport.py
+++ b/tests/fixtures/importexport.py
@@ -384,7 +384,7 @@ dataset_config: Dict[str, Any] = {
             "expression": "count(1)",
             "description": None,
             "d3format": None,
-            "extra": None,
+            "extra": {},
             "warning_text": None,
         },
     ],


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When importing a dataset, if a metric has `extra = {}` it doesn't get serialized to a string because it doesn't meet the condition `if metric.get("extra")`. I fixed it by being explicit and checking `if metric.get("extra") is not None`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Updated unit test to cover this case. Tested with dashboard that was not working before.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
