### PR TITLE
chore(native-filters): remove instant filtering option

### DIFF
--- a/superset-frontend/spec/fixtures/mockNativeFilters.ts
+++ b/superset-frontend/spec/fixtures/mockNativeFilters.ts
@@ -45,7 +45,6 @@ export const nativeFilters: NativeFiltersState = {
         rootPath: ['ROOT_ID'],
         excluded: [],
       },
-      isInstant: true,
       controlValues: {
         multiSelect: false,
         enableEmptyFilter: false,
@@ -79,7 +78,6 @@ export const nativeFilters: NativeFiltersState = {
         enableEmptyFilter: false,
         inverseSelection: false,
       },
-      isInstant: true,
     },
   },
 };
@@ -136,7 +134,6 @@ export const singleNativeFiltersState = {
       cascadeParentIds: [],
       scope: { rootPath: ['ROOT_ID'], excluded: [227, 229] },
       inverseSelection: false,
-      isInstant: true,
       allowsMultipleValues: false,
       isRequired: false,
     },

--- a/superset-frontend/spec/javascripts/dashboard/fixtures/mockNativeFilters.ts
+++ b/superset-frontend/spec/javascripts/dashboard/fixtures/mockNativeFilters.ts
@@ -62,7 +62,6 @@ export const nativeFiltersInfo: NativeFiltersState = {
         rootPath: [],
         excluded: [],
       },
-      isInstant: true,
       controlValues: {
         allowsMultipleValues: true,
         isRequired: false,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
@@ -157,7 +157,6 @@ describe('FilterBar', () => {
               "controlValues":{},
               "cascadeParentIds":[],
               "scope":{"rootPath":["ROOT_ID"],"excluded":[]},
-              "isInstant":false
             }],
             "filter_sets_configuration":[{
               "name":"${FILTER_SET_NAME}",
@@ -172,7 +171,6 @@ describe('FilterBar', () => {
                   "controlValues":{},
                   "cascadeParentIds":[],
                   "scope":{"rootPath":["ROOT_ID"],"excluded":[]},
-                  "isInstant":false
                 }
               },
               "dataMask":{

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
@@ -53,7 +53,7 @@ class MainPreset extends Preset {
   }
 }
 
-fetchMock.get(`glob:*/api/v1/dataset/1`, {
+fetchMock.get('glob:*/api/v1/dataset/7', {
   description_columns: {},
   id: 1,
   label_columns: {
@@ -156,7 +156,7 @@ describe('FilterBar', () => {
               "defaultDataMask":{"filterState":{"value":null}},
               "controlValues":{},
               "cascadeParentIds":[],
-              "scope":{"rootPath":["ROOT_ID"],"excluded":[]},
+              "scope":{"rootPath":["ROOT_ID"],"excluded":[]}
             }],
             "filter_sets_configuration":[{
               "name":"${FILTER_SET_NAME}",
@@ -167,16 +167,16 @@ describe('FilterBar', () => {
                   "name":"${FILTER_NAME}",
                   "filterType":"filter_time",
                   "targets":[{}],
-                  "defaultDataMask":{"filterState":{"value":"Last week"},"extraFormData":{"time_range":"Last week"}},
+                  "defaultDataMask":{"filterState":{},"extraFormData":{}},
                   "controlValues":{},
                   "cascadeParentIds":[],
-                  "scope":{"rootPath":["ROOT_ID"],"excluded":[]},
+                  "scope":{"rootPath":["ROOT_ID"],"excluded":[]}
                 }
               },
               "dataMask":{
                 "${filterId}":{
-                  "extraFormData":{"time_range":"Last week"},
-                  "filterState":{"value":"Last week"},
+                  "extraFormData":{},
+                  "filterState":{},
                   "ownState":{},
                   "id":"${filterId}"
                 }
@@ -190,7 +190,14 @@ describe('FilterBar', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     fetchMock.get(
-      'http://localhost/api/v1/time_range/?q=%27Last%20day%27',
+      'glob:*/api/v1/time_range/?q=%27No%20filter%27',
+      {
+        result: { since: '', until: '', timeRange: 'No filter' },
+      },
+      { overwriteRoutes: true },
+    );
+    fetchMock.get(
+      'glob:*/api/v1/time_range/?q=%27Last%20day%27',
       {
         result: {
           since: '2021-04-13T00:00:00',
@@ -201,7 +208,7 @@ describe('FilterBar', () => {
       { overwriteRoutes: true },
     );
     fetchMock.get(
-      'http://localhost/api/v1/time_range/?q=%27Last%20week%27',
+      'glob:*/api/v1/time_range/?q=%27Last%20week%27',
       {
         result: {
           since: '2021-04-07T00:00:00',

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -216,11 +216,10 @@ const FilterBar: React.FC<FiltersBarProps> = ({
       }
       // force instant updating on initialization for filters with `requiredFirst` is true or instant filters
       else if (
-        (dataMaskSelected[filter.id] && filter.isInstant) ||
         // filterState.value === undefined - means that value not initialized
-        (dataMask.filterState?.value !== undefined &&
-          dataMaskSelected[filter.id]?.filterState?.value === undefined &&
-          filter.requiredFirst)
+        dataMask.filterState?.value !== undefined &&
+        dataMaskSelected[filter.id]?.filterState?.value === undefined &&
+        filter.requiredFirst
       ) {
         dispatch(updateDataMask(filter.id, dataMask));
       }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -44,7 +44,7 @@ import React, {
 } from 'react';
 import { useSelector } from 'react-redux';
 import { FormItem } from 'src/components/Form';
-import { Checkbox, Input } from 'src/common/components';
+import { Input } from 'src/common/components';
 import { Select } from 'src/components/Select';
 import SupersetResourceSelect, {
   cachedSupersetGet,
@@ -850,16 +850,6 @@ const FiltersConfigForm = (
             {Object.keys(controlItems)
               .filter(key => BASIC_CONTROL_ITEMS.includes(key))
               .map(key => controlItems[key].element)}
-            <StyledRowFormItem
-              name={['filters', filterId, 'isInstant']}
-              initialValue={filterToEdit?.isInstant || false}
-              valuePropName="checked"
-              colon={false}
-            >
-              <Checkbox data-test="apply-changes-instantly-checkbox">
-                {t('Apply changes instantly')}
-              </Checkbox>
-            </StyledRowFormItem>
           </Collapse.Panel>
           {((hasDataset && hasAdditionalFilters) || hasMetrics) && (
             <Collapse.Panel

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/getControlItemsMap.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/getControlItemsMap.test.tsx
@@ -51,7 +51,6 @@ const formMock: FormInstance = {
 const filterMock: Filter = {
   cascadeParentIds: [],
   defaultDataMask: {},
-  isInstant: false,
   id: 'mock',
   name: 'mock',
   scope: {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
@@ -112,7 +112,6 @@ const ADVANCED_REGEX = /^advanced$/i;
 const DEFAULT_VALUE_REGEX = /^filter has default value$/i;
 const MULTIPLE_REGEX = /^multiple select$/i;
 const REQUIRED_REGEX = /^required$/i;
-const APPLY_INSTANTLY_REGEX = /^apply changes instantly$/i;
 const HIERARCHICAL_REGEX = /^filter is hierarchical$/i;
 const FIRST_ITEM_REGEX = /^default to first item$/i;
 const INVERSE_SELECTION_REGEX = /^inverse selection$/i;
@@ -169,7 +168,6 @@ test('renders a value filter type', () => {
 
   expect(getCheckbox(DEFAULT_VALUE_REGEX)).not.toBeChecked();
   expect(getCheckbox(REQUIRED_REGEX)).not.toBeChecked();
-  expect(getCheckbox(APPLY_INSTANTLY_REGEX)).not.toBeChecked();
   expect(getCheckbox(HIERARCHICAL_REGEX)).not.toBeChecked();
   expect(getCheckbox(FIRST_ITEM_REGEX)).not.toBeChecked();
   expect(getCheckbox(INVERSE_SELECTION_REGEX)).not.toBeChecked();
@@ -194,7 +192,6 @@ test('renders a numerical range filter type', () => {
   expect(screen.getByText(REQUIRED_REGEX)).toBeInTheDocument();
 
   expect(getCheckbox(DEFAULT_VALUE_REGEX)).not.toBeChecked();
-  expect(getCheckbox(APPLY_INSTANTLY_REGEX)).not.toBeChecked();
   expect(getCheckbox(PRE_FILTER_REGEX)).not.toBeChecked();
 
   expect(queryCheckbox(MULTIPLE_REGEX)).not.toBeInTheDocument();
@@ -217,7 +214,6 @@ test('renders a time range filter type', () => {
   expect(screen.queryByText(COLUMN_REGEX)).not.toBeInTheDocument();
 
   expect(getCheckbox(DEFAULT_VALUE_REGEX)).not.toBeChecked();
-  expect(getCheckbox(APPLY_INSTANTLY_REGEX)).not.toBeChecked();
 
   expect(screen.queryByText(ADVANCED_REGEX)).not.toBeInTheDocument();
 });
@@ -234,7 +230,6 @@ test('renders a time column filter type', () => {
   expect(screen.queryByText(COLUMN_REGEX)).not.toBeInTheDocument();
 
   expect(getCheckbox(DEFAULT_VALUE_REGEX)).not.toBeChecked();
-  expect(getCheckbox(APPLY_INSTANTLY_REGEX)).not.toBeChecked();
 
   expect(screen.queryByText(ADVANCED_REGEX)).not.toBeInTheDocument();
 });
@@ -251,7 +246,6 @@ test('renders a time grain filter type', () => {
   expect(screen.queryByText(COLUMN_REGEX)).not.toBeInTheDocument();
 
   expect(getCheckbox(DEFAULT_VALUE_REGEX)).not.toBeChecked();
-  expect(getCheckbox(APPLY_INSTANTLY_REGEX)).not.toBeChecked();
 
   expect(screen.queryByText(ADVANCED_REGEX)).not.toBeInTheDocument();
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/types.ts
@@ -41,7 +41,6 @@ export interface NativeFiltersFormItem {
     label: string;
   };
   sortMetric: string | null;
-  isInstant: boolean;
   adhoc_filters?: AdhocFilter[];
   time_range?: string;
   granularity_sqla?: string;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/utils.ts
@@ -56,18 +56,6 @@ export const validateForm = async (
         throw error;
       }
     }
-    const validateInstant = (filterId: string) => {
-      const isInstant = formValues.filters[filterId]
-        ? formValues.filters[filterId].isInstant
-        : filterConfigMap[filterId]?.isInstant;
-      if (!isInstant) {
-        addValidationError(
-          filterId,
-          'isInstant',
-          'For hierarchical filters changes must be applied instantly',
-        );
-      }
-    };
 
     const validateCycles = (filterId: string, trace: string[] = []) => {
       if (trace.includes(filterId)) {
@@ -81,7 +69,6 @@ export const validateForm = async (
         ? formValues.filters[filterId].parentFilter?.value
         : filterConfigMap[filterId]?.cascadeParentIds?.[0];
       if (parentId) {
-        validateInstant(parentId);
         validateCycles(parentId, [...trace, filterId]);
       }
     };
@@ -153,7 +140,6 @@ export const createHandleSave = (
           ? [formInputs.parentFilter.value]
           : [],
         scope: formInputs.scope,
-        isInstant: formInputs.isInstant,
         sortMetric: formInputs.sortMetric,
       };
     });

--- a/superset-frontend/src/dashboard/components/nativeFilters/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/types.ts
@@ -42,7 +42,6 @@ export interface Target {
 export interface Filter {
   cascadeParentIds: string[];
   defaultDataMask: DataMask;
-  isInstant: boolean;
   id: string; // randomly generated at filter creation
   name: string;
   scope: Scope;


### PR DESCRIPTION
### SUMMARY
This PR removes support for instant filtering from native filters. Primary motivations for the removal are as follows:
- performance implications of triggering filters with every change
- problems associated with mixing both instant and non-instant filters

### AFTER
Notice the absence of instant filtering options.
![image](https://user-images.githubusercontent.com/33317356/123265478-c57f3b00-d503-11eb-9c43-07b1f247b13a.png)

### BEFORE
Notice the control "Apply changes instantly":
![image](https://user-images.githubusercontent.com/33317356/123265649-ec3d7180-d503-11eb-92c6-535671c34bdd.png)

### TESTING INSTRUCTIONS
Local testing + updated tests

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #15067
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
