### PR TITLE
fix: Filter bar not occupying 100% height when filter sets FF unset

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -34,6 +34,7 @@ import { getUrlParam } from 'src/utils/urlUtils';
 import { DashboardLayout, RootState } from 'src/dashboard/types';
 import { setDirectPathToChild } from 'src/dashboard/actions/dashboardState';
 import { useElementOnScreen } from 'src/common/hooks/useElementOnScreen';
+import { FeatureFlag, isFeatureEnabled } from 'src/featureFlags';
 import {
   deleteTopLevelTabs,
   handleComponentDrop,
@@ -55,7 +56,8 @@ const TABS_HEIGHT = 50;
 const HEADER_HEIGHT = 72;
 const CLOSED_FILTER_BAR_WIDTH = 32;
 const OPEN_FILTER_BAR_WIDTH = 260;
-const FILTER_BAR_HEADER_HEIGHT = 128;
+const FILTER_BAR_HEADER_HEIGHT = 80;
+const FILTER_BAR_TABS_HEIGHT = 46;
 
 type DashboardBuilderProps = {};
 
@@ -192,7 +194,16 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
   const [containerRef, isSticky] = useElementOnScreen<HTMLDivElement>({
     threshold: [1],
   });
-  const offset = FILTER_BAR_HEADER_HEIGHT + (isSticky ? 0 : MAIN_HEADER_HEIGHT);
+
+  const filterSetEnabled = isFeatureEnabled(
+    FeatureFlag.DASHBOARD_NATIVE_FILTERS_SET,
+  );
+
+  const offset =
+    FILTER_BAR_HEADER_HEIGHT +
+    (isSticky ? 0 : MAIN_HEADER_HEIGHT) +
+    (filterSetEnabled ? FILTER_BAR_TABS_HEIGHT : 0);
+
   const filterBarHeight = `calc(100vh - ${offset}px)`;
   const filterBarOffset = dashboardFiltersOpen ? 0 : barTopOffset + 20;
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -72,7 +72,7 @@ const Bar = styled.div<{ width: number }>`
   left: 0;
   flex-direction: column;
   flex-grow: 1;
-  width: ${({ width }) => width}px; // arbitrary...
+  width: ${({ width }) => width}px;
   background: ${({ theme }) => theme.colors.grayscale.light5};
   border-right: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
   border-bottom: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
@@ -299,11 +299,13 @@ const FilterBar: React.FC<FiltersBarProps> = ({
             </Tabs.TabPane>
           </StyledTabs>
         ) : (
-          <FilterControls
-            dataMaskSelected={dataMaskSelected}
-            directPathToChild={directPathToChild}
-            onFilterSelectionChange={handleFilterSelectionChange}
-          />
+          <div css={{ overflow: 'auto', height }}>
+            <FilterControls
+              dataMaskSelected={dataMaskSelected}
+              directPathToChild={directPathToChild}
+              onFilterSelectionChange={handleFilterSelectionChange}
+            />
+          </div>
         )}
       </Bar>
     </BarWrapper>


### PR DESCRIPTION
### SUMMARY
Fixes https://github.com/apache/superset/issues/15218

@villebro @kgabryje @rusackas 

### AFTER VIDEO
https://user-images.githubusercontent.com/70410625/122401870-5ded4c80-cf53-11eb-9f67-3c307d5b869b.mov

### TESTING INSTRUCTIONS
See the original issue for instructions.

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
