### PR TITLE
chore: Migrates ControlHeader icons

### DIFF
--- a/superset-frontend/src/explore/components/ControlHeader.jsx
+++ b/superset-frontend/src/explore/components/ControlHeader.jsx
@@ -18,10 +18,11 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { t, css } from '@superset-ui/core';
+import { t, css, withTheme } from '@superset-ui/core';
 import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
 import { Tooltip } from 'src/components/Tooltip';
 import { FormLabel } from 'src/components/Form';
+import Icons from 'src/components/Icons';
 
 const propTypes = {
   name: PropTypes.string,
@@ -45,7 +46,7 @@ const defaultProps = {
   name: undefined,
 };
 
-export default class ControlHeader extends React.Component {
+class ControlHeader extends React.Component {
   renderOptionalIcons() {
     if (this.props.hovered) {
       return (
@@ -91,6 +92,9 @@ export default class ControlHeader extends React.Component {
     }
     const labelClass =
       this.props.validationErrors.length > 0 ? 'text-danger' : '';
+
+    const { theme } = this.props;
+
     return (
       <div className="ControlHeader" data-test={`${this.props.name}-header`}>
         <div className="pull-left">
@@ -117,7 +121,10 @@ export default class ControlHeader extends React.Component {
                   placement="top"
                   title={this.props.warning}
                 >
-                  <i className="fa fa-exclamation-circle text-warning" />
+                  <Icons.AlertSolid
+                    iconColor={theme.colors.alert.base}
+                    iconSize="s"
+                  />
                 </Tooltip>{' '}
               </span>
             )}
@@ -128,7 +135,10 @@ export default class ControlHeader extends React.Component {
                   placement="top"
                   title={this.props.danger}
                 >
-                  <i className="fa fa-exclamation-circle text-danger" />
+                  <Icons.ErrorSolid
+                    iconColor={theme.colors.error.base}
+                    iconSize="s"
+                  />
                 </Tooltip>{' '}
               </span>
             )}
@@ -139,7 +149,10 @@ export default class ControlHeader extends React.Component {
                   placement="top"
                   title={this.props.validationErrors.join(' ')}
                 >
-                  <i className="fa fa-exclamation-circle text-danger" />
+                  <Icons.ErrorSolid
+                    iconColor={theme.colors.error.base}
+                    iconSize="s"
+                  />
                 </Tooltip>{' '}
               </span>
             )}
@@ -157,3 +170,5 @@ export default class ControlHeader extends React.Component {
 
 ControlHeader.propTypes = propTypes;
 ControlHeader.defaultProps = defaultProps;
+
+export default withTheme(ControlHeader);


### PR DESCRIPTION
### SUMMARY
Migrates `ControlHeader` icons.

@pkdotson 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="309" alt="Screen Shot 2021-06-18 at 2 30 07 PM" src="https://user-images.githubusercontent.com/70410625/122597571-ee09bf80-d041-11eb-818a-b1ffdb344f02.png">
<img width="310" alt="Screen Shot 2021-06-18 at 2 19 46 PM" src="https://user-images.githubusercontent.com/70410625/122597578-f06c1980-d041-11eb-8131-ca18aca85220.png">
<img width="307" alt="Screen Shot 2021-06-18 at 2 30 43 PM" src="https://user-images.githubusercontent.com/70410625/122597592-f530cd80-d041-11eb-98c0-516ebb54c4c3.png">
<img width="311" alt="Screen Shot 2021-06-18 at 2 27 38 PM" src="https://user-images.githubusercontent.com/70410625/122597599-f8c45480-d041-11eb-9cf6-31b8856ef62a.png">

### TESTING INSTRUCTIONS
1 - Go to explore
2 - Change the controls to show the icons

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
