### PR TITLE
feat: supporting jinja templating in saved metrics 

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -404,9 +404,12 @@ class SqlMetric(Model, BaseMetric):
     )
     export_parent = "table"
 
+    def get_template_processor(self, **kwargs: Any) -> BaseTemplateProcessor:
+        return get_template_processor(table=self.table, database=self.table.database, **kwargs)
+
     def get_sqla_col(self, label: Optional[str] = None) -> Column:
         label = label or self.metric_name
-        sqla_col: ColumnClause = literal_column(self.expression)
+        sqla_col: ColumnClause = literal_column(self.get_template_processor().process_template(self.expression))
         return self.table.make_sqla_column_compatible(sqla_col, label)
 
     @property

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -405,11 +405,13 @@ class SqlMetric(Model, BaseMetric):
     export_parent = "table"
 
     def get_template_processor(self, **kwargs: Any) -> BaseTemplateProcessor:
-        return get_template_processor(table=self.table, database=self.table.database, **kwargs)
+        return self.table.get_template_processor()
 
     def get_sqla_col(self, label: Optional[str] = None) -> Column:
         label = label or self.metric_name
-        sqla_col: ColumnClause = literal_column(self.get_template_processor().process_template(self.expression))
+        sqla_col: ColumnClause = literal_column(
+            self.get_template_processor().process_template(self.expression)
+        )
         return self.table.make_sqla_column_compatible(sqla_col, label)
 
     @property

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -407,9 +407,7 @@ class SqlMetric(Model, BaseMetric):
     def get_sqla_col(self, label: Optional[str] = None) -> Column:
         label = label or self.metric_name
         tp = self.table.get_template_processor()
-        sqla_col: ColumnClause = literal_column(
-            tp.process_template(self.expression)
-        )
+        sqla_col: ColumnClause = literal_column(tp.process_template(self.expression))
         return self.table.make_sqla_column_compatible(sqla_col, label)
 
     @property

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -404,13 +404,11 @@ class SqlMetric(Model, BaseMetric):
     )
     export_parent = "table"
 
-    def get_template_processor(self, **kwargs: Any) -> BaseTemplateProcessor:
-        return self.table.get_template_processor()
-
     def get_sqla_col(self, label: Optional[str] = None) -> Column:
         label = label or self.metric_name
+        tp = self.table.get_template_processor()
         sqla_col: ColumnClause = literal_column(
-            self.get_template_processor().process_template(self.expression)
+            tp.process_template(self.expression)
         )
         return self.table.make_sqla_column_compatible(sqla_col, label)
 


### PR DESCRIPTION
### SUMMARY
Adding the ability to use jinja templating also in saved metrics. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/93029/124124529-346b0f80-da81-11eb-9290-2b3d0c3dcf2a.png)


### TESTING INSTRUCTIONS
1. A saved metric that uses a jinja expression
2. Go to Chart and use that saved metric
3. Look in the view query, and make sure the jinja expression was evaluated correctly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

- [X] Has associated issue:
   - Fixes: #6983
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
