### PR TITLE
fix: Incorrect translations in the SQLLab in Chinese

### DIFF
--- a/superset/translations/zh/LC_MESSAGES/messages.json
+++ b/superset/translations/zh/LC_MESSAGES/messages.json
@@ -986,7 +986,7 @@
         "在 SQL 编辑器中允许 CREATE TABLE AS 选项"
       ],
       "Allow CREATE VIEW AS option in SQL Lab": [
-        "在 SQL 编辑器中允许 CREATE TABLE AS 选项"
+        "在 SQL 编辑器中允许 CREATE VIEW AS 选项"
       ],
       "Allow users to run non-SELECT statements (UPDATE, DELETE, CREATE, ...) in SQL Lab": [
         "允许用户在 SQL 编辑器中运行非 SELECT 语句（UPDATE，DELETE，CREATE，...）"
@@ -1008,7 +1008,7 @@
       ],
       "Expose in SQL Lab": ["在 SQL 工具箱中公开"],
       "Allow CREATE TABLE AS": ["允许 CREATE TABLE AS"],
-      "Allow CREATE VIEW AS": ["允许 CREATE TABLE AS"],
+      "Allow CREATE VIEW AS": ["允许 CREATE VIEW AS"],
       "Allow DML": ["允许 DML"],
       "CTAS Schema": ["CTAS 模式"],
       "SQLAlchemy URI": ["SQLAlchemy URI"],
@@ -1248,7 +1248,7 @@
         "服务器端显示的查询结果中的行数似乎限制在 %s 以内。"
       ],
       "CREATE TABLE AS": ["允许 CREATE TABLE AS"],
-      "CREATE VIEW AS": ["允许 CREATE TABLE AS"],
+      "CREATE VIEW AS": ["允许 CREATE VIEW AS"],
       "Estimate the cost before running a query": [
         "在运行查询之前计算执行计划"
       ],


### PR DESCRIPTION
### SUMMARY
Chinese translation and English translation do not match，"CREATE VIEW AS" should correspond to "CREATE VIEW AS", not "CREATE TABLE AS"

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF


### TESTING INSTRUCTIONS


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
