### PR TITLE
feat(native-filters): Defer loading filters data until filter is visible

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CascadeFilters/CascadePopover/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CascadeFilters/CascadePopover/index.tsx
@@ -32,6 +32,7 @@ interface CascadePopoverProps {
   filter: CascadeFilter;
   visible: boolean;
   directPathToChild?: string[];
+  inView?: boolean;
   onVisibleChange: (visible: boolean) => void;
   onFilterSelectionChange: (filter: Filter, dataMask: DataMask) => void;
 }
@@ -80,6 +81,7 @@ const CascadePopover: React.FC<CascadePopoverProps> = ({
   onVisibleChange,
   onFilterSelectionChange,
   directPathToChild,
+  inView,
 }) => {
   const [currentPathToChild, setCurrentPathToChild] = useState<string[]>();
   const dataMask = dataMaskSelected[filter.id];
@@ -148,6 +150,7 @@ const CascadePopover: React.FC<CascadePopoverProps> = ({
         filter={filter}
         directPathToChild={directPathToChild}
         onFilterSelectionChange={onFilterSelectionChange}
+        inView={inView}
       />
     );
   }
@@ -192,6 +195,7 @@ const CascadePopover: React.FC<CascadePopoverProps> = ({
             filter={activeFilter}
             onFilterSelectionChange={onFilterSelectionChange}
             directPathToChild={currentPathToChild}
+            inView={inView}
             icon={
               <>
                 {filter.cascadeChildren.length !== 0 && (

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
@@ -47,6 +47,7 @@ const FilterControl: React.FC<FilterProps> = ({
   icon,
   onFilterSelectionChange,
   directPathToChild,
+  inView,
 }) => {
   const { name = '<undefined>' } = filter;
   return (
@@ -62,6 +63,7 @@ const FilterControl: React.FC<FilterProps> = ({
         filter={filter}
         directPathToChild={directPathToChild}
         onFilterSelectionChange={onFilterSelectionChange}
+        inView={inView}
       />
     </StyledFilterControlContainer>
   );

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -89,12 +89,13 @@ const FilterControls: FC<FilterControlsProps> = ({
               filter={cascadeFilters[index]}
               onFilterSelectionChange={onFilterSelectionChange}
               directPathToChild={directPathToChild}
+              inView={false}
             />
           </portals.InPortal>
         ))}
       {filtersInScope.map(filter => {
         const index = filterValues.findIndex(f => f.id === filter.id);
-        return <portals.OutPortal node={portalNodes[index]} />;
+        return <portals.OutPortal node={portalNodes[index]} inView />;
       })}
       {showCollapsePanel && (
         <Collapse
@@ -132,7 +133,7 @@ const FilterControls: FC<FilterControlsProps> = ({
           >
             {filtersOutOfScope.map(filter => {
               const index = cascadeFilters.findIndex(f => f.id === filter.id);
-              return <portals.OutPortal node={portalNodes[index]} />;
+              return <portals.OutPortal node={portalNodes[index]} inView />;
             })}
           </Collapse.Panel>
         </Collapse>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
@@ -57,6 +57,7 @@ const FilterValue: React.FC<FilterProps> = ({
   filter,
   directPathToChild,
   onFilterSelectionChange,
+  inView = true,
 }) => {
   const { id, targets, filterType, adhoc_filters, time_range } = filter;
   const metadata = getChartMetadataRegistry().get(filterType);
@@ -65,6 +66,7 @@ const FilterValue: React.FC<FilterProps> = ({
   const [error, setError] = useState<string>('');
   const [formData, setFormData] = useState<Partial<QueryFormData>>({});
   const [ownState, setOwnState] = useState<JsonObject>({});
+  const [inViewFirstTime, setInViewFirstTime] = useState(inView);
   const inputRef = useRef<HTMLInputElement>(null);
   const [target] = targets;
   const {
@@ -76,7 +78,17 @@ const FilterValue: React.FC<FilterProps> = ({
   const [isLoading, setIsLoading] = useState<boolean>(hasDataSource);
   const [isRefreshing, setIsRefreshing] = useState<boolean>(true);
   const dispatch = useDispatch();
+
   useEffect(() => {
+    if (!inViewFirstTime && inView) {
+      setInViewFirstTime(true);
+    }
+  }, [inView, inViewFirstTime, setInViewFirstTime]);
+
+  useEffect(() => {
+    if (!inViewFirstTime) {
+      return;
+    }
     const newFormData = getFormData({
       ...filter,
       datasetId,
@@ -134,6 +146,7 @@ const FilterValue: React.FC<FilterProps> = ({
         });
     }
   }, [
+    inViewFirstTime,
     cascadingFilters,
     datasetId,
     groupby,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/types.ts
@@ -29,4 +29,5 @@ export interface FilterProps {
   icon?: React.ReactElement;
   directPathToChild?: string[];
   onFilterSelectionChange: (filter: Filter, dataMask: DataMask) => void;
+  inView?: boolean;
 }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -178,7 +178,10 @@ const FilterBar: React.FC<FiltersBarProps> = ({
   useEffect(() => {
     setDataMaskSelected(draft => {
       Object.values(filters).forEach(filter => {
-        if (filter.filterType !== previousFilters?.[filter.id]?.filterType) {
+        if (
+          filter.filterType !== previousFilters?.[filter.id]?.filterType &&
+          previousFilters?.[filter.id]?.filterType !== undefined
+        ) {
           draft[filter.id] = getInitialDataMask(filter.id) as DataMaskWithId;
         }
       });


### PR DESCRIPTION
### SUMMARY
This PR introduces an optimization in running queries for native filters data. Currently when user opens a dashboard, we run queries for every native filter, regardless if it's hidden in the "Filters out of scope" panel or not. This PR defers running filter queries until the filter is visible.
There are 2 scenarios:
1. Initially we run queries only for the filters in scope. When user uncollapses "Filters out of scope" panel, we run queries for all the filters that haven't been loaded yet.
2. Initially we run queries only for the filters in scope. When user switches a tab, causing more filters to be in scope, we run queries only for the filters which have just become visible.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Please notice how many `data` requests there are in Network panel

Before:
https://user-images.githubusercontent.com/15073128/121710250-b64ac700-cad9-11eb-9ed0-df768225989f.mov

After:
Scenario 1:
https://user-images.githubusercontent.com/15073128/121710332-ccf11e00-cad9-11eb-80f2-7bf6f4bb0dbe.mov

Scenario 2:
https://user-images.githubusercontent.com/15073128/121710470-f01bcd80-cad9-11eb-8b8f-1104b18fc611.mov

### TESTING INSTRUCTIONS
0. Set `DASHBOARD_NATIVE_FILTERS` feature flag to True
1. Create a dashboard with tabs
2. Add a few native filters, so that some are initially in scope and some out of scope.
3. Verify that we run queries only for filters in scope, until you open "Filters out of scope" panel or navigate to a tab that has charts in scope of other filters.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc @villebro 