### PR TITLE
fix(explore): dnd multiple columns doesn't work

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -161,7 +161,7 @@ export const DndMetricSelect = (props: any) => {
   };
 
   const onNewMetric = (newMetric: Metric) => {
-    const newValue = props.isMulti ? [...value, newMetric] : [newMetric];
+    const newValue = props.multi ? [...value, newMetric] : [newMetric];
     setValue(newValue);
     handleChange(newValue);
   };


### PR DESCRIPTION
### SUMMARY
Due to recent changes, drag and dropping metrics or columns in controls that accept multiple values did not work correctly - instead of adding a new value, the first was replaced. This PR fixes that behaviour.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
https://user-images.githubusercontent.com/15073128/126191515-85cca674-e237-4b60-97f9-6a383a61718e.mov

After:
https://user-images.githubusercontent.com/15073128/126191555-b43c723e-7c60-45f6-90c0-7a6e7c1b82ea.mov

### TESTING INSTRUCTIONS
0. Enable drag and drop feature flag
1. Open a chart that has controls that accept multiple values (e.g. Line chart's Metrics control)
2. Add multiple values

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @junlincc 