### PR TITLE
fix: duplicate DB names

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -530,16 +530,16 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
     }
   };
 
-  const setDatabaseModel = (engine: string) => {
+  const setDatabaseModel = (database_name: string) => {
     const selectedDbModel = availableDbs?.databases.filter(
-      (db: DatabaseObject) => db.engine === engine,
+      (db: DatabaseObject) => db.name === database_name,
     )[0];
-    const { name, parameters } = selectedDbModel;
+    const { engine, parameters } = selectedDbModel;
     const isDynamic = parameters !== undefined;
     setDB({
       type: ActionType.dbSelected,
       payload: {
-        database_name: name,
+        database_name,
         configuration_method: isDynamic
           ? CONFIGURATION_METHOD.DYNAMIC_FORM
           : CONFIGURATION_METHOD.SQLALCHEMY_URI,
@@ -564,7 +564,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
             a.name.localeCompare(b.name),
           )
           .map((database: DatabaseForm) => (
-            <Select.Option value={database.engine} key={database.engine}>
+            <Select.Option value={database.name} key={database.name}>
               {database.name}
             </Select.Option>
           ))}
@@ -618,7 +618,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
         .map((database: DatabaseForm) => (
           <IconButton
             className="preferred-item"
-            onClick={() => setDatabaseModel(database.engine)}
+            onClick={() => setDatabaseModel(database.name)}
             buttonText={database.name}
             icon={dbImages?.[database.engine]}
           />

--- a/superset-frontend/src/views/CRUD/data/database/types.ts
+++ b/superset-frontend/src/views/CRUD/data/database/types.ts
@@ -25,6 +25,7 @@ export type DatabaseObject = {
   // Connection + general
   id?: number;
   database_name: string;
+  name: string; // synonym to database_name
   sqlalchemy_uri?: string;
   backend?: string;
   created_by?: null | DatabaseUser;


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fix the DB name selector by using `name` as the key, since it's unique. The key we're using, `engine`, is not unique, since multiple DBs can use the same engine — Apache Spark SQL and Apache Hive both use `hive` as their engine, eg.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

<img width="1478" alt="Screen Shot 2021-07-08 at 9 57 36 PM" src="https://user-images.githubusercontent.com/1534870/125025445-87bbff80-e037-11eb-8343-f6be3baf4066.png">

After:

<img width="1478" alt="Screen Shot 2021-07-08 at 9 56 24 PM" src="https://user-images.githubusercontent.com/1534870/125025452-8d194a00-e037-11eb-8129-9ce85ef9ddb3.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
