### PR TITLE
fix(dashboard): native filters highlight with multiple tabs jumps to first tab

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
@@ -30,9 +30,10 @@ import {
   DASHBOARD_GRID_ID,
   DASHBOARD_ROOT_DEPTH,
 } from 'src/dashboard/util/constants';
-import { getRootLevelTabIndex } from './utils';
+import { getRootLevelTabIndex, getRootLevelTabsComponent } from './utils';
 import { Filters } from '../../reducers/types';
 import { getChartIdsInFilterScope } from '../../util/activeDashboardFilters';
+import findTabIndexByComponentId from '../../util/findTabIndexByComponentId';
 import { findTabsWithChartsInScope } from '../nativeFilters/utils';
 import { setInScopeStatusOfFilters } from '../../actions/nativeFilters';
 
@@ -57,7 +58,13 @@ const DashboardContainer: FC<DashboardContainerProps> = ({ topLevelTabs }) => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    setTabIndex(getRootLevelTabIndex(dashboardLayout, directPathToChild));
+    const nextTabIndex = findTabIndexByComponentId({
+      currentComponent: getRootLevelTabsComponent(dashboardLayout),
+      directPathToChild,
+    });
+    if (nextTabIndex > -1) {
+      setTabIndex(nextTabIndex);
+    }
   }, [getLeafComponentIdFromPath(directPathToChild)]);
 
   // recalculate charts and tabs in scopes of native filters only when a scope or dashboard layout changes

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -185,7 +185,10 @@ export class Tabs extends React.PureComponent {
 
         // make sure nextFocusComponent is under this tabs component
         if (nextTabIndex > -1 && nextTabIndex !== this.state.tabIndex) {
-          this.setState(() => ({ tabIndex: nextTabIndex }));
+          this.setState(() => ({
+            tabIndex: nextTabIndex,
+            activeKey: nextTabsIds[nextTabIndex],
+          }));
         }
       }
     }


### PR DESCRIPTION
### SUMMARY
In some cases we were handling change of `directPathToChild` prop incorrectly, which caused rendering incorrect tab content. This PR fixes that issue.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
resolves #15420 
After:
https://user-images.githubusercontent.com/15073128/123821507-bf220200-d8fb-11eb-9068-5917c966c680.mov

### TESTING INSTRUCTIONS
0. Enable `DASHBOARD_NATIVE_FILTERS`  feature flag
1. Create a dashboard with top level tabs and apply some native filters
2. Go to second tab (or any other than first), click filters badge and click on the "magnifier" icon next to native filter's name
3. Verify that native filter got highlighted, but the tab didn't change

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes #15420 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

