### PR TITLE
fix: Stop [Object object] from appearing on the Additional Params

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -357,48 +357,50 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { id, ...update } = db || {};
 
-    if (update.configuration_method === CONFIGURATION_METHOD.DYNAMIC_FORM) {
-      if (update?.parameters?.query) {
+    // Clone DB object
+    const dbToUpdate = JSON.parse(JSON.stringify(update));
+    if (dbToUpdate.configuration_method === CONFIGURATION_METHOD.DYNAMIC_FORM) {
+      if (dbToUpdate?.parameters?.query) {
         // convert query params into dictionary
-        update.parameters.query = JSON.parse(
-          `{"${decodeURI((update?.parameters?.query as string) || '')
+        dbToUpdate.parameters.query = JSON.parse(
+          `{"${decodeURI((dbToUpdate?.parameters?.query as string) || '')
             .replace(/"/g, '\\"')
             .replace(/&/g, '","')
             .replace(/=/g, '":"')}"}`,
         );
-      } else if (update?.parameters?.query === '') {
-        update.parameters.query = {};
+      } else if (dbToUpdate?.parameters?.query === '') {
+        dbToUpdate.parameters.query = {};
       }
 
-      const engine = update.backend || update.engine;
-      if (engine === 'bigquery' && update.parameters?.credentials_info) {
+      const engine = dbToUpdate.backend || dbToUpdate.engine;
+      if (engine === 'bigquery' && dbToUpdate.parameters?.credentials_info) {
         // wrap encrypted_extra in credentials_info only for BigQuery
-        update.encrypted_extra = JSON.stringify({
-          credentials_info: JSON.parse(update.parameters?.credentials_info),
+        dbToUpdate.encrypted_extra = JSON.stringify({
+          credentials_info: JSON.parse(dbToUpdate.parameters?.credentials_info),
         });
       }
     }
 
     if (db?.id) {
-      if (update?.extra_json) {
+      if (dbToUpdate?.extra_json) {
         // convert extra_json to back to string
-        update.extra = JSON.stringify({
-          ...update.extra_json,
+        dbToUpdate.extra = JSON.stringify({
+          ...dbToUpdate.extra_json,
           metadata_params: JSON.parse(
-            update?.extra_json?.metadata_params as string,
+            dbToUpdate?.extra_json?.metadata_params as string,
           ),
           engine_params: JSON.parse(
-            update?.extra_json?.engine_params as string,
+            dbToUpdate?.extra_json?.engine_params as string,
           ),
           schemas_allowed_for_csv_upload: JSON.parse(
-            update?.extra_json?.schemas_allowed_for_csv_upload as string,
+            dbToUpdate?.extra_json?.schemas_allowed_for_csv_upload as string,
           ),
         });
       }
       setLoading(true);
       const result = await updateResource(
         db.id as number,
-        update as DatabaseObject,
+        dbToUpdate as DatabaseObject,
       );
       if (result) {
         if (onDatabaseAdd) {
@@ -408,23 +410,23 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       }
     } else if (db) {
       // Create
-      if (update?.extra_json) {
+      if (dbToUpdate?.extra_json) {
         // convert extra_json to back to string
-        update.extra = JSON.stringify({
-          ...update.extra_json,
+        dbToUpdate.extra = JSON.stringify({
+          ...dbToUpdate.extra_json,
           metadata_params: JSON.parse(
-            update?.extra_json?.metadata_params as string,
+            dbToUpdate?.extra_json?.metadata_params as string,
           ),
           engine_params: JSON.parse(
-            update?.extra_json?.engine_params as string,
+            dbToUpdate?.extra_json?.engine_params as string,
           ),
           schemas_allowed_for_csv_upload: JSON.parse(
-            update?.extra_json?.schemas_allowed_for_csv_upload as string,
+            dbToUpdate?.extra_json?.schemas_allowed_for_csv_upload as string,
           ),
         });
       }
       setLoading(true);
-      const dbId = await createResource(update as DatabaseObject);
+      const dbId = await createResource(dbToUpdate as DatabaseObject);
       if (dbId) {
         setHasConnectedDb(true);
         if (onDatabaseAdd) {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Whenever the user would save `Additional Params` the field would update with [Object object]. To stop the we've made a deep copy of db object before making the request


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
