### PR TITLE
fix: return query if it already exists

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2477,14 +2477,34 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             CtasMethod, query_params.get("ctas_method", CtasMethod.TABLE)
         )
         tmp_table_name: str = cast(str, query_params.get("tmp_table_name"))
-        client_id: str = cast(
-            str, query_params.get("client_id") or utils.shortid()[:10]
-        )
+        client_id: str = cast(str, query_params.get("client_id"))
+        client_id_or_short_id: str = cast(str, client_id or utils.shortid()[:10])
         sql_editor_id: str = cast(str, query_params.get("sql_editor_id"))
         tab_name: str = cast(str, query_params.get("tab"))
         status: str = QueryStatus.PENDING if async_flag else QueryStatus.RUNNING
+        user_id: int = g.user.get_id() if g.user else None
 
         session = db.session()
+
+        # check to see if this query is already running
+        query = (
+            session.query(Query)
+            .filter_by(
+                client_id=client_id, user_id=user_id, sql_editor_id=sql_editor_id
+            )
+            .one_or_none()
+        )
+        if query is not None and query.status in [
+            QueryStatus.RUNNING,
+            QueryStatus.PENDING,
+            QueryStatus.TIMED_OUT,
+        ]:
+            # return the existing query
+            payload = json.dumps(
+                {"query": query.to_dict()}, default=utils.json_int_dttm_ser
+            )
+            return json_success(payload)
+
         mydb = session.query(Database).get(database_id)
         if not mydb:
             return json_error_response("Database with id %i is missing.", database_id)
@@ -2512,8 +2532,8 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             sql_editor_id=sql_editor_id,
             tmp_table_name=tmp_table_name,
             tmp_schema_name=tmp_schema_name,
-            user_id=g.user.get_id() if g.user else None,
-            client_id=client_id,
+            user_id=user_id,
+            client_id=client_id_or_short_id,
         )
         try:
             session.add(query)

--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -228,10 +228,12 @@ class TabStateView(BaseSupersetView):
     @has_access_api
     @expose("<int:tab_state_id>/query/<client_id>", methods=["DELETE"])
     def delete_query(  # pylint: disable=no-self-use
-        self, tab_state_id: str, client_id: str
+        self, tab_state_id: int, client_id: str
     ) -> FlaskResponse:
         db.session.query(Query).filter_by(
-            client_id=client_id, user_id=g.user.get_id(), sql_editor_id=tab_state_id
+            client_id=client_id,
+            user_id=g.user.get_id(),
+            sql_editor_id=str(tab_state_id),
         ).delete(synchronize_session=False)
         db.session.commit()
         return json_success(json.dumps("OK"))

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -1412,7 +1412,7 @@ class TestCore(SupersetTestCase):
             "client_id_1",
             user_name=username,
             raise_on_error=True,
-            sql_editor_id=tab_state_id,
+            sql_editor_id=str(tab_state_id),
         )
         # run an orphan query (no tab)
         self.run_sql(


### PR DESCRIPTION
### SUMMARY
We were seeing some duplicate client_id errors when running queries. Here's the root cause: 

When we have a timeout on a query, we return a 408 , and when most browsers get a 408 response, they automatically retry the request. The issue with the query POST request is that the db request happens after we create the query, so if the db request times out, then the retry fails because the request is not idempotent, due to the fact that the client_id is created on the client and has a uniqueness constraint in the db. 

My solution here is to check to see if the query exists and if it is in a pending or timed out state, don't resave it, but rather just return the original query.

I had thought of a few different options for this issue, and here are the reasonings why I didn't go with other solutions: 
1) change client_id to query.id and generate it server side. The reason that we have the id generated client side and stored in the db is so that we can stop the query before the original response has returned. 
2) return something other than a 408 when the db has timed out. If the db timeout is long, it's possible that the server will time out before the db and we'll likely still be left with the same issue. 
3) run the db request before saving the query. Because the same endpoint is used with async query requests, the refactor would be much more prone to errors. 

Some concerns/questions: 
If a query is new, and happens to match an existing query that is running, (unlikely but possible), we don't want to return someone else's query. There's a check on this lookup for user_id, but that can be null. There's also a lookup on sql_editor_id. My assumption is that with the combination of these three factors, we should with certainty only get the request that we are intending, but I'd welcome another set of eyes on that. The last option is to check the sql string, but the comparison on what could potentially be a long string may be costly. 

In my testing, I was never able to reproduce a server timeout response, only a netstat error, and the query continued to have a status of "running" which means that it will continue to be polled for. You have to explicitly delete the query if you navigate away from the page without stopping the query. I didn't change that behavior, but it's something that we may want to investigate. 


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No visual changes

### TESTING INSTRUCTIONS
If you are testing locally and can put a debug statement somewhere in the sql_json POST request you can replicate a timeout. After about 2 minutes, you should see another sql_json POST request in your browser network tab, and it should return a 200 with the original query, and not raise an error. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
