### PR TITLE
fix: Make db service use correct env file

### DIFF
--- a/docker-compose-non-dev.yml
+++ b/docker-compose-non-dev.yml
@@ -33,7 +33,7 @@ services:
       - redis:/data
 
   db:
-    env_file: docker/.env
+    env_file: docker/.env-non-dev
     image: postgres:10
     container_name: superset_db
     restart: unless-stopped


### PR DESCRIPTION
Point the db service to docker/.env-non-dev instead of docker/.env.

### SUMMARY
The docker-compose.non-dev.yml db service is pointing to the docker/.env file when it should point to the docker/.env-non-dev file.

### TESTING INSTRUCTIONS
Run the docker compose service and see that it picks up the environment variables in docker/.env-non-dev instead of docker/.env.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
