### PR TITLE
feat(sql): add jinja support to metrics and expressions

### DIFF
--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -103,7 +103,7 @@ class QueryObject:
         applied_time_extras: Optional[Dict[str, str]] = None,
         apply_fetch_values_predicate: bool = False,
         granularity: Optional[str] = None,
-        metrics: Optional[List[Union[Dict[str, Any], str]]] = None,
+        metrics: Optional[List[Metric]] = None,
         groupby: Optional[List[str]] = None,
         filters: Optional[List[Dict[str, Any]]] = None,
         time_range: Optional[str] = None,

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -17,7 +17,7 @@
 # pylint: disable=R
 import logging
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, NamedTuple, Optional, Union
+from typing import Any, Dict, List, NamedTuple, Optional
 
 from flask_babel import gettext as _
 from pandas import DataFrame

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -55,7 +55,13 @@ from superset.exceptions import SupersetException
 from superset.extensions import encrypted_field_factory
 from superset.models.core import Database
 from superset.models.helpers import AuditMixinNullable, ImportExportMixin, QueryResult
-from superset.typing import FilterValues, Granularity, Metric, QueryObjectDict
+from superset.typing import (
+    AdhocMetric,
+    FilterValues,
+    Granularity,
+    Metric,
+    QueryObjectDict,
+)
 from superset.utils import core as utils
 from superset.utils.date_parser import parse_human_datetime, parse_human_timedelta
 
@@ -1010,7 +1016,7 @@ class DruidDatasource(Model, BaseDatasource):
         return ret
 
     @staticmethod
-    def druid_type_from_adhoc_metric(adhoc_metric: Dict[str, Any]) -> str:
+    def druid_type_from_adhoc_metric(adhoc_metric: AdhocMetric) -> str:
         column_type = adhoc_metric["column"]["type"].lower()
         aggregate = adhoc_metric["aggregate"].lower()
 
@@ -1025,7 +1031,7 @@ class DruidDatasource(Model, BaseDatasource):
     def get_aggregations(
         metrics_dict: Dict[str, Any],
         saved_metrics: Set[str],
-        adhoc_metrics: Optional[List[Dict[str, Any]]] = None,
+        adhoc_metrics: Optional[List[AdhocMetric]] = None,
     ) -> "OrderedDict[str, Any]":
         """
         Returns a dictionary of aggregation metric names to aggregation json objects

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -22,7 +22,18 @@ from collections import defaultdict, OrderedDict
 from contextlib import closing
 from dataclasses import dataclass, field  # pylint: disable=wrong-import-order
 from datetime import datetime, timedelta
-from typing import Any, Dict, Hashable, List, NamedTuple, Optional, Tuple, Type, Union
+from typing import (
+    Any,
+    cast,
+    Dict,
+    Hashable,
+    List,
+    NamedTuple,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 
 import pandas as pd
 import sqlalchemy as sa
@@ -241,7 +252,9 @@ class TableColumn(Model, BaseColumn):
         column_spec = db_engine_spec.get_column_spec(self.type)
         type_ = column_spec.sqla_type if column_spec else None
         if self.expression:
-            col = literal_column(self.expression, type_=type_)
+            tp = self.table.get_template_processor()
+            expression = tp.process_template(self.expression)
+            col = literal_column(expression, type_=type_)
         else:
             col = column(self.column_name, type_=type_)
         col = self.table.make_sqla_column_compatible(col, label)
@@ -879,7 +892,7 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
         label = utils.get_metric_name(metric)
 
         if expression_type == utils.AdhocMetricExpressionType.SIMPLE:
-            column_name = metric["column"].get("column_name")
+            column_name = cast(str, metric["column"].get("column_name"))
             table_column: Optional[TableColumn] = columns_by_name.get(column_name)
             if table_column:
                 sqla_column = table_column.get_sqla_col()
@@ -887,7 +900,9 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
                 sqla_column = column(column_name)
             sqla_metric = self.sqla_aggregations[metric["aggregate"]](sqla_column)
         elif expression_type == utils.AdhocMetricExpressionType.SQL:
-            sqla_metric = literal_column(metric.get("sqlExpression"))
+            tp = self.get_template_processor()
+            expression = tp.process_template(cast(str, metric["sqlExpression"]))
+            sqla_metric = literal_column(expression)
         else:
             raise QueryObjectValidationError("Adhoc metric expressionType is invalid")
 
@@ -1060,8 +1075,9 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
         # Since orderby may use adhoc metrics, too; we need to process them first
         orderby_exprs: List[ColumnElement] = []
         for orig_col, ascending in orderby:
-            col: Union[Metric, ColumnElement] = orig_col
+            col: Union[AdhocMetric, ColumnElement] = orig_col
             if isinstance(col, dict):
+                col = cast(AdhocMetric, col)
                 if utils.is_adhoc_metric(col):
                     # add adhoc sort by column to columns_by_name if not exists
                     col = self.adhoc_metric_to_sqla(col, columns_by_name)

--- a/superset/typing.py
+++ b/superset/typing.py
@@ -19,7 +19,22 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 from flask import Flask
 from flask_caching import Cache
+from typing_extensions import TypedDict
 from werkzeug.wrappers import Response
+
+
+class AdhocMetricColumn(TypedDict):
+    column_name: Optional[str]
+    type: str
+
+
+class AdhocMetric(TypedDict):
+    aggregate: str
+    column: AdhocMetricColumn
+    expressionType: str
+    label: str
+    sqlExpression: Optional[str]
+
 
 CacheConfig = Union[Callable[[Flask], Cache], Dict[str, Any]]
 DbapiDescriptionRow = Tuple[
@@ -31,7 +46,6 @@ FilterValue = Union[datetime, float, int, str]
 FilterValues = Union[FilterValue, List[FilterValue], Tuple[FilterValue]]
 FormData = Dict[str, Any]
 Granularity = Union[str, Dict[str, Union[str, float]]]
-AdhocMetric = Dict[str, Any]
 Metric = Union[AdhocMetric, str]
 OrderBy = Tuple[Metric, bool]
 QueryObjectDict = Dict[str, Any]

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -96,7 +96,7 @@ from superset.exceptions import (
     SupersetException,
     SupersetTimeoutException,
 )
-from superset.typing import FlaskResponse, FormData, Metric
+from superset.typing import AdhocMetric, FlaskResponse, FormData, Metric
 from superset.utils.dates import datetime_to_epoch, EPOCH
 from superset.utils.hashing import md5_sha_from_dict, md5_sha_from_str
 
@@ -1494,7 +1494,7 @@ def get_column_name_from_metric(metric: Metric) -> Optional[str]:
     :return: column name if simple metric, otherwise None
     """
     if is_adhoc_metric(metric):
-        metric = cast(Dict[str, Any], metric)
+        metric = cast(AdhocMetric, metric)
         if metric["expressionType"] == AdhocMetricExpressionType.SIMPLE:
             return cast(Dict[str, Any], metric["column"])["column_name"]
     return None

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -66,7 +66,7 @@ from superset.exceptions import (
 from superset.extensions import cache_manager, security_manager
 from superset.models.cache import CacheKey
 from superset.models.helpers import QueryResult
-from superset.typing import QueryObjectDict, VizData, VizPayload
+from superset.typing import Metric, QueryObjectDict, VizData, VizPayload
 from superset.utils import core as utils, csv
 from superset.utils.cache import set_and_log_cache
 from superset.utils.core import (
@@ -526,10 +526,7 @@ class BaseViz:
                     for col in (query_obj.get("columns") or [])
                     + (query_obj.get("groupby") or [])
                     + utils.get_column_names_from_metrics(
-                        cast(
-                            List[Union[str, Dict[str, Any]]],
-                            query_obj.get("metrics") or [],
-                        )
+                        cast(List[Metric], query_obj.get("metrics") or [],)
                     )
                     if col not in self.datasource.column_names
                 ]


### PR DESCRIPTION
### SUMMARY
This adds support for Jinja templating to calculated columns and SQL metrics. The PR also adds `TypedDict` types for adhoc metrics to improve code quality and linting.

### BEFORE
Before Jinja was not processed in calculated columns nor SQL metrics
![image](https://user-images.githubusercontent.com/33317356/122511144-79b62880-d00f-11eb-9c09-b2a8a9f91d77.png)
![image](https://user-images.githubusercontent.com/33317356/122510971-2e9c1580-d00f-11eb-86aa-2e93e840bc52.png)

### AFTER
Now Jinja in both calculated columns and SQL metrics are processed correctly:
![image](https://user-images.githubusercontent.com/33317356/122510834-f694d280-d00e-11eb-8c0f-3a78b70f3ec5.png)
![image](https://user-images.githubusercontent.com/33317356/122518915-8429ef80-d01a-11eb-87cb-3018d2a6b439.png)

### TESTING INSTRUCTIONS
1. Create a new chart
2. Add a SQL metric with Jinja
3. Add a calculated column to the dataset with Jinja
4. Press "Run"
5. See query execute successfully and notice that Jinja syntax in metric and and calculated column are rendered.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
