### PR TITLE
chore: Allows the user to force fetch the default values

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DefaultValue.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DefaultValue.tsx
@@ -61,7 +61,7 @@ const DefaultValue: FC<DefaultValueProps> = ({
     <Loading position="inline-centered" />
   ) : (
     <SuperChart
-      height={25}
+      height={32}
       width={formFilter?.filterType === 'filter_time' ? 350 : 250}
       appSection={AppSection.FILTER_CONFIG_MODAL}
       behaviors={[Behavior.NATIVE_FILTER]}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -57,6 +57,8 @@ import { getChartDataRequest } from 'src/chart/chartAction';
 import { FeatureFlag, isFeatureEnabled } from 'src/featureFlags';
 import { waitForAsyncData } from 'src/middleware/asyncEvent';
 import Tabs from 'src/components/Tabs';
+import Icons from 'src/components/Icons';
+import { Tooltip } from 'src/components/Tooltip';
 import BasicErrorAlert from 'src/components/ErrorMessage/BasicErrorAlert';
 import { ColumnSelect } from './ColumnSelect';
 import { NativeFiltersForm } from '../types';
@@ -132,6 +134,17 @@ export const StyledLabel = styled.span`
 
 const CleanFormItem = styled(FormItem)`
   margin-bottom: 0;
+`;
+
+const DefaultValueContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
+const RefreshIcon = styled(Icons.Refresh)`
+  margin-left: ${({ theme }) => theme.gridUnit * 2}px;
+  color: ${({ theme }) => theme.colors.primary.base};
 `;
 
 const StyledCollapse = styled(Collapse)`
@@ -349,54 +362,57 @@ const FiltersConfigForm = (
     forceUpdate();
   };
 
-  const refreshHandler = useCallback(() => {
-    if (!hasDataset || !formFilter?.dataset?.value) {
-      forceUpdate();
-      return;
-    }
-    const formData = getFormData({
-      datasetId: formFilter?.dataset?.value,
-      groupby: formFilter?.column,
-      ...formFilter,
-    });
-    setNativeFilterFieldValuesWrapper({
-      defaultValueQueriesData: null,
-      isDataDirty: false,
-    });
-    getChartDataRequest({
-      formData,
-      force: false,
-      requestParams: { dashboardId: 0 },
-    })
-      .then(response => {
-        if (isFeatureEnabled(FeatureFlag.GLOBAL_ASYNC_QUERIES)) {
-          // deal with getChartDataRequest transforming the response data
-          const result = 'result' in response ? response.result[0] : response;
-          waitForAsyncData(result)
-            .then((asyncResult: ChartDataResponseResult[]) => {
-              setNativeFilterFieldValuesWrapper({
-                defaultValueQueriesData: asyncResult,
-              });
-            })
-            .catch((error: ClientErrorObject) => {
-              setError(
-                error.message || error.error || t('Check configuration'),
-              );
-            });
-        } else {
-          setNativeFilterFieldValuesWrapper({
-            defaultValueQueriesData: response.result,
-          });
-        }
-      })
-      .catch((error: Response) => {
-        error.json().then(body => {
-          setErrorWrapper(
-            body.message || error.statusText || t('Check configuration'),
-          );
-        });
+  const refreshHandler = useCallback(
+    (force = false) => {
+      if (!hasDataset || !formFilter?.dataset?.value) {
+        forceUpdate();
+        return;
+      }
+      const formData = getFormData({
+        datasetId: formFilter?.dataset?.value,
+        groupby: formFilter?.column,
+        ...formFilter,
       });
-  }, [filterId, forceUpdate, form, formFilter, hasDataset]);
+      setNativeFilterFieldValuesWrapper({
+        defaultValueQueriesData: null,
+        isDataDirty: false,
+      });
+      getChartDataRequest({
+        formData,
+        force,
+        requestParams: { dashboardId: 0 },
+      })
+        .then(response => {
+          if (isFeatureEnabled(FeatureFlag.GLOBAL_ASYNC_QUERIES)) {
+            // deal with getChartDataRequest transforming the response data
+            const result = 'result' in response ? response.result[0] : response;
+            waitForAsyncData(result)
+              .then((asyncResult: ChartDataResponseResult[]) => {
+                setNativeFilterFieldValuesWrapper({
+                  defaultValueQueriesData: asyncResult,
+                });
+              })
+              .catch((error: ClientErrorObject) => {
+                setError(
+                  error.message || error.error || t('Check configuration'),
+                );
+              });
+          } else {
+            setNativeFilterFieldValuesWrapper({
+              defaultValueQueriesData: response.result,
+            });
+          }
+        })
+        .catch((error: Response) => {
+          error.json().then(body => {
+            setErrorWrapper(
+              body.message || error.statusText || t('Check configuration'),
+            );
+          });
+        });
+    },
+    [filterId, forceUpdate, form, formFilter, hasDataset],
+  );
 
   const defaultDatasetSelectOptions = Object.values(loadedDatasets).map(
     datasetToSelectOption,
@@ -691,22 +707,27 @@ const FiltersConfigForm = (
                     level="error"
                   />
                 ) : showDefaultValue ? (
-                  <DefaultValue
-                    setDataMask={dataMask => {
-                      setNativeFilterFieldValues(form, filterId, {
-                        defaultDataMask: dataMask,
-                      });
-                      form.validateFields([
-                        ['filters', filterId, 'defaultDataMask'],
-                      ]);
-                      forceUpdate();
-                    }}
-                    filterId={filterId}
-                    hasDataset={hasDataset}
-                    form={form}
-                    formData={newFormData}
-                    enableNoResults={enableNoResults}
-                  />
+                  <DefaultValueContainer>
+                    <DefaultValue
+                      setDataMask={dataMask => {
+                        setNativeFilterFieldValues(form, filterId, {
+                          defaultDataMask: dataMask,
+                        });
+                        form.validateFields([
+                          ['filters', filterId, 'defaultDataMask'],
+                        ]);
+                        forceUpdate();
+                      }}
+                      filterId={filterId}
+                      hasDataset={hasDataset}
+                      form={form}
+                      formData={newFormData}
+                      enableNoResults={enableNoResults}
+                    />
+                    <Tooltip title={t('Refresh the default values')}>
+                      <RefreshIcon onClick={() => refreshHandler(true)} />
+                    </Tooltip>
+                  </DefaultValueContainer>
                 ) : (
                   t('Fill all required fields to enable "Default Value"')
                 )}


### PR DESCRIPTION
### SUMMARY
Allows the user to force fetch the default values.

Fixes https://github.com/apache/superset/issues/14791

@rusackas @villebro @kgabryje @junlincc 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/122110755-4b5d0100-cdf5-11eb-96e2-a94bb70a7b37.mov

### TESTING INSTRUCTIONS
1 - Go to the native filters modal
2 - Expand the default value
3 - Check the available values
4 - Modify the values on the database
5 - Hit the refresh icon
6 - Check that the available values changed

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
