### PR TITLE
fix: Action icons on Antd Card in Homepage

### DIFF
--- a/superset-frontend/src/components/ListViewCard/index.tsx
+++ b/superset-frontend/src/components/ListViewCard/index.tsx
@@ -97,15 +97,16 @@ const TitleContainer = styled.div`
 `;
 
 const TitleLink = styled.span`
+  max-width: 50%;
+  overflow: hidden;
+  text-overflow: ellipsis;
   & a {
     color: ${({ theme }) => theme.colors.grayscale.dark1} !important;
-    overflow: hidden;
-    text-overflow: ellipsis;
-
-    & + .title-right {
-      margin-left: ${({ theme }) => theme.gridUnit * 2}px;
-    }
   }
+`;
+
+const TitleRight = styled.span`
+  margin-left: ${({ theme }) => theme.gridUnit * 2}px;
 `;
 
 const CoverFooter = styled.div`
@@ -246,7 +247,7 @@ function ListViewCard({
                   <Link to={url!}>{title}</Link>
                 </TitleLink>
               </Tooltip>
-              {titleRight && <div className="title-right"> {titleRight}</div>}
+              {titleRight && <TitleRight>{titleRight}</TitleRight>}
               <div className="card-actions" data-test="card-actions">
                 {actions}
               </div>


### PR DESCRIPTION
### SUMMARY
It fixes an issue that was hiding the action icons in the Antd Card in smaller screen sizes. It achieves that by setting a max title limit and overflowing with ellipsis.

Fixes #15369

### BEFORE
![123310435-5cf58580-d526-11eb-9903-da2ad276d58a](https://user-images.githubusercontent.com/60598000/125486579-5b29a95e-9e10-41b5-99aa-ab50173d7f04.png)

### AFTER
![Screen Shot 2021-07-13 at 17 59 21](https://user-images.githubusercontent.com/60598000/125486522-ad879852-6fb1-4a3d-bca6-cb3ae9bfaa9c.png)

### TESTING INSTRUCTIONS
1. Open the Welcome page
2. Observe the cards, especially those with long titles
3. Resize the screen
4. Observe the behavior

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #15369
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
