### PR TITLE
fix: validate DB-specific parameters

### DIFF
--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -1001,7 +1001,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         try:
             payload = DatabaseValidateParametersSchema().load(request.json)
         except ValidationError as error:
-            # {'port': ['Not a valid integer.']}
             errors = [
                 SupersetError(
                     message="\n".join(messages),

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -67,7 +67,7 @@ from superset.databases.schemas import (
 from superset.databases.utils import get_table_metadata
 from superset.db_engine_specs import get_available_engine_specs
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
-from superset.exceptions import InvalidPayloadFormatError, InvalidPayloadSchemaError
+from superset.exceptions import InvalidPayloadFormatError
 from superset.extensions import security_manager
 from superset.models.core import Database
 from superset.typing import FlaskResponse

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -335,9 +335,9 @@ class DatabaseValidateParametersSchema(Schema):
     )
 
     @validates_schema
-    def validate_parameters(
-        self, data: Dict[str, Any], **kwargs: Any
-    ) -> None:  # pylint: disable=no-self-use, unused-argument
+    def validate_parameters(  # pylint: disable=no-self-use
+        self, data: Dict[str, Any], **kwargs: Any  # pylint: disable=unused-argument
+    ) -> None:
         """
         Validate the DB engine spec specific parameters schema.
         """

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -16,7 +16,7 @@
 # under the License.
 import inspect
 import json
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Type
 
 from flask import current_app
 from flask_babel import lazy_gettext as _
@@ -27,7 +27,7 @@ from sqlalchemy import MetaData
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.exc import ArgumentError
 
-from superset.db_engine_specs import get_engine_specs
+from superset.db_engine_specs import BaseEngineSpec, get_engine_specs
 from superset.exceptions import CertificateException, SupersetSecurityException
 from superset.models.core import ConfigurationMethod, PASSWORD_MASK
 from superset.security.analytics_db_safety import check_sqlalchemy_uri
@@ -253,28 +253,11 @@ class DatabaseParametersSchemaMixin:
         the constructed SQLAlchemy URI to be passed.
         """
         parameters = data.pop("parameters", {})
-
-        # TODO (betodealmeida): remove second expression after making sure
-        # frontend is not passing engine inside parameters
-        engine = data.pop("engine", None) or parameters.pop("engine", None)
+        engine = data.pop("engine", None)
 
         configuration_method = data.get("configuration_method")
         if configuration_method == ConfigurationMethod.DYNAMIC_FORM:
-            if not engine:
-                raise ValidationError(
-                    [
-                        _(
-                            "An engine must be specified when passing "
-                            "individual parameters to a database."
-                        )
-                    ]
-                )
-            engine_specs = get_engine_specs()
-            if engine not in engine_specs:
-                raise ValidationError(
-                    [_('Engine "%(engine)s" is not a valid engine.', engine=engine,)]
-                )
-            engine_spec = engine_specs[engine]
+            engine_spec = get_engine_spec(engine)
 
             if not hasattr(engine_spec, "build_sqlalchemy_uri") or not hasattr(
                 engine_spec, "parameters_schema"
@@ -302,6 +285,24 @@ class DatabaseParametersSchemaMixin:
             )
 
         return data
+
+
+def get_engine_spec(engine: Optional[str]) -> Type[BaseEngineSpec]:
+    if not engine:
+        raise ValidationError(
+            [
+                _(
+                    "An engine must be specified when passing "
+                    "individual parameters to a database."
+                )
+            ]
+        )
+    engine_specs = get_engine_specs()
+    if engine not in engine_specs:
+        raise ValidationError(
+            [_('Engine "%(engine)s" is not a valid engine.', engine=engine,)]
+        )
+    return engine_specs[engine]
 
 
 class DatabaseValidateParametersSchema(Schema):
@@ -332,6 +333,15 @@ class DatabaseValidateParametersSchema(Schema):
         allow_none=True,
         description=configuration_method_description,
     )
+
+    @validates_schema
+    def validate_parameters(self, data: Dict[str, Any], **kwargs: Any) -> None:
+        """
+        Validate the DB engine spec specific parameters schema.
+        """
+        # TODO (aafghahi): use a single parameter
+        engine_spec = get_engine_spec(data.get("engine") or data.get("backend"))
+        engine_spec.parameters_schema.load(data["parameters"])  # type: ignore
 
 
 class DatabasePostSchema(Schema, DatabaseParametersSchemaMixin):

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -335,7 +335,9 @@ class DatabaseValidateParametersSchema(Schema):
     )
 
     @validates_schema
-    def validate_parameters(self, data: Dict[str, Any], **kwargs: Any) -> None:
+    def validate_parameters(
+        self, data: Dict[str, Any], **kwargs: Any
+    ) -> None:  # pylint: disable=no-self-use, unused-argument
         """
         Validate the DB engine spec specific parameters schema.
         """

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -333,8 +333,8 @@ class BigQueryEngineSpec(BaseEngineSpec):
 
     @classmethod
     def validate_parameters(
-        cls, parameters: BigQueryParametersType
-    ) -> List[SupersetError]:  # pylint: disable=unused-argument
+        cls, parameters: BigQueryParametersType  # pylint: disable=unused-argument
+    ) -> List[SupersetError]:
         return []
 
     @classmethod

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -29,7 +29,7 @@ from typing_extensions import TypedDict
 
 from superset.databases.schemas import encrypted_field_properties, EncryptedField
 from superset.db_engine_specs.base import BaseEngineSpec
-from superset.errors import SupersetErrorType
+from superset.errors import SupersetError, SupersetErrorType
 from superset.exceptions import SupersetGenericDBErrorException
 from superset.sql_parse import Table
 from superset.utils import core as utils
@@ -330,6 +330,12 @@ class BigQueryEngineSpec(BaseEngineSpec):
         raise SupersetGenericDBErrorException(
             message="Big Query encrypted_extra is not available.",
         )
+
+    @classmethod
+    def validate_parameters(
+        cls, parameters: BigQueryParametersType
+    ) -> List[SupersetError]:
+        return []
 
     @classmethod
     def parameters_json_schema(cls) -> Any:

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -334,7 +334,7 @@ class BigQueryEngineSpec(BaseEngineSpec):
     @classmethod
     def validate_parameters(
         cls, parameters: BigQueryParametersType
-    ) -> List[SupersetError]:
+    ) -> List[SupersetError]:  # pylint: disable=unused-argument
         return []
 
     @classmethod

--- a/tests/databases/api_tests.py
+++ b/tests/databases/api_tests.py
@@ -1746,7 +1746,10 @@ class TestDatabaseApi(SupersetTestCase):
 
     @mock.patch("superset.db_engine_specs.base.is_hostname_valid")
     @mock.patch("superset.db_engine_specs.base.is_port_open")
-    def test_validate_parameters_valid(self, is_port_open, is_hostname_valid):
+    @mock.patch("superset.databases.api.ValidateDatabaseParametersCommand")
+    def test_validate_parameters_valid_payload(
+        self, ValidateDatabaseParametersCommand, is_port_open, is_hostname_valid
+    ):
         is_hostname_valid.return_value = True
         is_port_open.return_value = True
 
@@ -1759,7 +1762,7 @@ class TestDatabaseApi(SupersetTestCase):
         payload["parameters"].update(
             {
                 "host": "localhost",
-                "port": 5432,
+                "port": 6789,
                 "username": "superset",
                 "password": "XXX",
                 "database": "test",

--- a/tests/databases/api_tests.py
+++ b/tests/databases/api_tests.py
@@ -1674,14 +1674,11 @@ class TestDatabaseApi(SupersetTestCase):
         assert response == {
             "errors": [
                 {
-                    "message": "An error happened when validating the request",
+                    "message": "Missing data for required field.",
                     "error_type": "INVALID_PAYLOAD_SCHEMA_ERROR",
                     "level": "error",
                     "extra": {
-                        "messages": {
-                            "engine": ["Missing data for required field."],
-                            "foo": ["Unknown field."],
-                        },
+                        "invalid": ["engine"],
                         "issue_codes": [
                             {
                                 "code": 1020,
@@ -1689,7 +1686,21 @@ class TestDatabaseApi(SupersetTestCase):
                             }
                         ],
                     },
-                }
+                },
+                {
+                    "message": "Unknown field.",
+                    "error_type": "INVALID_PAYLOAD_SCHEMA_ERROR",
+                    "level": "error",
+                    "extra": {
+                        "invalid": ["foo"],
+                        "issue_codes": [
+                            {
+                                "code": 1020,
+                                "message": "Issue 1020 - The submitted payload has the incorrect schema.",
+                            }
+                        ],
+                    },
+                },
             ]
         }
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The `validate_parameters` endpoint was not performing the DB-specific Marshmallow validation (based on `parameters_schema`), but only the validation from the `validate_parameters` schema in the DB engine spec (which does more deep validation like checking if the host is resolvable and the port is open, but doesn't validate the schema).

I changed the `DatabaseValidateParametersSchema` schema validation to also validate the DB-specific parameters, and changed the API to return the error messages expected by the frontend for the `onBlur` validation (with an `invalid` key in the `extra`).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Added unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
