### PR TITLE
refactor: type hints should not be load in runtime

### DIFF
--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -14,8 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
+
 import logging
-from typing import Any, ClassVar, Dict, List, Optional, Union
+from typing import Any, ClassVar, Dict, List, Optional, TYPE_CHECKING, Union
 
 import numpy as np
 import pandas as pd
@@ -34,7 +36,6 @@ from superset.exceptions import (
     SupersetException,
 )
 from superset.extensions import cache_manager, security_manager
-from superset.stats_logger import BaseStatsLogger
 from superset.utils import csv
 from superset.utils.cache import generate_cache_key, set_and_log_cache
 from superset.utils.core import (
@@ -49,6 +50,9 @@ from superset.utils.core import (
     QueryStatus,
 )
 from superset.views.utils import get_viz
+
+if TYPE_CHECKING:
+    from superset.stats_logger import BaseStatsLogger
 
 config = app.config
 stats_logger: BaseStatsLogger = config["STATS_LOGGER"]

--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -14,10 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
+
 import logging
 from datetime import datetime, timedelta
 from functools import wraps
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, Optional, TYPE_CHECKING, Union
 
 from flask import current_app as app, request
 from flask_caching import Cache
@@ -27,9 +29,11 @@ from werkzeug.wrappers.etag import ETagResponseMixin
 from superset import db
 from superset.extensions import cache_manager
 from superset.models.cache import CacheKey
-from superset.stats_logger import BaseStatsLogger
 from superset.utils.core import json_int_dttm_ser
 from superset.utils.hashing import md5_sha_from_dict
+
+if TYPE_CHECKING:
+    from superset.stats_logger import BaseStatsLogger
 
 config = app.config  # type: ignore
 stats_logger: BaseStatsLogger = config["STATS_LOGGER"]

--- a/superset/utils/decorators.py
+++ b/superset/utils/decorators.py
@@ -14,18 +14,22 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
+
 import time
 from functools import wraps
-from typing import Any, Callable, Dict, Iterator, Union
+from typing import Any, Callable, Dict, Iterator, TYPE_CHECKING, Union
 
 from contextlib2 import contextmanager
 from flask import current_app, Response
 
 from superset import is_feature_enabled
 from superset.dashboards.commands.exceptions import DashboardAccessDeniedError
-from superset.stats_logger import BaseStatsLogger
 from superset.utils import core as utils
 from superset.utils.dates import now_as_float
+
+if TYPE_CHECKING:
+    from superset.stats_logger import BaseStatsLogger
 
 
 @contextmanager

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
+
 import functools
 import inspect
 import json
@@ -22,14 +24,25 @@ import textwrap
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from datetime import datetime, timedelta
-from typing import Any, Callable, cast, Dict, Iterator, Optional, Type, Union
+from typing import (
+    Any,
+    Callable,
+    cast,
+    Dict,
+    Iterator,
+    Optional,
+    Type,
+    TYPE_CHECKING,
+    Union,
+)
 
 from flask import current_app, g, request
 from flask_appbuilder.const import API_URI_RIS_KEY
 from sqlalchemy.exc import SQLAlchemyError
 from typing_extensions import Literal
 
-from superset.stats_logger import BaseStatsLogger
+if TYPE_CHECKING:
+    from superset.stats_logger import BaseStatsLogger
 
 
 def collect_request_payload() -> Dict[str, Any]:


### PR DESCRIPTION
### SUMMARY
Any import type which is used only as type hints should not be loaded on run-time
now : BaseStatsLogger



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
