### PR TITLE
fix: Add waiting time for chart animation when screenshot

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -493,6 +493,8 @@ SCREENSHOT_LOAD_WAIT = 60
 SCREENSHOT_SELENIUM_RETRIES = 5
 # Give selenium an headstart, in seconds
 SCREENSHOT_SELENIUM_HEADSTART = 3
+# Wait for the chart animation, in seconds
+SCREENSHOT_SELENIUM_ANIMATION_WAIT = 5
 
 # ---------------------------------------------------
 # Image and file configuration

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -120,6 +120,9 @@ class WebDriverProxy:
                     (By.CLASS_NAME, "slice_container")
                 )
             )
+            selenium_animation_wait = current_app.config["SCREENSHOT_SELENIUM_ANIMATION_WAIT"]
+            logger.debug("Wait %i seconds for chart animation", selenium_animation_wait)
+            sleep(selenium_animation_wait)
             logger.info("Taking a PNG screenshot or url %s", url)
             img = element.screenshot_as_png
         except TimeoutException:

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -120,7 +120,9 @@ class WebDriverProxy:
                     (By.CLASS_NAME, "slice_container")
                 )
             )
-            selenium_animation_wait = current_app.config["SCREENSHOT_SELENIUM_ANIMATION_WAIT"]
+            selenium_animation_wait = current_app.config[
+                "SCREENSHOT_SELENIUM_ANIMATION_WAIT"
+            ]
             logger.debug("Wait %i seconds for chart animation", selenium_animation_wait)
             sleep(selenium_animation_wait)
             logger.info("Taking a PNG screenshot or url %s", url)

--- a/tests/integration_tests/thumbnails_tests.py
+++ b/tests/integration_tests/thumbnails_tests.py
@@ -117,6 +117,7 @@ class TestWebDriverProxy(SupersetTestCase):
         webdriver.get_screenshot(url, "chart-container", user=user)
         assert mock_sleep.call_args_list[1] == call(4)
 
+
 class TestThumbnails(SupersetTestCase):
 
     mock_image = b"bytes mock image"

--- a/tests/integration_tests/thumbnails_tests.py
+++ b/tests/integration_tests/thumbnails_tests.py
@@ -102,6 +102,20 @@ class TestWebDriverProxy(SupersetTestCase):
         webdriver.get_screenshot(url, "chart-container", user=user)
         assert mock_webdriver_wait.call_args_list[1] == call(ANY, 15)
 
+    @patch("superset.utils.webdriver.WebDriverWait")
+    @patch("superset.utils.webdriver.firefox")
+    @patch("superset.utils.webdriver.sleep")
+    def test_screenshot_selenium_animation_wait(
+        self, mock_sleep, mock_webdriver, mock_webdriver_wait
+    ):
+        webdriver = WebDriverProxy("firefox")
+        user = security_manager.get_user_by_username(
+            app.config["THUMBNAIL_SELENIUM_USER"]
+        )
+        url = get_url_path("Superset.slice", slice_id=1, standalone="true")
+        app.config["SCREENSHOT_SELENIUM_ANIMATION_WAIT"] = 4
+        webdriver.get_screenshot(url, "chart-container", user=user)
+        assert mock_sleep.call_args_list[1] == call(4)
 
 class TestThumbnails(SupersetTestCase):
 


### PR DESCRIPTION
### SUMMARY

Since the chart in the report screenshot is sent before the end of the animation
Added a wait time for chart animation when screenshot.

New configuration keys:
SCREENSHOT_SELENIUM_ANIMATION_WAIT: in seconds

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
