### PR TITLE
refactor: Moving get_user_datasources to security manager

### DIFF
--- a/superset/connectors/connector_registry.py
+++ b/superset/connectors/connector_registry.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from collections import defaultdict
 from typing import Dict, List, Optional, Set, Type, TYPE_CHECKING
 
 from flask_babel import _
@@ -99,41 +98,6 @@ class ConnectorRegistry:
                 # proceed to next datasource type
                 pass
         raise NoResultFound(_("Datasource id not found: %(id)s", id=datasource_id))
-
-    @classmethod
-    def get_user_datasources(cls, session: Session) -> List["BaseDatasource"]:
-        from superset import security_manager
-
-        # collect datasources which the user has explicit permissions to
-        user_perms = security_manager.user_view_menu_names("datasource_access")
-        schema_perms = security_manager.user_view_menu_names("schema_access")
-        user_datasources = set()
-        for datasource_class in ConnectorRegistry.sources.values():
-            user_datasources.update(
-                session.query(datasource_class)
-                .filter(
-                    or_(
-                        datasource_class.perm.in_(user_perms),
-                        datasource_class.schema_perm.in_(schema_perms),
-                    )
-                )
-                .all()
-            )
-
-        # group all datasources by database
-        all_datasources = cls.get_all_datasources(session)
-        datasources_by_database: Dict["Database", Set["BaseDatasource"]] = defaultdict(
-            set
-        )
-        for datasource in all_datasources:
-            datasources_by_database[datasource.database].add(datasource)
-
-        # add datasources with implicit permission (eg, database access)
-        for database, datasources in datasources_by_database.items():
-            if security_manager.can_access_database(database):
-                user_datasources.update(datasources)
-
-        return list(user_datasources)
 
     @classmethod
     def get_datasource_by_name(  # pylint: disable=too-many-arguments

--- a/superset/views/chart/views.py
+++ b/superset/views/chart/views.py
@@ -21,8 +21,7 @@ from flask_appbuilder import expose, has_access
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_babel import lazy_gettext as _
 
-from superset import db, is_feature_enabled
-from superset.connectors.connector_registry import ConnectorRegistry
+from superset import is_feature_enabled, security_manager
 from superset.constants import MODEL_VIEW_RW_METHOD_PERMISSION_MAP, RouteMethod
 from superset.models.slice import Slice
 from superset.typing import FlaskResponse
@@ -65,7 +64,7 @@ class SliceModelView(
     def add(self) -> FlaskResponse:
         datasources = [
             {"value": str(d.id) + "__" + d.type, "label": repr(d)}
-            for d in ConnectorRegistry.get_user_datasources(db.session)
+            for d in security_manager.get_user_datasources()
         ]
         payload = {
             "datasources": sorted(

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -186,7 +186,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             sorted(
                 [
                     datasource.short_data
-                    for datasource in ConnectorRegistry.get_user_datasources(db.session)
+                    for datasource in security_manager.get_user_datasources()
                     if datasource.short_data.get("name")
                 ],
                 key=lambda datasource: datasource["name"],

--- a/tests/access_tests.py
+++ b/tests/access_tests.py
@@ -18,7 +18,6 @@
 """Unit tests for Superset"""
 import json
 import unittest
-from collections import namedtuple
 from unittest import mock
 from tests.fixtures.birth_names_dashboard import load_birth_names_dashboard_with_slices
 
@@ -625,84 +624,6 @@ class TestRequestAccess(SupersetTestCase):
             gamma_user = security_manager.find_user(username="gamma")
             gamma_user.roles.remove(security_manager.find_role("dummy_role"))
             session.commit()
-
-
-class TestDatasources(SupersetTestCase):
-    def test_get_user_datasources_admin(self):
-        Datasource = namedtuple("Datasource", ["database", "schema", "name"])
-
-        mock_session = mock.MagicMock()
-        mock_session.query.return_value.filter.return_value.all.return_value = []
-
-        with mock.patch("superset.security_manager") as mock_security_manager:
-            mock_security_manager.can_access_database.return_value = True
-
-            with mock.patch.object(
-                ConnectorRegistry, "get_all_datasources"
-            ) as mock_get_all_datasources:
-                mock_get_all_datasources.return_value = [
-                    Datasource("database1", "schema1", "table1"),
-                    Datasource("database1", "schema1", "table2"),
-                    Datasource("database2", None, "table1"),
-                ]
-
-                datasources = ConnectorRegistry.get_user_datasources(mock_session)
-
-        assert sorted(datasources) == [
-            Datasource("database1", "schema1", "table1"),
-            Datasource("database1", "schema1", "table2"),
-            Datasource("database2", None, "table1"),
-        ]
-
-    def test_get_user_datasources_gamma(self):
-        Datasource = namedtuple("Datasource", ["database", "schema", "name"])
-
-        mock_session = mock.MagicMock()
-        mock_session.query.return_value.filter.return_value.all.return_value = []
-
-        with mock.patch("superset.security_manager") as mock_security_manager:
-            mock_security_manager.can_access_database.return_value = False
-
-            with mock.patch.object(
-                ConnectorRegistry, "get_all_datasources"
-            ) as mock_get_all_datasources:
-                mock_get_all_datasources.return_value = [
-                    Datasource("database1", "schema1", "table1"),
-                    Datasource("database1", "schema1", "table2"),
-                    Datasource("database2", None, "table1"),
-                ]
-
-                datasources = ConnectorRegistry.get_user_datasources(mock_session)
-
-        assert datasources == []
-
-    def test_get_user_datasources_gamma_with_schema(self):
-        Datasource = namedtuple("Datasource", ["database", "schema", "name"])
-
-        mock_session = mock.MagicMock()
-        mock_session.query.return_value.filter.return_value.all.return_value = [
-            Datasource("database1", "schema1", "table1"),
-            Datasource("database1", "schema1", "table2"),
-        ]
-
-        with mock.patch("superset.security_manager") as mock_security_manager:
-            mock_security_manager.can_access_database.return_value = False
-
-            with mock.patch.object(
-                ConnectorRegistry, "get_all_datasources"
-            ) as mock_get_all_datasources:
-                mock_get_all_datasources.return_value = [
-                    Datasource("database1", "schema1", "table1"),
-                    Datasource("database1", "schema1", "table2"),
-                    Datasource("database2", None, "table1"),
-                ]
-
-                datasources = ConnectorRegistry.get_user_datasources(mock_session)
-
-        assert sorted(datasources) == [
-            Datasource("database1", "schema1", "table1"),
-            Datasource("database1", "schema1", "table2"),
-        ]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### SUMMARY

Refactoring logic introduced to https://github.com/apache/superset/pull/15184 per https://github.com/apache/superset/pull/15184#discussion_r660139948 to move `get_user_datasources` to the security 
manager to allow custom overrides.

### TESTING INSTRUCTIONS

CI and unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
