### PR TITLE
fix: Add null var to native filter (#15291)

### DIFF
--- a/superset-frontend/src/filters/components/Select/buildQuery.ts
+++ b/superset-frontend/src/filters/components/Select/buildQuery.ts
@@ -33,28 +33,27 @@ const buildQuery: BuildQuery<PluginFilterSelectQueryFormData> = (
   const { sortAscending, sortMetric } = { ...DEFAULT_FORM_DATA, ...formData };
   return buildQueryContext(formData, baseQueryObject => {
     const { columns = [], filters = [] } = baseQueryObject;
-    const extra_filters: QueryObjectFilterClause[] = columns.map(column => {
+    var extra_filters: QueryObjectFilterClause[] = [];;
+    columns.map(column => {
       if (search && coltypeMap[column] === GenericDataType.STRING) {
-        return {
+        extra_filters = [{
           col: column,
           op: 'ILIKE',
           val: `%${search}%`,
-        };
+        }];
       }
-      if (
+      else if (
         search &&
         coltypeMap[column] === GenericDataType.NUMERIC &&
         !Number.isNaN(Number(search))
       ) {
         // for numeric columns we apply a >= where clause
-        return {
+        extra_filters = [{
           col: column,
           op: '>=',
           val: Number(search),
-        };
+        }];
       }
-      // if no search is defined, make sure the col value is not null
-      return { col: column, op: 'IS NOT NULL' };
     });
 
     const sortColumns = sortMetric ? [sortMetric] : columns;

--- a/superset-frontend/src/filters/components/Select/buildQuery.ts
+++ b/superset-frontend/src/filters/components/Select/buildQuery.ts
@@ -33,14 +33,14 @@ const buildQuery: BuildQuery<PluginFilterSelectQueryFormData> = (
   const { sortAscending, sortMetric } = { ...DEFAULT_FORM_DATA, ...formData };
   return buildQueryContext(formData, baseQueryObject => {
     const { columns = [], filters = [] } = baseQueryObject;
-    var extra_filters: QueryObjectFilterClause[] = [];;
+    var extra_filters: QueryObjectFilterClause[] = [];
     columns.map(column => {
       if (search && coltypeMap[column] === GenericDataType.STRING) {
-        extra_filters = [{
+        extra_filters.push({
           col: column,
           op: 'ILIKE',
           val: `%${search}%`,
-        }];
+        });
       }
       else if (
         search &&
@@ -48,11 +48,11 @@ const buildQuery: BuildQuery<PluginFilterSelectQueryFormData> = (
         !Number.isNaN(Number(search))
       ) {
         // for numeric columns we apply a >= where clause
-        extra_filters = [{
+        extra_filters.push({
           col: column,
           op: '>=',
           val: Number(search),
-        }];
+        });
       }
     });
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR add option of "null" for the select filter in the Dashboard's Native Filter.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![Screenshot_2021-06-25_17-52-38](https://user-images.githubusercontent.com/71277890/123443148-9fa97300-d5a3-11eb-8765-edb65edc3923.png)
![Screenshot_2021-06-25_17-53-18](https://user-images.githubusercontent.com/71277890/123443154-a0daa000-d5a3-11eb-952c-6f963e7944f0.png)
### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1) Set `"DASHBOARD_NATIVE_FILTERS": True` in `superset/config.py`
2) Open Dashboard with null var in DB (I use "Video Game Sales")
3) Open Dashboard Native Filter with column `publisher`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: Fixes #15291
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
