### PR TITLE
fix: downgrade selenium log level on timeout

### DIFF
--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -123,10 +123,10 @@ class WebDriverProxy:
             logger.info("Taking a PNG screenshot or url %s", url)
             img = element.screenshot_as_png
         except TimeoutException:
-            logger.error("Selenium timed out requesting url %s", url, exc_info=True)
+            logger.warning("Selenium timed out requesting url %s", url, exc_info=True)
         except StaleElementReferenceException:
             logger.error(
-                "Selenium timed out while waiting for chart(s) to load %s",
+                "Selenium got a stale element while requesting url %s",
                 url,
                 exc_info=True,
             )


### PR DESCRIPTION
### SUMMARY
The majority of `TimeoutException` are triggered due to charts that do not render correctly or take a long time to load data (normally the first)

Most of the execution stack is:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/superset/utils/webdriver.py", line 111, in get_screenshot
    EC.presence_of_element_located((By.CLASS_NAME, element_name))
  File "/usr/local/lib/python3.7/site-packages/selenium/webdriver/support/wait.py", line 80, in until
    raise TimeoutException(message, screen, stacktrace)
selenium.common.exceptions.TimeoutException: Message: 
```

So selenium timeout's while waiting for the chart container element, has an example it timeout's for:

<img width="456" alt="Screenshot 2021-06-23 at 10 46 15" src="https://user-images.githubusercontent.com/4025227/123075662-5b399e00-d410-11eb-8ca7-f80c5db199b1.png">


We should log these, but it's not critical so this PR downgrades the level to warning. 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
