### PR TITLE
fix(sqllab): add new tab when add sql query

### DIFF
--- a/superset-frontend/src/views/CRUD/welcome/EmptyState.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/EmptyState.tsx
@@ -43,7 +43,7 @@ export default function EmptyState({ tableName, tab }: EmptyStateProps) {
   const mineRedirects = {
     DASHBOARDS: '/dashboard/new',
     CHARTS: '/chart/add',
-    SAVED_QUERIES: '/superset/sqllab',
+    SAVED_QUERIES: '/superset/sqllab?new=true',
   };
   const favRedirects = {
     DASHBOARDS: '/dashboard/list/',

--- a/superset-frontend/src/views/CRUD/welcome/SavedQueries.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/SavedQueries.tsx
@@ -283,7 +283,7 @@ const SavedQueries = ({
             ),
             buttonStyle: 'tertiary',
             onClick: () => {
-              window.location.href = '/superset/sqllab';
+              window.location.href = '/superset/sqllab?new=true';
             },
           },
           {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add new tab when click on `+sql query` on welcome page.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### before

https://user-images.githubusercontent.com/11830681/124093852-cdeaef00-da8a-11eb-9afa-8123825540ff.mov


#### after

https://user-images.githubusercontent.com/11830681/124093899-d80ced80-da8a-11eb-948d-eaf6e3f97d3c.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/15370
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
