### PR TITLE
chore: Pylint reenable bad-option-value message

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -135,7 +135,6 @@ disable=
     import-outside-toplevel,
     raise-missing-from,
     super-with-arguments,
-    bad-option-value,
     too-few-public-methods,
     too-many-locals,
 

--- a/superset/commands/importers/v1/examples.py
+++ b/superset/commands/importers/v1/examples.py
@@ -135,5 +135,5 @@ class ImportExamplesCommand(ImportModelsCommand):
             {"dashboard_id": dashboard_id, "slice_id": chart_id}
             for (dashboard_id, chart_id) in dashboard_chart_ids
         ]
-        # pylint: disable=no-value-for-parameter (sqlalchemy/issues/4656)
+        # pylint: disable=no-value-for-parameter # sqlalchemy/issues/4656
         session.execute(dashboard_slices.insert(), values)

--- a/superset/dashboards/commands/importers/v1/__init__.py
+++ b/superset/dashboards/commands/importers/v1/__init__.py
@@ -135,5 +135,5 @@ class ImportDashboardsCommand(ImportModelsCommand):
             {"dashboard_id": dashboard_id, "slice_id": chart_id}
             for (dashboard_id, chart_id) in dashboard_chart_ids
         ]
-        # pylint: disable=no-value-for-parameter (sqlalchemy/issues/4656)
+        # pylint: disable=no-value-for-parameter # sqlalchemy/issues/4656
         session.execute(dashboard_slices.insert(), values)

--- a/superset/datasets/dao.py
+++ b/superset/datasets/dao.py
@@ -143,7 +143,7 @@ class DatasetDAO(BaseDAO):  # pylint: disable=too-many-public-methods
         return len(dataset_query) == 0
 
     @classmethod
-    def update(  # pylint: disable=W:279
+    def update(  # pylint: disable=arguments-differ
         cls,
         model: SqlaTable,
         properties: Dict[str, Any],

--- a/superset/utils/mock_data.py
+++ b/superset/utils/mock_data.py
@@ -202,11 +202,11 @@ def add_data(
     metadata.create_all(engine)
 
     if not append:
-        # pylint: disable=no-value-for-parameter (sqlalchemy/issues/4656)
+        # pylint: disable=no-value-for-parameter # sqlalchemy/issues/4656
         engine.execute(table.delete())
 
     data = generate_data(columns, num_rows)
-    # pylint: disable=no-value-for-parameter (sqlalchemy/issues/4656)
+    # pylint: disable=no-value-for-parameter # sqlalchemy/issues/4656
     engine.execute(table.insert(), data)
 
 


### PR DESCRIPTION
### SUMMARY

Re-enabling the Pylint `bad-option-value` message.

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: https://github.com/apache/superset/issues/9953
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
