### PR TITLE
docs: fix hyperlink

### DIFF
--- a/docs/src/pages/docs/frequently-asked-questions-page.mdx
+++ b/docs/src/pages/docs/frequently-asked-questions-page.mdx
@@ -76,7 +76,7 @@ SUPERSET_WEBSERVER_TIMEOUT = 60
 
 ### Why is the map not visible in the geospatial visualization?
 
-You need to register a free account at [Mapbox.com](www.mapbox.com), obtain an API key, and add it
+You need to register a free account at [Mapbox.com](https://www.mapbox.com), obtain an API key, and add it
 to **superset_config.py** at the key MAPBOX_API_KEY:
 
 ```


### PR DESCRIPTION
Current hyperlink is going to https://superset.apache.org/docs/www.mapbox.com

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
