### PR TITLE
fix: Updated documentation mapping in Google Sheets modal header

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm.tsx
@@ -66,6 +66,7 @@ interface FieldPropTypes {
   sslForced?: boolean;
   defaultDBName?: string;
   editNewDb?: boolean;
+  setPublicSheets: (value: string) => void;
 }
 
 const CredentialsInfo = ({
@@ -299,19 +300,42 @@ const displayField = ({
   getValidation,
   validationErrors,
   db,
+  setPublicSheets,
 }: FieldPropTypes) => (
-  <ValidatedInput
-    id="database_name"
-    name="database_name"
-    required
-    value={db?.database_name}
-    validationMethods={{ onBlur: getValidation }}
-    errorMessage={validationErrors?.database_name}
-    placeholder=""
-    label="Display Name"
-    onChange={changeMethods.onChange}
-    helpText={t('Pick a nickname for this database to display as in Superset.')}
-  />
+  <>
+    <ValidatedInput
+      id="database_name"
+      name="database_name"
+      required
+      value={db?.database_name}
+      validationMethods={{ onBlur: getValidation }}
+      errorMessage={validationErrors?.database_name}
+      placeholder=""
+      label="Display Name"
+      onChange={changeMethods.onChange}
+      helpText={t(
+        'Pick a nickname for this database to display as in Superset.',
+      )}
+    />
+
+    {db?.engine === 'gsheets' && (
+      <>
+        <FormLabel required>{t('Type of Google Sheets Allowed')}</FormLabel>
+        <Select
+          style={{ width: '100%' }}
+          onChange={(value: string) => setPublicSheets(value)}
+          defaultValue="true"
+        >
+          <Select.Option value="true" key={1}>
+            Publicly shared sheets only
+          </Select.Option>
+          <Select.Option value="false" key={2}>
+            Public and privately shared sheets
+          </Select.Option>
+        </Select>
+      </>
+    )}
+  </>
 );
 
 const queryField = ({
@@ -388,10 +412,13 @@ const DatabaseConnectionForm = ({
   isEditMode = false,
   sslForced,
   editNewDb,
+  setPublicSheets,
 }: {
   isEditMode?: boolean;
   sslForced: boolean;
   editNewDb?: boolean;
+  isPublic?: boolean;
+  setPublicSheets: (value: string) => void;
   dbModel: DatabaseForm;
   db: Partial<DatabaseObject> | null;
   onParametersChange: (
@@ -434,6 +461,7 @@ const DatabaseConnectionForm = ({
             isEditMode,
             sslForced,
             editNewDb,
+            setPublicSheets,
           }),
         )}
     </div>

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm.tsx
@@ -84,7 +84,6 @@ const CredentialsInfo = ({
   const [fileToUpload, setFileToUpload] = useState<string | null | undefined>(
     null,
   );
-  console.log('in credentials', isPublic);
   return (
     <CredentialInfoForm>
       {!isEditMode && db?.engine === 'bigquery' && (

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ModalHeader.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ModalHeader.tsx
@@ -35,6 +35,7 @@ const supersetTextDocs = getDatabaseDocumentationLinks();
 const irregularDocumentationLinks = {
   postgresql: 'https://superset.apache.org/docs/databases/postgres',
   mssql: 'https://superset.apache.org/docs/databases/sql-server',
+  gsheets: 'https://superset.apache.org/docs/databases/google-sheets',
 };
 
 const documentationLink = (engine: string | undefined) => {
@@ -50,6 +51,7 @@ const documentationLink = (engine: string | undefined) => {
   }
   return irregularDocumentationLinks[engine];
 };
+
 const ModalHeader = ({
   isLoading,
   isEditMode,

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -808,6 +808,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
     }
     return (
       <DatabaseConnectionForm
+        isPublic={isPublic}
         isEditMode
         sslForced={sslForced}
         dbModel={dbModel}
@@ -922,7 +923,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
           ) : (
             <DatabaseConnectionForm
               isEditMode
-              isPublic
+              isPublic={isPublic}
               setPublicSheets={setPublicSheets}
               sslForced={sslForced}
               dbModel={dbModel}
@@ -1081,6 +1082,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
                   </StyledAlertMargin>
                 )}
                 <DatabaseConnectionForm
+                  isPublic={isPublic}
                   db={db}
                   setPublicSheets={setPublicSheets}
                   sslForced={sslForced}

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -361,7 +361,6 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
     t('database'),
     addDangerToast,
   );
-  console.log(isPublic);
   const isDynamic = (engine: string | undefined) =>
     availableDbs?.databases.filter(
       (DB: DatabaseObject) => DB.backend === engine || DB.engine === engine,

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -338,6 +338,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
   const [dbName, setDbName] = useState('');
   const [editNewDb, setEditNewDb] = useState<boolean>(false);
   const [isLoading, setLoading] = useState<boolean>(false);
+  const [isPublic, setPublic] = useState<boolean>(true);
   const conf = useCommonConf();
   const dbImages = getDatabaseImages();
   const connectionAlert = getConnectionAlert();
@@ -360,7 +361,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
     t('database'),
     addDangerToast,
   );
-
+  console.log(isPublic);
   const isDynamic = (engine: string | undefined) =>
     availableDbs?.databases.filter(
       (DB: DatabaseObject) => DB.backend === engine || DB.engine === engine,
@@ -527,6 +528,14 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
           ),
         );
       }
+    }
+  };
+
+  const setPublicSheets = (value: string) => {
+    if (value === 'true') {
+      setPublic(true);
+    } else {
+      setPublic(false);
     }
   };
 
@@ -802,6 +811,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
         isEditMode
         sslForced={sslForced}
         dbModel={dbModel}
+        setPublicSheets={setPublicSheets}
         db={db as DatabaseObject}
         onParametersChange={({ target }: { target: HTMLInputElement }) =>
           onChange(ActionType.parametersChange, {
@@ -912,6 +922,8 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
           ) : (
             <DatabaseConnectionForm
               isEditMode
+              isPublic
+              setPublicSheets={setPublicSheets}
               sslForced={sslForced}
               dbModel={dbModel}
               db={db as DatabaseObject}
@@ -1070,6 +1082,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
                 )}
                 <DatabaseConnectionForm
                   db={db}
+                  setPublicSheets={setPublicSheets}
                   sslForced={sslForced}
                   dbModel={dbModel}
                   onParametersChange={({


### PR DESCRIPTION
### SUMMARY
Updated documentation mapping in Google Sheets modal header to direct to https://superset.apache.org/docs/databases/google-sheets.

### TESTING INSTRUCTIONS
- Hover over "Data" in the upper navigation bar
- Click "Database"
- Click the "+ Database" button below the navigation bar and to the right
- Select Google Sheets
- Click "connecting to Google Sheets" in the modal header
- Observe that the link directs to the correct documentation: https://superset.apache.org/docs/databases/google-sheets

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
