### PR TITLE
refactor: icon to icons for nativeFilter components

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CascadeFilters/CascadePopover/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CascadeFilters/CascadePopover/index.tsx
@@ -19,6 +19,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { styled, t, DataMask } from '@superset-ui/core';
 import Popover from 'src/components/Popover';
+import Icons from 'src/components/Icons';
 import Icon from 'src/components/Icon';
 import { Pill } from 'src/dashboard/components/FiltersBadge/Styles';
 import { DataMaskStateWithId } from 'src/dataMask/types';
@@ -61,7 +62,13 @@ const StyledTitle = styled.h4`
   padding: 0;
 `;
 
-const StyledIcon = styled(Icon)`
+const StyledEditIcon = styled(Icons.Edit)`
+  margin-right: ${({ theme }) => theme.gridUnit}px;
+  color: ${({ theme }) => theme.colors.grayscale.dark1};
+  width: ${({ theme }) => theme.gridUnit * 4}px;
+`;
+
+const StyledCloseIcon = styled(Icons.Close)`
   margin-right: ${({ theme }) => theme.gridUnit}px;
   color: ${({ theme }) => theme.colors.grayscale.dark1};
   width: ${({ theme }) => theme.gridUnit * 4}px;
@@ -163,10 +170,10 @@ const CascadePopover: React.FC<CascadePopoverProps> = ({
   const title = (
     <StyledTitleBox>
       <StyledTitle>
-        <StyledIcon name="edit" />
+        <StyledEditIcon iconSize="m" />
         {t('Select parent filters')} ({allFilters.length})
       </StyledTitle>
-      <StyledIcon name="close" onClick={() => onVisibleChange(false)} />
+      <StyledCloseIcon iconSize="l" onClick={() => onVisibleChange(false)} />
     </StyledTitleBox>
   );
 
@@ -207,7 +214,7 @@ const CascadePopover: React.FC<CascadePopoverProps> = ({
               <>
                 {filter.cascadeChildren.length !== 0 && (
                   <StyledPill onClick={() => onVisibleChange(true)}>
-                    <Icon name="filter" /> {allFilters.length}
+                    <Icons.Filter iconSize="m" /> {allFilters.length}
                   </StyledPill>
                 )}
               </>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CascadeFilters/CascadePopover/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CascadeFilters/CascadePopover/index.tsx
@@ -20,7 +20,6 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { styled, t, DataMask } from '@superset-ui/core';
 import Popover from 'src/components/Popover';
 import Icons from 'src/components/Icons';
-import Icon from 'src/components/Icon';
 import { Pill } from 'src/dashboard/components/FiltersBadge/Styles';
 import { DataMaskStateWithId } from 'src/dataMask/types';
 import FilterControl from 'src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl';
@@ -170,7 +169,7 @@ const CascadePopover: React.FC<CascadePopoverProps> = ({
   const title = (
     <StyledTitleBox>
       <StyledTitle>
-        <StyledEditIcon iconSize="m" />
+        <StyledEditIcon iconSize="l" />
         {t('Select parent filters')} ({allFilters.length})
       </StyledTitle>
       <StyledCloseIcon iconSize="l" onClick={() => onVisibleChange(false)} />

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CascadeFilters/CascadePopover/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CascadeFilters/CascadePopover/index.tsx
@@ -62,10 +62,12 @@ const StyledTitle = styled.h4`
 `;
 
 const StyledEditIcon = styled(Icons.Edit)`
-  margin-right: ${({ theme }) => theme.gridUnit}px;
-  color: ${({ theme }) => theme.colors.grayscale.dark1};
-  width: ${({ theme }) => theme.gridUnit * 4}px;
-`;
+  ${({ theme }) => `
+  margin-right: ${theme.gridUnit}px; 
+  color: ${theme.colors.grayscale.dark1};
+  width: ${theme.gridUnit * 4}px;
+  `}
+  `;
 
 const StyledCloseIcon = styled(Icons.Close)`
   margin-right: ${({ theme }) => theme.gridUnit}px;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CascadeFilters/CascadePopover/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CascadeFilters/CascadePopover/index.tsx
@@ -62,7 +62,7 @@ const StyledTitle = styled.h4`
 `;
 
 const IconStyles = (theme: SupersetTheme) => css`
-  margin-right: ${theme.gridUnit}px; 
+  margin-right: ${theme.gridUnit}px;
   color: ${theme.colors.grayscale.dark1};
   width: ${theme.gridUnit * 4}px;
 `;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CascadeFilters/CascadePopover/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CascadeFilters/CascadePopover/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { styled, t, DataMask } from '@superset-ui/core';
+import { styled, t, DataMask, css, SupersetTheme } from '@superset-ui/core';
 import Popover from 'src/components/Popover';
 import Icons from 'src/components/Icons';
 import { Pill } from 'src/dashboard/components/FiltersBadge/Styles';
@@ -61,18 +61,10 @@ const StyledTitle = styled.h4`
   padding: 0;
 `;
 
-const StyledEditIcon = styled(Icons.Edit)`
-  ${({ theme }) => `
+const IconStyles = (theme: SupersetTheme) => css`
   margin-right: ${theme.gridUnit}px; 
   color: ${theme.colors.grayscale.dark1};
   width: ${theme.gridUnit * 4}px;
-  `}
-  `;
-
-const StyledCloseIcon = styled(Icons.Close)`
-  margin-right: ${({ theme }) => theme.gridUnit}px;
-  color: ${({ theme }) => theme.colors.grayscale.dark1};
-  width: ${({ theme }) => theme.gridUnit * 4}px;
 `;
 
 const StyledPill = styled(Pill)`
@@ -171,10 +163,17 @@ const CascadePopover: React.FC<CascadePopoverProps> = ({
   const title = (
     <StyledTitleBox>
       <StyledTitle>
-        <StyledEditIcon iconSize="l" />
+        <Icons.Edit
+          iconSize="l"
+          css={(theme: SupersetTheme) => IconStyles(theme)}
+        />
         {t('Select parent filters')} ({allFilters.length})
       </StyledTitle>
-      <StyledCloseIcon iconSize="l" onClick={() => onVisibleChange(false)} />
+      <Icons.Close
+        iconSize="l"
+        css={(theme: SupersetTheme) => IconStyles(theme)}
+        onClick={() => onVisibleChange(false)}
+      />
     </StyledTitleBox>
   );
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTabs.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTabs.tsx
@@ -20,7 +20,7 @@ import { PlusOutlined } from '@ant-design/icons';
 import { styled, t } from '@superset-ui/core';
 import React, { FC } from 'react';
 import { LineEditableTabs } from 'src/components/Tabs';
-import Icon from 'src/components/Icon';
+import Icons from 'src/components/Icons';
 import { FilterRemoval } from './types';
 import { REMOVAL_DELAY_SECS } from './utils';
 
@@ -51,7 +51,7 @@ export const StyledAddFilterBox = styled.div`
   }
 `;
 
-export const StyledTrashIcon = styled(Icon)`
+export const StyledTrashIcon = styled(Icons.Trash)`
   color: ${({ theme }) => theme.colors.grayscale.light3};
 `;
 
@@ -124,14 +124,13 @@ const FilterTabsContainer = styled(LineEditableTabs)`
       margin: 0 ${theme.gridUnit * 2}px 0 0;
       padding: ${theme.gridUnit}px
         ${theme.gridUnit * 2}px;
-
       &:hover,
       &-active {
         color: ${theme.colors.grayscale.dark1};
         border-radius: ${theme.borderRadius}px;
         background-color: ${theme.colors.secondary.light4};
 
-        .ant-tabs-tab-remove > svg {
+        .ant-tabs-tab-remove > span {
           color: ${theme.colors.grayscale.base};
           transition: all 0.3s;
         }
@@ -238,9 +237,7 @@ const FilterTabs: FC<FilterTabsProps> = ({
           </FilterTabTitle>
         }
         key={id}
-        closeIcon={
-          removedFilters[id] ? <></> : <StyledTrashIcon name="trash" />
-        }
+        closeIcon={removedFilters[id] ? <></> : <StyledTrashIcon />}
       >
         {
           // @ts-ignore


### PR DESCRIPTION
### SUMMARY
This pr migrates the icons for native filters to the new icons component. The delete icon in the filter config modal and the icons in the cross filter componets.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="559" alt="Screen Shot 2021-07-02 at 7 56 30 AM" src="https://user-images.githubusercontent.com/17326228/124292974-0500e500-db0b-11eb-9573-6c3d6153705d.png">


### TESTING INSTRUCTIONS
Test in the filterconfig modal and the crossfilter propover

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
