### PR TITLE
feat: make Step 1 alerts configurable

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -555,20 +555,38 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
         closable={false}
         css={(theme: SupersetTheme) => antDAlertStyles(theme)}
         type="info"
-        message={t('Want to add a new database?')}
+        message={
+          connectionAlert?.ADD_DATABASE?.message ||
+          t('Want to add a new database?')
+        }
         description={
-          <>
-            Any databases that allow connetions via SQL Alchemy URIs can be
-            added. Learn about how to connect a database driver{' '}
-            <a
-              href={DOCUMENTATION_LINK}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              here
-            </a>
-            .
-          </>
+          connectionAlert?.ADD_DATABASE ? (
+            <>
+              Any databases that allow connetions via SQL Alchemy URIs can be
+              added.{' '}
+              <a
+                href={connectionAlert?.ADD_DATABASE.contact_link}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {connectionAlert?.ADD_DATABASE.contact_description_link}
+              </a>{' '}
+              {connectionAlert?.ADD_DATABASE.description}
+            </>
+          ) : (
+            <>
+              Any databases that allow connetions via SQL Alchemy URIs can be
+              added. Learn about how to connect a database driver{' '}
+              <a
+                href={DOCUMENTATION_LINK}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                here
+              </a>
+              .
+            </>
+          )
         }
       />
     </div>


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Allow Step 1 alerts to be configurable via superset_text config

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
