### PR TITLE
fix(native-filters): Assume that temporal columns exist if column_types is undefined

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -27,6 +27,7 @@ import {
   SupersetApiError,
   t,
   GenericDataType,
+  ensureIsArray,
 } from '@superset-ui/core';
 import {
   ColumnMeta,
@@ -275,10 +276,15 @@ const FILTER_TYPE_NAME_MAPPING = {
 };
 
 // TODO: add column_types field to DatasourceMeta
-// We return true if column_types is undefined as a precaution against backend failing to return column_types
+// We return true if column_types is undefined or empty as a precaution against backend failing to return column_types
 const hasTemporalColumns = (
   dataset: DatasourceMeta & { column_types: GenericDataType[] },
-) => dataset?.column_types?.includes(GenericDataType.TEMPORAL) ?? true;
+) => {
+  const columnTypes = ensureIsArray(dataset?.column_types);
+  return (
+    columnTypes.length === 0 || columnTypes.includes(GenericDataType.TEMPORAL)
+  );
+};
 
 /**
  * The configuration form for a specific filter.

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -275,9 +275,10 @@ const FILTER_TYPE_NAME_MAPPING = {
 };
 
 // TODO: add column_types field to DatasourceMeta
+// We return true if column_types is undefined as a precaution against backend failing to return column_types
 const hasTemporalColumns = (
   dataset: DatasourceMeta & { column_types: GenericDataType[] },
-) => dataset?.column_types?.includes(GenericDataType.TEMPORAL);
+) => dataset?.column_types?.includes(GenericDataType.TEMPORAL) ?? true;
 
 /**
  * The configuration form for a specific filter.


### PR DESCRIPTION
### SUMMARY
Currently, if for some reason backend doesn't return `column_types` field in datasets query, we disable selecting time filters in native filters modal. This PR makes the feature more foolproof, by assuming that temporal columns exist if `column_types` is undefined.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @villebro @graceguo-supercat 