### PR TITLE
feat(native-filters): Set default scope by filters' and charts' datasets 

### DIFF
--- a/superset-frontend/spec/javascripts/dashboard/util/getFormDataWithExtraFilters_spec.ts
+++ b/superset-frontend/spec/javascripts/dashboard/util/getFormDataWithExtraFilters_spec.ts
@@ -48,6 +48,7 @@ describe('getFormDataWithExtraFilters', () => {
           val: ['United States'],
         },
       ],
+      datasource: '123',
     },
   };
   const mockArgs: GetFormDataWithExtraFiltersArguments = {

--- a/superset-frontend/src/common/hooks/useComponentDidUpdate/index.ts
+++ b/superset-frontend/src/common/hooks/useComponentDidUpdate/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from './useComponentDidUpdate';

--- a/superset-frontend/src/common/hooks/useComponentDidUpdate/useComponentDidUpdate.test.ts
+++ b/superset-frontend/src/common/hooks/useComponentDidUpdate/useComponentDidUpdate.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { renderHook } from '@testing-library/react-hooks';
+import { useComponentDidUpdate } from './useComponentDidUpdate';
+
+test('the effect should not be executed on the first render', () => {
+  const effect = jest.fn();
+  const hook = renderHook((props) => useComponentDidUpdate(props.effect), { initialProps: { effect }});
+  expect(effect).toBeCalledTimes(0);
+  const changedEffect = jest.fn();
+  hook.rerender({ effect: changedEffect });
+  expect(changedEffect).toBeCalledTimes(1);
+});

--- a/superset-frontend/src/common/hooks/useComponentDidUpdate/useComponentDidUpdate.test.ts
+++ b/superset-frontend/src/common/hooks/useComponentDidUpdate/useComponentDidUpdate.test.ts
@@ -21,7 +21,9 @@ import { useComponentDidUpdate } from './useComponentDidUpdate';
 
 test('the effect should not be executed on the first render', () => {
   const effect = jest.fn();
-  const hook = renderHook((props) => useComponentDidUpdate(props.effect), { initialProps: { effect }});
+  const hook = renderHook(props => useComponentDidUpdate(props.effect), {
+    initialProps: { effect },
+  });
   expect(effect).toBeCalledTimes(0);
   const changedEffect = jest.fn();
   hook.rerender({ effect: changedEffect });

--- a/superset-frontend/src/common/hooks/useComponentDidUpdate/useComponentDidUpdate.ts
+++ b/superset-frontend/src/common/hooks/useComponentDidUpdate/useComponentDidUpdate.ts
@@ -21,14 +21,11 @@ import { EffectCallback, useEffect, useRef } from 'react';
 
 export const useComponentDidUpdate = (effect: EffectCallback) => {
   const isMountedRef = useRef(false);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (isMountedRef.current) {
       effect();
+    } else {
+      isMountedRef.current = true;
     }
   }, [effect]);
-
-  useEffect(() => {
-    isMountedRef.current = true;
-  }, []);
 };

--- a/superset-frontend/src/common/hooks/useComponentDidUpdate/useComponentDidUpdate.ts
+++ b/superset-frontend/src/common/hooks/useComponentDidUpdate/useComponentDidUpdate.ts
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { EffectCallback, useEffect, useRef } from 'react';
+
+export const useComponentDidUpdate = (
+  effect: EffectCallback,
+) => {
+  const isMountedRef = useRef(false);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (isMountedRef.current) {
+      effect();
+    }
+  }, [effect]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+  }, []);
+};

--- a/superset-frontend/src/common/hooks/useComponentDidUpdate/useComponentDidUpdate.ts
+++ b/superset-frontend/src/common/hooks/useComponentDidUpdate/useComponentDidUpdate.ts
@@ -19,9 +19,7 @@
 
 import { EffectCallback, useEffect, useRef } from 'react';
 
-export const useComponentDidUpdate = (
-  effect: EffectCallback,
-) => {
+export const useComponentDidUpdate = (effect: EffectCallback) => {
   const isMountedRef = useRef(false);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {

--- a/superset-frontend/src/dashboard/components/CrossFilterScopingModal/CrossFilterScopingForm/CrossFilterScopingForm.test.tsx
+++ b/superset-frontend/src/dashboard/components/CrossFilterScopingModal/CrossFilterScopingForm/CrossFilterScopingForm.test.tsx
@@ -43,9 +43,9 @@ test('Should send correct props', () => {
   expect(FilterScope).toHaveBeenCalledWith(
     expect.objectContaining({
       chartId: 123,
-      scope: 'Scope',
-      formScope: 'scope',
-      formScoping: 'scoping',
+      filterScope: 'Scope',
+      formFilterScope: 'scope',
+      formScopingType: 'scoping',
     }),
     {},
   );

--- a/superset-frontend/src/dashboard/components/CrossFilterScopingModal/CrossFilterScopingForm/index.tsx
+++ b/superset-frontend/src/dashboard/components/CrossFilterScopingModal/CrossFilterScopingForm/index.tsx
@@ -45,11 +45,11 @@ const CrossFilterScopingForm: FC<CrossFilterScopingFormProps> = ({
           ...values,
         });
       }}
-      scope={scope}
+      filterScope={scope}
       chartId={chartId}
-      formScope={formScope}
+      formFilterScope={formScope}
       forceUpdate={forceUpdate}
-      formScoping={formScoping}
+      formScopingType={formScoping}
     />
   );
 };

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.test.tsx
@@ -115,7 +115,6 @@ describe('FilterScope', () => {
     fireEvent.click(screen.getByText('Scoping'));
     fireEvent.click(screen.getByLabelText('Apply to specific panels'));
 
-    screen.debug(undefined, 30000);
     await waitFor(() => {
       expect(screen.getByRole('tree')).toBeInTheDocument();
       expect(

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.test.tsx
@@ -115,6 +115,7 @@ describe('FilterScope', () => {
     fireEvent.click(screen.getByText('Scoping'));
     fireEvent.click(screen.getByLabelText('Apply to specific panels'));
 
+    screen.debug(undefined, 30000);
     await waitFor(() => {
       expect(screen.getByRole('tree')).toBeInTheDocument();
       expect(

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.tsx
@@ -17,10 +17,11 @@
  * under the License.
  */
 
-import React, { FC, useCallback, useEffect, useState } from 'react';
+import React, { FC, useCallback, useState } from 'react';
 import { t, styled } from '@superset-ui/core';
 import { Radio } from 'src/components/Radio';
 import { Form, Typography } from 'src/common/components';
+import { useComponentDidUpdate } from 'src/common/hooks/useComponentDidUpdate/useComponentDidUpdate';
 import { Scope } from '../../../types';
 import { ScopingType } from './types';
 import ScopingTree from './ScopingTree';
@@ -79,7 +80,7 @@ const FilterScope: FC<FilterScopeProps> = ({
     [updateFormValues],
   );
 
-  useEffect(() => {
+  const updateScopes = useCallback(() => {
     if (filterScope || hasScopeBeenModified) {
       return;
     }
@@ -93,11 +94,12 @@ const FilterScope: FC<FilterScopeProps> = ({
     });
   }, [
     chartId,
+    filterScope,
     hasScopeBeenModified,
     initiallyExcludedCharts,
-    filterScope,
     updateFormValues,
   ]);
+  useComponentDidUpdate(updateScopes);
 
   return (
     <Wrapper>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.tsx
@@ -22,17 +22,17 @@ import { t, styled } from '@superset-ui/core';
 import { Radio } from 'src/components/Radio';
 import { Form, Typography } from 'src/common/components';
 import { Scope } from '../../../types';
-import { Scoping } from './types';
+import { ScopingType } from './types';
 import ScopingTree from './ScopingTree';
 import { getDefaultScopeValue, isScopingAll } from './utils';
 
 type FilterScopeProps = {
   pathToFormValue?: string[];
   updateFormValues: (values: any) => void;
-  formScope?: Scope;
+  formFilterScope?: Scope;
   forceUpdate: Function;
-  scope?: Scope;
-  formScoping?: Scoping;
+  filterScope?: Scope;
+  formScopingType?: ScopingType;
   chartId?: number;
   initiallyExcludedCharts?: number[];
 };
@@ -51,21 +51,25 @@ const CleanFormItem = styled(Form.Item)`
 
 const FilterScope: FC<FilterScopeProps> = ({
   pathToFormValue = [],
-  formScoping,
-  formScope,
+  formScopingType,
+  formFilterScope,
   forceUpdate,
-  scope,
+  filterScope,
   updateFormValues,
   chartId,
   initiallyExcludedCharts,
 }) => {
-  const [initialScope] = useState(
-    scope || getDefaultScopeValue(chartId, initiallyExcludedCharts),
+  const [initialFilterScope] = useState(
+    filterScope || getDefaultScopeValue(chartId, initiallyExcludedCharts),
   );
-  const [initialScoping] = useState(
-    isScopingAll(initialScope, chartId) ? Scoping.all : Scoping.specific,
+  const [initialScopingType] = useState(
+    isScopingAll(initialFilterScope, chartId)
+      ? ScopingType.all
+      : ScopingType.specific,
   );
-  const [hasScopeBeenModified, setHasScopeBeenModified] = useState(!!scope);
+  const [hasScopeBeenModified, setHasScopeBeenModified] = useState(
+    !!filterScope,
+  );
 
   const onUpdateFormValues = useCallback(
     (formValues: any) => {
@@ -76,20 +80,22 @@ const FilterScope: FC<FilterScopeProps> = ({
   );
 
   useEffect(() => {
-    if (scope || hasScopeBeenModified) {
+    if (filterScope || hasScopeBeenModified) {
       return;
     }
 
     const newScope = getDefaultScopeValue(chartId, initiallyExcludedCharts);
     updateFormValues({
       scope: newScope,
-      scoping: isScopingAll(newScope, chartId) ? Scoping.all : Scoping.specific,
+      scoping: isScopingAll(newScope, chartId)
+        ? ScopingType.all
+        : ScopingType.specific,
     });
   }, [
     chartId,
     hasScopeBeenModified,
     initiallyExcludedCharts,
-    scope,
+    filterScope,
     updateFormValues,
   ]);
 
@@ -97,11 +103,11 @@ const FilterScope: FC<FilterScopeProps> = ({
     <Wrapper>
       <CleanFormItem
         name={[...pathToFormValue, 'scoping']}
-        initialValue={initialScoping}
+        initialValue={initialScopingType}
       >
         <Radio.Group
           onChange={({ target: { value } }) => {
-            if (value === Scoping.all) {
+            if (value === ScopingType.all) {
               const scope = getDefaultScopeValue(chartId);
               updateFormValues({
                 scope,
@@ -111,22 +117,22 @@ const FilterScope: FC<FilterScopeProps> = ({
             forceUpdate();
           }}
         >
-          <Radio value={Scoping.all}>{t('Apply to all panels')}</Radio>
-          <Radio value={Scoping.specific}>
+          <Radio value={ScopingType.all}>{t('Apply to all panels')}</Radio>
+          <Radio value={ScopingType.specific}>
             {t('Apply to specific panels')}
           </Radio>
         </Radio.Group>
       </CleanFormItem>
       <Typography.Text type="secondary">
-        {(formScoping ?? initialScoping) === Scoping.specific
+        {(formScopingType ?? initialScopingType) === ScopingType.specific
           ? t('Only selected panels will be affected by this filter')
           : t('All panels with this column will be affected by this filter')}
       </Typography.Text>
-      {(formScoping ?? initialScoping) === Scoping.specific && (
+      {(formScopingType ?? initialScopingType) === ScopingType.specific && (
         <ScopingTree
           updateFormValues={onUpdateFormValues}
-          initialScope={initialScope}
-          formScope={formScope}
+          initialScope={initialFilterScope}
+          formScope={formFilterScope}
           forceUpdate={forceUpdate}
           chartId={chartId}
           initiallyExcludedCharts={initiallyExcludedCharts}
@@ -135,7 +141,7 @@ const FilterScope: FC<FilterScopeProps> = ({
       <CleanFormItem
         name={[...pathToFormValue, 'scope']}
         hidden
-        initialValue={initialScope}
+        initialValue={initialFilterScope}
       />
     </Wrapper>
   );

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.tsx
@@ -107,6 +107,7 @@ const FilterScope: FC<FilterScopeProps> = ({
                 scope,
               });
             }
+            setHasScopeBeenModified(true);
             forceUpdate();
           }}
         >

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/ScopingTree.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/ScopingTree.tsx
@@ -60,7 +60,7 @@ const ScopingTree: FC<ScopingTreeProps> = ({
   forceUpdate,
   updateFormValues,
   chartId,
-  initiallyExcludedCharts,
+  initiallyExcludedCharts = [],
 }) => {
   const [expandedKeys, setExpandedKeys] = useState<string[]>([
     DASHBOARD_ROOT_ID,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/ScopingTree.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/ScopingTree.tsx
@@ -20,6 +20,8 @@
 import React, { FC, useMemo, useState } from 'react';
 import { Tree } from 'src/common/components';
 import { DASHBOARD_ROOT_ID } from 'src/dashboard/util/constants';
+import { Tooltip } from 'src/components/Tooltip';
+import Icons from 'src/components/Icons';
 import { useFilterScopeTree } from './state';
 import { findFilterScope, getTreeCheckedItems } from './utils';
 import { Scope } from '../../../types';
@@ -30,6 +32,26 @@ type ScopingTreeProps = {
   formScope?: Scope;
   initialScope: Scope;
   chartId?: number;
+  initiallyExcludedCharts?: number[];
+};
+
+const buildTreeLeafTitle = (
+  label: string,
+  hasTooltip: boolean,
+  tooltipTitle?: string,
+) => {
+  let title = <span>{label}</span>;
+  if (hasTooltip) {
+    title = (
+      <>
+        {title}&nbsp;
+        <Tooltip title={tooltipTitle}>
+          <Icons.Info iconSize="m" />
+        </Tooltip>
+      </>
+    );
+  }
+  return title;
 };
 
 const ScopingTree: FC<ScopingTreeProps> = ({
@@ -38,12 +60,17 @@ const ScopingTree: FC<ScopingTreeProps> = ({
   forceUpdate,
   updateFormValues,
   chartId,
+  initiallyExcludedCharts,
 }) => {
   const [expandedKeys, setExpandedKeys] = useState<string[]>([
     DASHBOARD_ROOT_ID,
   ]);
 
-  const { treeData, layout } = useFilterScopeTree(chartId);
+  const { treeData, layout } = useFilterScopeTree(
+    chartId,
+    initiallyExcludedCharts,
+    buildTreeLeafTitle,
+  );
   const [autoExpandParent, setAutoExpandParent] = useState<boolean>(true);
 
   const handleExpand = (expandedKeys: string[]) => {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/state.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/state.ts
@@ -25,12 +25,14 @@ import {
   CHART_TYPE,
   DASHBOARD_ROOT_TYPE,
 } from 'src/dashboard/util/componentTypes';
-import { TreeItem } from './types';
+import { BuildTreeLeafTitle, TreeItem } from './types';
 import { buildTree } from './utils';
 
 // eslint-disable-next-line import/prefer-default-export
 export function useFilterScopeTree(
   currentChartId?: number,
+  initiallyExcludedCharts: number[] = [],
+  buildTreeLeafTitle: BuildTreeLeafTitle = label => label,
 ): {
   treeData: [TreeItem];
   layout: Layout;
@@ -61,8 +63,16 @@ export function useFilterScopeTree(
   );
 
   useMemo(() => {
-    buildTree(layout[DASHBOARD_ROOT_ID], tree, layout, charts, validNodes);
-  }, [charts, layout, tree]);
+    buildTree(
+      layout[DASHBOARD_ROOT_ID],
+      tree,
+      layout,
+      charts,
+      validNodes,
+      initiallyExcludedCharts,
+      buildTreeLeafTitle,
+    );
+  }, [layout, tree, charts, initiallyExcludedCharts, buildTreeLeafTitle]);
 
   return { treeData: [tree], layout };
 }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/types.ts
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+import { ReactNode } from 'react';
+
 export enum Scoping {
   all,
   specific,
@@ -26,5 +28,11 @@ export enum Scoping {
 export type TreeItem = {
   children: TreeItem[];
   key: string;
-  title: string;
+  title: ReactNode;
 };
+
+export type BuildTreeLeafTitle = (
+  label: string,
+  hasTooltip: boolean,
+  tooltipTitle?: string,
+) => ReactNode;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/types.ts
@@ -19,7 +19,7 @@
 
 import { ReactNode } from 'react';
 
-export enum Scoping {
+export enum ScopingType {
   all,
   specific,
 }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.ts
@@ -23,7 +23,8 @@ import {
   TAB_TYPE,
 } from 'src/dashboard/util/componentTypes';
 import { DASHBOARD_ROOT_ID } from 'src/dashboard/util/constants';
-import { TreeItem } from './types';
+import { t } from '@superset-ui/core';
+import { BuildTreeLeafTitle, TreeItem } from './types';
 import { Scope } from '../../../types';
 
 export const isShowTypeInTree = ({ type, meta }: LayoutItem, charts?: Charts) =>
@@ -36,6 +37,8 @@ export const buildTree = (
   layout: Layout,
   charts: Charts,
   validNodes: string[],
+  initiallyExcludedCharts: number[],
+  buildTreeLeafTitle: BuildTreeLeafTitle,
 ) => {
   let itemToPass: TreeItem = treeItem;
   if (
@@ -43,20 +46,35 @@ export const buildTree = (
     node.type !== DASHBOARD_ROOT_TYPE &&
     validNodes.includes(node.id)
   ) {
-    const currentTreeItem = {
-      key: node.id,
-      title:
-        node.meta.sliceNameOverride ||
+    const title = buildTreeLeafTitle(
+      node.meta.sliceNameOverride ||
         node.meta.sliceName ||
         node.meta.text ||
         node.id.toString(),
+      initiallyExcludedCharts.includes(node.meta?.chartId),
+      t(
+        "This chart might be incompatible with the filter (datasets don't match)",
+      ),
+    );
+
+    const currentTreeItem = {
+      key: node.id,
+      title,
       children: [],
     };
     treeItem.children.push(currentTreeItem);
     itemToPass = currentTreeItem;
   }
   node.children.forEach(child =>
-    buildTree(layout[child], itemToPass, layout, charts, validNodes),
+    buildTree(
+      layout[child],
+      itemToPass,
+      layout,
+      charts,
+      validNodes,
+      initiallyExcludedCharts,
+      buildTreeLeafTitle,
+    ),
   );
 };
 
@@ -148,9 +166,14 @@ export const findFilterScope = (
   };
 };
 
-export const getDefaultScopeValue = (chartId?: number): Scope => ({
+export const getDefaultScopeValue = (
+  chartId?: number,
+  initiallyExcludedCharts: number[] = [],
+): Scope => ({
   rootPath: [DASHBOARD_ROOT_ID],
-  excluded: chartId ? [chartId] : [],
+  excluded: chartId
+    ? [chartId, ...initiallyExcludedCharts]
+    : initiallyExcludedCharts,
 });
 
 export const isScopingAll = (scope: Scope, chartId?: number) =>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -608,7 +608,11 @@ const FiltersConfigForm = (
       }
     });
     return excluded;
-  }, [charts, formFilter?.dataset?.value, loadedDatasets]);
+  }, [
+    JSON.stringify(charts),
+    formFilter?.dataset?.value,
+    JSON.stringify(loadedDatasets),
+  ]);
 
   if (removed) {
     return <RemovedFilter onClick={() => restoreFilter(filterId)} />;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -599,7 +599,10 @@ const FiltersConfigForm = (
     }
 
     Object.values(charts).forEach((chart: Chart) => {
-      const chartDatasetUid = chart.formData.datasource;
+      const chartDatasetUid = chart.formData?.datasource;
+      if (chartDatasetUid === undefined) {
+        return;
+      }
       if (loadedDatasets[chartDatasetUid]?.id !== formFilter?.dataset?.value) {
         excluded.push(chart.id);
       }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -349,9 +349,9 @@ const FiltersConfigForm = (
     ?.datasourceCount;
   const hasColumn =
     hasDataset && !FILTERS_WITHOUT_COLUMN.includes(formFilter?.filterType);
+  const nativeFilterItem = nativeFilterItems[formFilter?.filterType] ?? {};
   // @ts-ignore
-  const enableNoResults = !!nativeFilterItems[formFilter?.filterType]?.value
-    ?.enableNoResults;
+  const enableNoResults = !!nativeFilterItem.value?.enableNoResults;
   const datasetId = formFilter?.dataset?.value;
 
   useEffect(() => {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -592,7 +592,7 @@ const FiltersConfigForm = (
     setActiveFilterPanelKey(activeFilterPanelKey);
   }, [hasCheckedAdvancedControl]);
 
-  const initiallyExcluded = useMemo(() => {
+  const initiallyExcludedCharts = useMemo(() => {
     const excluded: number[] = [];
     if (formFilter?.dataset?.value === undefined) {
       return [];
@@ -1072,10 +1072,10 @@ const FiltersConfigForm = (
           updateFormValues={updateFormValues}
           pathToFormValue={['filters', filterId]}
           forceUpdate={forceUpdate}
-          scope={filterToEdit?.scope}
-          formScope={formFilter?.scope}
-          formScoping={formFilter?.scoping}
-          initiallyExcludedCharts={initiallyExcluded}
+          filterScope={filterToEdit?.scope}
+          formFilterScope={formFilter?.scope}
+          formScopingType={formFilter?.scoping}
+          initiallyExcludedCharts={initiallyExcludedCharts}
         />
       </TabPane>
     </StyledTabs>

--- a/superset-frontend/src/dashboard/types.ts
+++ b/superset-frontend/src/dashboard/types.ts
@@ -16,7 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ChartProps, ExtraFormData, JsonObject } from '@superset-ui/core';
+import {
+  ChartProps,
+  ExtraFormData,
+  GenericDataType,
+  JsonObject,
+} from '@superset-ui/core';
+import { DatasourceMeta } from '@superset-ui/chart-controls';
 import { chart } from 'src/chart/chartReducer';
 import componentTypes from 'src/dashboard/util/componentTypes';
 import { DataMaskStateWithId } from '../dataMask/types';
@@ -38,6 +44,7 @@ export interface ChartQueryPayload extends Partial<ChartReducerInitialState> {
 export type Chart = ChartState & {
   formData: {
     viz_type: string;
+    datasource: string;
   };
 };
 
@@ -60,10 +67,16 @@ export type DashboardInfo = {
 };
 
 export type ChartsState = { [key: string]: Chart };
+export type DatasourcesState = {
+  [key: string]: DatasourceMeta & {
+    column_types: GenericDataType[];
+    table_name: string;
+  };
+};
 
 /** Root state of redux */
 export type RootState = {
-  datasources: JsonObject;
+  datasources: DatasourcesState;
   sliceEntities: JsonObject;
   charts: ChartsState;
   dashboardLayout: DashboardLayoutState;


### PR DESCRIPTION
### SUMMARY
When new native filter was created, "Apply to all panels" scope was always selected by default. In the case of dashboards that have charts built on multiple datasets (e.g. `Slack Dashboard` from test data), filter that uses given dataset usually is incompatible and does not have any effect on charts that use a different dataset. This PR implements "smarter" selection of default scope - when user created a new filter, charts that use different dataset than the filter will be unselected. Changing dataset updates the default scoping tree, but only if the user didn't make any changes there - if the user changes selection in the scoping tree and then changes dataset, we don't update the tree automatically.
The feature takes effect only on new filters. Once a filter is saved, we don't apply default selection to the scopong tree upon editing the filter and its dataset.
Next to "incompatible" charts I added an icon with a tooltip that explains why those charts were not selected by default. I used `Info` icon for that purpose. Other icons that I considered were `Alert` and `Warning` , but since potentially a lot of those icons can appear next to each other, I didn't want to use something too "aggressive". I'd greatly appreciate design input/approval! CC @mihir174.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/15073128/122973217-47028c00-d391-11eb-8a1a-0c21d13ca50e.mov

### TESTING INSTRUCTIONS
0. Enable `DASHBOARD_NATIVE_FILTERS` feature flag
1. Create a dashboard with charts that use the same dataset.
2. Create a native filter and verify that "Apply to all panels" scope is selected by default
3. Create a dashboard with charts that use multiple datasets
4. Create a native filter, choose a dataset and verify that only the charts that use that dataset are in scope by default.
5. Change dataset, verify that scope tree got updated so that charts that use the new dataset are now in scope.
6. Modify the scope, change dataset and verify that the scope didn't change.
7. Save the filter, edit it, change its dataset, verify that the scoe didn't change.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #14977 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @villebro @michael-s-molina @rusackas