### PR TITLE
refactor: icon to icons for tabs

### DIFF
--- a/superset-frontend/src/components/Tabs/Tabs.tsx
+++ b/superset-frontend/src/components/Tabs/Tabs.tsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import { css, styled } from '@superset-ui/core';
 import AntDTabs, { TabsProps as AntDTabsProps } from 'antd/lib/tabs';
-import Icon from 'src/components/Icon';
+import Icons from 'src/components/Icons';
 
 export interface TabsProps extends AntDTabsProps {
   fullWidth?: boolean;
@@ -119,6 +119,9 @@ const StyledEditableTabs = styled(StyledTabs)`
     `}
 `;
 
+const StyledCancelXIcon = styled(Icons.CancelX)`
+  color: ${({ theme }) => theme.colors.grayscale.base};
+`;
 export const EditableTabs = Object.assign(StyledEditableTabs, {
   TabPane: StyledTabPane,
 });
@@ -130,9 +133,7 @@ EditableTabs.defaultProps = {
 };
 
 EditableTabs.TabPane.defaultProps = {
-  closeIcon: (
-    <Icon role="button" tabIndex={0} cursor="pointer" name="cancel-x" />
-  ),
+  closeIcon: <StyledCancelXIcon role="button" tabIndex={0} />,
 };
 
 export const StyledLineEditableTabs = styled(EditableTabs)`


### PR DESCRIPTION
### SUMMARY
This pr migrates old icon to icons for tab cancelx icon.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before
<img width="192" alt="Untitled Query 2 0" src="https://user-images.githubusercontent.com/17326228/124627504-76ef6c00-de34-11eb-89ff-39c252b3b586.png">
after
<img width="197" alt="04 Untitled Query 2" src="https://user-images.githubusercontent.com/17326228/124627520-7a82f300-de34-11eb-9e17-0627a0a682eb.png">

### TESTING INSTRUCTIONS
Go to sql editor and check the tabbed cancel x icon

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
