### PR TITLE
fix: Error Icon not showing up on  errored input fieds on validation

### DIFF
--- a/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
+++ b/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
@@ -22,7 +22,7 @@ import { styled, css, SupersetTheme } from '@superset-ui/core';
 import InfoTooltip from 'src/components/InfoTooltip';
 import FormItem from './FormItem';
 import FormLabel from './FormLabel';
-
+import errorIcon from 'images/icons/error.svg'
 export interface LabeledErrorBoundInputProps {
   label?: string;
   validationMethods:
@@ -49,18 +49,17 @@ const alertIconStyles = (theme: SupersetTheme, hasError: boolean) => css`
   ${hasError &&
   `.ant-form-item-control-input-content {
       position: relative;
-
       &:after {
         content: ' ';
         display: inline-block;
         background: ${theme.colors.error.base};
-        mask: url('/images/icons/error.svg');
+        mask: url(${errorIcon});
         mask-size: cover;
         width: ${theme.gridUnit * 4}px;
         height: ${theme.gridUnit * 4}px;
         position: absolute;
-        right: 7px;
-        top: 15px;
+        right: 2%;
+        top: 26%;
       }
     }`}
 `;

--- a/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
+++ b/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
@@ -22,7 +22,7 @@ import { styled, css, SupersetTheme } from '@superset-ui/core';
 import InfoTooltip from 'src/components/InfoTooltip';
 import FormItem from './FormItem';
 import FormLabel from './FormLabel';
-import errorIcon from 'images/icons/error.svg'
+import errorIcon from 'images/icons/error.svg';
 export interface LabeledErrorBoundInputProps {
   label?: string;
   validationMethods:
@@ -58,8 +58,8 @@ const alertIconStyles = (theme: SupersetTheme, hasError: boolean) => css`
         width: ${theme.gridUnit * 4}px;
         height: ${theme.gridUnit * 4}px;
         position: absolute;
-        right: 2%;
-        top: 26%;
+        right: 5px;
+        top: 11px;
       }
     }`}
 `;

--- a/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
+++ b/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
@@ -20,9 +20,10 @@ import React from 'react';
 import { Input } from 'antd';
 import { styled, css, SupersetTheme } from '@superset-ui/core';
 import InfoTooltip from 'src/components/InfoTooltip';
+import errorIcon from 'images/icons/error.svg';
 import FormItem from './FormItem';
 import FormLabel from './FormLabel';
-import errorIcon from 'images/icons/error.svg';
+
 export interface LabeledErrorBoundInputProps {
   label?: string;
   validationMethods:

--- a/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
+++ b/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
@@ -59,8 +59,8 @@ const alertIconStyles = (theme: SupersetTheme, hasError: boolean) => css`
         width: ${theme.gridUnit * 4}px;
         height: ${theme.gridUnit * 4}px;
         position: absolute;
-        right: 5px;
-        top: 11px;
+        right: ${theme.gridUnit * 1.25}px;
+        top: ${theme.gridUnit * 2.75}px;
       }
     }`}
 `;


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
CSS `mask` for Icon SVG was triggering a get request to `localhost:.../Images/Icons/error.svg` and returning a 404 error. This was fixed by importing the SVG at the top of the file and adding it onto the `mask` inside the CSS variable. Some alignment was also needed on this CSS variable to get it centered in the field.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

* BEFORE:

<img width="1440" alt="Screen Shot 2021-06-28 at 11 13 56 AM" src="https://user-images.githubusercontent.com/50464395/123684346-31162080-d802-11eb-93ff-ec422c06e918.png">

* AFTER:

<img width="1440" alt="Screen Shot 2021-06-28 at 11 02 50 AM" src="https://user-images.githubusercontent.com/50464395/123684428-4c812b80-d802-11eb-8109-68f0986ca691.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
