### PR TITLE
refactor: Move is_user_admin() to security_manager

### DIFF
--- a/superset/dashboards/filters.py
+++ b/superset/dashboards/filters.py
@@ -27,7 +27,7 @@ from superset import db, is_feature_enabled, security_manager
 from superset.models.core import FavStar
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
-from superset.views.base import BaseFilter, get_user_roles, is_user_admin
+from superset.views.base import BaseFilter, get_user_roles
 from superset.views.base_api import BaseFavoriteFilter
 
 
@@ -70,7 +70,7 @@ class DashboardAccessFilter(BaseFilter):
     """
 
     def apply(self, query: Query, value: Any) -> Query:
-        if is_user_admin():
+        if security_manager.is_user_admin():
             return query
 
         datasource_perms = security_manager.user_view_menu_names("datasource_access")

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -270,11 +270,6 @@ def get_user_roles() -> List[Role]:
     return g.user.roles
 
 
-def is_user_admin() -> bool:
-    user_roles = [role.name.lower() for role in list(get_user_roles())]
-    return "admin" in user_roles
-
-
 class BaseSupersetView(BaseView):
     @staticmethod
     def json_response(
@@ -625,7 +620,7 @@ def check_ownership(obj: Any, raise_if_false: bool = True) -> bool:
         if raise_if_false:
             raise security_exception
         return False
-    if is_user_admin():
+    if security_manager.is_user_admin():
         return True
     scoped_session = db.create_scoped_session()
     orig_obj = scoped_session.query(obj.__class__).filter_by(id=obj.id).first()


### PR DESCRIPTION
### SUMMARY
Having is_user_admin is a design flaw, but in any
case should always be handled within the security
manager so it can be overridden.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
Test admin user works as befre

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
