### PR TITLE
feat: spinner for imports

### DIFF
--- a/superset-frontend/src/common/components/index.tsx
+++ b/superset-frontend/src/common/components/index.tsx
@@ -24,6 +24,7 @@ import {
   Input as AntdInput,
   InputNumber as AntdInputNumber,
   Skeleton,
+  Upload,
 } from 'antd';
 import { DropDownProps } from 'antd/lib/dropdown';
 /*

--- a/superset-frontend/src/common/components/index.tsx
+++ b/superset-frontend/src/common/components/index.tsx
@@ -24,7 +24,6 @@ import {
   Input as AntdInput,
   InputNumber as AntdInputNumber,
   Skeleton,
-  Upload,
 } from 'antd';
 import { DropDownProps } from 'antd/lib/dropdown';
 /*

--- a/superset-frontend/src/components/Button/index.tsx
+++ b/superset-frontend/src/components/Button/index.tsx
@@ -62,7 +62,7 @@ export interface ButtonProps {
   href?: string;
   htmlType?: 'button' | 'submit' | 'reset';
   cta?: boolean;
-  loading?: boolean;
+  loading?: boolean | { delay: number };
 }
 
 export default function Button(props: ButtonProps) {

--- a/superset-frontend/src/components/Button/index.tsx
+++ b/superset-frontend/src/components/Button/index.tsx
@@ -62,6 +62,7 @@ export interface ButtonProps {
   href?: string;
   htmlType?: 'button' | 'submit' | 'reset';
   cta?: boolean;
+  loading?: boolean;
 }
 
 export default function Button(props: ButtonProps) {

--- a/superset-frontend/src/components/Button/index.tsx
+++ b/superset-frontend/src/components/Button/index.tsx
@@ -62,7 +62,7 @@ export interface ButtonProps {
   href?: string;
   htmlType?: 'button' | 'submit' | 'reset';
   cta?: boolean;
-  loading?: boolean | { delay: number };
+  loading?: boolean | { delay?: number | undefined } | undefined;
 }
 
 export default function Button(props: ButtonProps) {

--- a/superset-frontend/src/components/ImportModal/index.tsx
+++ b/superset-frontend/src/components/ImportModal/index.tsx
@@ -24,7 +24,6 @@ import Button from 'src/components/Button';
 import Icon from 'src/components/Icon';
 import Modal from 'src/components/Modal';
 import { Upload } from 'src/common/components';
-import Loading from 'src/components/Loading';
 import { useImportResource } from 'src/views/CRUD/hooks';
 import { ImportResourceName } from 'src/views/CRUD/types';
 
@@ -292,31 +291,23 @@ const ImportModelsModal: FunctionComponent<ImportModelsModalProps> = ({
       show={show}
       title={<h4>{t('Import %s', resourceLabel)}</h4>}
     >
-      {importingModel ? (
-        <>
-          <Loading position="inline-centered" />
-        </>
-      ) : (
-        <>
-          <StyledInputContainer>
-            <Upload
-              name="modelFile"
-              id="modelFile"
-              data-test="model-file-input"
-              accept=".yaml,.json,.yml,.zip"
-              fileList={fileList}
-              onChange={changeFile}
-              onRemove={removeFile}
-              // upload is handled by hook
-              customRequest={() => {}}
-            >
-              <Button>Select file</Button>
-            </Upload>
-          </StyledInputContainer>
-          {renderPasswordFields()}
-          {renderOverwriteConfirmation()}
-        </>
-      )}
+      <StyledInputContainer>
+        <Upload
+          name="modelFile"
+          id="modelFile"
+          data-test="model-file-input"
+          accept=".yaml,.json,.yml,.zip"
+          fileList={fileList}
+          onChange={changeFile}
+          onRemove={removeFile}
+          // upload is handled by hook
+          customRequest={() => {}}
+        >
+          <Button loading={importingModel}>Select file</Button>
+        </Upload>
+      </StyledInputContainer>
+      {renderPasswordFields()}
+      {renderOverwriteConfirmation()}
     </Modal>
   );
 };

--- a/superset-frontend/src/components/ImportModal/index.tsx
+++ b/superset-frontend/src/components/ImportModal/index.tsx
@@ -165,8 +165,8 @@ const ImportModelsModal: FunctionComponent<ImportModelsModalProps> = ({
   }, [passwordsNeeded, setPasswordFields]);
 
   useEffect(() => {
+    setNeedsOverwriteConfirm(alreadyExists.length > 0);
     if (alreadyExists.length > 0) {
-      setNeedsOverwriteConfirm(true);
       setImportingModel(false);
     }
   }, [alreadyExists, setNeedsOverwriteConfirm]);


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Show a spinner during the import process.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->



https://user-images.githubusercontent.com/1534870/121291761-ae064800-c89d-11eb-8009-13d5fdd27d9e.mov





### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

I modified the import API endpoint to sleep for 5 seconds, and imported a databaset.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
