### PR TITLE
feat: import configuration from directory

### DIFF
--- a/superset/cli.py
+++ b/superset/cli.py
@@ -168,7 +168,7 @@ def load_examples_run(
         examples.load_big_data()
 
     # load examples that are stored as YAML config files
-    examples.load_from_configs(force, load_test_data)
+    examples.load_examples_from_configs(force, load_test_data)
 
 
 @with_appcontext
@@ -187,8 +187,26 @@ def load_examples(
     only_metadata: bool = False,
     force: bool = False,
 ) -> None:
-    """Loads a set of Slices and Dashboards and a supporting dataset """
+    """Loads a set of Slices and Dashboards and a supporting dataset"""
     load_examples_run(load_test_data, load_big_data, only_metadata, force)
+
+
+@with_appcontext
+@superset.command()
+@click.argument("directory")
+@click.option(
+    "--overwrite", "-o", is_flag=True, help="Overwriting existing metadata definitions"
+)
+@click.option(
+    "--force", "-f", is_flag=True, help="Force load data even if table already exists"
+)
+def import_directory(directory: str, overwrite: bool, force: bool) -> None:
+    """Imports configs from a given directory"""
+    from superset.examples.utils import load_configs_from_directory
+
+    load_configs_from_directory(
+        root=Path(directory), overwrite=overwrite, force_data=force,
+    )
 
 
 @with_appcontext

--- a/superset/commands/importers/v1/examples.py
+++ b/superset/commands/importers/v1/examples.py
@@ -14,8 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=protected-access
 
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Set, Tuple
 
 from marshmallow import Schema
 from sqlalchemy.orm import Session
@@ -23,19 +24,23 @@ from sqlalchemy.orm.exc import MultipleResultsFound
 from sqlalchemy.sql import select
 
 from superset import db
+from superset.charts.commands.importers.v1 import ImportChartsCommand
 from superset.charts.commands.importers.v1.utils import import_chart
 from superset.charts.schemas import ImportV1ChartSchema
 from superset.commands.exceptions import CommandException
 from superset.commands.importers.v1 import ImportModelsCommand
 from superset.dao.base import BaseDAO
+from superset.dashboards.commands.importers.v1 import ImportDashboardsCommand
 from superset.dashboards.commands.importers.v1.utils import (
     find_chart_uuids,
     import_dashboard,
     update_id_refs,
 )
 from superset.dashboards.schemas import ImportV1DashboardSchema
+from superset.databases.commands.importers.v1 import ImportDatabasesCommand
 from superset.databases.commands.importers.v1.utils import import_database
 from superset.databases.schemas import ImportV1DatabaseSchema
+from superset.datasets.commands.importers.v1 import ImportDatasetsCommand
 from superset.datasets.commands.importers.v1.utils import import_dataset
 from superset.datasets.schemas import ImportV1DatasetSchema
 from superset.models.core import Database
@@ -70,6 +75,15 @@ class ImportExamplesCommand(ImportModelsCommand):
         except Exception:
             db.session.rollback()
             raise self.import_error()
+
+    @classmethod
+    def _get_uuids(cls) -> Set[str]:
+        return (
+            ImportDatabasesCommand._get_uuids()
+            | ImportDatasetsCommand._get_uuids()
+            | ImportChartsCommand._get_uuids()
+            | ImportDashboardsCommand._get_uuids()
+        )
 
     # pylint: disable=too-many-locals, arguments-differ, too-many-branches
     @staticmethod

--- a/superset/dashboards/commands/importers/v1/utils.py
+++ b/superset/dashboards/commands/importers/v1/utils.py
@@ -119,7 +119,7 @@ def update_id_refs(
             child["meta"]["chartId"] = chart_ids[child["meta"]["uuid"]]
 
     # fix native filter references
-    native_filter_configuration = fixed["metadata"].get(
+    native_filter_configuration = fixed.get("metadata", {}).get(
         "native_filter_configuration", []
     )
     for native_filter in native_filter_configuration:

--- a/superset/datasets/commands/importers/v1/utils.py
+++ b/superset/datasets/commands/importers/v1/utils.py
@@ -119,10 +119,12 @@ def import_dataset(
     example_database = get_example_database()
     try:
         table_exists = example_database.has_table_by_name(dataset.table_name)
-    except Exception as ex:
+    except Exception:  # pylint: disable=broad-except
         # MySQL doesn't play nice with GSheets table names
-        logger.warning("Couldn't check if table %s exists, stopping import")
-        raise ex
+        logger.warning(
+            "Couldn't check if table %s exists, assuming it does", dataset.table_name
+        )
+        table_exists = True
 
     if data_uri and (not table_exists or force_data):
         load_data(data_uri, dataset, example_database, session)

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -167,5 +167,6 @@ class ImportV1DatasetSchema(Schema):
     columns = fields.List(fields.Nested(ImportV1ColumnSchema))
     metrics = fields.List(fields.Nested(ImportV1MetricSchema))
     version = fields.String(required=True)
-    database_uuid = fields.UUID(required=True)
+    # TODO (betodealmeida): disallow None when we have all imports being done by configs
+    database_uuid = fields.UUID(required=True, allow_none=True)
     data = fields.URL()

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -167,6 +167,5 @@ class ImportV1DatasetSchema(Schema):
     columns = fields.List(fields.Nested(ImportV1ColumnSchema))
     metrics = fields.List(fields.Nested(ImportV1MetricSchema))
     version = fields.String(required=True)
-    # TODO (betodealmeida): disallow None when we have all imports being done by configs
-    database_uuid = fields.UUID(required=True, allow_none=True)
+    database_uuid = fields.UUID(required=True)
     data = fields.URL()

--- a/superset/examples/__init__.py
+++ b/superset/examples/__init__.py
@@ -30,5 +30,5 @@ from .paris import load_paris_iris_geojson
 from .random_time_series import load_random_time_series_data
 from .sf_population_polygons import load_sf_population_polygons
 from .tabbed_dashboard import load_tabbed_dashboard
-from .utils import load_from_configs
+from .utils import load_examples_from_configs
 from .world_bank import load_world_bank_health_n_pop

--- a/superset/examples/utils.py
+++ b/superset/examples/utils.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import logging
 import re
 from pathlib import Path
 from typing import Any, Dict
@@ -21,8 +22,11 @@ from typing import Any, Dict
 import yaml
 from pkg_resources import resource_isdir, resource_listdir, resource_stream
 
+from superset.commands.exceptions import CommandInvalidError
 from superset.commands.importers.v1.examples import ImportExamplesCommand
 from superset.commands.importers.v1.utils import METADATA_FILE_NAME
+
+_logger = logging.getLogger(__name__)
 
 YAML_EXTENSIONS = {".yaml", ".yml"}
 
@@ -90,4 +94,7 @@ def load_configs_from_directory(
     command = ImportExamplesCommand(
         contents, overwrite=overwrite, force_data=force_data
     )
-    command.run()
+    try:
+        command.run()
+    except CommandInvalidError as ex:
+        _logger.error("An error occurred: %s", ex.normalized_messages())

--- a/superset/examples/utils.py
+++ b/superset/examples/utils.py
@@ -18,14 +18,21 @@ import re
 from pathlib import Path
 from typing import Any, Dict
 
+import yaml
 from pkg_resources import resource_isdir, resource_listdir, resource_stream
 
 from superset.commands.importers.v1.examples import ImportExamplesCommand
+from superset.commands.importers.v1.utils import METADATA_FILE_NAME
 
 YAML_EXTENSIONS = {".yaml", ".yml"}
 
 
-def load_from_configs(force_data: bool = False, load_test_data: bool = False) -> None:
+def load_examples_from_configs(
+    force_data: bool = False, load_test_data: bool = False
+) -> None:
+    """
+    Load all the examples inside superset/examples/configs/.
+    """
     contents = load_contents(load_test_data)
     command = ImportExamplesCommand(contents, overwrite=True, force_data=force_data)
     command.run()
@@ -55,3 +62,32 @@ def load_contents(load_test_data: bool = False) -> Dict[str, Any]:
             )
 
     return {str(path.relative_to(root)): content for path, content in contents.items()}
+
+
+def load_configs_from_directory(
+    root: Path, overwrite: bool = True, force_data: bool = False
+) -> None:
+    """
+    Load all the examples from a given directory.
+    """
+    contents: Dict[str, str] = {}
+    queue = [root]
+    while queue:
+        path_name = queue.pop()
+        if path_name.is_dir():
+            queue.extend(path_name.glob("*"))
+        elif path_name.suffix.lower() in YAML_EXTENSIONS:
+            with open(path_name) as fp:
+                contents[str(path_name.relative_to(root))] = fp.read()
+
+    # removing "type" from the metadata allows us to import any exported model
+    # from the unzipped directory directly
+    metadata = yaml.load(contents.get(METADATA_FILE_NAME, "{}"))
+    if "type" in metadata:
+        del metadata["type"]
+    contents[METADATA_FILE_NAME] = yaml.dump(metadata)
+
+    command = ImportExamplesCommand(
+        contents, overwrite=overwrite, force_data=force_data
+    )
+    command.run()


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This allows us to keep Superset updated from a repo:

```bash
$ superset import-directory /path/to/configs/
```

For example, I created a simple dashboard with a single chart:

![Screenshot 2021-07-14 at 11-08-02 Demo](https://user-images.githubusercontent.com/1534870/125672248-1f254db0-68c7-4551-9ff2-a5ece3bcdb65.png)



I then exported it to a file `dashboard_export_20210714T104600.zip` and unzipped it. After deleting the dashboard, chart, dataset, and database I imported everything back with:

```bash
$ superset import-directory ~/Downloads/dashboard_export_20210714T104600/
```

I then changed the chart title in `~/Downloads/dashboard_export_20210714T104600/charts/Cnt_per_country_1.yaml` and ran the command again. The chart was succesfully updated:

![Screenshot 2021-07-14 at 11-12-01 Demo](https://user-images.githubusercontent.com/1534870/125672259-62fb1e5f-f6dd-4b48-be13-438cd825b064.png)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Export something (preferably a dashboard)
2. Unzip export and modify a file (eg, a chart title)
3. Run `import-directory` on the directory

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
