### PR TITLE
fix(native-filters): chartsInScope were not recalculated in some cases

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
@@ -68,25 +68,24 @@ const DashboardContainer: FC<DashboardContainerProps> = ({ topLevelTabs }) => {
   }, [getLeafComponentIdFromPath(directPathToChild)]);
 
   // recalculate charts and tabs in scopes of native filters only when a scope or dashboard layout changes
-  const nativeFiltersValues = Object.values(nativeFilters);
-  const scopes = nativeFiltersValues.map(filter => ({
+  const filterScopes = Object.values(nativeFilters).map(filter => ({
     id: filter.id,
     scope: filter.scope,
   }));
   useEffect(() => {
     if (
       !isFeatureEnabled(FeatureFlag.DASHBOARD_NATIVE_FILTERS) ||
-      nativeFiltersValues.length === 0
+      filterScopes.length === 0
     ) {
       return;
     }
-    const filterScopes = nativeFiltersValues.map(filter => {
-      const filterScope = filter.scope;
+    const scopes = filterScopes.map(filterScope => {
+      const { scope } = filterScope;
       const chartsInScope: number[] = getChartIdsInFilterScope({
         filterScope: {
-          scope: filterScope.rootPath,
+          scope: scope.rootPath,
           // @ts-ignore
-          immune: filterScope.excluded,
+          immune: scope.excluded,
         },
       });
       const tabsInScope = findTabsWithChartsInScope(
@@ -94,13 +93,13 @@ const DashboardContainer: FC<DashboardContainerProps> = ({ topLevelTabs }) => {
         chartsInScope,
       );
       return {
-        filterId: filter.id,
+        filterId: filterScope.id,
         tabsInScope: Array.from(tabsInScope),
         chartsInScope,
       };
     });
-    dispatch(setInScopeStatusOfFilters(filterScopes));
-  }, [JSON.stringify(scopes), dashboardLayout, dispatch]);
+    dispatch(setInScopeStatusOfFilters(scopes));
+  }, [JSON.stringify(filterScopes), dashboardLayout, dispatch]);
 
   const childIds: string[] = topLevelTabs
     ? topLevelTabs.children

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
@@ -69,7 +69,10 @@ const DashboardContainer: FC<DashboardContainerProps> = ({ topLevelTabs }) => {
 
   // recalculate charts and tabs in scopes of native filters only when a scope or dashboard layout changes
   const nativeFiltersValues = Object.values(nativeFilters);
-  const scopes = nativeFiltersValues.map(filter => filter.scope);
+  const scopes = nativeFiltersValues.map(filter => ({
+    id: filter.id,
+    scope: filter.scope,
+  }));
   useEffect(() => {
     if (
       !isFeatureEnabled(FeatureFlag.DASHBOARD_NATIVE_FILTERS) ||
@@ -97,7 +100,7 @@ const DashboardContainer: FC<DashboardContainerProps> = ({ topLevelTabs }) => {
       };
     });
     dispatch(setInScopeStatusOfFilters(filterScopes));
-  }, [JSON.stringify(scopes), JSON.stringify(dashboardLayout)]);
+  }, [JSON.stringify(scopes), dashboardLayout, dispatch]);
 
   const childIds: string[] = topLevelTabs
     ? topLevelTabs.children

--- a/superset-frontend/src/dashboard/components/gridComponents/ChartHolder.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/ChartHolder.jsx
@@ -130,7 +130,7 @@ const FilterFocusHighlight = React.forwardRef(
 
     if (focusedNativeFilterId) {
       if (
-        nativeFilters.filters[focusedNativeFilterId].chartsInScope.includes(
+        nativeFilters.filters[focusedNativeFilterId].chartsInScope?.includes(
           chartId,
         )
       ) {


### PR DESCRIPTION
### SUMMARY
In `DashboardContainer` we recalculated `chartsInScope` only when scopes changed. However, when we deleted a filter and added a new one with the same scope, scopes were equal so we didn't calculate chartsInScope for the new filter. That resulted in `undefined` error. This PR adds filter's ID to scopes so that we sync `chartsInScope` when scopes change and when new filters are created

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
https://user-images.githubusercontent.com/15073128/124115398-0defa900-da6e-11eb-97c7-1d08df3fd70c.mp4

After:
https://user-images.githubusercontent.com/15073128/124115617-5018ea80-da6e-11eb-97cf-5daeb622cec7.mov

### TESTING INSTRUCTIONS
1. Add a native filter
2. Delete that filter and add a new one with the same scope
3. Verify that charts highlighting on filter focus works as expected

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @villebro 