### PR TITLE
fix(explore): wrong error message in conditional formatting

### DIFF
--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
@@ -102,9 +102,7 @@ export const FormattingPopoverContent = ({
         return Promise.resolve();
       }
       return Promise.reject(
-        new Error(
-          t('This value should be smaller than the right target value'),
-        ),
+        new Error(t('This value should be greater than the left target value')),
       );
     },
     [],


### PR DESCRIPTION
### SUMMARY
Fix an incorrect error message for right target value when it's bigger than left target value.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: 
![image](https://user-images.githubusercontent.com/15073128/125910473-9f97cb87-3742-42c4-93ee-3a4241a3e061.png)

After: 
![image](https://user-images.githubusercontent.com/15073128/125911362-2a81b8dc-fb0b-4e1d-9d0c-b4890efc9922.png)

### TESTING INSTRUCTIONS
This will be testable once we bump table and pivot table v2 plugins versions in Superset.

1. Create a Table or Pivot table v2 chart
2. Open conditional formatting popover
3. Select a "between" operator and set right target value to be smaller than left.
4. Verify that the error message is correct

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
