### PR TITLE
chore: Add 'fetching' status to QueryStatus

### DIFF
--- a/superset-frontend/src/SqlLab/components/QueryTable/index.jsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/index.jsx
@@ -120,6 +120,14 @@ const statusAttributes = {
       status: 'queued',
     },
   },
+  error: {
+    color: ({ theme }) => theme.colors.error.base,
+    config: {
+      name: 'error',
+      label: t('Unknown Status'),
+      status: 'unknown status!',
+    },
+  },
 };
 
 const StatusIcon = styled(Icon, {
@@ -172,6 +180,8 @@ const QueryTable = props => {
     return props.queries
       .map(query => {
         const q = { ...query };
+        const status = statusAttributes[q.state] || statusAttributes.error;
+
         if (q.endDttm) {
           q.duration = fDuration(q.startDttm, q.endDttm);
         }
@@ -268,14 +278,11 @@ const QueryTable = props => {
             />
           );
         q.state = (
-          <Tooltip
-            title={statusAttributes[q.state].config.label}
-            placement="bottom"
-          >
+          <Tooltip title={status.config.label} placement="bottom">
             <span>
               <StatusIcon
-                name={statusAttributes[q.state].config.name}
-                status={statusAttributes[q.state].config.status}
+                name={status.config.name}
+                status={status.config.status}
               />
             </span>
           </Tooltip>

--- a/superset-frontend/src/SqlLab/types.ts
+++ b/superset-frontend/src/SqlLab/types.ts
@@ -30,6 +30,7 @@ export type QueryState =
   | 'running'
   | 'scheduled'
   | 'success'
+  | 'fetching'
   | 'timed_out';
 
 export type Query = {

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -263,6 +263,7 @@ class QueryStatus(str, Enum):  # pylint: disable=too-few-public-methods
     RUNNING: str = "running"
     SCHEDULED: str = "scheduled"
     SUCCESS: str = "success"
+    FETCHING: str = "fetching"
     TIMED_OUT: str = "timed_out"
 
 


### PR DESCRIPTION
### SUMMARY
A. cosmetic change to the Query History tab in SQL Lab caused some new statuses to be seen. They were causing errors for the Icon images that we have set up. 

This PR adds the 'fetching' status into QueryStatus for frontend and into the backend QueryStatus enum as well. Furthermore, it creates a config called 'error' in the frontend for any status that does not exist. This will hopefully allow for the users to continue using sql lab, but also make an engineer aware that the status is new and needs to be added. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![Screen Shot 2021-06-09 at 11 04 33 AM](https://user-images.githubusercontent.com/48933336/121382318-78507600-c914-11eb-8f15-f865b2782289.png)

I don't have an unknown status but this is to show that query history still renders correctly. 

### TESTING INSTRUCTIONS
Go to Sql Lab
Run some queries
check query history

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
