### PR TITLE
fix: Unable to create alerts/report after introduced creation_method

### DIFF
--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -123,6 +123,7 @@ const DEFAULT_WORKING_TIMEOUT = 3600;
 const DEFAULT_CRON_VALUE = '0 * * * *'; // every hour
 const DEFAULT_ALERT = {
   active: true,
+  creation_method: 'alerts_reports',
   crontab: DEFAULT_CRON_VALUE,
   log_retention: DEFAULT_RETENTION,
   working_timeout: DEFAULT_WORKING_TIMEOUT,


### PR DESCRIPTION
### SUMMARY
Add default creation_method='alerts_reports' in Alerts/Reports page

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: 
  - [x] Fixes #15759, 
  - [x] Relates to #15685
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
