### PR TITLE
refactor: icon to icons in DatasourceEditor

### DIFF
--- a/superset-frontend/spec/javascripts/datasource/DatasourceEditor_spec.jsx
+++ b/superset-frontend/spec/javascripts/datasource/DatasourceEditor_spec.jsx
@@ -175,7 +175,7 @@ describe('DatasourceEditor', () => {
       const sourceTab = wrapper.find(Tabs.TabPane).first();
       expect(sourceTab.find(Radio).first().prop('disabled')).toBe(false);
 
-      const icon = wrapper.find(Icons.LockUnlocked); 
+      const icon = wrapper.find(Icons.LockUnlocked);
       expect(icon).toExist();
 
       const tableSelector = sourceTab.find(Field).shallow().find(TableSelector);
@@ -188,7 +188,7 @@ describe('DatasourceEditor', () => {
       expect(sourceTab.find(Radio).length).toBe(2);
       expect(sourceTab.find(Radio).first().prop('disabled')).toBe(true);
 
-      const icon = wrapper.find(Icons.LockLocked); 
+      const icon = wrapper.find(Icons.LockLocked);
       expect(icon).toExist();
       icon.parent().simulate('click');
       expect(wrapper.state('isEditMode')).toBe(true);

--- a/superset-frontend/spec/javascripts/datasource/DatasourceEditor_spec.jsx
+++ b/superset-frontend/spec/javascripts/datasource/DatasourceEditor_spec.jsx
@@ -27,6 +27,7 @@ import { render, screen } from 'spec/helpers/testing-library';
 import { Radio } from 'src/components/Radio';
 
 import Icon from 'src/components/Icon';
+import Icons from 'src/components/Icons';
 import Tabs from 'src/components/Tabs';
 import DatasourceEditor from 'src/datasource/DatasourceEditor';
 import Field from 'src/CRUD/Field';
@@ -174,8 +175,8 @@ describe('DatasourceEditor', () => {
       const sourceTab = wrapper.find(Tabs.TabPane).first();
       expect(sourceTab.find(Radio).first().prop('disabled')).toBe(false);
 
-      const icon = sourceTab.find(Icon);
-      expect(icon.prop('name')).toBe('lock-unlocked');
+      const icon = wrapper.find(Icons.LockUnlocked); 
+      expect(icon).toExist();
 
       const tableSelector = sourceTab.find(Field).shallow().find(TableSelector);
       expect(tableSelector.length).toBe(1);
@@ -187,8 +188,8 @@ describe('DatasourceEditor', () => {
       expect(sourceTab.find(Radio).length).toBe(2);
       expect(sourceTab.find(Radio).first().prop('disabled')).toBe(true);
 
-      const icon = sourceTab.find(Icon);
-      expect(icon.prop('name')).toBe('lock-locked');
+      const icon = wrapper.find(Icons.LockLocked); 
+      expect(icon).toExist();
       icon.parent().simulate('click');
       expect(wrapper.state('isEditMode')).toBe(true);
 

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -674,7 +674,6 @@ class DatasourceEditor extends React.PureComponent {
   renderSpatialTab() {
     const { datasource } = this.state;
     const { spatials, all_cols: allCols } = datasource;
-    console.log('Icons', Icons);
     return (
       <Tabs.TabPane
         tab={<CollectionTabTitle collection={spatials} title={t('Spatial')} />}

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -30,7 +30,6 @@ import Tabs from 'src/components/Tabs';
 import CertifiedIcon from 'src/components/CertifiedIcon';
 import WarningIconWithTooltip from 'src/components/WarningIconWithTooltip';
 import DatabaseSelector from 'src/components/DatabaseSelector';
-import Icon from 'src/components/Icon';
 import Label from 'src/components/Label';
 import Loading from 'src/components/Loading';
 import TableSelector from 'src/components/TableSelector';
@@ -51,6 +50,7 @@ import Field from 'src/CRUD/Field';
 
 import withToasts from 'src/messageToasts/enhancers/withToasts';
 import { FeatureFlag, isFeatureEnabled } from 'src/featureFlags';
+import Icons from 'src/components/Icons';
 
 const DatasourceContainer = styled.div`
   .change-warning {
@@ -93,6 +93,9 @@ const EditLockContainer = styled.div`
   align-items: center;
   a {
     padding: 0 10px;
+  }
+  span[role=img] {
+    margin-top: -3px; 
   }
 `;
 
@@ -671,6 +674,7 @@ class DatasourceEditor extends React.PureComponent {
   renderSpatialTab() {
     const { datasource } = this.state;
     const { spatials, all_cols: allCols } = datasource;
+    console.log('Icons', Icons)
     return (
       <Tabs.TabPane
         tab={<CollectionTabTitle collection={spatials} title={t('Spatial')} />}
@@ -842,10 +846,16 @@ class DatasourceEditor extends React.PureComponent {
         {this.allowEditSource && (
           <EditLockContainer>
             <span role="button" tabIndex={0} onClick={this.onChangeEditMode}>
-              <Icon
-                color={supersetTheme.colors.grayscale.base}
-                name={this.state.isEditMode ? 'lock-unlocked' : 'lock-locked'}
-              />
+              {
+                this.state.isEditMode ?
+                  <Icons.LockUnlocked
+                    iconColor={supersetTheme.colors.grayscale.base}
+                  />
+                :
+                  <Icons.LockLocked
+                    iconColor={supersetTheme.colors.grayscale.base}
+                  />
+              }
             </span>
             {!this.state.isEditMode && (
               <div>{t('Click the lock to make changes.')}</div>

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -94,8 +94,8 @@ const EditLockContainer = styled.div`
   a {
     padding: 0 10px;
   }
-  span[role=img] {
-    margin-top: -3px; 
+  span[role='img'] {
+    margin-top: -3px;
   }
 `;
 
@@ -674,7 +674,7 @@ class DatasourceEditor extends React.PureComponent {
   renderSpatialTab() {
     const { datasource } = this.state;
     const { spatials, all_cols: allCols } = datasource;
-    console.log('Icons', Icons)
+    console.log('Icons', Icons);
     return (
       <Tabs.TabPane
         tab={<CollectionTabTitle collection={spatials} title={t('Spatial')} />}
@@ -846,16 +846,15 @@ class DatasourceEditor extends React.PureComponent {
         {this.allowEditSource && (
           <EditLockContainer>
             <span role="button" tabIndex={0} onClick={this.onChangeEditMode}>
-              {
-                this.state.isEditMode ?
-                  <Icons.LockUnlocked
-                    iconColor={supersetTheme.colors.grayscale.base}
-                  />
-                :
-                  <Icons.LockLocked
-                    iconColor={supersetTheme.colors.grayscale.base}
-                  />
-              }
+              {this.state.isEditMode ? (
+                <Icons.LockUnlocked
+                  iconColor={supersetTheme.colors.grayscale.base}
+                />
+              ) : (
+                <Icons.LockLocked
+                  iconColor={supersetTheme.colors.grayscale.base}
+                />
+              )}
             </span>
             {!this.state.isEditMode && (
               <div>{t('Click the lock to make changes.')}</div>

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -94,9 +94,6 @@ const EditLockContainer = styled.div`
   a {
     padding: 0 10px;
   }
-  span[role='img'] {
-    margin-top: -3px;
-  }
 `;
 
 const ColumnButtonWrapper = styled.div`


### PR DESCRIPTION
### SUMMARY
This pr uses the new Icons component for the datasourceeditor.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before:
<img width="862" alt="Screen Shot 2021-06-17 at 2 43 06 PM" src="https://user-images.githubusercontent.com/17326228/122476266-be43b480-cf7a-11eb-8745-af0ca4c33840.png">

after
<img width="862" alt="Screen Shot 2021-06-17 at 2 43 18 PM" src="https://user-images.githubusercontent.com/17326228/122476317-d3204800-cf7a-11eb-94d8-987ef7a97580.png">



### TESTING INSTRUCTIONS
Go to datasource editor modal and check lock icon.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
