### PR TITLE
feat(api): add featured datatypes to dashboard dataset ep

### DIFF
--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -17,7 +17,7 @@
 import json
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, Hashable, List, Optional, Type, Union
+from typing import Any, Dict, Hashable, List, Optional, Set, Type, Union
 
 from flask_appbuilder.security.sqla.models import User
 from sqlalchemy import and_, Boolean, Column, Integer, String, Text
@@ -30,6 +30,7 @@ from superset.models.helpers import AuditMixinNullable, ImportExportMixin, Query
 from superset.models.slice import Slice
 from superset.typing import FilterValue, FilterValues, QueryObjectDict
 from superset.utils import core as utils
+from superset.utils.core import GenericDataType
 
 METRIC_FORM_DATA_PARAMS = [
     "metric",
@@ -306,12 +307,16 @@ class BaseDatasource(
             if metric["metric_name"] in metric_names
         ]
 
-        filtered_columns = [
-            column
-            for column in data["columns"]
-            if column["column_name"] in column_names
-        ]
+        filtered_columns: List[Column] = []
+        column_types: Set[GenericDataType] = set()
+        for column in data["columns"]:
+            generic_type = column["type_generic"]
+            if generic_type is not None:
+                column_types.add(generic_type)
+            if column["column_name"] in column_names:
+                filtered_columns.append(column)
 
+        data["column_types"] = list(column_types)
         del data["description"]
         data.update({"metrics": filtered_metrics})
         data.update({"columns": filtered_columns})

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -199,6 +199,7 @@ class DashboardDatasetSchema(Schema):
     template_params = fields.Str()
     owners = fields.List(fields.Int())
     columns = fields.List(fields.Dict())
+    column_types = fields.List(fields.Int())
     metrics = fields.List(fields.Dict())
     order_by_choices = fields.List(fields.List(fields.Str()))
     verbose_map = fields.Dict(fields.Str(), fields.Str())

--- a/tests/dashboards/api_tests.py
+++ b/tests/dashboards/api_tests.py
@@ -179,8 +179,10 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
         data = json.loads(response.data.decode("utf-8"))
         dashboard = Dashboard.get("world_health")
         expected_dataset_ids = set([s.datasource_id for s in dashboard.slices])
-        actual_dataset_ids = set([dataset["id"] for dataset in data["result"]])
+        result = data["result"]
+        actual_dataset_ids = set([dataset["id"] for dataset in result])
         self.assertEqual(actual_dataset_ids, expected_dataset_ids)
+        self.assertEqual(result[0]["column_types"], [0, 1, 2])
 
     @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
     def test_get_dashboard_datasets_not_found(self):


### PR DESCRIPTION
### SUMMARY
To be able to filter out unnecessary filter types on the native filters config form (primarily temporal filters, but potentially others later), we need to know what types of datatypes are available on the datasets that are referenced on the dashboard. While we recently added the `type_generic` field to the column object (see #14863) and could iterate through all columns to check if they are temporal or not, the list of columns that are returned by the response from `api/v1/dashboard/<pk>/datasets` have been pre-filtered to contain only a subset of the actually featured columns. Therefore, we either need to return the full list of columns in the response, or add a new field that contains a list of datatypes featured in the dataset columns. To avoid bloating the response payload, this PR proposes adding the latter, i.e. a new field `column_types` to the response, that contains a list of all `GenericDataType`s that are featured in the dataset columns.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
With this change, a new property `column_types` is available on Redux:
![image](https://user-images.githubusercontent.com/33317356/122184072-87936e80-ce94-11eb-9ab0-406c6dd3619c.png)

### TESTING INSTRUCTIONS
CI + updated test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
