### PR TITLE
fix(examples): calendar chart metric should be metrics

### DIFF
--- a/superset/examples/random_time_series.py
+++ b/superset/examples/random_time_series.py
@@ -69,7 +69,7 @@ def load_random_time_series_data(
         "row_limit": config["ROW_LIMIT"],
         "since": "2019-01-01",
         "until": "2019-02-01",
-        "metric": "count",
+        "metrics": ["count"],
         "viz_type": "cal_heatmap",
         "domain_granularity": "month",
         "subdomain_granularity": "day",

--- a/tests/dashboards/api_tests.py
+++ b/tests/dashboards/api_tests.py
@@ -37,6 +37,7 @@ from superset.models.dashboard import Dashboard
 from superset.models.core import FavStar, FavStarClassName
 from superset.models.reports import ReportSchedule, ReportScheduleType
 from superset.models.slice import Slice
+from superset.utils.core import backend
 from superset.views.base import generate_download_headers
 
 from tests.base_api_tests import ApiOwnersTestCaseMixin
@@ -182,7 +183,8 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
         result = data["result"]
         actual_dataset_ids = set([dataset["id"] for dataset in result])
         self.assertEqual(actual_dataset_ids, expected_dataset_ids)
-        self.assertEqual(result[0]["column_types"], [0, 1, 2])
+        expected_values = [0, 1] if backend() == "presto" else [0, 1, 2]
+        self.assertEqual(result[0]["column_types"], expected_values)
 
     @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
     def test_get_dashboard_datasets_not_found(self):


### PR DESCRIPTION
### SUMMARY
One of the example calendar heatmap charts has incorrectly defined the `metric` control value, while it really should be `metrics` (the value should also be an array of strings, not a string).

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/122042464-da145280-cde2-11eb-8133-269da44b95ee.png)

### AFTER
![image](https://user-images.githubusercontent.com/33317356/122042388-c2d56500-cde2-11eb-9364-7b2968d145c6.png)

### TESTING INSTRUCTIONS
1. Populate examples data
2. Open the "Calendar Heatmap" chart
3. See that previously it didn't work, but after the changes it works properly.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
