### PR TITLE
chore: move calling configure_feature_flags more earlier

### DIFF
--- a/superset/app.py
+++ b/superset/app.py
@@ -553,7 +553,6 @@ class SupersetAppInitializer:
         """
         Runs init logic in the context of the app
         """
-        self.configure_feature_flags()
         self.configure_fab()
         self.configure_url_map_converters()
         self.configure_data_sources()
@@ -576,6 +575,9 @@ class SupersetAppInitializer:
         self.pre_init()
         # Configuration of logging must be done first to apply the formatter properly
         self.configure_logging()
+        # Configuration of feature_flags must be done first to allow init features
+        # conditionally
+        self.configure_feature_flags()
         self.configure_db_encrypt()
         self.setup_db()
         self.configure_celery()


### PR DESCRIPTION
### SUMMARY
In order to allow init new features conditionally based on features flags, the feature flags manager should be initiated as soon as possible.
For example, as a future pull request, I would like to add a new feature that affects the db setup based on feature flag, so the new feature should be initiated before setup DB 

