### PR TITLE
refactor: icon to icons for toasts component

### DIFF
--- a/superset-frontend/spec/javascripts/messageToasts/components/Toast_spec.jsx
+++ b/superset-frontend/spec/javascripts/messageToasts/components/Toast_spec.jsx
@@ -18,6 +18,7 @@
  */
 import React from 'react';
 import { mount } from 'enzyme';
+import { ThemeProvider, supersetTheme } from '@superset-ui/core';
 import Toast from 'src/messageToasts/components/Toast';
 import { act } from 'react-dom/test-utils';
 import mockMessageToasts from '../mockMessageToasts';
@@ -27,7 +28,11 @@ const props = {
   onCloseToast() {},
 };
 
-const setup = overrideProps => mount(<Toast {...props} {...overrideProps} />);
+const setup = overrideProps =>
+  mount(<Toast {...props} {...overrideProps} />, {
+    wrappingComponent: ThemeProvider,
+    wrappingComponentProps: { theme: supersetTheme },
+  });
 
 describe('Toast', () => {
   it('should render', () => {

--- a/superset-frontend/src/messageToasts/components/Toast.tsx
+++ b/superset-frontend/src/messageToasts/components/Toast.tsx
@@ -16,11 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { styled } from '@superset-ui/core';
+import { styled, css, useTheme, SupersetTheme } from '@superset-ui/core';
 import cx from 'classnames';
 import Interweave from 'interweave';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import Icon, { IconName } from 'src/components/Icon';
+import Icons from 'src/components/Icons';
 import { ToastType } from 'src/messageToasts/constants';
 import { ToastMeta } from '../types';
 
@@ -34,8 +34,9 @@ const ToastContainer = styled.div`
   }
 `;
 
-const StyledIcon = styled(Icon)`
-  min-width: ${({ theme }) => theme.gridUnit * 5}px;
+const StyledIcon = (theme: SupersetTheme) => css`
+  min-width: ${theme.gridUnit * 5}px;
+  color: ${theme.colors.grayscale.base};
 `;
 
 interface ToastPresenterProps {
@@ -76,16 +77,20 @@ export default function Toast({ toast, onCloseToast }: ToastPresenterProps) {
     };
   }, [handleClosePress, toast.duration]);
 
-  let iconName: IconName = 'circle-check-solid';
+  console.log('toast', toast)
+
+  // const theme = useTheme();
   let className = 'toast--success';
+  let icon = <Icons.CircleCheckSolid css={theme => StyledIcon(theme)} />;
+
   if (toast.toastType === ToastType.WARNING) {
-    iconName = 'warning-solid';
+    icon = <Icons.WarningSolid css={theme => StyledIcon(theme)} />;
     className = 'toast--warning';
   } else if (toast.toastType === ToastType.DANGER) {
-    iconName = 'error-solid';
+    icon = <Icons.ErrorSolid css={theme => StyledIcon(theme)} />;
     className = 'toast--danger';
   } else if (toast.toastType === ToastType.INFO) {
-    iconName = 'info-solid';
+    icon = <Icons.InfoSolid css={theme => StyledIcon(theme)} />;
     className = 'toast--info';
   }
 
@@ -95,7 +100,7 @@ export default function Toast({ toast, onCloseToast }: ToastPresenterProps) {
       data-test="toast-container"
       role="alert"
     >
-      <StyledIcon name={iconName} />
+      {icon}
       <Interweave content={toast.text} />
       <i
         className="fa fa-close pull-right pointer"

--- a/superset-frontend/src/messageToasts/components/Toast.tsx
+++ b/superset-frontend/src/messageToasts/components/Toast.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { styled, css, useTheme, SupersetTheme } from '@superset-ui/core';
+import { styled, css, SupersetTheme } from '@superset-ui/core';
 import cx from 'classnames';
 import Interweave from 'interweave';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -77,9 +77,6 @@ export default function Toast({ toast, onCloseToast }: ToastPresenterProps) {
     };
   }, [handleClosePress, toast.duration]);
 
-  console.log('toast', toast)
-
-  // const theme = useTheme();
   let className = 'toast--success';
   let icon = <Icons.CircleCheckSolid css={theme => StyledIcon(theme)} />;
 

--- a/superset-frontend/src/messageToasts/components/Toast.tsx
+++ b/superset-frontend/src/messageToasts/components/Toast.tsx
@@ -81,7 +81,7 @@ export default function Toast({ toast, onCloseToast }: ToastPresenterProps) {
   let icon = <Icons.CircleCheckSolid css={theme => StyledIcon(theme)} />;
 
   if (toast.toastType === ToastType.WARNING) {
-    icon = <Icons.WarningSolid css={theme => StyledIcon(theme)} />;
+    icon = <Icons.WarningSolid css={StyledIcon} />;
     className = 'toast--warning';
   } else if (toast.toastType === ToastType.DANGER) {
     icon = <Icons.ErrorSolid css={theme => StyledIcon(theme)} />;

--- a/superset-frontend/src/messageToasts/components/Toast.tsx
+++ b/superset-frontend/src/messageToasts/components/Toast.tsx
@@ -84,7 +84,7 @@ export default function Toast({ toast, onCloseToast }: ToastPresenterProps) {
     icon = <Icons.WarningSolid css={StyledIcon} />;
     className = 'toast--warning';
   } else if (toast.toastType === ToastType.DANGER) {
-    icon = <Icons.ErrorSolid css={theme => StyledIcon(theme)} />;
+    icon = <Icons.ErrorSolid css={StyledIcon} />;
     className = 'toast--danger';
   } else if (toast.toastType === ToastType.INFO) {
     icon = <Icons.InfoSolid css={theme => StyledIcon(theme)} />;

--- a/superset-frontend/src/messageToasts/components/Toast.tsx
+++ b/superset-frontend/src/messageToasts/components/Toast.tsx
@@ -87,7 +87,7 @@ export default function Toast({ toast, onCloseToast }: ToastPresenterProps) {
     icon = <Icons.ErrorSolid css={StyledIcon} />;
     className = 'toast--danger';
   } else if (toast.toastType === ToastType.INFO) {
-    icon = <Icons.InfoSolid css={theme => StyledIcon(theme)} />;
+    icon = <Icons.InfoSolid css={StyledIcon} />;
     className = 'toast--info';
   }
 


### PR DESCRIPTION
### SUMMARY
This component migrates the icons for the toast component to the new icons.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="598" alt="Screen Shot 2021-07-07 at 3 06 05 PM" src="https://user-images.githubusercontent.com/17326228/124834586-ddf44a00-df34-11eb-9aca-794bc93e6b60.png">


### TESTING INSTRUCTIONS
Manually pulling the branch to hack the toast to present would be the easiest to test as hacking error in ephemereal envior nment is much harder.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
