### PR TITLE
feat(native-filters): Hide time filters if loaded datasets don't have temporal columns

### DIFF
--- a/superset-frontend/spec/fixtures/mockDatasource.js
+++ b/superset-frontend/spec/fixtures/mockDatasource.js
@@ -164,6 +164,7 @@ export default {
         column_name: 'num_girls',
       },
     ],
+    column_types: [0, 1, 2],
     id,
     granularity_sqla: [['ds', 'ds']],
     name: 'birth_names',

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -103,7 +103,7 @@ export const StyledFormItem = styled(FormItem)`
   margin-bottom: ${({ theme }) => theme.gridUnit * 4}px;
 
   & .ant-form-item-label {
-    padding-bottom: 0px;
+    padding-bottom: 0;
   }
 
   & .ant-form-item-control-input {
@@ -112,12 +112,12 @@ export const StyledFormItem = styled(FormItem)`
 `;
 
 export const StyledRowFormItem = styled(FormItem)`
-  margin-bottom: 0px;
-  padding-bottom: 0px;
+  margin-bottom: 0;
+  padding-bottom: 0;
   min-width: 50%;
 
   & .ant-form-item-label {
-    padding-bottom: 0px;
+    padding-bottom: 0;
   }
 
   .ant-form-item-control-input-content > div > div {
@@ -155,17 +155,17 @@ const StyledCollapse = styled(Collapse)`
   margin-right: ${({ theme }) => theme.gridUnit * -4}px;
   border-left: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
   border-top: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
-  border-radius: 0px;
+  border-radius: 0;
 
   .ant-collapse-header {
     border-bottom: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
     border-top: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
     margin-top: -1px;
-    border-radius: 0px;
+    border-radius: 0;
   }
 
   .ant-collapse-content {
-    border: 0px;
+    border: 0;
   }
 
   .ant-collapse-content-box {
@@ -173,8 +173,8 @@ const StyledCollapse = styled(Collapse)`
   }
 
   &.ant-collapse > .ant-collapse-item {
-    border: 0px;
-    border-radius: 0px;
+    border: 0;
+    border-radius: 0;
   }
 `;
 
@@ -183,17 +183,17 @@ const StyledTabs = styled(Tabs)`
     position: sticky;
     margin-left: ${({ theme }) => theme.gridUnit * -4}px;
     margin-right: ${({ theme }) => theme.gridUnit * -4}px;
-    top: 0px;
+    top: 0;
     background: white;
     z-index: 1;
   }
 
   .ant-tabs-nav-list {
-    padding: 0px;
+    padding: 0;
   }
 
   .ant-form-item-label {
-    padding-bottom: 0px;
+    padding-bottom: 0;
   }
 `;
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -590,23 +590,29 @@ const FiltersConfigForm = (
             {...getFiltersConfigModalTestId('filter-type')}
           >
             <Select
-              options={nativeFilterVizTypes
-                .filter(
-                  filterType =>
-                    !TIME_FILTERS.includes(filterType) ||
-                    doLoadedDatasetsHaveTemporalColumns,
-                )
-                .map(filterType => {
-                  // @ts-ignore
-                  const name = nativeFilterItems[filterType]?.value.name;
-                  const mappedName = name
-                    ? FILTER_TYPE_NAME_MAPPING[name]
-                    : undefined;
-                  return {
-                    value: filterType,
-                    label: mappedName || name,
-                  };
-                })}
+              options={nativeFilterVizTypes.map(filterType => {
+                // @ts-ignore
+                const name = nativeFilterItems[filterType]?.value.name;
+                const mappedName = name
+                  ? FILTER_TYPE_NAME_MAPPING[name]
+                  : undefined;
+                const isDisabled =
+                  TIME_FILTERS.includes(filterType) &&
+                  !doLoadedDatasetsHaveTemporalColumns;
+                return {
+                  value: filterType,
+                  label: isDisabled ? (
+                    <Tooltip
+                      title={t('Datasets do not contain a temporal column')}
+                    >
+                      {mappedName || name}
+                    </Tooltip>
+                  ) : (
+                    mappedName || name
+                  ),
+                  isDisabled,
+                };
+              })}
               onChange={({ value }: { value: string }) => {
                 setNativeFilterFieldValues(form, filterId, {
                   filterType: value,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils.ts
@@ -19,7 +19,7 @@
 import { flatMapDeep } from 'lodash';
 import { FormInstance } from 'antd/lib/form';
 import React from 'react';
-import { CustomControlItem } from '@superset-ui/chart-controls';
+import { CustomControlItem, DatasourceMeta } from '@superset-ui/chart-controls';
 
 const FILTERS_FIELD_NAME = 'filters';
 
@@ -64,7 +64,9 @@ type DatasetSelectValue = {
   label: string;
 };
 
-export const datasetToSelectOption = (item: any): DatasetSelectValue => ({
+export const datasetToSelectOption = (
+  item: DatasourceMeta & { table_name: string },
+): DatasetSelectValue => ({
   value: item.id,
   label: item.table_name,
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
@@ -28,7 +28,7 @@ import {
   TimeGrainFilterPlugin,
 } from 'src/filters/components';
 import { render, screen, waitFor } from 'spec/helpers/testing-library';
-import mockDatasource from 'spec/fixtures/mockDatasource';
+import mockDatasource, { datasourceId } from 'spec/fixtures/mockDatasource';
 import {
   FiltersConfigModal,
   FiltersConfigModalProps,
@@ -51,6 +51,17 @@ class MainPreset extends Preset {
 
 const initialStoreState = {
   datasources: mockDatasource,
+};
+
+const storeWithDatasourceWithoutTemporalColumns = {
+  ...initialStoreState,
+  datasources: {
+    ...initialStoreState.datasources,
+    [datasourceId]: {
+      ...initialStoreState.datasources[datasourceId],
+      column_types: [0, 1],
+    },
+  },
 };
 
 fetchMock.get('glob:*/api/v1/dataset/1', {
@@ -115,6 +126,7 @@ const DEFAULT_VALUE_REQUIRED_REGEX = /^default value is required$/i;
 const PARENT_REQUIRED_REGEX = /^parent filter is required$/i;
 const PRE_FILTER_REQUIRED_REGEX = /^pre-filter is required$/i;
 const FILL_REQUIRED_FIELDS_REGEX = /fill all required fields to enable/;
+const TIME_RANGE_PREFILTER_REGEX = /^time range$/i;
 
 const props: FiltersConfigModalProps = {
   isOpen: true,
@@ -244,6 +256,20 @@ test('renders a time grain filter type', () => {
   expect(screen.queryByText(ADVANCED_REGEX)).not.toBeInTheDocument();
 });
 
+test('render time filter types as disabled if there are no temporal columns in the dataset', () => {
+  defaultRender(undefined, storeWithDatasourceWithoutTemporalColumns);
+  userEvent.click(screen.getByText(VALUE_REGEX));
+  expect(screen.getByText(TIME_RANGE_REGEX).closest('div')).toHaveClass(
+    'Select__option--is-disabled',
+  );
+  expect(screen.getByText(TIME_GRAIN_REGEX).closest('div')).toHaveClass(
+    'Select__option--is-disabled',
+  );
+  expect(screen.getByText(TIME_COLUMN_REGEX).closest('div')).toHaveClass(
+    'Select__option--is-disabled',
+  );
+});
+
 test('validates the name', async () => {
   defaultRender();
   userEvent.click(screen.getByRole('button', { name: SAVE_REGEX }));
@@ -288,6 +314,14 @@ test('validates the pre-filter value', async () => {
   ).toBeInTheDocument();
 });
 
+test("doesn't render time range pre-filter if there are no temporal columns in datasource", async () => {
+  defaultRender(undefined, storeWithDatasourceWithoutTemporalColumns);
+  userEvent.click(screen.getByText(ADVANCED_REGEX));
+  userEvent.click(getCheckbox(PRE_FILTER_REGEX));
+  expect(
+    screen.queryByText(TIME_RANGE_PREFILTER_REGEX),
+  ).not.toBeInTheDocument();
+});
 /*
   TODO
     adds a new value filter type with all fields filled

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
@@ -16,7 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import React from 'react';
 import { Preset } from '@superset-ui/core';
+import fetchMock from 'fetch-mock';
+import userEvent, { specialChars } from '@testing-library/user-event';
 import {
   SelectFilterPlugin,
   RangeFilterPlugin,
@@ -25,9 +28,7 @@ import {
   TimeGrainFilterPlugin,
 } from 'src/filters/components';
 import { render, screen, waitFor } from 'spec/helpers/testing-library';
-import fetchMock from 'fetch-mock';
-import React from 'react';
-import userEvent, { specialChars } from '@testing-library/user-event';
+import mockDatasource from 'spec/fixtures/mockDatasource';
 import {
   FiltersConfigModal,
   FiltersConfigModalProps,
@@ -49,7 +50,7 @@ class MainPreset extends Preset {
 }
 
 const initialStoreState = {
-  datasources: [{ id: 1, table_name: 'Datasource 1' }],
+  datasources: mockDatasource,
 };
 
 fetchMock.get('glob:*/api/v1/dataset/1', {
@@ -128,7 +129,7 @@ beforeAll(() => {
 
 function defaultRender(
   overrides?: Partial<FiltersConfigModalProps>,
-  initialState?: {},
+  initialState = initialStoreState,
 ) {
   return render(<FiltersConfigModal {...props} {...overrides} />, {
     useRedux: true,


### PR DESCRIPTION
### SUMMARY
If none of the datasets used by charts on current dashboard have any temporal columns, there's no point in applying Time range, Time column or Time grain filters to them. This PR implements disables selecting those filter types on dashboards without datasets with temporal columns.
Also, there's no point in pre-filtering by time range datasets without temporal columns. This PR implements hiding time range picker pre-filter if current dataset doesn't have temporal columns.
I also removed "px" suffix from "0px" css values to remove linter warnings.

Second part of the related issue (https://github.com/apache/superset/issues/15068) was excluding charts that use dataset without temporal columns from scope when creating a time filter. We've decided to handle this as a separate issue (https://github.com/apache/superset/issues/14977). CC @junlincc 


Rejected alternatives: hiding time filters instead of disabling options in select button. We decided that it might be confusing for the users if some filter types just "disappeared".

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see https://github.com/apache/superset/issues/15068

After:
Case 1: only datasets without temporal columns - time filters disabled, time range pre-filter hidden
https://user-images.githubusercontent.com/15073128/122394612-7589fc80-cf76-11eb-9af4-f3662b71d432.mov

Case 2: only some datasets have temporal columns - time filters enabled, time range pre-filter hidden if a dataset without temporal columns is selected ("threads" dataset has temporal columns, "members_channels_2" doesn't)
https://user-images.githubusercontent.com/15073128/122388521-3eb0e800-cf70-11eb-96b6-ad5f2651bf69.mov

### TESTING INSTRUCTIONS
0. Enable `DASHBOARD_NATIVE_FILTERS` feature flag
1. Create a dashboard using datasets without temporal columns (e.g. `covid_vaccines` from test data)
2. Open native filters modal, verify that only Value and Numerical Range filter types are enabled.
3. Create a dashboard using multiple datasets, some of which have temporal columns, and some don't
4. Open native filters modal, verify that all 5 filter types are available
5. Select a dataset with temporal columns and check `Pre-filter available values`. Verify that time range filter shows up
6. Select a dataset without temporal columns and go to pre-filtering section. Verify that time range filter doesn't show up.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes #15068 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
