### PR TITLE
feat(native-filters): add support for import/export dashboard

### DIFF
--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, Hashable, List, Optional, Set, Type, Union
 from flask_appbuilder.security.sqla.models import User
 from sqlalchemy import and_, Boolean, Column, Integer, String, Text
 from sqlalchemy.ext.declarative import declared_attr
-from sqlalchemy.orm import foreign, Query, relationship, RelationshipProperty
+from sqlalchemy.orm import foreign, Query, relationship, RelationshipProperty, Session
 
 from superset import security_manager
 from superset.constants import NULL_STRING
@@ -515,6 +515,12 @@ class BaseDatasource(
         """
 
         security_manager.raise_for_access(datasource=self)
+
+    @classmethod
+    def get_datasource_by_name(
+        cls, session: Session, datasource_name: str, schema: str, database_name: str
+    ) -> Optional["BaseDatasource"]:
+        raise NotImplementedError()
 
 
 class BaseColumn(AuditMixinNullable, ImportExportMixin):

--- a/superset/connectors/connector_registry.py
+++ b/superset/connectors/connector_registry.py
@@ -87,7 +87,7 @@ class ConnectorRegistry:
         :return: Datasource corresponding to the id
         :raises NoResultFound: if no datasource is found corresponding to the id
         """
-        for datasource_type, datasource_class in ConnectorRegistry.sources.items():
+        for datasource_class in ConnectorRegistry.sources.values():
             try:
                 return (
                     session.query(datasource_class)

--- a/superset/connectors/connector_registry.py
+++ b/superset/connectors/connector_registry.py
@@ -16,8 +16,10 @@
 # under the License.
 from typing import Dict, List, Optional, Set, Type, TYPE_CHECKING
 
+from flask_babel import _
 from sqlalchemy import or_
 from sqlalchemy.orm import Session, subqueryload
+from sqlalchemy.orm.exc import NoResultFound
 
 from superset.datasets.commands.exceptions import DatasetNotFoundError
 
@@ -72,6 +74,30 @@ class ConnectorRegistry:
             qry = source_class.default_query(qry)
             datasources.extend(qry.all())
         return datasources
+
+    @classmethod
+    def get_datasource_by_id(  # pylint: disable=too-many-arguments
+        cls, session: Session, datasource_id: int,
+    ) -> "BaseDatasource":
+        """
+        Find a datasource instance based on the unique id.
+
+        :param session: Session to use
+        :param datasource_id: unique id of datasource
+        :return: Datasource corresponding to the id
+        :raises NoResultFound: if no datasource is found corresponding to the id
+        """
+        for datasource_type, datasource_class in ConnectorRegistry.sources.items():
+            try:
+                return (
+                    session.query(datasource_class)
+                    .filter(datasource_class.id == datasource_id)
+                    .one()
+                )
+            except NoResultFound:
+                # proceed to next datasource type
+                pass
+        raise NoResultFound(_("Datasource id not found: %(id)s", id=datasource_id))
 
     @classmethod
     def get_datasource_by_name(  # pylint: disable=too-many-arguments

--- a/superset/dashboards/commands/importers/v0.py
+++ b/superset/dashboards/commands/importers/v0.py
@@ -19,7 +19,7 @@ import logging
 import time
 from copy import copy
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from flask_babel import lazy_gettext as _
 from sqlalchemy.orm import make_transient, Session

--- a/superset/dashboards/commands/importers/v0.py
+++ b/superset/dashboards/commands/importers/v0.py
@@ -84,7 +84,7 @@ def import_chart(
 def import_dashboard(
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     dashboard_to_import: Dashboard,
-    dataset_id_mapping: Dict[int, int],
+    dataset_id_mapping: Optional[Dict[int, int]] = None,
     import_time: Optional[int] = None,
 ) -> int:
     """Imports the dashboard from the object to the database.
@@ -149,8 +149,10 @@ def import_dashboard(
         for native_filter in native_filter_configuration:
             for target in native_filter.get("targets", []):
                 old_dataset_id = target.get("datasetId")
-                if old_dataset_id is not None:
-                    target["datasetId"] = dataset_id_mapping[old_dataset_id]
+                if dataset_id_mapping and old_dataset_id is not None:
+                    target["datasetId"] = dataset_id_mapping.get(
+                        old_dataset_id, old_dataset_id,
+                    )
         dashboard.json_metadata = json.dumps(json_metadata)
 
     logger.info("Started import of the dashboard: %s", dashboard_to_import.to_json())

--- a/superset/dashboards/commands/importers/v0.py
+++ b/superset/dashboards/commands/importers/v0.py
@@ -19,7 +19,7 @@ import logging
 import time
 from copy import copy
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from flask_babel import lazy_gettext as _
 from sqlalchemy.orm import make_transient, Session
@@ -84,6 +84,7 @@ def import_chart(
 def import_dashboard(
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     dashboard_to_import: Dashboard,
+    dataset_id_mapping: Dict[int, int],
     import_time: Optional[int] = None,
 ) -> int:
     """Imports the dashboard from the object to the database.
@@ -139,6 +140,18 @@ def import_dashboard(
                 if old_slice_id in old_to_new_slc_id_dict:
                     value["meta"]["chartId"] = old_to_new_slc_id_dict[old_slice_id]
         dashboard.position_json = json.dumps(position_data)
+
+    def alter_native_filters(dashboard: Dashboard) -> None:
+        json_metadata = json.loads(dashboard.json_metadata)
+        native_filter_configuration = json_metadata.get("native_filter_configuration")
+        if not native_filter_configuration:
+            return
+        for native_filter in native_filter_configuration:
+            for target in native_filter.get("targets", []):
+                old_dataset_id = target.get("datasetId")
+                if old_dataset_id is not None:
+                    target["datasetId"] = dataset_id_mapping[old_dataset_id]
+        dashboard.json_metadata = json.dumps(json_metadata)
 
     logger.info("Started import of the dashboard: %s", dashboard_to_import.to_json())
     session = db.session
@@ -235,6 +248,8 @@ def import_dashboard(
             timed_refresh_immune_slices=new_timed_refresh_immune_slices
         )
 
+    alter_native_filters(dashboard_to_import)
+
     new_slices = (
         session.query(Slice).filter(Slice.id.in_(old_to_new_slc_id_dict.values())).all()
     )
@@ -301,11 +316,15 @@ def import_dashboards(
     data = json.loads(content, object_hook=decode_dashboards)
     if not data:
         raise DashboardImportException(_("No data in file"))
+    dataset_id_mapping: Dict[int, int] = {}
     for table in data["datasources"]:
-        import_dataset(table, database_id, import_time=import_time)
+        new_dataset_id = import_dataset(table, database_id, import_time=import_time)
+        params = json.loads(table.params)
+        dataset_id_mapping[params["remote_id"]] = new_dataset_id
+
     session.commit()
     for dashboard in data["dashboards"]:
-        import_dashboard(dashboard, import_time=import_time)
+        import_dashboard(dashboard, dataset_id_mapping, import_time=import_time)
     session.commit()
 
 

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -342,7 +342,9 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
             for native_filter in native_filter_configuration:
                 session = db.session()
                 for target in native_filter.get("targets", []):
-                    id_ = target["datasetId"]
+                    id_ = target.get("datasetId")
+                    if id_ is None:
+                        continue
                     datasource = ConnectorRegistry.get_datasource_by_id(session, id_)
                     datasource_ids.add((datasource.id, datasource.type))
 

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -334,6 +334,18 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
                 # set slices without creating ORM relations
                 slices = copied_dashboard.__dict__.setdefault("slices", [])
                 slices.append(copied_slc)
+
+            json_metadata = json.loads(dashboard.json_metadata)
+            native_filter_configuration: List[Dict[str, Any]] = json_metadata.get(
+                "native_filter_configuration", []
+            )
+            for native_filter in native_filter_configuration:
+                session = db.session()
+                for target in native_filter.get("targets", []):
+                    id_ = target["datasetId"]
+                    datasource = ConnectorRegistry.get_datasource_by_id(session, id_)
+                    datasource_ids.add((datasource.id, datasource.type))
+
             copied_dashboard.alter_params(remote_id=dashboard_id)
             copied_dashboards.append(copied_dashboard)
 


### PR DESCRIPTION
### SUMMARY
Add support for importing and exporting dashboards containing native filters. The modifications are needed to update the dataset ids that are referenced in the dashboard metadata.

### BEFORE
Currently native filter dataset references aren't updated during import (compare with the charts that render correctly):
![image](https://user-images.githubusercontent.com/33317356/122555004-607a9f80-d042-11eb-97c5-5255e92a2b20.png)

### AFTER
Now the native filter dataset references are updated to match those available on the target env:
![image](https://user-images.githubusercontent.com/33317356/122555117-8b64f380-d042-11eb-94e8-543719d4d1e1.png)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. export a dashboard
2. import into a new environment where the datasource ids corresponding to those referenced in the native filter metadata are either missing or have a different id.

TODO:
- add tests

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #15050
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
