### PR TITLE
feat: show spinner on exports

### DIFF
--- a/superset-frontend/src/utils/export.ts
+++ b/superset-frontend/src/utils/export.ts
@@ -38,7 +38,7 @@ export default function handleResourceExport(
   document.body.appendChild(iframe);
 
   const timer = window.setInterval(() => {
-    const cookie = parseCookie();
+    const cookie: { [cookieId: string]: string } = parseCookie();
     if (cookie[token] === 'done') {
       window.clearInterval(timer);
       document.body.removeChild(iframe);

--- a/superset-frontend/src/utils/export.ts
+++ b/superset-frontend/src/utils/export.ts
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import parseCookie from 'src/utils/parseCookie';
+import rison from 'rison';
+import shortid from 'shortid';
+
+export default function handleResourceExport(
+  resource: string,
+  ids: number[],
+  done: () => void,
+  interval = 200,
+): void {
+  const token = shortid.generate();
+  const url = `/api/v1/${resource}/export/?q=${rison.encode(
+    ids,
+  )}&token=${token}`;
+
+  // create new iframe for export
+  const iframe = document.createElement('iframe');
+  iframe.style.display = 'none';
+  iframe.src = url;
+  document.body.appendChild(iframe);
+
+  const timer = window.setInterval(() => {
+    const cookie = parseCookie();
+    if (cookie[token] === 'done') {
+      window.clearInterval(timer);
+      document.body.removeChild(iframe);
+      done();
+    }
+  }, interval);
+}

--- a/superset-frontend/src/views/CRUD/chart/ChartCard.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartCard.tsx
@@ -29,7 +29,7 @@ import Label from 'src/components/Label';
 import { Dropdown, Menu } from 'src/common/components';
 import FaveStar from 'src/components/FaveStar';
 import FacePile from 'src/components/FacePile';
-import { handleChartDelete, handleBulkChartExport, CardStyles } from '../utils';
+import { handleChartDelete, CardStyles } from '../utils';
 
 interface ChartCardProps {
   chart: Chart;
@@ -45,6 +45,7 @@ interface ChartCardProps {
   chartFilter?: string;
   userId?: number;
   showThumbnails?: boolean;
+  handleBulkChartExport: (chartsToExport: Chart[]) => void;
 }
 
 export default function ChartCard({
@@ -61,6 +62,7 @@ export default function ChartCard({
   favoriteStatus,
   chartFilter,
   userId,
+  handleBulkChartExport,
 }: ChartCardProps) {
   const canEdit = hasPerm('can_write');
   const canDelete = hasPerm('can_write');

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardCard.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardCard.tsx
@@ -19,11 +19,7 @@
 import React from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import { t } from '@superset-ui/core';
-import {
-  handleDashboardDelete,
-  handleBulkDashboardExport,
-  CardStyles,
-} from 'src/views/CRUD/utils';
+import { handleDashboardDelete, CardStyles } from 'src/views/CRUD/utils';
 import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 import { Dropdown, Menu } from 'src/common/components';
 import ConfirmStatusChange from 'src/components/ConfirmStatusChange';
@@ -49,6 +45,7 @@ interface DashboardCardProps {
   dashboardFilter?: string;
   userId?: number;
   showThumbnails?: boolean;
+  handleBulkDashboardExport: (dashboardsToExport: Dashboard[]) => void;
 }
 
 function DashboardCard({
@@ -64,6 +61,7 @@ function DashboardCard({
   favoriteStatus,
   saveFavoriteStatus,
   showThumbnails,
+  handleBulkDashboardExport,
 }: DashboardCardProps) {
   const history = useHistory();
   const canEdit = hasPerm('can_write');

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
@@ -174,7 +174,7 @@ function DashboardList(props: DashboardListProps) {
 
   const handleBulkDashboardExport = (dashboardsToExport: Dashboard[]) => {
     const ids = dashboardsToExport.map(({ id }) => id);
-    handleResourceExport('chart', ids, () => {
+    handleResourceExport('dashboard', ids, () => {
       setPreparingExport(false);
     });
     setPreparingExport(true);

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
@@ -25,10 +25,11 @@ import {
   createFetchRelated,
   createErrorHandler,
   handleDashboardDelete,
-  handleBulkDashboardExport,
 } from 'src/views/CRUD/utils';
 import { useListViewResource, useFavoriteStatus } from 'src/views/CRUD/hooks';
 import ConfirmStatusChange from 'src/components/ConfirmStatusChange';
+import handleResourceExport from 'src/utils/export';
+import Loading from 'src/components/Loading';
 import SubMenu, { SubMenuProps } from 'src/components/Menu/SubMenu';
 import ListView, {
   ListViewProps,
@@ -123,6 +124,7 @@ function DashboardList(props: DashboardListProps) {
 
   const [importingDashboard, showImportModal] = useState<boolean>(false);
   const [passwordFields, setPasswordFields] = useState<string[]>([]);
+  const [preparingExport, setPreparingExport] = useState<boolean>(false);
 
   const openDashboardImportModal = () => {
     showImportModal(true);
@@ -169,6 +171,14 @@ function DashboardList(props: DashboardListProps) {
       ),
     );
   }
+
+  const handleBulkDashboardExport = (dashboardsToExport: Dashboard[]) => {
+    const ids = dashboardsToExport.map(({ id }) => id);
+    handleResourceExport('chart', ids, () => {
+      setPreparingExport(false);
+    });
+    setPreparingExport(true);
+  };
 
   function handleBulkDashboardDelete(dashboardsToDelete: Dashboard[]) {
     return SupersetClient.delete({
@@ -487,6 +497,7 @@ function DashboardList(props: DashboardListProps) {
         openDashboardEditModal={openDashboardEditModal}
         saveFavoriteStatus={saveFavoriteStatus}
         favoriteStatus={favoriteStatus[dashboard.id]}
+        handleBulkDashboardExport={handleBulkDashboardExport}
       />
     );
   }
@@ -605,6 +616,7 @@ function DashboardList(props: DashboardListProps) {
         passwordFields={passwordFields}
         setPasswordFields={setPasswordFields}
       />
+      {preparingExport && <Loading />}
     </>
   );
 }

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
@@ -33,11 +33,13 @@ import { useListViewResource } from 'src/views/CRUD/hooks';
 import ConfirmStatusChange from 'src/components/ConfirmStatusChange';
 import DatasourceModal from 'src/datasource/DatasourceModal';
 import DeleteModal from 'src/components/DeleteModal';
+import handleResourceExport from 'src/utils/export';
 import ListView, {
   ListViewProps,
   Filters,
   FilterOperator,
 } from 'src/components/ListView';
+import Loading from 'src/components/Loading';
 import SubMenu, {
   SubMenuProps,
   ButtonProps,
@@ -131,6 +133,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
 
   const [importingDataset, showImportModal] = useState<boolean>(false);
   const [passwordFields, setPasswordFields] = useState<string[]>([]);
+  const [preparingExport, setPreparingExport] = useState<boolean>(false);
 
   const openDatasetImportModal = () => {
     showImportModal(true);
@@ -547,12 +550,13 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
     );
   };
 
-  const handleBulkDatasetExport = (datasetsToExport: Dataset[]) =>
-    window.location.assign(
-      `/api/v1/dataset/export/?q=${rison.encode(
-        datasetsToExport.map(({ id }) => id),
-      )}`,
-    );
+  const handleBulkDatasetExport = (datasetsToExport: Dataset[]) => {
+    const ids = datasetsToExport.map(({ id }) => id);
+    handleResourceExport('dataset', ids, () => {
+      setPreparingExport(false);
+    });
+    setPreparingExport(true);
+  };
 
   return (
     <>
@@ -682,6 +686,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
         passwordFields={passwordFields}
         setPasswordFields={setPasswordFields}
       />
+      {preparingExport && <Loading />}
     </>
   );
 };

--- a/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.test.jsx
+++ b/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.test.jsx
@@ -26,7 +26,6 @@ import { render, screen, cleanup, waitFor } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
 import { QueryParamProvider } from 'use-query-params';
 import { act } from 'react-dom/test-utils';
-import { handleBulkSavedQueryExport } from 'src/views/CRUD/utils';
 import * as featureFlags from 'src/featureFlags';
 import SavedQueryList from 'src/views/CRUD/data/savedquery/SavedQueryList';
 import SubMenu from 'src/components/Menu/SubMenu';
@@ -283,14 +282,6 @@ describe('RTL', () => {
       name: /export query/i,
     });
     expect(exportTooltip).toBeInTheDocument();
-  });
-
-  it('runs handleBulkSavedQueryExport when export is clicked', () => {
-    // Grab Export action button and mock mouse clicking it
-    const exportActionButton = screen.getAllByRole('button')[18];
-    userEvent.click(exportActionButton);
-
-    expect(handleBulkSavedQueryExport).toHaveBeenCalled();
   });
 
   it('renders an import button in the submenu', () => {

--- a/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx
+++ b/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx
@@ -25,12 +25,12 @@ import {
   createFetchRelated,
   createFetchDistinct,
   createErrorHandler,
-  handleBulkSavedQueryExport,
 } from 'src/views/CRUD/utils';
 import Popover from 'src/components/Popover';
 import withToasts from 'src/messageToasts/enhancers/withToasts';
 import { useListViewResource } from 'src/views/CRUD/hooks';
 import ConfirmStatusChange from 'src/components/ConfirmStatusChange';
+import handleResourceExport from 'src/utils/export';
 import SubMenu, {
   SubMenuProps,
   ButtonProps,
@@ -40,6 +40,7 @@ import ListView, {
   Filters,
   FilterOperator,
 } from 'src/components/ListView';
+import Loading from 'src/components/Loading';
 import DeleteModal from 'src/components/DeleteModal';
 import ActionsBar, { ActionProps } from 'src/components/ListView/ActionsBar';
 import { Tooltip } from 'src/components/Tooltip';
@@ -117,6 +118,7 @@ function SavedQueryList({
   ] = useState<SavedQueryObject | null>(null);
   const [importingSavedQuery, showImportModal] = useState<boolean>(false);
   const [passwordFields, setPasswordFields] = useState<string[]>([]);
+  const [preparingExport, setPreparingExport] = useState<boolean>(false);
 
   const openSavedQueryImportModal = () => {
     showImportModal(true);
@@ -236,6 +238,16 @@ function SavedQueryList({
         addDangerToast(t('There was an issue deleting %s: %s', label, errMsg)),
       ),
     );
+  };
+
+  const handleBulkSavedQueryExport = (
+    savedQueriesToExport: SavedQueryObject[],
+  ) => {
+    const ids = savedQueriesToExport.map(({ id }) => id);
+    handleResourceExport('chart', ids, () => {
+      setPreparingExport(false);
+    });
+    setPreparingExport(true);
   };
 
   const handleBulkQueryDelete = (queriesToDelete: SavedQueryObject[]) => {
@@ -542,6 +554,7 @@ function SavedQueryList({
         passwordFields={passwordFields}
         setPasswordFields={setPasswordFields}
       />
+      {preparingExport && <Loading />}
     </>
   );
 }

--- a/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx
+++ b/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx
@@ -244,7 +244,7 @@ function SavedQueryList({
     savedQueriesToExport: SavedQueryObject[],
   ) => {
     const ids = savedQueriesToExport.map(({ id }) => id);
-    handleResourceExport('chart', ids, () => {
+    handleResourceExport('saved_query', ids, () => {
       setPreparingExport(false);
     });
     setPreparingExport(true);

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -219,32 +219,6 @@ export function handleChartDelete(
   );
 }
 
-export function handleBulkChartExport(chartsToExport: Chart[]) {
-  return window.location.assign(
-    `/api/v1/chart/export/?q=${rison.encode(
-      chartsToExport.map(({ id }) => id),
-    )}`,
-  );
-}
-
-export function handleBulkDashboardExport(dashboardsToExport: Dashboard[]) {
-  return window.location.assign(
-    `/api/v1/dashboard/export/?q=${rison.encode(
-      dashboardsToExport.map(({ id }) => id),
-    )}`,
-  );
-}
-
-export function handleBulkSavedQueryExport(
-  savedQueriesToExport: SavedQueryObject[],
-) {
-  return window.location.assign(
-    `/api/v1/saved_query/export/?q=${rison.encode(
-      savedQueriesToExport.map(({ id }) => id),
-    )}`,
-  );
-}
-
 export function handleDashboardDelete(
   { id, dashboard_title: dashboardTitle }: Dashboard,
   refreshData: (config?: FetchDataConfig | null) => void,

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -29,7 +29,7 @@ import rison from 'rison';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 import { FetchDataConfig } from 'src/components/ListView';
 import SupersetText from 'src/utils/textUtils';
-import { Dashboard, Filters, SavedQueryObject } from './types';
+import { Dashboard, Filters } from './types';
 
 const createFetchResourceMethod = (method: string) => (
   resource: string,

--- a/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
@@ -33,6 +33,7 @@ import PropertiesModal from 'src/explore/components/PropertiesModal';
 import { User } from 'src/types/bootstrapTypes';
 import ChartCard from 'src/views/CRUD/chart/ChartCard';
 import Chart from 'src/types/Chart';
+import handleResourceExport from 'src/utils/export';
 import Loading from 'src/components/Loading';
 import ErrorBoundary from 'src/components/ErrorBoundary';
 import SubMenu from 'src/components/Menu/SubMenu';
@@ -90,6 +91,7 @@ function ChartTable({
   } = useChartEditModal(setCharts, charts);
 
   const [chartFilter, setChartFilter] = useState('Mine');
+  const [preparingExport, setPreparingExport] = useState<boolean>(false);
 
   useEffect(() => {
     const filter = getFromLocalStorage('chart', null);
@@ -97,6 +99,14 @@ function ChartTable({
       setChartFilter('Mine');
     } else setChartFilter(filter.tab);
   }, []);
+
+  const handleBulkChartExport = (chartsToExport: Chart[]) => {
+    const ids = chartsToExport.map(({ id }) => id);
+    handleResourceExport('chart', ids, () => {
+      setPreparingExport(false);
+    });
+    setPreparingExport(true);
+  };
 
   const getFilters = (filterName: string) => {
     const filters = [];
@@ -208,12 +218,14 @@ function ChartTable({
               addSuccessToast={addSuccessToast}
               favoriteStatus={favoriteStatus[e.id]}
               saveFavoriteStatus={saveFavoriteStatus}
+              handleBulkChartExport={handleBulkChartExport}
             />
           ))}
         </CardContainer>
       ) : (
         <EmptyState tableName="CHARTS" tab={chartFilter} />
       )}
+      {preparingExport && <Loading />}
     </ErrorBoundary>
   );
 }

--- a/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
@@ -84,7 +84,7 @@ function DashboardTable({
 
   const handleBulkDashboardExport = (dashboardsToExport: Dashboard[]) => {
     const ids = dashboardsToExport.map(({ id }) => id);
-    handleResourceExport('chart', ids, () => {
+    handleResourceExport('dashboard', ids, () => {
       setPreparingExport(false);
     });
     setPreparingExport(true);

--- a/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
@@ -20,6 +20,7 @@ import React, { useState, useMemo, useEffect } from 'react';
 import { SupersetClient, t } from '@superset-ui/core';
 import { useListViewResource, useFavoriteStatus } from 'src/views/CRUD/hooks';
 import { Dashboard, DashboardTableProps } from 'src/views/CRUD/types';
+import handleResourceExport from 'src/utils/export';
 import { useHistory } from 'react-router-dom';
 import {
   setInLocalStorage,
@@ -72,6 +73,7 @@ function DashboardTable({
   );
   const [editModal, setEditModal] = useState<Dashboard>();
   const [dashboardFilter, setDashboardFilter] = useState('Mine');
+  const [preparingExport, setPreparingExport] = useState<boolean>(false);
 
   useEffect(() => {
     const filter = getFromLocalStorage('dashboard', null);
@@ -79,6 +81,14 @@ function DashboardTable({
       setDashboardFilter('Mine');
     } else setDashboardFilter(filter.tab);
   }, []);
+
+  const handleBulkDashboardExport = (dashboardsToExport: Dashboard[]) => {
+    const ids = dashboardsToExport.map(({ id }) => id);
+    handleResourceExport('chart', ids, () => {
+      setPreparingExport(false);
+    });
+    setPreparingExport(true);
+  };
 
   const handleDashboardEdit = (edits: Dashboard) =>
     SupersetClient.get({
@@ -221,6 +231,7 @@ function DashboardTable({
               }
               saveFavoriteStatus={saveFavoriteStatus}
               favoriteStatus={favoriteStatus[e.id]}
+              handleBulkDashboardExport={handleBulkDashboardExport}
             />
           ))}
         </CardContainer>
@@ -228,6 +239,7 @@ function DashboardTable({
       {dashboards.length === 0 && (
         <EmptyState tableName="DASHBOARDS" tab={dashboardFilter} />
       )}
+      {preparingExport && <Loading />}
     </>
   );
 }

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -903,6 +903,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
+        token = request.args.get("token")
         requested_ids = kwargs["rison"]
         timestamp = datetime.now().strftime("%Y%m%dT%H%M%S")
         root = f"chart_export_{timestamp}"
@@ -918,12 +919,15 @@ class ChartRestApi(BaseSupersetModelRestApi):
                 return self.response_404()
         buf.seek(0)
 
-        return send_file(
+        response = send_file(
             buf,
             mimetype="application/zip",
             as_attachment=True,
             attachment_filename=filename,
         )
+        if token:
+            response.set_cookie(token, "done", max_age=600)
+        return response
 
     @expose("/favorite_status/", methods=["GET"])
     @protect()

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -706,6 +706,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         requested_ids = kwargs["rison"]
 
         if is_feature_enabled("VERSIONED_EXPORT"):
+            token = request.args.get("token")
             timestamp = datetime.now().strftime("%Y%m%dT%H%M%S")
             root = f"dashboard_export_{timestamp}"
             filename = f"{root}.zip"
@@ -722,12 +723,15 @@ class DashboardRestApi(BaseSupersetModelRestApi):
                     return self.response_404()
             buf.seek(0)
 
-            return send_file(
+            response = send_file(
                 buf,
                 mimetype="application/zip",
                 as_attachment=True,
                 attachment_filename=filename,
             )
+            if token:
+                response.set_cookie(token, "done", max_age=600)
+            return response
 
         query = self.datamodel.session.query(Dashboard).filter(
             Dashboard.id.in_(requested_ids)

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -748,7 +748,8 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
                 attachment_filename=filename,
             )
         )
-        response.set_cookie(token, "done")
+        if token:
+            response.set_cookie(token, "done")
         return response
 
     @expose("/import/", methods=["POST"])

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -21,7 +21,7 @@ from io import BytesIO
 from typing import Any, Dict, List, Optional
 from zipfile import ZipFile
 
-from flask import g, make_response, request, Response, send_file
+from flask import g, request, Response, send_file
 from flask_appbuilder.api import expose, protect, rison, safe
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from marshmallow import ValidationError
@@ -740,16 +740,14 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
                 return self.response_404()
         buf.seek(0)
 
-        response = make_response(
-            send_file(
-                buf,
-                mimetype="application/zip",
-                as_attachment=True,
-                attachment_filename=filename,
-            )
+        response = send_file(
+            buf,
+            mimetype="application/zip",
+            as_attachment=True,
+            attachment_filename=filename,
         )
         if token:
-            response.set_cookie(token, "done")
+            response.set_cookie(token, "done", max_age=600)
         return response
 
     @expose("/import/", methods=["POST"])

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -432,6 +432,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         requested_ids = kwargs["rison"]
 
         if is_feature_enabled("VERSIONED_EXPORT"):
+            token = request.args.get("token")
             timestamp = datetime.now().strftime("%Y%m%dT%H%M%S")
             root = f"dataset_export_{timestamp}"
             filename = f"{root}.zip"
@@ -448,12 +449,15 @@ class DatasetRestApi(BaseSupersetModelRestApi):
                     return self.response_404()
             buf.seek(0)
 
-            return send_file(
+            response = send_file(
                 buf,
                 mimetype="application/zip",
                 as_attachment=True,
                 attachment_filename=filename,
             )
+            if token:
+                response.set_cookie(token, "done", max_age=600)
+            return response
 
         query = self.datamodel.session.query(SqlaTable).filter(
             SqlaTable.id.in_(requested_ids)

--- a/superset/queries/saved_queries/api.py
+++ b/superset/queries/saved_queries/api.py
@@ -237,6 +237,7 @@ class SavedQueryRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
+        token = request.args.get("token")
         requested_ids = kwargs["rison"]
         timestamp = datetime.now().strftime("%Y%m%dT%H%M%S")
         root = f"saved_query_export_{timestamp}"
@@ -254,12 +255,15 @@ class SavedQueryRestApi(BaseSupersetModelRestApi):
                 return self.response_404()
         buf.seek(0)
 
-        return send_file(
+        response = send_file(
             buf,
             mimetype="application/zip",
             as_attachment=True,
             attachment_filename=filename,
         )
+        if token:
+            response.set_cookie(token, "done", max_age=600)
+        return response
 
     @expose("/import/", methods=["POST"])
     @protect()


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Show a spinner while an export is being generated.

This is tricky because currently when the user clicks "export" we immediately redirect them to `/api/v1/database/export/?q=${rison.encode([database.id])}` using `window.assign`. So while we can set a spinner, we don't know when the download is generated to stop the spinner.

With this PR, in order to stop the spinner the frontend generates a short ID, which is passed to the backend with the export request. Once the export is ready, the backend will set a cookie with the short ID as name. The frontend is constantly polling for that cookie, and when it finds the cookie it hides the spinner.

One problem with this solution is that the GIF stops animating while the export is being generated, since the animation runs on the main thread. To keep the GIF animated the export code injects an iframe, and loads the export there. When the cookie indicating that the download is ready is found, the iframe is deleted.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before, no spinner.

After:


https://user-images.githubusercontent.com/1534870/121730924-2559f880-caa5-11eb-82b3-aa31c89d18d2.mov

Note: I added an artificial 5 seconds delay in generating the exports for the video, so the spinner can be seen.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Tested with all exports (see screencast). Also tested with the non-card view, though not shown in the video.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
