### PR TITLE
fix(api): type_generic typo

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -711,7 +711,7 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
                 # from different drivers that fall outside CompileError
                 except Exception:  # pylint: disable=broad-except
                     col.update(
-                        {"type": "UNKNOWN", "generic_type": None, "is_dttm": None,}
+                        {"type": "UNKNOWN", "type_generic": None, "is_dttm": None,}
                     )
         return cols
 


### PR DESCRIPTION
### SUMMARY
Fixing what I think is a typo. This was missed in the `generic_type` -> `type_generic` rename, and it caused a fatal error with some dashboards in the datasets API after [this change](https://github.com/apache/superset/pull/15188/files#diff-f7dd033ada4e47e82f1341b9d7d77c7f0b980bd3c21d54b6e0b4c7e5ad30f3c4L312).

Error:
```
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/srv/superset-internal/superset-fork/superset/dashboards/dao.py", line 52, in get_datasets_for_dashboard
    return dashboard.datasets_trimmed_for_slices()
  File "/usr/local/lib/python3.8/dist-packages/flask_caching/__init__.py", line 952, in decorated_function
    rv = f(*args, **kwargs)
  File "/srv/superset-internal/superset-fork/superset/models/dashboard.py", line 250, in datasets_trimmed_for_slices
    return [
  File "/srv/superset-internal/superset-fork/superset/models/dashboard.py", line 252, in <listcomp>
    datasource.data_for_slices(slices)
  File "/srv/superset-internal/superset-fork/superset/connectors/base/models.py", line 313, in data_for_slices
    generic_type = column["type_generic"]
KeyError: 'type_generic'
```

### TESTING INSTRUCTIONS
Easiest way to reproduce is by editing the code to manually throw an exception so that the except clause is activated.