### PR TITLE
build(docker): build images for release branches

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - '[0-9]+.[0-9]+(.[0-9]*)*'
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - 'master'
-      - '[0-9]+.[0-9]+(.[0-9]*)*'
+      - 'v*[0-9]+.[0-9]+(.[0-9]*)*'
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding a regex (matching semver) to match release branches for docker builds. This should enabled us to open PRs with merge conflicts and still have a docker image build for the code (which is necessary for spinning up an ephemeral env). 

BLOCKERS:
- ephemeral env jobs only run for pull-request events
- aws resources are tagged with PR number, which is not available for push events

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
N/A

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
