### PR TITLE
feat(cross-filters): add option to clear set cross filters

### DIFF
--- a/superset-frontend/src/dashboard/components/FiltersBadge/FilterIndicator/index.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/FilterIndicator/index.tsx
@@ -21,6 +21,7 @@ import { SearchOutlined } from '@ant-design/icons';
 import React, { FC } from 'react';
 import { getFilterValueForDisplay } from 'src/dashboard/components/nativeFilters/FilterBar/FilterSets/utils';
 import {
+  FilterIndicatorText,
   FilterValue,
   Item,
   ItemIcon,
@@ -31,24 +32,29 @@ import { Indicator } from 'src/dashboard/components/FiltersBadge/selectors';
 export interface IndicatorProps {
   indicator: Indicator;
   onClick?: (path: string[]) => void;
+  text?: string;
 }
 
 const FilterIndicator: FC<IndicatorProps> = ({
   indicator: { column, name, value, path = [] },
   onClick = () => {},
+  text,
 }) => {
   const resultValue = getFilterValueForDisplay(value);
   return (
-    <Item onClick={() => onClick([...path, `LABEL-${column}`])}>
-      <Title bold>
-        <ItemIcon>
-          <SearchOutlined />
-        </ItemIcon>
-        {name}
-        {resultValue ? ': ' : ''}
-      </Title>
-      <FilterValue>{resultValue}</FilterValue>
-    </Item>
+    <>
+      <Item onClick={() => onClick([...path, `LABEL-${column}`])}>
+        <Title bold>
+          <ItemIcon>
+            <SearchOutlined />
+          </ItemIcon>
+          {name}
+          {resultValue ? ': ' : ''}
+        </Title>
+        <FilterValue>{resultValue}</FilterValue>
+      </Item>
+      {text && <FilterIndicatorText>{text}</FilterIndicatorText>}
+    </>
   );
 };
 

--- a/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
@@ -153,3 +153,12 @@ export const FilterValue = styled.div`
   overflow: auto;
   color: ${({ theme }) => theme.colors.grayscale.light5};
 `;
+
+export const FilterIndicatorText = styled.div`
+  padding-top: ${({ theme }) => theme.gridUnit * 3}px;
+  font-weight: ${({ theme }) => theme.typography.weights.bold};
+  max-width: 100%;
+  flex-grow: 1;
+  overflow: auto;
+  color: ${({ theme }) => theme.colors.grayscale.light5};
+`;

--- a/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
@@ -155,10 +155,11 @@ export const FilterValue = styled.div`
 `;
 
 export const FilterIndicatorText = styled.div`
-  padding-top: ${({ theme }) => theme.gridUnit * 3}px;
-  font-weight: ${({ theme }) => theme.typography.weights.bold};
+  ${({ theme }) => `
+  padding-top: ${theme.gridUnit * 3}px;
   max-width: 100%;
   flex-grow: 1;
   overflow: auto;
-  color: ${({ theme }) => theme.colors.grayscale.light5};
+  color: ${theme.colors.grayscale.light5};
+  `}
 `;

--- a/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
@@ -19,13 +19,14 @@
 import React, { FC } from 'react';
 import { styled, t } from '@superset-ui/core';
 import { Tooltip } from 'src/components/Tooltip';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import EditableTitle from 'src/components/EditableTitle';
 import SliceHeaderControls from 'src/dashboard/components/SliceHeaderControls';
 import FiltersBadge from 'src/dashboard/components/FiltersBadge';
 import Icon from 'src/components/Icon';
 import { RootState } from 'src/dashboard/types';
 import FilterIndicator from 'src/dashboard/components/FiltersBadge/FilterIndicator';
+import { clearDataMask } from 'src/dataMask/actions';
 
 type SliceHeaderProps = {
   innerRef?: string;
@@ -70,6 +71,7 @@ const annotationsError = t('One ore more annotation layers failed loading.');
 
 const CrossFilterIcon = styled(Icon)`
   fill: ${({ theme }) => theme.colors.grayscale.light5};
+  cursor: pointer;
   & circle {
     fill: ${({ theme }) => theme.colors.primary.base};
   }
@@ -105,6 +107,7 @@ const SliceHeader: FC<SliceHeaderProps> = ({
   chartStatus,
   formData,
 }) => {
+  const dispatch = useDispatch();
   // TODO: change to indicator field after it will be implemented
   const crossFilterValue = useSelector<RootState, any>(
     state => state.dataMask[slice?.slice_id]?.filterState?.value,
@@ -164,10 +167,14 @@ const SliceHeader: FC<SliceHeaderProps> = ({
                       value: crossFilterValue,
                       name: t('Emitted values'),
                     }}
+                    text={t('Click to clear emitted filter')}
                   />
                 }
               >
-                <CrossFilterIcon name="cross-filter-badge" />
+                <CrossFilterIcon
+                  name="cross-filter-badge"
+                  onClick={() => dispatch(clearDataMask(slice?.slice_id))}
+                />
               </Tooltip>
             )}
             <FiltersBadge chartId={slice.slice_id} />

--- a/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
@@ -75,6 +75,8 @@ const CrossFilterIcon = styled(Icon)`
   & circle {
     fill: ${({ theme }) => theme.colors.primary.base};
   }
+  height: 22px;
+  width: 22px;
 `;
 
 const SliceHeader: FC<SliceHeaderProps> = ({
@@ -167,7 +169,7 @@ const SliceHeader: FC<SliceHeaderProps> = ({
                       value: crossFilterValue,
                       name: t('Emitted values'),
                     }}
-                    text={t('Click to clear emitted filter')}
+                    text={t('Click to clear emitted filters')}
                   />
                 }
               >

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx
@@ -21,9 +21,8 @@ import { styled, t, useTheme } from '@superset-ui/core';
 import React, { FC } from 'react';
 import Icons from 'src/components/Icons';
 import Button from 'src/components/Button';
-import { updateDataMask } from 'src/dataMask/actions';
+import { clearDataMask } from 'src/dataMask/actions';
 import { useDispatch, useSelector } from 'react-redux';
-import { getInitialDataMask } from 'src/dataMask/reducer';
 import { DataMaskState, DataMaskStateWithId } from 'src/dataMask/types';
 import FilterConfigurationLink from 'src/dashboard/components/nativeFilters/FilterBar/FilterConfigurationLink';
 import { useFilters } from 'src/dashboard/components/nativeFilters/FilterBar/state';
@@ -93,16 +92,7 @@ const Header: FC<HeaderProps> = ({
     const filterIds = Object.keys(dataMaskSelected);
     filterIds.forEach(filterId => {
       if (dataMaskSelected[filterId]) {
-        dispatch(
-          updateDataMask(
-            filterId,
-            getInitialDataMask(filterId, {
-              filterState: {
-                value: null,
-              },
-            }),
-          ),
-        );
+        dispatch(clearDataMask(filterId));
       }
     });
   };

--- a/superset-frontend/src/dataMask/actions.ts
+++ b/superset-frontend/src/dataMask/actions.ts
@@ -20,6 +20,7 @@ import { DataMask } from '@superset-ui/core';
 import { FilterConfiguration } from '../dashboard/components/nativeFilters/types';
 import { FeatureFlag, isFeatureEnabled } from '../featureFlags';
 import { Filters } from '../dashboard/reducers/types';
+import { getInitialDataMask } from './reducer';
 
 export const UPDATE_DATA_MASK = 'UPDATE_DATA_MASK';
 export interface UpdateDataMask {
@@ -55,7 +56,7 @@ export function setDataMaskForFilterConfigComplete(
   };
 }
 export function updateDataMask(
-  filterId: string,
+  filterId: string | number,
   dataMask: DataMask,
 ): UpdateDataMask {
   // Only apply data mask if one of the relevant features is enabled
@@ -67,6 +68,17 @@ export function updateDataMask(
     filterId,
     dataMask: isFeatureFlagActive ? dataMask : {},
   };
+}
+
+export function clearDataMask(filterId: string | number) {
+  return updateDataMask(
+    filterId,
+    getInitialDataMask(filterId, {
+      filterState: {
+        value: null,
+      },
+    }),
+  );
 }
 
 export type AnyDataMaskAction =

--- a/superset-frontend/src/dataMask/actions.ts
+++ b/superset-frontend/src/dataMask/actions.ts
@@ -25,7 +25,7 @@ import { getInitialDataMask } from './reducer';
 export const UPDATE_DATA_MASK = 'UPDATE_DATA_MASK';
 export interface UpdateDataMask {
   type: typeof UPDATE_DATA_MASK;
-  filterId: string;
+  filterId: string | number;
   dataMask: DataMask;
 }
 

--- a/superset-frontend/src/dataMask/reducer.ts
+++ b/superset-frontend/src/dataMask/reducer.ts
@@ -37,9 +37,12 @@ import {
 import { areObjectsEqual } from '../reduxUtils';
 import { Filters } from '../dashboard/reducers/types';
 
-export function getInitialDataMask(id?: string, moreProps?: DataMask): DataMask;
 export function getInitialDataMask(
-  id: string,
+  id?: string | number,
+  moreProps?: DataMask,
+): DataMask;
+export function getInitialDataMask(
+  id: string | number,
   moreProps: DataMask = {},
 ): DataMaskWithId {
   let otherProps = {};


### PR DESCRIPTION
### SUMMARY
This adds the option to clear emitted cross filters by adding an `onClick` to the cross filter indicator. Also fixes 

### AFTER
![image](https://user-images.githubusercontent.com/33317356/124231477-fd483d00-db18-11eb-9621-7692c9514b2d.png)

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/124232663-a0e61d00-db1a-11eb-8bdf-b83f5247f73f.png)

### TESTING INSTRUCTIONS
1. Enable the `DASHBOARD_CROSS_FILTERS` feature flag
2. create a chart that supports cross filters and check the "emit cross filters" control
3. add the chart to a dashboard
4. emit a cross filter
5. Hover on the cross filter indicator, see the updated tooltip and click on the indicator to clear emitted filters

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
