### PR TITLE
style: Database Connection Modal UI Polish R5

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm.tsx
@@ -130,6 +130,7 @@ const CredentialsInfo = ({
               tooltip={t(
                 'Use the JSON file you automatically downloaded when creating your service account in Google BigQuery.',
               )}
+              viewBox="0 0 24 24"
             />
           </span>
 

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm.tsx
@@ -22,6 +22,7 @@ import { InputProps } from 'antd/lib/input';
 import { Switch, Select, Button } from 'src/common/components';
 import InfoTooltip from 'src/components/InfoTooltip';
 import ValidatedInput from 'src/components/Form/LabeledErrorBoundInput';
+import FormLabel from 'src/components/Form/FormLabel';
 import { DeleteFilled } from '@ant-design/icons';
 import {
   formScrollableStyles,
@@ -83,9 +84,9 @@ const CredentialsInfo = ({
     <CredentialInfoForm>
       {!isEditMode && (
         <>
-          <span className="label-select">
+          <FormLabel required>
             How do you want to enter service account credentials?
-          </span>
+          </FormLabel>
           <Select
             defaultValue={uploadOption}
             style={{ width: '100%' }}
@@ -105,12 +106,19 @@ const CredentialsInfo = ({
       isEditMode ||
       editNewDb ? (
         <div className="input-container">
-          <span className="label-select">Service Account</span>
+          <FormLabel required>Service Account</FormLabel>
           <textarea
             className="input-form"
             name="credentials_info"
             value={db?.parameters?.credentials_info}
             onChange={changeMethods.onParametersChange}
+            placeholder={JSON.stringify(
+              {
+                credentials_info: '<contents of credentials JSON file>',
+              },
+              null,
+              '  ',
+            )}
           />
           <span className="label-paste">
             Copy and paste the entire service account .json file here
@@ -121,18 +129,15 @@ const CredentialsInfo = ({
           className="input-container"
           css={(theme: SupersetTheme) => infoTooltip(theme)}
         >
-          <span
-            css={{ display: 'flex', alignItems: 'center' }}
-            className="label-select"
-          >
-            Upload Credentials{' '}
+          <div css={{ display: 'flex', alignItems: 'center' }}>
+            <FormLabel required>Upload Credentials</FormLabel>
             <InfoTooltip
               tooltip={t(
                 'Use the JSON file you automatically downloaded when creating your service account in Google BigQuery.',
               )}
               viewBox="0 0 24 24"
             />
-          </span>
+          </div>
 
           {!fileToUpload && (
             <Button

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -801,11 +801,11 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       ]}
       name="database"
       data-test="database-modal"
-      height="600px"
       onHandledPrimaryAction={onSave}
       onHide={onClose}
       primaryButtonName={isEditMode ? t('Save') : t('Connect')}
       width="500px"
+      centered
       show={show}
       title={
         <h4>{isEditMode ? t('Edit database') : t('Connect a database')}</h4>
@@ -971,11 +971,11 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
         formStyles(theme),
       ]}
       name="database"
-      height="600px"
       onHandledPrimaryAction={onSave}
       onHide={onClose}
       primaryButtonName={hasConnectedDb ? t('Finish') : t('Connect')}
       width="500px"
+      centered
       show={show}
       title={<h4>{t('Connect a database')}</h4>}
       footer={renderModalFooter()}

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
@@ -378,9 +378,10 @@ export const StyledBasicTab = styled(Tabs.TabPane)`
   margin-top: ${({ theme }) => theme.gridUnit * 6}px;
 `;
 
-export const buttonLinkStyles = css`
+export const buttonLinkStyles = (theme: SupersetTheme) => css`
   font-weight: 400;
   text-transform: initial;
+  padding-right: ${theme.gridUnit * 2}px;
 `;
 
 export const alchemyButtonLinkStyles = (theme: SupersetTheme) => css`

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
@@ -148,6 +148,10 @@ export const antDModalStyles = (theme: SupersetTheme) => css`
   .ant-modal-body {
     height: ${theme.gridUnit * 180.5}px;
   }
+
+  .ant-modal-footer {
+    height: ${theme.gridUnit * 16.25}px;
+  }
 `;
 
 export const antDAlertStyles = (theme: SupersetTheme) => css`

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
@@ -56,6 +56,7 @@ export const StyledFormHeader = styled.header`
   }
 
   .select-db {
+    padding: ${({ theme }) => theme.gridUnit}px;
     .helper {
       margin: 0;
     }

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
@@ -451,7 +451,13 @@ export const CredentialInfoForm = styled.div`
     height: 100px;
     width: 100%;
     border: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
+    border-radius: ${({ theme }) => theme.gridUnit}px;
     resize: vertical;
+    padding: ${({ theme }) => theme.gridUnit * 1.5}px
+      ${({ theme }) => theme.gridUnit * 2}px;
+    &::placeholder {
+      color: ${({ theme }) => theme.colors.grayscale.light1};
+    }
   }
 
   .input-container {


### PR DESCRIPTION
### SUMMARY
Implemented UI polish tasks in [Clubhouse ticket](https://app.clubhouse.io/preset/story/17847/ui-polish-r5)
- Centered modal in window
- Fixed inconsistent header spacing
- Touched up tooltips
- Added red *s to BigQuery form

Extra:
- Styled placeholder text in BigQuery > Service Account

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
- #### Centered modal, Consistent header spacing, Styled placeholder text in BigQuery > Service Account
![dbmServiceAcct](https://user-images.githubusercontent.com/55605634/123584038-4a897f00-d7a6-11eb-9a38-ee0862174699.gif)

- #### Red *s in BigQuery form
<img width="502" alt="BQJSON" src="https://user-images.githubusercontent.com/55605634/123584969-f089b900-d7a7-11eb-9cf9-a37bf33a4093.png">
<img width="502" alt="BQcopyPaste" src="https://user-images.githubusercontent.com/55605634/123584974-f2ec1300-d7a7-11eb-83ac-cf2c4ededd9b.png">

- #### Tooltips
<img width="347" alt="hostTooltip" src="https://user-images.githubusercontent.com/55605634/123584618-50cc2b00-d7a7-11eb-9e0d-24b2620065bc.png">
<img width="641" alt="SQLAlchemyTooltip" src="https://user-images.githubusercontent.com/55605634/123584624-53c71b80-d7a7-11eb-9510-a5074de465aa.png">
<img width="425" alt="uploadCredentialsTooltip" src="https://user-images.githubusercontent.com/55605634/123584631-5590df00-d7a7-11eb-85d8-ea8fec223296.png">


### TESTING INSTRUCTIONS
From the Superset home page:
- Hover over "Data" in the upper navigation bar
- Click "Database"
- Click the "+ Database" button below the navigation bar and to the right
- Navigation through the database modal and observe the styling described above

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
