### PR TITLE
fix(db-connection-ui): Allow Dynamic Big Query Edits

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm.tsx
@@ -66,7 +66,9 @@ interface FieldPropTypes {
 }
 
 const CredentialsInfo = ({ changeMethods, isEditMode, db }: FieldPropTypes) => {
-  const [uploadOption, setUploadOption] = useState<number>(CredentialInfoOptions.copyPaste.valueOf());
+  const [uploadOption, setUploadOption] = useState<number>(
+    CredentialInfoOptions.copyPaste.valueOf(),
+  );
   const [fileToUpload, setFileToUpload] = useState<string | null | undefined>(
     null,
   );

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm.tsx
@@ -65,32 +65,40 @@ interface FieldPropTypes {
   sslForced?: boolean;
 }
 
-const CredentialsInfo = ({ changeMethods }: FieldPropTypes) => {
-  const [uploadOption, setUploadOption] = useState<number>(0);
+const CredentialsInfo = ({ changeMethods, isEditMode, db }: FieldPropTypes) => {
+  const [uploadOption, setUploadOption] = useState<number>(1);
   const [fileToUpload, setFileToUpload] = useState<string | null | undefined>(
     null,
   );
   return (
     <CredentialInfoForm>
-      <span className="label-select">
-        How do you want to enter service account credentials?
-      </span>
-      <Select
-        defaultValue={CredentialInfoOptions.jsonUpload}
-        style={{ width: '100%' }}
-        onChange={option => setUploadOption(option)}
-      >
-        <Select.Option value={CredentialInfoOptions.jsonUpload}>
-          Upload JSON file
-        </Select.Option>
-        <Select.Option value={CredentialInfoOptions.copyPaste}>
-          Copy and Paste JSON credentials
-        </Select.Option>
-      </Select>
+      {!isEditMode && (
+        <>
+          <span className="label-select">
+            How do you want to enter service account credentials?
+          </span>
+          <Select
+            style={{ width: '100%' }}
+            onChange={option => setUploadOption(option)}
+          >
+            <Select.Option value={CredentialInfoOptions.jsonUpload}>
+              Upload JSON file
+            </Select.Option>
+
+            <Select.Option value={CredentialInfoOptions.copyPaste}>
+              Copy and Paste JSON credentials
+            </Select.Option>
+          </Select>
+        </>
+      )}
       {uploadOption === CredentialInfoOptions.copyPaste ? (
         <div className="input-container" onChange={changeMethods.onChange}>
           <span className="label-select">Service Account</span>
-          <textarea className="input-form" name="encrypted_extra" />
+          <textarea
+            className="input-form"
+            name="encrypted_extra"
+            value={db?.parameters?.credentials_info}
+          />
           <span className="label-paste">
             Copy and paste the entire service account .json file here
           </span>

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm.tsx
@@ -66,7 +66,7 @@ interface FieldPropTypes {
 }
 
 const CredentialsInfo = ({ changeMethods, isEditMode, db }: FieldPropTypes) => {
-  const [uploadOption, setUploadOption] = useState<number>(1);
+  const [uploadOption, setUploadOption] = useState<number>(CredentialInfoOptions.copyPaste.valueOf());
   const [fileToUpload, setFileToUpload] = useState<string | null | undefined>(
     null,
   );
@@ -78,6 +78,7 @@ const CredentialsInfo = ({ changeMethods, isEditMode, db }: FieldPropTypes) => {
             How do you want to enter service account credentials?
           </span>
           <Select
+            defaultValue={uploadOption}
             style={{ width: '100%' }}
             onChange={option => setUploadOption(option)}
           >

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -229,6 +229,13 @@ function dbReducer(
         ).toString();
       }
 
+      if (action.payload?.parameters?.credentials_info) {
+        // deserialize credentials info for big query editting
+        action.payload.parameters.credentials_info = JSON.stringify(
+          action.payload?.parameters.credentials_info,
+        );
+      }
+
       return {
         ...action.payload,
         engine: trimmedState.engine,
@@ -299,7 +306,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
     availableDbs?.databases?.find(
       (available: { engine: string | undefined }) =>
         // TODO: we need a centralized engine in one place
-        available.engine === db?.engine || db?.backend,
+        available.engine === db?.backend || db?.engine,
     ) || {};
 
   // Test Connection logic

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -210,17 +210,18 @@ function dbReducer(
     case ActionType.fetched:
       // convert all the keys in this payload into strings
       // eslint-disable-next-line no-case-declarations
-      let extra_json = {};
+      let deserializeExtraJSON = {};
       if (action.payload.extra) {
-        extra_json = {
+        const extra_json = {
           ...JSON.parse(action.payload.extra || ''),
-        };
-        extra_json = {
-          ...extra_json,
-          metadata_params: JSON.stringify(extra_json.metadata_params),
-          engine_params: JSON.stringify(extra_json.engine_params),
+        } as DatabaseObject['extra_json'];
+
+        deserializeExtraJSON = {
+          ...JSON.parse(action.payload.extra || ''),
+          metadata_params: JSON.stringify(extra_json?.metadata_params),
+          engine_params: JSON.stringify(extra_json?.engine_params),
           schemas_allowed_for_csv_upload: JSON.stringify(
-            extra_json.schemas_allowed_for_csv_upload,
+            extra_json?.schemas_allowed_for_csv_upload,
           ),
         };
       }
@@ -243,7 +244,7 @@ function dbReducer(
         ...action.payload,
         engine: trimmedState.engine,
         configuration_method: trimmedState.configuration_method,
-        extra_json,
+        extra_json: deserializeExtraJSON,
         parameters: {
           ...action.payload.parameters,
           query,
@@ -454,8 +455,6 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       availableDbs?.databases.filter(
         (db: DatabaseObject) => db.engine || db.backend === engine,
       )[0].parameters !== undefined;
-
-    console.log('choosing', engine);
     setDB({
       type: ActionType.dbSelected,
       payload: {

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -210,17 +210,20 @@ function dbReducer(
     case ActionType.fetched:
       // convert all the keys in this payload into strings
       // eslint-disable-next-line no-case-declarations
-      let extra_json = {
-        ...JSON.parse(action.payload.extra || ''),
-      };
-      extra_json = {
-        ...extra_json,
-        metadata_params: JSON.stringify(extra_json.metadata_params),
-        engine_params: JSON.stringify(extra_json.engine_params),
-        schemas_allowed_for_csv_upload: JSON.stringify(
-          extra_json.schemas_allowed_for_csv_upload,
-        ),
-      };
+      let extra_json = {};
+      if (action.payload.extra) {
+        extra_json = {
+          ...JSON.parse(action.payload.extra || ''),
+        };
+        extra_json = {
+          ...extra_json,
+          metadata_params: JSON.stringify(extra_json.metadata_params),
+          engine_params: JSON.stringify(extra_json.engine_params),
+          schemas_allowed_for_csv_upload: JSON.stringify(
+            extra_json.schemas_allowed_for_csv_upload,
+          ),
+        };
+      }
 
       if (action.payload?.parameters?.query) {
         // convert query into URI params string
@@ -306,7 +309,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
     availableDbs?.databases?.find(
       (available: { engine: string | undefined }) =>
         // TODO: we need a centralized engine in one place
-        available.engine === db?.backend || db?.engine,
+        available.engine === (isEditMode ? db?.backend : db?.engine),
     ) || {};
 
   // Test Connection logic
@@ -449,8 +452,10 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
   const setDatabaseModel = (engine: string) => {
     const isDynamic =
       availableDbs?.databases.filter(
-        (db: DatabaseObject) => db.engine === engine,
+        (db: DatabaseObject) => db.engine || db.backend === engine,
       )[0].parameters !== undefined;
+
+    console.log('choosing', engine);
     setDB({
       type: ActionType.dbSelected,
       payload: {

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -473,7 +473,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       </h4>
       <div className="control-label">Supported databases</div>
       <Select
-        style={{ width: '100%' }}
+        className="available-select"
         onChange={setDatabaseModel}
         placeholder="Choose a database..."
       >

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
@@ -431,6 +431,9 @@ export const SelectDatabaseStyles = styled.div`
       font-weight: bold;
       margin: ${({ theme }) => theme.gridUnit * 6}px 0;
     }
+    .available-select {
+      width: 100%;
+    }
   }
 
   .label-available-select {

--- a/superset-frontend/src/views/CRUD/data/database/types.ts
+++ b/superset-frontend/src/views/CRUD/data/database/types.ts
@@ -64,7 +64,7 @@ export type DatabaseObject = {
 
   // Extra
   extra_json?: {
-    engine_params?: {} | string | object;
+    engine_params?: {} | string;
     metadata_params?: {} | string;
     metadata_cache_timeout?: {
       schema_cache_timeout?: number; // in Performance

--- a/superset-frontend/src/views/CRUD/data/database/types.ts
+++ b/superset-frontend/src/views/CRUD/data/database/types.ts
@@ -38,6 +38,7 @@ export type DatabaseObject = {
     username?: string;
     password?: string;
     encryption?: boolean;
+    credentials_info?: string;
     query?: string | object;
   };
   configuration_method: CONFIGURATION_METHOD;
@@ -63,7 +64,7 @@ export type DatabaseObject = {
 
   // Extra
   extra_json?: {
-    engine_params?: {} | string;
+    engine_params?: {} | string | object;
     metadata_params?: {} | string;
     metadata_cache_timeout?: {
       schema_cache_timeout?: number; // in Performance

--- a/superset-frontend/src/views/CRUD/data/database/types.ts
+++ b/superset-frontend/src/views/CRUD/data/database/types.ts
@@ -112,6 +112,11 @@ export type DatabaseForm = {
         nullable: boolean;
         type: string;
       };
+      credentials_info: {
+        description: string;
+        nullable: boolean;
+        type: string;
+      };
     };
     required: string[];
     type: string;

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -49,7 +49,7 @@ ma_plugin = MarshmallowPlugin()
 
 class BigQueryParametersSchema(Schema):
     credentials_info = EncryptedField(
-        required=True, description="Contents of BigQuery JSON credentials.",
+        required=False, description="Contents of BigQuery JSON credentials.",
     )
 
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Before users couldn't edit Big Query using dynamic forms, this PR fixes this issue and allows users to directly edit there service credentials information.

<img width="674" alt="Screen Shot 2021-06-16 at 12 06 57 PM" src="https://user-images.githubusercontent.com/27827808/122263987-098b9380-cea5-11eb-9f0f-67472eb7f762.png">

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
