### PR TITLE
fix: move metric parsing to state instantiation

### DIFF
--- a/superset-frontend/spec/javascripts/datasource/DatasourceEditor_spec.jsx
+++ b/superset-frontend/spec/javascripts/datasource/DatasourceEditor_spec.jsx
@@ -233,4 +233,21 @@ describe('DatasourceEditor RTL', () => {
     );
     expect(warningMarkdown.value).toEqual('someone');
   });
+  it('properly updates the metric information', async () => {
+    render(<DatasourceEditor {...props} />, {
+      useRedux: true,
+    });
+    const metricButton = screen.getByTestId('collection-tab-Metrics');
+    userEvent.click(metricButton);
+    const expandToggle = await screen.findAllByLabelText(/toggle expand/i);
+    userEvent.click(expandToggle[1]);
+    const certifiedBy = await screen.findByPlaceholderText(/certified by/i);
+    userEvent.type(certifiedBy, 'I am typing a new name');
+    const certificationDetails = await screen.findByPlaceholderText(
+      /certification details/i,
+    );
+    expect(certifiedBy.value).toEqual('I am typing a new name');
+    userEvent.type(certificationDetails, 'I am typing something new');
+    expect(certificationDetails.value).toEqual('I am typing something new');
+  });
 });

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -307,7 +307,21 @@ class DatasourceEditor extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      datasource: props.datasource,
+      datasource: {
+        ...props.datasource,
+        metrics: props.datasource.metrics?.map(metric => {
+          const {
+            certification: { details, certified_by: certifiedBy } = {},
+            warning_markdown: warningMarkdown,
+          } = JSON.parse(metric.extra || '{}') || {};
+          return {
+            ...metric,
+            certification_details: details || '',
+            warning_markdown: warningMarkdown || '',
+            certified_by: certifiedBy,
+          };
+        }),
+      },
       errors: [],
       isDruid:
         props.datasource.type === 'druid' ||
@@ -936,18 +950,7 @@ class DatasourceEditor extends React.PureComponent {
             </Fieldset>
           </FormContainer>
         }
-        collection={this.state.datasource.metrics?.map(metric => {
-          const {
-            certification: { details, certified_by: certifiedBy } = {},
-            warning_markdown: warningMarkdown,
-          } = JSON.parse(metric.extra || '{}') || {};
-          return {
-            ...metric,
-            certification_details: details || '',
-            warning_markdown: warningMarkdown || '',
-            certified_by: certifiedBy,
-          };
-        })}
+        collection={this.state.datasource.metrics}
         allowAddItem
         onChange={this.onDatasourcePropChange.bind(this, 'metrics')}
         itemGenerator={() => ({


### PR DESCRIPTION
### SUMMARY
I noticed while testing that the markdown metric field isn't updating properly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After: 

https://user-images.githubusercontent.com/5186919/121429307-9c6b8180-c92b-11eb-84ba-5faceb57dbe8.mov



### TESTING INSTRUCTIONS
 It's difficult to write any kind of tests for the ace editor when looking at value because it always renders "xxx". Something we can try to figure out in the future. In the meantime I added more tests around editing the other metrics. 

Manual testing: click to edit a dataset, go to metrics, and try to add some test in the markdown field. It should show the text. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
