### PR TITLE
fix(native-filters): handle descending sorting correctly

### DIFF
--- a/superset-frontend/src/filters/components/Select/buildQuery.test.ts
+++ b/superset-frontend/src/filters/components/Select/buildQuery.test.ts
@@ -25,7 +25,7 @@ describe('Select buildQuery', () => {
     datasource: '5__table',
     groupby: ['my_col'],
     viz_type: 'filter_select',
-    sortAscending: false,
+    sortAscending: undefined,
     sortMetric: undefined,
     filters: undefined,
     enableEmptyFilter: false,
@@ -47,7 +47,7 @@ describe('Select buildQuery', () => {
     expect(query.orderby).toEqual([]);
   });
 
-  it('should handle sort metric correctly', () => {
+  it('should sort descending by metric', () => {
     const queryContext = buildQuery({
       ...formData,
       sortMetric: 'my_metric',
@@ -58,6 +58,43 @@ describe('Select buildQuery', () => {
     expect(query.groupby).toEqual(['my_col']);
     expect(query.metrics).toEqual(['my_metric']);
     expect(query.orderby).toEqual([['my_metric', false]]);
+  });
+
+  it('should sort ascending by metric', () => {
+    const queryContext = buildQuery({
+      ...formData,
+      sortMetric: 'my_metric',
+      sortAscending: true,
+    });
+    expect(queryContext.queries.length).toEqual(1);
+    const [query] = queryContext.queries;
+    expect(query.groupby).toEqual(['my_col']);
+    expect(query.metrics).toEqual(['my_metric']);
+    expect(query.orderby).toEqual([['my_metric', true]]);
+  });
+
+  it('should sort ascending by column', () => {
+    const queryContext = buildQuery({
+      ...formData,
+      sortAscending: true,
+    });
+    expect(queryContext.queries.length).toEqual(1);
+    const [query] = queryContext.queries;
+    expect(query.groupby).toEqual(['my_col']);
+    expect(query.metrics).toEqual([]);
+    expect(query.orderby).toEqual([['my_col', true]]);
+  });
+
+  it('should sort descending by column', () => {
+    const queryContext = buildQuery({
+      ...formData,
+      sortAscending: false,
+    });
+    expect(queryContext.queries.length).toEqual(1);
+    const [query] = queryContext.queries;
+    expect(query.groupby).toEqual(['my_col']);
+    expect(query.metrics).toEqual([]);
+    expect(query.orderby).toEqual([['my_col', false]]);
   });
 
   it('should add text search parameter to query filter', () => {

--- a/superset-frontend/src/filters/components/Select/buildQuery.ts
+++ b/superset-frontend/src/filters/components/Select/buildQuery.ts
@@ -65,8 +65,8 @@ const buildQuery: BuildQuery<PluginFilterSelectQueryFormData> = (
         metrics: sortMetric ? [sortMetric] : [],
         filters: filters.concat(extra_filters),
         orderby:
-          sortMetric || sortAscending
-            ? sortColumns.map(column => [column, sortAscending])
+          sortMetric || sortAscending !== undefined
+            ? sortColumns.map(column => [column, !!sortAscending])
             : [],
       },
     ];

--- a/superset-frontend/src/filters/components/Select/types.ts
+++ b/superset-frontend/src/filters/components/Select/types.ts
@@ -39,7 +39,7 @@ interface PluginFilterSelectCustomizeProps {
   defaultToFirstItem: boolean;
   inputRef?: RefObject<HTMLInputElement>;
   searchAllOptions: boolean;
-  sortAscending: boolean;
+  sortAscending?: boolean;
   sortMetric?: string;
 }
 


### PR DESCRIPTION
### SUMMARY
Add support for descending sorting to Value Filter.

### BEFORE
Setting the sort order to descending didn't affect the sort order:
![image](https://user-images.githubusercontent.com/33317356/121641608-0ef97000-ca98-11eb-8104-902296f975c1.png)

### AFTER
Now the data is correctly sorted in descending order:
![image](https://user-images.githubusercontent.com/33317356/121641951-85966d80-ca98-11eb-9501-61d7e3a7ee5e.png)

### TESTING INSTRUCTIONS
CI + new tests

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #15043
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
