### PR TITLE
fix: Honor ROW_LIMIT setting in elasticsearch queries

### DIFF
--- a/superset/db_engine_specs/elasticsearch.py
+++ b/superset/db_engine_specs/elasticsearch.py
@@ -24,6 +24,7 @@ from superset.db_engine_specs.exceptions import (
     SupersetDBAPIProgrammingError,
 )
 from superset.utils import core as utils
+from typing import Any
 
 
 class ElasticSearchEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method

--- a/superset/db_engine_specs/elasticsearch.py
+++ b/superset/db_engine_specs/elasticsearch.py
@@ -25,6 +25,7 @@ from superset.db_engine_specs.exceptions import (
 )
 from superset.utils import core as utils
 from typing import Any
+from superset import app
 
 
 class ElasticSearchEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method

--- a/superset/db_engine_specs/elasticsearch.py
+++ b/superset/db_engine_specs/elasticsearch.py
@@ -63,6 +63,11 @@ class ElasticSearchEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-metho
             return f"""CAST('{dttm.isoformat(timespec="seconds")}' AS DATETIME)"""
         return None
 
+    @classmethod
+    def execute(cls, cursor: Any, query: str, **kwargs: Any) -> None:
+        cursor.fetch_size = app.config['ROW_LIMIT']
+        return super().execute(cursor, query, **kwargs)
+
 
 class OpenDistroEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method
 

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -381,7 +381,7 @@ class Database(
             cursor = conn.cursor()
             if hasattr(cursor, 'fetch_size'):
                 cursor.fetch_size = config['ROW_LIMIT']
-                
+
             for sql_ in sqls[:-1]:
                 _log_query(sql_)
                 self.db_engine_spec.execute(cursor, sql_)

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -379,6 +379,9 @@ class Database(
 
         with closing(engine.raw_connection()) as conn:
             cursor = conn.cursor()
+            if hasattr(cursor, 'fetch_size'):
+                cursor.fetch_size = config['ROW_LIMIT']
+                
             for sql_ in sqls[:-1]:
                 _log_query(sql_)
                 self.db_engine_spec.execute(cursor, sql_)

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -379,9 +379,6 @@ class Database(
 
         with closing(engine.raw_connection()) as conn:
             cursor = conn.cursor()
-            if hasattr(cursor, 'fetch_size'):
-                cursor.fetch_size = config['ROW_LIMIT']
-
             for sql_ in sqls[:-1]:
                 _log_query(sql_)
                 self.db_engine_spec.execute(cursor, sql_)


### PR DESCRIPTION
### SUMMARY
In order to adjust the fetch size of the elasticsearch-dbapi (https://github.com/preset-io/elasticsearch-dbapi#fetch-size) to the ROW_LIMIT setting, the fetch_size attribute of the cursor needs to be set.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TESTING INSTRUCTIONS
- set ROW_LIMIT=20000 in config.py
- set ROW_LIMIT=50000 in a chart that uses an Elasticsearch data set
- run query on a sufficiently large data set
- observe that 20k rows are displayed in the chart

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
