### PR TITLE
[DRAFT] fix: Change url in cache-warmup celery task

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -475,6 +475,7 @@ EXTRA_SEQUENTIAL_COLOR_SCHEMES: List[Dict[str, Any]] = []
 # ---------------------------------------------------
 # Thumbnail config (behind feature flag)
 # Also used by Alerts & Reports
+# THUMBNAIL_SELENIUM_USER is also used by cache warm-up
 # ---------------------------------------------------
 THUMBNAIL_SELENIUM_USER = "admin"
 THUMBNAIL_CACHE_CONFIG: CacheConfig = {

--- a/tests/integration_tests/cache_warm_up_strategy_tests.py
+++ b/tests/integration_tests/cache_warm_up_strategy_tests.py
@@ -198,7 +198,12 @@ class TestCacheWarmUp(SupersetTestCase):
 
         strategy = TopNDashboardsStrategy(1)
         result = sorted(strategy.get_urls())
-        expected = sorted([f"{URL_PREFIX}{slc.url}" for slc in dash.slices])
+        expected = sorted(
+            [
+                f"{URL_PREFIX}/superset/warm_up_cache/?slice_id={slc.id}"
+                for slc in dash.slices
+            ]
+        )
         self.assertEqual(result, expected)
 
     def reset_tag(self, tag):
@@ -224,7 +229,12 @@ class TestCacheWarmUp(SupersetTestCase):
         # tag dashboard 'births' with `tag1`
         tag1 = get_tag("tag1", db.session, TagTypes.custom)
         dash = self.get_dash_by_slug("births")
-        tag1_urls = sorted([f"{URL_PREFIX}{slc.url}" for slc in dash.slices])
+        tag1_urls = sorted(
+            [
+                f"{URL_PREFIX}/superset/warm_up_cache/?slice_id={slc.id}"
+                for slc in dash.slices
+            ]
+        )
         tagged_object = TaggedObject(
             tag_id=tag1.id, object_id=dash.id, object_type=ObjectTypes.dashboard
         )
@@ -244,7 +254,7 @@ class TestCacheWarmUp(SupersetTestCase):
         # tag first slice
         dash = self.get_dash_by_slug("unicode-test")
         slc = dash.slices[0]
-        tag2_urls = [f"{URL_PREFIX}{slc.url}"]
+        tag2_urls = [f"{URL_PREFIX}/superset/warm_up_cache/?slice_id={slc.id}"]
         object_id = slc.id
         tagged_object = TaggedObject(
             tag_id=tag2.id, object_id=object_id, object_type=ObjectTypes.chart


### PR DESCRIPTION
### SUMMARY
Currently, there is cache-warmup task allows us to warm up dashboards/slices. But this feature is not working at all.
There is also available endpoint to warmup cache, this pull request will use that endpoint.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
- Add cache task: 'cache-warmup' to CELERYBEAT_SCHEDULE
- Very that the selected slice in dashboard is refreshed after every warmup

Example Beat schedule config

```
CELERYBEAT_SCHEDULE = {
	'cache-warmup-3-minute': {
		'task': 'cache-warmup',
		'schedule': crontab(minute='*/3'),  # Every 3 minutes for testing
		'kwargs': {
			'strategy_name': 'top_n_dashboards',
			'top_n': 1,
			'since': '7 days ago',
		},
	},
}
```

### ADDITIONAL INFORMATION

- [x] Has associated issue: 
  - #10150,
  - #9597
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
