### PR TITLE
fix(explore): Set label max width with Drag&Drop in Datasource panel

### DIFF
--- a/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanelDragWrapper/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanelDragWrapper/index.tsx
@@ -28,6 +28,10 @@ const DatasourceItemContainer = styled.div`
   height: ${({ theme }) => theme.gridUnit * 6}px;
   cursor: pointer;
 
+  > div {
+    width: 100%;
+  }
+
   :hover {
     background-color: ${({ theme }) => theme.colors.grayscale.light2};
   }


### PR DESCRIPTION
### SUMMARY
It applies a max width to the columns options when drag and drop is enabled so to avoid a glitch when dragging the column. The label will overflow with ellipsis consistently with the metrics.

Fixes #14825

### BEFORE

https://user-images.githubusercontent.com/60598000/125817625-aa75a0df-b6ab-4830-a5bc-f1d883370f41.mov

### AFTER

<img width="1680" alt="Screen Shot 2021-07-15 at 17 51 33" src="https://user-images.githubusercontent.com/60598000/125818297-c13a952d-3013-4f50-8da3-420d60124cf3.png">

### TESTING INSTRUCTIONS
1. Enable drag and drop
2. Open a chart
3. Edit the dataset and set a column option to have a long name
4. Try to drag and drop the column
5. Observe the behavior

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #14825
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
