### PR TITLE
fix: import superset_config

### DIFF
--- a/superset/app.py
+++ b/superset/app.py
@@ -77,11 +77,11 @@ def load_override_config() -> Union[Dict[Any, Any], ModuleType]:
         # for case where app is being executed via pex.
         cfg_path = os.environ[CONFIG_PATH_ENV_VAR]
         try:
-            mod_name = "superset_config"
-            loader = importlib.machinery.SourceFileLoader(mod_name, cfg_path)
-            spec = importlib.util.spec_from_loader(mod_name, loader)
+            CONFIG_MODULE_NAME = "superset_config"  # pylint: disable=C0103
+            loader = importlib.machinery.SourceFileLoader(CONFIG_MODULE_NAME, cfg_path)
+            spec = importlib.util.spec_from_loader(CONFIG_MODULE_NAME, loader)
             override_conf = importlib.util.module_from_spec(spec)
-            sys.modules[mod_name] = override_conf
+            sys.modules[CONFIG_MODULE_NAME] = override_conf
             loader.exec_module(override_conf)
 
             print(f"Loaded your LOCAL configuration at [{cfg_path}]")

--- a/superset/app.py
+++ b/superset/app.py
@@ -16,10 +16,11 @@
 # under the License.
 from __future__ import annotations
 
-import importlib
+import importlib.machinery
 import importlib.util
 import logging
 import os
+import sys
 from types import ModuleType
 from typing import Any, Dict, Union
 
@@ -76,8 +77,12 @@ def load_override_config() -> Union[Dict[Any, Any], ModuleType]:
         # for case where app is being executed via pex.
         cfg_path = os.environ[CONFIG_PATH_ENV_VAR]
         try:
-
-            override_conf = importlib.import_module("superset_config", cfg_path)
+            mod_name = "superset_config"
+            loader = importlib.machinery.SourceFileLoader(mod_name, cfg_path)
+            spec = importlib.util.spec_from_loader(mod_name, loader)
+            override_conf = importlib.util.module_from_spec(spec)
+            sys.modules[mod_name] = override_conf
+            loader.exec_module(override_conf)
 
             print(f"Loaded your LOCAL configuration at [{cfg_path}]")
             return override_conf


### PR DESCRIPTION
### SUMMARY
A recent PR #15405 replaced the use of the deprecated `imp.load_source` with `importlib.load_module`, which caused the following error on some deployments:

```
Failed to import config for SUPERSET_CONFIG_PATH=/Users/ville/superset/superset_config.py
Traceback (most recent call last):
  File "/Users/ville/src/superset/superset/app.py", line 80, in load_override_config
    override_conf = importlib.import_module("superset_config", cfg_path)
  File "/Users/ville/.pyenv/versions/3.8-dev/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'superset_config'
Failed to create app
Traceback (most recent call last):
  File "/Users/ville/src/superset/superset/app.py", line 40, in create_app
    config = init_config()
  File "/Users/ville/src/superset/superset/app.py", line 56, in init_config
    override_conf = convert_to_dict(load_override_config())
  File "/Users/ville/src/superset/superset/app.py", line 80, in load_override_config
    override_conf = importlib.import_module("superset_config", cfg_path)
  File "/Users/ville/.pyenv/versions/3.8-dev/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'superset_config'
Traceback (most recent call last):
  File "/Users/ville/src/superset/venv/bin/superset", line 11, in <module>
    load_entry_point('apache-superset', 'console_scripts', 'superset')()
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/flask/cli.py", line 586, in main
    return super(FlaskGroup, self).main(*args, **kwargs)
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/click/core.py", line 1256, in invoke
    Command.invoke(self, ctx)
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/flask/cli.py", line 425, in decorator
    with __ctx.ensure_object(ScriptInfo).load_app().app_context():
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/flask/cli.py", line 381, in load_app
    app = call_factory(self, self.create_app)
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/flask/cli.py", line 119, in call_factory
    return app_factory()
  File "/Users/ville/src/superset/superset/app.py", line 51, in create_app
    raise ex
  File "/Users/ville/src/superset/superset/app.py", line 40, in create_app
    config = init_config()
  File "/Users/ville/src/superset/superset/app.py", line 56, in init_config
    override_conf = convert_to_dict(load_override_config())
  File "/Users/ville/src/superset/superset/app.py", line 80, in load_override_config
    override_conf = importlib.import_module("superset_config", cfg_path)
  File "/Users/ville/.pyenv/versions/3.8-dev/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'superset_config'
```

A similar change was done on Airflow last year: https://github.com/apache/airflow/pull/7099 , which is based on the official documentation found here: https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
