### PR TITLE
refactor: Move fields from Extra section IIII

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx
@@ -48,6 +48,7 @@ const ExtraOptions = ({
 }) => {
   const expandableModalIsOpen = !!db?.expose_in_sqllab;
   const createAsOpen = !!(db?.allow_ctas || db?.allow_cvas);
+  const MDPstring = JSON.stringify(db?.extra_json?.metadata_params);
 
   return (
     <Collapse
@@ -237,7 +238,10 @@ const ExtraOptions = ({
             <input
               type="number"
               name="schema_cache_timeout"
-              value={db?.extra_json?.schema_cache_timeout || ''}
+              value={
+                db?.extra_json?.metadata_cache_timeout?.schema_cache_timeout ||
+                ''
+              }
               placeholder={t('Enter duration in seconds')}
               onChange={onExtraInputChange}
               data-test="schema-cache-timeout-test"
@@ -256,7 +260,10 @@ const ExtraOptions = ({
             <input
               type="number"
               name="table_cache_timeout"
-              value={db?.extra_json?.table_cache_timeout || ''}
+              value={
+                db?.extra_json?.metadata_cache_timeout?.table_cache_timeout ||
+                ''
+              }
               placeholder={t('Enter duration in seconds')}
               onChange={onExtraInputChange}
               data-test="table-cache-timeout-test"
@@ -412,9 +419,9 @@ const ExtraOptions = ({
           <div className="input-container">
             <StyledJsonEditor
               name="metadata_params"
-              value={db?.extra_json?.metadata_params || '{}'}
+              value={MDPstring || '{}'}
               placeholder={t('Metadata Parameters')}
-              onChange={(json: string) =>
+              onChange={(json: object) =>
                 onExtraEditorChange({ json, name: 'metadata_params' })
               }
               width="100%"
@@ -434,9 +441,9 @@ const ExtraOptions = ({
           <div className="input-container">
             <StyledJsonEditor
               name="engine_params"
-              value={db?.extra_json?.engine_params || '{}'}
+              value={JSON.stringify(db?.extra_json?.engine_params || {})}
               placeholder={t('Engine Parameters')}
-              onChange={(json: string) =>
+              onChange={(json: object) =>
                 onExtraEditorChange({ json, name: 'engine_params' })
               }
               width="100%"

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx
@@ -27,23 +27,24 @@ import {
   StyledJsonEditor,
   StyledExpandableForm,
   antdCollapseStyles,
+  no_margin_bottom,
 } from './styles';
 import { DatabaseObject } from '../types';
-
-const defaultExtra =
-  '{\n  "metadata_params": {},\n  "engine_params": {},' +
-  '\n  "metadata_cache_timeout": {},\n  "schemas_allowed_for_csv_upload": [] \n}';
 
 const ExtraOptions = ({
   db,
   onInputChange,
   onTextChange,
   onEditorChange,
+  onExtraInputChange,
+  onExtraEditorChange,
 }: {
   db: DatabaseObject | null;
   onInputChange: EventHandler<ChangeEvent<HTMLInputElement>>;
   onTextChange: EventHandler<ChangeEvent<HTMLTextAreaElement>>;
   onEditorChange: Function;
+  onExtraInputChange: EventHandler<ChangeEvent<HTMLInputElement>>;
+  onExtraEditorChange: Function;
 }) => {
   const expandableModalIsOpen = !!db?.expose_in_sqllab;
   const createAsOpen = !!(db?.allow_ctas || db?.allow_cvas);
@@ -59,20 +60,20 @@ const ExtraOptions = ({
           <div>
             <h4>SQL Lab</h4>
             <p className="helper">
-              Configure how this database will function in SQL Lab.
+              Adjust how this database will interact with SQL Lab.
             </p>
           </div>
         }
         key="1"
       >
-        <StyledInputContainer className="mb-0">
+        <StyledInputContainer css={{ ...no_margin_bottom }}>
           <div className="input-container">
             <IndeterminateCheckbox
               id="expose_in_sqllab"
               indeterminate={false}
               checked={!!db?.expose_in_sqllab}
               onChange={onInputChange}
-              labelText={t('Expose in SQL Lab')}
+              labelText={t('Expose database in SQL Lab')}
             />
             <InfoTooltip
               tooltip={t('Allow this database to be queried in SQL Lab')}
@@ -84,7 +85,7 @@ const ExtraOptions = ({
               'ctas-open': createAsOpen,
             })}
           >
-            <StyledInputContainer className="mb-0">
+            <StyledInputContainer css={{ ...no_margin_bottom }}>
               <div className="input-container">
                 <IndeterminateCheckbox
                   id="allow_ctas"
@@ -98,7 +99,7 @@ const ExtraOptions = ({
                 />
               </div>
             </StyledInputContainer>
-            <StyledInputContainer className="mb-0">
+            <StyledInputContainer css={{ ...no_margin_bottom }}>
               <div className="input-container">
                 <IndeterminateCheckbox
                   id="allow_cvas"
@@ -120,19 +121,18 @@ const ExtraOptions = ({
                     type="text"
                     name="force_ctas_schema"
                     value={db?.force_ctas_schema || ''}
-                    placeholder={t('Search or select schema')}
+                    placeholder={t('Create or select schema...')}
                     onChange={onInputChange}
                   />
                 </div>
                 <div className="helper">
                   {t(
-                    'When allowing CREATE TABLE AS option in SQL Lab, this option ' +
-                      'forces the table to be created in this schema.',
+                    'Force all tables and views to be created in this schema when clicking CTAS or CVAS in SQL Lab.',
                   )}
                 </div>
               </StyledInputContainer>
             </StyledInputContainer>
-            <StyledInputContainer className="mb-0">
+            <StyledInputContainer css={{ ...no_margin_bottom }}>
               <div className="input-container">
                 <IndeterminateCheckbox
                   id="allow_dml"
@@ -148,20 +148,52 @@ const ExtraOptions = ({
                 />
               </div>
             </StyledInputContainer>
-            <StyledInputContainer>
+            <StyledInputContainer css={{ ...no_margin_bottom }}>
               <div className="input-container">
                 <IndeterminateCheckbox
                   id="allow_multi_schema_metadata_fetch"
                   indeterminate={false}
                   checked={!!db?.allow_multi_schema_metadata_fetch}
                   onChange={onInputChange}
-                  labelText={t('Allow multi schema metadata fetch')}
+                  labelText={t('Allow Multi Schema Metadata Fetch')}
                 />
                 <InfoTooltip
                   tooltip={t(
                     'Allow SQL Lab to fetch a list of all tables and all views across all database ' +
                       'schemas. For large data warehouse with thousands of tables, this can be ' +
                       'expensive and put strain on the system.',
+                  )}
+                />
+              </div>
+            </StyledInputContainer>
+            <StyledInputContainer css={{ ...no_margin_bottom }}>
+              <div className="input-container">
+                <IndeterminateCheckbox
+                  id="cost_query_enabled"
+                  indeterminate={false}
+                  checked={!!db?.extra_json?.cost_query_enabled}
+                  onChange={onExtraInputChange}
+                  labelText={t('Enable query cost estimation')}
+                />
+                <InfoTooltip
+                  tooltip={t(
+                    'For Presto and Postgres, shows a button to compute cost before running a query.',
+                  )}
+                />
+              </div>
+            </StyledInputContainer>
+            <StyledInputContainer>
+              <div className="input-container">
+                <IndeterminateCheckbox
+                  id="allows_virtual_table_explore"
+                  indeterminate={false}
+                  checked={!!db?.extra_json?.allows_virtual_table_explore}
+                  onChange={onExtraInputChange}
+                  labelText={t('Allow this database to be explored')}
+                />
+                <InfoTooltip
+                  tooltip={t(
+                    'When enabled, users are able to visualize SQL Lab results in Explore.',
                   )}
                 />
               </div>
@@ -174,7 +206,7 @@ const ExtraOptions = ({
           <div>
             <h4>Performance</h4>
             <p className="helper">
-              Adjust settings that will impact the performance of this database.
+              Adjust performance settings of this database.
             </p>
           </div>
         }
@@ -187,7 +219,7 @@ const ExtraOptions = ({
               type="number"
               name="cache_timeout"
               value={db?.cache_timeout || ''}
-              placeholder={t('Chart cache timeout')}
+              placeholder={t('Enter duration in seconds')}
               onChange={onInputChange}
             />
           </div>
@@ -199,7 +231,45 @@ const ExtraOptions = ({
             )}
           </div>
         </StyledInputContainer>
-        <StyledInputContainer className="mb-0">
+        <StyledInputContainer>
+          <div className="control-label">{t('Schema cache timeout')}</div>
+          <div className="input-container">
+            <input
+              type="number"
+              name="schema_cache_timeout"
+              value={db?.extra_json?.schema_cache_timeout || ''}
+              placeholder={t('Enter duration in seconds')}
+              onChange={onExtraInputChange}
+              data-test="schema-cache-timeout-test"
+            />
+          </div>
+          <div className="helper">
+            {t(
+              'Duration (in seconds) of the metadata caching timeout for schemas of ' +
+                'this database. If left unset, the cache never expires.',
+            )}
+          </div>
+        </StyledInputContainer>
+        <StyledInputContainer>
+          <div className="control-label">{t('Table cache timeout')}</div>
+          <div className="input-container">
+            <input
+              type="number"
+              name="table_cache_timeout"
+              value={db?.extra_json?.table_cache_timeout || ''}
+              placeholder={t('Enter duration in seconds')}
+              onChange={onExtraInputChange}
+              data-test="table-cache-timeout-test"
+            />
+          </div>
+          <div className="helper">
+            {t(
+              'Duration (in seconds) of the metadata caching timeout for tables of ' +
+                'this database. If left unset, the cache never expires. ',
+            )}
+          </div>
+        </StyledInputContainer>
+        <StyledInputContainer css={{ ...no_margin_bottom }}>
           <div className="input-container">
             <IndeterminateCheckbox
               id="allow_run_async"
@@ -246,13 +316,11 @@ const ExtraOptions = ({
           </div>
           <div className="helper">
             <div>
-              {t('JSON string containing additional connection configuration.')}
-            </div>
-            <div>
               {t(
-                'This is used to provide connection information for systems like Hive, ' +
-                  'Presto, and BigQuery, which do not conform to the username:password syntax ' +
-                  'normally used by SQLAlchemy.',
+                'JSON string containing additional connection configuration. ' +
+                  'This is used to provide connection information for systems ' +
+                  'like Hive, Presto and BigQuery whih do not conform to the ' +
+                  'username:password syntax normally used by SQLAlchemy.',
               )}
             </div>
           </div>
@@ -263,15 +331,70 @@ const ExtraOptions = ({
             <textarea
               name="server_cert"
               value={db?.server_cert || ''}
-              placeholder={t('Root certificate')}
+              placeholder={t('Enter CA_BUNDLE')}
               onChange={onTextChange}
             />
           </div>
           <div className="helper">
             {t(
-              'Optional CA_BUNDLE contents to validate HTTPS requests. Only available on ' +
-                'certain database engines.',
+              'JSON string containing additional connection configuration. ' +
+                'This is used to provide connection information for systems ' +
+                'like Hive, Presto and BigQuery whih do not conform to the ' +
+                'username:password syntax normally used by SQLAlchemy.',
             )}
+          </div>
+        </StyledInputContainer>
+        <StyledInputContainer>
+          <div className="control-label">
+            {t('Schemas allowed for CSV upload')}
+          </div>
+          <div className="input-container">
+            <input
+              type="text"
+              name="schemas_allowed_for_csv_upload"
+              value={db?.extra_json?.schemas_allowed_for_csv_upload || ''}
+              placeholder={t('Select one or multiple schemas')}
+              onChange={onInputChange}
+            />
+          </div>
+          <div className="helper">
+            {t('A list of schemas that CSVs are allowed to upload to.')}
+          </div>
+        </StyledInputContainer>
+        <StyledInputContainer css={{ ...no_margin_bottom }}>
+          <div className="input-container">
+            <IndeterminateCheckbox
+              id="impersonate_user"
+              indeterminate={false}
+              checked={!!db?.extra_json?.impersonate_user}
+              onChange={onExtraInputChange}
+              labelText={t('Impersonate logged in user (Presto & Hive)')}
+            />
+            <InfoTooltip
+              tooltip={t(
+                'If Presto, all the queries in SQL Lab are going to be executed as the ' +
+                  'currently logged on user who must have permission to run them. If Hive ' +
+                  'and hive.server2.enable.doAs is enabled, will run the queries as ' +
+                  'service account, but impersonate the currently logged on user via ' +
+                  'hive.server2.proxy.user property.',
+              )}
+            />
+          </div>
+        </StyledInputContainer>
+        <StyledInputContainer css={{ ...no_margin_bottom }}>
+          <div className="input-container">
+            <IndeterminateCheckbox
+              id="allow_csv_upload"
+              indeterminate={false}
+              checked={!!db?.extra_json?.allow_csv_upload}
+              onChange={onExtraInputChange}
+              labelText={t('Allow data upload')}
+            />
+            <InfoTooltip
+              tooltip={t(
+                'If selected, please set the schemas allowed for data upload in Extra.',
+              )}
+            />
           </div>
         </StyledInputContainer>
       </Collapse.Panel>
@@ -284,53 +407,15 @@ const ExtraOptions = ({
         }
         key="4"
       >
-        <StyledInputContainer className="mb-0">
-          <div className="input-container">
-            <IndeterminateCheckbox
-              id="impersonate_user"
-              indeterminate={false}
-              checked={!!db?.impersonate_user}
-              onChange={onInputChange}
-              labelText={t(
-                'Impersonate Logged In User (Presto, Trino, Hive, and GSheets)',
-              )}
-            />
-            <InfoTooltip
-              tooltip={t(
-                'If Presto or Trino, all the queries in SQL Lab are going to be executed as the ' +
-                  'currently logged on user who must have permission to run them. If Hive ' +
-                  'and hive.server2.enable.doAs is enabled, will run the queries as ' +
-                  'service account, but impersonate the currently logged on user via ' +
-                  'hive.server2.proxy.user property.',
-              )}
-            />
-          </div>
-        </StyledInputContainer>
-        <StyledInputContainer className="mb-0">
-          <div className="input-container">
-            <IndeterminateCheckbox
-              id="allow_csv_upload"
-              indeterminate={false}
-              checked={!!db?.allow_csv_upload}
-              onChange={onInputChange}
-              labelText={t('Allow data upload')}
-            />
-            <InfoTooltip
-              tooltip={t(
-                'If selected, please set the schemas allowed for data upload in Extra.',
-              )}
-            />
-          </div>
-        </StyledInputContainer>
-        <StyledInputContainer className="extra-container">
-          <div className="control-label">{t('Extra')}</div>
+        <StyledInputContainer>
+          <div className="control-label">{t('Metadata Parameters')}</div>
           <div className="input-container">
             <StyledJsonEditor
-              name="extra"
-              value={db?.extra ?? defaultExtra}
-              placeholder={t('Secure extra')}
+              name="metadata_params"
+              value={db?.extra_json?.metadata_params || '{}'}
+              placeholder={t('Metadata Parameters')}
               onChange={(json: string) =>
-                onEditorChange({ json, name: 'extra' })
+                onExtraEditorChange({ json, name: 'metadata_params' })
               }
               width="100%"
               height="160px"
@@ -338,45 +423,52 @@ const ExtraOptions = ({
           </div>
           <div className="helper">
             <div>
-              {t('JSON string containing extra configuration elements.')}
-            </div>
-            <div>
               {t(
-                '1. The engine_params object gets unpacked into the sqlalchemy.create_engine ' +
-                  'call, while the metadata_params gets unpacked into the sqlalchemy.MetaData ' +
-                  'call.',
+                'The metadata_params object gets unpacked into the sqlalchemy.MetaData call.',
               )}
             </div>
+          </div>
+        </StyledInputContainer>
+        <StyledInputContainer>
+          <div className="control-label">{t('Engine Parameters')}</div>
+          <div className="input-container">
+            <StyledJsonEditor
+              name="engine_params"
+              value={db?.extra_json?.engine_params || '{}'}
+              placeholder={t('Engine Parameters')}
+              onChange={(json: string) =>
+                onExtraEditorChange({ json, name: 'engine_params' })
+              }
+              width="100%"
+              height="160px"
+            />
+          </div>
+          <div className="helper">
             <div>
               {t(
-                '2. The metadata_cache_timeout is a cache timeout setting in seconds for ' +
-                  'metadata fetch of this database. Specify it as "metadata_cache_timeout": ' +
-                  '{"schema_cache_timeout": 600, "table_cache_timeout": 600}. If unset, cache ' +
-                  'will not be enabled for the functionality. A timeout of 0 indicates that ' +
-                  'the cache never expires.',
+                'The engine_params object gets unpacked into the sqlalchemy.create_engine call.',
               )}
             </div>
-            <div>
-              {t(
-                '3. The schemas_allowed_for_csv_upload is a comma separated list of schemas ' +
-                  'that CSVs are allowed to upload to. Specify it as ' +
-                  '"schemas_allowed_for_csv_upload": ["public", "csv_upload"]. If database ' +
-                  'flavor does not support schema or any schema is allowed to be accessed, ' +
-                  'just leave the list empty.',
-              )}
-            </div>
-            <div>
-              {t(
-                "4. The version field is a string specifying this db's version. This " +
-                  'should be used with Presto DBs so that the syntax is correct.',
-              )}
-            </div>
-            <div>
-              {t(
-                '5. The allows_virtual_table_explore field is a boolean specifying whether ' +
-                  'or not the Explore button in SQL Lab results is shown.',
-              )}
-            </div>
+          </div>
+        </StyledInputContainer>
+        <StyledInputContainer>
+          <div className="control-label" data-test="version-label-test">
+            {t('Version')}
+          </div>
+          <div className="input-container" data-test="version-spinbutton-test">
+            <input
+              type="number"
+              name="version"
+              value={db?.extra_json?.version || ''}
+              placeholder={t('Version number')}
+              onChange={onExtraInputChange}
+            />
+          </div>
+          <div className="helper">
+            {t(
+              'Specify this database’s version. This should be used with ' +
+                'Presto databases so that the syntax is correct.',
+            )}
           </div>
         </StyledInputContainer>
       </Collapse.Panel>

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.test.jsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.test.jsx
@@ -69,7 +69,7 @@ describe('DatabaseModal', () => {
       });
       userEvent.click(sqlLabSettingsTab);
 
-      const exposeInSqlLab = screen.getByText('Expose in SQL Lab');
+      const exposeInSqlLab = screen.getByText('Expose database in SQL Lab');
       const exposeChoicesForm = exposeInSqlLab.parentElement.nextSibling;
       const schemaField = screen.getByText('CTAS & CVAS SCHEMA').parentElement;
       expect(exposeChoicesForm).not.toHaveClass('open');
@@ -93,9 +93,8 @@ describe('DatabaseModal', () => {
     userEvent.click(sqlLabSettingsTab);
 
     // Grab all SQL Lab settings by their labels
-    // const exposeInSqlLab = screen.getByText('Expose in SQL Lab');
     const exposeInSqlLab = screen.getByRole('checkbox', {
-      name: /expose in sql lab/i,
+      name: /expose database in sql lab/i,
     });
 
     expect(exposeInSqlLab).not.toBeChecked();
@@ -107,7 +106,7 @@ describe('DatabaseModal', () => {
       .getAllByRole('checkbox')
       .filter(checkbox => !checkbox.checked);
 
-    expect(checkboxes.length).toEqual(4);
+    expect(checkboxes.length).toEqual(6);
   });
 
   it('renders the schema field when allowCTAS is checked', () => {

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -41,6 +41,7 @@ import {
   DatabaseForm,
   CONFIGURATION_METHOD,
 } from 'src/views/CRUD/data/database/types';
+import { typeOf } from 'mathjs';
 import ExtraOptions from './ExtraOptions';
 import SqlAlchemyForm from './SqlAlchemyForm';
 
@@ -135,6 +136,10 @@ function dbReducer(
 
   switch (action.type) {
     case ActionType.extraEditorChange:
+      console.log(
+        'trimmedState.extra_json',
+        typeOf(trimmedState.extra_json?.metadata_params),
+      );
       return {
         ...trimmedState,
         extra_json: {
@@ -183,10 +188,14 @@ function dbReducer(
         [action.payload.name]: action.payload.value,
       };
     case ActionType.fetched:
+      console.log(action.payload.extra_json);
       return {
         engine: trimmedState.engine,
         configuration_method: trimmedState.configuration_method,
         ...action.payload,
+        extra_json: {
+          ...JSON.parse(action.payload.extra || ''),
+        },
       };
     case ActionType.dbSelected:
     case ActionType.configMethodChange:
@@ -219,23 +228,6 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
   const [hasConnectedDb, setHasConnectedDb] = useState<boolean>(false);
   const [dbName, setDbName] = useState('');
   const conf = useCommonConf();
-
-  // Using this to structure extra_json in onSave
-  // const extraValues = {
-  //   metadata_cache_timeout: {
-  //     schema_cache_timeout: db?.extra_json?.schema_cache_timeout,
-  //     table_cache_timeout: db?.extra_json?.table_cache_timeout,
-  //   },
-  //   cost_query_enabled: db?.extra_json?.cost_query_enabled,
-  //   allows_virtual_table_explore: db?.extra_json?.allows_virtual_table_explore,
-  //   schemas_allowed_for_csv_upload:
-  //     db?.extra_json?.schemas_allowed_for_csv_upload,
-  //   impersonate_user: db?.extra_json?.impersonate_user,
-  //   allow_csv_upload: db?.extra_json?.allow_csv_upload,
-  //   version: db?.extra_json?.version,
-  //   metadata_params: db?.extra_json?.metadata_params,
-  //   engine_params: db?.extra_json?.engine_params,
-  // };
 
   const isEditMode = !!databaseId;
   const useSqlAlchemyForm =
@@ -288,14 +280,51 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
         delete update.parameters;
       }
 
-      // // Structure extra_json
+      // const extraValues = {
+      //   metadata_cache_timeout: {
+      //     schema_cache_timeout:
+      //       db?.extra_json?.metadata_cache_timeout?.schema_cache_timeout || '',
+      //     table_cache_timeout:
+      //       db?.extra_json?.metadata_cache_timeout?.table_cache_timeout || '',
+      //   },
+      //   cost_query_enabled: db?.extra_json?.cost_query_enabled || undefined,
+      //   allows_virtual_table_explore:
+      //     db?.extra_json?.allows_virtual_table_explore || undefined,
+      //   schemas_allowed_for_csv_upload:
+      //     db?.extra_json?.schemas_allowed_for_csv_upload || '',
+      //   impersonate_user: db?.extra_json?.impersonate_user || undefined,
+      //   allow_csv_upload: db?.extra_json?.allow_csv_upload || undefined,
+      //   version: db?.extra_json?.version || '',
+      //   metadata_params: db?.extra_json?.metadata_params || {},
+      //   engine_params: db?.extra_json?.engine_params || {},
+      // };
+
+      // console.log('extraValues', extraValues);
+
+      // Structure extra_json
       // const extraValuesStructured = {
       //   ...extraValues,
       //   ...db?.extra_json,
       // };
 
+      // console.log('extraValuesStructured', extraValuesStructured);
+
+      console.log(
+        'db?.extra_json',
+        JSON.parse(db?.extra_json?.metadata_params),
+      );
+
+      const updateExtraMDP = JSON.parse(db?.extra_json?.metadata_params);
+      // update?.extra_json?.metadata_params = updateExtraMDP;
+      console.log(updateExtraMDP);
+
       // Add values back to extra field
-      update.extra = JSON.stringify(db?.extra_json, null, '  ');
+      update.extra = JSON.stringify(
+        { ...db?.extra_json, metadata_params: updateExtraMDP },
+        null,
+        '  ',
+      );
+      console.log('update.extra', update.extra);
 
       const result = await updateResource(
         db.id as number,
@@ -512,9 +541,10 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
                 value: target.value,
               });
             }}
-            onExtraEditorChange={(payload: { name: string; json: any }) =>
-              onChange(ActionType.extraEditorChange, payload)
-            }
+            onExtraEditorChange={(payload: { name: string; json: any }) => {
+              console.log('payload in onExtraEditorChange', payload);
+              onChange(ActionType.extraEditorChange, payload);
+            }}
           />
         </Tabs.TabPane>
       </Tabs>

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
@@ -22,7 +22,7 @@ import { JsonEditor } from 'src/components/AsyncAceEditor';
 import Tabs from 'src/components/Tabs';
 
 const CTAS_CVAS_SCHEMA_FORM_HEIGHT = 102;
-const EXPOSE_IN_SQLLAB_FORM_HEIGHT = CTAS_CVAS_SCHEMA_FORM_HEIGHT + 52;
+const EXPOSE_IN_SQLLAB_FORM_HEIGHT = CTAS_CVAS_SCHEMA_FORM_HEIGHT + 153;
 const EXPOSE_ALL_FORM_HEIGHT = EXPOSE_IN_SQLLAB_FORM_HEIGHT + 102;
 
 const anticonHeight = 12;
@@ -189,9 +189,6 @@ export const validatedFormStyles = (theme: SupersetTheme) => css`
 
 export const StyledInputContainer = styled.div`
   margin-bottom: ${({ theme }) => theme.gridUnit * 6}px;
-  &.mb-0 {
-    margin-bottom: 0;
-  }
   &.mb-8 {
     margin-bottom: ${({ theme }) => theme.gridUnit * 2}px;
   }
@@ -337,4 +334,8 @@ export const EditHeaderSubtitle = styled.div`
   color: ${({ theme }) => theme.colors.grayscale.dark1};
   font-size: ${({ theme }) => theme.typography.sizes.l}px;
   font-weight: bold;
+`;
+
+export const no_margin_bottom = css`
+  margin-bottom: 0;
 `;

--- a/superset-frontend/src/views/CRUD/data/database/types.ts
+++ b/superset-frontend/src/views/CRUD/data/database/types.ts
@@ -52,9 +52,10 @@ export type DatabaseObject = {
 
   // Extra
   extra_json?: {
-    schema_cache_timeout?: string; // in Performance
-    table_cache_timeout?: string; // in Performance
-    metadata_cache_timeout?: {}; // No field, holds schema and table timeout
+    metadata_cache_timeout?: {
+      schema_cache_timeout?: string; // in Performance
+      table_cache_timeout?: string; // in Performance
+    }; // No field, holds schema and table timeout
     cost_query_enabled?: boolean; // in SQL Lab
     allows_virtual_table_explore?: boolean; // in SQL Lab
     schemas_allowed_for_csv_upload?: string; // in Security

--- a/superset-frontend/src/views/CRUD/data/database/types.ts
+++ b/superset-frontend/src/views/CRUD/data/database/types.ts
@@ -51,8 +51,19 @@ export type DatabaseObject = {
   server_cert?: string;
 
   // Extra
-  impersonate_user?: boolean;
-  allow_csv_upload?: boolean;
+  extra_json?: {
+    schema_cache_timeout?: string; // in Performance
+    table_cache_timeout?: string; // in Performance
+    metadata_cache_timeout?: {}; // No field, holds schema and table timeout
+    cost_query_enabled?: boolean; // in SQL Lab
+    allows_virtual_table_explore?: boolean; // in SQL Lab
+    schemas_allowed_for_csv_upload?: string; // in Security
+    impersonate_user?: boolean; // in Security
+    allow_csv_upload?: boolean; // in Security
+    version?: string;
+    metadata_params?: {};
+    engine_params?: {};
+  };
   extra?: string;
 };
 


### PR DESCRIPTION
### SUMMARY
Move the existing fields from the "Extra" section to the following sections. This also includes splitting the JSON field in "Other" and the metadata_cache_timeout field into multiple fields. The extra fields now live in the following locations:

-  SQL Lab
	- Enable query cost estimation (allows_virtual_table_explore)
	- Allow this database to be explored (cost_query_enabled)

- Performance
	- Metadata Cache Timeout with Schema and Table options

	  ```
	  metadata_cache_timeout: {
		  schema_cache_timeout,
		  table_cache_timeout,
	  }
	  ```

- Security
	- Schema select for uploading data (schemas_allowed_for_csv_upload)
	- Impersonate logged in user (impersonate_user)
	- Allow data upload (allow_csv_upload)

- Other
	- engine_params and metadata params (in separate json fields)
	- version


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

- ---------- BEFORE ----------

	**SQL Lab**
	<img width="500" alt="sqllab-before" src="https://user-images.githubusercontent.com/55605634/115647165-f6b37300-a2e8-11eb-9c7c-49b8835d3bce.png">

	**Performance**
	<img width="500" alt="performance-before" src="https://user-images.githubusercontent.com/55605634/115647195-ffa44480-a2e8-11eb-89fd-2ab0ca2083b9.png">

	**Security**
	<img width="500" alt="security-before" src="https://user-images.githubusercontent.com/55605634/115647201-029f3500-a2e9-11eb-82c5-9bbfd3fee560.png">

	**Other**
	<img width="500" alt="other-before" src="https://user-images.githubusercontent.com/55605634/115647217-06cb5280-a2e9-11eb-9892-ec3cfd9e9914.png">


- ---------- AFTER ----------

	**SQL Lab**
	<img width="499" alt="sqllab-after" src="https://user-images.githubusercontent.com/55605634/121289357-69cd7480-c8aa-11eb-9c2c-9b88b6535f1f.png">

	**Performance**
	<img width="499" alt="performance-after" src="https://user-images.githubusercontent.com/55605634/121289371-705bec00-c8aa-11eb-9293-e1552d30c04d.png">

	**Security**
	
	<img width="499" alt="security-after-1" src="https://user-images.githubusercontent.com/55605634/121289380-76ea6380-c8aa-11eb-976d-7ae1d8db97a4.png">
	<img width="499" alt="security-after-2" src="https://user-images.githubusercontent.com/55605634/121289387-79e55400-c8aa-11eb-8718-88051acd81fd.png">

	**Other**
	<img width="499" alt="other-after" src="https://user-images.githubusercontent.com/55605634/121289421-8a95ca00-c8aa-11eb-8062-dca2ffbce8e9.png">


### TEST PLAN

1. From the "Databases" page, open the database modal by clicking either the "+ DATABASE" button or the "Edit" action button on any listed database.
2. Observe the described changes on the following tabs: SQL Lab, Performance, Security, Other

### ADDITIONAL INFORMATION
- [x] Has associated issue: [Clubhouse Ticket](https://app.clubhouse.io/preset/story/6947/step-3-move-fields-from-extra-section)
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API