### PR TITLE
fix: Remove default values for engine and schemas

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx
@@ -414,7 +414,7 @@ const ExtraOptions = ({
           <div className="input-container">
             <StyledJsonEditor
               name="metadata_params"
-              value={db?.extra_json?.metadata_params || '{}'}
+              value={db?.extra_json?.metadata_params || ''}
               placeholder={t('Metadata Parameters')}
               onChange={(json: string) =>
                 onExtraEditorChange({ json, name: 'metadata_params' })
@@ -436,7 +436,7 @@ const ExtraOptions = ({
           <div className="input-container">
             <StyledJsonEditor
               name="engine_params"
-              value={db?.extra_json?.engine_params || '{}'}
+              value={db?.extra_json?.engine_params || ''}
               placeholder={t('Engine Parameters')}
               onChange={(json: string) =>
                 onExtraEditorChange({ json, name: 'engine_params' })

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -468,9 +468,10 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
         engine_params: JSON.parse(
           (dbToUpdate?.extra_json?.engine_params as string) || '{}',
         ),
-        schemas_allowed_for_csv_upload:
+        schemas_allowed_for_csv_upload: JSON.parse(
           (dbToUpdate?.extra_json?.schemas_allowed_for_csv_upload as string) ||
-          '',
+            '[]',
+        ),
       });
     }
 

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -463,14 +463,14 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       dbToUpdate.extra = JSON.stringify({
         ...dbToUpdate.extra_json,
         metadata_params: JSON.parse(
-          (dbToUpdate?.extra_json?.metadata_params as string) || '{}',
+          (dbToUpdate?.extra_json?.metadata_params as string) || '',
         ),
         engine_params: JSON.parse(
-          (dbToUpdate?.extra_json?.engine_params as string) || '{}',
+          (dbToUpdate?.extra_json?.engine_params as string) || '',
         ),
         schemas_allowed_for_csv_upload:
           (dbToUpdate?.extra_json?.schemas_allowed_for_csv_upload as string) ||
-          '[]',
+          '',
       });
     }
 

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -463,10 +463,10 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       dbToUpdate.extra = JSON.stringify({
         ...dbToUpdate.extra_json,
         metadata_params: JSON.parse(
-          (dbToUpdate?.extra_json?.metadata_params as string) || '',
+          (dbToUpdate?.extra_json?.metadata_params as string) || '{}',
         ),
         engine_params: JSON.parse(
-          (dbToUpdate?.extra_json?.engine_params as string) || '',
+          (dbToUpdate?.extra_json?.engine_params as string) || '{}',
         ),
         schemas_allowed_for_csv_upload:
           (dbToUpdate?.extra_json?.schemas_allowed_for_csv_upload as string) ||


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove putting a default JSON object whenever engine_params or metadata_params is set. Also removed the allow_schemas_csv_upload quotation marks on that field

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

<img width="513" alt="Screen Shot 2021-07-12 at 10 44 13 AM" src="https://user-images.githubusercontent.com/27827808/125332728-3ee99c80-e2fe-11eb-8268-97f1770507df.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
