### PR TITLE
refactor: icon to icons for popoversection

### DIFF
--- a/superset-frontend/src/components/PopoverSection/index.tsx
+++ b/superset-frontend/src/components/PopoverSection/index.tsx
@@ -19,7 +19,7 @@
 import React, { MouseEventHandler, ReactNode } from 'react';
 import { useTheme } from '@superset-ui/core';
 import { Tooltip } from 'src/components/Tooltip';
-import Icon from 'src/components/Icon';
+import Icons from 'src/components/Icons';
 
 export interface PopoverSectionProps {
   title: string;
@@ -57,19 +57,17 @@ export default function PopoverSection({
         <strong data-test="popover-title">{title}</strong>
         {info && (
           <Tooltip title={info} css={{ marginLeft: theme.gridUnit }}>
-            <Icon
+            <Icons.InfoSolidSmall
               role="img"
-              name="info-solid"
               width={14}
               height={14}
-              color={theme.colors.grayscale.light1}
+              iconColor={theme.colors.grayscale.light1}
             />
           </Tooltip>
         )}
-        <Icon
+        <Icons.Check
           role="img"
-          name="check"
-          color={
+          iconColor={
             isSelected ? theme.colors.primary.base : theme.colors.grayscale.base
           }
         />


### PR DESCRIPTION
### SUMMARY
This pr migrates the icons infosmall and check within popoversection to icons.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="557" alt="Screen Shot 2021-06-29 at 10 36 49 AM" src="https://user-images.githubusercontent.com/17326228/123842691-eb229080-d8c5-11eb-9b1f-ef3505183e8b.png">


### TESTING INSTRUCTIONS
check icons in annotation layer controls and spatial controls

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
