### PR TITLE
Allow to set service account on Helm deployment

### DIFF
--- a/helm/superset/templates/deployment.yaml
+++ b/helm/superset/templates/deployment.yaml
@@ -62,6 +62,9 @@ spec:
       initContainers:
       {{-  tpl (toYaml .Values.supersetNode.initContainers) . | nindent 6 }}
       {{- end }}
+      {{- if .Values.supersetNode.serviceAccount }}
+      serviceAccountName: {{ .Values.supersetNode.serviceAccount }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
### SUMMARY
When deploying to AWS with helm3, the standard way to give a pod an IAM role is to use service accounts. This change allows to set the service account name on the deployment.

Since we cannot alter the deployment object ourselves, this is our only way to set this, except for overriding the whole deployment

### TESTING INSTRUCTIONS
Deploy superset after setting the "supersetNode.serviceAccount" value. Then check that the node has the rights provided by the service account.
