### PR TITLE
refactor: icon to icons for sliceheader component

### DIFF
--- a/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
@@ -157,7 +157,7 @@ const SliceHeader: FC<SliceHeaderProps> = ({
       <div className="header-controls">
         {!editMode && (
           <>
-            {true && (
+            {crossFilterValue && (
               <Tooltip
                 placement="top"
                 title={

--- a/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
@@ -23,7 +23,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import EditableTitle from 'src/components/EditableTitle';
 import SliceHeaderControls from 'src/dashboard/components/SliceHeaderControls';
 import FiltersBadge from 'src/dashboard/components/FiltersBadge';
-import Icon from 'src/components/Icon';
+import Icons from 'src/components/Icons';
 import { RootState } from 'src/dashboard/types';
 import FilterIndicator from 'src/dashboard/components/FiltersBadge/FilterIndicator';
 import { clearDataMask } from 'src/dataMask/actions';
@@ -69,12 +69,9 @@ type SliceHeaderProps = {
 const annotationsLoading = t('Annotation layers are still loading.');
 const annotationsError = t('One ore more annotation layers failed loading.');
 
-const CrossFilterIcon = styled(Icon)`
-  fill: ${({ theme }) => theme.colors.grayscale.light5};
+const CrossFilterIcon = styled(Icons.CursorTarget)`
   cursor: pointer;
-  & circle {
-    fill: ${({ theme }) => theme.colors.primary.base};
-  }
+  color: ${({ theme }) => theme.colors.primary.base};
   height: 22px;
   width: 22px;
 `;
@@ -160,7 +157,7 @@ const SliceHeader: FC<SliceHeaderProps> = ({
       <div className="header-controls">
         {!editMode && (
           <>
-            {crossFilterValue && (
+            {true && (
               <Tooltip
                 placement="top"
                 title={
@@ -174,7 +171,6 @@ const SliceHeader: FC<SliceHeaderProps> = ({
                 }
               >
                 <CrossFilterIcon
-                  name="cross-filter-badge"
                   onClick={() => dispatch(clearDataMask(slice?.slice_id))}
                 />
               </Tooltip>


### PR DESCRIPTION
### SUMMARY
mirgrates the filter indicator icon to the icons component

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before
<img width="162" alt="Screen Shot 2021-07-06 at 7 08 45 PM" src="https://user-images.githubusercontent.com/17326228/124703313-eaca5c80-dea6-11eb-8c4c-a78a3152a561.png">


after
<img width="152" alt="Screen Shot 2021-07-06 at 9 52 21 PM" src="https://user-images.githubusercontent.com/17326228/124703291-e1d98b00-dea6-11eb-8a29-ea8c69dc410d.png">

### TESTING INSTRUCTIONS
Must enable native filters and crossfiltering feature flags and go to dashboard component

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
