### PR TITLE
chore: Reverts reset form in native filters

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
@@ -164,6 +164,15 @@ export function FiltersConfigModal({
     addFilter,
   );
 
+  // After this, it should be as if the modal was just opened fresh.
+  // Called when the modal is closed.
+  const resetForm = () => {
+    setNewFilterIds([]);
+    setCurrentFilterId(initialCurrentFilterId);
+    setRemovedFilters({});
+    setSaveAlertVisible(false);
+  };
+
   const getFilterTitle = (id: string) =>
     formValues.filters[id]?.name ??
     filterConfigMap[id]?.name ??
@@ -208,6 +217,7 @@ export function FiltersConfigModal({
   };
 
   const handleConfirmCancel = () => {
+    resetForm();
     onCancel();
   };
 


### PR DESCRIPTION
### SUMMARY
Revert the removal of `resetForm` made in https://github.com/apache/superset/pull/15572. Changes made in that PR caused the cancel functionality to stop working.

@simcha90 @kgabryje @rusackas 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/70410625/125358428-40878480-e33f-11eb-87f6-7c5d53935156.mp4

https://user-images.githubusercontent.com/70410625/125358523-5eed8000-e33f-11eb-8600-990daad7ff59.mp4

### TESTING INSTRUCTIONS
See before/after videos.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
