### PR TITLE
fix(db-connection-ui): Additional Query Parameters render

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -130,6 +130,7 @@ function dbReducer(
   const trimmedState = {
     ...(state || {}),
   };
+  let query = '';
 
   switch (action.type) {
     case ActionType.inputChange:
@@ -169,10 +170,11 @@ function dbReducer(
         [action.payload.name]: action.payload.value,
       };
     case ActionType.fetched:
-      let query = '';
       if (action.payload?.parameters?.query) {
         // convert query into URI params string
-        query = new URLSearchParams(action.payload.parameters.query).toString();
+        query = new URLSearchParams(
+          action.payload.parameters.query as string,
+        ).toString();
       }
       return {
         engine: trimmedState.engine,
@@ -278,12 +280,12 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
     if (update?.parameters?.query) {
       // convert query params into dictionary
       update.parameters.query = JSON.parse(
-        `{"${decodeURI(update?.parameters?.query || '')
+        `{"${decodeURI((update?.parameters?.query as string) || '')
           .replace(/"/g, '\\"')
           .replace(/&/g, '","')
           .replace(/=/g, '":"')}"}`,
       );
-    } else {
+    } else if (update.parameters) {
       update.parameters.query = {};
     }
 
@@ -309,7 +311,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       if (update?.parameters?.query) {
         // convert query params into dictionary
         update.parameters.query = JSON.parse(
-          `{"${decodeURI(db.parameters?.query || '')
+          `{"${decodeURI((db.parameters?.query as string) || '')
             .replace(/"/g, '\\"')
             .replace(/&/g, '","')
             .replace(/=/g, '":"')}"}`,

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -169,10 +169,19 @@ function dbReducer(
         [action.payload.name]: action.payload.value,
       };
     case ActionType.fetched:
+      let query = '';
+      if (action.payload?.parameters?.query) {
+        // convert query into URI params string
+        query = new URLSearchParams(action.payload.parameters.query).toString();
+      }
       return {
         engine: trimmedState.engine,
         configuration_method: trimmedState.configuration_method,
         ...action.payload,
+        parameters: {
+          ...action.payload.parameters,
+          query,
+        },
       };
     case ActionType.dbSelected:
       return {
@@ -266,6 +275,18 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { id, ...update } = db || {};
     if (db?.id) {
+      if (update?.parameters?.query) {
+        // convert query params into dictionary
+        update.parameters.query = JSON.parse(
+          `{"${decodeURI(db.parameters?.query || '')
+            .replace(/"/g, '\\"')
+            .replace(/&/g, '","')
+            .replace(/=/g, '":"')}"}`,
+        );
+      } else {
+        update.parameters.query = {};
+      }
+
       const result = await updateResource(
         db.id as number,
         update as DatabaseObject,

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -274,19 +274,20 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
   const onSave = async () => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { id, ...update } = db || {};
-    if (db?.id) {
-      if (update?.parameters?.query) {
-        // convert query params into dictionary
-        update.parameters.query = JSON.parse(
-          `{"${decodeURI(db.parameters?.query || '')
-            .replace(/"/g, '\\"')
-            .replace(/&/g, '","')
-            .replace(/=/g, '":"')}"}`,
-        );
-      } else {
-        update.parameters.query = {};
-      }
 
+    if (update?.parameters?.query) {
+      // convert query params into dictionary
+      update.parameters.query = JSON.parse(
+        `{"${decodeURI(update?.parameters?.query || '')
+          .replace(/"/g, '\\"')
+          .replace(/&/g, '","')
+          .replace(/=/g, '":"')}"}`,
+      );
+    } else {
+      update.parameters.query = {};
+    }
+
+    if (db?.id) {
       const result = await updateResource(
         db.id as number,
         update as DatabaseObject,

--- a/superset-frontend/src/views/CRUD/data/database/types.ts
+++ b/superset-frontend/src/views/CRUD/data/database/types.ts
@@ -38,7 +38,7 @@ export type DatabaseObject = {
     username?: string;
     password?: string;
     encryption?: boolean;
-    query?: string;
+    query?: string | object;
   };
   configuration_method: CONFIGURATION_METHOD;
   engine?: string;


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix rendering the query parameters on edit. Before the field would render an object instead of the query params formatted.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### Before
<img width="481" alt="Screen Shot 2021-06-14 at 11 26 35 AM" src="https://user-images.githubusercontent.com/27827808/121917720-64858500-cd03-11eb-9344-c6f692bed599.png">

#### After
<img width="476" alt="Screen Shot 2021-06-14 at 11 27 55 AM" src="https://user-images.githubusercontent.com/27827808/121917939-94cd2380-cd03-11eb-9e59-dc1f495d216d.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Goto Database page
2. Click edit on datebase with dynamic form setting
3. if empty, add query param (sslmode=disable)
4. Click Connect
5. Click on same database, and see the additional parameter render in field.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
