### PR TITLE
fix: add another wait for chart element

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -21,20 +21,22 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@superset-ui/core';
 
-import { exploreChart, exportChart } from '../../../explore/exploreUtils';
-import SliceHeader from '../SliceHeader';
-import ChartContainer from '../../../chart/ChartContainer';
-import MissingChart from '../MissingChart';
-import { slicePropShape, chartPropShape } from '../../util/propShapes';
+import { exploreChart, exportChart } from 'src/explore/exploreUtils';
+import ChartContainer from 'src/chart/ChartContainer';
 import {
   LOG_ACTIONS_CHANGE_DASHBOARD_FILTER,
   LOG_ACTIONS_EXPLORE_DASHBOARD_CHART,
   LOG_ACTIONS_EXPORT_CSV_DASHBOARD_CHART,
   LOG_ACTIONS_FORCE_REFRESH_CHART,
-} from '../../../logger/LogUtils';
+} from 'src/logger/LogUtils';
+import { areObjectsEqual } from 'src/reduxUtils';
+
+import SliceHeader from '../SliceHeader';
+import MissingChart from '../MissingChart';
+import { slicePropShape, chartPropShape } from '../../util/propShapes';
+
 import { isFilterBox } from '../../util/activeDashboardFilters';
 import getFilterValuesByFilterId from '../../util/getFilterValuesByFilterId';
-import { areObjectsEqual } from '../../../reduxUtils';
 
 const propTypes = {
   id: PropTypes.number.isRequired,

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -114,6 +114,12 @@ class WebDriverProxy:
             WebDriverWait(driver, self._screenshot_load_wait).until_not(
                 EC.presence_of_all_elements_located((By.CLASS_NAME, "loading"))
             )
+            logger.debug("Wait for chart to have content")
+            WebDriverWait(driver, self._screenshot_locate_wait).until(
+                EC.visibility_of_all_elements_located(
+                    (By.CLASS_NAME, "slice_container")
+                )
+            )
             logger.info("Taking a PNG screenshot or url %s", url)
             img = element.screenshot_as_png
         except TimeoutException:


### PR DESCRIPTION
### SUMMARY
Some dashboard reports were being generated with blank charts. Although we wait for the loading element to be removed from the page before taking the screenshot, there was still an instance where the chart was rendering nothing and hadn't yet been updated. I added another check to make sure that the "slice_container" had a value if it exists. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: 
<img width="1062" alt="_Report__FOO__USA_Births_Names_-_elizandwolf_gmail_com_-_Gmail" src="https://user-images.githubusercontent.com/5186919/121613292-00b44100-ca11-11eb-8032-5be3f1e59970.png">


After:
<img width="1043" alt="_Report__test_test__USA_Births_Names_-_elizandwolf_gmail_com_-_Gmail" src="https://user-images.githubusercontent.com/5186919/121613249-eed29e00-ca10-11eb-80e4-4edbd3bb308d.png">


### TESTING INSTRUCTIONS
I tested this on dashboard reports, but we should also thoroughly test on other report types. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
