### PR TITLE
feat(native-filters): Hide filters which don't affect any visible charts

### DIFF
--- a/superset-frontend/spec/javascripts/dashboard/components/DashboardBuilder_spec.jsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/DashboardBuilder_spec.jsx
@@ -50,21 +50,21 @@ jest.mock('src/dashboard/actions/dashboardState');
 
 describe('DashboardBuilder', () => {
   let favStarStub;
-  let focusedTabStub;
+  let activeTabsStub;
 
   beforeAll(() => {
     // this is invoked on mount, so we stub it instead of making a request
     favStarStub = sinon
       .stub(dashboardStateActions, 'fetchFaveStar')
       .returns({ type: 'mock-action' });
-    focusedTabStub = sinon
-      .stub(dashboardStateActions, 'setLastFocusedTab')
+    activeTabsStub = sinon
+      .stub(dashboardStateActions, 'setActiveTabs')
       .returns({ type: 'mock-action' });
   });
 
   afterAll(() => {
     favStarStub.restore();
-    focusedTabStub.restore();
+    activeTabsStub.restore();
   });
 
   function setup(overrideState = {}, overrideStore) {

--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -344,9 +344,9 @@ export function setDirectPathToChild(path) {
   return { type: SET_DIRECT_PATH, path };
 }
 
-export const SET_LAST_FOCUSED_TAB = 'SET_LAST_FOCUSED_TAB';
-export function setLastFocusedTab(tabId) {
-  return { type: SET_LAST_FOCUSED_TAB, tabId };
+export const SET_ACTIVE_TABS = 'SET_ACTIVE_TABS';
+export function setActiveTabs(tabIds) {
+  return { type: SET_ACTIVE_TABS, tabIds };
 }
 
 export const SET_FOCUSED_FILTER_FIELD = 'SET_FOCUSED_FILTER_FIELD';

--- a/superset-frontend/src/dashboard/actions/hydrate.js
+++ b/superset-frontend/src/dashboard/actions/hydrate.js
@@ -377,7 +377,7 @@ export const hydrateDashboard = (dashboardData, chartData, datasourcesData) => (
         hasUnsavedChanges: false,
         maxUndoHistoryExceeded: false,
         lastModifiedTime: dashboardData.changed_on,
-        lastFocusedTabId: null,
+        activeTabs: [],
       },
       dashboardLayout,
     },

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -46,9 +46,11 @@ const propTypes = {
   editMode: PropTypes.bool.isRequired,
   renderHoverMenu: PropTypes.bool,
   directPathToChild: PropTypes.arrayOf(PropTypes.string),
+  activeTabs: PropTypes.arrayOf(PropTypes.string),
 
   // actions (from DashboardComponent.jsx)
   logEvent: PropTypes.func.isRequired,
+  setActiveTabs: PropTypes.func,
 
   // grid related
   availableColumnCount: PropTypes.number,
@@ -71,6 +73,8 @@ const defaultProps = {
   availableColumnCount: 0,
   columnWidth: 0,
   directPathToChild: [],
+  activeTabs: [],
+  setActiveTabs() {},
   onResizeStart() {},
   onResize() {},
   onResizeStop() {},

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -31,11 +31,7 @@ import findTabIndexByComponentId from '../../util/findTabIndexByComponentId';
 import getDirectPathToTabIndex from '../../util/getDirectPathToTabIndex';
 import getLeafComponentIdFromPath from '../../util/getLeafComponentIdFromPath';
 import { componentShape } from '../../util/propShapes';
-import {
-  NEW_TAB_ID,
-  DASHBOARD_ROOT_ID,
-  DASHBOARD_GRID_ID,
-} from '../../util/constants';
+import { NEW_TAB_ID, DASHBOARD_ROOT_ID } from '../../util/constants';
 import { RENDER_TAB, RENDER_TAB_CONTENT } from './Tab';
 import { TAB_TYPE } from '../../util/componentTypes';
 
@@ -128,6 +124,24 @@ class Tabs extends React.PureComponent {
     this.handleDeleteComponent = this.handleDeleteComponent.bind(this);
     this.handleDeleteTab = this.handleDeleteTab.bind(this);
     this.handleDropOnTab = this.handleDropOnTab.bind(this);
+  }
+
+  componentDidMount() {
+    this.props.setActiveTabs([
+      ...this.props.activeTabs,
+      this.state.activeKey,
+    ]);
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (prevState.activeKey !== this.state.activeKey) {
+      this.props.setActiveTabs([
+        ...this.props.activeTabs.filter(
+          tabId => tabId !== prevState.activeKey,
+        ),
+        this.state.activeKey,
+      ]);
+    }
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
@@ -277,21 +291,12 @@ class Tabs extends React.PureComponent {
       isComponentVisible: isCurrentTabVisible,
       editMode,
       nativeFilters,
-      dashboardLayout,
-      lastFocusedTabId,
-      setLastFocusedTab,
+      activeTabs,
+      setActiveTabs,
     } = this.props;
 
     const { children: tabIds } = tabsComponent;
     const { tabIndex: selectedTabIndex, activeKey } = this.state;
-
-    // On dashboards with top level tabs, set initial focus to the active top level tab
-    const dashboardRoot = dashboardLayout[DASHBOARD_ROOT_ID];
-    const rootChildId = dashboardRoot.children[0];
-    const isTopLevelTabs = rootChildId !== DASHBOARD_GRID_ID;
-    if (isTopLevelTabs && !lastFocusedTabId) {
-      setLastFocusedTab(activeKey);
-    }
 
     let tabsToHighlight;
     if (nativeFilters.focusedFilterId) {
@@ -332,7 +337,6 @@ class Tabs extends React.PureComponent {
               onEdit={this.handleEdit}
               data-test="nav-list"
               type={editMode ? 'editable-card' : 'card'}
-              onTabClick={setLastFocusedTab}
             >
               {tabIds.map((tabId, tabIndex) => (
                 <LineEditableTabs.TabPane

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -127,18 +127,13 @@ class Tabs extends React.PureComponent {
   }
 
   componentDidMount() {
-    this.props.setActiveTabs([
-      ...this.props.activeTabs,
-      this.state.activeKey,
-    ]);
+    this.props.setActiveTabs([...this.props.activeTabs, this.state.activeKey]);
   }
 
   componentDidUpdate(prevProps, prevState) {
     if (prevState.activeKey !== this.state.activeKey) {
       this.props.setActiveTabs([
-        ...this.props.activeTabs.filter(
-          tabId => tabId !== prevState.activeKey,
-        ),
+        ...this.props.activeTabs.filter(tabId => tabId !== prevState.activeKey),
         this.state.activeKey,
       ]);
     }
@@ -291,8 +286,6 @@ class Tabs extends React.PureComponent {
       isComponentVisible: isCurrentTabVisible,
       editMode,
       nativeFilters,
-      activeTabs,
-      setActiveTabs,
     } = this.props;
 
     const { children: tabIds } = tabsComponent;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -85,24 +85,22 @@ const FilterControls: FC<FilterControlsProps> = ({
   if (!dashboardHasTabs) {
     filtersInScope = cascadeFilters;
   } else {
-    cascadeFilters.forEach((filter, index) => {
+    cascadeFilters.forEach(filter => {
       // Filter is in scope if any of it's charts is visible.
       // Chart is visible if it's placed in an active tab tree or if it's not attached to any tab.
       // Chart is in an active tab tree if all of it's ancestors of type TAB are active
-      const isFilterInScope = cascadeFilters[index].chartsInScope?.some(
-        chartId => {
-          const chartLayoutItem = Object.values(dashboardLayout).find(
-            layoutItem => layoutItem.meta?.chartId === chartId,
-          );
-          const tabParents = chartLayoutItem?.parents.filter(
-            (parent: string) => dashboardLayout[parent].type === TAB_TYPE,
-          );
-          return (
-            tabParents?.length === 0 ||
-            tabParents?.every(tab => activeTabs.includes(tab))
-          );
-        },
-      );
+      const isFilterInScope = filter.chartsInScope?.some(chartId => {
+        const chartLayoutItem = Object.values(dashboardLayout).find(
+          layoutItem => layoutItem.meta?.chartId === chartId,
+        );
+        const tabParents = chartLayoutItem?.parents.filter(
+          (parent: string) => dashboardLayout[parent].type === TAB_TYPE,
+        );
+        return (
+          tabParents?.length === 0 ||
+          tabParents?.every(tab => activeTabs.includes(tab))
+        );
+      });
 
       if (isFilterInScope) {
         filtersInScope.push(filter);

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -80,10 +80,15 @@ const FilterControls: FC<FilterControlsProps> = ({
     element => element.type === TAB_TYPE,
   );
   const showCollapsePanel = dashboardHasTabs && cascadeFilters.length > 0;
-  if (!activeTabs || !dashboardHasTabs) {
+
+  // we check native filters scopes only on dashboards with tabs
+  if (!dashboardHasTabs) {
     filtersInScope = cascadeFilters;
   } else {
     cascadeFilters.forEach((filter, index) => {
+      // Filter is in scope if any of it's charts is visible.
+      // Chart is visible if it's placed in an active tab tree or if it's not attached to any tab.
+      // Chart is in an active tab tree if all of it's ancestors of type TAB are active
       const isFilterInScope = cascadeFilters[index].chartsInScope?.some(
         chartId => {
           const chartLayoutItem = Object.values(dashboardLayout).find(

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -19,18 +19,14 @@
 import React, { FC, useMemo, useState } from 'react';
 import { DataMask, styled, t } from '@superset-ui/core';
 import { css } from '@emotion/react';
-import { useSelector } from 'react-redux';
 import * as portals from 'react-reverse-portal';
 import { DataMaskStateWithId } from 'src/dataMask/types';
 import { Collapse } from 'src/common/components';
-import { TAB_TYPE } from 'src/dashboard/util/componentTypes';
-import { ActiveTabs, RootState } from 'src/dashboard/types';
 import CascadePopover from '../CascadeFilters/CascadePopover';
 import { buildCascadeFiltersTree } from './utils';
 import { useFilters } from '../state';
 import { Filter } from '../../types';
-import { CascadeFilter } from '../CascadeFilters/types';
-import { useDashboardLayout } from '../../state';
+import { useDashboardHasTabs, useSelectFiltersInScope } from '../../state';
 
 const Wrapper = styled.div`
   padding: ${({ theme }) => theme.gridUnit * 4}px;
@@ -52,10 +48,6 @@ const FilterControls: FC<FilterControlsProps> = ({
 }) => {
   const [visiblePopoverId, setVisiblePopoverId] = useState<string | null>(null);
   const filters = useFilters();
-  const dashboardLayout = useDashboardLayout();
-  const activeTabs = useSelector<RootState, ActiveTabs>(
-    state => state.dashboardState?.activeTabs,
-  );
   const filterValues = Object.values<Filter>(filters);
   const portalNodes = React.useMemo(() => {
     const nodes = new Array(filterValues.length);
@@ -74,41 +66,11 @@ const FilterControls: FC<FilterControlsProps> = ({
   }, [filterValues, dataMaskSelected]);
   const cascadeFilterIds = new Set(cascadeFilters.map(item => item.id));
 
-  let filtersInScope: CascadeFilter[] = [];
-  const filtersOutOfScope: CascadeFilter[] = [];
-  const dashboardHasTabs = Object.values(dashboardLayout).some(
-    element => element.type === TAB_TYPE,
+  const [filtersInScope, filtersOutOfScope] = useSelectFiltersInScope(
+    cascadeFilters,
   );
+  const dashboardHasTabs = useDashboardHasTabs();
   const showCollapsePanel = dashboardHasTabs && cascadeFilters.length > 0;
-
-  // we check native filters scopes only on dashboards with tabs
-  if (!dashboardHasTabs) {
-    filtersInScope = cascadeFilters;
-  } else {
-    cascadeFilters.forEach(filter => {
-      // Filter is in scope if any of it's charts is visible.
-      // Chart is visible if it's placed in an active tab tree or if it's not attached to any tab.
-      // Chart is in an active tab tree if all of it's ancestors of type TAB are active
-      const isFilterInScope = filter.chartsInScope?.some(chartId => {
-        const chartLayoutItem = Object.values(dashboardLayout).find(
-          layoutItem => layoutItem.meta?.chartId === chartId,
-        );
-        const tabParents = chartLayoutItem?.parents.filter(
-          (parent: string) => dashboardLayout[parent].type === TAB_TYPE,
-        );
-        return (
-          tabParents?.length === 0 ||
-          tabParents?.every(tab => activeTabs.includes(tab))
-        );
-      });
-
-      if (isFilterInScope) {
-        filtersInScope.push(filter);
-      } else {
-        filtersOutOfScope.push(filter);
-      }
-    });
-  }
 
   return (
     <Wrapper>

--- a/superset-frontend/src/dashboard/components/nativeFilters/state.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/state.ts
@@ -19,7 +19,9 @@
 import { useSelector } from 'react-redux';
 import { useMemo } from 'react';
 import { Filter, FilterConfiguration } from './types';
-import { DashboardLayout } from '../../types';
+import { ActiveTabs, DashboardLayout, RootState } from '../../types';
+import { TAB_TYPE } from '../../util/componentTypes';
+import { CascadeFilter } from './FilterBar/CascadeFilters/types';
 
 const defaultFilterConfiguration: Filter[] = [];
 
@@ -51,4 +53,74 @@ export function useDashboardLayout() {
   return useSelector<any, DashboardLayout>(
     state => state.dashboardLayout?.present,
   );
+}
+
+export function useDashboardHasTabs() {
+  const dashboardLayout = useDashboardLayout();
+  return useMemo(
+    () =>
+      Object.values(dashboardLayout).some(element => element.type === TAB_TYPE),
+    [dashboardLayout],
+  );
+}
+
+function useActiveDashboardTabs() {
+  return useSelector<RootState, ActiveTabs>(
+    state => state.dashboardState?.activeTabs,
+  );
+}
+
+function useSelectChartTabParents() {
+  const dashboardLayout = useDashboardLayout();
+  return (chartId: number) => {
+    const chartLayoutItem = Object.values(dashboardLayout).find(
+      layoutItem => layoutItem.meta?.chartId === chartId,
+    );
+    return chartLayoutItem?.parents.filter(
+      (parent: string) => dashboardLayout[parent].type === TAB_TYPE,
+    );
+  };
+}
+
+function useIsFilterInScope() {
+  const activeTabs = useActiveDashboardTabs();
+  const selectChartTabParents = useSelectChartTabParents();
+
+  // Filter is in scope if any of it's charts is visible.
+  // Chart is visible if it's placed in an active tab tree or if it's not attached to any tab.
+  // Chart is in an active tab tree if all of it's ancestors of type TAB are active
+  return (filter: CascadeFilter) =>
+    filter.chartsInScope?.some((chartId: number) => {
+      const tabParents = selectChartTabParents(chartId);
+      return (
+        tabParents?.length === 0 ||
+        tabParents?.every(tab => activeTabs.includes(tab))
+      );
+    });
+}
+
+export function useSelectFiltersInScope(cascadeFilters: CascadeFilter[]) {
+  const dashboardHasTabs = useDashboardHasTabs();
+  const isFilterInScope = useIsFilterInScope();
+
+  return useMemo(() => {
+    let filtersInScope: CascadeFilter[] = [];
+    const filtersOutOfScope: CascadeFilter[] = [];
+
+    // we check native filters scopes only on dashboards with tabs
+    if (!dashboardHasTabs) {
+      filtersInScope = cascadeFilters;
+    } else {
+      cascadeFilters.forEach((filter: CascadeFilter) => {
+        const filterInScope = isFilterInScope(filter);
+
+        if (filterInScope) {
+          filtersInScope.push(filter);
+        } else {
+          filtersOutOfScope.push(filter);
+        }
+      });
+    }
+    return [filtersInScope, filtersOutOfScope];
+  }, [cascadeFilters, dashboardHasTabs, isFilterInScope]);
 }

--- a/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
+++ b/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
@@ -37,7 +37,7 @@ import {
 } from '../actions/dashboardLayout';
 import {
   setDirectPathToChild,
-  setLastFocusedTab,
+  setActiveTabs,
 } from '../actions/dashboardState';
 
 const propTypes = {
@@ -104,7 +104,7 @@ function mapStateToProps(
     redoLength: undoableLayout.future.length,
     filters: getActiveFilters(),
     directPathToChild: dashboardState.directPathToChild,
-    lastFocusedTabId: dashboardState.lastFocusedTabId,
+    activeTabs: dashboardState.activeTabs,
     directPathLastUpdated: dashboardState.directPathLastUpdated,
     dashboardId: dashboardInfo.id,
     nativeFilters,
@@ -141,7 +141,7 @@ function mapDispatchToProps(dispatch) {
       updateComponents,
       handleComponentDrop,
       setDirectPathToChild,
-      setLastFocusedTab,
+      setActiveTabs,
       logEvent,
     },
     dispatch,

--- a/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
+++ b/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
@@ -35,10 +35,7 @@ import {
   updateComponents,
   handleComponentDrop,
 } from '../actions/dashboardLayout';
-import {
-  setDirectPathToChild,
-  setActiveTabs,
-} from '../actions/dashboardState';
+import { setDirectPathToChild, setActiveTabs } from '../actions/dashboardState';
 
 const propTypes = {
   id: PropTypes.string,

--- a/superset-frontend/src/dashboard/reducers/dashboardState.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.js
@@ -35,7 +35,7 @@ import {
   SET_DIRECT_PATH,
   SET_FOCUSED_FILTER_FIELD,
   UNSET_FOCUSED_FILTER_FIELD,
-  SET_LAST_FOCUSED_TAB,
+  SET_ACTIVE_TABS,
 } from '../actions/dashboardState';
 import { HYDRATE_DASHBOARD } from '../actions/hydrate';
 
@@ -134,10 +134,10 @@ export default function dashboardStateReducer(state = {}, action) {
         directPathLastUpdated: Date.now(),
       };
     },
-    [SET_LAST_FOCUSED_TAB]() {
+    [SET_ACTIVE_TABS]() {
       return {
         ...state,
-        lastFocusedTabId: action.tabId,
+        activeTabs: action.tabIds,
       };
     },
     [SET_FOCUSED_FILTER_FIELD]() {

--- a/superset-frontend/src/dashboard/types.ts
+++ b/superset-frontend/src/dashboard/types.ts
@@ -41,12 +41,13 @@ export type Chart = ChartState & {
   };
 };
 
+export type ActiveTabs = string[];
 export type DashboardLayout = { [key: string]: LayoutItem };
 export type DashboardLayoutState = { present: DashboardLayout };
 export type DashboardState = {
   editMode: boolean;
   directPathToChild: string[];
-  lastFocusedTabId: string | null;
+  activeTabs: ActiveTabs;
 };
 export type DashboardInfo = {
   common: {


### PR DESCRIPTION
### SUMMARY
This PR changes the behaviour of hiding native filters out of scope, which was originally implemented in https://github.com/apache/superset/pull/14933.
Before, we considered filters to be "in scope" if they were placed in the last clicked tab. This approach presented several issues. The most significant issue was that in case of dashboards without top level tabs, there was no way to have charts unattached to any tab to be considered in scope once some row level tab had been clicked (as the scope was set only by clicking tabs).
The new proposal, implemented in this PR, is that we consider all visible charts to be "in scope". That means that in order to determine if a filter is in scope, we no longer check only the last clicked tab, but the whole tabs tree of the dashboard. For details, see attached recordings of the new native filters behaviour presented on dashboards with (the first video) and without (second video) top level tabs

Potential improvement: rename "Filters out of scope" section or add a label for filters in scope to make it clear for the user why specific filters are out of scope. If you have any ideas, I'm open for suggestions 🙂 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see https://github.com/apache/superset/pull/14933
After:
https://user-images.githubusercontent.com/15073128/121371437-d6de1a00-c93d-11eb-9776-5ba53f35ab33.mov
https://user-images.githubusercontent.com/15073128/121371703-0ab93f80-c93e-11eb-8b92-3d216a049450.mov

### TESTING INSTRUCTIONS
0. Set `DASHBOARD_NATIVE_FILTERS` feature flag to `True`
1. Create dashboards with tabs (top level and/or row level)
2. Add some native filters, go crazy with their scopes
3. Verify that filters that don't have any visible charts in scope are moved to "Out of scope" panel
4. Edit native filters's scopes and dashboard's layout (add some new tabs or charts) and verify that the feature "picked up" the changes

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc @villebro @michael-s-molina 