### PR TITLE
fix: safe removal of empty tab with scoped filters

### DIFF
--- a/superset-frontend/src/dashboard/util/activeAllDashboardFilters.ts
+++ b/superset-frontend/src/dashboard/util/activeAllDashboardFilters.ts
@@ -104,7 +104,7 @@ export const getAllActiveFilters = ({
       };
     // Iterate over all roots to find all affected charts
     scope.rootPath.forEach((layoutItemId: string | number) => {
-      layout[layoutItemId].children.forEach((child: string) => {
+      layout[layoutItemId]?.children?.forEach((child: string) => {
         // Need exclude from affected charts, charts that located in scope `excluded`
         findAffectedCharts({
           child,


### PR DESCRIPTION
### SUMMARY
Fixes a bug where some tabs couldn't be deleted due to native filters that point to no-longer existing charts within the tab.

This PR fixes the acute issue, but there's room for improvement! Whenever a chart is removed, we should
1) confirm that no filter is scoped to that missing chart any longer.
2) (optional) if the filter no longer has ANY charts within scope, we could ask the user if they want to delete it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![before](https://user-images.githubusercontent.com/812905/125387559-5d31b580-e35b-11eb-82a7-eb54af3fa94f.gif)

After:
![After](https://user-images.githubusercontent.com/812905/125387575-628f0000-e35b-11eb-9f80-5a17ed4a6c87.gif)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
To repro the issue (prior to this PR):

1) Make a dashboard
2) Add tabs
3) Add a chart to a tab (I just used a table)
4) Add a native filter scoped to that chart.
5) (Problem 1) Try to delete the tab containing the chart with the scoped filter. You get an ugly error.
6) Remove the chart with the scoped filter, optionally saving the dash
7) (Problem 2) Try to delete the tab again. Even with the chart gone, you still can't remove the tab.

With this PR, you should be able to remove the tab _with or without_ the chart.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
