### PR TITLE
chore: update dataset count badge and tash icon sizing

### DIFF
--- a/superset-frontend/src/CRUD/CollectionTable.tsx
+++ b/superset-frontend/src/CRUD/CollectionTable.tsx
@@ -352,7 +352,6 @@ export default class CRUDCollection extends React.PureComponent<
             aria-label="Delete item"
             className="pointer"
             data-test="crud-delete-icon"
-            css={{ fontSize: '18px' }}
             role="button"
             tabIndex={0}
             onClick={this.deleteItem.bind(this, record.id)}

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -89,7 +89,9 @@ const StyledTableTabs = styled(Tabs)`
 
 const StyledBadge = styled(Badge)`
   .ant-badge-count {
+    line-height: ${({ theme }) => theme.gridUnit * 4}px;
     height: ${({ theme }) => theme.gridUnit * 4}px;
+    margin-left: ${({ theme }) => theme.gridUnit}px;
   }
 `;
 
@@ -123,7 +125,10 @@ DATASOURCE_TYPES_ARR.forEach(o => {
 
 function CollectionTabTitle({ title, collection }) {
   return (
-    <div data-test={`collection-tab-${title}`}>
+    <div
+      css={{ display: 'flex', alignItems: 'center' }}
+      data-test={`collection-tab-${title}`}
+    >
       {title}{' '}
       <StyledBadge count={collection ? collection.length : 0} showZero />
     </div>

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -87,6 +87,12 @@ const StyledTableTabs = styled(Tabs)`
   }
 `;
 
+const StyledBadge = styled(Badge)`
+  .ant-badge-count {
+    height: ${({ theme }) => theme.gridUnit * 4}px;
+  }
+`;
+
 const EditLockContainer = styled.div`
   font-size: ${supersetTheme.typography.sizes.s}px;
   display: flex;
@@ -118,7 +124,8 @@ DATASOURCE_TYPES_ARR.forEach(o => {
 function CollectionTabTitle({ title, collection }) {
   return (
     <div data-test={`collection-tab-${title}`}>
-      {title} <Badge count={collection ? collection.length : 0} showZero />
+      {title}{' '}
+      <StyledBadge count={collection ? collection.length : 0} showZero />
     </div>
   );
 }


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Created a `styledComponent` to set hight and center numbers on the `count-badge` on `dataset-tabs`. Also added inline `css={{...align-items:center}}` to parent div - centers badge and tab-title.

Removed inline `css` from `EditDatasetModals`'s `Icon.Trash`. This Icon now matches the sizing of the other `TrashIcon` on the datasets homepage(see screenshot).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

#### CountBadge:
<img width="1417" alt="Screen Shot 2021-07-08 at 6 57 53 PM" src="https://user-images.githubusercontent.com/50464395/125014902-5b968380-e023-11eb-97be-250d08366526.png">

##

|ModalTrashIcon | DatasetHompageTrashIcon  |
|-------|--|
|<img width="1417" alt="Screen Shot 2021-07-08 at 11 38 36 AM" src="https://user-images.githubusercontent.com/50464395/125015082-a7e1c380-e023-11eb-97c9-33159a6d64bd.png">|<img width="1417" alt="Screen Shot 2021-07-08 at 11 30 10 AM" src="https://user-images.githubusercontent.com/50464395/125014948-71a44400-e023-11eb-8923-a60b36f3b45b.png">|

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
