### PR TITLE
refactor: adopt --app as celery global option

### DIFF
--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -73,7 +73,7 @@ jobs:
             setup-postgres
       - name: Run celery
         if: steps.check.outcome == 'failure'
-        run: celery worker --app=superset.tasks.celery_app:app -Ofair -c 2 &
+        run: celery --app=superset.tasks.celery_app:app worker -Ofair -c 2 &
       - name: Python unit tests (PostgreSQL)
         if: steps.check.outcome == 'failure'
         run: |
@@ -148,7 +148,7 @@ jobs:
             setup-postgres
       - name: Run celery
         if: steps.check.outcome == 'failure'
-        run: celery worker --app=superset.tasks.celery_app:app -Ofair -c 2 &
+        run: celery --app=superset.tasks.celery_app:app worker -Ofair -c 2 &
       - name: Python unit tests (PostgreSQL)
         if: steps.check.outcome == 'failure'
         run: |

--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -62,7 +62,7 @@ jobs:
             setup-mysql
       - name: Run celery
         if: steps.check.outcome == 'failure'
-        run: celery worker --app=superset.tasks.celery_app:app -Ofair -c 2 &
+        run: celery --app=superset.tasks.celery_app:app worker -Ofair -c 2 &
       - name: Python unit tests (MySQL)
         if: steps.check.outcome == 'failure'
         run: |
@@ -126,7 +126,7 @@ jobs:
             setup-postgres
       - name: Run celery
         if: steps.check.outcome == 'failure'
-        run: celery worker --app=superset.tasks.celery_app:app -Ofair -c 2 &
+        run: celery --app=superset.tasks.celery_app:app worker -Ofair -c 2 &
       - name: Python unit tests (PostgreSQL)
         if: steps.check.outcome == 'failure'
         run: |
@@ -182,7 +182,7 @@ jobs:
             mkdir ${{ github.workspace }}/.temp
       - name: Run celery
         if: steps.check.outcome == 'failure'
-        run: celery worker --app=superset.tasks.celery_app:app -Ofair -c 2 &
+        run: celery --app=superset.tasks.celery_app:app worker -Ofair -c 2 &
       - name: Python unit tests (SQLite)
         if: steps.check.outcome == 'failure'
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1264,7 +1264,7 @@ To do this, you'll need to:
 - Start up a celery worker
 
   ```shell script
-  celery worker --app=superset.tasks.celery_app:app -Ofair
+  celery --app=superset.tasks.celery_app:app worker -Ofair
   ```
 
 Note that:

--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -38,10 +38,10 @@ fi
 
 if [[ "${1}" == "worker" ]]; then
   echo "Starting Celery worker..."
-  celery worker --app=superset.tasks.celery_app:app -Ofair -l INFO
+  celery --app=superset.tasks.celery_app:app worker -Ofair -l INFO
 elif [[ "${1}" == "beat" ]]; then
   echo "Starting Celery beat..."
-  celery beat --app=superset.tasks.celery_app:app --pidfile /tmp/celerybeat.pid -l INFO -s "${SUPERSET_HOME}"/celerybeat-schedule
+  celery --app=superset.tasks.celery_app:app beat --pidfile /tmp/celerybeat.pid -l INFO -s "${SUPERSET_HOME}"/celerybeat-schedule
 elif [[ "${1}" == "app" ]]; then
   echo "Starting web app..."
   flask run -p 8088 --with-threads --reload --debugger --host=0.0.0.0

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1080,11 +1080,11 @@ have the same configuration.
 
 * To start a Celery worker to leverage the configuration run: ::
 
-    celery worker --app=superset.tasks.celery_app:app --pool=prefork -O fair -c 4
+    celery --app=superset.tasks.celery_app:app worker --pool=prefork -O fair -c 4
 
 * To start a job which schedules periodic background jobs, run ::
 
-    celery beat --app=superset.tasks.celery_app:app
+    celery --app=superset.tasks.celery_app:app beat
 
 To setup a result backend, you need to pass an instance of a derivative
 of ``from cachelib.base.BaseCache`` to the ``RESULTS_BACKEND``

--- a/docs/src/pages/docs/installation/alerts_reports.mdx
+++ b/docs/src/pages/docs/installation/alerts_reports.mdx
@@ -246,7 +246,7 @@ services:
       - superset
       - postgres
       - redis
-    command: "celery worker --app=superset.tasks.celery_app:app --pool=gevent --concurrency=500"
+    command: "celery --app=superset.tasks.celery_app:app worker --pool=gevent --concurrency=500"
     volumes:
       - ./config/:/app/pythonpath/
   beat:
@@ -258,7 +258,7 @@ services:
       - superset
       - postgres
       - redis
-    command: "celery beat --app=superset.tasks.celery_app:app --pidfile /tmp/celerybeat.pid --schedule /tmp/celerybeat-schedule"
+    command: "celery --app=superset.tasks.celery_app:app beat --pidfile /tmp/celerybeat.pid --schedule /tmp/celerybeat-schedule"
     volumes:
       - ./config/:/app/pythonpath/
   superset:

--- a/docs/src/pages/docs/installation/async_queries_celery.mdx
+++ b/docs/src/pages/docs/installation/async_queries_celery.mdx
@@ -57,13 +57,13 @@ CELERY_CONFIG = CeleryConfig
 To start a Celery worker to leverage the configuration, run the following command:
 
 ```
-celery worker --app=superset.tasks.celery_app:app --pool=prefork -O fair -c 4
+celery --app=superset.tasks.celery_app:app worker --pool=prefork -O fair -c 4
 ```
 
 To start a job which schedules periodic background jobs, run the following command:
 
 ```
-celery beat --app=superset.tasks.celery_app:app
+celery --app=superset.tasks.celery_app:app beat
 ```
 
 To setup a result backend, you need to pass an instance of a derivative of from

--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
   - name: craig-rueda
     email: craig@craigrueda.com
     url: https://github.com/craig-rueda
-version: 0.1.3
+version: 0.1.4
 dependencies:
 - name: postgresql
   version: 10.2.0

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -203,7 +203,7 @@ supersetCeleryBeat:
   command:
     - "/bin/sh"
     - "-c"
-    - ". {{ .Values.configMountPath }}/superset_bootstrap.sh; celery beat --app=superset.tasks.celery_app:app --pidfile /tmp/celerybeat.pid --schedule /tmp/celerybeat-schedule"
+    - ". {{ .Values.configMountPath }}/superset_bootstrap.sh; celery --app=superset.tasks.celery_app:app beat --pidfile /tmp/celerybeat.pid --schedule /tmp/celerybeat-schedule"
   forceReload: false # If true, forces deployment to reload on each upgrade
   initContainers:
     - name: wait-for-postgres

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@
 #
 
 # Remember to start celery workers to run celery tests, e.g.
-# celery worker --app=superset.tasks.celery_app:app -Ofair -c 2
+# celery --app=superset.tasks.celery_app:app worker -Ofair -c 2
 [testenv]
 basepython = python3.8
 ignore_basepython_conflict = true


### PR DESCRIPTION
### SUMMARY
This is the [step 1](https://docs.celeryproject.org/en/stable/history/whatsnew-5.0.html#step-1-adjust-your-command-line-invocation) of upgrading to Celery 5

> Celery 5.0 introduces a new CLI implementation which isn’t completely backwards compatible.
The global options can no longer be positioned after the sub-command. Instead, they must be positioned as an option for the celery command like so:

    celery --app path.to.app worker

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #14925
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
