### PR TITLE
fix: downloadasimage for dashboard

### DIFF
--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
@@ -162,6 +162,8 @@ class HeaderActionsDropdown extends React.PureComponent {
         downloadAsImage(
           SCREENSHOT_NODE_SELECTOR,
           this.props.dashboardTitle,
+          {},
+          true,
         )(domEvent).then(() => {
           menu.style.visibility = 'visible';
         });


### PR DESCRIPTION
### SUMMARY
This pr fixes the download as image for dashboard. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

before 


https://user-images.githubusercontent.com/17326228/124843685-4e0bcb80-df47-11eb-9310-6f0b6ca4810c.mov

after

https://user-images.githubusercontent.com/17326228/124843281-7e9f3580-df46-11eb-8e65-2caaf7ed9ca0.mov

closes: https://github.com/apache/superset/issues/15536

### TESTING INSTRUCTIONS
Go to dashboard and click the download as image for the dashboard.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x ] Has associated issue: https://github.com/apache/superset/issues/15536
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
