### PR TITLE
feat: run extra query on QueryObject and add compare operator for post_processing

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -89,7 +89,7 @@ disable=
     raise-missing-from,
     super-with-arguments,
     too-few-public-methods,
-    too-many-locals
+    too-many-locals,
 
 
 [REPORTS]

--- a/.pylintrc
+++ b/.pylintrc
@@ -90,6 +90,8 @@ disable=
     super-with-arguments,
     too-few-public-methods,
     too-many-locals,
+    too-many-arguments,
+    too-many-statements
 
 
 [REPORTS]

--- a/.pylintrc
+++ b/.pylintrc
@@ -89,9 +89,7 @@ disable=
     raise-missing-from,
     super-with-arguments,
     too-few-public-methods,
-    too-many-locals,
-    too-many-arguments,
-    too-many-statements
+    too-many-locals
 
 
 [REPORTS]

--- a/Makefile
+++ b/Makefile
@@ -76,5 +76,8 @@ format: py-format js-format
 py-format: pre-commit
 	pre-commit run black --all-files
 
+py-lint: pre-commit
+	pylint -j 0 superset
+
 js-format:
 	cd superset-frontend; npm run prettier

--- a/superset/charts/commands/exceptions.py
+++ b/superset/charts/commands/exceptions.py
@@ -28,15 +28,15 @@ from superset.commands.exceptions import (
 )
 
 
-class TimeRangeUnclearError(ValidationError):
+class TimeRangeAmbiguousError(ValidationError):
     """
-    Time range is unclear error.
+    Time range is ambiguous error.
     """
 
     def __init__(self, human_readable: str) -> None:
         super().__init__(
             _(
-                "Time string is unclear."
+                "Time string is ambiguous."
                 " Please specify [%(human_readable)s ago]"
                 " or [%(human_readable)s later].",
                 human_readable=human_readable,
@@ -56,15 +56,15 @@ class TimeRangeParseFailError(ValidationError):
         )
 
 
-class TimeDeltaUnclearError(ValidationError):
+class TimeDeltaAmbiguousError(ValidationError):
     """
-    Time delta is unclear error.
+    Time delta is ambiguous error.
     """
 
     def __init__(self, human_readable: str) -> None:
         super().__init__(
             _(
-                "Time delta is unclear."
+                "Time delta is ambiguous."
                 " Please specify [%(human_readable)s ago]"
                 " or [%(human_readable)s later].",
                 human_readable=human_readable,

--- a/superset/charts/commands/exceptions.py
+++ b/superset/charts/commands/exceptions.py
@@ -56,6 +56,23 @@ class TimeRangeParseFailError(ValidationError):
         )
 
 
+class TimeDeltaUnclearError(ValidationError):
+    """
+    Time delta is in valid error.
+    """
+
+    def __init__(self, human_readable: str) -> None:
+        super().__init__(
+            _(
+                "Time delta is unclear."
+                " Please specify [%(human_readable)s ago]"
+                " or [%(human_readable)s later].",
+                human_readable=human_readable,
+            ),
+            field_name="time_range",
+        )
+
+
 class DatabaseNotFoundValidationError(ValidationError):
     """
     Marshmallow validation error for database does not exist

--- a/superset/charts/commands/exceptions.py
+++ b/superset/charts/commands/exceptions.py
@@ -30,7 +30,7 @@ from superset.commands.exceptions import (
 
 class TimeRangeUnclearError(ValidationError):
     """
-    Time range is in valid error.
+    Time range is unclear error.
     """
 
     def __init__(self, human_readable: str) -> None:
@@ -58,7 +58,7 @@ class TimeRangeParseFailError(ValidationError):
 
 class TimeDeltaUnclearError(ValidationError):
     """
-    Time delta is in valid error.
+    Time delta is unclear error.
     """
 
     def __init__(self, human_readable: str) -> None:

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -1076,7 +1076,7 @@ class ChartDataQueryObjectSchema(Schema):
         description="Should the rowcount of the actual query be returned",
         allow_none=True,
     )
-    time_offset = fields.List(fields.String(), allow_none=True,)
+    time_offsets = fields.List(fields.String(), allow_none=True,)
 
 
 class ChartDataQueryContextSchema(Schema):

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -730,6 +730,8 @@ class ChartDataPostProcessingOperationSchema(Schema):
                 "rolling",
                 "select",
                 "sort",
+                "diff",
+                "compare",
             )
         ),
         example="aggregate",
@@ -1074,6 +1076,7 @@ class ChartDataQueryObjectSchema(Schema):
         description="Should the rowcount of the actual query be returned",
         allow_none=True,
     )
+    time_offset = fields.List(fields.String(), allow_none=True,)
 
 
 class ChartDataQueryContextSchema(Schema):

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -105,17 +105,17 @@ class QueryContext:
             "result_format": self.result_format,
         }
 
-    def processing_time_offset(
+    def processing_time_offsets(
         self, df: pd.DataFrame, query_object: QueryObject,
     ) -> Tuple[pd.DataFrame, List[str]]:
         # ensure query_object is immutable
         query_object_clone = copy.copy(query_object)
         rv_sql = []
 
-        time_offset = query_object.time_offset
+        time_offsets = query_object.time_offsets
         outer_from_dttm = query_object.from_dttm
         outer_to_dttm = query_object.to_dttm
-        for offset in time_offset:
+        for offset in time_offsets:
             try:
                 query_object_clone.from_dttm = get_past_or_future(
                     offset, outer_from_dttm,
@@ -126,7 +126,7 @@ class QueryContext:
             # make sure subquery use main query where clause
             query_object_clone.inner_from_dttm = outer_from_dttm
             query_object_clone.inner_to_dttm = outer_to_dttm
-            query_object_clone.time_offset = []
+            query_object_clone.time_offsets = []
 
             if not query_object.from_dttm or not query_object.to_dttm:
                 raise QueryObjectValidationError(
@@ -195,8 +195,8 @@ class QueryContext:
             if self.enforce_numerical_metrics:
                 self.df_metrics_to_num(df, query_object)
 
-            if query_object.time_offset:
-                df, offset_sql = self.processing_time_offset(df, query_object)
+            if query_object.time_offsets:
+                df, offset_sql = self.processing_time_offsets(df, query_object)
                 query += ";\n\n".join(offset_sql)
                 query += ";\n\n"
 

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -147,7 +147,6 @@ class QueryContext:
                 )
             # `offset` is added to the hash function
             cache_key = self.query_cache_key(query_object_clone, time_offset=offset)
-            logger.info("Cache key: %s", cache_key)
             _cache = QueryCacheManager.get(cache_key, CacheRegion.DATA, self.force)
             # whether to hit the cache
             if _cache.is_loaded:
@@ -433,7 +432,6 @@ class QueryContext:
     ) -> Dict[str, Any]:
         """Handles caching around the df payload retrieval"""
         cache_key = self.query_cache_key(query_obj)
-        logger.info("Cache key: %s", cache_key)
         _cache = QueryCacheManager.get(
             cache_key, CacheRegion.DATA, self.force, force_cached,
         )

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -31,6 +31,7 @@ from superset.common.query_actions import get_query_results
 from superset.common.query_object import QueryObject
 from superset.connectors.base.models import BaseDatasource
 from superset.connectors.connector_registry import ConnectorRegistry
+from superset.constants import PandasAxis
 from superset.exceptions import (
     CacheLoadError,
     QueryObjectValidationError,
@@ -81,7 +82,7 @@ class QueryContext:
 
     # TODO: Type datasource and query_object dictionary with TypedDict when it becomes
     #  a vanilla python type https://github.com/python/mypy/issues/5288
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(
         self,
         datasource: DatasourceDict,
         queries: List[Dict[str, Any]],
@@ -158,7 +159,7 @@ class QueryContext:
                 )
 
                 # combine `offset_metrics_df` with main query df
-                df = pd.concat([df, offset_metrics_df], axis=1)
+                df = pd.concat([df, offset_metrics_df], axis=PandasAxis.COLUMN)
         return df, rv_sql
 
     def get_query_result(self, query_object: QueryObject) -> Dict[str, Any]:
@@ -374,7 +375,7 @@ class QueryContext:
             )
         return annotation_data
 
-    def get_df_payload(  # pylint: disable=too-many-statements,too-many-locals
+    def get_df_payload(
         self, query_obj: QueryObject, force_cached: Optional[bool] = False,
     ) -> Dict[str, Any]:
         """Handles caching around the df payload retrieval"""

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -143,7 +143,7 @@ class QueryContext:
                 get_metric_names(query_object_clone_dct.get("metrics", []))
             ]
 
-            # rename metrics: SUM(value) => SUM(value) 1 year offset
+            # rename metrics: SUM(value) => SUM(value) 1 year ago
             _columns = list(offset_metrics_df.columns)
             _renamed_columns = [
                 TIME_COMPARISION.join([column, offset]) for column in _columns

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import copy
 import logging
-from typing import Any, ClassVar, Dict, List, Optional, TYPE_CHECKING, Union
+from typing import Any, ClassVar, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
 import pandas as pd
@@ -37,7 +37,6 @@ from superset.constants import CacheRegion
 from superset.exceptions import QueryObjectValidationError, SupersetException
 from superset.extensions import cache_manager, security_manager
 from superset.models.helpers import QueryResult
-from superset.stats_logger import BaseStatsLogger
 from superset.utils import csv
 from superset.utils.cache import generate_cache_key, set_and_log_cache
 from superset.utils.core import (

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -96,7 +96,7 @@ class QueryObject:
     datasource: Optional[BaseDatasource]
     result_type: Optional[ChartDataResultType]
     is_rowcount: bool
-    time_offset: List[str]
+    time_offsets: List[str]
 
     def __init__(
         self,
@@ -128,7 +128,7 @@ class QueryObject:
         groupby = groupby or []
         extras = extras or {}
         annotation_layers = annotation_layers or []
-        self.time_offset = kwargs.get("time_offset", [])
+        self.time_offsets = kwargs.get("time_offsets", [])
         self.inner_from_dttm = kwargs.get("inner_from_dttm")
         self.inner_to_dttm = kwargs.get("inner_to_dttm")
 

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -77,6 +77,8 @@ class QueryObject:
     granularity: Optional[str]
     from_dttm: Optional[datetime]
     to_dttm: Optional[datetime]
+    inner_from_dttm: Optional[datetime]
+    inner_to_dttm: Optional[datetime]
     is_timeseries: bool
     time_shift: Optional[timedelta]
     groupby: List[str]
@@ -94,6 +96,7 @@ class QueryObject:
     datasource: Optional[BaseDatasource]
     result_type: Optional[ChartDataResultType]
     is_rowcount: bool
+    time_offset: List[str]
 
     def __init__(
         self,
@@ -125,6 +128,9 @@ class QueryObject:
         groupby = groupby or []
         extras = extras or {}
         annotation_layers = annotation_layers or []
+        self.time_offset = kwargs.get("time_offset", [])
+        self.inner_from_dttm = kwargs.get("inner_from_dttm")
+        self.inner_to_dttm = kwargs.get("inner_to_dttm")
 
         self.is_rowcount = is_rowcount
         self.datasource = None
@@ -268,6 +274,8 @@ class QueryObject:
             "groupby": self.groupby,
             "from_dttm": self.from_dttm,
             "to_dttm": self.to_dttm,
+            "inner_from_dttm": self.inner_from_dttm,
+            "inner_to_dttm": self.inner_to_dttm,
             "is_rowcount": self.is_rowcount,
             "is_timeseries": self.is_timeseries,
             "metrics": self.metrics,

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -315,6 +315,8 @@ class QueryObject:
             cache_dict["time_range"] = self.time_range
         if self.post_processing:
             cache_dict["post_processing"] = self.post_processing
+        if self.time_offsets:
+            cache_dict["time_offsets"] = self.time_offsets
 
         for k in ["from_dttm", "to_dttm"]:
             del cache_dict[k]

--- a/superset/common/utils.py
+++ b/superset/common/utils.py
@@ -1,0 +1,142 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import logging
+from typing import Any, Dict, Optional
+
+from flask_caching import Cache
+from pandas import DataFrame
+
+from superset import app
+from superset.constants import CacheRegion
+from superset.exceptions import CacheLoadError
+from superset.extensions import cache_manager
+from superset.stats_logger import BaseStatsLogger
+from superset.utils.cache import set_and_log_cache
+from superset.utils.core import error_msg_from_exception, get_stacktrace, QueryStatus
+
+config = app.config
+stats_logger: BaseStatsLogger = config["STATS_LOGGER"]
+logger = logging.getLogger(__name__)
+
+_cache: Dict[CacheRegion, Cache] = {
+    CacheRegion.DEFAULT: cache_manager.cache,
+    CacheRegion.DATA: cache_manager.data_cache,
+}
+
+
+class QueryCacheManager:
+    # pylint: disable=too-many-instance-attributes
+    def __init__(
+        self,
+        df: DataFrame = DataFrame(),
+        query: str = "",
+        annotation_data: Optional[Dict[str, Any]] = None,
+        status: Optional[QueryStatus] = None,
+        error_message: Optional[str] = None,
+        is_loaded: bool = False,
+        stacktrace: Optional[str] = None,
+        is_cached: Optional[bool] = None,
+        cache_dttm: Optional[str] = None,
+    ) -> None:
+        self.df = df
+        self.query = query
+        self.annotation_data = {} if annotation_data is None else annotation_data
+        self.status = status
+        self.error_message = error_message
+
+        self.is_loaded = is_loaded
+        self.stacktrace = stacktrace
+        self.is_cached = is_cached
+        self.cache_dttm = cache_dttm
+
+    def load_query(
+        self,
+        query_result: Dict[str, Any],
+        annotation_data: Optional[Dict[str, Any]] = None,
+        force_query: Optional[bool] = False,
+    ) -> None:
+        try:
+            self.status = query_result["status"]
+            self.query = query_result["query"]
+            self.error_message = query_result["error_message"]
+            self.df = query_result["df"]
+            self.annotation_data = {} if annotation_data is None else annotation_data
+
+            if self.status != QueryStatus.FAILED:
+                stats_logger.incr("loaded_from_source")
+                if not force_query:
+                    stats_logger.incr("loaded_from_source_without_force")
+                self.is_loaded = True
+        except Exception as ex:  # pylint: disable=broad-except
+            logger.exception(ex)
+            if not self.error_message:
+                self.error_message = str(ex)
+            self.status = QueryStatus.FAILED
+            self.stacktrace = get_stacktrace()
+
+    @classmethod
+    def get(
+        cls,
+        key: Optional[str],
+        region: CacheRegion = CacheRegion.DEFAULT,
+        force_query: Optional[bool] = False,
+        force_cached: Optional[bool] = False,
+    ) -> "QueryCacheManager":
+        query_cache = cls()
+        if not key or not _cache[region] or force_query:
+            return query_cache
+
+        cache_value = _cache[region].get(key)
+        if cache_value:
+            stats_logger.incr("loading_from_cache")
+            try:
+                query_cache.df = cache_value["df"]
+                query_cache.query = cache_value["query"]
+                query_cache.annotation_data = cache_value.get("annotation_data", {})
+                query_cache.status = QueryStatus.SUCCESS
+                query_cache.is_loaded = True
+                query_cache.is_cached = cache_value is not None
+                query_cache.cache_dttm = (
+                    cache_value["dttm"] if cache_value is not None else None
+                )
+                stats_logger.incr("loaded_from_cache")
+            except KeyError as ex:
+                logger.exception(ex)
+                logger.error(
+                    "Error reading cache: %s",
+                    error_msg_from_exception(ex),
+                    exc_info=True,
+                )
+            logger.info("Serving from cache")
+
+        if force_cached and not query_cache.is_loaded:
+            logger.warning(
+                "force_cached (QueryContext): value not found for key %s", key
+            )
+            raise CacheLoadError("Error loading data from cache")
+        return query_cache
+
+    def set(
+        self,
+        key: Optional[str],
+        value: Dict[str, Any],
+        timeout: Optional[int] = None,
+        datasource_uid: Optional[str] = None,
+        region: CacheRegion = CacheRegion.DEFAULT,
+    ) -> None:
+        if self.is_loaded and key and self.status != QueryStatus.FAILED:
+            set_and_log_cache(_cache[region], key, value, timeout, datasource_uid)

--- a/superset/common/utils.py
+++ b/superset/common/utils.py
@@ -44,7 +44,7 @@ class QueryCacheManager:
     Class for manage query-cache getting and setting
     """
 
-    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-instance-attributes,too-many-arguments
     def __init__(
         self,
         df: DataFrame = DataFrame(),
@@ -70,6 +70,7 @@ class QueryCacheManager:
         self.cache_dttm = cache_dttm
         self.cache_value = cache_value
 
+    # pylint: disable=too-many-arguments
     def set_query_result(
         self,
         key: str,

--- a/superset/common/utils.py
+++ b/superset/common/utils.py
@@ -120,6 +120,7 @@ class QueryCacheManager:
 
         cache_value = _cache[region].get(key)
         if cache_value:
+            logger.info("Cache key: %s", key)
             stats_logger.incr("loading_from_cache")
             try:
                 query_cache.df = cache_value["df"]

--- a/superset/constants.py
+++ b/superset/constants.py
@@ -167,3 +167,9 @@ class PandasPostprocessingCompare(str, Enum):
     ABS = "absolute"
     PCT = "percentage"
     RAT = "ratio"
+
+
+class CacheRegion(str, Enum):
+    DEFAULT = "default"
+    DATA = "data"
+    THUMBNAIL = "thumbnail"

--- a/superset/constants.py
+++ b/superset/constants.py
@@ -18,6 +18,8 @@
 # ATTENTION: If you change any constants, make sure to also change utils/common.js
 
 # string to use when None values *need* to be converted to/from strings
+from enum import Enum
+
 NULL_STRING = "<NULL>"
 
 
@@ -154,3 +156,14 @@ EXTRA_FORM_DATA_OVERRIDE_KEYS = (
     set(EXTRA_FORM_DATA_OVERRIDE_REGULAR_MAPPINGS.values())
     | EXTRA_FORM_DATA_OVERRIDE_EXTRA_KEYS
 )
+
+
+class PandasAxis(int, Enum):
+    ROW = 0
+    COLUMN = 1
+
+
+class PandasPostprocessingCompare(str, Enum):
+    ABS = "absolute"
+    PCT = "percentage"
+    RAT = "ratio"

--- a/superset/examples/birth_names.py
+++ b/superset/examples/birth_names.py
@@ -528,9 +528,9 @@ def create_dashboard(slices: List[Slice]) -> Dashboard:
         }
     }"""
     )
+    # pylint: disable=line-too-long
     pos = json.loads(
         textwrap.dedent(
-            # pylint: disable=line-too-long
             """\
         {
           "CHART-6GdlekVise": {
@@ -800,9 +800,10 @@ def create_dashboard(slices: List[Slice]) -> Dashboard:
             "type": "ROW"
           }
         }
-        """  # pylint: enable=line-too-long
+        """
         )
     )
+    # pylint: enable=line-too-long
     # dashboard v2 doesn't allow add markup slice
     dash.slices = [slc for slc in slices if slc.viz_type != "markup"]
     update_slice_ids(pos, dash.slices)

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -115,6 +115,8 @@ logger = logging.getLogger(__name__)
 
 DTTM_ALIAS = "__timestamp"
 
+TIME_COMPARISION = "__"
+
 JS_MAX_INTEGER = 9007199254740991  # Largest int Java Script can handle 2^53-1
 
 InputType = TypeVar("InputType")

--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -106,6 +106,16 @@ def dttm_from_timetuple(date_: struct_time) -> datetime:
     )
 
 
+def get_past_or_future(
+    human_readable: Optional[str], source_time: Optional[datetime] = None,
+) -> datetime:
+    cal = parsedatetime.Calendar()
+    source_dttm = dttm_from_timetuple(
+        source_time.timetuple() if source_time else datetime.now().timetuple()
+    )
+    return dttm_from_timetuple(cal.parse(human_readable or "", source_dttm)[0])
+
+
 def parse_human_timedelta(
     human_readable: Optional[str], source_time: Optional[datetime] = None,
 ) -> timedelta:
@@ -115,12 +125,10 @@ def parse_human_timedelta(
     >>> parse_human_timedelta('1 day') == timedelta(days=1)
     True
     """
-    cal = parsedatetime.Calendar()
     source_dttm = dttm_from_timetuple(
         source_time.timetuple() if source_time else datetime.now().timetuple()
     )
-    modified_dttm = dttm_from_timetuple(cal.parse(human_readable or "", source_dttm)[0])
-    return modified_dttm - source_dttm
+    return get_past_or_future(human_readable, source_time) - source_dttm
 
 
 def parse_past_timedelta(

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -32,6 +32,7 @@ from superset.utils.core import (
     DTTM_ALIAS,
     PostProcessingBoxplotWhiskerType,
     PostProcessingContributionOrientation,
+    TIME_COMPARISION,
 )
 
 NUMPY_FUNCTIONS = {
@@ -489,7 +490,9 @@ def compare(
         else:
             # compare_type == "ratio"
             diff_series = df[s_col] / df[c_col]
-        diff_df = diff_series.to_frame(name=f"__{compare_type}__{s_col}__{c_col}")
+        diff_df = diff_series.to_frame(
+            name=TIME_COMPARISION.join([compare_type, s_col, c_col])
+        )
         df = pd.concat([df, diff_df], axis=1)
 
     if drop_original_columns:

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -484,7 +484,7 @@ def compare(
     if len(source_columns) == 0:
         return df
 
-    for s_col, c_col in list(zip(source_columns, compare_columns)):
+    for s_col, c_col in zip(source_columns, compare_columns):
         if compare_type == "absolute":
             diff_series = df[s_col] - df[c_col]
         elif compare_type == "percentage":

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -329,7 +329,7 @@ def rolling(  # pylint: disable=too-many-arguments
     df: DataFrame,
     columns: Dict[str, str],
     rolling_type: str,
-    window: int,
+    window: Optional[int] = None,
     rolling_type_options: Optional[Dict[str, Any]] = None,
     center: bool = False,
     win_type: Optional[str] = None,
@@ -359,7 +359,7 @@ def rolling(  # pylint: disable=too-many-arguments
     rolling_type_options = rolling_type_options or {}
     df_rolling = df[columns.keys()]
     kwargs: Dict[str, Union[str, int]] = {}
-    if not window and window != 0:
+    if window is None:
         raise QueryObjectValidationError(_("Undefined window for rolling operation"))
     if window == 0:
         raise QueryObjectValidationError(_("Window must be > 0"))

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -458,6 +458,7 @@ def compare(
     compare_columns: List[str],
     compare_type: Optional[str],
     drop_original_columns: Optional[bool] = False,
+    precision: Optional[int] = 4,
 ) -> DataFrame:
     """
     Calculate column-by-column changing for select columns.
@@ -468,6 +469,7 @@ def compare(
     :param compare_type: Type of compare. Choice of `absolute`, `percentage` or `ratio`
     :param drop_original_columns: Whether to remove the source columns and
            compare columns.
+    :param precision: Round a change rate to a variable number of decimal places.
     :return: DataFrame with compared columns.
     :raises QueryObjectValidationError: If the request in incorrect.
     """
@@ -486,10 +488,12 @@ def compare(
         if compare_type == "absolute":
             diff_series = df[s_col] - df[c_col]
         elif compare_type == "percentage":
-            diff_series = (df[s_col] - df[c_col]) / df[s_col]
+            diff_series = (
+                ((df[s_col] - df[c_col]) / df[s_col]).astype(float).round(precision)
+            )
         else:
             # compare_type == "ratio"
-            diff_series = df[s_col] / df[c_col]
+            diff_series = (df[s_col] / df[c_col]).astype(float).round(precision)
         diff_df = diff_series.to_frame(
             name=TIME_COMPARISION.join([compare_type, s_col, c_col])
         )

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -21,6 +21,7 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 import geohash as geohash_lib
 import numpy as np
+import pandas as pd
 from flask_babel import gettext as _
 from geopy.point import Point
 from pandas import DataFrame, NamedAgg, Series, Timestamp
@@ -357,8 +358,10 @@ def rolling(  # pylint: disable=too-many-arguments
     rolling_type_options = rolling_type_options or {}
     df_rolling = df[columns.keys()]
     kwargs: Dict[str, Union[str, int]] = {}
-    if not window:
+    if not window and window != 0:
         raise QueryObjectValidationError(_("Undefined window for rolling operation"))
+    if window == 0:
+        raise QueryObjectValidationError(_("Window must be > 0"))
 
     kwargs["window"] = window
     if min_periods is not None:
@@ -425,9 +428,11 @@ def select(
 
 
 @validate_column_args("columns")
-def diff(df: DataFrame, columns: Dict[str, str], periods: int = 1,) -> DataFrame:
+def diff(
+    df: DataFrame, columns: Dict[str, str], periods: int = 1, axis: int = 0,
+) -> DataFrame:
     """
-    Calculate row-by-row difference for select columns.
+    Calculate row-by-row or column-by-column difference for select columns.
 
     :param df: DataFrame on which the diff will be based.
     :param columns: columns on which to perform diff, mapping source column to
@@ -436,12 +441,60 @@ def diff(df: DataFrame, columns: Dict[str, str], periods: int = 1,) -> DataFrame
            on diff values calculated from `y`, leaving the original column `y`
            unchanged.
     :param periods: periods to shift for calculating difference.
+    :param axis: 0 for row, 1 for column. default 0.
     :return: DataFrame with diffed columns
     :raises QueryObjectValidationError: If the request in incorrect
     """
     df_diff = df[columns.keys()]
-    df_diff = df_diff.diff(periods=periods)
+    df_diff = df_diff.diff(periods=periods, axis=axis)
     return _append_columns(df, df_diff, columns)
+
+
+@validate_column_args("source_columns", "compare_columns")
+def compare(
+    df: DataFrame,
+    source_columns: List[str],
+    compare_columns: List[str],
+    compare_type: Optional[str],
+    drop_original_columns: Optional[bool] = False,
+) -> DataFrame:
+    """
+    Calculate column-by-column changing for select columns.
+
+    :param df: DataFrame on which the compare will be based.
+    :param source_columns: Main query columns
+    :param compare_columns: Columns being compared
+    :param compare_type: Type of compare. Choice of `absolute`, `percentage` or `ratio`
+    :param drop_original_columns: Whether to remove the source columns and
+           compare columns.
+    :return: DataFrame with compared columns.
+    :raises QueryObjectValidationError: If the request in incorrect.
+    """
+    if len(source_columns) != len(compare_columns):
+        raise QueryObjectValidationError(
+            _("`compare_columns` must have the same length as `source_columns`.")
+        )
+    if compare_type not in ["absolute", "percentage", "ratio"]:
+        raise QueryObjectValidationError(
+            _("`compare_type` must be `absolute`, `percentage` or `ratio`")
+        )
+    if len(source_columns) == 0:
+        return df
+
+    for s_col, c_col in list(zip(source_columns, compare_columns)):
+        if compare_type == "absolute":
+            diff_series = df[s_col] - df[c_col]
+        elif compare_type == "percentage":
+            diff_series = (df[s_col] - df[c_col]) / df[s_col]
+        else:
+            # compare_type == "ratio"
+            diff_series = df[s_col] / df[c_col]
+        diff_df = diff_series.to_frame(name=f"__{compare_type}__{s_col}__{c_col}")
+        df = pd.concat([df, diff_df], axis=1)
+
+    if drop_original_columns:
+        df = df.drop(source_columns + compare_columns, axis=1)
+    return df
 
 
 @validate_column_args("columns")

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -454,6 +454,7 @@ def diff(
     return _append_columns(df, df_diff, columns)
 
 
+# pylint: disable=too-many-arguments
 @validate_column_args("source_columns", "compare_columns")
 def compare(
     df: DataFrame,

--- a/superset/views/api.py
+++ b/superset/views/api.py
@@ -25,8 +25,8 @@ from flask_appbuilder.security.decorators import has_access_api
 
 from superset import db, event_logger
 from superset.charts.commands.exceptions import (
+    TimeRangeAmbiguousError,
     TimeRangeParseFailError,
-    TimeRangeUnclearError,
 )
 from superset.common.query_context import QueryContext
 from superset.legacy import update_time_range
@@ -97,6 +97,6 @@ class Api(BaseSupersetView):
                 "timeRange": time_range,
             }
             return self.json_response({"result": result})
-        except (ValueError, TimeRangeParseFailError, TimeRangeUnclearError) as error:
+        except (ValueError, TimeRangeParseFailError, TimeRangeAmbiguousError) as error:
             error_msg = {"message": f"Unexpected time range: {error}"}
             return self.json_response(error_msg, 400)

--- a/tests/integration_tests/fixtures/dataframes.py
+++ b/tests/integration_tests/fixtures/dataframes.py
@@ -130,6 +130,15 @@ timeseries_df = DataFrame(
     data={"label": ["x", "y", "z", "q"], "y": [1.0, 2.0, 3.0, 4.0]},
 )
 
+timeseries_df2 = DataFrame(
+    index=to_datetime(["2019-01-01", "2019-01-02", "2019-01-05", "2019-01-07"]),
+    data={
+        "label": ["x", "y", "z", "q"],
+        "y": [2.0, 2.0, 2.0, 2.0],
+        "z": [2.0, 4.0, 10.0, 8.0],
+    },
+)
+
 lonlat_df = DataFrame(
     {
         "city": ["New York City", "Sydney"],

--- a/tests/integration_tests/fixtures/query_context.py
+++ b/tests/integration_tests/fixtures/query_context.py
@@ -195,7 +195,7 @@ POSTPROCESSING_OPERATIONS = {
 
 
 def get_query_object(
-    query_name: str, add_postprocessing_operations: bool
+    query_name: str, add_postprocessing_operations: bool, add_time_offsets: bool,
 ) -> Dict[str, Any]:
     if query_name not in QUERY_OBJECTS:
         raise Exception(f"QueryObject fixture not defined for datasource: {query_name}")
@@ -212,6 +212,9 @@ def get_query_object(
     query_object = copy.deepcopy(obj)
     if add_postprocessing_operations:
         query_object["post_processing"] = _get_postprocessing_operation(query_name)
+    if add_time_offsets:
+        query_object["time_offsets"] = ["1 year ago"]
+
     return query_object
 
 
@@ -224,7 +227,9 @@ def _get_postprocessing_operation(query_name: str) -> List[Dict[str, Any]]:
 
 
 def get_query_context(
-    query_name: str, add_postprocessing_operations: bool = False,
+    query_name: str,
+    add_postprocessing_operations: bool = False,
+    add_time_offsets: bool = False,
 ) -> Dict[str, Any]:
     """
     Create a request payload for retrieving a QueryContext object via the
@@ -236,11 +241,16 @@ def get_query_context(
     :param datasource_id: id of datasource to query.
     :param datasource_type: type of datasource to query.
     :param add_postprocessing_operations: Add post-processing operations to QueryObject
+    :param add_time_offsets: Add time offsets to QueryObject(advanced analytics)
     :return: Request payload
     """
     table_name = query_name.split(":")[0]
     table = get_table_by_name(table_name)
     return {
         "datasource": {"id": table.id, "type": table.type},
-        "queries": [get_query_object(query_name, add_postprocessing_operations)],
+        "queries": [
+            get_query_object(
+                query_name, add_postprocessing_operations, add_time_offsets,
+            )
+        ],
     }

--- a/tests/integration_tests/pandas_postprocessing_tests.py
+++ b/tests/integration_tests/pandas_postprocessing_tests.py
@@ -437,10 +437,10 @@ class TestPostProcessing(SupersetTestCase):
             compare_type="absolute",
         )
         self.assertListEqual(
-            post_df.columns.tolist(), ["label", "y", "z", "__absolute__y__z",]
+            post_df.columns.tolist(), ["label", "y", "z", "absolute__y__z",]
         )
         self.assertListEqual(
-            series_to_list(post_df["__absolute__y__z"]), [0.0, -2.0, -8.0, -6.0],
+            series_to_list(post_df["absolute__y__z"]), [0.0, -2.0, -8.0, -6.0],
         )
 
         # drop original columns
@@ -451,7 +451,7 @@ class TestPostProcessing(SupersetTestCase):
             compare_type="absolute",
             drop_original_columns=True,
         )
-        self.assertListEqual(post_df.columns.tolist(), ["label", "__absolute__y__z",])
+        self.assertListEqual(post_df.columns.tolist(), ["label", "absolute__y__z",])
 
         # `percentage` comparison
         post_df = proc.compare(
@@ -461,10 +461,10 @@ class TestPostProcessing(SupersetTestCase):
             compare_type="percentage",
         )
         self.assertListEqual(
-            post_df.columns.tolist(), ["label", "y", "z", "__percentage__y__z",]
+            post_df.columns.tolist(), ["label", "y", "z", "percentage__y__z",]
         )
         self.assertListEqual(
-            series_to_list(post_df["__percentage__y__z"]), [0.0, -1.0, -4.0, -3],
+            series_to_list(post_df["percentage__y__z"]), [0.0, -1.0, -4.0, -3],
         )
 
         # `ratio` comparison
@@ -475,10 +475,10 @@ class TestPostProcessing(SupersetTestCase):
             compare_type="ratio",
         )
         self.assertListEqual(
-            post_df.columns.tolist(), ["label", "y", "z", "__ratio__y__z",]
+            post_df.columns.tolist(), ["label", "y", "z", "ratio__y__z",]
         )
         self.assertListEqual(
-            series_to_list(post_df["__ratio__y__z"]), [1.0, 0.5, 0.2, 0.25],
+            series_to_list(post_df["ratio__y__z"]), [1.0, 0.5, 0.2, 0.25],
         )
 
     def test_cum(self):

--- a/tests/integration_tests/pandas_postprocessing_tests.py
+++ b/tests/integration_tests/pandas_postprocessing_tests.py
@@ -38,6 +38,7 @@ from .fixtures.dataframes import (
     names_df,
     timeseries_df,
     prophet_df,
+    timeseries_df2,
 )
 
 AGGREGATES_SINGLE = {"idx_nulls": {"operator": "sum"}}
@@ -420,6 +421,64 @@ class TestPostProcessing(SupersetTestCase):
             proc.diff,
             df=timeseries_df,
             columns={"abc": "abc"},
+        )
+
+        # diff by columns
+        post_df = proc.diff(df=timeseries_df2, columns={"y": "y", "z": "z"}, axis=1)
+        self.assertListEqual(post_df.columns.tolist(), ["label", "y", "z"])
+        self.assertListEqual(series_to_list(post_df["z"]), [0.0, 2.0, 8.0, 6.0])
+
+    def test_compare(self):
+        # `absolute` comparison
+        post_df = proc.compare(
+            df=timeseries_df2,
+            source_columns=["y"],
+            compare_columns=["z"],
+            compare_type="absolute",
+        )
+        self.assertListEqual(
+            post_df.columns.tolist(), ["label", "y", "z", "__absolute__y__z",]
+        )
+        self.assertListEqual(
+            series_to_list(post_df["__absolute__y__z"]), [0.0, -2.0, -8.0, -6.0],
+        )
+
+        # drop original columns
+        post_df = proc.compare(
+            df=timeseries_df2,
+            source_columns=["y"],
+            compare_columns=["z"],
+            compare_type="absolute",
+            drop_original_columns=True,
+        )
+        self.assertListEqual(post_df.columns.tolist(), ["label", "__absolute__y__z",])
+
+        # `percentage` comparison
+        post_df = proc.compare(
+            df=timeseries_df2,
+            source_columns=["y"],
+            compare_columns=["z"],
+            compare_type="percentage",
+        )
+        self.assertListEqual(
+            post_df.columns.tolist(), ["label", "y", "z", "__percentage__y__z",]
+        )
+        self.assertListEqual(
+            series_to_list(post_df["__percentage__y__z"]), [0.0, -1.0, -4.0, -3],
+        )
+
+        # `ratio` comparison
+        post_df = proc.compare(
+            df=timeseries_df2,
+            source_columns=["y"],
+            compare_columns=["z"],
+            compare_type="ratio",
+        )
+        self.assertListEqual(
+            post_df.columns.tolist(), ["label", "y", "z", "__ratio__y__z",]
+        )
+        self.assertListEqual(
+            series_to_list(post_df["__ratio__y__z"]), [1.0, 0.5, 0.2, 0.25],
         )
 
     def test_cum(self):

--- a/tests/integration_tests/query_context_tests.py
+++ b/tests/integration_tests/query_context_tests.py
@@ -222,6 +222,20 @@ class TestQueryContext(SupersetTestCase):
         cache_key = query_context.query_cache_key(query_object)
         self.assertNotEqual(cache_key_original, cache_key)
 
+    def test_query_cache_key_changes_when_time_offsets_is_updated(self):
+        self.login(username="admin")
+        payload = get_query_context("birth_names", add_time_offsets=True)
+
+        query_context = ChartDataQueryContextSchema().load(payload)
+        query_object = query_context.queries[0]
+        cache_key_original = query_context.query_cache_key(query_object)
+
+        payload["queries"][0]["time_offsets"].pop()
+        query_context = ChartDataQueryContextSchema().load(payload)
+        query_object = query_context.queries[0]
+        cache_key = query_context.query_cache_key(query_object)
+        self.assertNotEqual(cache_key_original, cache_key)
+
     def test_query_context_time_range_endpoints(self):
         """
         Ensure that time_range_endpoints are populated automatically when missing

--- a/tests/integration_tests/query_context_tests.py
+++ b/tests/integration_tests/query_context_tests.py
@@ -489,6 +489,7 @@ class TestQueryContext(SupersetTestCase):
         payload["queries"][0]["time_range"] = "1990 : 1991"
         query_context = ChartDataQueryContextSchema().load(payload)
         responses = query_context.get_payload()
+        print(responses)
         self.assertEqual(
             responses["queries"][0]["colnames"],
             [

--- a/tests/integration_tests/query_context_tests.py
+++ b/tests/integration_tests/query_context_tests.py
@@ -478,9 +478,9 @@ class TestQueryContext(SupersetTestCase):
         self.assertEqual(orig_cache_key, new_cache_key)
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
-    def test_time_offset_in_query_object(self):
+    def test_time_offsets_in_query_object(self):
         """
-        Ensure that time_offset can generate the correct query
+        Ensure that time_offsets can generate the correct query
         """
         self.login(username="admin")
         payload = get_query_context("birth_names")
@@ -488,7 +488,7 @@ class TestQueryContext(SupersetTestCase):
         payload["queries"][0]["groupby"] = ["name"]
         payload["queries"][0]["is_timeseries"] = True
         payload["queries"][0]["timeseries_limit"] = 5
-        payload["queries"][0]["time_offset"] = ["1 year ago", "1 year later"]
+        payload["queries"][0]["time_offsets"] = ["1 year ago", "1 year later"]
         payload["queries"][0]["time_range"] = "1990 : 1991"
         query_context = ChartDataQueryContextSchema().load(payload)
         responses = query_context.get_payload()

--- a/tests/integration_tests/query_context_tests.py
+++ b/tests/integration_tests/query_context_tests.py
@@ -477,19 +477,21 @@ class TestQueryContext(SupersetTestCase):
         new_cache_key = responses["queries"][0]["cache_key"]
         self.assertEqual(orig_cache_key, new_cache_key)
 
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_time_offset_in_query_object(self):
         """
         Ensure that time_offset can generate the correct query
         """
         self.login(username="admin")
         payload = get_query_context("birth_names")
-        payload["queries"][0]["timeseries_limit"] = 5
+        payload["queries"][0]["metrics"] = ["sum__num"]
+        payload["queries"][0]["groupby"] = ["name"]
         payload["queries"][0]["is_timeseries"] = True
+        payload["queries"][0]["timeseries_limit"] = 5
         payload["queries"][0]["time_offset"] = ["1 year ago", "1 year later"]
         payload["queries"][0]["time_range"] = "1990 : 1991"
         query_context = ChartDataQueryContextSchema().load(payload)
         responses = query_context.get_payload()
-        print(responses)
         self.assertEqual(
             responses["queries"][0]["colnames"],
             [

--- a/tests/integration_tests/query_context_tests.py
+++ b/tests/integration_tests/query_context_tests.py
@@ -554,7 +554,8 @@ class TestQueryContext(SupersetTestCase):
         # query without cache
         query_context.processing_time_offsets(df, query_object)
         # query with cache
-        _, _, cache_keys = query_context.processing_time_offsets(df, query_object)
+        rv = query_context.processing_time_offsets(df, query_object)
+        cache_keys = rv["cache_keys"]
         cache_keys__1_year_ago = cache_keys[0]
         cache_keys__1_year_later = cache_keys[1]
         self.assertIsNotNone(cache_keys__1_year_ago)
@@ -565,7 +566,8 @@ class TestQueryContext(SupersetTestCase):
         payload["queries"][0]["time_offsets"] = ["1 year later", "1 year ago"]
         query_context = ChartDataQueryContextSchema().load(payload)
         query_object = query_context.queries[0]
-        _, _, cache_keys = query_context.processing_time_offsets(df, query_object)
+        rv = query_context.processing_time_offsets(df, query_object)
+        cache_keys = rv["cache_keys"]
         self.assertEqual(cache_keys__1_year_ago, cache_keys[1])
         self.assertEqual(cache_keys__1_year_later, cache_keys[0])
 
@@ -573,9 +575,7 @@ class TestQueryContext(SupersetTestCase):
         payload["queries"][0]["time_offsets"] = []
         query_context = ChartDataQueryContextSchema().load(payload)
         query_object = query_context.queries[0]
-        processed_df, sql, cache_keys = query_context.processing_time_offsets(
-            df, query_object,
-        )
-        self.assertIs(processed_df, df)
-        self.assertEqual(sql, [])
-        self.assertEqual(cache_keys, [])
+        rv = query_context.processing_time_offsets(df, query_object,)
+        self.assertIs(rv["df"], df)
+        self.assertEqual(rv["queries"], [])
+        self.assertEqual(rv["cache_keys"], [])

--- a/tests/integration_tests/utils/date_parser_tests.py
+++ b/tests/integration_tests/utils/date_parser_tests.py
@@ -24,6 +24,7 @@ from superset.charts.commands.exceptions import (
 from superset.utils.date_parser import (
     DateRangeMigration,
     datetime_eval,
+    get_past_or_future,
     get_since_until,
     parse_human_datetime,
     parse_human_timedelta,
@@ -287,6 +288,14 @@ class TestDateParser(SupersetTestCase):
         self.assertEqual(parse_past_timedelta("-1 year"), timedelta(365))
         self.assertEqual(parse_past_timedelta("52 weeks"), timedelta(364))
         self.assertEqual(parse_past_timedelta("1 month"), timedelta(31))
+
+    def test_get_past_or_future(self):
+        # 2020 is a leap year
+        dttm = datetime(2020, 2, 29)
+        self.assertEqual(get_past_or_future("1 year", dttm), datetime(2021, 2, 28))
+        self.assertEqual(get_past_or_future("-1 year", dttm), datetime(2019, 2, 28))
+        self.assertEqual(get_past_or_future("1 month", dttm), datetime(2020, 3, 29))
+        self.assertEqual(get_past_or_future("3 month", dttm), datetime(2020, 5, 29))
 
     def test_parse_human_datetime(self):
         with self.assertRaises(TimeRangeUnclearError):

--- a/tests/integration_tests/utils/date_parser_tests.py
+++ b/tests/integration_tests/utils/date_parser_tests.py
@@ -14,12 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from unittest.mock import patch
 
+from dateutil.relativedelta import relativedelta
+
 from superset.charts.commands.exceptions import (
+    TimeRangeAmbiguousError,
     TimeRangeParseFailError,
-    TimeRangeUnclearError,
 )
 from superset.utils.date_parser import (
     DateRangeMigration,
@@ -298,14 +300,38 @@ class TestDateParser(SupersetTestCase):
         self.assertEqual(get_past_or_future("3 month", dttm), datetime(2020, 5, 29))
 
     def test_parse_human_datetime(self):
-        with self.assertRaises(TimeRangeUnclearError):
+        with self.assertRaises(TimeRangeAmbiguousError):
             parse_human_datetime("  2 days  ")
 
-        with self.assertRaises(TimeRangeUnclearError):
+        with self.assertRaises(TimeRangeAmbiguousError):
             parse_human_datetime("2 day")
 
         with self.assertRaises(TimeRangeParseFailError):
             parse_human_datetime("xxxxxxx")
+
+        self.assertEqual(parse_human_datetime("2015-04-03"), datetime(2015, 4, 3, 0, 0))
+
+        self.assertEqual(
+            parse_human_datetime("2/3/1969"), datetime(1969, 2, 3, 0, 0),
+        )
+
+        self.assertLessEqual(parse_human_datetime("now"), datetime.now())
+
+        self.assertLess(parse_human_datetime("yesterday"), datetime.now())
+
+        self.assertEqual(
+            date.today() - timedelta(1), parse_human_datetime("yesterday").date()
+        )
+
+        self.assertEqual(
+            parse_human_datetime("one year ago").date(),
+            (datetime.now() - relativedelta(years=1)).date(),
+        )
+
+        self.assertEqual(
+            parse_human_datetime("2 years after").date(),
+            (datetime.now() + relativedelta(years=2)).date(),
+        )
 
     def test_DateRangeMigration(self):
         params = '{"time_range": "   8 days     : 2020-03-10T00:00:00"}'


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR is part of the `advanced analytics`. in this PR introduces:
- `run extra query` on the v1 data API
- add `compare` operator for time compare
- refactoring `get_df_payload`
- persistent extra query results(per time offset)
- unit test for these new functions
- minor improvements in `Makefile`, `diff operator` and `pylint`

client-side codes at: https://github.com/apache-superset/superset-ui/pull/1170

### Preparing test data
please use `random_time_series` dataset for this test.

### Calculation changes (there are 3 changes)
Now the time offset calculation has some changes from before. 

1. Extra query `where clause` offset calculation, use **time units(x years/x months/x weeks)** as calculation offset instead of **day timedelta** to calculate offsets. This will avoid leap year with incorrect calculation

Before **Main** query(line chart) 
```
SELECT DATE_TRUNC('month', ds) AS __timestamp,
       COUNT(*) AS count
FROM random_time_series
WHERE ds >= TO_TIMESTAMP('2016-03-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
  AND ds < TO_TIMESTAMP('2017-03-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
GROUP BY DATE_TRUNC('month', ds)
ORDER BY count DESC
LIMIT 50000
```

Befor **1 year ago offset** query(line chart) 
```
SELECT DATE_TRUNC('month', ds) AS __timestamp,
       COUNT(*) AS count
FROM random_time_series
WHERE ds >= TO_TIMESTAMP('2015-03-02 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
  AND ds < TO_TIMESTAMP('2016-03-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
GROUP BY DATE_TRUNC('month', ds)
ORDER BY count DESC
LIMIT 50000
```

After **Main** query (time-series chart)
```
SELECT DATE_TRUNC('month', ds) AS __timestamp,
       COUNT(*) AS count
FROM random_time_series
WHERE ds >= TO_TIMESTAMP('2016-03-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
  AND ds < TO_TIMESTAMP('2017-03-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
GROUP BY DATE_TRUNC('month', ds)
LIMIT 50000
```

After **1 year ago offset** query
```
SELECT DATE_TRUNC('month', ds) AS __timestamp,
       COUNT(*) AS count
FROM random_time_series
WHERE ds >= TO_TIMESTAMP('2015-03-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
  AND ds < TO_TIMESTAMP('2016-03-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
GROUP BY DATE_TRUNC('month', ds)
LIMIT 50000
```

2. Use `join on __timestamp` instead of `concat` merge main dataframe and extra dataframe. This ensures that the main query and the extension query have the same time granularity calculation on metrics.

Consider this scenario(time-series chart):
![Screen Shot 2021-07-01 at 1 10 50 PM](https://user-images.githubusercontent.com/2016594/124069649-185e7280-da6f-11eb-9927-91b3cea5fb06.png)


The main query is:
```
SELECT DATE_TRUNC('month', ds) AS __timestamp,
       COUNT(*) AS count
FROM random_time_series
WHERE ds >= TO_TIMESTAMP('2016-03-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
  AND ds < TO_TIMESTAMP('2017-03-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
GROUP BY DATE_TRUNC('month', ds)
LIMIT 50000
```

with the time shift `28 days ago` query is:
```
SELECT DATE_TRUNC('month', ds) AS __timestamp,
       COUNT(*) AS count
FROM random_time_series
WHERE ds >= TO_TIMESTAMP('2016-02-02 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
  AND ds < TO_TIMESTAMP('2017-02-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
GROUP BY DATE_TRUNC('month', ds)
LIMIT 50000
```

It is obvious that the extra query is missing the data of **2016-02-01**(the main query grain is month, but the extra query is missing a day, the metric is incorrect), when **main dataframe left join extra dataframe on __timestamp**, the extra data that is not "align" on the main dataframe will be removed automatically.

extra query dataframe
<img width="713" alt="image" src="https://user-images.githubusercontent.com/2016594/124073902-43e45b80-da75-11eb-9f74-d6751c319bc4.png">


merged dataframe
<img width="734" alt="image" src="https://user-images.githubusercontent.com/2016594/124073868-34fda900-da75-11eb-890d-a6637179ce70.png">


3. Not allowed `x time unit` format for timeoffset. Must be specified `x timeunit ago` or `x timeunit later`


### How to test it.
#### A. prepare code
1. pull associated PR in `superset-ui`: https://github.com/apache-superset/superset-ui/pull/1170 
2. pull current pr in `superset`
3. the directory like this:
```bash
$ tree -L 1
.
├── superset-ui
└── superset
```

#### B. Build superset-ui
run after commands in terminal
```bash
$ cd superset-ui
superset-ui$ yarn clean
superset-ui$ rm -rf ./{packages,plugins}/*/node_modules ./node_modules
superset-ui$ yarn clean-npm-lock

superset-ui$ yarn
superset-ui$ yarn build
```

#### C. Build superset-frontend
```
$ cd superset/superset-frontend
superset-frontend$ npm ci
superset-frontend$ npm link --legacy-peer-deps ../../superset-ui/plugins/plugin-chart-echarts/ ../../superset-ui/packages/superset-ui-chart-controls/ ../../superset-ui/packages/superset-ui-core/
```

#### D. Hack core module
1. change `package.json` in superset-ui-core
```
diff --git a/packages/superset-ui-core/package.json b/packages/superset-ui-core/package.json
index 30a78f1e..a67dfd40 100644
--- a/packages/superset-ui-core/package.json
+++ b/packages/superset-ui-core/package.json
@@ -32,8 +32,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "@emotion/cache": "^11.1.3",
-    "@emotion/react": "^11.1.5",
     "@emotion/styled": "^11.3.0",
     "@types/d3-format": "^1.3.0",
     "@types/d3-interpolate": "^1.3.1",
@@ -65,6 +63,8 @@
     "@types/react": "*",
     "@types/react-loadable": "*",
     "react": "^16.13.1",
-    "react-loadable": "^5.5.0"
+    "react-loadable": "^5.5.0",
+    "@emotion/cache": "^11.1.3",
+    "@emotion/react": "^11.1.5"
   }
 }
```
2. build each package of superset-ui
```
$ cd superset-ui/packages/superset-ui-core/
superset-ui-core$ yarn

$ cd superset-ui/packages/superset-ui-chart-controls/
superset-ui-chart-controls$ yarn

$ cd superset-ui/plugins/plugin-chart-echarts/
plugin-chart-echarts$ yarn
```

#### E. run dev server in Superset
```
$ cd superset/superset-frontend
superset-frontend$ npm run dev-server
```

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Added UT in python codebase

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache-superset/superset-ui/pull/1170
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
