### PR TITLE
WIP fix: evaluate thumbnail listeners at request time

### DIFF
--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -269,8 +269,10 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
         return {}
 
     def update_thumbnail(self) -> None:
-        url = get_url_path("Superset.dashboard", dashboard_id_or_slug=self.id)
-        cache_dashboard_thumbnail.delay(url, self.digest, force=True)
+        # Feature is evaluated an request time
+        if is_feature_enabled("THUMBNAILS_SQLA_LISTENERS"):
+            url = get_url_path("Superset.dashboard", dashboard_id_or_slug=self.id)
+            cache_dashboard_thumbnail.delay(url, self.digest, force=True)
 
     @debounce(0.1)
     def clear_cache(self) -> None:


### PR DESCRIPTION
### SUMMARY

Makes `THUMBNAILS_SQLA_LISTENERS` be evaluated at boot time (adds listener) but makes it dynamic enough that it get's evaluated at run time also (for the possibility of having dynamic feature flags)

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
