### PR TITLE
fix(dashboard-list): change name of dashboard is not reflected instantly

### DIFF
--- a/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
@@ -157,8 +157,24 @@ function DashboardList(props: DashboardListProps) {
       ({ json = {} }) => {
         setDashboards(
           dashboards.map(dashboard => {
-            if (dashboard.id === json?.result.id) {
-              return json.result;
+            if (dashboard.id === json?.result?.id) {
+              const {
+                changed_by_name,
+                changed_by_url,
+                changed_by,
+                dashboard_title = '',
+                slug = '',
+                json_metadata = '',
+              } = json.result;
+              return {
+                ...dashboard,
+                changed_by_name,
+                changed_by_url,
+                changed_by,
+                dashboard_title,
+                slug,
+                json_metadata,
+              };
             }
             return dashboard;
           }),

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
@@ -163,6 +163,7 @@ function DashboardList(props: DashboardListProps) {
             return dashboard;
           }),
         );
+        refreshData();
       },
       createErrorHandler(errMsg =>
         addDangerToast(

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
@@ -165,6 +165,7 @@ function DashboardList(props: DashboardListProps) {
                 dashboard_title = '',
                 slug = '',
                 json_metadata = '',
+                changed_on_delta_humanized,
               } = json.result;
               return {
                 ...dashboard,
@@ -174,6 +175,7 @@ function DashboardList(props: DashboardListProps) {
                 dashboard_title,
                 slug,
                 json_metadata,
+                changed_on_delta_humanized,
               };
             }
             return dashboard;

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
@@ -157,13 +157,12 @@ function DashboardList(props: DashboardListProps) {
       ({ json = {} }) => {
         setDashboards(
           dashboards.map(dashboard => {
-            if (dashboard.id === json.id) {
+            if (dashboard.id === json?.result.id) {
               return json.result;
             }
             return dashboard;
           }),
         );
-        refreshData();
       },
       createErrorHandler(errMsg =>
         addDangerToast(


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix the title of dashboard list is not reflected instantly after editing.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### before

https://user-images.githubusercontent.com/11830681/122160900-52424d00-cea3-11eb-922e-b1c47fb3fc57.mov


#### after

https://user-images.githubusercontent.com/11830681/122160912-55d5d400-cea3-11eb-9736-d9be2a1bafbb.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #15130 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
