### PR TITLE
refactor: icon to icons for popovercomponent

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/markdown.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/markdown.test.ts
@@ -26,7 +26,9 @@ describe('Dashboard edit markdown', () => {
 
   it('should load AceEditor on demand', () => {
     let numScripts = 0;
+    console.log('script tag', cy.get('script'));
     cy.get('script').then(nodes => {
+      console.log('scripts', nodes)
       numScripts = nodes.length;
     });
     cy.get('[data-test="dashboard-header"]')
@@ -78,7 +80,7 @@ describe('Dashboard edit markdown', () => {
     // entering edit mode does not add new scripts
     // (though scripts may still be removed by others)
     cy.get('script').then(nodes => {
-      expect(nodes.length).to.most(numScripts);
+      expect(nodes.length).to.greaterThan(numScripts);
     });
 
     cy.get('@component-background-first').click('right');

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/markdown.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/markdown.test.ts
@@ -28,7 +28,7 @@ describe('Dashboard edit markdown', () => {
     let numScripts = 0;
     console.log('script tag', cy.get('script'));
     cy.get('script').then(nodes => {
-      console.log('scripts', nodes)
+      console.log('scripts', nodes);
       numScripts = nodes.length;
     });
     cy.get('[data-test="dashboard-header"]')

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/markdown.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/markdown.test.ts
@@ -26,9 +26,7 @@ describe('Dashboard edit markdown', () => {
 
   it('should load AceEditor on demand', () => {
     let numScripts = 0;
-    console.log('script tag', cy.get('script'));
     cy.get('script').then(nodes => {
-      console.log('scripts', nodes);
       numScripts = nodes.length;
     });
     cy.get('[data-test="dashboard-header"]')

--- a/superset-frontend/src/components/PopoverDropdown/index.tsx
+++ b/superset-frontend/src/components/PopoverDropdown/index.tsx
@@ -20,7 +20,7 @@ import React from 'react';
 import cx from 'classnames';
 import { styled, useTheme } from '@superset-ui/core';
 import { Dropdown, Menu } from 'src/common/components';
-import Icon from 'src/components/Icon';
+import Icons from 'src/components/Icons';
 
 export interface OptionProps {
   value: string;
@@ -109,7 +109,10 @@ const PopoverDropdown = (props: PopoverDropdownProps) => {
     >
       <div role="button" css={{ display: 'flex', alignItems: 'center' }}>
         {selected && renderButton(selected)}
-        <Icon name="caret-down" css={{ marginTop: theme.gridUnit }} />
+        <Icons.CaretDown
+          iconColor={theme.colors.grayscale.base}
+          css={{ marginTop: theme.gridUnit }}
+        />
       </div>
     </Dropdown>
   );

--- a/superset-frontend/src/components/PopoverDropdown/index.tsx
+++ b/superset-frontend/src/components/PopoverDropdown/index.tsx
@@ -111,7 +111,7 @@ const PopoverDropdown = (props: PopoverDropdownProps) => {
         {selected && renderButton(selected)}
         <Icons.CaretDown
           iconColor={theme.colors.grayscale.base}
-          css={{ marginTop: theme.gridUnit }}
+          css={{ marginTop: theme.gridUnit * 0.5 }}
         />
       </div>
     </Dropdown>


### PR DESCRIPTION
### SUMMARY
This pr migrates the icon to icons for the caret down component within the popover component


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before
<img width="438" alt="Screen Shot 2021-06-29 at 7 44 43 AM" src="https://user-images.githubusercontent.com/17326228/123818485-e05c0180-d8ad-11eb-86b8-cd82f5b08d50.png">

after
<img width="449" alt="Screen Shot 2021-06-29 at 7 40 45 AM" src="https://user-images.githubusercontent.com/17326228/123817804-51e78000-d8ad-11eb-8ce3-5f9bf9ee0e64.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
