### PR TITLE
refactor: icon to icons for headeractionsdropdown

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/controls.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/controls.test.ts
@@ -63,7 +63,7 @@ describe('Dashboard top-level controls', () => {
     // should allow force refresh
     WORLD_HEALTH_CHARTS.forEach(waitForChartLoad);
     getChartAliasesBySpec(WORLD_HEALTH_CHARTS).then(aliases => {
-      cy.get('[data-test="more-horiz"]').click();
+      cy.get('[aria-label="more-horiz"]').click();
       cy.get('[data-test="refresh-dashboard-menu-item"]').should(
         'not.have.class',
         'ant-dropdown-menu-item-disabled',
@@ -92,7 +92,7 @@ describe('Dashboard top-level controls', () => {
         });
       });
     });
-    cy.get('[data-test="more-horiz"]').click();
+    cy.get('[aria-label="more-horiz"]').click();
     cy.get('[data-test="refresh-dashboard-menu-item"]').and(
       'not.have.class',
       'ant-dropdown-menu-item-disabled',

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/markdown.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/markdown.test.ts
@@ -35,7 +35,7 @@ describe('Dashboard edit markdown', () => {
 
     // lazy load - need to open dropdown for the scripts to load
     cy.get('[data-test="dashboard-header"]')
-      .find('[data-test="more-horiz"]')
+      .find('[aria-label="more-horiz"]')
       .click();
     cy.get('script').then(nodes => {
       // load 5 new script chunks for css editor

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/save.test.js
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/save.test.js
@@ -42,7 +42,7 @@ describe('Dashboard save action', () => {
           'copyRequest',
         );
 
-        cy.get('[data-test="more-horiz"]').trigger('click', { force: true });
+        cy.get('[aria-label="more-horiz"]').trigger('click', { force: true });
         cy.get('[data-test="save-as-menu-item"]').trigger('click', {
           force: true,
         });

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
@@ -22,7 +22,7 @@ import PropTypes from 'prop-types';
 import { styled, SupersetClient, t } from '@superset-ui/core';
 
 import { Menu, NoAnimationDropdown } from 'src/common/components';
-import Icon from 'src/components/Icon';
+import Icons from 'src/components/Icons';
 import { URL_PARAMS } from 'src/constants';
 import ShareMenuItems from 'src/dashboard/components/menu/ShareMenuItems';
 import CssEditor from 'src/dashboard/components/CssEditor';
@@ -88,6 +88,9 @@ const MENU_KEYS = {
 
 const DropdownButton = styled.div`
   margin-left: ${({ theme }) => theme.gridUnit * 2.5}px;
+  span {
+    color: ${({ theme }) => theme.colors.grayscale.base};
+  }
 `;
 
 const SCREENSHOT_NODE_SELECTOR = '.dashboard';
@@ -328,7 +331,7 @@ class HeaderActionsDropdown extends React.PureComponent {
         }
       >
         <DropdownButton id="save-dash-split-button" role="button">
-          <Icon name="more-horiz" />
+          <Icons.MoreHoriz />
         </DropdownButton>
       </NoAnimationDropdown>
     );


### PR DESCRIPTION
### SUMMARY
This pr refactors the icon to icons component for the headeractionsdropdown more-horiz icon.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before
<img width="104" alt="Screen Shot 2021-07-06 at 2 49 10 PM" src="https://user-images.githubusercontent.com/17326228/124673066-0f094780-de6d-11eb-8623-6a1f4316e114.png">

after
<img width="90" alt="Screen Shot 2021-07-06 at 3 07 03 PM" src="https://user-images.githubusercontent.com/17326228/124673075-14669200-de6d-11eb-8842-8307a56c7dfa.png">


### TESTING INSTRUCTIONS
Go to a dashboard to test the new icon

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
