### PR TITLE
chore: Add tags to the new viz gallery

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/VizTypeControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/VizTypeControl_spec.jsx
@@ -50,7 +50,7 @@ describe('VizTypeControl', () => {
       new ChartMetadata({
         name: 'vis1',
         thumbnail: '',
-        tags: ['Popular'],
+        tags: ['Highly-used'],
       }),
     )
     .registerValue(

--- a/superset-frontend/spec/javascripts/explore/components/VizTypeControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/VizTypeControl_spec.jsx
@@ -50,6 +50,7 @@ describe('VizTypeControl', () => {
       new ChartMetadata({
         name: 'vis1',
         thumbnail: '',
+        tags: ['Popular']
       }),
     )
     .registerValue(
@@ -57,6 +58,7 @@ describe('VizTypeControl', () => {
       new ChartMetadata({
         name: 'vis2',
         thumbnail: '',
+        tags: ['foobar']
       }),
     );
 
@@ -80,10 +82,10 @@ describe('VizTypeControl', () => {
 
   it('filters images based on text input', async () => {
     const thumbnails = screen.getAllByTestId('viztype-selector-container');
-    expect(thumbnails).toHaveLength(2);
+    expect(thumbnails).toHaveLength(1);
 
     const searchInput = screen.getByPlaceholderText('Search');
-    userEvent.type(searchInput, '2');
+    userEvent.type(searchInput, 'foo');
     await waitForEffects();
 
     const thumbnail = screen.getByTestId('viztype-selector-container');

--- a/superset-frontend/spec/javascripts/explore/components/VizTypeControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/VizTypeControl_spec.jsx
@@ -50,7 +50,7 @@ describe('VizTypeControl', () => {
       new ChartMetadata({
         name: 'vis1',
         thumbnail: '',
-        tags: ['Popular']
+        tags: ['Popular'],
       }),
     )
     .registerValue(
@@ -58,7 +58,7 @@ describe('VizTypeControl', () => {
       new ChartMetadata({
         name: 'vis2',
         thumbnail: '',
-        tags: ['foobar']
+        tags: ['foobar'],
       }),
     );
 
@@ -81,8 +81,8 @@ describe('VizTypeControl', () => {
   });
 
   it('filters images based on text input', async () => {
-    const thumbnails = screen.getAllByTestId('viztype-selector-container');
-    expect(thumbnails).toHaveLength(1);
+    const thumbnails = screen.getByTestId('viztype-selector-container');
+    expect(thumbnails).toBeInTheDocument();
 
     const searchInput = screen.getByPlaceholderText('Search');
     userEvent.type(searchInput, 'foo');

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -33,6 +33,7 @@ import {
   useTheme,
 } from '@superset-ui/core';
 import { Input } from 'src/common/components';
+import Label from 'src/components/Label';
 import { usePluginContext } from 'src/components/DynamicPlugins';
 import Icons from 'src/components/Icons';
 import { nativeFilterGate } from 'src/dashboard/components/nativeFilters/utils';
@@ -102,6 +103,8 @@ const THUMBNAIL_GRID_UNITS = 24;
 export const MAX_ADVISABLE_VIZ_GALLERY_WIDTH = 1090;
 
 const OTHER_CATEGORY = t('Other');
+
+const DEFAULT_SEARCH_INPUT_VALUE = t('Popular');
 
 export const VIZ_TYPE_CONTROL_TEST_ID = 'viz-type-control';
 
@@ -206,6 +209,7 @@ const DetailsPopulated = (theme: SupersetTheme) => css`
   grid-template-rows: auto 1fr;
   grid-template-areas:
     'viz-name examples-header'
+    'viz-tags examples'
     'description examples';
 `;
 
@@ -220,6 +224,11 @@ const DetailsEmpty = (theme: SupersetTheme) => css`
 
 // overflow hidden on the details pane and overflow auto on the description
 // (plus grid layout) enables the description to scroll while the header stays in place.
+const TagsWrapper = styled.div`
+  grid-area: viz-tags;
+  width: ${({ theme }) => theme.gridUnit * 120}px;
+  padding-right: ${({ theme }) => theme.gridUnit * 14}px;
+`;
 
 const Description = styled.p`
   grid-area: description;
@@ -358,8 +367,10 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
   const { selectedViz, onChange, className } = props;
   const { mountedPluginMetadata } = usePluginContext();
   const searchInputRef = useRef<HTMLInputElement>();
-  const [searchInputValue, setSearchInputValue] = useState('');
-  const [isSearchFocused, setIsSearchFocused] = useState(false);
+  const [searchInputValue, setSearchInputValue] = useState(
+    DEFAULT_SEARCH_INPUT_VALUE,
+  );
+  const [isSearchFocused, setIsSearchFocused] = useState(true);
   const isActivelySearching = isSearchFocused && !!searchInputValue;
 
   const selectedVizMetadata: ChartMetadata | null = selectedViz
@@ -525,6 +536,19 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
             >
               {selectedVizMetadata?.name}
             </SectionTitle>
+            <TagsWrapper>
+              {selectedVizMetadata?.tags.map(tag => (
+                <Label
+                  key={tag}
+                  onClick={() => {
+                    focusSearch();
+                    setSearchInputValue(tag);
+                  }}
+                >
+                  {tag}
+                </Label>
+              ))}
+            </TagsWrapper>
             <Description>
               {selectedVizMetadata?.description ||
                 t('No description available.')}

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -96,6 +96,8 @@ const DEFAULT_ORDER = [
   'country_map',
 ];
 
+const ALL_TAGS = [t('Popular'), t('Text'), t('Trend'), t('Formattable')];
+
 const typesWithDefaultOrder = new Set(DEFAULT_ORDER);
 
 const THUMBNAIL_GRID_UNITS = 24;
@@ -134,6 +136,19 @@ const LeftPane = styled.div`
   border-right: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
   padding: ${({ theme }) => theme.gridUnit * 2}px;
   overflow: hidden;
+`;
+
+const RightPane = styled.div`
+  grid-area: main;
+`;
+
+const AllTagsWrapper = styled.div`
+  ${({ theme }) => `
+    margin: ${theme.gridUnit * 4}px ${theme.gridUnit * 2}px 0;
+    input {
+      font-size: ${theme.typography.sizes.s};
+    }
+  `}
 `;
 
 const CategoriesWrapper = styled.div`
@@ -182,7 +197,6 @@ const CategoryLabel = styled.button`
 `;
 
 const IconsPane = styled.div`
-  grid-area: main;
   overflow: auto;
   display: grid;
   grid-template-columns: repeat(
@@ -515,11 +529,26 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
         </CategoriesWrapper>
       </LeftPane>
 
-      <ThumbnailGallery
-        vizEntries={vizEntriesToDisplay}
-        selectedViz={selectedViz}
-        setSelectedViz={onChange}
-      />
+      <RightPane>
+        <AllTagsWrapper>
+          {ALL_TAGS.map(tag => (
+            <Label
+              key={tag}
+              onClick={() => {
+                focusSearch();
+                setSearchInputValue(tag);
+              }}
+            >
+              {tag}
+            </Label>
+          ))}
+        </AllTagsWrapper>
+        <ThumbnailGallery
+          vizEntries={vizEntriesToDisplay}
+          selectedViz={selectedViz}
+          setSelectedViz={onChange}
+        />
+      </RightPane>
 
       {selectedVizMetadata ? (
         <div
@@ -538,15 +567,7 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
             </SectionTitle>
             <TagsWrapper>
               {selectedVizMetadata?.tags.map(tag => (
-                <Label
-                  key={tag}
-                  onClick={() => {
-                    focusSearch();
-                    setSearchInputValue(tag);
-                  }}
-                >
-                  {tag}
-                </Label>
+                <Label key={tag}>{tag}</Label>
               ))}
             </TagsWrapper>
             <Description>

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -96,7 +96,7 @@ const DEFAULT_ORDER = [
   'country_map',
 ];
 
-const ALL_TAGS = [t('Popular'), t('Text'), t('Trend'), t('Formattable')];
+const ALL_TAGS = [t('Highly-used'), t('Text'), t('Trend'), t('Formattable')];
 
 const typesWithDefaultOrder = new Set(DEFAULT_ORDER);
 
@@ -106,15 +106,16 @@ export const MAX_ADVISABLE_VIZ_GALLERY_WIDTH = 1090;
 
 const OTHER_CATEGORY = t('Other');
 
-const DEFAULT_SEARCH_INPUT_VALUE = t('Popular');
+const DEFAULT_SEARCH_INPUT_VALUE = t('Highly-used');
 
 export const VIZ_TYPE_CONTROL_TEST_ID = 'viz-type-control';
 
 const VizPickerLayout = styled.div`
   display: grid;
-  grid-template-rows: minmax(100px, 1fr) minmax(200px, 35%);
+  grid-template-rows: auto minmax(100px, 1fr) minmax(200px, 35%);
   grid-template-columns: 1fr 5fr;
   grid-template-areas:
+    'sidebar tags'
     'sidebar main'
     'details details';
   height: 70vh;
@@ -140,10 +141,12 @@ const LeftPane = styled.div`
 
 const RightPane = styled.div`
   grid-area: main;
+  overflow-y: scroll;
 `;
 
 const AllTagsWrapper = styled.div`
   ${({ theme }) => `
+    grid-area: tags;
     margin: ${theme.gridUnit * 4}px ${theme.gridUnit * 2}px 0;
     input {
       font-size: ${theme.typography.sizes.s};
@@ -220,7 +223,7 @@ const DetailsPopulated = (theme: SupersetTheme) => css`
   padding: ${theme.gridUnit * 4}px;
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-template-rows: auto 1fr;
+  grid-template-rows: auto auto 1fr;
   grid-template-areas:
     'viz-name examples-header'
     'viz-tags examples'
@@ -242,6 +245,7 @@ const TagsWrapper = styled.div`
   grid-area: viz-tags;
   width: ${({ theme }) => theme.gridUnit * 120}px;
   padding-right: ${({ theme }) => theme.gridUnit * 14}px;
+  padding-bottom: ${({ theme }) => theme.gridUnit * 2}px;
 `;
 
 const Description = styled.p`
@@ -529,20 +533,21 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
         </CategoriesWrapper>
       </LeftPane>
 
+      <AllTagsWrapper>
+        {ALL_TAGS.map(tag => (
+          <Label
+            key={tag}
+            onClick={() => {
+              focusSearch();
+              setSearchInputValue(tag);
+            }}
+          >
+            {tag}
+          </Label>
+        ))}
+      </AllTagsWrapper>
+
       <RightPane>
-        <AllTagsWrapper>
-          {ALL_TAGS.map(tag => (
-            <Label
-              key={tag}
-              onClick={() => {
-                focusSearch();
-                setSearchInputValue(tag);
-              }}
-            >
-              {tag}
-            </Label>
-          ))}
-        </AllTagsWrapper>
         <ThumbnailGallery
           vizEntries={vizEntriesToDisplay}
           selectedViz={selectedViz}


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
1. Added tags list in the chart description
2. tags-selection to the Gallery
3. The default tag value populate to `Highly-used` in the viz gallery 
4. rename `Popular` and `Popularity` to `Highly-used` for charts

closes: https://github.com/apache/superset/issues/15720

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### After
![image](https://user-images.githubusercontent.com/2016594/126077915-358b171e-ab7a-4209-9c92-62ab262c59cd.png)



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
