### PR TITLE
refactor: migrate icon to icons in tablecollection

### DIFF
--- a/superset-frontend/src/components/AlteredSliceTag/AlteredSliceTag.test.jsx
+++ b/superset-frontend/src/components/AlteredSliceTag/AlteredSliceTag.test.jsx
@@ -18,7 +18,6 @@
  */
 import React from 'react';
 import { styledMount as mount } from 'spec/helpers/theming';
-import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
 import { getChartControlPanelRegistry } from '@superset-ui/core';
 
 import AlteredSliceTag from 'src/components/AlteredSliceTag';

--- a/superset-frontend/src/components/AlteredSliceTag/AlteredSliceTag.test.jsx
+++ b/superset-frontend/src/components/AlteredSliceTag/AlteredSliceTag.test.jsx
@@ -18,6 +18,7 @@
  */
 import React from 'react';
 import { styledMount as mount } from 'spec/helpers/theming';
+import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
 import { getChartControlPanelRegistry } from '@superset-ui/core';
 
 import AlteredSliceTag from 'src/components/AlteredSliceTag';
@@ -128,8 +129,8 @@ describe('AlteredSliceTag', () => {
       );
       const th = getTableWrapperFromModalBody(modalBody).find('th');
       expect(th).toHaveLength(3);
-      ['Control', 'Before', 'After'].forEach((v, i) => {
-        expect(th.find('span').get(i).props.children[0]).toBe(v);
+      ['Control', 'Before', 'After'].forEach(async (v, i) => {
+        await expect(th.find('span').get(i).props.children[0]).toBe(v);
       });
     });
 

--- a/superset-frontend/src/components/dataViewCommon/TableCollection.tsx
+++ b/superset-frontend/src/components/dataViewCommon/TableCollection.tsx
@@ -20,7 +20,7 @@ import React from 'react';
 import cx from 'classnames';
 import { TableInstance } from 'react-table';
 import { styled } from '@superset-ui/core';
-import Icon from 'src/components/Icon';
+import Icons from 'src/components/Icons';
 
 interface TableCollectionProps {
   getTableProps: (userProps?: any) => any;
@@ -228,11 +228,11 @@ export default React.memo(
         {headerGroups.map(headerGroup => (
           <tr {...headerGroup.getHeaderGroupProps()}>
             {headerGroup.headers.map(column => {
-              let sortIcon = <Icon name="sort" />;
+              let sortIcon = <Icons.Sort />;
               if (column.isSorted && column.isSortedDesc) {
-                sortIcon = <Icon name="sort-desc" />;
+                sortIcon = <Icons.SortDesc />;
               } else if (column.isSorted && !column.isSortedDesc) {
-                sortIcon = <Icon name="sort-asc" />;
+                sortIcon = <Icons.SortAsc />;
               }
               return column.hidden ? null : (
                 <th


### PR DESCRIPTION
### SUMMARY
migrates the sort icon to icons in the listviews and also fixes a flaky/broken test on master.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before 
<img width="1196" alt="Dataset" src="https://user-images.githubusercontent.com/17326228/123001909-1fe29500-d366-11eb-9c16-cf664f7416d5.png">
 
after 
<img width="1521" alt="Dataset" src="https://user-images.githubusercontent.com/17326228/123001923-25d87600-d366-11eb-9a1c-1de15fffa29e.png">


### TESTING INSTRUCTIONS
checkout any of the listviews sort icons in the table

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
