### PR TITLE
fix(dashboard): avoid duplicated toast component

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -26,7 +26,6 @@ import DashboardHeader from 'src/dashboard/containers/DashboardHeader';
 import IconButton from 'src/dashboard/components/IconButton';
 import DragDroppable from 'src/dashboard/components/dnd/DragDroppable';
 import DashboardComponent from 'src/dashboard/containers/DashboardComponent';
-import ToastPresenter from 'src/messageToasts/containers/ToastPresenter';
 import WithPopoverMenu from 'src/dashboard/components/menu/WithPopoverMenu';
 import getDirectPathToTabIndex from 'src/dashboard/util/getDirectPathToTabIndex';
 import { URL_PARAMS } from 'src/constants';
@@ -284,7 +283,6 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
           </StyledDashboardContent>
         </div>
       </StyledContent>
-      <ToastPresenter />
     </StyledDiv>
   );
 };


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes the explore toast that will render twice when going to the dashboard. Essentially, toast has two identical components in the dashboard, it will be rendered twice.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### before

https://user-images.githubusercontent.com/11830681/121802769-c3e68500-cc70-11eb-90ad-f3d28910a700.mov

components:
![image](https://user-images.githubusercontent.com/11830681/121804274-1ecfaa80-cc78-11eb-8ffb-c00211eade9e.png)
#### after

https://user-images.githubusercontent.com/11830681/121802776-c9dc6600-cc70-11eb-9057-d9b73ca41a9e.mov

components:
![image](https://user-images.githubusercontent.com/11830681/121804313-50487600-cc78-11eb-816a-80370573c31a.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #15099 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
