### PR TITLE
chore: use numeric separators on big numbers

### DIFF
--- a/superset-frontend/src/SqlLab/components/QueryAutoRefresh.jsx
+++ b/superset-frontend/src/SqlLab/components/QueryAutoRefresh.jsx
@@ -26,8 +26,8 @@ import * as Actions from '../actions/sqlLab';
 
 const QUERY_UPDATE_FREQ = 2000;
 const QUERY_UPDATE_BUFFER_MS = 5000;
-const MAX_QUERY_AGE_TO_POLL = 21600000;
-const QUERY_TIMEOUT_LIMIT = 10000;
+const MAX_QUERY_AGE_TO_POLL = 21_600_000;
+const QUERY_TIMEOUT_LIMIT = 10_000;
 
 class QueryAutoRefresh extends React.PureComponent {
   constructor(props) {

--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -74,7 +74,7 @@ import SqlEditorLeftBar from './SqlEditorLeftBar';
 import AceEditorWrapper from './AceEditorWrapper';
 import RunQueryActionButton from './RunQueryActionButton';
 
-const LIMIT_DROPDOWN = [10, 100, 1000, 10000, 100000];
+const LIMIT_DROPDOWN = [10, 100, 1000, 10_000, 100_000];
 const SQL_EDITOR_PADDING = 10;
 const INITIAL_NORTH_PERCENT = 30;
 const INITIAL_SOUTH_PERCENT = 70;

--- a/superset-frontend/src/components/LastUpdated/index.tsx
+++ b/superset-frontend/src/components/LastUpdated/index.tsx
@@ -21,7 +21,7 @@ import moment, { Moment, MomentInput } from 'moment';
 import { t, styled } from '@superset-ui/core';
 import Icon from 'src/components/Icon';
 
-const REFRESH_INTERVAL = 60000; // every minute
+const REFRESH_INTERVAL = 60_000; // every minute
 
 interface LastUpdatedProps {
   updatedAt: MomentInput;

--- a/superset-frontend/src/explore/controls.jsx
+++ b/superset-frontend/src/explore/controls.jsx
@@ -90,7 +90,7 @@ export const D3_FORMAT_OPTIONS = [
   ['DURATION_SUB', 'Duration in ms (100.40008 => 100ms 400µs 80ns)'],
 ];
 
-const ROW_LIMIT_OPTIONS = [10, 50, 100, 250, 500, 1000, 5000, 10000, 50000];
+const ROW_LIMIT_OPTIONS = [10, 50, 100, 250, 500, 1000, 5000, 10_000, 50_000];
 
 const SERIES_LIMITS = [0, 5, 10, 25, 50, 100, 500];
 
@@ -361,7 +361,7 @@ export const controls = {
     freeForm: true,
     label: t('Row limit'),
     validators: [legacyValidateInteger],
-    default: 10000,
+    default: 10_000,
     choices: formatSelectOptions(ROW_LIMIT_OPTIONS),
   },
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Use [numeric separators](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#numeric-separators) to increase readability.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

N/A

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
