### PR TITLE
fix(dashboard): Filters panel height

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -72,6 +72,7 @@ const StyledDiv = styled.div`
 const FiltersPanel = styled.div`
   grid-column: 1;
   grid-row: 1 / span 2;
+  min-height: 100vh;
   z-index: 2;
 `;
 

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -204,11 +204,10 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
     FeatureFlag.DASHBOARD_NATIVE_FILTERS_SET,
   );
 
-  const offset = isStandalone
-    ? 0
-    : FILTER_BAR_HEADER_HEIGHT +
-      (isSticky ? 0 : MAIN_HEADER_HEIGHT) +
-      (filterSetEnabled ? FILTER_BAR_TABS_HEIGHT : 0);
+  const offset =
+    FILTER_BAR_HEADER_HEIGHT +
+    (isSticky || isStandalone ? 0 : MAIN_HEADER_HEIGHT) +
+    (filterSetEnabled ? FILTER_BAR_TABS_HEIGHT : 0);
 
   const filterBarHeight = `calc(100vh - ${offset}px)`;
   const filterBarOffset = dashboardFiltersOpen ? 0 : barTopOffset + 20;

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -72,12 +72,10 @@ const StyledDiv = styled.div`
 const FiltersPanel = styled.div`
   grid-column: 1;
   grid-row: 1 / span 2;
-  min-height: 100vh;
   z-index: 2;
 `;
 
 const StickyPanel = styled.div<{ width: number }>`
-  height: 100%;
   position: sticky;
   top: -1px;
   width: ${({ width }) => width}px;
@@ -179,10 +177,9 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
     rootChildId !== DASHBOARD_GRID_ID
       ? dashboardLayout[rootChildId]
       : undefined;
-
+  const isStandalone = getUrlParam(URL_PARAMS.standalone);
   const hideDashboardHeader =
-    getUrlParam(URL_PARAMS.standalone) ===
-    DashboardStandaloneMode.HIDE_NAV_AND_TITLE;
+    isStandalone === DashboardStandaloneMode.HIDE_NAV_AND_TITLE;
 
   const barTopOffset =
     (hideDashboardHeader ? 0 : HEADER_HEIGHT) +
@@ -207,10 +204,11 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
     FeatureFlag.DASHBOARD_NATIVE_FILTERS_SET,
   );
 
-  const offset =
-    FILTER_BAR_HEADER_HEIGHT +
-    (isSticky ? 0 : MAIN_HEADER_HEIGHT) +
-    (filterSetEnabled ? FILTER_BAR_TABS_HEIGHT : 0);
+  const offset = isStandalone
+    ? 0
+    : FILTER_BAR_HEADER_HEIGHT +
+      (isSticky ? 0 : MAIN_HEADER_HEIGHT) +
+      (filterSetEnabled ? FILTER_BAR_TABS_HEIGHT : 0);
 
   const filterBarHeight = `calc(100vh - ${offset}px)`;
   const filterBarOffset = dashboardFiltersOpen ? 0 : barTopOffset + 20;

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -76,6 +76,7 @@ const FiltersPanel = styled.div`
 `;
 
 const StickyPanel = styled.div<{ width: number }>`
+  height: 100%;
   position: sticky;
   top: -1px;
   width: ${({ width }) => width}px;


### PR DESCRIPTION
### SUMMARY
It fixes an issue with the Filters panel height not taking the full view height in "Full-screen" mode. Additionally, it fixes an issue for which the panel appeared cut at the bottom while the page was still loading.

Fixes #15347 

### BEFORE
<img width="1792" alt="123208296-ab961780-d473-11eb-8c32-dfd920683b4f" src="https://user-images.githubusercontent.com/60598000/125471676-4e5259aa-6a8d-4df3-a515-da48d3a2a970.png">

### AFTER
![Screen Shot 2021-07-13 at 16 34 44](https://user-images.githubusercontent.com/60598000/125471701-5ba3b22f-35c8-4f81-8a46-fe4bb19d9dc2.png)


### TESTING INSTRUCTIONS
1. Open a Dashboard with native filters enbabled
2. Observe the left side panel and make sure it takes the full height when loading
3. Click on the dots menu far right and enable the "Full-screen" mode
4. Observe the left side panel and make sure it gets the full height

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #15347 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
