### PR TITLE
fix: no roles being returned for anonymous user

### DIFF
--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -62,16 +62,18 @@ if not app.config["ENABLE_JAVASCRIPT_CONTROLS"]:
 
 def bootstrap_user_data(user: User, include_perms: bool = False) -> Dict[str, Any]:
     if user.is_anonymous:
-        return {}
-    payload = {
-        "username": user.username,
-        "firstName": user.first_name,
-        "lastName": user.last_name,
-        "userId": user.id,
-        "isActive": user.is_active,
-        "createdOn": user.created_on.isoformat(),
-        "email": user.email,
-    }
+        payload = {}
+        user.roles = (security_manager.find_role("Public"),)
+    else:
+        payload = {
+            "username": user.username,
+            "firstName": user.first_name,
+            "lastName": user.last_name,
+            "userId": user.id,
+            "isActive": user.is_active,
+            "createdOn": user.created_on.isoformat(),
+            "email": user.email,
+        }
 
     if include_perms:
         roles, permissions = get_permissions(user)


### PR DESCRIPTION
### SUMMARY
Since 1.2.0 an anonymous user is unable to see a public dashboard.
This is caused because:
1. no roles are attached to an anonymous user
2. on the [bootstrap_user_data](https://github.com/apache/superset/blob/86a59a292725f70336e3fa7c1109fec15103fdad/superset/views/utils.py#L63) function, when the user is anonymous, the permissions fetching process is skipped.

This will lead to an empty user payload
![empty_user_on_state](https://user-images.githubusercontent.com/23409890/122455632-85b8d080-cfa4-11eb-9a79-f1d0a8535f3e.png)
leading to an Unexpected error on the dashboard page.

My changes: since an anonymous user doesn't have roles associated, on the bootstrap_user_data function, I associate the public role to it, which then on [this](https://github.com/apache/superset/blob/86a59a292725f70336e3fa7c1109fec15103fdad/superset/views/utils.py#L77) line respective permissions can be fetched.

### BEFORE/AFTER
Before:
Screenshots present on the three issues descriptions

After:
Dashboards are displayed without login

### TESTING INSTRUCTIONS
1. Add the permission mentioned in [this](https://github.com/apache/superset/issues/14912#issuecomment-876377800) comment to the public role OR set PUBLIC_ROLE_LIKE = "Gamma"
2. Create a dashboard if don't have any
3. Copy the URL for the dashboard 
4. Logout or enter an anonymous browser session
5. Enter in the dashboard's URL
6. Check if it renders properly with no Unexpected error.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #14912, #15280, #14504
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
