### PR TITLE
chore: Add metrics_b as viable metric form data parameter

### DIFF
--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -34,8 +34,9 @@ from superset.utils.core import GenericDataType
 
 METRIC_FORM_DATA_PARAMS = [
     "metric",
-    "metrics",
     "metric_2",
+    "metrics",
+    "metrics_b",
     "percent_metrics",
     "secondary_metric",
     "size",


### PR DESCRIPTION
### SUMMARY

Only because nine encodings for metrics wasn't enough. See [here](https://github.com/apache-superset/superset-ui/blob/447d888663d4fbbebd60a3d1ad45e21e2ffde29e/plugins/plugin-chart-echarts/src/MixedTimeseries/buildQuery.ts#L38) for details regarding where this is defined.

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
