### PR TITLE
feat: Adding a show all button to the column/metrics list in the explore view (Allow more than 50 columns to be shown)

### DIFF
--- a/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
@@ -243,7 +243,7 @@ export default function DataSourcePanel({
             {lists.metrics.length > DEFAULT_MAX_METRIC_LENGTH ? (
               <ButtonContainer>
                 <Button onClick={() => setShowAllMetrics(!showAllMetrics)}>
-                  {showAllMetrics ? t('Show Less...') : t('Show all...')}
+                  {showAllMetrics ? t('Show less...') : t('Show all...')}
                 </Button>
               </ButtonContainer>
             ) : (

--- a/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
@@ -129,7 +129,7 @@ export default function DataSourcePanel({
   const [showAllColumns, setShowAllColumns] = useState(false);
 
   const DEFAULT_MAX_COLUMNS_LENGTH = 50;
-  const DEFAULT_MAX_METRIC_LENGTH = 50;
+  const DEFAULT_MAX_METRICS_LENGTH = 50;
 
   const search = debounce((value: string) => {
     if (value === '') {

--- a/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
@@ -42,6 +42,18 @@ export interface Props {
   actions: Partial<ExploreActions> & Pick<ExploreActions, 'setControlValue'>;
 }
 
+const Button = styled.button`
+  background: none;
+  border: none;
+  text-decoration: underline;
+  color: ${({ theme }) => theme.colors.primary.dark1};
+`;
+
+const ButtonContainer = styled.div`
+  text-align: center;
+  padding-top: 2px;
+`;
+
 const DatasourceContainer = styled.div`
   background-color: ${({ theme }) => theme.colors.grayscale.light4};
   position: relative;
@@ -113,6 +125,11 @@ export default function DataSourcePanel({
     columns,
     metrics,
   });
+  const [showAllMetrics, setShowAllMetrics] = useState(false);
+  const [showAllColumns, setShowAllColumns] = useState(false);
+
+  const DEFAULT_MAX_COLUMNS_LENGTH = 50;
+  const DEFAULT_MAX_METRIC_LENGTH = 50;
 
   const search = debounce((value: string) => {
     if (value === '') {
@@ -176,8 +193,12 @@ export default function DataSourcePanel({
     setInputValue('');
   }, [columns, datasource, metrics]);
 
-  const metricSlice = lists.metrics.slice(0, 50);
-  const columnSlice = lists.columns.slice(0, 50);
+  const metricSlice = showAllMetrics
+    ? lists.metrics
+    : lists.metrics.slice(0, DEFAULT_MAX_COLUMNS_LENGTH);
+  const columnSlice = showAllColumns
+    ? lists.columns
+    : lists.columns.slice(0, DEFAULT_MAX_METRIC_LENGTH);
 
   const mainBody = (
     <>
@@ -219,6 +240,15 @@ export default function DataSourcePanel({
                 )}
               </LabelContainer>
             ))}
+            {lists.metrics.length > DEFAULT_MAX_METRIC_LENGTH ? (
+              <ButtonContainer>
+                <Button onClick={() => setShowAllMetrics(!showAllMetrics)}>
+                  {showAllMetrics ? t('Show Less...') : t('Show all...')}
+                </Button>
+              </ButtonContainer>
+            ) : (
+              <></>
+            )}
           </Collapse.Panel>
           <Collapse.Panel
             header={<span className="header">{t('Columns')}</span>}
@@ -241,6 +271,15 @@ export default function DataSourcePanel({
                 )}
               </LabelContainer>
             ))}
+            {lists.columns.length > DEFAULT_MAX_COLUMNS_LENGTH ? (
+              <ButtonContainer>
+                <Button onClick={() => setShowAllColumns(!showAllColumns)}>
+                  {showAllColumns ? t('Show Less...') : t('Show all...')}
+                </Button>
+              </ButtonContainer>
+            ) : (
+              <></>
+            )}
           </Collapse.Panel>
         </Collapse>
       </div>

--- a/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
@@ -198,7 +198,7 @@ export default function DataSourcePanel({
     : lists.metrics.slice(0, DEFAULT_MAX_COLUMNS_LENGTH);
   const columnSlice = showAllColumns
     ? lists.columns
-    : lists.columns.slice(0, DEFAULT_MAX_METRIC_LENGTH);
+    : lists.columns.slice(0, DEFAULT_MAX_METRICS_LENGTH);
 
   const mainBody = (
     <>
@@ -240,7 +240,7 @@ export default function DataSourcePanel({
                 )}
               </LabelContainer>
             ))}
-            {lists.metrics.length > DEFAULT_MAX_METRIC_LENGTH ? (
+            {lists.metrics.length > DEFAULT_MAX_METRICS_LENGTH ? (
               <ButtonContainer>
                 <Button onClick={() => setShowAllMetrics(!showAllMetrics)}>
                   {showAllMetrics ? t('Show less...') : t('Show all...')}


### PR DESCRIPTION
### SUMMARY
This is a simple addition to the explore view. The explore view limits the amount of data / columns displayed at once to 50. We wish to have the option of showing all of the columns / metrics at one time. The look / functionality was discussed in

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before at 50 columns

![before_over_50](https://user-images.githubusercontent.com/71385290/122448042-5ab58900-cf72-11eb-97ea-7b198fc65b3e.PNG)

After the changes on a datasource with over 50 columns (in various states Before at 50 columns)

![less shown](https://user-images.githubusercontent.com/71385290/122448189-7fa9fc00-cf72-11eb-895e-d97c3fad9aa9.PNG)

![showall](https://user-images.githubusercontent.com/71385290/122448144-7325a380-cf72-11eb-9a9a-6d7b4dd0d07c.PNG)
)

![Capture](https://user-images.githubusercontent.com/71385290/122448210-846eb000-cf72-11eb-936d-875922564fd2.PNG)

![showless](https://user-images.githubusercontent.com/71385290/122448225-88023700-cf72-11eb-96f1-533e1a3dd237.PNG)

After the changes on a datasource with less than 50 columns 

![under_50](https://user-images.githubusercontent.com/71385290/122448298-9e0ff780-cf72-11eb-853d-ce185040e5f2.PNG)

### TESTING INSTRUCTIONS
Open a data source with with more than 50 columns or metrics. At the button of there will be a "Show All..." button, clicking this button will cause  full list of columns / metrics to render. If all columns / metrics are rendering a "Show Less..." button will appear, clicking this will cause only 50 elements to render.

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
