### PR TITLE
fix(native-filters): Don't send unnecessary PUT request on dashboard render

### DIFF
--- a/superset-frontend/src/dashboard/actions/nativeFilters.ts
+++ b/superset-frontend/src/dashboard/actions/nativeFilters.ts
@@ -49,6 +49,11 @@ export interface SetFilterConfigFail {
   type: typeof SET_FILTER_CONFIG_FAIL;
   filterConfig: FilterConfiguration;
 }
+export const SET_FILTER_SCOPES = 'SET_FILTER_SCOPES';
+export interface SetFilterScopes {
+  type: typeof SET_FILTER_SCOPES;
+  filterConfig: FilterConfiguration;
+}
 export const SET_FILTER_SETS_CONFIG_BEGIN = 'SET_FILTER_SETS_CONFIG_BEGIN';
 export interface SetFilterSetsConfigBegin {
   type: typeof SET_FILTER_SETS_CONFIG_BEGIN;
@@ -122,6 +127,25 @@ export const setFilterConfiguration = (
       filterConfig: mergedFilterConfig,
     });
   }
+};
+
+export const setFilterScopes = (
+  filterScopes: {
+    filterId: string;
+    chartsInScope: number[];
+    tabsInScope: string[];
+  }[],
+) => async (dispatch: Dispatch, getState: () => any) => {
+  const filters = getState().nativeFilters?.filters;
+  const filtersWithScopes = filterScopes.map(scope => ({
+    ...filters[scope.filterId],
+    chartsInScope: scope.chartsInScope,
+    tabsInScope: scope.tabsInScope,
+  }));
+  dispatch({
+    type: SET_FILTER_SCOPES,
+    filterConfig: filtersWithScopes,
+  });
 };
 
 type BootstrapData = {
@@ -227,6 +251,7 @@ export type AnyFilterAction =
   | SetFilterSetsConfigBegin
   | SetFilterSetsConfigComplete
   | SetFilterSetsConfigFail
+  | SetFilterScopes
   | SaveFilterSets
   | SetBootstrapData
   | SetFocusedNativeFilter

--- a/superset-frontend/src/dashboard/actions/nativeFilters.ts
+++ b/superset-frontend/src/dashboard/actions/nativeFilters.ts
@@ -49,9 +49,9 @@ export interface SetFilterConfigFail {
   type: typeof SET_FILTER_CONFIG_FAIL;
   filterConfig: FilterConfiguration;
 }
-export const SET_FILTER_SCOPES = 'SET_FILTER_SCOPES';
-export interface SetFilterScopes {
-  type: typeof SET_FILTER_SCOPES;
+export const SET_IN_SCOPE_STATUS_OF_FILTERS = 'SET_IN_SCOPE_STATUS_OF_FILTERS';
+export interface SetInScopeStatusOfFilters {
+  type: typeof SET_IN_SCOPE_STATUS_OF_FILTERS;
   filterConfig: FilterConfiguration;
 }
 export const SET_FILTER_SETS_CONFIG_BEGIN = 'SET_FILTER_SETS_CONFIG_BEGIN';
@@ -129,7 +129,7 @@ export const setFilterConfiguration = (
   }
 };
 
-export const setFilterScopes = (
+export const setInScopeStatusOfFilters = (
   filterScopes: {
     filterId: string;
     chartsInScope: number[];
@@ -143,7 +143,7 @@ export const setFilterScopes = (
     tabsInScope: scope.tabsInScope,
   }));
   dispatch({
-    type: SET_FILTER_SCOPES,
+    type: SET_IN_SCOPE_STATUS_OF_FILTERS,
     filterConfig: filtersWithScopes,
   });
 };
@@ -251,7 +251,7 @@ export type AnyFilterAction =
   | SetFilterSetsConfigBegin
   | SetFilterSetsConfigComplete
   | SetFilterSetsConfigFail
-  | SetFilterScopes
+  | SetInScopeStatusOfFilters
   | SaveFilterSets
   | SetBootstrapData
   | SetFocusedNativeFilter

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
@@ -18,10 +18,11 @@
  */
 // ParentSize uses resize observer so the dashboard will update size
 // when its container size changes, due to e.g., builder side panel opening
-import { ParentSize } from '@vx/responsive';
-import Tabs from 'src/components/Tabs';
 import React, { FC, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { FeatureFlag, isFeatureEnabled } from '@superset-ui/core';
+import { ParentSize } from '@vx/responsive';
+import Tabs from 'src/components/Tabs';
 import DashboardGrid from 'src/dashboard/containers/DashboardGrid';
 import getLeafComponentIdFromPath from 'src/dashboard/util/getLeafComponentIdFromPath';
 import { DashboardLayout, LayoutItem, RootState } from 'src/dashboard/types';
@@ -43,9 +44,9 @@ const DashboardContainer: FC<DashboardContainerProps> = ({ topLevelTabs }) => {
   const dashboardLayout = useSelector<RootState, DashboardLayout>(
     state => state.dashboardLayout.present,
   );
-  const nativeFilters = useSelector<RootState, Filters>(
-    state => state.nativeFilters.filters,
-  );
+  const nativeFilters =
+    useSelector<RootState, Filters>(state => state.nativeFilters?.filters) ??
+    {};
   const directPathToChild = useSelector<RootState, string[]>(
     state => state.dashboardState.directPathToChild,
   );
@@ -63,6 +64,9 @@ const DashboardContainer: FC<DashboardContainerProps> = ({ topLevelTabs }) => {
   const nativeFiltersValues = Object.values(nativeFilters);
   const scopes = nativeFiltersValues.map(filter => filter.scope);
   useEffect(() => {
+    if (!isFeatureEnabled(FeatureFlag.DASHBOARD_NATIVE_FILTERS)) {
+      return;
+    }
     const filterScopes = nativeFiltersValues.map(filter => {
       const filterScope = filter.scope;
       const chartsInScope: number[] = getChartIdsInFilterScope({

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
@@ -64,7 +64,7 @@ const DashboardContainer: FC<DashboardContainerProps> = ({ topLevelTabs }) => {
   const nativeFiltersValues = Object.values(nativeFilters);
   const scopes = nativeFiltersValues.map(filter => filter.scope);
   useEffect(() => {
-    if (!isFeatureEnabled(FeatureFlag.DASHBOARD_NATIVE_FILTERS)) {
+    if (!isFeatureEnabled(FeatureFlag.DASHBOARD_NATIVE_FILTERS) || nativeFiltersValues.length === 0) {
       return;
     }
     const filterScopes = nativeFiltersValues.map(filter => {

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
@@ -34,7 +34,7 @@ import { getRootLevelTabIndex } from './utils';
 import { Filters } from '../../reducers/types';
 import { getChartIdsInFilterScope } from '../../util/activeDashboardFilters';
 import { findTabsWithChartsInScope } from '../nativeFilters/utils';
-import { setFilterScopes } from '../../actions/nativeFilters';
+import { setInScopeStatusOfFilters } from '../../actions/nativeFilters';
 
 type DashboardContainerProps = {
   topLevelTabs?: LayoutItem;
@@ -86,7 +86,7 @@ const DashboardContainer: FC<DashboardContainerProps> = ({ topLevelTabs }) => {
         chartsInScope,
       };
     });
-    dispatch(setFilterScopes(filterScopes));
+    dispatch(setInScopeStatusOfFilters(filterScopes));
   }, [JSON.stringify(scopes), JSON.stringify(dashboardLayout)]);
 
   const childIds: string[] = topLevelTabs

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
@@ -33,7 +33,7 @@ import { getRootLevelTabIndex } from './utils';
 import { Filters } from '../../reducers/types';
 import { getChartIdsInFilterScope } from '../../util/activeDashboardFilters';
 import { findTabsWithChartsInScope } from '../nativeFilters/utils';
-import { setFilterConfiguration } from '../../actions/nativeFilters';
+import { setFilterScopes } from '../../actions/nativeFilters';
 
 type DashboardContainerProps = {
   topLevelTabs?: LayoutItem;
@@ -63,9 +63,9 @@ const DashboardContainer: FC<DashboardContainerProps> = ({ topLevelTabs }) => {
   const nativeFiltersValues = Object.values(nativeFilters);
   const scopes = nativeFiltersValues.map(filter => filter.scope);
   useEffect(() => {
-    nativeFiltersValues.forEach(filter => {
+    const filterScopes = nativeFiltersValues.map(filter => {
       const filterScope = filter.scope;
-      const chartsInScope = getChartIdsInFilterScope({
+      const chartsInScope: number[] = getChartIdsInFilterScope({
         filterScope: {
           scope: filterScope.rootPath,
           // @ts-ignore
@@ -76,12 +76,13 @@ const DashboardContainer: FC<DashboardContainerProps> = ({ topLevelTabs }) => {
         dashboardLayout,
         chartsInScope,
       );
-      Object.assign(filter, {
-        chartsInScope,
+      return {
+        filterId: filter.id,
         tabsInScope: Array.from(tabsInScope),
-      });
+        chartsInScope,
+      };
     });
-    dispatch(setFilterConfiguration(nativeFiltersValues));
+    dispatch(setFilterScopes(filterScopes));
   }, [JSON.stringify(scopes), JSON.stringify(dashboardLayout)]);
 
   const childIds: string[] = topLevelTabs

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
@@ -64,7 +64,10 @@ const DashboardContainer: FC<DashboardContainerProps> = ({ topLevelTabs }) => {
   const nativeFiltersValues = Object.values(nativeFilters);
   const scopes = nativeFiltersValues.map(filter => filter.scope);
   useEffect(() => {
-    if (!isFeatureEnabled(FeatureFlag.DASHBOARD_NATIVE_FILTERS) || nativeFiltersValues.length === 0) {
+    if (
+      !isFeatureEnabled(FeatureFlag.DASHBOARD_NATIVE_FILTERS) ||
+      nativeFiltersValues.length === 0
+    ) {
       return;
     }
     const filterScopes = nativeFiltersValues.map(filter => {

--- a/superset-frontend/src/dashboard/reducers/nativeFilters.ts
+++ b/superset-frontend/src/dashboard/reducers/nativeFilters.ts
@@ -20,7 +20,7 @@ import {
   AnyFilterAction,
   SAVE_FILTER_SETS,
   SET_FILTER_CONFIG_COMPLETE,
-  SET_FILTER_SCOPES,
+  SET_IN_SCOPE_STATUS_OF_FILTERS,
   SET_FILTER_SETS_CONFIG_COMPLETE,
   SET_FOCUSED_NATIVE_FILTER,
   UNSET_FOCUSED_NATIVE_FILTER,
@@ -93,7 +93,7 @@ export default function nativeFilterReducer(
       };
 
     case SET_FILTER_CONFIG_COMPLETE:
-    case SET_FILTER_SCOPES:
+    case SET_IN_SCOPE_STATUS_OF_FILTERS:
       return getInitialState({ filterConfig: action.filterConfig, state });
 
     case SET_FILTER_SETS_CONFIG_COMPLETE:

--- a/superset-frontend/src/dashboard/reducers/nativeFilters.ts
+++ b/superset-frontend/src/dashboard/reducers/nativeFilters.ts
@@ -20,6 +20,7 @@ import {
   AnyFilterAction,
   SAVE_FILTER_SETS,
   SET_FILTER_CONFIG_COMPLETE,
+  SET_FILTER_SCOPES,
   SET_FILTER_SETS_CONFIG_COMPLETE,
   SET_FOCUSED_NATIVE_FILTER,
   UNSET_FOCUSED_NATIVE_FILTER,
@@ -92,6 +93,7 @@ export default function nativeFilterReducer(
       };
 
     case SET_FILTER_CONFIG_COMPLETE:
+    case SET_FILTER_SCOPES:
       return getInitialState({ filterConfig: action.filterConfig, state });
 
     case SET_FILTER_SETS_CONFIG_COMPLETE:


### PR DESCRIPTION
### SUMMARY
When dashboard first renders, we calculate tabs and charts in scope of each native filter. Before, we used to send a PUT request with the results, which also modified dashboard's metadata. This PR fixes that behaviour by saving the results only in redux, without sending them to the backend. Also, now we run the calculations only if the native filters feature flag is enabled
This PR is related to an issue raised by @graceguo-supercat in comments https://github.com/apache/superset/pull/14933#discussion_r650331375 and https://github.com/apache/superset/pull/14933#issuecomment-860168672. The problem with setting properties `show_native_filters` and `native_filter_configuration` was not caused directly by PR https://github.com/apache/superset/pull/14933, but the problem was elevated by that PR because of sending unnecessary PUT request. The root of the issue will be handled in a separate PR by @villebro.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Notice that in "AFTER" screenshot there's no request to `/dashboard` endpoint which modifies metadata.
Before:
![image](https://user-images.githubusercontent.com/15073128/121876082-70744580-cd09-11eb-87f8-278a831739e0.png)

After:
![image](https://user-images.githubusercontent.com/15073128/121875923-4753b500-cd09-11eb-8652-732cd5701365.png)

### TESTING INSTRUCTIONS
0. Set `DASHBOARD_NATIVE_FILTERS` feature flag to True
1. Add some native filters
2. Reload the dashboard
3. Verify that `SET_FILTER_SCOPES` action was dispatched and no request to `/dashboard` endpoint was made
4. Verify that highlighting tabs and charts in scope of filters works as before
5. Unset `DASHBOARD_NATIVE_FILTERS` feature flag
6. Verify that `SET_FILTER_SCOPES` action was NOT dispatched

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #15125
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @villebro @graceguo-supercat 