### PR TITLE
fix(api): handle undefined column type_generic

### DIFF
--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -310,7 +310,7 @@ class BaseDatasource(
         filtered_columns: List[Column] = []
         column_types: Set[GenericDataType] = set()
         for column in data["columns"]:
-            generic_type = column["type_generic"]
+            generic_type = column.get("type_generic")
             if generic_type is not None:
                 column_types.add(generic_type)
             if column["column_name"] in column_names:


### PR DESCRIPTION
### SUMMARY
We saw some fatal errors for dashboards based on druid datasources in the `/dashboard/<id>/datasets` API. The root cause seems to be [this change](https://github.com/apache/superset/pull/15188/files#diff-f7dd033ada4e47e82f1341b9d7d77c7f0b980bd3c21d54b6e0b4c7e5ad30f3c4L312), which fails for druid datasources because `type_generic` is not defined on the columns. I'm not sure whether this property should be added to druid columns, so just to be safe, I switched to using `.get()` so that the datasets API would not fail if `type_generic` was not defined.

The error:

```
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/srv/superset-internal/superset-fork/superset/dashboards/dao.py", line 52, in get_datasets_for_dashboard
    return dashboard.datasets_trimmed_for_slices()
  File "/usr/local/lib/python3.8/dist-packages/flask_caching/__init__.py", line 952, in decorated_function
    rv = f(*args, **kwargs)
  File "/srv/superset-internal/superset-fork/superset/models/dashboard.py", line 250, in datasets_trimmed_for_slices
    return [
  File "/srv/superset-internal/superset-fork/superset/models/dashboard.py", line 252, in <listcomp>
    datasource.data_for_slices(slices)
  File "/srv/superset-internal/superset-fork/superset/connectors/base/models.py", line 313, in data_for_slices
    generic_type = column["type_generic"]
KeyError: 'type_generic'
```

### TESTING INSTRUCTIONS
Call `data_for_slices` using a Druid Datasource.

@villebro @graceguo-supercat 