### PR TITLE
fix(explore): fix y-axis lower bound  0 value

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/BoundsControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/BoundsControl_spec.jsx
@@ -51,3 +51,12 @@ test('calls onChange with correct values', async () => {
     expect(defaultProps.onChange).toHaveBeenLastCalledWith([1, 2]),
   );
 });
+
+test('receives 0 value', async () => {
+  render(<BoundsControl {...defaultProps} />);
+  const minInput = screen.getAllByRole('spinbutton')[0];
+  userEvent.type(minInput, '0');
+  await waitFor(() =>
+    expect(defaultProps.onChange).toHaveBeenCalledWith([0, null]),
+  );
+});

--- a/superset-frontend/spec/javascripts/explore/components/BoundsControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/BoundsControl_spec.jsx
@@ -57,6 +57,6 @@ test('receives 0 value', async () => {
   const minInput = screen.getAllByRole('spinbutton')[0];
   userEvent.type(minInput, '0');
   await waitFor(() =>
-    expect(defaultProps.onChange).toHaveBeenCalledWith([0, null]),
+    expect(defaultProps.onChange).toHaveBeenLastCalledWith([0, null]),
   );
 });

--- a/superset-frontend/src/explore/components/controls/BoundsControl.jsx
+++ b/superset-frontend/src/explore/components/controls/BoundsControl.jsx
@@ -97,8 +97,8 @@ export default class BoundsControl extends React.Component {
 
   onChange() {
     const mm = this.state.minMax;
-    const min = parseFloat(mm[0]) || null;
-    const max = parseFloat(mm[1]) || null;
+    const min = parseFloat(mm[0]) ?? null;
+    const max = parseFloat(mm[1]) ?? null;
     this.props.onChange([min, max]);
   }
 

--- a/superset-frontend/src/explore/components/controls/BoundsControl.jsx
+++ b/superset-frontend/src/explore/components/controls/BoundsControl.jsx
@@ -97,8 +97,8 @@ export default class BoundsControl extends React.Component {
 
   onChange() {
     const mm = this.state.minMax;
-    const min = parseFloat(mm[0]) ?? null;
-    const max = parseFloat(mm[1]) ?? null;
+    const min = Number.isNaN(parseFloat(mm[0])) ? null : parseFloat(mm[0]);
+    const max = Number.isNaN(parseFloat(mm[1])) ? null : parseFloat(mm[1]);
     this.props.onChange([min, max]);
   }
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This pr fixes the viz that cannot be updated when the y-axis lower bound is changed to 0.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### Before

https://user-images.githubusercontent.com/11830681/121550073-fdd14480-ca40-11eb-95ee-5a160e57d631.mov

#### After

https://user-images.githubusercontent.com/11830681/121550116-07f34300-ca41-11eb-8d91-20ecad49bdc7.mov



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:   #14998 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
