### PR TITLE
feat(native-filters): add optional time col to time range

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.tsx
@@ -18,7 +18,7 @@
  */
 import React, { useCallback, useState } from 'react';
 import { FormInstance } from 'antd/lib/form';
-import { SupersetClient, t } from '@superset-ui/core';
+import { Column, SupersetClient, t } from '@superset-ui/core';
 import { useChangeEffect } from 'src/common/hooks/useChangeEffect';
 import { Select } from 'src/common/components';
 import { useToasts } from 'src/messageToasts/enhancers/withToasts';
@@ -27,7 +27,10 @@ import { cacheWrapper } from 'src/utils/cacheWrapper';
 import { NativeFiltersForm } from '../types';
 
 interface ColumnSelectProps {
+  allowClear?: boolean;
+  filterValues?: (column: Column) => boolean;
   form: FormInstance<NativeFiltersForm>;
+  formField?: string;
   filterId: string;
   datasetId?: number;
   value?: string;
@@ -45,7 +48,10 @@ const cachedSupersetGet = cacheWrapper(
 /** Special purpose AsyncSelect that selects a column from a dataset */
 // eslint-disable-next-line import/prefer-default-export
 export function ColumnSelect({
+  allowClear = false,
+  filterValues = () => true,
   form,
+  formField = 'column',
   filterId,
   datasetId,
   value,
@@ -55,7 +61,7 @@ export function ColumnSelect({
   const { addDangerToast } = useToasts();
   const resetColumnField = useCallback(() => {
     form.setFields([
-      { name: ['filters', filterId, 'column'], touched: false, value: null },
+      { name: ['filters', filterId, formField], touched: false, value: null },
     ]);
   }, [form, filterId]);
 
@@ -69,6 +75,7 @@ export function ColumnSelect({
       }).then(
         ({ json: { result } }) => {
           const columns = result.columns
+            .filter(filterValues)
             .map((col: any) => col.column_name)
             .sort((a: string, b: string) => a.localeCompare(b));
           if (!columns.includes(value)) {
@@ -97,6 +104,7 @@ export function ColumnSelect({
       options={options}
       placeholder={t('Select a column')}
       showSearch
+      allowClear={allowClear}
     />
   );
 }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/types.ts
@@ -44,6 +44,7 @@ export interface NativeFiltersFormItem {
   isInstant: boolean;
   adhoc_filters?: AdhocFilter[];
   time_range?: string;
+  granularity_sqla?: string;
 }
 
 export interface NativeFiltersForm {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/utils.ts
@@ -140,6 +140,7 @@ export const createHandleSave = (
         adhoc_filters: formInputs.adhoc_filters,
         time_range: formInputs.time_range,
         controlValues: formInputs.controlValues ?? {},
+        granularity_sqla: formInputs.granularity_sqla,
         requiredFirst: Object.values(formInputs.requiredFirst ?? {}).find(
           rf => rf,
         ),

--- a/superset-frontend/src/dashboard/components/nativeFilters/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/types.ts
@@ -55,6 +55,7 @@ export interface Filter {
   };
   sortMetric?: string | null;
   adhoc_filters?: AdhocFilter[];
+  granularity_sqla?: string;
   time_range?: string;
   requiredFirst?: boolean;
   tabsInScope?: string[];

--- a/superset-frontend/src/dashboard/components/nativeFilters/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/utils.ts
@@ -46,6 +46,7 @@ export const getFormData = ({
   sortMetric,
   adhoc_filters,
   time_range,
+  granularity_sqla,
 }: Partial<Filter> & {
   datasetId?: number;
   inputRef?: RefObject<HTMLInputElement>;
@@ -74,7 +75,7 @@ export const getFormData = ({
     adhoc_filters: adhoc_filters ?? [],
     extra_filters: [],
     extra_form_data: cascadingFilters,
-    granularity_sqla: 'ds',
+    granularity_sqla,
     metrics: ['count'],
     row_limit: 1000,
     showSearch: true,


### PR DESCRIPTION
### SUMMARY
Adds an optional time column option to the filter config modal to achieve full feature parity with Filter Box.

### BEFORE
Currently time ranges can only be applied to the default time column:
![image](https://user-images.githubusercontent.com/33317356/121689603-75e54c00-cacd-11eb-802f-d60ffba41bb5.png)

### AFTER
When no time range is specified, the time column control is hidden:
![image](https://user-images.githubusercontent.com/33317356/121689193-ffe0e500-cacc-11eb-929c-23394ca61b79.png)

When a time range is specified, the optional time column control is exposed (when left unpopulated, the default time column is used):
![image](https://user-images.githubusercontent.com/33317356/121689379-3585ce00-cacd-11eb-97e9-880474f3d590.png)

In addition, the sort metric is moved to a row of it's own, and a tooltip is added to the control:
![image](https://user-images.githubusercontent.com/33317356/121689459-4b938e80-cacd-11eb-9e90-01195e2fa917.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #14744
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
