### PR TITLE
feat(homepage): move savequeries table and render open conditionally

### DIFF
--- a/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
@@ -114,9 +114,17 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
     null,
   );
   const [loadedCount, setLoadedCount] = useState(0);
-  const [activeState, setActiveState] = useState(['1', '2', '3']);
+  const [activeState, setActiveState] = useState<Array<string>>([
+    '1',
+    '2',
+    '3',
+  ]);
   const userid = user.userId;
   const id = userid.toString();
+
+  const handleCollapse = (state: Array<string>) => {
+    setActiveState(state);
+  };
 
   useEffect(() => {
     const userKey = getFromLocalStorage(id, null);
@@ -216,7 +224,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
           </div>
         ) : null}
       </WelcomeNav>
-      <Collapse activeKey={activeState} ghost bigger>
+      <Collapse activeKey={activeState} onChange={handleCollapse} ghost bigger>
         <Collapse.Panel header={t('Recents')} key="1">
           {activityData &&
           (activityData.Viewed ||

--- a/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
@@ -114,7 +114,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
     null,
   );
   const [loadedCount, setLoadedCount] = useState(0);
-
+  const [activeState, setActiveState] = useState(['1', '2', '3']);
   const userid = user.userId;
   const id = userid.toString();
 
@@ -192,6 +192,9 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
   };
 
   useEffect(() => {
+    if (queryData?.length) {
+      setActiveState(['1', '2', '3', '4']);
+    }
     setActivityData(activityData => ({
       ...activityData,
       Created: [
@@ -213,7 +216,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
           </div>
         ) : null}
       </WelcomeNav>
-      <Collapse defaultActiveKey={['1', '2', '3', '4']} ghost bigger>
+      <Collapse activeKey={activeState} ghost bigger>
         <Collapse.Panel header={t('Recents')} key="1">
           {activityData &&
           (activityData.Viewed ||
@@ -242,7 +245,14 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
             />
           )}
         </Collapse.Panel>
-        <Collapse.Panel header={t('Saved queries')} key="3">
+        <Collapse.Panel header={t('Charts')} key="3">
+          {!chartData ? (
+            <Loading position="inline" />
+          ) : (
+            <ChartTable showThumbnails={checked} user={user} mine={chartData} />
+          )}
+        </Collapse.Panel>
+        <Collapse.Panel header={t('Saved queries')} key="4">
           {!queryData ? (
             <Loading position="inline" />
           ) : (
@@ -252,13 +262,6 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
               mine={queryData}
               featureFlag={isFeatureEnabled(FeatureFlag.THUMBNAILS)}
             />
-          )}
-        </Collapse.Panel>
-        <Collapse.Panel header={t('Charts')} key="4">
-          {!chartData ? (
-            <Loading position="inline" />
-          ) : (
-            <ChartTable showThumbnails={checked} user={user} mine={chartData} />
           )}
         </Collapse.Panel>
       </Collapse>


### PR DESCRIPTION
### SUMMARY
This pr moves the savequeries table to the bottom of the welcome page and renders the table open if there is query data.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before 

https://user-images.githubusercontent.com/17326228/125820896-702c59b0-a3b2-46e8-ada4-40739f0299fa.mov

after

https://user-images.githubusercontent.com/17326228/125820922-6e9687c8-2ede-4195-af5d-c258e5bb06cc.mov



### TESTING INSTRUCTIONS
test on welcomepage

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
