### PR TITLE
feat(config): load config with hybrid strategies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ combine_as_imports = true
 include_trailing_comma = true
 line_length = 88
 known_first_party = superset
-known_third_party =alembic,apispec,backoff,bleach,cachelib,celery,click,colorama,contextlib2,cron_descriptor,croniter,cryptography,dateutil,deprecation,flask,flask_appbuilder,flask_babel,flask_caching,flask_compress,flask_jwt_extended,flask_login,flask_migrate,flask_sqlalchemy,flask_talisman,flask_testing,flask_wtf,freezegun,geohash,geopy,graphlib,holidays,humanize,isodate,jinja2,jwt,markdown,markupsafe,marshmallow,marshmallow_enum,msgpack,numpy,pandas,parameterized,parsedatetime,pathlib2,pgsanity,pkg_resources,polyline,prison,pyarrow,pyhive,pyparsing,pytest,pytz,redis,requests,retry,selenium,setuptools,simplejson,slack,sqlalchemy,sqlalchemy_utils,sqlparse,typing_extensions,werkzeug,wtforms,wtforms_json,yaml
+known_third_party =alembic,apispec,backoff,bleach,cachelib,celery,click,colorama,contextlib2,cron_descriptor,croniter,cryptography,dateutil,deprecation,flask,flask_appbuilder,flask_babel,flask_caching,flask_compress,flask_jwt_extended,flask_login,flask_migrate,flask_sqlalchemy,flask_talisman,flask_testing,flask_wtf,freezegun,geohash,geopy,graphlib,holidays,humanize,isodate,jinja2,jwt,markdown,markupsafe,marshmallow,marshmallow_enum,msgpack,numpy,pandas,parameterized,parsedatetime,pathlib2,pgsanity,pkg_resources,polyline,prison,pyarrow,pydash,pyhive,pyparsing,pytest,pytz,redis,requests,retry,selenium,setuptools,simplejson,slack,sqlalchemy,sqlalchemy_utils,sqlparse,typing_extensions,werkzeug,wtforms,wtforms_json,yaml
 multi_line_output = 3
 order_by_type = false
 

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ setup(
         "pyparsing>=2.4.7, <3.0.0",
         "holidays==0.10.3",  # PINNED! https://github.com/dr-prodigy/python-holidays/issues/406
         "deprecation>=2.1.0, <2.2.0",
+        "pydash>=5.0.1, <5.1.0",
     ],
     extras_require={
         "athena": ["pyathena>=1.10.8,<1.11"],

--- a/superset/initialization/configurations/__init__.py
+++ b/superset/initialization/configurations/__init__.py
@@ -17,11 +17,11 @@
 from __future__ import annotations
 
 import logging
-from types import ModuleType
-from typing import Any, Dict, Type, Union
+from typing import Any, Dict
 
 from .loader import load_default_config_module, load_override_config_module
 from .meta_configurations import union_values
+from .utils import take_conf_keys_and_convert_to_dict
 
 logger = logging.getLogger(__name__)
 
@@ -47,10 +47,3 @@ def create_one_configuration_object(
             right_value = right_config[key]
             result_dict[key] = union_values(left_value, right_value, key)
     return result_dict
-
-
-def take_conf_keys_and_convert_to_dict(
-    module: Union[ModuleType, Type[Any], Dict[Any, Any]]
-) -> Dict[Any, Any]:
-    raw_dict = module if isinstance(module, dict) else module.__dict__
-    return {k: v for k, v in raw_dict.items() if k.isupper() and not k.startswith("_")}

--- a/superset/initialization/configurations/__init__.py
+++ b/superset/initialization/configurations/__init__.py
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import logging
+from types import ModuleType
+from typing import Any, Dict, Type, Union
+
+from .loader import load_default_config_module, load_override_config_module
+from .meta_configurations import union_values
+
+logger = logging.getLogger(__name__)
+
+
+def init_config() -> Dict[Any, Any]:
+    config = take_conf_keys_and_convert_to_dict(load_default_config_module())
+    override_conf = take_conf_keys_and_convert_to_dict(load_override_config_module())
+    return create_one_configuration_object(config, override_conf)
+
+
+def create_one_configuration_object(
+    left_config: Dict[str, Any], right_config: Dict[str, Any]
+) -> Dict[str, Any]:
+    left_config_keys = set(left_config.keys())
+    right_config_keys = set(right_config.keys())
+    keys_in_both = left_config_keys.intersection(right_config_keys)
+    result_dict = left_config
+    for key in right_config:
+        if key not in keys_in_both:
+            result_dict[key] = right_config[key]
+        else:
+            left_value = left_config[key]
+            right_value = right_config[key]
+            result_dict[key] = union_values(left_value, right_value, key)
+    return result_dict
+
+
+def take_conf_keys_and_convert_to_dict(
+    module: Union[ModuleType, Type[Any], Dict[Any, Any]]
+) -> Dict[Any, Any]:
+    raw_dict = module if isinstance(module, dict) else module.__dict__
+    return {k: v for k, v in raw_dict.items() if k.isupper() and not k.startswith("_")}

--- a/superset/initialization/configurations/loader.py
+++ b/superset/initialization/configurations/loader.py
@@ -1,0 +1,84 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import logging
+import os
+import sys
+from types import ModuleType
+from typing import Any, Dict, Union
+
+from werkzeug.utils import import_string
+
+from superset.utils.core import is_test
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SUPERSET_CONFIG_LOCATION_ENV_NAME = "SUPERSET_CONFIG"
+DEFAULT_SUPERSET_CONFIG_LOCATION = "superset.config"
+OVERRIDE_CONFIG_PATH_ENV_VAR = "SUPERSET_CONFIG_PATH"
+DEFAULT_CONFIG_MODULE_NAME = "superset_config"
+
+
+def load_default_config_module() -> ModuleType:
+    config_module = os.environ.get(
+        DEFAULT_SUPERSET_CONFIG_LOCATION_ENV_NAME, DEFAULT_SUPERSET_CONFIG_LOCATION
+    )
+    config: ModuleType = import_string(config_module)
+    return config
+
+
+def load_override_config_module() -> Union[Dict[Any, Any], ModuleType]:
+    if OVERRIDE_CONFIG_PATH_ENV_VAR in os.environ:
+        return _load_based_on_env_var()
+    return _load_based_on_python_path()
+
+
+def _load_based_on_env_var() -> Union[Dict[Any, Any], ModuleType]:
+    # Explicitly import config module that is not necessarily in pythonpath; useful
+    # for case where app is being executed via pex.
+    cfg_path = os.environ[OVERRIDE_CONFIG_PATH_ENV_VAR]
+    try:
+        loader = importlib.machinery.SourceFileLoader(
+            DEFAULT_CONFIG_MODULE_NAME, cfg_path
+        )
+        spec = importlib.util.spec_from_loader(DEFAULT_CONFIG_MODULE_NAME, loader)
+        override_conf = importlib.util.module_from_spec(spec)
+        sys.modules[DEFAULT_CONFIG_MODULE_NAME] = override_conf
+        loader.exec_module(override_conf)
+        print(f"Loaded your LOCAL configuration at [{cfg_path}]")
+        return override_conf
+    except Exception:
+        logger.exception(
+            "Failed to import config for %s=%s", OVERRIDE_CONFIG_PATH_ENV_VAR, cfg_path
+        )
+        raise
+
+
+def _load_based_on_python_path() -> Union[Dict[Any, Any], ModuleType]:
+    if importlib.util.find_spec("superset_config") and not is_test():
+        try:
+            import superset_config  # pylint: disable=import-error
+
+            print(f"Loaded your LOCAL configuration at [{superset_config.__file__}]")
+            return superset_config
+        except Exception:
+            logger.exception("Found but failed to import local superset_config")
+            raise
+    return {}

--- a/superset/initialization/configurations/meta_configurations.py
+++ b/superset/initialization/configurations/meta_configurations.py
@@ -1,0 +1,106 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import Any, Dict, Type, Union
+
+from .utils import merge_dicts_recursive, take_conf_keys_and_convert_to_dict
+
+ConfigurationValue = Union[Type[Any], Dict[Any, Any]]
+
+
+def union_values(left_value: Any, right_value: Any, conf_name: str) -> Any:
+    strategy = meta_union_strategy.get(
+        (type(left_value), type(right_value)), take_right_strategy
+    )
+    return strategy(left_value, right_value, conf_name)
+
+
+def override_right_as_class_strategy(
+    left_value: ConfigurationValue, right_value: ConfigurationValue, conf_name: str
+) -> Type[Any]:
+    if isinstance(right_value, dict):
+        return type(conf_name, (), right_value)
+    return right_value
+
+
+def merge_as_class_strategy(
+    left_value: ConfigurationValue, right_value: ConfigurationValue, conf_name: str
+) -> Type[Any]:
+    left_dict = take_conf_keys_and_convert_to_dict(left_value)
+    right_dict = (
+        right_value if isinstance(right_value, dict) else dict(right_value.__dict__)
+    )
+    base = left_value if isinstance(left_value, type) else object
+    merged = {}
+    merged.update(left_dict)
+    merged.update(right_dict)
+    return type(conf_name, (base,), merged)
+
+
+def override_right_as_dict_strategy(
+    left_value: ConfigurationValue, right_value: ConfigurationValue, conf_name: str
+) -> Dict[Any, Any]:
+    return take_conf_keys_and_convert_to_dict(right_value)
+
+
+def merge_as_dict_strategy(
+    left_value: ConfigurationValue, right_value: ConfigurationValue, conf_name: str
+) -> Dict[Any, Any]:
+    left_dict = take_conf_keys_and_convert_to_dict(left_value)
+    right_dict = take_conf_keys_and_convert_to_dict(right_value)
+    try:
+        return merge_dicts_recursive(left_dict, right_dict)
+    except:
+        merged = {}
+        merged.update(left_dict)
+        merged.update(right_dict)
+        return merged
+
+
+def take_right_strategy(left: Any, right: Any, key_name: str) -> Any:
+    return right
+
+
+meta_union_strategy = {
+    (type, type): override_right_as_class_strategy,
+    (type, dict): override_right_as_class_strategy,
+    (dict, type): override_right_as_class_strategy,
+    (dict, dict): merge_as_dict_strategy,
+}
+
+if __name__ == "__main__":
+
+    class A:
+        NAME = "ofek"
+        LAST = "israel"
+
+    class B:
+        NAME = "amit"
+        ADDRESS = "aaa"
+
+    rv = override_right_as_class_strategy(A, B, "A")  # type: ignore
+    print(rv)
+    rv = merge_as_class_strategy(A, B, "A")  # type: ignore
+    print(rv)
+    rv = override_right_as_dict_strategy(A, B, "A")  # type: ignore
+    print(rv)
+    rv = merge_as_dict_strategy(A, B, "A")  # type: ignore
+    print(rv)
+    rv = take_right_strategy(A, B, "A")  # type: ignore
+    print(rv)
+    print("done")

--- a/superset/initialization/configurations/meta_configurations.py
+++ b/superset/initialization/configurations/meta_configurations.py
@@ -22,6 +22,8 @@ from .utils import merge_dicts_recursive, take_conf_keys_and_convert_to_dict
 
 ConfigurationValue = Union[Type[Any], Dict[Any, Any]]
 
+# pylint: disable=C0103, W0613
+
 
 def union_values(left_value: Any, right_value: Any, conf_name: str) -> Any:
     strategy = meta_union_strategy.get(
@@ -52,20 +54,20 @@ def merge_as_class_strategy(
     return type(conf_name, (base,), merged)
 
 
-def override_right_as_dict_strategy(
+def override_right_as_dict_strategy(  # pylint: disable=C0103, W0613
     left_value: ConfigurationValue, right_value: ConfigurationValue, conf_name: str
 ) -> Dict[Any, Any]:
     return take_conf_keys_and_convert_to_dict(right_value)
 
 
-def merge_as_dict_strategy(
+def merge_as_dict_strategy(  # pylint: disable=W0613
     left_value: ConfigurationValue, right_value: ConfigurationValue, conf_name: str
 ) -> Dict[Any, Any]:
     left_dict = take_conf_keys_and_convert_to_dict(left_value)
     right_dict = take_conf_keys_and_convert_to_dict(right_value)
     try:
         return merge_dicts_recursive(left_dict, right_dict)
-    except:
+    except Exception:  # pylint: disable=W0703
         merged = {}
         merged.update(left_dict)
         merged.update(right_dict)

--- a/superset/initialization/configurations/meta_configurations.py
+++ b/superset/initialization/configurations/meta_configurations.py
@@ -82,25 +82,3 @@ meta_union_strategy = {
     (dict, type): override_right_as_class_strategy,
     (dict, dict): merge_as_dict_strategy,
 }
-
-if __name__ == "__main__":
-
-    class A:
-        NAME = "ofek"
-        LAST = "israel"
-
-    class B:
-        NAME = "amit"
-        ADDRESS = "aaa"
-
-    rv = override_right_as_class_strategy(A, B, "A")  # type: ignore
-    print(rv)
-    rv = merge_as_class_strategy(A, B, "A")  # type: ignore
-    print(rv)
-    rv = override_right_as_dict_strategy(A, B, "A")  # type: ignore
-    print(rv)
-    rv = merge_as_dict_strategy(A, B, "A")  # type: ignore
-    print(rv)
-    rv = take_right_strategy(A, B, "A")  # type: ignore
-    print(rv)
-    print("done")

--- a/superset/initialization/configurations/utils.py
+++ b/superset/initialization/configurations/utils.py
@@ -16,34 +16,14 @@
 # under the License.
 from __future__ import annotations
 
-import logging
+from types import ModuleType
+from typing import Any, Dict, Type, Union
 
-from flask import Flask
-
-from superset.initialization import SupersetAppInitializer
-from superset.initialization.configurations import init_config
-
-logger = logging.getLogger(__name__)
+from pydash.objects import merge as merge_dicts_recursive
 
 
-def create_app() -> Flask:
-    app = SupersetApp(__name__)
-
-    try:
-        # Allow user to override our config completely
-        config = init_config()
-        app.config.from_mapping(config)
-
-        app_initializer = app.config.get("APP_INITIALIZER", SupersetAppInitializer)(app)
-        app_initializer.init_app()
-
-        return app
-
-    # Make sure that bootstrap errors ALWAYS get logged
-    except Exception as ex:
-        logger.exception("Failed to create app")
-        raise ex
-
-
-class SupersetApp(Flask):
-    pass
+def take_conf_keys_and_convert_to_dict(
+    module: Union[ModuleType, Type[Any], Dict[Any, Any]]
+) -> Dict[Any, Any]:
+    raw_dict = module if isinstance(module, dict) else module.__dict__
+    return {k: v for k, v in raw_dict.items() if k.isupper() and not k.startswith("_")}

--- a/superset/initialization/configurations/utils.py
+++ b/superset/initialization/configurations/utils.py
@@ -19,10 +19,10 @@ from __future__ import annotations
 from types import ModuleType
 from typing import Any, Dict, Type, Union
 
-from pydash.objects import merge as merge_dicts_recursive
+from pydash.objects import merge as merge_dicts_recursive  # pylint: disable=W0611
 
 
-def take_conf_keys_and_convert_to_dict(
+def take_conf_keys_and_convert_to_dict(  # pylint: disable=C0103
     module: Union[ModuleType, Type[Any], Dict[Any, Any]]
 ) -> Dict[Any, Any]:
     raw_dict = module if isinstance(module, dict) else module.__dict__

--- a/tests/initializations/__init__.py
+++ b/tests/initializations/__init__.py
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# isort:skip_file

--- a/tests/initializations/configurations/__init__.py
+++ b/tests/initializations/configurations/__init__.py
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# isort:skip_file

--- a/tests/initializations/configurations/conftest.py
+++ b/tests/initializations/configurations/conftest.py
@@ -1,0 +1,159 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple, Type
+
+from pytest import fixture
+
+
+@fixture
+def left_unique_key_value() -> Tuple[str, Any]:
+    return "left_unique", "left_unique_value"
+
+
+@fixture
+def right_unique_key_value() -> Tuple[str, Any]:
+    return "right_unique", "right_unique_value"
+
+
+@fixture
+def similar_key_of_str() -> str:
+    return "similar_str"
+
+
+@fixture
+def similar_key_of_type() -> str:
+    return "similar_type"
+
+
+@fixture
+def similar_key_of_dict() -> str:
+    return "similar_dict"
+
+
+@fixture
+def similar_key_of_object() -> str:
+    return "similar_object"
+
+
+@fixture
+def left_similar_str_key_value(similar_key_of_str: str) -> Tuple[str, str]:
+    return similar_key_of_str, "left_similar_str_value"
+
+
+@fixture
+def left_similar_type_key_value(similar_key_of_type: str) -> Tuple[str, Type[Any]]:
+    class SimilarType:
+        left_key = "left_value"
+
+    return similar_key_of_type, SimilarType
+
+
+@fixture
+def left_similar_dict_key_value(
+    similar_key_of_dict: str,
+    left_unique_key_value: Tuple[str, Any],
+    left_similar_str_key_value: Tuple[str, str],
+) -> Tuple[str, Dict[Any, Any]]:
+    return (
+        similar_key_of_dict,
+        {
+            left_unique_key_value[0]: left_unique_key_value[1],
+            left_similar_str_key_value[0]: left_similar_str_key_value[1],
+        },
+    )
+
+
+@fixture
+def left_similar_object_key_value(
+    similar_key_of_object: str, left_similar_dict_key_value: Tuple[str, Dict[Any, Any]]
+):
+    obj = object()
+    obj.__dict__.update(left_similar_dict_key_value[1])
+    return similar_key_of_object, obj
+
+
+@fixture
+def right_similar_str_key_value(similar_key_of_str: str) -> Tuple[str, str]:
+    return similar_key_of_str, "right_similar_str_value"
+
+
+@fixture
+def right_similar_type_key_value(similar_key_of_type: str) -> Tuple[str, Type[Any]]:
+    class SimilarType:
+        right_key = "right_value"
+
+    return similar_key_of_type, SimilarType
+
+
+@fixture
+def right_similar_dict_key_value(
+    similar_key_of_dict: str,
+    right_unique_key_value: Tuple[str, Any],
+    right_similar_str_key_value: Tuple[str, str],
+) -> Tuple[str, Dict[Any, Any]]:
+    return (
+        similar_key_of_dict,
+        {
+            right_unique_key_value[0]: right_unique_key_value[1],
+            right_similar_str_key_value[0]: right_similar_str_key_value[1],
+        },
+    )
+
+
+@fixture
+def right_similar_object_key_value(
+    similar_key_of_object: str, right_similar_dict_key_value: Tuple[str, Dict[Any, Any]]
+):
+    obj = object()
+    obj.__dict__.update(right_similar_dict_key_value[1])
+    return similar_key_of_object, obj
+
+
+@fixture
+def left_values(
+    left_unique_key_value: Tuple[str, Any],
+    left_similar_str_key_value: Tuple[str, str],
+    left_similar_type_key_value: Tuple[str, Type[Any]],
+    left_similar_dict_key_value: Tuple[str, Dict[Any, Any]],
+    left_similar_object_key_value: Tuple[str, object],
+) -> Dict[str, Any]:
+    return {
+        left_unique_key_value[0]: left_unique_key_value[1],
+        left_similar_str_key_value[0]: left_similar_str_key_value[1],
+        left_similar_type_key_value[0]: left_similar_type_key_value[1],
+        left_similar_dict_key_value[0]: left_similar_dict_key_value[1],
+        left_similar_object_key_value[0]: left_similar_object_key_value[1],
+    }
+
+
+@fixture
+def right_values(
+    right_unique_key_value: Tuple[str, Any],
+    right_similar_str_key_value: Tuple[str, str],
+    right_similar_type_key_value: Tuple[str, Type[Any]],
+    right_similar_dict_key_value: Tuple[str, Dict[Any, Any]],
+    right_similar_object_key_value: Tuple[str, object],
+) -> Dict[str, Any]:
+    return {
+        right_unique_key_value[0]: left_unique_key_value[1],
+        right_similar_str_key_value[0]: right_similar_str_key_value[1],
+        right_similar_type_key_value[0]: right_similar_type_key_value[1],
+        right_similar_dict_key_value[0]: right_similar_dict_key_value[1],
+        right_similar_object_key_value[0]: right_similar_object_key_value[1],
+    }

--- a/tests/initializations/configurations/meta_configurations_tests.py
+++ b/tests/initializations/configurations/meta_configurations_tests.py
@@ -1,0 +1,203 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# isort:skip_file
+from __future__ import annotations
+from superset.initialization.configurations.meta_configurations import (
+    override_right_as_class_strategy,
+    merge_as_class_strategy,
+    override_right_as_dict_strategy,
+    merge_as_dict_strategy,
+)
+from pytest import fixture
+from typing import Type, Any, Dict
+
+TEST_KEY = "TestKey"
+
+
+@fixture
+def left_class() -> Type[Any]:
+    class TestKey:
+        FIRST = "left_first"
+        SECOND = "left_second"
+
+    return TestKey
+
+
+@fixture
+def right_class() -> Type[Any]:
+    class TestKey:
+        FIRST = "right_first"
+        THIRD = "right_third"
+
+    return TestKey
+
+
+@fixture
+def left_dict() -> Dict[str, Any]:
+    return {"FIRST": "left_first", "SECOND": "left_second"}
+
+
+@fixture
+def right_dict() -> Dict[str, Any]:
+    return {"FIRST": "right_first", "THIRD": "right_third"}
+
+
+@fixture
+def setup_sample_data():
+    pass
+
+
+class TestOverrideRightAsClassStrategy:
+    def test_with_classes(self, left_class: Type[Any], right_class: Type[Any]) -> None:
+        union_class = override_right_as_class_strategy(
+            left_class, right_class, TEST_KEY
+        )
+
+        self.assert_union_class(union_class)
+
+    def assert_union_class(self, union_class):
+        union_class_dict = union_class.__dict__
+        assert union_class.__name__ == TEST_KEY
+        assert "FIRST" in union_class_dict
+        assert "SECOND" not in union_class_dict
+        assert "THIRD" in union_class_dict
+        assert "right_first" == union_class_dict["FIRST"]
+
+    def test_with_class_and_dict(
+        self, left_class: Type[Any], right_dict: Dict[str, Any]
+    ) -> None:
+        union_class = override_right_as_class_strategy(left_class, right_dict, TEST_KEY)
+
+        self.assert_union_class(union_class)
+
+    def test_with_dicts(
+        self, left_dict: Dict[str, Any], right_dict: Dict[str, Any]
+    ) -> None:
+        union_class = override_right_as_class_strategy(left_dict, right_dict, TEST_KEY)
+
+        self.assert_union_class(union_class)
+
+    def test_with_dict_and_class(
+        self, left_dict: Dict[str, Any], right_class: Type[Any]
+    ) -> None:
+        union_class = override_right_as_class_strategy(left_dict, right_class, TEST_KEY)
+
+        self.assert_union_class(union_class)
+
+
+class TestMergeAsClassStrategy:
+    def test_with_classes(self, left_class: Type[Any], right_class: Type[Any]) -> None:
+        union_class = merge_as_class_strategy(left_class, right_class, TEST_KEY)
+
+        self.assert_union_class(union_class)
+
+    def assert_union_class(self, union_class):
+        union_class_dict = union_class.__dict__
+        assert union_class.__name__ == TEST_KEY
+        assert "FIRST" in union_class_dict
+        assert "SECOND" in union_class_dict
+        assert "THIRD" in union_class_dict
+        assert "right_first" == union_class_dict["FIRST"]
+
+    def test_with_class_and_dict(
+        self, left_class: Type[Any], right_dict: Dict[str, Any]
+    ) -> None:
+        union_class = merge_as_class_strategy(left_class, right_dict, TEST_KEY)
+
+        self.assert_union_class(union_class)
+
+    def test_with_dicts(
+        self, left_dict: Dict[str, Any], right_dict: Dict[str, Any]
+    ) -> None:
+        union_class = merge_as_class_strategy(left_dict, right_dict, TEST_KEY)
+
+        self.assert_union_class(union_class)
+
+    def test_with_dict_and_class(
+        self, left_dict: Dict[str, Any], right_class: Type[Any]
+    ) -> None:
+        union_class = merge_as_class_strategy(left_dict, right_class, TEST_KEY)
+
+        self.assert_union_class(union_class)
+
+
+class TestOverrideRightAsDictStrategy:
+    def test_with_classes(self, left_class: Type[Any], right_class: Type[Any]) -> None:
+        union_dict = override_right_as_dict_strategy(left_class, right_class, TEST_KEY)
+
+        self.assert_union_dict(union_dict)
+
+    def assert_union_dict(self, union_dict):
+        assert "FIRST" in union_dict
+        assert "SECOND" not in union_dict
+        assert "THIRD" in union_dict
+        assert "right_first" == union_dict["FIRST"]
+
+    def test_with_class_and_dict(
+        self, left_class: Type[Any], right_dict: Dict[str, Any]
+    ) -> None:
+        union_dict = override_right_as_dict_strategy(left_class, right_dict, TEST_KEY)
+
+        self.assert_union_dict(union_dict)
+
+    def test_with_dicts(
+        self, left_dict: Dict[str, Any], right_dict: Dict[str, Any]
+    ) -> None:
+        union_dict = override_right_as_dict_strategy(left_dict, right_dict, TEST_KEY)
+
+        self.assert_union_dict(union_dict)
+
+    def test_with_dict_and_class(
+        self, left_dict: Dict[str, Any], right_class: Type[Any]
+    ) -> None:
+        union_dict = override_right_as_dict_strategy(left_dict, right_class, TEST_KEY)
+
+        self.assert_union_dict(union_dict)
+
+
+class TestMergeAsDictStrategy:
+    def test_with_classes(self, left_class: Type[Any], right_class: Type[Any]) -> None:
+        union_dict = merge_as_dict_strategy(left_class, right_class, TEST_KEY)
+
+        self.assert_union_dict(union_dict)
+
+    def assert_union_dict(self, union_dict):
+        assert "FIRST" in union_dict
+        assert "SECOND" in union_dict
+        assert "THIRD" in union_dict
+        assert "right_first" == union_dict["FIRST"]
+
+    def test_with_class_and_dict(
+        self, left_class: Type[Any], right_dict: Dict[str, Any]
+    ) -> None:
+        union_dict = merge_as_dict_strategy(left_class, right_dict, TEST_KEY)
+
+        self.assert_union_dict(union_dict)
+
+    def test_with_dicts(
+        self, left_dict: Dict[str, Any], right_dict: Dict[str, Any]
+    ) -> None:
+        union_dict = merge_as_dict_strategy(left_dict, right_dict, TEST_KEY)
+
+        self.assert_union_dict(union_dict)
+
+    def test_with_dict_and_class(
+        self, left_dict: Dict[str, Any], right_class: Type[Any]
+    ) -> None:
+        union_dict = merge_as_dict_strategy(left_dict, right_class, TEST_KEY)
+
+        self.assert_union_dict(union_dict)


### PR DESCRIPTION
### SUMMARY
following the latest config loading mechanism changes and breaking changes and its follow-ups fixes:

https://github.com/apache/superset/pull/15448
https://github.com/apache/superset/pull/15444
https://github.com/apache/superset/pull/15435

we wanted to propose a new way for two configurations files (.py) to be unioned 
and to allow flexibility to choose a strategy based on the value type

Assume config.py contains  (left side)
KEY1 = { ... }
KEY2 = SomeClass

and superset_config.py contains (right side)
KEY1 = { ... }
KEY2 = SomeClass


There are 5 kinds of strategies how to union those KEY - Values 
1) take_right_strategy - simple - just override 
2) override_right_as_class_strategy - will create a class with the KEY name and its fields will be what inside the right value
2) merge_as_class_strategy - will create a class with the KEY name and its fields will be what inside the left and right value.
3) override_right_as_dict_strategy - will create a dict and its keys-values will be what inside the right value.
4) merge_as_dict_strategy - will create a dict and its keys-values will be what inside the left and right value.

current meta configurations

meta_union_strategy = {
    (type, type): override_right_as_class_strategy,
    (type, dict): override_right_as_class_strategy,
    (dict, type): override_right_as_class_strategy,
    (dict, dict): merge_as_dict_strategy,
    (Any, Any):  take_right_strategy
}

this PR will in the future enables us to :
1. change the strategy -
2. defines new tuple and its strategy 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
tests/initializations/configurations/meta_configurations_tests.py

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
