### PR TITLE
fix: Revert "fix: SQL Lab show "Refetch Results" button while fetching new query results"

### DIFF
--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -517,20 +517,7 @@ export default function sqlLabReducer(state = {}, action) {
           if (changedQuery.changedOn > queriesLastUpdate) {
             queriesLastUpdate = changedQuery.changedOn;
           }
-          const prevState = state.queries[id].state;
-          const currentState = changedQuery.state;
-          newQueries[id] = {
-            ...state.queries[id],
-            ...changedQuery,
-            // race condition:
-            // because of async behavior, sql lab may still poll a couple of seconds
-            // when it started fetching or finished rendering results
-            state:
-              currentState === 'success' &&
-              ['fetching', 'success'].includes(prevState)
-                ? prevState
-                : currentState,
-          };
+          newQueries[id] = { ...state.queries[id], ...changedQuery };
           change = true;
         }
       });


### PR DESCRIPTION
Reverts apache/superset#15109

This PR fixed the "Refetch Results" button as expected, but it seems it introduced another issue in airbnb. Some of our users saw "offline" message when they start new query. I am not sure the root cause yet, but have to revert to PR and investigate more. 