### PR TITLE
fix: nvd3 bar chart sortby metric

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1760,8 +1760,12 @@ class DistributionBarViz(BaseViz):
         df = df.copy()
         df[filled_cols] = df[filled_cols].fillna(value=NULL_STRING)
 
-        row = df.groupby(self.groupby).sum()[metrics[0]].copy()
-        row.sort_values(ascending=False, inplace=True)
+        sortby = utils.get_metric_name(
+            self.form_data.get("timeseries_limit_metric") or metrics[0]
+        )
+        row = df.groupby(self.groupby).sum()[sortby].copy()
+        is_asc = not self.form_data.get("order_desc")
+        row.sort_values(ascending=is_asc, inplace=True)
         pt = df.pivot_table(index=self.groupby, columns=columns, values=metrics)
         if fd.get("contribution"):
             pt = pt.T

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -976,6 +976,7 @@ class TestCore(SupersetTestCase):
                     "optionName": "metric_80g1qb9b6o7_ci5vquydcbe",
                 },
             ],
+            "order_desc": True,
             "adhoc_filters": [],
             "groupby": ["name"],
             "columns": [],
@@ -999,7 +1000,8 @@ class TestCore(SupersetTestCase):
             SELECT count(name) AS count_name, count(ds) AS count_ds
             FROM birth_names
             WHERE ds >= '1921-01-22 00:00:00.000000' AND ds < '2021-01-22 00:00:00.000000'
-            GROUP BY name ORDER BY count_name DESC, count_ds DESC
+            GROUP BY name
+            ORDER BY count_name DESC
             LIMIT 10;
             """,
             client_id="client_id_1",

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -462,6 +462,7 @@ class TestDistBarViz(SupersetTestCase):
             "adhoc_filters": [],
             "groupby": ["toppings"],
             "columns": [],
+            "order_desc": True,
         }
         datasource = self.get_datasource_mock()
         df = pd.DataFrame(
@@ -487,6 +488,7 @@ class TestDistBarViz(SupersetTestCase):
             "adhoc_filters": [],
             "groupby": ["beds"],
             "columns": [],
+            "order_desc": True,
         }
         datasource = self.get_datasource_mock()
         df = pd.DataFrame({"beds": [0, 1, nan, 2], "count": [30, 42, 3, 29]})
@@ -508,6 +510,7 @@ class TestDistBarViz(SupersetTestCase):
             "adhoc_filters": [],
             "groupby": ["toppings"],
             "columns": ["role"],
+            "order_desc": True,
         }
         datasource = self.get_datasource_mock()
         df = pd.DataFrame(
@@ -537,6 +540,7 @@ class TestDistBarViz(SupersetTestCase):
             "adhoc_filters": [],
             "groupby": ["toppings"],
             "columns": [],
+            "order_desc": True,
         }
         datasource = self.get_datasource_mock()
         df = pd.DataFrame(
@@ -574,6 +578,7 @@ class TestDistBarViz(SupersetTestCase):
             "adhoc_filters": [],
             "groupby": ["toppings"],
             "columns": ["role"],
+            "order_desc": True,
         }
         datasource = self.get_datasource_mock()
         df = pd.DataFrame(


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

currently, nvd3 bar chart(non-timeseries) can not be sorted by metric. this PR fixed it.

closes: https://github.com/apache/superset/issues/15260



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### before
issue link: https://github.com/apache/superset/issues/15260
### after
https://user-images.githubusercontent.com/2016594/122980678-83eb7480-d3cb-11eb-9898-3a2529f434b0.mp4



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
tested in local

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/15260
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
