### PR TITLE
feat: show rich error messages on past failed queries

### DIFF
--- a/superset-frontend/src/SqlLab/components/SouthPane/SouthPane.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/SouthPane.tsx
@@ -118,6 +118,9 @@ export default function SouthPane({
     }
     let results;
     if (latestQuery) {
+      if (latestQuery?.extra?.errors) {
+        latestQuery.errors = latestQuery.extra.errors;
+      }
       if (
         isFeatureEnabled(FeatureFlag.SQLLAB_BACKEND_PERSISTENCE) &&
         latestQuery.state === 'success' &&

--- a/superset/db_engine_specs/sqlite.py
+++ b/superset/db_engine_specs/sqlite.py
@@ -14,17 +14,23 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import re
 from datetime import datetime
-from typing import List, Optional, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Pattern, Tuple, TYPE_CHECKING
 
+from flask_babel import gettext as __
 from sqlalchemy.engine.reflection import Inspector
 
 from superset.db_engine_specs.base import BaseEngineSpec
+from superset.errors import SupersetErrorType
 from superset.utils import core as utils
 
 if TYPE_CHECKING:
     # prevent circular imports
     from superset.models.core import Database
+
+
+COLUMN_DOES_NOT_EXIST_REGEX = re.compile("no such column: (?P<column_name>.+)")
 
 
 class SqliteEngineSpec(BaseEngineSpec):
@@ -51,6 +57,14 @@ class SqliteEngineSpec(BaseEngineSpec):
         "P1Y": "DATETIME(STRFTIME('%Y-01-01T00:00:00', {col}))",
         "P1W/1970-01-03T00:00:00Z": "DATE({col}, 'weekday 6')",
         "1969-12-28T00:00:00Z/P1W": "DATE({col}, 'weekday 0', '-7 days')",
+    }
+
+    custom_errors: Dict[Pattern[str], Tuple[str, SupersetErrorType, Dict[str, Any]]] = {
+        COLUMN_DOES_NOT_EXIST_REGEX: (
+            __('We can\'t seem to resolve the column "%(column_name)s"'),
+            SupersetErrorType.COLUMN_DOES_NOT_EXIST_ERROR,
+            {},
+        ),
     }
 
     @classmethod

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=comparison-with-callable, line-too-long, too-many-branches
-import dataclasses
 import logging
 import re
 from contextlib import closing

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=comparison-with-callable, line-too-long, too-many-branches
+import dataclasses
 import logging
 import re
 from contextlib import closing
@@ -73,6 +74,7 @@ from superset.dashboards.dao import DashboardDAO
 from superset.databases.dao import DatabaseDAO
 from superset.databases.filters import DatabaseFilter
 from superset.datasets.commands.exceptions import DatasetNotFoundError
+from superset.errors import SupersetError
 from superset.exceptions import (
     CacheLoadError,
     CertificateException,
@@ -2427,15 +2429,15 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             raise SupersetGenericDBErrorException(utils.error_msg_from_exception(ex))
 
         if data.get("status") == QueryStatus.FAILED:
-            msg = data["error"]
-            query = _session.query(Query).filter_by(id=query_id).one()
-            database = query.database
-            db_engine_spec = database.db_engine_spec
-            errors = db_engine_spec.extract_errors(msg)
-            _session.close()
-            if errors:
-                raise SupersetErrorsException(errors)
-            raise SupersetGenericDBErrorException(msg)
+            # new error payload with rich context
+            if data["errors"]:
+                raise SupersetErrorsException(
+                    [SupersetError(**params) for params in data["errors"]]
+                )
+
+            # old string-only error message
+            raise SupersetGenericDBErrorException(data["error"])
+
         return json_success(payload)
 
     @has_access_api


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR makes SQL Lab show rich error messages when refreshing queries that failed.

The steps needed were:

1. Modify `superset/sql_lab.py` so that the SIP-40 error payload gets saved with the query in the `extra_json` column under the `errors` key.
2. Modify the south pane component to attach `query.extra.errors` to `query.errors`, so that errors are shown with the rich error component.
3. [Optional: Add a custom column error to the SQLite engine spec in order to test.]

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before, when refreshing a failed query we'd see:

![Screenshot 2021-06-14 at 17-57-06 Superset](https://user-images.githubusercontent.com/1534870/121977057-f314f900-cd39-11eb-8626-b8e08ecd6624.png)

After, when we refresh the page we see:

![Screenshot 2021-06-14 at 17-55-58 Superset](https://user-images.githubusercontent.com/1534870/121976998-d678c100-cd39-11eb-847f-cd7f0a8476fb.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Tested manually with sync and async queries.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
