### PR TITLE
refactor: icon to icons for refreshlabel 

### DIFF
--- a/superset-frontend/src/components/Icons/index.tsx
+++ b/superset-frontend/src/components/Icons/index.tsx
@@ -160,6 +160,8 @@ IconFileNames.forEach(fileName => {
   );
 });
 
+export { IconType };
+
 export default {
   ...AntdEnhancedIcons,
   ...iconOverrides,

--- a/superset-frontend/src/components/RefreshLabel/index.tsx
+++ b/superset-frontend/src/components/RefreshLabel/index.tsx
@@ -19,17 +19,17 @@
 import React, { MouseEventHandler } from 'react';
 import { SupersetTheme } from '@superset-ui/core';
 import { Tooltip } from 'src/components/Tooltip';
-import Icon, { IconProps } from 'src/components/Icon';
+import Icons, { IconType } from 'src/components/Icons';
 
 export interface RefreshLabelProps {
-  onClick: MouseEventHandler<SVGSVGElement>;
+  onClick: MouseEventHandler<HTMLSpanElement>;
   tooltipContent: string;
 }
 
 const RefreshLabel = ({ onClick, tooltipContent }: RefreshLabelProps) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const IconWithoutRef = React.forwardRef((props: IconProps, ref: any) => (
-    <Icon {...props} />
+  const IconWithoutRef = React.forwardRef((props: IconType, ref: any) => (
+    <Icons.Refresh {...props} />
   ));
 
   return (
@@ -37,7 +37,6 @@ const RefreshLabel = ({ onClick, tooltipContent }: RefreshLabelProps) => {
       <IconWithoutRef
         role="button"
         onClick={onClick}
-        name="refresh"
         css={(theme: SupersetTheme) => ({
           cursor: 'pointer',
           color: theme.colors.grayscale.base,


### PR DESCRIPTION
### SUMMARY
This pr migrates the icon to icons for the refresh label component within dataset editor.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="561" alt="Screen Shot 2021-06-29 at 3 04 31 PM" src="https://user-images.githubusercontent.com/17326228/123873419-503cad00-d8eb-11eb-906f-5bda656694c7.png">



### TESTING INSTRUCTIONS
Go to dataset editor modal to and view the refreshlabel icon

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
