### PR TITLE
fix: avoid fetching favorite status for anonymous user

### DIFF
--- a/superset-frontend/src/dashboard/components/Header/Header.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/Header.test.tsx
@@ -32,12 +32,13 @@ const createProps = () => ({
     dash_edit_perm: false,
     dash_save_perm: false,
     dash_share_perm: false,
-    userId: 1,
+    userId: "1",
     metadata: {},
     common: {
       conf: {},
     },
   },
+  userId: 1,
   dashboardTitle: 'Dashboard Title',
   charts: {},
   layout: {},
@@ -246,6 +247,22 @@ test('should render the selected fave icon', () => {
   expect(
     screen.getByRole('img', { name: 'favorite-selected' }),
   ).toBeInTheDocument();
+});
+
+test('should NOT render the fave icon on anonymous user', () => {
+  const mockedProps = createProps();
+  const anonymousUserProps = {
+    ...mockedProps,
+    userId: undefined,
+  };
+  render(setup(anonymousUserProps));
+  expect(mockedProps.fetchFaveStar).not.toHaveBeenCalled();
+  expect(
+    () => screen.getByRole('img', { name: 'favorite-unselected' }),
+  ).toThrowError("Unable to find");
+  expect(
+    () => screen.getByRole('img', { name: 'favorite-selected' }),
+  ).toThrowError("Unable to find");
 });
 
 test('should fave', async () => {

--- a/superset-frontend/src/dashboard/components/Header/Header.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/Header.test.tsx
@@ -32,7 +32,7 @@ const createProps = () => ({
     dash_edit_perm: false,
     dash_save_perm: false,
     dash_share_perm: false,
-    userId: "1",
+    userId: '1',
     metadata: {},
     common: {
       conf: {},
@@ -257,12 +257,12 @@ test('should NOT render the fave icon on anonymous user', () => {
   };
   render(setup(anonymousUserProps));
   expect(mockedProps.fetchFaveStar).not.toHaveBeenCalled();
-  expect(
-    () => screen.getByRole('img', { name: 'favorite-unselected' }),
-  ).toThrowError("Unable to find");
-  expect(
-    () => screen.getByRole('img', { name: 'favorite-selected' }),
-  ).toThrowError("Unable to find");
+  expect(() =>
+    screen.getByRole('img', { name: 'favorite-unselected' }),
+  ).toThrowError('Unable to find');
+  expect(() =>
+    screen.getByRole('img', { name: 'favorite-selected' }),
+  ).toThrowError('Unable to find');
 });
 
 test('should fave', async () => {

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
@@ -32,7 +32,7 @@ const createProps = () => ({
     id: 1,
     dash_edit_perm: true,
     dash_save_perm: true,
-    userId: 1,
+    userId: "1",
     metadata: {},
     common: {
       conf: {},

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
@@ -32,7 +32,7 @@ const createProps = () => ({
     id: 1,
     dash_edit_perm: true,
     dash_save_perm: true,
-    userId: "1",
+    userId: '1',
     metadata: {},
     common: {
       conf: {},

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -51,6 +51,7 @@ const propTypes = {
   addSuccessToast: PropTypes.func.isRequired,
   addDangerToast: PropTypes.func.isRequired,
   addWarningToast: PropTypes.func.isRequired,
+  userId: PropTypes.number,
   dashboardInfo: PropTypes.object.isRequired,
   dashboardTitle: PropTypes.string.isRequired,
   dataMask: PropTypes.object.isRequired,
@@ -366,6 +367,7 @@ class Header extends React.PureComponent {
       updateCss,
       editMode,
       isPublished,
+      userId,
       dashboardInfo,
       hasUnsavedChanges,
       isLoading,
@@ -404,7 +406,7 @@ class Header extends React.PureComponent {
             canEdit={userCanEdit}
             canSave={userCanSaveAs}
           />
-          {dashboardInfo.userId && (
+          {userId && (
             <FaveStar
               itemId={dashboardInfo.id}
               fetchFaveStar={this.props.fetchFaveStar}

--- a/superset-frontend/src/dashboard/components/Header/types.ts
+++ b/superset-frontend/src/dashboard/components/Header/types.ts
@@ -22,7 +22,7 @@ import { ChartState } from 'src/explore/types';
 
 interface DashboardInfo {
   id: number;
-  userId: number;
+  userId: string | undefined;
   dash_edit_perm: boolean;
   dash_save_perm: boolean;
   metadata?: Record<string, any>;
@@ -65,6 +65,7 @@ export interface HeaderProps {
   charts: ChartState | {};
   colorScheme?: string;
   customCss: string;
+  userId: number | undefined;
   dashboardInfo: DashboardInfo;
   dashboardTitle: string;
   setColorSchemeAndUnsavedChanges: () => void;

--- a/superset-frontend/src/dashboard/containers/DashboardHeader.jsx
+++ b/superset-frontend/src/dashboard/containers/DashboardHeader.jsx
@@ -63,6 +63,7 @@ function mapStateToProps({
   dashboardInfo,
   charts,
   dataMask,
+  user,
 }) {
   return {
     dashboardInfo,
@@ -80,7 +81,7 @@ function mapStateToProps({
     colorScheme: dashboardState.colorScheme,
     charts,
     dataMask,
-    userId: dashboardInfo.userId,
+    userId: user.userId,
     isStarred: !!dashboardState.isStarred,
     isPublished: !!dashboardState.isPublished,
     isLoading: isDashboardLoading(charts),


### PR DESCRIPTION
Note: this fix won't be visible because since 1.2.0 there is a bug where anonymous users receive an Unexpected Error when viewing a dashboard, however, it will be fixed in #15585

### SUMMARY
This problem had already been fixed in #8527, however, the value of `dashboard.userId` is now being converted into a string [here](https://github.com/apache/superset/blob/301b94f49abef8a2d8e680fcd1c636be6cd45fa4/superset-frontend/src/dashboard/actions/hydrate.js#L339), so in cases of an anonymous user, its value will be `"undefined"`.
With this, the fav star component will render due to [this](https://github.com/apache/superset/blob/301b94f49abef8a2d8e680fcd1c636be6cd45fa4/superset-frontend/src/dashboard/components/Header/index.jsx#L407) condition.

My changes:
Since [hydrate.js](https://github.com/apache/superset/blob/301b94f49abef8a2d8e680fcd1c636be6cd45fa4/superset-frontend/src/dashboard/actions/hydrate.js#L339) says that `dashboard.userId` is legacy, I pass the value of `user.userId` as a prop to the header component, which is value is `undefined` when there is no user logged in.

### TESTING INSTRUCTIONS
1. Add the permission mentioned in [this](https://github.com/apache/superset/issues/14912#issuecomment-876377800) comment to the public role OR set PUBLIC_ROLE_LIKE = "Gamma"
2. Create a dashboard if don't have any
3. Copy the URL for the dashboard 
4. Logout or enter an anonymous browser session
5. Enter in the dashboard's URL
6. Check if the error message doesn't appear

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #14720
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
