### PR TITLE
feat(import): requester as owner option

### DIFF
--- a/superset-frontend/src/components/ImportModal/index.tsx
+++ b/superset-frontend/src/components/ImportModal/index.tsx
@@ -26,6 +26,7 @@ import Modal from 'src/components/Modal';
 import { Upload } from 'src/common/components';
 import { useImportResource } from 'src/views/CRUD/hooks';
 import { ImportResourceName } from 'src/views/CRUD/types';
+import Checkbox from '../Checkbox';
 
 export const StyledIcon = styled(Icon)`
   margin: auto ${({ theme }) => theme.gridUnit * 2}px auto 0;
@@ -135,6 +136,10 @@ const ImportModelsModal: FunctionComponent<ImportModelsModalProps> = ({
     false,
   );
   const [confirmedOverwrite, setConfirmedOverwrite] = useState<boolean>(false);
+  const [
+    confirmedRequesterAsOwner,
+    setConfirmedRequesterAsOwner,
+  ] = useState<boolean>(false);
   const [fileList, setFileList] = useState<UploadFile[]>([]);
   const [importingModel, setImportingModel] = useState<boolean>(false);
 
@@ -144,6 +149,7 @@ const ImportModelsModal: FunctionComponent<ImportModelsModalProps> = ({
     setPasswords({});
     setNeedsOverwriteConfirm(false);
     setConfirmedOverwrite(false);
+    setConfirmedRequesterAsOwner(false);
     setImportingModel(false);
   };
 
@@ -188,6 +194,7 @@ const ImportModelsModal: FunctionComponent<ImportModelsModalProps> = ({
       fileList[0].originFileObj,
       passwords,
       confirmedOverwrite,
+      confirmedRequesterAsOwner,
     ).then(result => {
       if (result) {
         addSuccessToast(t('The import was successful'));
@@ -269,6 +276,22 @@ const ImportModelsModal: FunctionComponent<ImportModelsModalProps> = ({
     );
   };
 
+  const renderRequesterAsOwner = () => (
+    <>
+      <StyledInputContainer>
+        <div className="confirm-requester-as-owner">
+          {confirmOverwriteMessage}
+        </div>
+        <div className="control-label">{t('Set My User as owner')}</div>
+        <Checkbox
+          data-test="requester-as-owner-modal-input"
+          onChange={(val?: boolean) => setConfirmedRequesterAsOwner(val)}
+          checked={confirmedRequesterAsOwner}
+        />
+      </StyledInputContainer>
+    </>
+  );
+
   // Show/hide
   if (isHidden && show) {
     setIsHidden(false);
@@ -308,6 +331,7 @@ const ImportModelsModal: FunctionComponent<ImportModelsModalProps> = ({
       </StyledInputContainer>
       {renderPasswordFields()}
       {renderOverwriteConfirmation()}
+      {renderRequesterAsOwner()}
     </Modal>
   );
 };

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -394,6 +394,7 @@ export function useImportResource(
       bundle: File,
       databasePasswords: Record<string, string> = {},
       overwrite = false,
+      requesterAsOwner = false,
     ) => {
       // Set loading state
       updateState({
@@ -414,6 +415,10 @@ export function useImportResource(
        */
       if (overwrite) {
         formData.append('overwrite', 'true');
+      }
+
+      if (requesterAsOwner) {
+        formData.append('requesterAsOwner', 'true');
       }
 
       return SupersetClient.post({

--- a/superset/charts/commands/importers/v1/__init__.py
+++ b/superset/charts/commands/importers/v1/__init__.py
@@ -48,7 +48,10 @@ class ImportChartsCommand(ImportModelsCommand):
 
     @staticmethod
     def _import(
-        session: Session, configs: Dict[str, Any], overwrite: bool = False
+        session: Session,
+        configs: Dict[str, Any],
+        overwrite: bool = False,
+        requester_as_owner: bool = False,
     ) -> None:
         # discover datasets associated with charts
         dataset_uuids: Set[str] = set()
@@ -95,4 +98,9 @@ class ImportChartsCommand(ImportModelsCommand):
                     }
                 )
                 config["params"].update({"datasource": dataset.uid})
-                import_chart(session, config, overwrite=overwrite)
+                import_chart(
+                    session,
+                    config,
+                    overwrite=overwrite,
+                    requester_as_owner=requester_as_owner,
+                )

--- a/superset/charts/commands/importers/v1/utils.py
+++ b/superset/charts/commands/importers/v1/utils.py
@@ -24,7 +24,10 @@ from superset.models.slice import Slice
 
 
 def import_chart(
-    session: Session, config: Dict[str, Any], overwrite: bool = False
+    session: Session,
+    config: Dict[str, Any],
+    overwrite: bool = False,
+    requester_as_owner: bool = False,
 ) -> Slice:
     existing = session.query(Slice).filter_by(uuid=config["uuid"]).first()
     if existing:
@@ -36,6 +39,8 @@ def import_chart(
     config["params"] = json.dumps(config["params"])
 
     chart = Slice.import_from_dict(session, config, recursive=False)
+    if requester_as_owner:
+        chart.reset_ownership()
     if chart.id is None:
         session.flush()
 

--- a/superset/commands/importers/v1/examples.py
+++ b/superset/commands/importers/v1/examples.py
@@ -76,6 +76,7 @@ class ImportExamplesCommand(ImportModelsCommand):
         session: Session,
         configs: Dict[str, Any],
         overwrite: bool = False,
+        requester_as_owner: bool = False,
         force_data: bool = False,
     ) -> None:
         # import databases
@@ -124,7 +125,12 @@ class ImportExamplesCommand(ImportModelsCommand):
         for file_name, config in configs.items():
             if file_name.startswith("dashboards/"):
                 config = update_id_refs(config, chart_ids)
-                dashboard = import_dashboard(session, config, overwrite=overwrite)
+                dashboard = import_dashboard(
+                    session,
+                    config,
+                    overwrite=overwrite,
+                    requester_as_owner=requester_as_owner,
+                )
                 for uuid in find_chart_uuids(config["position"]):
                     chart_id = chart_ids[uuid]
                     if (dashboard.id, chart_id) not in existing_relationships:

--- a/superset/commands/importers/v1/examples.py
+++ b/superset/commands/importers/v1/examples.py
@@ -76,7 +76,6 @@ class ImportExamplesCommand(ImportModelsCommand):
         session: Session,
         configs: Dict[str, Any],
         overwrite: bool = False,
-        requester_as_owner: bool = False,
         force_data: bool = False,
     ) -> None:
         # import databases
@@ -128,8 +127,7 @@ class ImportExamplesCommand(ImportModelsCommand):
                 dashboard = import_dashboard(
                     session,
                     config,
-                    overwrite=overwrite,
-                    requester_as_owner=requester_as_owner,
+                    overwrite=overwrite
                 )
                 for uuid in find_chart_uuids(config["position"]):
                     chart_id = chart_ids[uuid]

--- a/superset/config.py
+++ b/superset/config.py
@@ -361,7 +361,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     "DASHBOARD_CROSS_FILTERS": False,
     "DASHBOARD_NATIVE_FILTERS_SET": False,
     "GLOBAL_ASYNC_QUERIES": False,
-    "VERSIONED_EXPORT": False,
+    "VERSIONED_EXPORT": True,
     # Note that: RowLevelSecurityFilter is only given by default to the Admin role
     # and the Admin Role does have the all_datasources security permission.
     # But, if users create a specific role with access to RowLevelSecurityFilter MVC

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -955,9 +955,13 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             else None
         )
         overwrite = request.form.get("overwrite") == "true"
-
+        requester_as_owner = request.form.get("requesterAsOwner")
+        logger.info(f"import formdata {request.form}")
         command = ImportDashboardsCommand(
-            contents, passwords=passwords, overwrite=overwrite
+            contents,
+            passwords=passwords,
+            overwrite=overwrite,
+            requester_as_owner=requester_as_owner,
         )
         command.run()
         return self.response(200, message="OK")

--- a/superset/dashboards/commands/importers/v1/utils.py
+++ b/superset/dashboards/commands/importers/v1/utils.py
@@ -107,7 +107,10 @@ def update_id_refs(config: Dict[str, Any], chart_ids: Dict[str, int]) -> Dict[st
 
 
 def import_dashboard(
-    session: Session, config: Dict[str, Any], overwrite: bool = False
+    session: Session,
+    config: Dict[str, Any],
+    overwrite: bool = False,
+    requester_as_owner: bool = False,
 ) -> Dashboard:
     existing = session.query(Dashboard).filter_by(uuid=config["uuid"]).first()
     if existing:
@@ -126,6 +129,9 @@ def import_dashboard(
                 logger.info("Unable to encode `%s` field: %s", key, value)
 
     dashboard = Dashboard.import_from_dict(session, config, recursive=False)
+    logger.info(f"requester_as_owner: {requester_as_owner}")
+    if requester_as_owner:
+        dashboard.reset_ownership()
     if dashboard.id is None:
         session.flush()
 

--- a/superset/databases/commands/importers/v1/__init__.py
+++ b/superset/databases/commands/importers/v1/__init__.py
@@ -44,13 +44,21 @@ class ImportDatabasesCommand(ImportModelsCommand):
 
     @staticmethod
     def _import(
-        session: Session, configs: Dict[str, Any], overwrite: bool = False
+        session: Session,
+        configs: Dict[str, Any],
+        overwrite: bool = False,
+        requester_as_owner: bool = False,
     ) -> None:
         # first import databases
         database_ids: Dict[str, int] = {}
         for file_name, config in configs.items():
             if file_name.startswith("databases/"):
-                database = import_database(session, config, overwrite=overwrite)
+                database = import_database(
+                    session,
+                    config,
+                    overwrite=overwrite,
+                    requester_as_owner=requester_as_owner,
+                )
                 database_ids[str(database.uuid)] = database.id
 
         # import related datasets
@@ -61,4 +69,9 @@ class ImportDatabasesCommand(ImportModelsCommand):
             ):
                 config["database_id"] = database_ids[config["database_uuid"]]
                 # overwrite=False prevents deleting any non-imported columns/metrics
-                import_dataset(session, config, overwrite=False)
+                import_dataset(
+                    session,
+                    config,
+                    overwrite=False,
+                    requester_as_owner=requester_as_owner,
+                )

--- a/superset/databases/commands/importers/v1/utils.py
+++ b/superset/databases/commands/importers/v1/utils.py
@@ -24,7 +24,10 @@ from superset.models.core import Database
 
 
 def import_database(
-    session: Session, config: Dict[str, Any], overwrite: bool = False
+    session: Session,
+    config: Dict[str, Any],
+    overwrite: bool = False,
+    requester_as_owner: bool = False,
 ) -> Database:
     existing = session.query(Database).filter_by(uuid=config["uuid"]).first()
     if existing:
@@ -36,6 +39,8 @@ def import_database(
     config["extra"] = json.dumps(config["extra"])
 
     database = Database.import_from_dict(session, config, recursive=False)
+    if requester_as_owner:
+        database.reset_ownership()
     if database.id is None:
         session.flush()
 

--- a/superset/datasets/commands/importers/v1/__init__.py
+++ b/superset/datasets/commands/importers/v1/__init__.py
@@ -44,7 +44,10 @@ class ImportDatasetsCommand(ImportModelsCommand):
 
     @staticmethod
     def _import(
-        session: Session, configs: Dict[str, Any], overwrite: bool = False
+        session: Session,
+        configs: Dict[str, Any],
+        overwrite: bool = False,
+        requester_as_owner: bool = False,
     ) -> None:
         # discover databases associated with datasets
         database_uuids: Set[str] = set()
@@ -56,7 +59,12 @@ class ImportDatasetsCommand(ImportModelsCommand):
         database_ids: Dict[str, int] = {}
         for file_name, config in configs.items():
             if file_name.startswith("databases/") and config["uuid"] in database_uuids:
-                database = import_database(session, config, overwrite=False)
+                database = import_database(
+                    session,
+                    config,
+                    overwrite=False,
+                    requester_as_owner=requester_as_owner,
+                )
                 database_ids[str(database.uuid)] = database.id
 
         # import datasets with the correct parent ref
@@ -66,4 +74,9 @@ class ImportDatasetsCommand(ImportModelsCommand):
                 and config["database_uuid"] in database_ids
             ):
                 config["database_id"] = database_ids[config["database_uuid"]]
-                import_dataset(session, config, overwrite=overwrite)
+                import_dataset(
+                    session,
+                    config,
+                    overwrite=overwrite,
+                    requester_as_owner=requester_as_owner,
+                )

--- a/superset/datasets/commands/importers/v1/utils.py
+++ b/superset/datasets/commands/importers/v1/utils.py
@@ -81,6 +81,7 @@ def import_dataset(
     session: Session,
     config: Dict[str, Any],
     overwrite: bool = False,
+    requester_as_owner: bool = False,
     force_data: bool = False,
 ) -> SqlaTable:
     existing = session.query(SqlaTable).filter_by(uuid=config["uuid"]).first()
@@ -113,6 +114,8 @@ def import_dataset(
 
     # import recursively to include columns and metrics
     dataset = SqlaTable.import_from_dict(session, config, recursive=True, sync=sync)
+    if requester_as_owner:
+        dataset.reset_ownership()
     if dataset.id is None:
         session.flush()
 

--- a/superset/queries/saved_queries/commands/importers/v1/__init__.py
+++ b/superset/queries/saved_queries/commands/importers/v1/__init__.py
@@ -46,7 +46,10 @@ class ImportSavedQueriesCommand(ImportModelsCommand):
 
     @staticmethod
     def _import(
-        session: Session, configs: Dict[str, Any], overwrite: bool = False
+        session: Session,
+        configs: Dict[str, Any],
+        overwrite: bool = False,
+        requester_as_owner: bool = False,
     ) -> None:
         # discover databases associated with saved queries
         database_uuids: Set[str] = set()
@@ -58,7 +61,12 @@ class ImportSavedQueriesCommand(ImportModelsCommand):
         database_ids: Dict[str, int] = {}
         for file_name, config in configs.items():
             if file_name.startswith("databases/") and config["uuid"] in database_uuids:
-                database = import_database(session, config, overwrite=False)
+                database = import_database(
+                    session,
+                    config,
+                    overwrite=False,
+                    requester_as_owner=requester_as_owner,
+                )
                 database_ids[str(database.uuid)] = database.id
 
         # import saved queries with the correct parent ref


### PR DESCRIPTION
### SUMMARY
There are scenarios that Alpha role type of user will want to import dashboards/datasets/charts and etc' and set themselves as owners upon importing.
this naive solution is a simple ready to opt-in checkbox on the import modal

An alternative solution would we to have a select dropdown of all of the users and choosing them as owners , therefore you can include yourself on the list as well . 
This solution might be suitable for Admin but as a Alpha role user we should only have control on our own user and not other users

this is why I think for now we can start with a boolean only flag and later on the roadmap upgrade this feature when we'll have a multi-tenant /workspace solution that can isolate different groups of users for each other and can access objects like dashboards/charts/datasets only on their group scope.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/47772523/122878725-bc923c00-d340-11eb-8385-6ec8c15c0feb.png)


### TESTING INSTRUCTIONS
Scenario 1
1. import a dashboard in v1 version.
2. mark the checkbox that says "set my user as owner" and submit 
3. see that created dashboards/charts/datasets and etc' were added with your user as their owner

scenario 2 
same as scenario 1 but with a different user

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
