### PR TITLE
fix: improve dashboard fullscreen text

### DIFF
--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
@@ -112,7 +112,7 @@ test('should render the menu items', async () => {
   expect(screen.getByText('Refresh dashboard')).toBeInTheDocument();
   expect(screen.getByText('Set auto-refresh interval')).toBeInTheDocument();
   expect(screen.getByText('Download as image')).toBeInTheDocument();
-  expect(screen.getByText('Toggle fullscreen')).toBeInTheDocument();
+  expect(screen.getByText('Enter fullscreen')).toBeInTheDocument();
 });
 
 test('should render the menu items in edit mode', async () => {

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
@@ -307,7 +307,9 @@ class HeaderActionsDropdown extends React.PureComponent {
 
         {!editMode && (
           <Menu.Item key={MENU_KEYS.TOGGLE_FULLSCREEN}>
-            {getUrlParam(URL_PARAMS.standalone)? t('Exit fullscreen') : t('Enter fullscreen')}
+            {getUrlParam(URL_PARAMS.standalone)
+              ? t('Exit fullscreen')
+              : t('Enter fullscreen')}
           </Menu.Item>
         )}
       </Menu>

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
@@ -307,7 +307,7 @@ class HeaderActionsDropdown extends React.PureComponent {
 
         {!editMode && (
           <Menu.Item key={MENU_KEYS.TOGGLE_FULLSCREEN}>
-            {t('Toggle fullscreen')}
+            {getUrlParam(URL_PARAMS.standalone)? t('Exit fullscreen') : t('Enter fullscreen')}
           </Menu.Item>
         )}
       </Menu>


### PR DESCRIPTION
### SUMMARY
Semantic name from `toggle fullscreen` to `Enter fullscreen` and `Exit fullscreen`.

### BEFORE/AFTER ANIMATED GIF
**before**
![toggle fullscreen2](https://user-images.githubusercontent.com/10264972/121808905-44b37a00-cc8d-11eb-844a-ab7777d54537.gif)

**after**
![toggle fullscreen](https://user-images.githubusercontent.com/10264972/121808837-f69e7680-cc8c-11eb-9ddf-73f6f62afb0e.gif)


### TESTING INSTRUCTIONS
* Go to dashboard 3 dot menu, click `Enter fullscreen`
* After dashboard become fullscreen, click on 3 dot menu again
* Observe the last option `Exit fullscreen` to toggle back to normal screen

### ADDITIONAL INFORMATION
issue: https://github.com/apache/superset/issues/15110
