### PR TITLE
fix: Test connection before starting on create transaction

### DIFF
--- a/superset/databases/commands/create.py
+++ b/superset/databases/commands/create.py
@@ -68,6 +68,7 @@ class CreateDatabaseCommand(BaseCommand):
             security_manager.add_permission_view_menu("database_access", database.perm)
             db.session.commit()
         except DAOCreateFailedError as ex:
+            db.session.rollback()
             event_logger.log_with_context(
                 action=f"db_creation_failed.{ex.__class__.__name__}",
                 engine=database.db_engine_spec.__name__,

--- a/superset/databases/commands/create.py
+++ b/superset/databases/commands/create.py
@@ -44,19 +44,20 @@ class CreateDatabaseCommand(BaseCommand):
 
     def run(self) -> Model:
         self.validate()
+
+        try:
+            # Test connection before starting create transaction
+            TestConnectionDatabaseCommand(self._actor, self._properties).run()
+        except Exception as ex:  # pylint: disable=broad-except
+            event_logger.log_with_context(
+                action=f"db_creation_failed.{ex.__class__.__name__}",
+                engine=self._properties.get("sqlalchemy_uri", "").split(":")[0],
+            )
+            raise DatabaseConnectionFailedError()
+
         try:
             database = DatabaseDAO.create(self._properties, commit=False)
             database.set_sqlalchemy_uri(database.sqlalchemy_uri)
-
-            try:
-                TestConnectionDatabaseCommand(self._actor, self._properties).run()
-            except Exception as ex:  # pylint: disable=broad-except
-                db.session.rollback()
-                event_logger.log_with_context(
-                    action=f"db_creation_failed.{ex.__class__.__name__}",
-                    engine=database.db_engine_spec.__name__,
-                )
-                raise DatabaseConnectionFailedError()
 
             # adding a new database we always want to force refresh schema list
             schemas = database.get_all_schema_names(cache=False)


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Small bug where on failure of db connection, service fails to rollback. To fix this i've put the db connection before running on create database

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Goto Database Connection modal
2. Enter bad sqlalchemy_uri
3. See failure raise in toast
4. Refresh page and make sure the db wasn't add to the list

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
