### PR TITLE
refactor: icon to icons for filterbadge components

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/filter.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/filter.test.ts
@@ -38,7 +38,7 @@ describe('Dashboard filter', () => {
       cy.get('.Select__placeholder:first').click();
 
       // should show the filter indicator
-      cy.get('svg[data-test="filter"]:visible').should(nodes => {
+      cy.get('span[aria-label="filter"]:visible').should(nodes => {
         expect(nodes.length).to.least(9);
       });
 
@@ -50,7 +50,7 @@ describe('Dashboard filter', () => {
       cy.get('.Select__menu').first().contains('South Asia').click();
 
       // should still have all filter indicators
-      cy.get('svg[data-test="filter"]:visible').should(nodes => {
+      cy.get('span[aria-label="filter"]:visible').should(nodes => {
         expect(nodes.length).to.least(9);
       });
 

--- a/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel/index.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel/index.tsx
@@ -26,7 +26,7 @@ import {
 } from '@ant-design/icons';
 import Popover from 'src/components/Popover';
 import Collapse from 'src/components/Collapse';
-import Icon from 'src/components/Icon';
+import Icons from 'src/components/Icons';
 import {
   Indent,
   Panel,
@@ -169,9 +169,9 @@ const DetailsPanelPopover = ({
               key="appliedCrossFilters"
               header={
                 <Title bold color={theme.colors.primary.light1}>
-                  <Icon
-                    name="cross-filter-badge"
+                  <Icons.CursorTarget
                     css={{ fill: theme.colors.primary.light1 }}
+                    iconSize="xl"
                   />
                   {t(
                     'Applied Cross Filters (%d)',

--- a/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
@@ -35,7 +35,7 @@ export const Pill = styled.div`
 
   svg {
     position: relative;
-    top: -1px;
+    top: -2px;
     color: ${({ theme }) => theme.colors.grayscale.light5};
     width: 1em;
     height: 1em;

--- a/superset-frontend/src/dashboard/components/FiltersBadge/index.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/index.tsx
@@ -20,7 +20,6 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { uniqWith } from 'lodash';
 import cx from 'classnames';
-import Icon from 'src/components/Icon';
 import Icons from 'src/components/Icons';
 import { usePrevious } from 'src/common/hooks/usePrevious';
 import { DataMaskStateWithId } from 'src/dataMask/types';
@@ -199,7 +198,7 @@ export const FiltersBadge = ({ chartId }: FiltersBadgeProps) => {
           isInactive && 'filters-inactive',
         )}
       >
-        <Icon name="filter" />
+        <Icons.Filter iconSize="m" />
         {!isInactive && (
           <span data-test="applied-filter-count">
             {appliedIndicators.length + appliedCrossFilterIndicators.length}


### PR DESCRIPTION
### SUMMARY
This pr migrates the original icon to icons for filterbadge components. Specifically the crossfilter filter icon

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="289" alt="Screen Shot 2021-07-06 at 12 32 45 PM" src="https://user-images.githubusercontent.com/17326228/124656603-46202e80-de56-11eb-9da6-0755e663177a.png">

### TESTING INSTRUCTIONS
To test you must enable native filters and cross filtering.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
