### PR TITLE
fix(native-filters): empty label indicator

### DIFF
--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -150,7 +150,7 @@ describe('SelectFilterPlugin', () => {
         ],
       },
       filterState: {
-        label: '',
+        label: undefined,
         value: null,
       },
     });
@@ -165,7 +165,7 @@ describe('SelectFilterPlugin', () => {
       },
       extraFormData: {},
       filterState: {
-        label: '',
+        label: undefined,
         value: null,
       },
     });

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -138,7 +138,9 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
           inverseSelection,
         ),
         filterState: {
-          label: `${(values || []).join(', ')}${suffix}`,
+          label: values?.length
+            ? `${(values || []).join(', ')}${suffix}`
+            : undefined,
           value:
             appSection === AppSection.FILTER_CONFIG_MODAL && defaultToFirstItem
               ? undefined


### PR DESCRIPTION
### SUMMARY
Currently clearing the Value filter's values leaves the native filter indicator showing as Applied despite no filter having been emitted. This is due to the label being set to a falsy string value `''`, despite being checked with a [nullish coalescing operator `??`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator): https://github.com/apache/superset/blob/65714cc2015db660b71afbf5f4643a112a1b0352/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts#L229-L232

### BEFORE
A filter that has previously had values but is cleared shows up as set (gender):
![image](https://user-images.githubusercontent.com/33317356/121511109-fc782b80-c9f0-11eb-8458-f2715ba6df32.png)


### AFTER
Now the indicator correctly shows as unapplied:
![image](https://user-images.githubusercontent.com/33317356/121510922-cfc41400-c9f0-11eb-8d51-6b6a14873374.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #15072
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
