### PR TITLE
fix: missing orderby in query on the nvd3 timeseries chart

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1269,6 +1269,11 @@ def get_metric_names(metrics: Sequence[Metric]) -> List[str]:
     return [get_metric_name(metric) for metric in metrics]
 
 
+def get_main_metric_name(metrics: Sequence[Metric]) -> Optional[str]:
+    metric_labels = get_metric_names(metrics)
+    return metric_labels[0] if metric_labels else None
+
+
 def ensure_path_exists(path: str) -> None:
     try:
         os.makedirs(path)

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1228,13 +1228,15 @@ class NVD3TimeSeriesViz(NVD3Viz):
 
     def query_obj(self) -> QueryObjectDict:
         d = super().query_obj()
-        sort_by = self.form_data.get("timeseries_limit_metric")
+        sort_by = self.form_data.get(
+            "timeseries_limit_metric"
+        ) or utils.get_main_metric_name(d.get("metrics") or [])
+        is_asc = not self.form_data.get("order_desc")
         if sort_by:
             sort_by_label = utils.get_metric_name(sort_by)
             if sort_by_label not in utils.get_metric_names(d["metrics"]):
                 d["metrics"].append(sort_by)
-            if self.form_data.get("order_desc"):
-                d["orderby"] = [(sort_by, not self.form_data.get("order_desc", True))]
+            d["orderby"] = [(sort_by, not self.form_data.get("order_desc", is_asc))]
         return d
 
     def to_series(


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
currently, `order by` clause must be explicitly selected in the explore control, and cannot send `asc` query to database. 

this PR fixed
- make the first metric as the main metric for implicit orderby column
- ensure `asc` orderby

Partially fixed https://github.com/apache/superset/issues/13792

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

#### after
<img width="1277" alt="image" src="https://user-images.githubusercontent.com/2016594/123203584-2d745800-d4e9-11eb-91bb-479eb568de99.png">

<img width="1260" alt="image" src="https://user-images.githubusercontent.com/2016594/123203702-54328e80-d4e9-11eb-9322-ff137e0aef75.png">



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/13792
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
