### PR TITLE
fix(native-filters): show default text on filter scoping tree

### DIFF
--- a/superset-frontend/spec/fixtures/mockDashboardLayout.js
+++ b/superset-frontend/spec/fixtures/mockDashboardLayout.js
@@ -129,7 +129,7 @@ export const dashboardLayoutWithTabs = {
       children: ['ROW_ID2'],
       parents: ['ROOT_ID', 'TABS_ID'],
       meta: {
-        text: 'tab2',
+        text: '',
         defaultText: 'tab2',
       },
     },

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.ts
@@ -49,6 +49,7 @@ export const buildTree = (
         node.meta.sliceNameOverride ||
         node.meta.sliceName ||
         node.meta.text ||
+        node.meta.defaultText ||
         node.id.toString(),
       children: [],
     };

--- a/superset-frontend/src/dashboard/types.ts
+++ b/superset-frontend/src/dashboard/types.ts
@@ -92,7 +92,9 @@ export type LayoutItem = {
   id: string;
   meta: {
     chartId: number;
+    defaultText?: string;
     height: number;
+    placeholder?: string;
     sliceName?: string;
     sliceNameOverride?: string;
     text?: string;


### PR DESCRIPTION
### SUMMARY
Currently the filter scoping tree is showing titles that are not in line with those displayed on the dashboard. This PR changes the scoping tree to show the `defaultTitle` if a real title hasn't been given, similar to how the dashboard layout is rendered.

### AFTER
![image](https://user-images.githubusercontent.com/33317356/123218772-cba9f300-d4d4-11eb-84be-b0ede4f0e6b5.png)

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/123218828-dcf2ff80-d4d4-11eb-812a-33d0a9e85a1a.png)

### TESTING INSTRUCTIONS
Updated test mock to reflect a use case where the tab's `text` isn't provided.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #15126
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
