### PR TITLE
fix: ignore errors in GetLog

### DIFF
--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -331,7 +331,12 @@ class HiveEngineSpec(PrestoEngineSpec):
                 cursor.cancel()
                 break
 
-            log = cursor.fetch_logs() or ""
+            try:
+                log = cursor.fetch_logs() or ""
+            except Exception:  # pylint: disable=broad-except
+                logger.warning("Call to GetLog() failed")
+                log = ""
+
             if log:
                 log_lines = log.splitlines()
                 progress = cls.progress(log_lines)


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

We're seeing errors in Databricks that say:

```
databricks error: Couldn't find log associated with operation handle: OperationHandle [opType=EXECUTE_STATEMENT, getHandleIdentifier()=bbb31ca6-63bf-40f7-8724-f4d5856522e2]
```

Searching for the message suggests that this happens when the Hive2 server can't retrieve logs, but the results should still be there. I added a try/except block when fetching logs, trying to fix the problem.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

I was able to reproduce the problem locally. The call for `fetch_logs` raised this exception:

```
TFetchResultsResp(status=TStatus(statusCode=3, infoMessages=["*org.apache.hive.service.cli.HiveSQLException:Couldn't find log associated with operation handle: OperationHandle [opType=EXECUTE_STATEMENT, getHandleIdentifier()=65bc061c-482b-4ed3-a26a-f45013d89f4c]:48:47", 'org.apache.hive.service.cli.operation.OperationManager:getOperationLogRowSet:OperationManager.java:286', 'org.apache.hive.service.cli.session.HiveSessionImpl:fetchResults:HiveSessionImpl.java:876', 'org.apache.hive.service.cli.CLIService:fetchResults:CLIService.java:578', 'org.apache.hive.service.cli.thrift.ThriftCLIService:FetchResults:ThriftCLIService.java:876', 'org.apache.hive.service.rpc.thrift.TCLIService$Processor$FetchResults:getResult:TCLIService.java:1717', 'org.apache.hive.service.rpc.thrift.TCLIService$Processor$FetchResults:getResult:TCLIService.java:1702', 'org.apache.thrift.ProcessFunction:process:ProcessFunction.java:38', 'org.apache.thrift.TBaseProcessor:process:TBaseProcessor.java:39', 'org.apache.thrift.server.TServlet:doPost:TServlet.java:83', 'org.apache.hive.service.cli.thrift.ThriftHttpServlet:doPost:ThriftHttpServlet.java:195', 'javax.servlet.http.HttpServlet:service:HttpServlet.java:707', 'javax.servlet.http.HttpServlet:service:HttpServlet.java:790', 'org.eclipse.jetty.servlet.ServletHolder:handle:ServletHolder.java:791', 'org.eclipse.jetty.servlet.ServletHandler:doHandle:ServletHandler.java:550', 'org.eclipse.jetty.server.handler.ScopedHandler:handle:ScopedHandler.java:143', 'org.eclipse.jetty.security.SecurityHandler:handle:SecurityHandler.java:602', 'org.eclipse.jetty.server.handler.HandlerWrapper:handle:HandlerWrapper.java:127', 'org.eclipse.jetty.server.handler.ScopedHandler:nextHandle:ScopedHandler.java:235', 'org.eclipse.jetty.server.session.SessionHandler:doHandle:SessionHandler.java:1624', 'org.eclipse.jetty.server.handler.ScopedHandler:nextHandle:ScopedHandler.java:233', 'org.eclipse.jetty.server.handler.ContextHandler:doHandle:ContextHandler.java:1435', 'org.eclipse.jetty.server.handler.ScopedHandler:nextScope:ScopedHandler.java:188', 'org.eclipse.jetty.servlet.ServletHandler:doScope:ServletHandler.java:501', 'org.eclipse.jetty.server.session.SessionHandler:doScope:SessionHandler.java:1594', 'org.eclipse.jetty.server.handler.ScopedHandler:nextScope:ScopedHandler.java:186', 'org.eclipse.jetty.server.handler.ContextHandler:doScope:ContextHandler.java:1350', 'org.eclipse.jetty.server.handler.ScopedHandler:handle:ScopedHandler.java:141', 'org.eclipse.jetty.server.handler.HandlerWrapper:handle:HandlerWrapper.java:127', 'org.eclipse.jetty.server.Server:handle:Server.java:516', 'org.eclipse.jetty.server.HttpChannel:lambda$handle$1:HttpChannel.java:388', 'org.eclipse.jetty.server.HttpChannel:dispatch:HttpChannel.java:633', 'org.eclipse.jetty.server.HttpChannel:handle:HttpChannel.java:380', 'org.eclipse.jetty.server.HttpConnection:onFillable:HttpConnection.java:273', 'org.eclipse.jetty.io.AbstractConnection$ReadCallback:succeeded:AbstractConnection.java:311', 'org.eclipse.jetty.io.FillInterest:fillable:FillInterest.java:105', 'org.eclipse.jetty.io.ssl.SslConnection$DecryptedEndPoint:onFillable:SslConnection.java:540', 'org.eclipse.jetty.io.ssl.SslConnection:onFillable:SslConnection.java:395', 'org.eclipse.jetty.io.ssl.SslConnection$2:succeeded:SslConnection.java:161', 'org.eclipse.jetty.io.FillInterest:fillable:FillInterest.java:105', 'org.eclipse.jetty.io.ChannelEndPoint$1:run:ChannelEndPoint.java:104', 'org.eclipse.jetty.util.thread.strategy.EatWhatYouKill:runTask:EatWhatYouKill.java:336', 'org.eclipse.jetty.util.thread.strategy.EatWhatYouKill:doProduce:EatWhatYouKill.java:313', 'org.eclipse.jetty.util.thread.strategy.EatWhatYouKill:tryProduce:EatWhatYouKill.java:171', 'org.eclipse.jetty.util.thread.strategy.EatWhatYouKill:run:EatWhatYouKill.java:129', 'org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread:run:ReservedThreadExecutor.java:375', 'java.util.concurrent.ThreadPoolExecutor:runWorker:ThreadPoolExecutor.java:1149', 'java.util.concurrent.ThreadPoolExecutor$Worker:run:ThreadPoolExecutor.java:624', 'java.lang.Thread:run:Thread.java:748'], sqlState=None, errorCode=0, errorMessage="Couldn't find log associated with operation handle: OperationHandle [opType=EXECUTE_STATEMENT, getHandleIdentifier()=65bc061c-482b-4ed3-a26a-f45013d89f4c]"), hasMoreRows=None, results=None)%
```

With this PR the exception is ignored (but logged), and the results are displayed correctly.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
