### PR TITLE
feat(explore): support useSafeState and avoid toast rerendering

### DIFF
--- a/superset-frontend/src/common/hooks/useSafeState/index.ts
+++ b/superset-frontend/src/common/hooks/useSafeState/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from './useSafeState';

--- a/superset-frontend/src/common/hooks/useSafeState/useSafeState.test.ts
+++ b/superset-frontend/src/common/hooks/useSafeState/useSafeState.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useSafeState } from './useSafeState';
+
+test('render with initialValue', () => {
+  const hook = renderHook(() => {
+    const [state, setState] = useSafeState('initial');
+    return {
+      state,
+      setState,
+    };
+  });
+  expect(hook.result.current.state).toBe('initial');
+});
+
+test('should update with setState', () => {
+  const hook = renderHook(() => {
+    const [state, setState] = useSafeState(0);
+    return {
+      state,
+      setState,
+    };
+  });
+  act(() => {
+    hook.result.current.setState(1);
+  });
+  expect(hook.result.current.state).toBe(1);
+});
+
+test('should not update when unmounted', () => {
+  const hook = renderHook(() => {
+    const [state, setState] = useSafeState(0);
+    return {
+      state,
+      setState,
+    };
+  });
+  hook.unmount();
+  act(() => {
+    hook.result.current.setState(1);
+  });
+  expect(hook.result.current.state).toBe(0);
+});

--- a/superset-frontend/src/common/hooks/useSafeState/useSafeState.ts
+++ b/superset-frontend/src/common/hooks/useSafeState/useSafeState.ts
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+export function useSafeState<T>(
+  initialState: T | (() => T),
+): [T, Dispatch<SetStateAction<T>>];
+export function useSafeState<T = undefined>(): [
+  T | undefined,
+  Dispatch<SetStateAction<T | undefined>>,
+];
+export function useSafeState(initialState?: any) {
+  const unmountedRef = useUnmountedRef();
+  const [state, setState] = useState(initialState);
+  const setCurrentState = useCallback(currentState => {
+    if (unmountedRef.current) return;
+    setState(currentState);
+  }, []);
+
+  return [state, setCurrentState];
+}
+
+function useUnmountedRef() {
+  const unmountedRef = useRef(false);
+  useEffect(
+    () => () => {
+      unmountedRef.current = true;
+    },
+    [],
+  );
+  return unmountedRef;
+}

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -232,7 +232,7 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
         )}
         {editMode && <BuilderComponentPane topOffset={barTopOffset} />}
       </StyledDashboardContent>
-      <ToastPresenter />
+      {/* <ToastPresenter /> */}
     </StickyContainer>
   );
 };

--- a/superset-frontend/src/messageToasts/components/Toast.tsx
+++ b/superset-frontend/src/messageToasts/components/Toast.tsx
@@ -20,6 +20,7 @@ import { styled } from '@superset-ui/core';
 import cx from 'classnames';
 import Interweave from 'interweave';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useSafeState } from 'src/common/hooks/useSafeState';
 import Icon, { IconName } from 'src/components/Icon';
 import { ToastType } from 'src/messageToasts/constants';
 import { ToastMeta } from '../types';
@@ -45,7 +46,7 @@ interface ToastPresenterProps {
 
 export default function Toast({ toast, onCloseToast }: ToastPresenterProps) {
   const hideTimer = useRef<ReturnType<typeof setTimeout>>();
-  const [visible, setVisible] = useState(false);
+  const [visible, setVisible] = useSafeState(false);
   const showToast = () => {
     setVisible(true);
   };


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds `useSafeState` hook which is the same as `useState`. The big difference is that setState will not be executed after the component is unmounted.It can avoid memory leaks or multiple renderings.
It is also to fix the explore toast that will render twice when going to the dashboard.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### before

https://user-images.githubusercontent.com/11830681/121802769-c3e68500-cc70-11eb-90ad-f3d28910a700.mov


#### after

https://user-images.githubusercontent.com/11830681/121802776-c9dc6600-cc70-11eb-9057-d9b73ca41a9e.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #15099 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
