### PR TITLE
feat: migration to add timezone to report schedule

### DIFF
--- a/superset/migrations/versions/ae1ed299413b_add_timezone_to_report_schedule.py
+++ b/superset/migrations/versions/ae1ed299413b_add_timezone_to_report_schedule.py
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add_timezone_to_report_schedule
+
+Revision ID: ae1ed299413b
+Revises: 030c840e3a1c
+Create Date: 2021-07-09 12:18:52.057815
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "ae1ed299413b"
+down_revision = "030c840e3a1c"
+
+import sqlalchemy as sa
+from alembic import op
+
+
+def upgrade():
+    with op.batch_alter_table("report_schedule") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "timezone", sa.String(length=100), nullable=False, server_default="UTC"
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("report_schedule") as batch_op:
+        batch_op.drop_column("timezone")


### PR DESCRIPTION
### SUMMARY
Adds timezone to report schedule db in order to allow us to add a UI on the reports for users to select a timezone for their schedule. Timezones are strings of locations, such as "America/Los_Angeles" or "UTC".

The default value of UTC as an example will be GMT, which is the current +0 offset time that we are using. 

In the future UI, the plan is to "guess" the user's timezone and default the selection to their current timezone. 

![TimezoneSelector_-_Interactive_Timezone_Selector_⋅_Storybook](https://user-images.githubusercontent.com/5186919/125994241-19404025-40bb-4668-a2fb-d37de7a10a0f.png)

For context, the full PR is https://github.com/apache/superset/pull/15743/files

### TESTING INSTRUCTIONS
results of db migration script:

Current: 0.33 s
10+: 0.34 s
100+: 0.32 s
1000+: 0.33 s

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
