### PR TITLE
feat(viz): Clear viz gallery when navigating between categories

### DIFF
--- a/superset-frontend/src/addSlice/AddSliceContainer.test.tsx
+++ b/superset-frontend/src/addSlice/AddSliceContainer.test.tsx
@@ -52,10 +52,6 @@ describe('AddSliceContainer', () => {
     await act(() => new Promise(resolve => setTimeout(resolve, 0)));
   });
 
-  it('uses table as default visType', () => {
-    expect(wrapper.state().visType).toBe('table');
-  });
-
   it('renders a select and a VizTypeControl', () => {
     expect(wrapper.find(Select)).toExist();
     expect(wrapper.find(VizTypeGallery)).toExist();
@@ -71,12 +67,13 @@ describe('AddSliceContainer', () => {
     ).toHaveLength(1);
   });
 
-  it('renders an enabled button if datasource is selected', () => {
+  it('renders an enabled button if datasource and viz type is selected', () => {
     const datasourceValue = defaultProps.datasources[0].value;
     wrapper.setState({
       datasourceValue,
       datasourceId: datasourceValue.split('__')[0],
       datasourceType: datasourceValue.split('__')[1],
+      visType: 'table',
     });
     expect(
       wrapper.find(Button).find({ disabled: true }).hostNodes(),
@@ -89,6 +86,7 @@ describe('AddSliceContainer', () => {
       datasourceValue,
       datasourceId: datasourceValue.split('__')[0],
       datasourceType: datasourceValue.split('__')[1],
+      visType: 'table',
     });
     const formattedUrl =
       '/superset/explore/?form_data=%7B%22viz_type%22%3A%22table%22%2C%22datasource%22%3A%221__table%22%7D';

--- a/superset-frontend/src/addSlice/AddSliceContainer.tsx
+++ b/superset-frontend/src/addSlice/AddSliceContainer.tsx
@@ -38,7 +38,7 @@ export type AddSliceContainerState = {
   datasourceId?: string;
   datasourceType?: string;
   datasourceValue?: string;
-  visType: string;
+  visType: string | null;
 };
 
 const ESTIMATED_NAV_HEIGHT = '56px';
@@ -76,7 +76,7 @@ export default class AddSliceContainer extends React.PureComponent<
   constructor(props: AddSliceContainerProps) {
     super(props);
     this.state = {
-      visType: 'table',
+      visType: null,
     };
 
     this.changeDatasource = this.changeDatasource.bind(this);
@@ -105,7 +105,7 @@ export default class AddSliceContainer extends React.PureComponent<
     });
   }
 
-  changeVisType(visType: string) {
+  changeVisType(visType: string | null) {
     this.setState({ visType });
   }
 
@@ -152,7 +152,7 @@ export default class AddSliceContainer extends React.PureComponent<
         </div>
         <StyledVizTypeGallery
           onChange={this.changeVisType}
-          value={this.state.visType}
+          selectedViz={this.state.visType}
         />
         <Button
           css={[

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -194,9 +194,12 @@ const IconsPane = styled.div`
   padding: ${({ theme }) => theme.gridUnit * 2}px;
 `;
 
-const DetailsPane = styled.div`
+const DetailsPaneBase = styled.div`
   grid-area: details;
   border-top: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
+`;
+
+const DetailsPanePopulated = styled(DetailsPaneBase)`
   padding: ${({ theme }) => theme.gridUnit * 4}px;
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -204,6 +207,15 @@ const DetailsPane = styled.div`
   grid-template-areas:
     'viz-name examples-header'
     'description examples';
+`;
+
+const DetailsPaneEmpty = styled(DetailsPaneBase)`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  font-style: italic;
+  color: ${({ theme }) => theme.colors.grayscale.light1};
 `;
 
 // overflow hidden on the details pane and overflow auto on the description
@@ -497,8 +509,8 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
         setSelectedViz={onChange}
       />
 
-      <DetailsPane>
-        {selectedVizMetadata && (
+      {selectedVizMetadata ? (
+        <DetailsPanePopulated>
           <>
             <SectionTitle
               css={css`
@@ -528,8 +540,10 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
               ))}
             </Examples>
           </>
-        )}
-      </DetailsPane>
+        </DetailsPanePopulated>
+      ) : (
+        <DetailsPaneEmpty>{t('Select a visualization type')}</DetailsPaneEmpty>
+      )}
     </VizPickerLayout>
   );
 }

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -194,13 +194,13 @@ const IconsPane = styled.div`
   padding: ${({ theme }) => theme.gridUnit * 2}px;
 `;
 
-const DetailsPaneBase = styled.div`
+const DetailsPane = (theme: SupersetTheme) => css`
   grid-area: details;
-  border-top: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
+  border-top: 1px solid ${theme.colors.grayscale.light2};
 `;
 
-const DetailsPanePopulated = styled(DetailsPaneBase)`
-  padding: ${({ theme }) => theme.gridUnit * 4}px;
+const DetailsPopulated = (theme: SupersetTheme) => css`
+  padding: ${theme.gridUnit * 4}px;
   display: grid;
   grid-template-columns: 1fr 1fr;
   grid-template-rows: auto 1fr;
@@ -209,13 +209,13 @@ const DetailsPanePopulated = styled(DetailsPaneBase)`
     'description examples';
 `;
 
-const DetailsPaneEmpty = styled(DetailsPaneBase)`
+const DetailsEmpty = (theme: SupersetTheme) => css`
   display: flex;
   justify-content: center;
   align-items: center;
   text-align: center;
   font-style: italic;
-  color: ${({ theme }) => theme.colors.grayscale.light1};
+  color: ${theme.colors.grayscale.light1};
 `;
 
 // overflow hidden on the details pane and overflow auto on the description
@@ -510,7 +510,12 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
       />
 
       {selectedVizMetadata ? (
-        <DetailsPanePopulated>
+        <div
+          css={(theme: SupersetTheme) => [
+            DetailsPane(theme),
+            DetailsPopulated(theme),
+          ]}
+        >
           <>
             <SectionTitle
               css={css`
@@ -540,9 +545,16 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
               ))}
             </Examples>
           </>
-        </DetailsPanePopulated>
+        </div>
       ) : (
-        <DetailsPaneEmpty>{t('Select a visualization type')}</DetailsPaneEmpty>
+        <div
+          css={(theme: SupersetTheme) => [
+            DetailsPane(theme),
+            DetailsEmpty(theme),
+          ]}
+        >
+          {t('Select a visualization type')}
+        </div>
       )}
     </VizPickerLayout>
   );

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/index.tsx
@@ -41,8 +41,8 @@ interface VizTypeControlProps {
   description?: string;
   label?: string;
   name: string;
-  onChange: (vizType: string) => void;
-  value: string;
+  onChange: (vizType: string | null) => void;
+  value: string | null;
   labelType?: Type;
   isModalOpenInit?: boolean;
 }
@@ -83,7 +83,7 @@ const VizTypeControl = (props: VizTypeControlProps) => {
   // a trick to force re-initialization of the gallery each time the modal opens,
   // ensuring that the modal always opens to the correct category.
   const [modalKey, setModalKey] = useState(0);
-  const [selectedViz, setSelectedViz] = useState(initialValue);
+  const [selectedViz, setSelectedViz] = useState<string | null>(initialValue);
 
   const openModal = useCallback(() => {
     setShowModal(true);
@@ -101,8 +101,9 @@ const VizTypeControl = (props: VizTypeControlProps) => {
     setSelectedViz(initialValue);
   }, [initialValue]);
 
-  const labelContent =
-    mountedPluginMetadata[initialValue]?.name || `${initialValue}`;
+  const labelContent = initialValue
+    ? mountedPluginMetadata[initialValue]?.name || `${initialValue}`
+    : t('Select Viz Type');
 
   return (
     <div>
@@ -120,7 +121,7 @@ const VizTypeControl = (props: VizTypeControlProps) => {
           >
             {labelContent}
           </Label>
-          <VizSupportValidation vizType={initialValue} />
+          {initialValue && <VizSupportValidation vizType={initialValue} />}
         </>
       </Tooltip>
 
@@ -129,6 +130,7 @@ const VizTypeControl = (props: VizTypeControlProps) => {
         onHide={onCancel}
         title={t('Select a visualization type')}
         primaryButtonName={t('Select')}
+        disablePrimaryButton={!selectedViz}
         onHandledPrimaryAction={onSubmit}
         maxWidth={`${MAX_ADVISABLE_VIZ_GALLERY_WIDTH}px`}
         responsive
@@ -136,7 +138,7 @@ const VizTypeControl = (props: VizTypeControlProps) => {
         {/* When the key increments, it forces react to re-init the gallery component */}
         <VizTypeGallery
           key={modalKey}
-          value={selectedViz}
+          selectedViz={selectedViz}
           onChange={setSelectedViz}
         />
       </UnpaddedModal>


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

- The Add Chart page starts with no viz selected.
- When changing categories in the viz gallery, the selected viz will be cleared - _Unless_ the selected viz is applicable to that category.
- Disables the submit button on the modal if no viz is selected

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

<img width="1076" alt="Screen Shot 2021-07-07 at 1 36 55 PM" src="https://user-images.githubusercontent.com/1858430/124825405-6a4c4000-df28-11eb-8e0d-426b41a133e5.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
