### PR TITLE
fix(dashboard): charts in nested tab is missing control and filter indicator

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -156,7 +156,11 @@ class Tabs extends React.PureComponent {
       const lastTabId = nextTabsIds[nextTabsIds.length - 1];
       // if a new tab is added focus on it immediately
       if (nextTabsIds.length > currTabsIds.length) {
-        this.setState(() => ({ activeKey: lastTabId }));
+        // a new tab's path may be empty, here also need to set tabIndex
+        this.setState(() => ({
+          activeKey: lastTabId,
+          tabIndex: maxIndex,
+        }));
       }
       // if a tab is removed focus on the first
       if (nextTabsIds.length < currTabsIds.length) {
@@ -200,7 +204,7 @@ class Tabs extends React.PureComponent {
       onOk: () => {
         deleteComponent(key, component.id);
         const tabIndex = component.children.indexOf(key);
-        this.handleClickTab(Math.max(0, tabIndex - 1));
+        this.handleDeleteTab(tabIndex);
       },
       okType: 'danger',
       okText: 'DELETE',


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes the charts in nested tab is missing control and filter indicator.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### before

https://user-images.githubusercontent.com/11830681/121783107-7110bd00-cbdf-11eb-926c-24d2822b77e1.mov


#### after

https://user-images.githubusercontent.com/11830681/121783139-9dc4d480-cbdf-11eb-8ee8-14342ce78e61.mov




### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #14801 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
