### PR TITLE
fix: Allow users to override database connection docs

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ModalHeader.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ModalHeader.tsx
@@ -18,6 +18,7 @@
  */
 
 import React from 'react';
+import { getDatabaseDocumentationLinks } from 'src/views/CRUD/hooks';
 import {
   EditHeaderTitle,
   EditHeaderSubtitle,
@@ -31,6 +32,8 @@ import { DatabaseForm, DatabaseObject } from '../types';
 export const DOCUMENTATION_LINK =
   'https://superset.apache.org/docs/databases/installing-database-drivers';
 
+const supersetTextDocs = getDatabaseDocumentationLinks();
+
 const irregularDocumentationLinks = {
   postgresql: 'https://superset.apache.org/docs/databases/postgres',
   mssql: 'https://superset.apache.org/docs/databases/sql-server',
@@ -38,6 +41,12 @@ const irregularDocumentationLinks = {
 
 const documentationLink = (engine: string | undefined) => {
   if (!engine) return null;
+
+  if (supersetTextDocs) {
+    // override doc link for superset_txt yml
+    return supersetTextDocs[engine] || supersetTextDocs.default;
+  }
+
   if (!irregularDocumentationLinks[engine]) {
     return `https://superset.apache.org/docs/databases/${engine}`;
   }

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -604,7 +604,8 @@ export const copyQueryLink = (
 export const getDatabaseImages = () => SupersetText.DB_IMAGES;
 
 export const getConnectionAlert = () => SupersetText.DB_CONNECTION_ALERTS;
-export const getDatabaseDocumentationLinks = () => SupersetText.DB_CONNECTION_DOC_LINKS
+export const getDatabaseDocumentationLinks = () =>
+  SupersetText.DB_CONNECTION_DOC_LINKS;
 
 export const testDatabaseConnection = (
   connection: DatabaseObject,

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -604,6 +604,7 @@ export const copyQueryLink = (
 export const getDatabaseImages = () => SupersetText.DB_IMAGES;
 
 export const getConnectionAlert = () => SupersetText.DB_CONNECTION_ALERTS;
+export const getDatabaseDocumentationLinks = () => SupersetText.DB_CONNECTION_DOC_LINKS
 
 export const testDatabaseConnection = (
   connection: DatabaseObject,


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Allow users to override documentation in DB Connection UI headers

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
