### PR TITLE
feat(explore): Examples image gallery in the viz type control

### DIFF
--- a/superset-frontend/src/explore/components/controls/VizTypeControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/index.tsx
@@ -123,6 +123,8 @@ const DEFAULT_ORDER = [
 
 const typesWithDefaultOrder = new Set(DEFAULT_ORDER);
 
+const THUMBNAIL_GRID_UNITS = 24;
+
 export const VIZ_TYPE_CONTROL_TEST_ID = 'viz-type-control';
 
 function VizSupportValidation({ vizType }: { vizType: string }) {
@@ -223,20 +225,39 @@ const DetailsPane = styled.div`
   border-top: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
   padding: ${({ theme }) => theme.gridUnit * 4}px;
   display: grid;
+  grid-template-columns: 50% 50%;
   grid-template-rows: auto 1fr;
-  overflow: hidden;
+  grid-template-areas:
+    'viz-name examples-header'
+    'description examples';
 `;
 
 // overflow hidden on the details pane and overflow auto on the description
 // (plus grid layout) enables the description to scroll while the header stays in place.
 
 const Description = styled.p`
+  grid-area: description;
   overflow: auto;
+`;
+
+const Examples = styled.div`
+  grid-area: examples;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  overflow: auto;
+  gap: ${({ theme }) => theme.gridUnit * 4}px;
+
+  img {
+    height: 100%;
+    border-radius: ${({ theme }) => theme.gridUnit}px;
+    border: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
+  }
 `;
 
 const thumbnailContainerCss = (theme: SupersetTheme) => css`
   cursor: pointer;
-  width: ${theme.gridUnit * 24}px;
+  width: ${theme.gridUnit * THUMBNAIL_GRID_UNITS}px;
   margin: ${theme.gridUnit * 2}px;
 
   img {
@@ -436,7 +457,8 @@ const VizTypeControl = (props: VizTypeControlProps) => {
   const labelContent =
     mountedPluginMetadata[initialValue]?.name || `${initialValue}`;
 
-  const selectedVizMetadata = mountedPluginMetadata[selectedViz];
+  const selectedVizMetadata: ChartMetadata | undefined =
+    mountedPluginMetadata[selectedViz];
 
   const vizEntriesToDisplay = isSearching
     ? searchResults
@@ -512,11 +534,33 @@ const VizTypeControl = (props: VizTypeControlProps) => {
           />
 
           <DetailsPane>
-            <SectionTitle>{selectedVizMetadata?.name}</SectionTitle>
+            <SectionTitle
+              css={css`
+                grid-area: viz-name;
+              `}
+            >
+              {selectedVizMetadata?.name}
+            </SectionTitle>
             <Description>
               {selectedVizMetadata?.description ||
                 t('No description available.')}
             </Description>
+            <SectionTitle
+              css={css`
+                grid-area: examples-header;
+              `}
+            >
+              {!!selectedVizMetadata?.exampleGallery?.length && t('Examples')}
+            </SectionTitle>
+            <Examples>
+              {(selectedVizMetadata?.exampleGallery || []).map(example => (
+                <img
+                  src={example.url}
+                  alt={example.caption}
+                  title={example.caption}
+                />
+              ))}
+            </Examples>
           </DetailsPane>
         </VizPickerLayout>
       </UnpaddedModal>

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/index.tsx
@@ -225,7 +225,7 @@ const DetailsPane = styled.div`
   border-top: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
   padding: ${({ theme }) => theme.gridUnit * 4}px;
   display: grid;
-  grid-template-columns: 50% 50%;
+  grid-template-columns: 1fr 1fr;
   grid-template-rows: auto 1fr;
   grid-template-areas:
     'viz-name examples-header'
@@ -238,6 +238,7 @@ const DetailsPane = styled.div`
 const Description = styled.p`
   grid-area: description;
   overflow: auto;
+  padding-right: ${({ theme }) => theme.gridUnit * 14}px;
 `;
 
 const Examples = styled.div`

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -384,7 +384,7 @@ const config = {
       },
       /* for css linking images (and viz plugin thumbnails) */
       {
-        test: /\.(png|jpg)$/,
+        test: /\.(png)$/,
         issuer: {
           exclude: /\/src\/assets\/staticPages\//,
         },
@@ -395,7 +395,7 @@ const config = {
         },
       },
       {
-        test: /\.(png|jpg)$/,
+        test: /\.(png)$/,
         issuer: {
           test: /\/src\/assets\/staticPages\//,
         },


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

_This PR is against a feature branch, not the main branch._

Adds a section for example images to the viz modal. The examples will scroll to the side if there are more than fit in the allotted space. If an example image has a description, hovering over it will display a tooltip. Adding some kind of "click to zoom" functionality is left for later.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

<img width="1070" alt="Screen Shot 2021-07-01 at 12 26 11 AM" src="https://user-images.githubusercontent.com/1858430/124086343-cf260880-da05-11eb-9d7b-60f4204480c2.png">

When the selected plugin has no example images:
<img width="1072" alt="Screen Shot 2021-07-01 at 12 26 26 AM" src="https://user-images.githubusercontent.com/1858430/124086383-d9480700-da05-11eb-8757-fa3546dd8323.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

look at the modal

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
