### PR TITLE
fix: small fixes for Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@
 # limitations under the License.
 #
 
+# Python version installed; we need 3.8 or 3.7
+PYTHON=`command -v python3.8 || command -v python3.7`
+
 .PHONY: install superset venv pre-commit
 
 install: superset pre-commit
@@ -59,8 +62,9 @@ update-js:
 
 venv:
 	# Create a virtual environment and activate it (recommended)
-	python3 -m venv venv # setup a python3 virtualenv
-	source venv/bin/activate
+	if ! [ -x "${PYTHON}" ]; then echo "You need Python 3.7 or 3.8 installed"; exit 1; fi
+	test -d venv || ${PYTHON} -m venv venv # setup a python3 virtualenv
+	. venv/bin/activate
 
 pre-commit:
 	# setup pre commit dependencies


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

2 small fixes for our `Makefile`:

1. `source venv/bin/activate` doesn't work within the Makefile, since `source` is a shell builtin. I fixed it by doing `. venv/bin/activate` instead.
2. Superset only runs on Python 3.7 or 3.8 (some deps fail to install on 3.9). I added a check for the version.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

`$ make venv`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
