### PR TITLE
fix(explore): switch to correct scheme registry for custom sequential color schemes

### DIFF
--- a/superset-frontend/src/setup/setupColors.ts
+++ b/superset-frontend/src/setup/setupColors.ts
@@ -58,7 +58,7 @@ export default function setupColors(
 
   if (extraSequentialColorSchemes?.length > 0) {
     extraSequentialColorSchemes.forEach(scheme => {
-      categoricalSchemeRegistry.registerValue(scheme.id, scheme);
+      sequentialSchemeRegistry.registerValue(scheme.id, new SequentialScheme(scheme));
     });
   }
 

--- a/superset-frontend/src/setup/setupColors.ts
+++ b/superset-frontend/src/setup/setupColors.ts
@@ -58,7 +58,10 @@ export default function setupColors(
 
   if (extraSequentialColorSchemes?.length > 0) {
     extraSequentialColorSchemes.forEach(scheme => {
-      sequentialSchemeRegistry.registerValue(scheme.id, new SequentialScheme(scheme));
+      sequentialSchemeRegistry.registerValue(
+        scheme.id,
+        new SequentialScheme(scheme),
+      );
     });
   }
 


### PR DESCRIPTION
### SUMMARY
When new sequential color scheme is added to the `EXTRA_SEQUENTIAL_COLOR_SCHEMES` variable in `config.py` it does not appear in the list of linear color schemes. Instead it can be found in the list of categorical color schemes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TESTING INSTRUCTIONS

1. Add
```EXTRA_SEQUENTIAL_COLOR_SCHEMES = [
{
    "id": "GnYlRd",
    "label": "green/yellow/red",
    "colors": ['#006837','#1a9850','#66bd63','#a6d96a','#d9ef8b','#fee08b','#fdae61','#f46d43','#d73027','#a50026'],
    "isDiverging": True,
    "description": "",
  }
]
```
to the config.py file.
2. Once the superset_app container reloads, open any visualization that uses sequential schemes.
3. Click color scheme dropdown and ensure that green/yellow/red color scheme present.
4. Open any visualization that uses categorical schemes.
5. Click on the color scheme dropdown, green/yellow/red scheme should not be there.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
