### PR TITLE
chore: Removes unnecessary uses of preselectNativeFilters

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/state.ts
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/state.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 import { useSelector } from 'react-redux';
-import { JsonObject } from '@superset-ui/core';
 import { FeatureFlag, isFeatureEnabled } from 'src/featureFlags';
 import { useEffect, useState } from 'react';
 import { URL_PARAMS } from 'src/constants';
@@ -38,9 +37,6 @@ export const useNativeFilters = () => {
   const showNativeFilters = useSelector<RootState, boolean>(
     state => state.dashboardInfo.metadata?.show_native_filters,
   );
-  const preselectNativeFilters = useSelector<RootState, JsonObject>(
-    state => state.dashboardState?.preselectNativeFilters || {},
-  );
   const canEdit = useSelector<RootState, boolean>(
     ({ dashboardInfo }) => dashboardInfo.dash_edit_perm,
   );
@@ -54,7 +50,7 @@ export const useNativeFilters = () => {
     (canEdit || (!canEdit && filterValues.length !== 0));
 
   const requiredFirstFilter = filterValues.filter(
-    filter => filter.requiredFirst || preselectNativeFilters[filter.id],
+    filter => filter.requiredFirst,
   );
   const dataMask = useNativeFiltersDataMask();
   const showDashboard =
@@ -93,6 +89,5 @@ export const useNativeFilters = () => {
     dashboardFiltersOpen,
     toggleDashboardFiltersOpen,
     nativeFiltersEnabled,
-    preselectNativeFilters,
   };
 };

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
@@ -43,7 +43,6 @@ import { ClientErrorObject } from 'src/utils/getClientErrorObject';
 import { FilterProps } from './types';
 import { getFormData } from '../../utils';
 import { useCascadingFilters } from './state';
-import { usePreselectNativeFilter } from '../../state';
 import { checkIsMissingRequiredValue } from '../utils';
 
 const HEIGHT = 32;
@@ -83,7 +82,6 @@ const FilterValue: React.FC<FilterProps> = ({
   const hasDataSource = !!datasetId;
   const [isLoading, setIsLoading] = useState<boolean>(hasDataSource);
   const [isRefreshing, setIsRefreshing] = useState(true);
-  const preselection = usePreselectNativeFilter(filter.id);
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -206,9 +204,6 @@ const FilterValue: React.FC<FilterProps> = ({
     ...filter.dataMask?.filterState,
     validateStatus: isMissingRequiredValue && 'error',
   };
-  if (filterState.value === undefined && preselection) {
-    filterState.value = preselection;
-  }
 
   return (
     <StyledDiv data-test="form-item-value">

--- a/superset-frontend/src/dashboard/components/nativeFilters/state.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/state.ts
@@ -18,7 +18,6 @@
  */
 import { useSelector } from 'react-redux';
 import { useMemo } from 'react';
-import { JsonObject } from '@superset-ui/core';
 import { Filter, FilterConfiguration } from './types';
 import { ActiveTabs, DashboardLayout, RootState } from '../../types';
 import { TAB_TYPE } from '../../util/componentTypes';
@@ -124,14 +123,4 @@ export function useSelectFiltersInScope(cascadeFilters: CascadeFilter[]) {
     }
     return [filtersInScope, filtersOutOfScope];
   }, [cascadeFilters, dashboardHasTabs, isFilterInScope]);
-}
-
-export function usePreselectNativeFilters(): JsonObject | undefined {
-  return useSelector<RootState, any>(
-    state => state.dashboardState?.preselectNativeFilters,
-  );
-}
-
-export function usePreselectNativeFilter(id: string): JsonObject | undefined {
-  return usePreselectNativeFilters()?.[id];
 }


### PR DESCRIPTION
### SUMMARY
Follow up of https://github.com/apache/superset/pull/15583 to remove unnecessary uses of `preselectNativeFilters`.

### TESTING INSTRUCTIONS
All tests should pass.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
