### PR TITLE
fix: datasource payload is incorrect

### DIFF
--- a/superset/connectors/connector_registry.py
+++ b/superset/connectors/connector_registry.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from collections import defaultdict
 from typing import Dict, List, Optional, Set, Type, TYPE_CHECKING
 
 from flask_babel import _
@@ -98,6 +99,47 @@ class ConnectorRegistry:
                 # proceed to next datasource type
                 pass
         raise NoResultFound(_("Datasource id not found: %(id)s", id=datasource_id))
+
+    @classmethod
+    def get_user_datasources(cls, session: Session) -> List["BaseDatasource"]:
+        from superset import security_manager
+
+        # collect datasources which the user has explicit permissions to
+        user_perms = security_manager.user_view_menu_names("datasource_access")
+        schema_perms = security_manager.user_view_menu_names("schema_access")
+        user_datasources = []
+        for datasource_class in ConnectorRegistry.sources.values():
+            user_datasources.extend(
+                session.query(datasource_class)
+                .filter(
+                    or_(
+                        datasource_class.perm.in_(user_perms),
+                        datasource_class.schema_perm.in_(schema_perms),
+                    )
+                )
+                .all()
+            )
+
+        # get all datasources and organize by database -> schema -> datasource
+        all_datasources = cls.get_all_datasources(session)
+        hierarchy: Dict[
+            "Database", Dict[Optional[str], Set["BaseDatasource"]]
+        ] = defaultdict(lambda: defaultdict(set))
+        for datasource in all_datasources:
+            hierarchy[datasource.database][datasource.schema].add(datasource)
+
+        # add datasources with implicit permission (eg, database access)
+        for database, schemas_tables in hierarchy.items():
+            has_database_access = security_manager.can_access_database(database)
+            for schema, datasources in schemas_tables.items():
+                schema_perm = security_manager.get_schema_perm(database, schema)
+                if has_database_access or (
+                    schema_perm
+                    and security_manager.can_access("schema_access", schema_perm)
+                ):
+                    user_datasources.extend(datasources)
+
+        return user_datasources
 
     @classmethod
     def get_datasource_by_name(  # pylint: disable=too-many-arguments

--- a/superset/views/chart/views.py
+++ b/superset/views/chart/views.py
@@ -65,7 +65,7 @@ class SliceModelView(
     def add(self) -> FlaskResponse:
         datasources = [
             {"value": str(d.id) + "__" + d.type, "label": repr(d)}
-            for d in ConnectorRegistry.get_all_datasources(db.session)
+            for d in ConnectorRegistry.get_user_datasources(db.session)
         ]
         payload = {
             "datasources": sorted(

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -184,7 +184,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             sorted(
                 [
                     datasource.short_data
-                    for datasource in ConnectorRegistry.get_all_datasources(db.session)
+                    for datasource in ConnectorRegistry.get_user_datasources(db.session)
                     if datasource.short_data.get("name")
                 ],
                 key=lambda datasource: datasource["name"],


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

We currently return all datasources in the `/datasources/` and `/chart/add` endpoints. This PR changes the payload to have only user-accessible datasources.

The PR adds a new method `get_user_datasources`, which replaces `get_all_datasources` in the two views.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Will add unit tests, wanted to check the approach first.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
