### PR TITLE
fix: fix dataset select list

### DIFF
--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -498,7 +498,7 @@ function ChartList(props: ChartListProps) {
           ),
         ),
       ),
-      paginate: false,
+      paginate: true,
     },
     ...(props.user.userId ? [favoritesFilter] : []),
     {


### PR DESCRIPTION
### SUMMARY
The chart listview dataset select list before would only load the first page of datasets and would not paginate. This pr fixes the issue to allow the dataset select list to paginate on scroll

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before 

https://user-images.githubusercontent.com/17326228/122298685-eb786000-ceb1-11eb-84be-0fff360d448c.mov


after

https://user-images.githubusercontent.com/17326228/122298529-bff57580-ceb1-11eb-8e51-4b00296bf97a.mov



### TESTING INSTRUCTIONS
Go to chart listview and click on dataset select and ensure that it loads all datasets.

fixes https://github.com/apache/superset/issues/15131

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ x] Has associated issue: https://github.com/apache/superset/issues/15131
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
