### PR TITLE
chore: add default themecolor to Icons component

### DIFF
--- a/superset-frontend/src/components/Icons/Icon.tsx
+++ b/superset-frontend/src/components/Icons/Icon.tsx
@@ -19,7 +19,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import AntdIcon from '@ant-design/icons';
-import { styled } from '@superset-ui/core';
+import { styled, useTheme } from '@superset-ui/core';
 import { ReactComponent as TransparentIcon } from 'images/icons/transparent.svg';
 import IconType from './IconType';
 
@@ -33,9 +33,11 @@ const AntdIconComponent = ({
 }: Omit<IconType, 'ref' | 'css'>) => (
   <AntdIcon viewBox={viewBox || '0 0 24 24'} {...rest} />
 );
+  
+const theme = useTheme();
 
 export const StyledIcon = styled(AntdIconComponent)<IconType>`
-  ${({ iconColor }) => iconColor && `color: ${iconColor};`};
+  ${({ iconColor }) => iconColor ? `color: ${iconColor};` : `color: ${theme.colors.grayscale.base};`};
   font-size: ${({ iconSize, theme }) =>
     iconSize
       ? `${theme.typography.sizes[iconSize] || theme.typography.sizes.m}px`

--- a/superset-frontend/src/components/Icons/Icon.tsx
+++ b/superset-frontend/src/components/Icons/Icon.tsx
@@ -19,7 +19,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import AntdIcon from '@ant-design/icons';
-import { styled, useTheme } from '@superset-ui/core';
+import { styled } from '@superset-ui/core';
 import { ReactComponent as TransparentIcon } from 'images/icons/transparent.svg';
 import IconType from './IconType';
 
@@ -33,11 +33,12 @@ const AntdIconComponent = ({
 }: Omit<IconType, 'ref' | 'css'>) => (
   <AntdIcon viewBox={viewBox || '0 0 24 24'} {...rest} />
 );
-  
-const theme = useTheme();
 
 export const StyledIcon = styled(AntdIconComponent)<IconType>`
-  ${({ iconColor }) => iconColor ? `color: ${iconColor};` : `color: ${theme.colors.grayscale.base};`};
+  ${({ iconColor, theme }) =>
+    iconColor
+      ? `color: ${iconColor};`
+      : `color: ${theme.colors.grayscale.base};`};
   font-size: ${({ iconSize, theme }) =>
     iconSize
       ? `${theme.typography.sizes[iconSize] || theme.typography.sizes.m}px`


### PR DESCRIPTION
### SUMMARY
This pr is to add the default base theme color for icon when one is not specified. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF


### TESTING INSTRUCTIONS
Will be checking icons throughout the app to ensure no visual regressions from change.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
