### PR TITLE
fix: Revert "build(webpack): use [contenthash] instead of [chunkhash]"

### DIFF
--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -60,11 +60,11 @@ if (isDevMode) {
   output.filename = '[name].[hash:8].entry.js';
   output.chunkFilename = '[name].[hash:8].chunk.js';
 } else if (nameChunks) {
-  output.filename = '[name].[contenthash].entry.js';
-  output.chunkFilename = '[name].[contenthash].chunk.js';
+  output.filename = '[name].[chunkhash].entry.js';
+  output.chunkFilename = '[name].[chunkhash].chunk.js';
 } else {
-  output.filename = '[name].[contenthash].entry.js';
-  output.chunkFilename = '[contenthash].chunk.js';
+  output.filename = '[name].[chunkhash].entry.js';
+  output.chunkFilename = '[chunkhash].chunk.js';
 }
 
 const plugins = [
@@ -157,8 +157,8 @@ if (!isDevMode) {
   // text loading (webpack 4+)
   plugins.push(
     new MiniCssExtractPlugin({
-      filename: '[name].[contenthash].entry.css',
-      chunkFilename: '[name].[contenthash].chunk.css',
+      filename: '[name].[chunkhash].entry.css',
+      chunkFilename: '[name].[chunkhash].chunk.css',
     }),
   );
   plugins.push(new OptimizeCSSAssetsPlugin());


### PR DESCRIPTION
Reverts apache/superset#14942

Initiating a revert for conversations while we test this in Airbnb's environment.

We suspect that this PR is the root cause for an increase in infinite spinners in Superset due to 404s from static asset requests. I'm not 100% sure why this PR might've caused the issue, but the working theory right now is that something may have broken with how this interacts with lazy loaded code. We suspect the contenthash of a parent chunk is not changed if a dependent chunk’s hash also changes, and therefore is causing an issue.

If reverting this PR resolves the issue in Airbnb's prod environment, then we'll aim to merge this on Wednesday.

Test Plan:
test in (Airbnb) prod

to: @nytai @graceguo-supercat