### PR TITLE
feat(menu): expand support for custom branding

### DIFF
--- a/superset-frontend/src/components/Menu/Menu.test.tsx
+++ b/superset-frontend/src/components/Menu/Menu.test.tsx
@@ -75,8 +75,11 @@ const mockedProps = {
       icon: '/static/assets/images/superset-logo-horiz.png',
       alt: 'Superset',
       width: '126',
+      tooltip: '',
+      text: '',
     },
     navbar_right: {
+      show_watermark: false,
       bug_report_url: '/report/',
       documentation_url: '/docs/',
       languages: {

--- a/superset-frontend/src/components/Menu/Menu.tsx
+++ b/superset-frontend/src/components/Menu/Menu.tsx
@@ -22,22 +22,25 @@ import { debounce } from 'lodash';
 import { Global } from '@emotion/react';
 import { getUrlParam } from 'src/utils/urlUtils';
 import { MainNav as DropdownMenu, MenuMode } from 'src/common/components';
+import { Tooltip } from 'src/components/Tooltip';
 import { Link } from 'react-router-dom';
 import { Row, Col, Grid } from 'antd';
 import Icons from 'src/components/Icons';
+import { URL_PARAMS } from 'src/constants';
 import RightMenu from './MenuRight';
 import { Languages } from './LanguagePicker';
-import { URL_PARAMS } from '../../constants';
 
 interface BrandProps {
   path: string;
   icon: string;
   alt: string;
   width: string | number;
+  tooltip: string;
   text: string;
 }
 
 export interface NavBarProps {
+  show_watermark: boolean;
   bug_report_url?: string;
   version_string?: string;
   version_sha?: string;
@@ -97,14 +100,14 @@ const StyledHeader = styled.header`
     height: 100%;
     color: ${({ theme }) => theme.colors.grayscale.dark1};
     padding-left: ${({ theme }) => theme.gridUnit * 4}px;
-    padding-right:${({ theme }) => theme.gridUnit * 4}px;
+    padding-right: ${({ theme }) => theme.gridUnit * 4}px;
     margin-right: ${({ theme }) => theme.gridUnit * 6}px;
     font-size: ${({ theme }) => theme.gridUnit * 4}px;
     float: left;
     display: flex;
     flex-direction: column;
     justify-content: center;
-    
+
     span {
       max-width: ${({ theme }) => theme.gridUnit * 58}px;
       white-space: nowrap;
@@ -254,14 +257,19 @@ export function Menu({
       />
       <Row>
         <Col md={16} xs={24}>
-          <a className="navbar-brand" href={brand.path}>
-            <img width={brand.width} src={brand.icon} alt={brand.alt} />
-          </a>
+          <Tooltip
+            id="brand-tooltip"
+            placement="bottomLeft"
+            title={brand.tooltip}
+            arrowPointAtCenter
+          >
+            <a className="navbar-brand" href={brand.path}>
+              <img width={brand.width} src={brand.icon} alt={brand.alt} />
+            </a>
+          </Tooltip>
           {brand.text && (
             <div className="navbar-brand-text">
-              <span>
-                {brand.text}
-              </span>
+              <span>{brand.text}</span>
             </div>
           )}
           <DropdownMenu
@@ -303,7 +311,7 @@ export function Menu({
 }
 
 // transform the menu data to reorganize components
-export default function MenuWrapper({ data, isFrontendRoute }: MenuProps) {
+export default function MenuWrapper({ data, ...rest }: MenuProps) {
   const newMenuData = {
     ...data,
   };
@@ -349,5 +357,5 @@ export default function MenuWrapper({ data, isFrontendRoute }: MenuProps) {
   newMenuData.menu = cleanedMenu;
   newMenuData.settings = settings;
 
-  return <Menu data={newMenuData} isFrontendRoute={isFrontendRoute}/>;
+  return <Menu data={newMenuData} {...rest} />;
 }

--- a/superset-frontend/src/components/Menu/Menu.tsx
+++ b/superset-frontend/src/components/Menu/Menu.tsx
@@ -34,6 +34,7 @@ interface BrandProps {
   icon: string;
   alt: string;
   width: string | number;
+  text: string;
 }
 
 export interface NavBarProps {
@@ -78,7 +79,6 @@ export interface MenuObjectProps extends MenuObjectChildProps {
 const StyledHeader = styled.header`
   background-color: white;
   margin-bottom: 2px;
-  border-bottom: 2px solid ${({ theme }) => theme.colors.grayscale.light4}px;
   &:nth-last-of-type(2) nav {
     margin-bottom: 2px;
   }
@@ -90,6 +90,32 @@ const StyledHeader = styled.header`
     display: flex;
     flex-direction: column;
     justify-content: center;
+  }
+  .navbar-brand-text {
+    border-left: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
+    border-right: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
+    height: 100%;
+    color: ${({ theme }) => theme.colors.grayscale.dark1};
+    padding-left: ${({ theme }) => theme.gridUnit * 4}px;
+    padding-right:${({ theme }) => theme.gridUnit * 4}px;
+    margin-right: ${({ theme }) => theme.gridUnit * 6}px;
+    font-size: ${({ theme }) => theme.gridUnit * 4}px;
+    float: left;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    
+    span {
+      max-width: ${({ theme }) => theme.gridUnit * 58}px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+  @media (max-width: 1010px) {
+    .navbar-brand-text {
+      display: none;
+    }
   }
   .main-nav .ant-menu-submenu-title > svg {
     top: ${({ theme }) => theme.gridUnit * 5.25}px;
@@ -231,6 +257,13 @@ export function Menu({
           <a className="navbar-brand" href={brand.path}>
             <img width={brand.width} src={brand.icon} alt={brand.alt} />
           </a>
+          {brand.text && (
+            <div className="navbar-brand-text">
+              <span>
+                {brand.text}
+              </span>
+            </div>
+          )}
           <DropdownMenu
             mode={showMenu}
             data-test="navbar-top"
@@ -270,7 +303,7 @@ export function Menu({
 }
 
 // transform the menu data to reorganize components
-export default function MenuWrapper({ data, ...rest }: MenuProps) {
+export default function MenuWrapper({ data, isFrontendRoute }: MenuProps) {
   const newMenuData = {
     ...data,
   };
@@ -316,5 +349,5 @@ export default function MenuWrapper({ data, ...rest }: MenuProps) {
   newMenuData.menu = cleanedMenu;
   newMenuData.settings = settings;
 
-  return <Menu data={newMenuData} {...rest} />;
+  return <Menu data={newMenuData} isFrontendRoute={isFrontendRoute}/>;
 }

--- a/superset-frontend/src/components/Menu/Menu.tsx
+++ b/superset-frontend/src/components/Menu/Menu.tsx
@@ -114,9 +114,7 @@ const StyledHeader = styled.header`
       overflow: hidden;
       text-overflow: ellipsis;
     }
-  }
-  @media (max-width: 1010px) {
-    .navbar-brand-text {
+    @media (max-width: 1070px) {
       display: none;
     }
   }

--- a/superset-frontend/src/components/Menu/Menu.tsx
+++ b/superset-frontend/src/components/Menu/Menu.tsx
@@ -114,7 +114,7 @@ const StyledHeader = styled.header`
       overflow: hidden;
       text-overflow: ellipsis;
     }
-    @media (max-width: 1070px) {
+    @media (max-width: 1127px) {
       display: none;
     }
   }

--- a/superset-frontend/src/components/Menu/MenuRight.tsx
+++ b/superset-frontend/src/components/Menu/MenuRight.tsx
@@ -71,7 +71,7 @@ const StyledAnchor = styled.a`
 
 const WaterMark = styled.span`
   font-size: 13px;
-  color: ${({ theme }) => theme.colors.grayscale.base};
+  color: #B0B4C3;
   margin: 0 ${({ theme }) => theme.gridUnit * 4}px;
   @media (max-width: 1070px) {
     display: none;

--- a/superset-frontend/src/components/Menu/MenuRight.tsx
+++ b/superset-frontend/src/components/Menu/MenuRight.tsx
@@ -69,6 +69,15 @@ const StyledAnchor = styled.a`
   padding-left: ${({ theme }) => theme.gridUnit}px;
 `;
 
+const WaterMark = styled.span`
+  font-size: 13px;
+  color: ${({ theme }) => theme.colors.grayscale.base};
+  margin: 0 ${({ theme }) => theme.gridUnit * 4}px;
+  @media (max-width: 1070px) {
+    display: none;
+  }
+`;
+
 const { SubMenu } = Menu;
 
 interface RightMenuProps {
@@ -86,6 +95,9 @@ const RightMenu = ({
 }: RightMenuProps) => (
   <StyledDiv align={align}>
     <Menu mode="horizontal">
+      {navbarRight.show_watermark && (
+        <WaterMark>{t('Powered by Apache Superset')}</WaterMark>
+      )}
       {!navbarRight.user_is_anonymous && (
         <SubMenu
           data-test="new-dropdown"

--- a/superset-frontend/src/components/Menu/MenuRight.tsx
+++ b/superset-frontend/src/components/Menu/MenuRight.tsx
@@ -71,7 +71,7 @@ const StyledAnchor = styled.a`
 
 const WaterMark = styled.span`
   font-size: 13px;
-  color: #B0B4C3;
+  color: #b0b4c3;
   margin: 0 ${({ theme }) => theme.gridUnit * 4}px;
   @media (max-width: 1070px) {
     display: none;

--- a/superset/config.py
+++ b/superset/config.py
@@ -212,13 +212,16 @@ PROXY_FIX_CONFIG = {"x_for": 1, "x_proto": 1, "x_host": 1, "x_port": 1, "x_prefi
 # Uncomment to setup Your App name
 APP_NAME = "Superset"
 
-# Uncomment to setup an App icon
+# Specify the App icon
 APP_ICON = "/static/assets/images/superset-logo-horiz.png"
 APP_ICON_WIDTH = 126
 
 # Specify where clicking the logo would take the user
 # e.g. setting it to '/' would take the user to '/superset/welcome/'
 LOGO_TARGET_PATH = None
+
+# Specify tooltip that should appear when hovering over the App Icon/Logo
+LOGO_TOOLTIP = ""
 
 # Specify any text that should appear to the right of the logo
 LOGO_RIGHT_TEXT: Union[Callable[[], str], str] = ""

--- a/superset/config.py
+++ b/superset/config.py
@@ -221,7 +221,7 @@ APP_ICON_WIDTH = 126
 LOGO_TARGET_PATH = None
 
 # Specify any text that should appear to the right of the logo
-LOGO_RIGHT_TEXT = ""
+LOGO_RIGHT_TEXT: Union[Callable[[], str], str] = ""
 
 # Enables SWAGGER UI for superset openapi spec
 # ex: http://localhost:8080/swagger/v1

--- a/superset/config.py
+++ b/superset/config.py
@@ -216,9 +216,12 @@ APP_NAME = "Superset"
 APP_ICON = "/static/assets/images/superset-logo-horiz.png"
 APP_ICON_WIDTH = 126
 
-# Uncomment to specify where clicking the logo would take the user
+# Specify where clicking the logo would take the user
 # e.g. setting it to '/' would take the user to '/superset/welcome/'
 LOGO_TARGET_PATH = None
+
+# Specify any text that should appear to the right of the logo
+LOGO_RIGHT_TEXT = ""
 
 # Enables SWAGGER UI for superset openapi spec
 # ex: http://localhost:8080/swagger/v1

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -309,7 +309,9 @@ def menu_data() -> Dict[str, Any]:
             **appbuilder.languages[lang],
             "url": appbuilder.get_url_for_locale(lang),
         }
-
+    brand_text = appbuilder.app.config["LOGO_RIGHT_TEXT"]
+    if callable(brand_text):
+        brand_text = brand_text()
     return {
         "menu": menu,
         "brand": {
@@ -317,7 +319,7 @@ def menu_data() -> Dict[str, Any]:
             "icon": appbuilder.app_icon,
             "alt": appbuilder.app_name,
             "width": appbuilder.app.config["APP_ICON_WIDTH"],
-            "text": appbuilder.app.config["LOGO_RIGHT_TEXT"],
+            "text": brand_text,
         },
         "navbar_right": {
             "bug_report_url": appbuilder.app.config["BUG_REPORT_URL"],

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -324,9 +324,7 @@ def menu_data() -> Dict[str, Any]:
         },
         "navbar_right": {
             # show the watermark if the default app icon has been overriden
-            "show_watermark": (
-               "superset-logo-horiz" not in appbuilder.app_icon
-            ),
+            "show_watermark": ("superset-logo-horiz" not in appbuilder.app_icon),
             "bug_report_url": appbuilder.app.config["BUG_REPORT_URL"],
             "documentation_url": appbuilder.app.config["DOCUMENTATION_URL"],
             "version_string": appbuilder.app.config["VERSION_STRING"],

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -319,9 +319,14 @@ def menu_data() -> Dict[str, Any]:
             "icon": appbuilder.app_icon,
             "alt": appbuilder.app_name,
             "width": appbuilder.app.config["APP_ICON_WIDTH"],
+            "tooltip": appbuilder.app.config["LOGO_TOOLTIP"],
             "text": brand_text,
         },
         "navbar_right": {
+            # show the watermark if the default app icon has been overriden
+            "show_watermark": (
+               "superset-logo-horiz" not in appbuilder.app_icon
+            ),
             "bug_report_url": appbuilder.app.config["BUG_REPORT_URL"],
             "documentation_url": appbuilder.app.config["DOCUMENTATION_URL"],
             "version_string": appbuilder.app.config["VERSION_STRING"],

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -309,6 +309,7 @@ def menu_data() -> Dict[str, Any]:
             **appbuilder.languages[lang],
             "url": appbuilder.get_url_for_locale(lang),
         }
+
     return {
         "menu": menu,
         "brand": {
@@ -316,6 +317,7 @@ def menu_data() -> Dict[str, Any]:
             "icon": appbuilder.app_icon,
             "alt": appbuilder.app_name,
             "width": appbuilder.app.config["APP_ICON_WIDTH"],
+            "text": appbuilder.app.config["LOGO_RIGHT_TEXT"],
         },
         "navbar_right": {
             "bug_report_url": appbuilder.app.config["BUG_REPORT_URL"],


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Expands support for custom branding in superset via config options:
- LOGO_RIGHT_TEXT: text that should appear next to the logo
- LOGO_TOOLTIP: tooltip that should appear when hovering over logo

Additionally, a watermark `Powered by Apache Superset` is added if the logo (APP_ICON) is changed from the default superset logo `superset-logo-horiz`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
After:
<img width="1680" alt="Screen Shot 2021-07-09 at 5 13 56 PM" src="https://user-images.githubusercontent.com/10255196/125146175-c908e980-e0e1-11eb-8ff5-116322e49eab.png">

<img width="775" alt="Screen Shot 2021-07-09 at 5 54 44 PM" src="https://user-images.githubusercontent.com/10255196/125147221-310dfe80-e0e7-11eb-88d9-87f2d84ede7f.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Manually tested by setting configs


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
