### PR TITLE
fix(dashboard): Add resize handles to right and bottom of component

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/markdown.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/markdown.test.ts
@@ -70,7 +70,7 @@ describe('Dashboard edit markdown', () => {
       .type('Test resize');
 
     resize(
-      '[data-test="dashboard-markdown-editor"] .resizable-container span div',
+      '[data-test="dashboard-markdown-editor"] .resizable-container span div:last-child',
     ).to(500, 600);
 
     cy.get('[data-test="dashboard-markdown-editor"]').contains('Test resize');

--- a/superset-frontend/src/dashboard/util/resizableConfig.ts
+++ b/superset-frontend/src/dashboard/util/resizableConfig.ts
@@ -19,8 +19,8 @@
 // config for a ResizableContainer
 const adjustableWidthAndHeight = {
   top: false,
-  right: false,
-  bottom: false,
+  right: true,
+  bottom: true,
   left: false,
   topRight: false,
   bottomRight: true,
@@ -30,19 +30,21 @@ const adjustableWidthAndHeight = {
 
 const adjustableWidth = {
   ...adjustableWidthAndHeight,
-  right: true,
   bottomRight: false,
+  bottom: false,
 };
 
 const adjustableHeight = {
   ...adjustableWidthAndHeight,
-  bottom: true,
   bottomRight: false,
+  right: false,
 };
 
 const notAdjustable = {
   ...adjustableWidthAndHeight,
   bottomRight: false,
+  bottom: false,
+  right: false,
 };
 
 export default {


### PR DESCRIPTION
### SUMMARY
Previously in Dashboard builder we could resize charts only by dragging bottom right corner. This PR enables resizing by also dragging right or bottom border.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see #15695 
After:
https://user-images.githubusercontent.com/15073128/126162577-1575ae78-3418-4ed0-a0bc-86e4b7903abf.mov


### TESTING INSTRUCTIONS
1. Open a dashboard in edit mode
2. Verify that charts and markdowns are resizable by dragging bottom, right and bottom-right corner

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes #15695 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @junlincc 