### PR TITLE
fix: show all DBs in available endpoint

### DIFF
--- a/superset/db_engine_specs/drill.py
+++ b/superset/db_engine_specs/drill.py
@@ -29,6 +29,7 @@ class DrillEngineSpec(BaseEngineSpec):
 
     engine = "drill"
     engine_name = "Apache Drill"
+    default_driver = "sadrill"
 
     _time_grain_expressions = {
         None: "{col}",

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -545,3 +545,8 @@ class HiveEngineSpec(PrestoEngineSpec):
             or parsed_query.is_set()
             or parsed_query.is_show()
         )
+
+
+class SparkEngineSpec(HiveEngineSpec):
+
+    engine_name = "Apache Spark SQL"

--- a/superset/db_engine_specs/mssql.py
+++ b/superset/db_engine_specs/mssql.py
@@ -44,7 +44,7 @@ CONNECTION_HOST_DOWN_REGEX = re.compile(
 
 class MssqlEngineSpec(BaseEngineSpec):
     engine = "mssql"
-    engine_name = "Microsoft SQL"
+    engine_name = "Microsoft SQL Server"
     limit_method = LimitMethod.WRAP_SQL
     max_column_name_length = 128
 
@@ -126,3 +126,9 @@ class MssqlEngineSpec(BaseEngineSpec):
                 "have an alias on MSSQL. For example: SELECT COUNT(*) AS C1 FROM TABLE1"
             )
         return f"{cls.engine} error: {cls._extract_error_message(ex)}"
+
+
+class AzureSynapseSpec(MssqlEngineSpec):
+    engine = "mssql"
+    engine_name = "Azure Synapse"
+    default_driver = "pyodbc"

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -986,7 +986,7 @@ class TestDatabaseApi(SupersetTestCase):
         expected_response = {
             "errors": [
                 {
-                    "message": "Could not load database driver: MssqlEngineSpec",
+                    "message": "Could not load database driver: AzureSynapseSpec",
                     "error_type": "GENERIC_COMMAND_ERROR",
                     "level": "warning",
                     "extra": {

--- a/tests/integration_tests/db_engine_specs/mssql_tests.py
+++ b/tests/integration_tests/db_engine_specs/mssql_tests.py
@@ -169,7 +169,7 @@ Unable to connect: Adaptive Server is unavailable or does not exist (locahost)
                 message='The hostname "locahost" cannot be resolved.',
                 level=ErrorLevel.ERROR,
                 extra={
-                    "engine_name": "Microsoft SQL",
+                    "engine_name": "Microsoft SQL Server",
                     "issue_codes": [
                         {
                             "code": 1007,
@@ -199,7 +199,7 @@ Net-Lib error during Connection refused (61)
                 message='Port 12345 on hostname "localhost" refused the connection.',
                 level=ErrorLevel.ERROR,
                 extra={
-                    "engine_name": "Microsoft SQL",
+                    "engine_name": "Microsoft SQL Server",
                     "issue_codes": [
                         {"code": 1008, "message": "Issue 1008 - The port is closed."}
                     ],
@@ -229,7 +229,7 @@ Net-Lib error during Operation timed out (60)
                 ),
                 level=ErrorLevel.ERROR,
                 extra={
-                    "engine_name": "Microsoft SQL",
+                    "engine_name": "Microsoft SQL Server",
                     "issue_codes": [
                         {
                             "code": 1009,
@@ -262,7 +262,7 @@ Net-Lib error during Operation timed out (60)
                 ),
                 level=ErrorLevel.ERROR,
                 extra={
-                    "engine_name": "Microsoft SQL",
+                    "engine_name": "Microsoft SQL Server",
                     "issue_codes": [
                         {
                             "code": 1009,
@@ -292,7 +292,7 @@ Adaptive Server connection failed (mssqldb.cxiotftzsypc.us-west-2.rds.amazonaws.
                 error_type=SupersetErrorType.CONNECTION_ACCESS_DENIED_ERROR,
                 level=ErrorLevel.ERROR,
                 extra={
-                    "engine_name": "Microsoft SQL",
+                    "engine_name": "Microsoft SQL Server",
                     "issue_codes": [
                         {
                             "code": 1014,


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Some DBs were not showing up in the `/available/` endpoint.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

After:

```json
{
  "databases": [
    {
      "available_drivers": [
        "psycopg2"
      ],
      "default_driver": "psycopg2",
      "engine": "postgresql",
      "name": "PostgreSQL",
      "parameters": {
        "properties": {
          "database": {
            "description": "Database name",
            "type": "string"
          },
          "encryption": {
            "description": "Use an encrypted connection to the database",
            "type": "boolean"
          },
          "host": {
            "description": "Hostname or IP address",
            "type": "string"
          },
          "password": {
            "description": "Password",
            "nullable": true,
            "type": "string"
          },
          "port": {
            "description": "Database port",
            "format": "int32",
            "maximum": 65536,
            "minimum": 0,
            "type": "integer"
          },
          "query": {
            "additionalProperties": {},
            "description": "Additional parameters",
            "type": "object"
          },
          "username": {
            "description": "Username",
            "nullable": true,
            "type": "string"
          }
        },
        "required": [
          "database",
          "host",
          "port",
          "username"
        ],
        "type": "object"
      },
      "preferred": true,
      "sqlalchemy_uri_placeholder": "postgresql://user:password@host:port/dbname[?key=value&key=value...]"
    },
    {
      "available_drivers": [],
      "engine": "",
      "name": "PostgreSQL",
      "preferred": true
    },
    {
      "available_drivers": [
        "rest"
      ],
      "engine": "presto",
      "name": "Presto",
      "preferred": true
    },
    {
      "available_drivers": [],
      "engine": "awsathena",
      "name": "Amazon Athena",
      "preferred": false
    },
    {
      "available_drivers": [],
      "default_driver": "psycopg2",
      "engine": "redshift",
      "name": "Amazon Redshift",
      "preferred": false
    },
    {
      "available_drivers": [],
      "default_driver": "sadrill",
      "engine": "drill",
      "name": "Apache Drill",
      "preferred": false
    },
    {
      "available_drivers": [
        "rest"
      ],
      "engine": "druid",
      "name": "Apache Druid",
      "preferred": false
    },
    {
      "available_drivers": [
        "thrift"
      ],
      "engine": "hive",
      "name": "Apache Hive",
      "preferred": false
    },
    {
      "available_drivers": [],
      "engine": "impala",
      "name": "Apache Impala",
      "preferred": false
    },
    {
      "available_drivers": [],
      "engine": "kylin",
      "name": "Apache Kylin",
      "preferred": false
    },
    {
      "available_drivers": [],
      "engine": "pinot",
      "name": "Apache Pinot",
      "preferred": false
    },
    {
      "available_drivers": [],
      "engine": "solr",
      "name": "Apache Solr",
      "preferred": false
    },
    {
      "available_drivers": [
        "thrift"
      ],
      "engine": "hive",
      "name": "Apache Spark SQL",
      "preferred": false
    },
    {
      "available_drivers": [],
      "engine": "ascend",
      "name": "Ascend",
      "preferred": false
    },
    {
      "available_drivers": [
        "pymssql",
        "pyodbc",
        "turbodbc"
      ],
      "default_driver": "pyodbc",
      "engine": "mssql",
      "name": "Azure Synapse",
      "preferred": false
    },
    {
      "available_drivers": [],
      "engine": "clickhouse",
      "name": "ClickHouse",
      "preferred": false
    },
    {
      "available_drivers": [],
      "default_driver": "",
      "engine": "cockroachdb",
      "name": "CockroachDB",
      "preferred": false
    },
    {
      "available_drivers": [],
      "engine": "crate",
      "name": "CrateDB",
      "preferred": false
    },
    {
      "available_drivers": [
        "pyhive",
        "pyodbc"
      ],
      "engine": "databricks",
      "name": "Databricks Hive",
      "preferred": false
    },
    {
      "available_drivers": [],
      "engine": "dremio",
      "name": "Dremio",
      "preferred": false
    },
    {
      "available_drivers": [],
      "engine": "odelasticsearch",
      "name": "ElasticSearch (OpenDistro SQL)",
      "preferred": false
    },
    {
      "available_drivers": [],
      "engine": "elasticsearch",
      "name": "ElasticSearch (SQL API)",
      "preferred": false
    },
    {
      "available_drivers": [],
      "engine": "exa",
      "name": "Exasol",
      "preferred": false
    },
    {
      "available_drivers": [],
      "engine": "firebird",
      "name": "Firebird",
      "preferred": false
    },
    {
      "available_drivers": [
        "bigquery"
      ],
      "default_driver": "bigquery",
      "engine": "bigquery",
      "name": "Google BigQuery",
      "parameters": {
        "properties": {
          "credentials_info": {
            "description": "Contents of BigQuery JSON credentials.",
            "type": "string",
            "x-encrypted-extra": true
          },
          "query": {
            "type": "object"
          }
        },
        "type": "object"
      },
      "preferred": false,
      "sqlalchemy_uri_placeholder": "bigquery://{project_id}"
    },
    {
      "available_drivers": [
        "apsw"
      ],
      "engine": "gsheets",
      "name": "Google Sheets",
      "preferred": false
    },
    {
      "available_drivers": [],
      "engine": "db2",
      "name": "IBM Db2",
      "preferred": false
    },
    {
      "available_drivers": [],
      "default_driver": "nzpy",
      "engine": "netezza",
      "name": "IBM Netezza Performance Server",
      "preferred": false
    },
    {
      "available_drivers": [
        "pymssql",
        "pyodbc",
        "turbodbc"
      ],
      "engine": "mssql",
      "name": "Microsoft SQL Server",
      "preferred": false
    },
    {
      "available_drivers": [
        "mysqlconnector",
        "mysqldb",
        "pyodbc"
      ],
      "default_driver": "mysqldb",
      "engine": "mysql",
      "name": "MySQL",
      "parameters": {
        "properties": {
          "database": {
            "description": "Database name",
            "type": "string"
          },
          "encryption": {
            "description": "Use an encrypted connection to the database",
            "type": "boolean"
          },
          "host": {
            "description": "Hostname or IP address",
            "type": "string"
          },
          "password": {
            "description": "Password",
            "nullable": true,
            "type": "string"
          },
          "port": {
            "description": "Database port",
            "format": "int32",
            "maximum": 65536,
            "minimum": 0,
            "type": "integer"
          },
          "query": {
            "additionalProperties": {},
            "description": "Additional parameters",
            "type": "object"
          },
          "username": {
            "description": "Username",
            "nullable": true,
            "type": "string"
          }
        },
        "required": [
          "database",
          "host",
          "port",
          "username"
        ],
        "type": "object"
      },
      "preferred": false,
      "sqlalchemy_uri_placeholder": "mysql://user:password@host:port/dbname[?key=value&key=value...]"
    },
    {
      "available_drivers": [],
      "engine": "oracle",
      "name": "Oracle",
      "preferred": false
    },
    {
      "available_drivers": [],
      "engine": "hana",
      "name": "SAP HANA",
      "preferred": false
    },
    {
      "available_drivers": [
        "pysqlite"
      ],
      "engine": "sqlite",
      "name": "SQLite",
      "preferred": false
    },
    {
      "available_drivers": [],
      "engine": "snowflake",
      "name": "Snowflake",
      "preferred": false
    },
    {
      "available_drivers": [],
      "engine": "teradata",
      "name": "Teradata",
      "preferred": false
    },
    {
      "available_drivers": [],
      "engine": "trino",
      "name": "Trino",
      "preferred": false
    },
    {
      "available_drivers": [
        "vertica_python"
      ],
      "engine": "vertica",
      "name": "Vertica",
      "preferred": false
    }
  ]
}
```

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
