### PR TITLE
fix(ci): better change detection on github actions

### DIFF
--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -56,11 +56,13 @@ jobs:
           ref: "refs/pull/${{ github.event.number }}/merge"
           persist-credentials: false
           submodules: recursive
+      - id: find-pr
+        uses: ./.github/actions/gh-find-current-pr
       - name: Check if python or frontend changes are present
         id: check
         env:
           GITHUB_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ steps.find-pr.outputs.pr }}
         continue-on-error: true
         run: ./scripts/ci_check_no_file_changes.sh python frontend
       - name: Setup Python

--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -18,11 +18,13 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+      - id: find-pr
+        uses: ./.github/actions/gh-find-current-pr
       - name: Check if frontend changes are present
         id: check
         env:
           GITHUB_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ steps.find-pr.outputs.pr }}
         continue-on-error: true
         run: ./scripts/ci_check_no_file_changes.sh frontend
       - name: Install dependencies

--- a/.github/workflows/superset-python-misc.yml
+++ b/.github/workflows/superset-python-misc.yml
@@ -21,11 +21,13 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+      - id: find-pr
+        uses: ./.github/actions/gh-find-current-pr
       - name: Check if python changes are present
         id: check
         env:
           GITHUB_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ steps.find-pr.outputs.pr }}
         continue-on-error: true
         run: ./scripts/ci_check_no_file_changes.sh python
       - name: Setup Python

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -56,7 +56,7 @@ jobs:
         id: check
         env:
           GITHUB_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ steps.findPr.outputs.pr }}
+          PR_NUMBER: ${{ github.event.issue.number }}
         continue-on-error: true
         run: ./scripts/ci_check_no_file_changes.sh python
       - name: Setup Python
@@ -118,13 +118,11 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - id: findPr
-        uses: jwalton/gh-find-current-pr@v1
       - name: Check if python changes are present
         id: check
         env:
           GITHUB_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ steps.findPr.outputs.pr }}
+          PR_NUMBER: ${{ github.event.issue.number }}
         continue-on-error: true
         run: ./scripts/ci_check_no_file_changes.sh python
       - name: Create csv upload directory

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -50,8 +50,6 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - id: findPr
-        uses: jwalton/gh-find-current-pr@v1
       - name: Check if python changes are present
         id: check
         env:

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -50,11 +50,13 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+      - id: find-pr
+        uses: ./.github/actions/gh-find-current-pr
       - name: Check if python changes are present
         id: check
         env:
           GITHUB_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.issue.number }}
+          PR_NUMBER: ${{ steps.find-pr.outputs.pr }}
         continue-on-error: true
         run: ./scripts/ci_check_no_file_changes.sh python
       - name: Setup Python
@@ -116,11 +118,13 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+      - id: find-pr
+        uses: ./.github/actions/gh-find-current-pr
       - name: Check if python changes are present
         id: check
         env:
           GITHUB_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.issue.number }}
+          PR_NUMBER: ${{ steps.find-pr.outputs.pr }}
         continue-on-error: true
         run: ./scripts/ci_check_no_file_changes.sh python
       - name: Create csv upload directory

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -50,11 +50,13 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+      - id: findPr
+        uses: jwalton/gh-find-current-pr@v1
       - name: Check if python changes are present
         id: check
         env:
           GITHUB_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ steps.findPr.outputs.pr }}
         continue-on-error: true
         run: ./scripts/ci_check_no_file_changes.sh python
       - name: Setup Python

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -50,7 +50,8 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - id: findPr
+      - name: "Find PR"
+        id: findPr
         uses: jwalton/gh-find-current-pr@v1
       - name: Check if python changes are present
         id: check
@@ -118,7 +119,8 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - id: findPr
+      - name: "Find PR"
+        id: findPr
         uses: jwalton/gh-find-current-pr@v1
       - name: Check if python changes are present
         id: check

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -118,11 +118,13 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+      - id: findPr
+        uses: jwalton/gh-find-current-pr@v1
       - name: Check if python changes are present
         id: check
         env:
           GITHUB_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ steps.findPr.outputs.pr }}
         continue-on-error: true
         run: ./scripts/ci_check_no_file_changes.sh python
       - name: Create csv upload directory

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -50,8 +50,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - name: "Find PR"
-        id: findPr
+      - id: findPr
         uses: jwalton/gh-find-current-pr@v1
       - name: Check if python changes are present
         id: check
@@ -119,8 +118,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - name: "Find PR"
-        id: findPr
+      - id: findPr
         uses: jwalton/gh-find-current-pr@v1
       - name: Check if python changes are present
         id: check

--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -39,11 +39,13 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+      - id: find-pr
+        uses: ./.github/actions/gh-find-current-pr
       - name: Check if python changes are present
         id: check
         env:
           GITHUB_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ steps.find-pr.outputs.pr }}
         continue-on-error: true
         run: ./scripts/ci_check_no_file_changes.sh python
       - name: Setup Python
@@ -103,11 +105,13 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+      - id: find-pr
+        uses: ./.github/actions/gh-find-current-pr
       - name: Check if python changes are present
         id: check
         env:
           GITHUB_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ steps.find-pr.outputs.pr }}
         continue-on-error: true
         run: ./scripts/ci_check_no_file_changes.sh python
       - name: Setup Python
@@ -159,11 +163,13 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+      - id: find-pr
+        uses: ./.github/actions/gh-find-current-pr
       - name: Check if python changes are present
         id: check
         env:
           GITHUB_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ steps.find-pr.outputs.pr }}
         continue-on-error: true
         run: ./scripts/ci_check_no_file_changes.sh python
       - name: Setup Python

--- a/.gitmodules
+++ b/.gitmodules
@@ -39,3 +39,6 @@
 [submodule ".github/actions/github-action-push-to-another-repository"]
 	path = .github/actions/github-action-push-to-another-repository
 	url = https://github.com/cpina/github-action-push-to-another-repository
+[submodule ".github/actions/gh-find-current-pr"]
+	path = .github/actions/gh-find-current-pr
+	url = git@github.com:jwalton/gh-find-current-pr.git


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When a `push` event is triggered, GitHub doesn't make the PR number available, so our CI actions are not able to check for changes to files. I've found a way to get around this, using the [find-current-pull-request](https://github.com/marketplace/actions/find-current-pull-request) action.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

N/A

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
