### PR TITLE
fix: error page status codes

### DIFF
--- a/superset/typing.py
+++ b/superset/typing.py
@@ -57,5 +57,9 @@ Base = Union[bytes, str]
 Status = Union[int, str]
 Headers = Dict[str, Any]
 FlaskResponse = Union[
-    Response, Base, Tuple[Base, Status], Tuple[Base, Status, Headers],
+    Response,
+    Base,
+    Tuple[Base, Status],
+    Tuple[Base, Status, Headers],
+    Tuple[Response, Status],
 ]

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -397,7 +397,7 @@ def show_http_exception(ex: HTTPException) -> FlaskResponse:
         and ex.code in {404, 500}
     ):
         path = resource_filename("superset", f"static/assets/{ex.code}.html")
-        return send_file(path)
+        return send_file(path), ex.code
 
     return json_errors_response(
         errors=[


### PR DESCRIPTION
### SUMMARY
We've been having infinite spinners in our superset instance because static resources have been returned with an html file instead. I suspected these static resources are 404ing, but when looking at the superset pods, the resources did exist. Since doing a force refresh resolves the bug, i'm thinking we may have cached the 404 page response, perhaps when a user was loading superset during a deploy. Investigation shows that the 404 page was being returned with a 200 status code and caching headers, so at the very least we should return the proper status code here. And hopefully this will resolve our infinite spinner bugs too.

### TESTING INSTRUCTIONS
Go to a non existent page in superset, see the 404 page is returned with status code 404

Before:
<img width="786" alt="Screen Shot 2021-07-09 at 9 26 45 PM" src="https://user-images.githubusercontent.com/7409244/125127499-744d7a80-e0b1-11eb-9944-9bdcd5ea6739.png">
After:
<img width="784" alt="Screen Shot 2021-07-09 at 9 26 19 PM" src="https://user-images.githubusercontent.com/7409244/125127494-7283b700-e0b1-11eb-9651-d83dc422d25f.png">


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @betodealmeida @john-bodley @graceguo-supercat 