### PR TITLE
refactor: stop using deprecated celery task API

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -25,8 +25,8 @@ import backoff
 import msgpack
 import pyarrow as pa
 import simplejson as json
+from celery import Task
 from celery.exceptions import SoftTimeLimitExceeded
-from celery.task.base import Task
 from flask_babel import lazy_gettext as _
 from sqlalchemy.orm import Session
 from werkzeug.local import LocalProxy


### PR DESCRIPTION
### SUMMARY

Replace deprecated celery task API (has been removed in Celery 5). see details from [Removals for version 5.0 - Celery Deprecation Timeline](https://docs.celeryproject.org/en/stable/internals/deprecation.html#old-task-api)

This is splitted from #14926

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #14925 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
