### PR TITLE
fix: GSheets supports JOINs

### DIFF
--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -32,7 +32,7 @@ class GSheetsEngineSpec(SqliteEngineSpec):
 
     engine = "gsheets"
     engine_name = "Google Sheets"
-    allows_joins = False
+    allows_joins = True
     allows_subqueries = True
 
     custom_errors: Dict[Pattern[str], Tuple[str, SupersetErrorType, Dict[str, Any]]] = {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

GSheets is now based on [shillelagh](https://github.com/betodealmeida/shillelagh/), which supports JOINs since it leverages the SQLite engine.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

N/A

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
