### PR TITLE
fix: chartlist card-link to 404

### DIFF
--- a/superset-frontend/src/components/ListViewCard/index.tsx
+++ b/superset-frontend/src/components/ListViewCard/index.tsx
@@ -137,7 +137,7 @@ interface LinkProps {
 }
 
 const AnchorLink: React.FC<LinkProps> = ({ to, children }) => (
-  <a href={to}>{children}</a>
+  <a {...(to ? { href: to } : {})}>{children}</a>
 );
 
 interface CardProps {

--- a/superset-frontend/src/views/CRUD/chart/ChartCard.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartCard.tsx
@@ -134,7 +134,7 @@ export default function ChartCard({
   return (
     <CardStyles
       onClick={() => {
-        if (!bulkSelectEnabled) {
+        if (!bulkSelectEnabled && chart.url) {
           window.location.href = chart.url;
         }
       }}


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* bugfix: https://github.com/apache/superset/issues/15239.
* make sure to do not go to `/chart/list/undefined`

### BEFORE ANIMATED GIF
<!--- Skip this if not applicable -->
![404](https://user-images.githubusercontent.com/10264972/124288477-ce1ae580-db83-11eb-8de4-59d90e4a29e8.gif)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
* Go to the chart list view in card mode. eg: `/chart/list/?pageIndex=0&sortColumn=changed_on_delta_humanized&sortOrder=desc&viewMode=card`
* Refresh the page
* While the results are not yet loaded, click on a card
* before bugfix: See 404 page. after bugfix: no link to 404 page

