### PR TITLE
fix: no lazy translation on SupersetError

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -250,18 +250,22 @@ export function queryFailed(query, msg, link, errors) {
           })
         : Promise.resolve();
 
-    return sync
-      .then(() => dispatch({ type: QUERY_FAILED, query, msg, link, errors }))
-      .catch(() =>
-        dispatch(
-          addDangerToast(
-            t(
-              'An error occurred while storing the latest query id in the backend. ' +
-                'Please contact your administrator if this problem persists.',
+    return (
+      sync
+        .catch(() =>
+          dispatch(
+            addDangerToast(
+              t(
+                'An error occurred while storing the latest query id in the backend. ' +
+                  'Please contact your administrator if this problem persists.',
+              ),
             ),
           ),
-        ),
-      );
+        )
+        // We should always show the error message, even if we couldn't sync the
+        // state to the backend
+        .then(() => dispatch({ type: QUERY_FAILED, query, msg, link, errors }))
+    );
   };
 }
 

--- a/superset-frontend/src/setup/setupErrorMessages.ts
+++ b/superset-frontend/src/setup/setupErrorMessages.ts
@@ -44,6 +44,10 @@ export default function setupErrorMessages() {
     DatabaseErrorMessage,
   );
   errorMessageComponentRegistry.registerValue(
+    ErrorTypeEnum.GENERIC_BACKEND_ERROR,
+    DatabaseErrorMessage,
+  );
+  errorMessageComponentRegistry.registerValue(
     ErrorTypeEnum.COLUMN_DOES_NOT_EXIST_ERROR,
     DatabaseErrorMessage,
   );

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2037,15 +2037,17 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             database_id = data["dbId"]
         except KeyError:
             raise SupersetGenericErrorException(
-                "One or more required fields are missing in the request. Please try "
-                "again, and if the problem persists conctact your administrator.",
+                __(
+                    "One or more required fields are missing in the request. Please try "
+                    "again, and if the problem persists conctact your administrator."
+                ),
                 status=400,
             )
         database = db.session.query(Database).get(database_id)
         if not database:
             raise SupersetErrorException(
                 SupersetError(
-                    message="The database was not found.",
+                    message=__("The database was not found."),
                     error_type=SupersetErrorType.DATABASE_NOT_FOUND_ERROR,
                     level=ErrorLevel.ERROR,
                 ),
@@ -2115,7 +2117,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             )
             raise SupersetErrorException(
                 SupersetError(
-                    message="The database was not found.",
+                    message=__("The database was not found."),
                     error_type=SupersetErrorType.DATABASE_NOT_FOUND_ERROR,
                     level=ErrorLevel.ERROR,
                 ),
@@ -2456,7 +2458,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         except Exception as ex:  # pylint: disable=broad-except
             logger.exception("Query %i: %s", query.id, str(ex))
 
-            message = _("Failed to start remote query on a worker.")
+            message = __("Failed to start remote query on a worker.")
             error = SupersetError(
                 message=message,
                 error_type=SupersetErrorType.ASYNC_WORKERS_ERROR,
@@ -2620,7 +2622,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         mydb = session.query(Database).get(database_id)
         if not mydb:
             raise SupersetGenericErrorException(
-                _(
+                __(
                     "The database referenced in this query was not found. Please "
                     "contact an administrator for further assistance or try again."
                 )
@@ -2663,7 +2665,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             query_id = None
         if not query_id:
             raise SupersetGenericErrorException(
-                _(
+                __(
                     "The query record was not created as expected. Please "
                     "contact an administrator for further assistance or try again."
                 )
@@ -2674,7 +2676,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         try:
             query.raise_for_access()
         except SupersetSecurityException as ex:
-            message = _(
+            message = __(
                 "You are not authorized to see this query. If you think this "
                 "is an error, please reach out to your administrator."
             )
@@ -2703,7 +2705,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             query.status = QueryStatus.FAILED
             session.commit()
             raise SupersetTemplateParamsErrorException(
-                message=_(
+                message=__(
                     'The query contains one or more malformed template parameters. Please check your query and confirm that all template parameters are surround by double braces, for example, "{{ ds }}". Then, try running your query again.'
                 ),
                 error=SupersetErrorType.INVALID_TEMPLATE_PARAMS_ERROR,


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

We were using lazy translations on some of the SIP-40 error payloads, but they can't be serialized to JSON. I fixed the errors introduced in https://github.com/apache/superset/pull/15482, and added (non-lazy) translation calls to a few error messages that were missing them.

While testing, I also noticed that if we fail to sync the query to the backend because we couldn't save its state we never update it to failed. I changed the order of `then()`/`catch()` to ensure we show the error messages even if the state is not synced properly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before, if we failed to store the state we would only show a toaster, and the query would keep polling even after a failure (note, the screenshot is not showing but a toaster shows up):

<img width="1904" alt="Screen Shot 2021-07-13 at 2 31 30 PM" src="https://user-images.githubusercontent.com/1534870/125527997-1c1f4629-abda-40c2-981b-65c4f47d9fcf.png">

The SIP-40 payload would not show because:

1. We would not dispatch `QUERY_FAILED` if we failed to sync the state, swallowing the SIP-40 error message.
2. The `GENERIC_BACKEND_ERROR` error was not registered to show the error in a component.

After, once I changed the SQL Lab action to dispatch `QUERY_FAILED` after a failed sync, and once I registered the `GENERIC_BACKEND_ERROR` error:

<img width="1904" alt="Screen Shot 2021-07-13 at 2 44 20 PM" src="https://user-images.githubusercontent.com/1534870/125529916-f4ac7f5a-b22e-4ba3-929f-5e206d8e1685.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

I hardcoded `mydb = 0` to simulate an error in the `sql_json` endpoint, and ran a query.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
