### PR TITLE
fix: skip set and log when use NullCache

### DIFF
--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -21,6 +21,7 @@ from typing import Any, Callable, Dict, Optional, Union
 
 from flask import current_app as app, request
 from flask_caching import Cache
+from flask_caching.backends import NullCache
 from werkzeug.wrappers.etag import ETagResponseMixin
 
 from superset import db
@@ -47,6 +48,9 @@ def set_and_log_cache(
     cache_timeout: Optional[int] = None,
     datasource_uid: Optional[str] = None,
 ) -> None:
+    if isinstance(cache_instance.cache, NullCache):
+        return
+
     timeout = cache_timeout if cache_timeout else config["CACHE_DEFAULT_TIMEOUT"]
     try:
         dttm = datetime.utcnow().isoformat().split(".")[0]


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
skip set cache when use NullCache

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
