### PR TITLE
fix: use npm v7 in docker compose

### DIFF
--- a/docker/docker-frontend.sh
+++ b/docker/docker-frontend.sh
@@ -18,6 +18,7 @@
 set -e
 
 cd /app/superset-frontend
+npm install -g npm@7
 npm install -f --no-optional --global webpack webpack-cli
 npm install -f --no-optional
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This should get rid of the unwanted `package-lock.json` edits when running docker-compose.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Run docker-compose?

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
