### PR TITLE
fix: Enlarged select filter value

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
@@ -23,16 +23,24 @@ import FilterValue from './FilterValue';
 import { FilterProps } from './types';
 import { checkIsMissingRequiredValue } from '../utils';
 
+const StyledFormItem = styled(FormItem)`
+  & label {
+    width: 100%;
+  }
+`;
+
 const StyledFilterControlTitle = styled.h4`
-  width: 100%;
+  flex: 1;
   font-size: ${({ theme }) => theme.typography.sizes.s}px;
   color: ${({ theme }) => theme.colors.grayscale.dark1};
   margin: 0;
+  margin-right: ${({ theme }) => theme.gridUnit}px;
   overflow-wrap: break-word;
 `;
 
 const StyledFilterControlTitleBox = styled.div`
   display: flex;
+  flex: 1;
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
@@ -60,7 +68,7 @@ const FilterControl: React.FC<FilterProps> = ({
 
   return (
     <StyledFilterControlContainer layout="vertical">
-      <FormItem
+      <StyledFormItem
         label={
           <StyledFilterControlTitleBox>
             <StyledFilterControlTitle data-test="filter-control-name">
@@ -79,7 +87,7 @@ const FilterControl: React.FC<FilterProps> = ({
           onFilterSelectionChange={onFilterSelectionChange}
           inView={inView}
         />
-      </FormItem>
+      </StyledFormItem>
     </StyledFilterControlContainer>
   );
 };

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
@@ -29,8 +29,12 @@ const StyledFormItem = styled(FormItem)`
   }
 `;
 
+const StyledIcon = styled.div`
+  position: absolute;
+  right: 0;
+`;
+
 const StyledFilterControlTitle = styled.h4`
-  flex: 1;
   font-size: ${({ theme }) => theme.typography.sizes.s}px;
   color: ${({ theme }) => theme.colors.grayscale.dark1};
   margin: 0;
@@ -40,7 +44,6 @@ const StyledFilterControlTitle = styled.h4`
 
 const StyledFilterControlTitleBox = styled.div`
   display: flex;
-  flex: 1;
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
@@ -74,7 +77,7 @@ const FilterControl: React.FC<FilterProps> = ({
             <StyledFilterControlTitle data-test="filter-control-name">
               {name}
             </StyledFilterControlTitle>
-            <div data-test="filter-icon">{icon}</div>
+            <StyledIcon data-test="filter-icon">{icon}</StyledIcon>
           </StyledFilterControlTitleBox>
         }
         required={filter?.controlValues?.enableEmptyFilter}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
@@ -18,8 +18,10 @@
  */
 import React from 'react';
 import { styled } from '@superset-ui/core';
+import { Form, FormItem } from 'src/components/Form';
 import FilterValue from './FilterValue';
 import { FilterProps } from './types';
+import { checkIsMissingRequiredValue } from '../utils';
 
 const StyledFilterControlTitle = styled.h4`
   width: 100%;
@@ -37,7 +39,7 @@ const StyledFilterControlTitleBox = styled.div`
   margin-bottom: ${({ theme }) => theme.gridUnit}px;
 `;
 
-const StyledFilterControlContainer = styled.div`
+const StyledFilterControlContainer = styled(Form)`
   width: 100%;
 `;
 
@@ -50,21 +52,34 @@ const FilterControl: React.FC<FilterProps> = ({
   inView,
 }) => {
   const { name = '<undefined>' } = filter;
+
+  const isMissingRequiredValue = checkIsMissingRequiredValue(
+    filter,
+    filter.dataMask?.filterState,
+  );
+
   return (
-    <StyledFilterControlContainer>
-      <StyledFilterControlTitleBox>
-        <StyledFilterControlTitle data-test="filter-control-name">
-          {name}
-        </StyledFilterControlTitle>
-        <div data-test="filter-icon">{icon}</div>
-      </StyledFilterControlTitleBox>
-      <FilterValue
-        dataMaskSelected={dataMaskSelected}
-        filter={filter}
-        directPathToChild={directPathToChild}
-        onFilterSelectionChange={onFilterSelectionChange}
-        inView={inView}
-      />
+    <StyledFilterControlContainer layout="vertical">
+      <FormItem
+        label={
+          <StyledFilterControlTitleBox>
+            <StyledFilterControlTitle data-test="filter-control-name">
+              {name}
+            </StyledFilterControlTitle>
+            <div data-test="filter-icon">{icon}</div>
+          </StyledFilterControlTitleBox>
+        }
+        required={filter?.controlValues?.enableEmptyFilter}
+        validateStatus={isMissingRequiredValue ? 'error' : undefined}
+      >
+        <FilterValue
+          dataMaskSelected={dataMaskSelected}
+          filter={filter}
+          directPathToChild={directPathToChild}
+          onFilterSelectionChange={onFilterSelectionChange}
+          inView={inView}
+        />
+      </FormItem>
     </StyledFilterControlContainer>
   );
 };

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
@@ -26,6 +26,7 @@ import { checkIsMissingRequiredValue } from '../utils';
 const StyledFormItem = styled(FormItem)`
   & label {
     width: 100%;
+    padding-right: ${({ theme }) => theme.gridUnit * 11}px;
   }
 `;
 
@@ -38,7 +39,6 @@ const StyledFilterControlTitle = styled.h4`
   font-size: ${({ theme }) => theme.typography.sizes.s}px;
   color: ${({ theme }) => theme.colors.grayscale.dark1};
   margin: 0;
-  margin-right: ${({ theme }) => theme.gridUnit}px;
   overflow-wrap: break-word;
 `;
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
@@ -19,10 +19,10 @@
 import React, { useEffect, useRef, useState } from 'react';
 import {
   QueryFormData,
-  styled,
   SuperChart,
   DataMask,
   t,
+  styled,
   Behavior,
   ChartDataResponseResult,
   JsonObject,
@@ -43,13 +43,14 @@ import { ClientErrorObject } from 'src/utils/getClientErrorObject';
 import { FilterProps } from './types';
 import { getFormData } from '../../utils';
 import { useCascadingFilters } from './state';
-import { checkIsMissingRequiredValue } from '../utils';
 
-const FilterItem = styled.div`
-  min-height: ${({ theme }) => theme.gridUnit * 11}px;
-  padding-bottom: ${({ theme }) => theme.gridUnit * 3}px;
-  & > div > div {
-    height: auto;
+const HEIGHT = 32;
+
+// Overrides superset-ui height with min-height
+const StyledDiv = styled.div`
+  & > div {
+    height: auto !important;
+    min-height: ${HEIGHT}px;
   }
 `;
 
@@ -195,35 +196,27 @@ const FilterValue: React.FC<FilterProps> = ({
     );
   }
 
-  const isMissingRequiredValue = checkIsMissingRequiredValue(
-    filter,
-    filter.dataMask?.filterState,
-  );
-
   return (
-    <FilterItem data-test="form-item-value">
+    <StyledDiv data-test="form-item-value">
       {isLoading ? (
         <Loading position="inline-centered" />
       ) : (
         <SuperChart
-          height={50}
+          height={HEIGHT}
           width="100%"
           formData={formData}
           // For charts that don't have datasource we need workaround for empty placeholder
           queriesData={hasDataSource ? state : [{ data: [{}] }]}
           chartType={filterType}
           behaviors={[Behavior.NATIVE_FILTER]}
-          filterState={{
-            ...filter.dataMask?.filterState,
-            validateMessage: isMissingRequiredValue && t('Value is required'),
-          }}
+          filterState={{ ...filter.dataMask?.filterState }}
           ownState={filter.dataMask?.ownState}
           enableNoResults={metadata?.enableNoResults}
           isRefreshing={isRefreshing}
           hooks={{ setDataMask, setFocusedFilter, unsetFocusedFilter }}
         />
       )}
-    </FilterItem>
+    </StyledDiv>
   );
 };
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DefaultValue.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DefaultValue.tsx
@@ -22,7 +22,6 @@ import {
   SetDataMaskHook,
   SuperChart,
   AppSection,
-  t,
 } from '@superset-ui/core';
 import { FormInstance } from 'antd/lib/form';
 import Loading from 'src/components/Loading';
@@ -57,10 +56,6 @@ const DefaultValue: FC<DefaultValueProps> = ({
       setLoading(true);
     }
   }, [hasDataset, queriesData]);
-  const value = formFilter.defaultDataMask?.filterState.value;
-  const isMissingRequiredValue =
-    (value === null || value === undefined) &&
-    formFilter?.controlValues?.enableEmptyFilter;
   return loading ? (
     <Loading position="inline-centered" />
   ) : (
@@ -79,7 +74,6 @@ const DefaultValue: FC<DefaultValueProps> = ({
       enableNoResults={enableNoResults}
       filterState={{
         ...formFilter.defaultDataMask?.filterState,
-        validateMessage: isMissingRequiredValue && t('Value is required'),
       }}
     />
   );

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -137,12 +137,22 @@ export const StyledRowFormItem = styled(FormItem)`
 `;
 
 export const StyledRowSubFormItem = styled(FormItem)`
+  min-width: 50%;
+
   & .ant-form-item-label {
     padding-bottom: 0;
   }
 
+  .ant-form-item {
+    margin-bottom: 0;
+  }
+
   .ant-form-item-control-input-content > div > div {
     height: auto;
+  }
+
+  .ant-form-item-extra {
+    display: none;
   }
 
   & .ant-form-item-control-input {
@@ -801,7 +811,9 @@ const FiltersConfigForm = (
                       if (hasValue) {
                         return Promise.resolve();
                       }
-                      return Promise.reject();
+                      return Promise.reject(
+                        new Error(t('Default value is required')),
+                      );
                     },
                   },
                 ]}
@@ -1010,7 +1022,7 @@ const FiltersConfigForm = (
                   onChange={checked => onSortChanged(checked || undefined)}
                   initialValue={hasSorting}
                 >
-                  <StyledFormItem
+                  <StyledRowFormItem
                     name={[
                       'filters',
                       filterId,
@@ -1038,7 +1050,7 @@ const FiltersConfigForm = (
                         onSortChanged(value)
                       }
                     />
-                  </StyledFormItem>
+                  </StyledRowFormItem>
                   {hasMetrics && (
                     <StyledRowSubFormItem
                       name={['filters', filterId, 'sortMetric']}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/state.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/state.ts
@@ -54,8 +54,7 @@ export const useDefaultValue = (
   filterToEdit?: Filter,
 ) => {
   const [hasDefaultValue, setHasPartialDefaultValue] = useState(
-    !!filterToEdit?.defaultDataMask?.filterState?.value ||
-      formFilter?.controlValues?.enableEmptyFilter,
+    !!filterToEdit?.defaultDataMask?.filterState?.value,
   );
   const [isRequired, setisRequired] = useState(
     formFilter?.controlValues?.enableEmptyFilter,

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -26,11 +26,9 @@ import {
   GenericDataType,
   JsonObject,
   smartDateDetailedFormatter,
-  styled,
   t,
   tn,
 } from '@superset-ui/core';
-import { FormItem } from 'src/components/Form';
 import React, {
   RefObject,
   ReactElement,
@@ -81,10 +79,6 @@ function reducer(
       return draft;
   }
 }
-
-const Error = styled.div`
-  color: ${({ theme }) => theme.colors.error.base};
-`;
 
 export default function PluginFilterSelect(props: PluginFilterSelectProps) {
   const {
@@ -279,57 +273,52 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
 
   return (
     <Styles height={height} width={width}>
-      <FormItem
-        validateStatus={filterState.validateMessage && 'error'}
-        extra={<Error>{filterState.validateMessage}</Error>}
+      <StyledSelect
+        allowClear
+        // @ts-ignore
+        value={filterState.value || []}
+        disabled={isDisabled}
+        showSearch={showSearch}
+        mode={multiSelect ? 'multiple' : undefined}
+        placeholder={placeholderText}
+        onSearch={searchWrapper}
+        onSelect={clearSuggestionSearch}
+        onBlur={handleBlur}
+        onDropdownVisibleChange={setIsDropdownVisible}
+        dropdownRender={(
+          originNode: ReactElement & { ref?: RefObject<HTMLElement> },
+        ) => {
+          if (isDropdownVisible && !wasDropdownVisible) {
+            originNode.ref?.current?.scrollTo({ top: 0 });
+          }
+          return originNode;
+        }}
+        onFocus={setFocusedFilter}
+        // @ts-ignore
+        onChange={handleChange}
+        ref={inputRef}
+        loading={isRefreshing}
+        maxTagCount={5}
+        menuItemSelectedIcon={<Icon iconSize="m" />}
       >
-        <StyledSelect
-          allowClear
-          // @ts-ignore
-          value={filterState.value || []}
-          disabled={isDisabled}
-          showSearch={showSearch}
-          mode={multiSelect ? 'multiple' : undefined}
-          placeholder={placeholderText}
-          onSearch={searchWrapper}
-          onSelect={clearSuggestionSearch}
-          onBlur={handleBlur}
-          onDropdownVisibleChange={setIsDropdownVisible}
-          dropdownRender={(
-            originNode: ReactElement & { ref?: RefObject<HTMLElement> },
-          ) => {
-            if (isDropdownVisible && !wasDropdownVisible) {
-              originNode.ref?.current?.scrollTo({ top: 0 });
-            }
-            return originNode;
-          }}
-          onFocus={setFocusedFilter}
-          // @ts-ignore
-          onChange={handleChange}
-          ref={inputRef}
-          loading={isRefreshing}
-          maxTagCount={5}
-          menuItemSelectedIcon={<Icon iconSize="m" />}
-        >
-          {sortedData.map(row => {
-            const [value] = groupby.map(col => row[col]);
-            return (
-              // @ts-ignore
-              <Option key={`${value}`} value={value}>
-                {labelFormatter(value, datatype)}
-              </Option>
-            );
-          })}
-          {currentSuggestionSearch &&
-            !ensureIsArray(filterState.value).some(
-              suggestion => suggestion === currentSuggestionSearch,
-            ) && (
-              <Option value={currentSuggestionSearch}>
-                {`${t('Create "%s"', currentSuggestionSearch)}`}
-              </Option>
-            )}
-        </StyledSelect>
-      </FormItem>
+        {sortedData.map(row => {
+          const [value] = groupby.map(col => row[col]);
+          return (
+            // @ts-ignore
+            <Option key={`${value}`} value={value}>
+              {labelFormatter(value, datatype)}
+            </Option>
+          );
+        })}
+        {currentSuggestionSearch &&
+          !ensureIsArray(filterState.value).some(
+            suggestion => suggestion === currentSuggestionSearch,
+          ) && (
+            <Option value={currentSuggestionSearch}>
+              {`${t('Create "%s"', currentSuggestionSearch)}`}
+            </Option>
+          )}
+      </StyledSelect>
     </Styles>
   );
 }

--- a/superset-frontend/src/filters/components/common.ts
+++ b/superset-frontend/src/filters/components/common.ts
@@ -21,7 +21,7 @@ import { Select } from 'src/common/components';
 import { PluginFilterStylesProps } from './types';
 
 export const Styles = styled.div<PluginFilterStylesProps>`
-  height: ${({ height }) => height}px;
+  min-height: ${({ height }) => height}px;
   width: ${({ width }) => width}px;
 `;
 


### PR DESCRIPTION
### SUMMARY
- Fixes https://github.com/apache/superset/issues/15322
- Fixes https://github.com/apache/superset/issues/15360
- Improves the header of the filters in the filter bar

Fixes some regressions introduced in https://github.com/apache/superset/pull/15276:
- Fixes the size of the inputs in the modal
- Fixes the display of the required message in the modal
- Fixes the spacing of the filter items in the filter bar
- When the user unchecked the required field, the application unchecked the default value. This is not the intended behavior.
- Replaced the required message with an icon in the filter bar
- Simplifies the logic of the required checkbox in the modal. If the user checks that a filter has a default value, then the default value is validated. If the user checks the required checkbox, the application automatically checks the default value, which will trigger the validation.

@villebro @kgabryje @rusackas 

@jinghua-qa Can you help with testing?

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/123415032-0a9a8000-d58b-11eb-94bb-9032811e4fa8.mov

https://user-images.githubusercontent.com/70410625/123414290-16397700-d58a-11eb-90ed-75964e012a61.mov

### TESTING INSTRUCTIONS
See the before/after videos for instructions.

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
