### PR TITLE
fix: SQL Lab show "Refetch Results" button while fetching new query results

### DIFF
--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -519,21 +519,18 @@ export default function sqlLabReducer(state = {}, action) {
           }
           const prevState = state.queries[id].state;
           const currentState = changedQuery.state;
-          let updatedState = {
+          newQueries[id] = {
+            ...state.queries[id],
             ...changedQuery,
-          };
-          if (currentState === 'success') {
             // race condition:
-            // because of asyc behavior, sql lab may still poll a couple of seconds
+            // because of async behavior, sql lab may still poll a couple of seconds
             // when it started fetching or finished rendering results
-            if (['fetching', 'success'].includes(prevState)) {
-              updatedState = {
-                ...updatedState,
-                state: prevState,
-              };
-            }
-          }
-          newQueries[id] = { ...state.queries[id], ...updatedState };
+            state:
+              currentState === 'success' &&
+              ['fetching', 'success'].includes(prevState)
+                ? prevState
+                : currentState,
+          };
           change = true;
         }
       });

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -517,7 +517,23 @@ export default function sqlLabReducer(state = {}, action) {
           if (changedQuery.changedOn > queriesLastUpdate) {
             queriesLastUpdate = changedQuery.changedOn;
           }
-          newQueries[id] = { ...state.queries[id], ...changedQuery };
+          const prevState = state.queries[id].state;
+          const currentState = changedQuery.state;
+          let updatedState = {
+            ...changedQuery,
+          };
+          if (currentState === 'success') {
+            // race condition:
+            // because of asyc behavior, sql lab may still poll a couple of seconds
+            // when it started fetching or finished rendering results
+            if (['fetching', 'success'].includes(prevState)) {
+              updatedState = {
+                ...updatedState,
+                state: prevState,
+              };
+            }
+          }
+          newQueries[id] = { ...state.queries[id], ...updatedState };
           change = true;
         }
       });


### PR DESCRIPTION
### SUMMARY
when user run a query in SQL Lab, after query is done from engine, and then results are fetched into browser, SQL Lab should show results table. But when the results data is big, it may take a few seconds download. Many users saw the "Refetch results" button show up after query is succeed. Here is a screenshot:
I run a simple query against Presto engine:
```
select * from superset_production_logs_v01
where ds > '2019-01-01'
```
Because it has a lot of data, it takes long time to download results. SQL Lab shows  "Refetch results" for a few seconds, then after results are fetched, it shows results table.

![68gFOulZiO-1](https://user-images.githubusercontent.com/27990562/121631742-839ac300-ca34-11eb-95b7-bb94883d5713.gif)

This "Refetch Results" button is very confusing. Many users will just click the button, which cause SQL Lab even longer time to fetch results.

The root cause is pretty simple: race condition. SQL Lab polling query status every second, and once resultKey is returned, it will start another request to fetch result. Sometimes the fetching request sends out **_before_** the last poll request returned. So the last poll response reset query state from `fetching` to `success`, and this will trigger "Refetch Results" button. After fetch response returned, this strange state will be reset to correct state, results table will show up.

This PR is trying to fix this race condition. Currently SQL Lab's query states are bad designed. It seems we are re-use same "success" state twice:
`pending -> running -> success -> fetching -> success`
there are a lot of logic depends on the current states. If i introduce another state to replace the final "success", it will cause many trouble :( So my fix here is hacky but simple: if query is in "fetching" state, polling should not change its state back to "success". 

### TESTING INSTRUCTIONS
CI and manual test.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
