### PR TITLE
refactor: icon to icons for Alert & Reports

### DIFF
--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -17,11 +17,17 @@
  * under the License.
  */
 import React, { FunctionComponent, useState, useEffect } from 'react';
-import { styled, t, SupersetClient } from '@superset-ui/core';
+import {
+  styled,
+  t,
+  SupersetClient,
+  css,
+  SupersetTheme,
+} from '@superset-ui/core';
 import rison from 'rison';
 import { useSingleViewResource } from 'src/views/CRUD/hooks';
 
-import Icon from 'src/components/Icon';
+import Icons from 'src/components/Icons';
 import { Switch } from 'src/components/Switch';
 import Modal from 'src/components/Modal';
 import { Radio } from 'src/components/Radio';
@@ -135,8 +141,9 @@ const StyledModal = styled(Modal)`
   }
 `;
 
-const StyledIcon = styled(Icon)`
-  margin: auto ${({ theme }) => theme.gridUnit * 2}px auto 0;
+const StyledIcon = (theme: SupersetTheme) => css`
+  margin: auto ${theme.gridUnit * 2}px auto 0;
+  color: ${theme.colors.grayscale.base};
 `;
 
 const StyledSectionContainer = styled.div`
@@ -998,9 +1005,9 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
       title={
         <h4 data-test="alert-report-modal-title">
           {isEditMode ? (
-            <StyledIcon name="edit-alt" />
+            <Icons.EditAlt css={StyledIcon} />
           ) : (
-            <StyledIcon name="plus-large" />
+            <Icons.PlusLarge css={StyledIcon} />
           )}
           {isEditMode
             ? t(`Edit ${isReport ? 'Report' : 'Alert'}`)

--- a/superset-frontend/src/views/CRUD/alert/components/NotificationMethod.tsx
+++ b/superset-frontend/src/views/CRUD/alert/components/NotificationMethod.tsx
@@ -17,9 +17,9 @@
  * under the License.
  */
 import React, { FunctionComponent, useState } from 'react';
-import { styled, t } from '@superset-ui/core';
+import { styled, t, useTheme } from '@superset-ui/core';
 import { NativeGraySelect as Select } from 'src/components/Select';
-import Icon from 'src/components/Icon';
+import Icons from 'src/components/Icons';
 import { StyledInputContainer } from '../AlertReportModal';
 
 const StyledNotificationMethod = styled.div`
@@ -74,6 +74,7 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
   const [recipientValue, setRecipientValue] = useState<string>(
     recipients || '',
   );
+  const theme = useTheme();
 
   if (!setting) {
     return null;
@@ -144,7 +145,7 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
             className="delete-button"
             onClick={() => onRemove(index)}
           >
-            <Icon name="trash" />
+            <Icons.Trash iconColor={theme.colors.grayscale.base} />
           </span>
         ) : null}
       </div>

--- a/superset-frontend/src/views/CRUD/alert/components/RecipientIcon.tsx
+++ b/superset-frontend/src/views/CRUD/alert/components/RecipientIcon.tsx
@@ -16,38 +16,38 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { styled, t } from '@superset-ui/core';
-import React from 'react';
+import { t, SupersetTheme, css } from '@superset-ui/core';
+import React, { ReactElement } from 'react';
 import { Tooltip } from 'src/components/Tooltip';
-import Icon, { IconName } from 'src/components/Icon';
+import Icons from 'src/components/Icons';
 import { RecipientIconName } from '../types';
 
-const StyledIcon = styled(Icon)`
-  color: ${({ theme }) => theme.colors.grayscale.light1};
-  margin-right: ${({ theme }) => theme.gridUnit * 2}px;
+const StyledIcon = (theme: SupersetTheme) => css`
+  color: ${theme.colors.grayscale.light1};
+  margin-right: ${theme.gridUnit * 2}px;
 `;
 
 export default function RecipientIcon({ type }: { type: string }) {
-  const recipientIconConfig = {
-    name: '',
+  const recipientIconConfig: { icon: null | ReactElement; label: string } = {
+    icon: null,
     label: '',
   };
   switch (type) {
     case RecipientIconName.email:
-      recipientIconConfig.name = 'email';
+      recipientIconConfig.icon = <Icons.Email css={StyledIcon} />;
       recipientIconConfig.label = t(`${RecipientIconName.email}`);
       break;
     case RecipientIconName.slack:
-      recipientIconConfig.name = 'slack';
+      recipientIconConfig.icon = <Icons.Slack css={StyledIcon} />;
       recipientIconConfig.label = t(`${RecipientIconName.slack}`);
       break;
     default:
-      recipientIconConfig.name = '';
+      recipientIconConfig.icon = null;
       recipientIconConfig.label = '';
   }
-  return recipientIconConfig.name.length ? (
+  return recipientIconConfig.icon ? (
     <Tooltip title={recipientIconConfig.label} placement="bottom">
-      <StyledIcon name={recipientIconConfig.name as IconName} />
+      {recipientIconConfig.icon}
     </Tooltip>
   ) : null;
 }


### PR DESCRIPTION
### SUMMARY
This pr refactors icons for the alert and report modal and alerts listview icons.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="350" alt="Screen Shot 2021-07-08 at 2 28 54 PM" src="https://user-images.githubusercontent.com/17326228/124993163-d5654780-dff8-11eb-80e7-e289fee900ec.png">


### TESTING INSTRUCTIONS
The first few icons are located inside the alerts and reports modal and the slack and email icons are located in the after creating a job.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
