### PR TITLE
fix: Allow for updates on Step 3

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm.tsx
@@ -173,6 +173,7 @@ const CredentialsInfo = ({
               if (event.target.files) {
                 file = event.target.files[0];
               }
+
               setFileToUpload(file?.name);
               changeMethods.onParametersChange({
                 target: {

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -270,10 +270,13 @@ function dbReducer(
         ).toString();
       }
 
-      if (action.payload.backend === 'bigquery') {
+      if (
+        action.payload.backend === 'bigquery' &&
+        action.payload.configuration_method ===
+          CONFIGURATION_METHOD.SQLALCHEMY_URI
+      ) {
         return {
           ...action.payload,
-          encrypted_extra: '',
           engine: action.payload.backend,
           configuration_method: action.payload.configuration_method,
           extra_json: deserializeExtraJSON,

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -180,7 +180,6 @@ function dbReducer(
     ...(state || {}),
   };
   let query = '';
-
   switch (action.type) {
     case ActionType.extraEditorChange:
       return {
@@ -648,7 +647,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
           <StyledFooterButton
             key="submit"
             buttonStyle="primary"
-            onClick={onClose}
+            onClick={onSave}
             data-test="modal-confirm-button"
           >
             Finish

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -273,7 +273,7 @@ function dbReducer(
       if (
         action.payload.backend === 'bigquery' &&
         action.payload.configuration_method ===
-          CONFIGURATION_METHOD.SQLALCHEMY_URI
+          CONFIGURATION_METHOD.DYNAMIC_FORM
       ) {
         return {
           ...action.payload,
@@ -432,9 +432,27 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       const engine = dbToUpdate.backend || dbToUpdate.engine;
       if (engine === 'bigquery' && dbToUpdate.parameters?.credentials_info) {
         // wrap encrypted_extra in credentials_info only for BigQuery
-        dbToUpdate.encrypted_extra = JSON.stringify({
-          credentials_info: JSON.parse(dbToUpdate.parameters?.credentials_info),
-        });
+        if (
+          dbToUpdate.parameters?.credentials_info &&
+          typeof dbToUpdate.parameters?.credentials_info === 'object' &&
+          dbToUpdate.parameters?.credentials_info.constructor === Object
+        ) {
+          // Don't cast if object
+          dbToUpdate.encrypted_extra = JSON.stringify({
+            credentials_info: dbToUpdate.parameters?.credentials_info,
+          });
+
+          // Convert credentials info string before updating
+          dbToUpdate.parameters.credentials_info = JSON.stringify(
+            dbToUpdate.parameters.credentials_info,
+          );
+        } else {
+          dbToUpdate.encrypted_extra = JSON.stringify({
+            credentials_info: JSON.parse(
+              dbToUpdate.parameters?.credentials_info,
+            ),
+          });
+        }
       }
     }
 

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -246,6 +246,11 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
             new_model = CreateDatabaseCommand(g.user, item).run()
             # Return censored version for sqlalchemy URI
             item["sqlalchemy_uri"] = new_model.sqlalchemy_uri
+
+            # If parameters are available return them in the payload
+            if new_model.parameters:
+                item["parameters"] = new_model.parameters
+
             return self.response(201, id=new_model.id, result=item)
         except DatabaseInvalidError as ex:
             return self.response_422(message=ex.normalized_messages())


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Once creating a DB via dynamic form, we wouldn't allow for updating after finish. Update the Finish command to do an update once the user is done editing.

Also fixed the edit issue with bigquery engines on sqla forms, user's can now see secure extra fields

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Create a DB
2. Add values to step 3
3. Click Finish
4. Make sure the value stay

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
