### PR TITLE
fix: double click slq lab table cell

### DIFF
--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -396,7 +396,7 @@ export default class FilterableTable extends PureComponent<
           }}
           className={`${className} grid-cell grid-header-cell`}
         >
-          {label}
+          <div>{label}</div>
         </div>
       </Tooltip>
     );
@@ -428,7 +428,7 @@ export default class FilterableTable extends PureComponent<
         }}
         className={`grid-cell ${this.rowClassName({ index: rowIndex })}`}
       >
-        {content}
+        <div>{content}</div>
       </div>
     );
 


### PR DESCRIPTION
### SUMMARY
To reproduce this issue:
1. open sql lab, run a simple search: `select * from wb_health_population`
2. **double click** any cell in the first column: the highlight spread out to many other cells
3. paste the selected text: it has text in many other columns

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![ar7FekcDi5](https://user-images.githubusercontent.com/27990562/123528890-2d6a8880-d6a0-11eb-922a-32b0f7849d1e.gif)

After:
![f6s0Y3PU0d](https://user-images.githubusercontent.com/27990562/123528927-8803e480-d6a0-11eb-8cb3-b80f4ad29d39.gif)


### TESTING INSTRUCTIONS
CI and manual test
