### PR TITLE
fix: remove form title

### DIFF
--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
@@ -180,7 +180,6 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
       <ExplorePopoverContent>
         <AdhocMetricEditPopover
           adhocMetric={adhocMetric}
-          title={title}
           columns={columns}
           savedMetricsOptions={savedMetricsOptions}
           savedMetric={savedMetric}


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
form title showed `[object Object]` title.  should to remove the title. because  we already used `Popover` component to show title.

### BEFORE
<!--- Skip this if not applicable -->
![image](https://user-images.githubusercontent.com/10264972/125610338-2dcf2223-80e6-459f-b47a-84fc5fefca2b.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
* Go to /superset/explore/table/2/
* Click on METRICS controlbox
* hover the dropdown list
* no error [object, Object]

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: https://github.com/apache/superset/issues/15679
