### PR TITLE
Force users to set their own SECRET_KEY

### DIFF
--- a/helm/superset/templates/_helpers.tpl
+++ b/helm/superset/templates/_helpers.tpl
@@ -70,7 +70,9 @@ DATA_CACHE_CONFIG = CACHE_CONFIG
 
 SQLALCHEMY_DATABASE_URI = f"postgresql+psycopg2://{env('DB_USER')}:{env('DB_PASS')}@{env('DB_HOST')}:{env('DB_PORT')}/{env('DB_NAME')}"
 SQLALCHEMY_TRACK_MODIFICATIONS = True
-SECRET_KEY = env('SECRET_KEY', 'thisISaSECRET_1234')
+SECRET_KEY = env('SECRET_KEY', '')
+if '' == SECRET_KEY:
+    raise 'Must set your own SECRET_KEY'
 
 # Flask-WTF flag for CSRF
 WTF_CSRF_ENABLED = True


### PR DESCRIPTION
Force users to set their own SECRET_KEY

We ran into this situation and felt it is a security issue that should be shared.

Using a hard coded default SECRET_KEY seems dangerous and shouldn't be encouraged.

I'm not sure the best way to document this or if there's a better way of doing this?
