### PR TITLE
chore: add changed_on_delta_humanized field on dashboard schema

### DIFF
--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -159,6 +159,7 @@ class DashboardGetResponseSchema(Schema):
     owners = fields.List(fields.Nested(UserSchema))
     roles = fields.List(fields.Nested(RolesSchema))
     table_names = fields.String()  # legacy nonsense
+    changed_on_humanized = fields.String(data_key="changed_on_delta_humanized")
 
 
 class DatabaseSchema(Schema):

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -344,9 +344,10 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
         }
         data = json.loads(rv.data.decode("utf-8"))
         self.assertIn("changed_on", data["result"])
+        self.assertIn("changed_on_delta_humanized", data["result"])
         for key, value in data["result"].items():
             # We can't assert timestamp values
-            if key != "changed_on":
+            if key not in ("changed_on", "changed_on_delta_humanized",):
                 self.assertEqual(value, expected_result[key])
         # rollback changes
         db.session.delete(dashboard)


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
added `changed_on_delta_humanized` field on dashboard schema. ensure rest API has this response data.

related PR: https://github.com/apache/superset/pull/15186

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
