### PR TITLE
fix: trim string value of spaces in listview search

### DIFF
--- a/superset-frontend/src/components/ListView/Filters/Search.tsx
+++ b/superset-frontend/src/components/ListView/Filters/Search.tsx
@@ -35,7 +35,7 @@ export default function SearchFilter({
   const [value, setValue] = useState(initialValue || '');
   const handleSubmit = () => {
     if (value) {
-      onSubmit(value);
+      onSubmit(value.trim());
     }
   };
   const onClear = () => {


### PR DESCRIPTION
### SUMMARY
This pr fixes an issue with the listview search were if a space was either at the front or end of the string it would not return any results.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before:
https://user-images.githubusercontent.com/17326228/122089466-a540d500-cdbb-11eb-811f-1b442e0dd5cb.mov

after:

https://user-images.githubusercontent.com/17326228/122090130-4b8cda80-cdbc-11eb-8f50-01431bff51a1.mov

### TESTING INSTRUCTIONS
Go to listviews and try searching with spaces in string

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
