### PR TITLE
style/tooltip

### DIFF
--- a/superset-frontend/src/SqlLab/components/TableElement.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.tsx
@@ -192,23 +192,34 @@ const TableElement = ({ table, actions, ...props }: TableElementProps) => {
     );
   };
 
-  const renderHeader = () => (
+  // Rationale for 30 characters
+  // Avg number of characters (since width dependent) triggering truncation
+  const renderTableName = () => {
+    if (table.name.length > 30) {
+      return (
+        <Tooltip
+          id="copy-to-clipboard-tooltip"
+          placement="topLeft"
+          style={{ cursor: 'pointer' }}
+          title={table.name}
+          trigger={['hover']}
+        >
+          <strong>{table.name}</strong>
+        </Tooltip>
+      );
+    }
+    return <strong>{table.name}</strong>;
+  };
+
+  const renderHeader = () => {
     <div
       className="clearfix header-container"
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
     >
-      <Tooltip
-        id="copy-to-clipboard-tooltip"
-        placement="topLeft"
-        style={{ cursor: 'pointer' }}
-        title={table.name}
-        trigger={['hover']}
-      >
-        <StyledSpan data-test="collapse" className="table-name">
-          <strong>{table.name}</strong>
-        </StyledSpan>
-      </Tooltip>
+      <StyledSpan data-test="collapse" className="table-name">
+        {renderTableName()}
+      </StyledSpan>
 
       <div className="pull-right header-right-side">
         {table.isMetadataLoading || table.isExtraMetadataLoading ? (
@@ -223,8 +234,8 @@ const TableElement = ({ table, actions, ...props }: TableElementProps) => {
           </Fade>
         )}
       </div>
-    </div>
-  );
+    </div>;
+  };
 
   const renderBody = () => {
     let cols;


### PR DESCRIPTION
### SUMMARY
Only hovering over table name, and when table name is truncated - the tooltip is triggered. Rationale for choosing 30 character limit for table name is that it was the average number of characters (since it is width dependent) to trigger truncation.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE
<img width="492" alt="Screenshot 2021-07-01 at 11 41 21" src="https://user-images.githubusercontent.com/17345270/124152210-5359a980-da61-11eb-9c79-48bce19069a2.png">

AFTER
<img width="858" alt="Screenshot 2021-07-01 at 11 40 12" src="https://user-images.githubusercontent.com/17345270/124152084-34f3ae00-da61-11eb-93ec-6206a49ccfe4.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
