### PR TITLE
feat: add Column to reports model

### DIFF
--- a/superset/migrations/versions/3317e9248280_add_creation_method_to_reports_model.py
+++ b/superset/migrations/versions/3317e9248280_add_creation_method_to_reports_model.py
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add_creation_method_to_reports_model
+
+Revision ID: 3317e9248280
+Revises: 453530256cea
+Create Date: 2021-07-14 10:31:38.610095
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "3317e9248280"
+down_revision = "453530256cea"
+
+import sqlalchemy as sa
+from alembic import op
+
+
+def upgrade():
+    with op.batch_alter_table("report_schedule") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "creation_method", sa.VARCHAR(255), server_default="alert_report",
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("report_schedule") as batch_op:
+        batch_op.drop_column("configuration_method")

--- a/superset/migrations/versions/3317e9248280_add_creation_method_to_reports_model.py
+++ b/superset/migrations/versions/3317e9248280_add_creation_method_to_reports_model.py
@@ -34,11 +34,15 @@ def upgrade():
     with op.batch_alter_table("report_schedule") as batch_op:
         batch_op.add_column(
             sa.Column(
-                "creation_method", sa.VARCHAR(255), server_default="alert_report",
+                "creation_method", sa.VARCHAR(255), server_default="alert_reports",
             )
+        )
+        batch_op.create_index(
+            op.f("ix_creation_method"), ["creation_method"], unique=False
         )
 
 
 def downgrade():
     with op.batch_alter_table("report_schedule") as batch_op:
-        batch_op.drop_column("configuration_method")
+        batch_op.drop_index("ix_creation_method")
+        batch_op.drop_column("creation_method")

--- a/superset/utils/mock_data.py
+++ b/superset/utils/mock_data.py
@@ -69,6 +69,9 @@ days_range = (MAXIMUM_DATE - MINIMUM_DATE).days
 
 # pylint: disable=too-many-return-statements, too-many-branches
 def get_type_generator(sqltype: sqlalchemy.sql.sqltypes) -> Callable[[], Any]:
+    if isinstance(sqltype, sqlalchemy.dialects.mysql.types.TINYINT):
+        return lambda: random.choice([0, 1])
+
     if isinstance(
         sqltype, (sqlalchemy.sql.sqltypes.INTEGER, sqlalchemy.sql.sqltypes.Integer)
     ):
@@ -83,7 +86,7 @@ def get_type_generator(sqltype: sqlalchemy.sql.sqltypes) -> Callable[[], Any]:
         length = random.randrange(sqltype.length or 255)
         length = max(8, length)  # for unique values
         length = min(100, length)  # for FAB perms
-        return lambda: "".join(random.choices(string.printable, k=length))
+        return lambda: "".join(random.choices(string.ascii_letters, k=length))
 
     if isinstance(
         sqltype, (sqlalchemy.sql.sqltypes.TEXT, sqlalchemy.sql.sqltypes.Text)
@@ -91,7 +94,7 @@ def get_type_generator(sqltype: sqlalchemy.sql.sqltypes) -> Callable[[], Any]:
         length = random.randrange(65535)
         # "practicality beats purity"
         length = max(length, 2048)
-        return lambda: "".join(random.choices(string.printable, k=length))
+        return lambda: "".join(random.choices(string.ascii_letters, k=length))
 
     if isinstance(
         sqltype, (sqlalchemy.sql.sqltypes.BOOLEAN, sqlalchemy.sql.sqltypes.Boolean)
@@ -130,7 +133,7 @@ def get_type_generator(sqltype: sqlalchemy.sql.sqltypes) -> Callable[[], Any]:
 
     if isinstance(sqltype, sqlalchemy.sql.sqltypes.JSON):
         return lambda: {
-            "".join(random.choices(string.printable, k=8)): random.randrange(65535)
+            "".join(random.choices(string.ascii_letters, k=8)): random.randrange(65535)
             for _ in range(10)
         }
 


### PR DESCRIPTION
### SUMMARY
This adds a creation method to the reports model. The logic for the column can be found here https://github.com/apache/superset/pull/15685

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF


### TESTING INSTRUCTIONS
Using Migration Script:
```
Identifying models used in the migration:
- report_schedule (0 rows in table report_schedule)
Benchmarking migration
WARNI [alembic.env] SQLite Database support for metadata databases will         be removed in a future version of Superset.
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 453530256cea -> 3317e9248280, add_creation_method_to_reports_model
Migration on current DB took: 0.26 seconds
WARNI [alembic.env] SQLite Database support for metadata databases will         be removed in a future version of Superset.
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade 3317e9248280 -> 453530256cea, add_creation_method_to_reports_model
Running with at least 10 entities of each model
- Adding 10 entities to the report_schedule model
WARNI [alembic.env] SQLite Database support for metadata databases will         be removed in a future version of Superset.
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 453530256cea -> 3317e9248280, add_creation_method_to_reports_model
Migration for 10+ entities took: 0.35 seconds
WARNI [alembic.env] SQLite Database support for metadata databases will         be removed in a future version of Superset.
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade 3317e9248280 -> 453530256cea, add_creation_method_to_reports_model
Running with at least 100 entities of each model
- Adding 90 entities to the report_schedule model
WARNI [alembic.env] SQLite Database support for metadata databases will         be removed in a future version of Superset.
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 453530256cea -> 3317e9248280, add_creation_method_to_reports_model
Migration for 100+ entities took: 0.28 seconds
WARNI [alembic.env] SQLite Database support for metadata databases will         be removed in a future version of Superset.
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade 3317e9248280 -> 453530256cea, add_creation_method_to_reports_model
Running with at least 1000 entities of each model
- Adding 900 entities to the report_schedule model
WARNI [alembic.env] SQLite Database support for metadata databases will         be removed in a future version of Superset.
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 453530256cea -> 3317e9248280, add_creation_method_to_reports_model
Migration for 1000+ entities took: 0.25 seconds
WARNI [alembic.env] SQLite Database support for metadata databases will         be removed in a future version of Superset.
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade 3317e9248280 -> 453530256cea, add_creation_method_to_reports_model
Running with at least 10000 entities of each model
- Adding 9000 entities to the report_schedule model
WARNI [alembic.env] SQLite Database support for metadata databases will         be removed in a future version of Superset.
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 453530256cea -> 3317e9248280, add_creation_method_to_reports_model
Migration for 10000+ entities took: 0.32 seconds
WARNI [alembic.env] SQLite Database support for metadata databases will         be removed in a future version of Superset.
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade 3317e9248280 -> 453530256cea, add_creation_method_to_reports_model
Running with at least 100000 entities of each model
- Adding 90000 entities to the report_schedule model
WARNI [alembic.env] SQLite Database support for metadata databases will         be removed in a future version of Superset.
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 453530256cea -> 3317e9248280, add_creation_method_to_reports_model
Migration for 100000+ entities took: 0.38 seconds
WARNI [alembic.env] SQLite Database support for metadata databases will         be removed in a future version of Superset.
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade 3317e9248280 -> 453530256cea, add_creation_method_to_reports_model
Running with at least 1000000 entities of each model
- Adding 900000 entities to the report_schedule model
WARNI [alembic.env] SQLite Database support for metadata databases will         be removed in a future version of Superset.
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 453530256cea -> 3317e9248280, add_creation_method_to_reports_model
Migration for 1000000+ entities took: 3.17 seconds
WARNI [alembic.env] SQLite Database support for metadata databases will         be removed in a future version of Superset.
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade 3317e9248280 -> 453530256cea, add_creation_method_to_reports_model
```
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [x ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
