### PR TITLE
fix(native-filters): default value checkbox in config modal

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/CollapsibleControl.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/CollapsibleControl.tsx
@@ -85,7 +85,7 @@ const CollapsibleControl = (props: CollapsibleControlProps) => {
         }}
       >
         <>
-          {title}{' '}
+          {title}&nbsp;
           {tooltip && (
             <InfoTooltipWithTrigger placement="top" tooltip={tooltip} />
           )}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/CollapsibleControl.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/CollapsibleControl.tsx
@@ -19,12 +19,14 @@
 import React, { ReactNode, useEffect, useState } from 'react';
 import { styled } from '@superset-ui/core';
 import { Checkbox } from 'src/common/components';
+import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
 
 interface CollapsibleControlProps {
   initialValue?: boolean;
   disabled?: boolean;
   checked?: boolean;
   title: string;
+  tooltip?: string;
   children: ReactNode;
   onChange?: (checked: boolean) => void;
 }
@@ -51,6 +53,7 @@ const CollapsibleControl = (props: CollapsibleControlProps) => {
     checked,
     disabled,
     title,
+    tooltip,
     children,
     onChange = () => {},
     initialValue = false,
@@ -81,7 +84,12 @@ const CollapsibleControl = (props: CollapsibleControlProps) => {
           onChange(value);
         }}
       >
-        {title}
+        <>
+          {title}{' '}
+          {tooltip && (
+            <InfoTooltipWithTrigger placement="top" tooltip={tooltip} />
+          )}
+        </>
       </Checkbox>
       {isChecked && children}
     </StyledContainer>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/CollapsibleControl.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/CollapsibleControl.tsx
@@ -22,6 +22,7 @@ import { Checkbox } from 'src/common/components';
 
 interface CollapsibleControlProps {
   initialValue?: boolean;
+  disabled?: boolean;
   checked?: boolean;
   title: string;
   children: ReactNode;
@@ -48,6 +49,7 @@ const StyledContainer = styled.div<{ checked: boolean }>`
 const CollapsibleControl = (props: CollapsibleControlProps) => {
   const {
     checked,
+    disabled,
     title,
     children,
     onChange = () => {},
@@ -68,6 +70,7 @@ const CollapsibleControl = (props: CollapsibleControlProps) => {
       <Checkbox
         className="checkbox"
         checked={isChecked}
+        disabled={disabled}
         onChange={e => {
           const value = e.target.checked;
           // external `checked` value has more priority then local state

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -302,7 +302,6 @@ const FiltersConfigForm = (
   const [activeFilterPanelKey, setActiveFilterPanelKey] = useState<
     string | string[]
   >(FilterPanels.basic.key);
-  const [defaultValueTooltip, setDefaultValueTooltip] = useState<string>('');
 
   const forceUpdate = useForceUpdate();
   const [datasetDetails, setDatasetDetails] = useState<Record<string, any>>();
@@ -469,10 +468,12 @@ const FiltersConfigForm = (
     ...formFilter,
   });
 
-  const [hasDefaultValue, isRequired, setHasDefaultValue] = useDefaultValue(
-    formFilter,
-    filterToEdit,
-  );
+  const [
+    hasDefaultValue,
+    isRequired,
+    defaultValueTooltip,
+    setHasDefaultValue,
+  ] = useDefaultValue(formFilter, filterToEdit);
 
   useEffect(() => {
     if (hasDataset && hasFilledDataset && hasDefaultValue && isDataDirty) {
@@ -556,18 +557,6 @@ const FiltersConfigForm = (
   const hasAdhoc = formFilter?.adhoc_filters?.length > 0;
 
   const defaultToFirstItem = formFilter?.controlValues?.defaultToFirstItem;
-
-  useEffect(() => {
-    let tooltip = '';
-    if (defaultToFirstItem) {
-      tooltip = t(
-        'Default value set automatically when "Default to first item" is selected',
-      );
-    } else if (isRequired) {
-      tooltip = t('Default value must be set when "Required" is active');
-    }
-    setDefaultValueTooltip(tooltip);
-  }, [isRequired, defaultToFirstItem]);
 
   const preFilterValidator = () => {
     if (hasTimeRange || hasAdhoc) {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -129,6 +129,20 @@ export const StyledRowFormItem = styled(FormItem)`
   }
 `;
 
+export const StyledRowSubFormItem = styled(FormItem)`
+  & .ant-form-item-label {
+    padding-bottom: 0;
+  }
+
+  .ant-form-item-control-input-content > div > div {
+    height: auto;
+  }
+
+  & .ant-form-item-control-input {
+    height: auto;
+  }
+`;
+
 export const StyledLabel = styled.span`
   color: ${({ theme }) => theme.colors.grayscale.base};
   font-size: ${({ theme }) => theme.typography.sizes.s}px;
@@ -714,10 +728,14 @@ const FiltersConfigForm = (
               title={t('Filter has default value')}
               initialValue={hasDefaultValue}
               disabled={isRequired}
+              tooltip={
+                isRequired &&
+                t('Default value must be set when "Required" is active')
+              }
               checked={hasDefaultValue}
               onChange={value => setHasDefaultValue(value)}
             >
-              <StyledRowFormItem
+              <StyledRowSubFormItem
                 name={['filters', filterId, 'defaultDataMask']}
                 initialValue={filterToEdit?.defaultDataMask}
                 data-test="default-input"
@@ -776,7 +794,7 @@ const FiltersConfigForm = (
                 ) : (
                   t('Fill all required fields to enable "Default Value"')
                 )}
-              </StyledRowFormItem>
+              </StyledRowSubFormItem>
             </CollapsibleControl>
             {Object.keys(controlItems)
               .filter(key => BASIC_CONTROL_ITEMS.includes(key))
@@ -815,7 +833,7 @@ const FiltersConfigForm = (
                     }
                   }}
                 >
-                  <StyledRowFormItem
+                  <StyledRowSubFormItem
                     name={['filters', filterId, 'parentFilter']}
                     label={<StyledLabel>{t('Parent filter')}</StyledLabel>}
                     initialValue={parentFilter}
@@ -833,7 +851,7 @@ const FiltersConfigForm = (
                       options={parentFilterOptions}
                       isClearable
                     />
-                  </StyledRowFormItem>
+                  </StyledRowSubFormItem>
                 </CollapsibleControl>
               )}
               {Object.keys(controlItems)
@@ -849,7 +867,7 @@ const FiltersConfigForm = (
                     }
                   }}
                 >
-                  <StyledRowFormItem
+                  <StyledRowSubFormItem
                     name={['filters', filterId, 'adhoc_filters']}
                     initialValue={filterToEdit?.adhoc_filters}
                     required
@@ -881,7 +899,7 @@ const FiltersConfigForm = (
                         </span>
                       }
                     />
-                  </StyledRowFormItem>
+                  </StyledRowSubFormItem>
                   {showTimeRangePicker && (
                     <StyledRowFormItem
                       name={['filters', filterId, 'time_range']}
@@ -977,7 +995,7 @@ const FiltersConfigForm = (
                     />
                   </StyledFormItem>
                   {hasMetrics && (
-                    <StyledRowFormItem
+                    <StyledRowSubFormItem
                       name={['filters', filterId, 'sortMetric']}
                       initialValue={filterToEdit?.sortMetric}
                       label={
@@ -1010,7 +1028,7 @@ const FiltersConfigForm = (
                           }
                         }}
                       />
-                    </StyledRowFormItem>
+                    </StyledRowSubFormItem>
                   )}
                 </CollapsibleControl>
               )}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -454,7 +454,7 @@ const FiltersConfigForm = (
     ...formFilter,
   });
 
-  const [hasDefaultValue, setHasDefaultValue] = useDefaultValue(
+  const [hasDefaultValue, isRequired, setHasDefaultValue] = useDefaultValue(
     formFilter,
     filterToEdit,
   );
@@ -713,6 +713,7 @@ const FiltersConfigForm = (
             <CollapsibleControl
               title={t('Filter has default value')}
               initialValue={hasDefaultValue}
+              disabled={isRequired}
               checked={hasDefaultValue}
               onChange={value => setHasDefaultValue(value)}
             >

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/getControlItemsMap.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/getControlItemsMap.tsx
@@ -116,7 +116,7 @@ export default function getControlItemsMap({
                   forceUpdate();
                 }}
               >
-                {controlItem.config.label}{' '}
+                {controlItem.config.label}&nbsp;
                 {controlItem.config.description && (
                   <InfoTooltipWithTrigger
                     placement="top"

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/state.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/state.ts
@@ -56,9 +56,13 @@ export const useDefaultValue = (
     !!filterToEdit?.defaultDataMask?.filterState?.value ||
       formFilter?.controlValues?.enableEmptyFilter,
   );
+  const [isRequired, setisRequired] = useState(
+    formFilter?.controlValues?.enableEmptyFilter,
+  );
   const setHasDefaultValue = useCallback(
     (value?) => {
-      const required = !!formFilter?.controlValues?.enableEmptyFilter;
+      const required = !!formFilter?.controlValues?.enableEmptyFilter
+      setisRequired(required);
       setHasPartialDefaultValue(required ? true : value);
     },
     [formFilter?.controlValues?.enableEmptyFilter],
@@ -68,5 +72,5 @@ export const useDefaultValue = (
     setHasDefaultValue();
   }, [setHasDefaultValue]);
 
-  return [hasDefaultValue, setHasDefaultValue];
+  return [hasDefaultValue, isRequired, setHasDefaultValue];
 };

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/state.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/state.ts
@@ -59,18 +59,26 @@ export const useDefaultValue = (
   const [isRequired, setisRequired] = useState(
     formFilter?.controlValues?.enableEmptyFilter,
   );
+
+  const defaultToFirstItem = formFilter?.controlValues?.defaultToFirstItem;
+
   const setHasDefaultValue = useCallback(
     (value?) => {
-      const required = !!formFilter?.controlValues?.enableEmptyFilter
+      const required =
+        !!formFilter?.controlValues?.enableEmptyFilter && !defaultToFirstItem;
       setisRequired(required);
       setHasPartialDefaultValue(required ? true : value);
     },
-    [formFilter?.controlValues?.enableEmptyFilter],
+    [formFilter?.controlValues?.enableEmptyFilter, defaultToFirstItem],
   );
 
   useEffect(() => {
-    setHasDefaultValue();
-  }, [setHasDefaultValue]);
+    setHasDefaultValue(
+      defaultToFirstItem
+        ? false
+        : !!formFilter?.defaultDataMask?.filterState?.value,
+    );
+  }, [setHasDefaultValue, defaultToFirstItem]);
 
   return [hasDefaultValue, isRequired, setHasDefaultValue];
 };

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/state.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/state.ts
@@ -18,6 +18,7 @@
  */
 import { useCallback, useEffect, useState } from 'react';
 import { FormInstance } from 'antd/lib/form';
+import { t } from '@superset-ui/core';
 import { NativeFiltersForm, NativeFiltersFormItem } from '../types';
 import { setNativeFilterFieldValues, useForceUpdate } from './utils';
 import { Filter } from '../../types';
@@ -60,6 +61,8 @@ export const useDefaultValue = (
     formFilter?.controlValues?.enableEmptyFilter,
   );
 
+  const [defaultValueTooltip, setDefaultValueTooltip] = useState('');
+
   const defaultToFirstItem = formFilter?.controlValues?.defaultToFirstItem;
 
   const setHasDefaultValue = useCallback(
@@ -80,5 +83,21 @@ export const useDefaultValue = (
     );
   }, [setHasDefaultValue, defaultToFirstItem]);
 
-  return [hasDefaultValue, isRequired, setHasDefaultValue];
+  useEffect(() => {
+    let tooltip = '';
+    if (defaultToFirstItem) {
+      tooltip = t(
+        'Default value set automatically when "Default to first item" is checked',
+      );
+    } else if (isRequired) {
+      tooltip = t('Default value must be set when "Required" is checked');
+    } else if (hasDefaultValue) {
+      tooltip = t(
+        'Default value must be set when "Filter has default value" is checked',
+      );
+    }
+    setDefaultValueTooltip(tooltip);
+  }, [hasDefaultValue, isRequired, defaultToFirstItem]);
+
+  return [hasDefaultValue, isRequired, defaultValueTooltip, setHasDefaultValue];
 };

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/state.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/state.ts
@@ -58,11 +58,8 @@ export const useDefaultValue = (
   );
   const setHasDefaultValue = useCallback(
     (value?) => {
-      setHasPartialDefaultValue(
-        value || formFilter?.controlValues?.enableEmptyFilter
-          ? true
-          : undefined,
-      );
+      const required = !!formFilter?.controlValues?.enableEmptyFilter;
+      setHasPartialDefaultValue(required ? true : value);
     },
     [formFilter?.controlValues?.enableEmptyFilter],
   );

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -284,7 +284,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
         extra={<Error>{filterState.validateMessage}</Error>}
       >
         <StyledSelect
-          allowClear={!enableEmptyFilter}
+          allowClear
           // @ts-ignore
           value={filterState.value || []}
           disabled={isDisabled}

--- a/superset-frontend/src/filters/components/Select/controlPanel.ts
+++ b/superset-frontend/src/filters/components/Select/controlPanel.ts
@@ -77,8 +77,7 @@ const config: ControlPanelConfig = {
               default: enableEmptyFilter,
               renderTrigger: true,
               description: t(
-                'User must select a value for this filter when filter is in single select mode. ' +
-                  'If selection is empty, an always false filter is emitted.',
+                'User must select a value before applying the filter',
               ),
             },
           },


### PR DESCRIPTION
### SUMMARY
Currently the default value picker requires two clicks on the checkbox to disable the default value. Other improvements:
- When "Default to first item" is checked, automatically uncheck and disable "Filter has default value".
- When "Required" is checked, automatically check and disable "Filter has default value".
- When "Filter has default value" is selected, validate that default value is selected.
- Add tooltip to default value picker when it is disabled or required (either if "Filter has default value", "Required", "Default to first item" is selected)
- When "Required" is unchecked and default selection is empty, automatically uncheck "Default has default value" (don't do anything if default selection is non-empty).
- Make minimum height of child row in `CollapsibleControl` 32 px (currently 40 px).
- When unchecking "Required" and default value is unset, automatically uncheck "Filter has default value" (don't uncheck if default value is defined)

### AFTER
https://user-images.githubusercontent.com/33317356/122758784-df214800-d2a1-11eb-89ec-306facab1620.mp4

### BEFORE
https://user-images.githubusercontent.com/33317356/122741000-310ba300-d28d-11eb-8c10-94f1b3dd87e9.mp4

### TESTING INSTRUCTIONS
Local testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
