### PR TITLE
fix(native-filters): filter type check when using experimental flag

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -669,8 +669,8 @@ const FiltersConfigForm = (
                   ? FILTER_TYPE_NAME_MAPPING[name]
                   : undefined;
                 const isDisabled =
-                  FILTER_SUPPORTED_TYPES[filterType].length === 1 &&
-                  FILTER_SUPPORTED_TYPES[filterType].includes(
+                  FILTER_SUPPORTED_TYPES[filterType]?.length === 1 &&
+                  FILTER_SUPPORTED_TYPES[filterType]?.includes(
                     GenericDataType.TEMPORAL,
                   ) &&
                   !doLoadedDatasetsHaveTemporalColumns;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils.ts
@@ -97,4 +97,5 @@ export const hasTemporalColumns = (
 
 export const doesColumnMatchFilterType = (filterType: string, column: Column) =>
   !column.type_generic ||
+  !(filterType in FILTER_SUPPORTED_TYPES) ||
   FILTER_SUPPORTED_TYPES[filterType].includes(column.type_generic);


### PR DESCRIPTION
### SUMMARY
When the `DASHBOARD_FILTERS_EXPERIMENTAL` flag is set, the filter config modal produces an error due to the experimental filters not being mapped in the `FILTER_SUPPORTED_TYPES` map. This changes the flow so that if a filter is not mapped in the filter type map, the data type is assumed to be supported.

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/123784847-89235480-d8e0-11eb-8c42-544aab7f9e6e.png)

### AFTER
![image](https://user-images.githubusercontent.com/33317356/123785009-b112b800-d8e0-11eb-9643-5099f39936df.png)

### TESTING INSTRUCTIONS
1. Enable the `DASHBOARD_FILTERS_EXPERIMENTAL` feature flag
2. Open the filter config modal on a dashboard.
3. See the error

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
