### PR TITLE
refactor: migrate to icons for searchinput icons

### DIFF
--- a/superset-frontend/src/components/SearchInput/SearchInput.test.jsx
+++ b/superset-frontend/src/components/SearchInput/SearchInput.test.jsx
@@ -17,7 +17,8 @@
  * under the License.
  */
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
+import { ThemeProvider, supersetTheme } from '@superset-ui/core';
 
 import SearchInput from 'src/components/SearchInput';
 
@@ -31,7 +32,11 @@ describe('SearchInput', () => {
 
   const factory = overrideProps => {
     const props = { ...defaultProps, ...(overrideProps || {}) };
-    return shallow(<SearchInput {...props} />);
+    return mount(
+      <ThemeProvider theme={supersetTheme}>
+        <SearchInput {...props} />
+      </ThemeProvider>,
+    );
   };
 
   let wrapper;
@@ -53,6 +58,7 @@ describe('SearchInput', () => {
   const typeSearchInput = value => {
     wrapper
       .find('[data-test="search-input"]')
+      .first()
       .props()
       .onChange({ currentTarget: { value } });
   };
@@ -62,6 +68,7 @@ describe('SearchInput', () => {
 
     wrapper
       .find('[data-test="search-input"]')
+      .first()
       .props()
       .onKeyDown({ key: 'Enter' });
 
@@ -72,14 +79,14 @@ describe('SearchInput', () => {
   it('submits on search icon click', () => {
     typeSearchInput('bar');
 
-    wrapper.find('[data-test="search-submit"]').props().onClick();
+    wrapper.find('[data-test="search-submit"]').first().props().onClick();
 
     expect(defaultProps.onSubmit).toHaveBeenCalled();
   });
 
   it('clears on clear icon click', () => {
     const wrapper2 = factory({ value: 'fizz' });
-    wrapper2.find('[data-test="search-clear"]').props().onClick();
+    wrapper2.find('[data-test="search-clear"]').first().props().onClick();
 
     expect(defaultProps.onClear).toHaveBeenCalled();
   });

--- a/superset-frontend/src/components/SearchInput/index.tsx
+++ b/superset-frontend/src/components/SearchInput/index.tsx
@@ -65,7 +65,6 @@ const ClearIcon = styled(Icons.CancelX)`
   top: 4px;
 `;
 
-
 export default function SearchInput({
   onChange,
   onClear,

--- a/superset-frontend/src/components/SearchInput/index.tsx
+++ b/superset-frontend/src/components/SearchInput/index.tsx
@@ -16,9 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { styled } from '@superset-ui/core';
+import { styled, useTheme } from '@superset-ui/core';
 import React from 'react';
-import Icon from 'src/components/Icon';
+import Icons from 'src/components/Icons';
 
 export interface SearchInputProps {
   onSubmit: () => void;
@@ -53,17 +53,18 @@ const commonStyles = `
   display: block;
   cursor: pointer;
 `;
-const SearchIcon = styled(Icon)`
+const SearchIcon = styled(Icons.Search)`
   ${commonStyles};
   top: 4px;
   left: 2px;
 `;
 
-const ClearIcon = styled(Icon)`
+const ClearIcon = styled(Icons.CancelX)`
   ${commonStyles};
   right: 0px;
   top: 4px;
 `;
+
 
 export default function SearchInput({
   onChange,
@@ -73,12 +74,13 @@ export default function SearchInput({
   name,
   value,
 }: SearchInputProps) {
+  const theme = useTheme();
   return (
     <SearchInputWrapper>
       <SearchIcon
+        iconColor={theme.colors.grayscale.base}
         data-test="search-submit"
         role="button"
-        name="search"
         onClick={() => onSubmit()}
       />
       <StyledInput
@@ -98,7 +100,7 @@ export default function SearchInput({
         <ClearIcon
           data-test="search-clear"
           role="button"
-          name="cancel-x"
+          iconColor={theme.colors.grayscale.base}
           onClick={() => onClear()}
         />
       )}


### PR DESCRIPTION
### SUMMARY
This pr migrates the old icon to icons for the search and cancel x component in the listview.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before 
<img width="282" alt="Screen Shot 2021-07-02 at 10 48 29 AM" src="https://user-images.githubusercontent.com/17326228/124312562-5bc6e880-db24-11eb-9a72-c35fd7dc0cc4.png">

after
<img width="292" alt="Q dkfjla" src="https://user-images.githubusercontent.com/17326228/124312578-5e294280-db24-11eb-983c-0abd7b33e81f.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
