### PR TITLE
Fix helm chart db connection credentials Fixes #15133

### DIFF
--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -178,10 +178,10 @@ supersetNode:
     redis_host: '{{ template "superset.fullname" . }}-redis-headless'
     redis_port: "6379"
     db_host: '{{ template "superset.fullname" . }}-postgresql'
-    db_port: "5432"
-    db_user: superset
-    db_pass: superset
-    db_name: superset
+    db_port: {{ .Values.postgresql.service.port }}
+    db_user: {{ .Values.postgresql.postgresqlUsername }}
+    db_pass: {{ .Values.postgresql.postgresqlPassword }}
+    db_name: {{ .Values.postgresql.postgresqlDatabase }}
   forceReload: false # If true, forces deployment to reload on each upgrade
   initContainers:
     - name: wait-for-postgres

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -178,10 +178,10 @@ supersetNode:
     redis_host: '{{ template "superset.fullname" . }}-redis-headless'
     redis_port: "6379"
     db_host: '{{ template "superset.fullname" . }}-postgresql'
-    db_port: {{ .Values.postgresql.service.port }}
-    db_user: {{ .Values.postgresql.postgresqlUsername }}
-    db_pass: {{ .Values.postgresql.postgresqlPassword }}
-    db_name: {{ .Values.postgresql.postgresqlDatabase }}
+    db_port: '{{ .Values.postgresql.service.port }}'
+    db_user: '{{ .Values.postgresql.postgresqlUsername }}'
+    db_pass: '{{ .Values.postgresql.postgresqlPassword }}'
+    db_name: '{{ .Values.postgresql.postgresqlDatabase }}'
   forceReload: false # If true, forces deployment to reload on each upgrade
   initContainers:
     - name: wait-for-postgres


### PR DESCRIPTION
### SUMMARY
The helm chart is using hardcoded values for the db connection that are different than the postgres values.
For security reasons and to make sure the db connection use the correct password for postgres, I've modified the db connection values to refer to the postgres values.

### TESTING INSTRUCTIONS
Follow instructions on
https://superset.apache.org/docs/installation/running-on-kubernetes
with default security settings:
```
postgresql:
  postgresqlPassword: **UNIQUEPASSWORD**
```

### ADDITIONAL INFORMATION
- x] Has associated issue: https://github.com/apache/superset/issues/15133
