### PR TITLE
fix: margin right on warning icon to 8px

### DIFF
--- a/superset-frontend/src/components/WarningIconWithTooltip/index.tsx
+++ b/superset-frontend/src/components/WarningIconWithTooltip/index.tsx
@@ -37,7 +37,7 @@ function WarningIconWithTooltip({
     >
       <Icons.AlertSolid
         iconColor={theme.colors.alert.base}
-        css={{ marginRight: `8px` }}
+        css={{ marginRight: theme.gridUnit * 2 }}
       />
     </Tooltip>
   );

--- a/superset-frontend/src/components/WarningIconWithTooltip/index.tsx
+++ b/superset-frontend/src/components/WarningIconWithTooltip/index.tsx
@@ -35,7 +35,10 @@ function WarningIconWithTooltip({
       id="warning-tooltip"
       title={<SafeMarkdown source={warningMarkdown} />}
     >
-      <Icons.AlertSolid iconColor={theme.colors.alert.base} />
+      <Icons.AlertSolid
+        iconColor={theme.colors.alert.base}
+        css={{ marginRight: `8px` }}
+      />
     </Tooltip>
   );
 }


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="155" alt="Screen_Shot_2021-06-05_at_12 31 12_PM_(1)" src="https://user-images.githubusercontent.com/17345270/125840935-a3c7ea29-ab65-4655-9e8c-1c002bf81d5c.png">
<img width="327" alt="Screenshot 2021-07-15 at 14 40 15" src="https://user-images.githubusercontent.com/17345270/125840971-ff0f5546-1525-43eb-8f58-6f8772a94d5c.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
