### PR TITLE
fix: Utilizing dashboard native filter feature flag

### DIFF
--- a/superset-frontend/src/dashboard/actions/hydrate.js
+++ b/superset-frontend/src/dashboard/actions/hydrate.js
@@ -288,7 +288,8 @@ export const hydrateDashboard = (dashboardData, chartData, datasourcesData) => (
   }
 
   metadata.show_native_filters =
-    dashboardData?.metadata?.show_native_filters ?? true;
+    dashboardData?.metadata?.show_native_filters ??
+    isFeatureEnabled(FeatureFlag.DASHBOARD_NATIVE_FILTERS);
 
   if (isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS)) {
     // If user just added cross filter to dashboard it's not saving it scope on server,


### PR DESCRIPTION
### SUMMARY

Historically we've seen records in our database where the Dashboard JSON metadata had `"show_native_filters": true` even though we never enabled the `DASHBOARD_NATIVE_FILTERS` feature. This was problematic as both native and legacy filters were then present resulting in incorrect behavior when filters were cleared.

It seemed prudent that the default adheres to the feature flag setting rather than being set to `true`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
