### PR TITLE
chore: Makes the refresh button only appear when the filter has a datasource

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -726,9 +726,11 @@ const FiltersConfigForm = (
                       formData={newFormData}
                       enableNoResults={enableNoResults}
                     />
-                    <Tooltip title={t('Refresh the default values')}>
-                      <RefreshIcon onClick={() => refreshHandler(true)} />
-                    </Tooltip>
+                    {hasDataset && datasetId && (
+                      <Tooltip title={t('Refresh the default values')}>
+                        <RefreshIcon onClick={() => refreshHandler(true)} />
+                      </Tooltip>
+                    )}
                   </DefaultValueContainer>
                 ) : (
                   t('Fill all required fields to enable "Default Value"')


### PR DESCRIPTION
### SUMMARY
Makes the refresh button only appear when the filter has a datasource.

@villebro 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
