### PR TITLE
fix: raise unexpected error when orderby is empty

### DIFF
--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -1007,11 +1007,21 @@ class ChartDataQueryObjectSchema(Schema):
         allow_none=True,
     )
     orderby = fields.List(
-        fields.List(fields.Raw()),
+        fields.Tuple(
+            (
+                fields.Raw(
+                    validate=[
+                        Length(min=1, error=_("orderby column must be populated"))
+                    ],
+                    allow_none=False,
+                ),
+                fields.Boolean(),
+            )
+        ),
         description="Expects a list of lists where the first element is the column "
         "name which to sort by, and the second element is a boolean.",
         allow_none=True,
-        example=[["my_col_1", False], ["my_col_2", True]],
+        example=[("my_col_1", False), ("my_col_2", True)],
     )
     where = fields.String(
         description="WHERE clause to be added to queries using AND operator."

--- a/tests/fixtures/query_context.py
+++ b/tests/fixtures/query_context.py
@@ -31,7 +31,7 @@ query_birth_names = {
     },
     "groupby": ["name"],
     "metrics": [{"label": "sum__num"}],
-    "orderby": [["sum__num", False]],
+    "orderby": [("sum__num", False)],
     "row_limit": 100,
     "granularity": "ds",
     "time_range": "100 years ago : now",


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
currently, Superset raises python unexpected error when `orderby` missing column. 

This PR catch this exception by Marshmallow, I will fix this issue in superset-ui repo

### How to reproduce this issue
1. open mixed timeseries chart
2. populate a column to sort by
3. click query button
4. remove existing column from sort by control
5. click query button
6. raise `unhashable type` error

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### before
![image](https://user-images.githubusercontent.com/2016594/123224833-bbaa0780-d504-11eb-8437-3b3b86fe5db4.png)

#### after
![image](https://user-images.githubusercontent.com/2016594/123224675-9fa66600-d504-11eb-914b-318a5a7b7a7f.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
