### PR TITLE
fix: edit BQ w/o encrypted_extra

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -239,15 +239,12 @@ class Database(
 
     @property
     def parameters(self) -> Dict[str, Any]:
-        # Build parameters if db_engine_spec is a subclass of BasicParametersMixin
-        parameters = {"engine": self.backend}
-
-        if hasattr(self.db_engine_spec, "parameters_schema") and hasattr(
-            self.db_engine_spec, "get_parameters_from_uri"
-        ):
-            uri = make_url(self.sqlalchemy_uri_decrypted)
-            encrypted_extra = self.get_encrypted_extra()
-            return {**parameters, **self.db_engine_spec.get_parameters_from_uri(uri, encrypted_extra=encrypted_extra)}  # type: ignore
+        uri = make_url(self.sqlalchemy_uri_decrypted)
+        encrypted_extra = self.get_encrypted_extra()
+        try:
+            parameters = self.db_engine_spec.get_parameters_from_uri(uri, encrypted_extra=encrypted_extra)  # type: ignore
+        except Exception:
+            parameters = {}
 
         return parameters
 

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -243,7 +243,7 @@ class Database(
         encrypted_extra = self.get_encrypted_extra()
         try:
             parameters = self.db_engine_spec.get_parameters_from_uri(uri, encrypted_extra=encrypted_extra)  # type: ignore
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             parameters = {}
 
         return parameters


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When we import a BQ database (directly or indirectly) the `secure_extra` needs to be added manually. But when editing the DB the request fails because it tries to fetch `parameters`, which fails because `encrypted_extra` is empty:

```python
      @classmethod
      def get_parameters_from_uri(
          cls, _: str, encrypted_extra: Optional[Dict[str, str]] = None
      ) -> Any:
          # BigQuery doesn't have parameters
          if encrypted_extra:
              return encrypted_extra

          raise SupersetGenericDBErrorException(
              message="Big Query encrypted_extra is not available.",
          )
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before we couldn't edit a DB, now we can.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Imported BQ DB, was able to edit it successfully.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
