### PR TITLE
fix(native-filters): show human readable time grain label in indicator

### DIFF
--- a/superset-frontend/src/filters/components/TimeGrain/TimeGrainFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/TimeGrain/TimeGrainFilterPlugin.tsx
@@ -52,15 +52,17 @@ export default function PluginFilterTimegrain(
   const { defaultValue, inputRef } = formData;
 
   const [value, setValue] = useState<string[]>(defaultValue ?? []);
-  const durationMap = useMemo(() => {
-    return data.reduce((agg, row) => {
-      const { duration, name } = row as { duration: string, name: string};
-      return {
-        ...agg,
-        [duration]: name,
-      }
-    }, {} as {[key in string]: string});
-  }, [JSON.stringify(data)]);
+  const durationMap = useMemo(
+    () =>
+      data.reduce((agg, row) => {
+        const { duration, name } = row as { duration: string; name: string };
+        return {
+          ...agg,
+          [duration]: name,
+        };
+      }, {} as { [key in string]: string }),
+    [JSON.stringify(data)],
+  );
 
   const handleChange = (values: string[] | string | undefined | null) => {
     const resultValue: string[] = ensureIsArray<string>(values);

--- a/superset-frontend/src/filters/components/TimeGrain/TimeGrainFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/TimeGrain/TimeGrainFilterPlugin.tsx
@@ -24,7 +24,7 @@ import {
   TimeGranularity,
   tn,
 } from '@superset-ui/core';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Select } from 'src/common/components';
 import { Styles, StyledSelect } from '../common';
 import { PluginFilterTimeGrainProps } from './types';
@@ -52,10 +52,20 @@ export default function PluginFilterTimegrain(
   const { defaultValue, inputRef } = formData;
 
   const [value, setValue] = useState<string[]>(defaultValue ?? []);
+  const durationMap = useMemo(() => {
+    return data.reduce((agg, row) => {
+      const { duration, name } = row as { duration: string, name: string};
+      return {
+        ...agg,
+        [duration]: name,
+      }
+    }, {} as {[key in string]: string});
+  }, [JSON.stringify(data)]);
 
   const handleChange = (values: string[] | string | undefined | null) => {
     const resultValue: string[] = ensureIsArray<string>(values);
     const [timeGrain] = resultValue;
+    const label = timeGrain ? durationMap[timeGrain] : undefined;
 
     const extraFormData: ExtraFormData = {};
     if (timeGrain) {
@@ -65,6 +75,7 @@ export default function PluginFilterTimegrain(
     setDataMask({
       extraFormData,
       filterState: {
+        label,
         value: resultValue.length ? resultValue : null,
       },
     });

--- a/superset-frontend/src/filters/components/TimeGrain/TimeGrainFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/TimeGrain/TimeGrainFilterPlugin.tsx
@@ -54,13 +54,13 @@ export default function PluginFilterTimegrain(
   const [value, setValue] = useState<string[]>(defaultValue ?? []);
   const durationMap = useMemo(
     () =>
-      data.reduce((agg, row) => {
-        const { duration, name } = row as { duration: string; name: string };
-        return {
+      data.reduce(
+        (agg, { duration, name }: { duration: string; name: string }) => ({
           ...agg,
           [duration]: name,
-        };
-      }, {} as { [key in string]: string }),
+        }),
+        {} as { [key in string]: string },
+      ),
     [JSON.stringify(data)],
   );
 


### PR DESCRIPTION
### SUMMARY
Currently when using a time grain native filter, the ISO-8601 time duration is shown in the filter indicator. Instead of showing the technical duration in the indicator (e.g. `PT1H`), it is preferable to show the human readable filter value (e.g. "Hour").

### AFTER
Now the human readable label is displayed in the filter indicator:
![image](https://user-images.githubusercontent.com/33317356/123584445-0ae48680-d7ea-11eb-82f6-266984eb0867.png)

### BEFORE
Previously the ISO-8601 time duration was shown in the filter indicator
![image](https://user-images.githubusercontent.com/33317356/123584532-2ea7cc80-d7ea-11eb-9892-fe006fdd3ea3.png)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #15361
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
