### PR TITLE
fix(explore): DndColumnSelect sometimes not working with multi: false

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
@@ -30,12 +30,12 @@ import { StyledColumnOption } from 'src/explore/components/optionRenderers';
 
 export const DndColumnSelect = (props: LabelProps) => {
   const { value, options, multi = true } = props;
-  const optionSelector = new OptionSelector(options, value);
+  const optionSelector = new OptionSelector(options, multi, value);
   const [values, setValues] = useState<ColumnMeta[]>(optionSelector.values);
 
   const onDrop = (item: DatasourcePanelDndItem) => {
     const column = item.value as ColumnMeta;
-    if (!optionSelector.isArray && !isEmpty(optionSelector.values)) {
+    if (!optionSelector.multi && !isEmpty(optionSelector.values)) {
       optionSelector.replace(0, column.column_name);
     } else {
       optionSelector.add(column.column_name);

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useState } from 'react';
+import React, { useEffect } from 'react';
 import { tn } from '@superset-ui/core';
 import { ColumnMeta } from '@superset-ui/chart-controls';
 import { isEmpty } from 'lodash';
@@ -29,9 +29,32 @@ import { DndItemType } from 'src/explore/components/DndItemType';
 import { StyledColumnOption } from 'src/explore/components/optionRenderers';
 
 export const DndColumnSelect = (props: LabelProps) => {
-  const { value, options, multi = true } = props;
+  const { value, options, multi = true, onChange } = props;
   const optionSelector = new OptionSelector(options, multi, value);
-  const [values, setValues] = useState<ColumnMeta[]>(optionSelector.values);
+
+  // synchronize values in case of dataset changes
+  useEffect(() => {
+    const optionSelectorValues = optionSelector.getValues();
+    if (typeof value !== typeof optionSelectorValues) {
+      onChange(optionSelectorValues);
+    }
+    if (
+      typeof value === 'string' &&
+      typeof optionSelectorValues === 'string' &&
+      value !== optionSelectorValues
+    ) {
+      onChange(optionSelectorValues);
+    }
+    if (
+      Array.isArray(optionSelectorValues) &&
+      Array.isArray(value) &&
+      (optionSelectorValues.length !== value.length ||
+        optionSelectorValues.every((val, index) => val === value[index]))
+    ) {
+      onChange(optionSelectorValues);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(value), JSON.stringify(optionSelector.getValues())]);
 
   const onDrop = (item: DatasourcePanelDndItem) => {
     const column = item.value as ColumnMeta;
@@ -40,8 +63,7 @@ export const DndColumnSelect = (props: LabelProps) => {
     } else {
       optionSelector.add(column.column_name);
     }
-    setValues(optionSelector.values);
-    props.onChange(optionSelector.getValues());
+    onChange(optionSelector.getValues());
   };
 
   const canDrop = (item: DatasourcePanelDndItem) =>
@@ -50,18 +72,16 @@ export const DndColumnSelect = (props: LabelProps) => {
 
   const onClickClose = (index: number) => {
     optionSelector.del(index);
-    setValues(optionSelector.values);
-    props.onChange(optionSelector.getValues());
+    onChange(optionSelector.getValues());
   };
 
   const onShiftOptions = (dragIndex: number, hoverIndex: number) => {
     optionSelector.swap(dragIndex, hoverIndex);
-    setValues(optionSelector.values);
-    props.onChange(optionSelector.getValues());
+    onChange(optionSelector.getValues());
   };
 
   const valuesRenderer = () =>
-    values.map((column, idx) => (
+    optionSelector.values.map((column, idx) => (
       <OptionWrapper
         key={idx}
         index={idx}

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/optionSelector.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/optionSelector.ts
@@ -63,8 +63,8 @@ export class OptionSelector {
     [this.values[a], this.values[b]] = [this.values[b], this.values[a]];
   }
 
-  has(groupBy: string): boolean {
-    return !!this.getValues()?.includes(groupBy);
+  has(value: string): boolean {
+    return !!this.getValues()?.includes(value);
   }
 
   getValues(): string[] | string | undefined {

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/optionSelector.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/optionSelector.ts
@@ -17,28 +17,23 @@
  * under the License.
  */
 import { ColumnMeta } from '@superset-ui/chart-controls';
+import { ensureIsArray } from '@superset-ui/core';
 
 export class OptionSelector {
   values: ColumnMeta[];
 
   options: { string: ColumnMeta };
 
-  isArray: boolean;
+  multi: boolean;
 
   constructor(
     options: { string: ColumnMeta },
+    multi: boolean,
     initialValues?: string[] | string,
   ) {
     this.options = options;
-    let values: string[];
-    if (Array.isArray(initialValues)) {
-      values = initialValues;
-      this.isArray = true;
-    } else {
-      values = initialValues ? [initialValues] : [];
-      this.isArray = false;
-    }
-    this.values = values
+    this.multi = multi;
+    this.values = ensureIsArray(initialValues)
       .map(value => {
         if (value in options) {
           return options[value];
@@ -73,7 +68,7 @@ export class OptionSelector {
   }
 
   getValues(): string[] | string | undefined {
-    if (!this.isArray) {
+    if (!this.multi) {
       return this.values.length > 0 ? this.values[0].column_name : undefined;
     }
     return this.values.map(option => option.column_name);


### PR DESCRIPTION
### SUMMARY
Due to incorrect handling of `multi: false` prop in `DndColumnSelect`, we sometimes passed an array of arrays of column names, when the chart was expecting an array of column names. Moreover, I noticed that sometimes when we create a chart and then change dataset, chart still tries to use some column names from the old dataset.
This PR fixes both issues.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see https://github.com/apache/superset/issues/15532
After:
https://user-images.githubusercontent.com/15073128/125910050-317b3f22-8ccd-4a42-b14d-06c01cb38421.mov

### TESTING INSTRUCTIONS
0. Set `ENABLE_EXPLORE_DRAG_AND_DROP` to True
1. Create a chart that uses controls that accept only single column, e.g. Chord
2. Verify that chart is created correctly
3. Change dataset and try to create a chart again
4. Verify that there are no "leftovers" from previous dataset (before, sometimes chart tried to use column names from previous dataset even though they were removed from controls)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: fixes #15532 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc 