### PR TITLE
chore: freeze the UUID of examples DB

### DIFF
--- a/superset/commands/importers/v1/examples.py
+++ b/superset/commands/importers/v1/examples.py
@@ -70,7 +70,7 @@ class ImportExamplesCommand(ImportModelsCommand):
             db.session.rollback()
             raise self.import_error()
 
-    # pylint: disable=too-many-locals, arguments-differ
+    # pylint: disable=too-many-locals, arguments-differ, too-many-branches
     @staticmethod
     def _import(
         session: Session,
@@ -86,16 +86,23 @@ class ImportExamplesCommand(ImportModelsCommand):
                 database_ids[str(database.uuid)] = database.id
 
         # import datasets
-        # TODO (betodealmeida): once we have all examples being imported we can
-        # have a stable UUID for the database stored in the dataset YAML; for
-        # now we need to fetch the current ID.
-        examples_id = (
-            db.session.query(Database).filter_by(database_name="examples").one().id
+        # If database_uuid is not in the list of UUIDs it means that the examples
+        # database was created before its UUID was frozen, so it has a random UUID.
+        # We need to determine its ID so we can point the dataset to it.
+        examples_db = (
+            db.session.query(Database).filter_by(database_name="examples").first()
         )
         dataset_info: Dict[str, Dict[str, Any]] = {}
         for file_name, config in configs.items():
             if file_name.startswith("datasets/"):
-                config["database_id"] = examples_id
+                # find the ID of the corresponding database
+                if config["database_uuid"] not in database_ids:
+                    if examples_db is None:
+                        raise Exception("Cannot find examples database")
+                    config["database_id"] = examples_db.id
+                else:
+                    config["database_id"] = database_ids[config["database_uuid"]]
+
                 dataset = import_dataset(
                     session, config, overwrite=overwrite, force_data=force_data
                 )

--- a/superset/constants.py
+++ b/superset/constants.py
@@ -21,6 +21,10 @@
 NULL_STRING = "<NULL>"
 
 
+# UUID for the examples database
+EXAMPLES_DB_UUID = "a2dc77af-e654-49bb-b321-40f6b559a1ee"
+
+
 class RouteMethod:  # pylint: disable=too-few-public-methods
     """
     Route methods are a FAB concept around ModelView and RestModelView

--- a/superset/examples/configs/datasets/examples/users_channels-uzooNNtSRO.yaml
+++ b/superset/examples/configs/datasets/examples/users_channels-uzooNNtSRO.yaml
@@ -73,4 +73,4 @@ columns:
   description: null
   python_date_format: null
 version: 1.0.0
-database_uuid: 566ca280-3da8-967e-4aa4-4b349218736a
+database_uuid: a2dc77af-e654-49bb-b321-40f6b559a1ee

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -85,6 +85,7 @@ from typing_extensions import TypedDict
 
 import _thread  # pylint: disable=C0411
 from superset.constants import (
+    EXAMPLES_DB_UUID,
     EXTRA_FORM_DATA_APPEND_KEYS,
     EXTRA_FORM_DATA_OVERRIDE_EXTRA_KEYS,
     EXTRA_FORM_DATA_OVERRIDE_REGULAR_MAPPINGS,
@@ -1167,9 +1168,16 @@ def get_or_create_db(
         db.session.query(models.Database).filter_by(database_name=database_name).first()
     )
 
+    # databases with a fixed UUID
+    uuids = {
+        "examples": EXAMPLES_DB_UUID,
+    }
+
     if not database and always_create:
         logger.info("Creating database reference for %s", database_name)
-        database = models.Database(database_name=database_name)
+        database = models.Database(
+            database_name=database_name, uuid=uuids.get(database_name)
+        )
         db.session.add(database)
 
     if database:


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Currently when we run `load-examples` the examples DB is created with a random UUID. This makes it hard to move across instances datasets/charts/dashboards that reference the examples DB, since the UUID doesn't match.

This PR freezes the UUID of the examples DB.

There's one gotcha. If the user has created the examples DB **before** this PR, but runs `load-examples` **after** this patch we won't find the examples DB by searching for the frozen UUID. Instead, we need to search by name. This is how currently the `load-examples` process works. I kept the logic for when we can't find the examples DB via the UUID.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Loaded examples:

```bash
$ superset load-examples
```

Then checked the UUID of the examples DB created:

```
mysql> SELECT uuid FROM dbs;
+------------------------------------+
| uuid                               |
+------------------------------------+
| 0xA2DC77AFE65449BBB32140F6B559A1EE |
+------------------------------------+
1 row in set (0.00 sec)

mysql>
```

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
