### PR TITLE
chore: better copy for SQL dialog

### DIFF
--- a/superset-frontend/src/SqlLab/components/HighlightedSql.tsx
+++ b/superset-frontend/src/SqlLab/components/HighlightedSql.tsx
@@ -80,7 +80,7 @@ function HighlightSqlModal({ rawSql, sql }: HighlightedSqlModalTypes) {
       </SyntaxHighlighter>
       {rawSql && rawSql !== sql && (
         <div>
-          <h4>{t('Raw SQL')}</h4>
+          <h4>{t('Executed SQL')}</h4>
           <SyntaxHighlighter language="sql" style={github}>
             {rawSql}
           </SyntaxHighlighter>


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Right now we say "Raw SQL" for the executed SQL:

<img width="530" alt="Screen Shot 2021-07-15 at 10 58 15 AM" src="https://user-images.githubusercontent.com/1534870/125835239-0fadd0ce-a21d-411f-884f-10e3c271e757.png">

I changed the copy to "Executed SQL" after talking to @yousoph, since the term "raw" is confusing and incorrect.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
