### PR TITLE
fix: Bust chart cache when metric/column is changed

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -43,9 +43,12 @@ from sqlalchemy import (
     Table,
     Text,
     UniqueConstraint,
+    update,
 )
+from sqlalchemy.engine.base import Connection
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import backref, relationship, Session
+from sqlalchemy.orm.mapper import Mapper
 from sqlalchemy.sql import expression
 
 from superset import conf, db, security_manager
@@ -1688,5 +1691,24 @@ class DruidDatasource(Model, BaseDatasource):
         return [{"name": k, "type": v.get("type")} for k, v in latest_metadata.items()]
 
 
+def update_datasource(
+    _mapper: Mapper, _connection: Connection, obj: Union[DruidColumn, DruidMetric]
+) -> None:
+    """
+    Forces an update to the datasource's changed_on value when a metric or column on
+    the datasource is updated. This busts the cache key for all charts that use the
+    datasource.
+
+    :param _mapper: Unused.
+    :param _connection: Unused.
+    :param obj: The metric or column that was updated.
+    """
+    db.session.execute(
+        update(DruidDatasource).where(DruidDatasource.id == obj.datasource.id)
+    )
+
+
 sa.event.listen(DruidDatasource, "after_insert", security_manager.set_perm)
 sa.event.listen(DruidDatasource, "after_update", security_manager.set_perm)
+sa.event.listen(DruidMetric, "after_update", update_datasource)
+sa.event.listen(DruidColumn, "after_update", update_datasource)

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -57,8 +57,11 @@ from sqlalchemy import (
     String,
     Table,
     Text,
+    update,
 )
+from sqlalchemy.engine.base import Connection
 from sqlalchemy.orm import backref, Query, relationship, RelationshipProperty, Session
+from sqlalchemy.orm.mapper import Mapper
 from sqlalchemy.schema import UniqueConstraint
 from sqlalchemy.sql import (
     column,
@@ -1683,9 +1686,24 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
         return extra_cache_keys
 
 
+def update_table(
+    _mapper: Mapper, _connection: Connection, obj: Union[SqlMetric, TableColumn]
+) -> None:
+    """
+    Forces an update to the table's changed_on value when a metric or column on the
+    table is updated. This busts the cache key for all charts that use the table.
+
+    :param _mapper: Unused.
+    :param _connection: Unused.
+    :param obj: The metric or column that was updated.
+    """
+    db.session.execute(update(SqlaTable).where(SqlaTable.id == obj.table.id))
+
+
 sa.event.listen(SqlaTable, "after_insert", security_manager.set_perm)
 sa.event.listen(SqlaTable, "after_update", security_manager.set_perm)
-
+sa.event.listen(SqlMetric, "after_update", update_table)
+sa.event.listen(TableColumn, "after_update", update_table)
 
 RLSFilterRoles = Table(
     "rls_filter_roles",


### PR DESCRIPTION
### SUMMARY
Back in https://github.com/apache/superset/pull/8901 @villebro made changes to include `datasource.changed_on` to the chart cache key so that a change to the datasource would bust the chart cache. This was important because a user could change the sql for a datasource, but rerunning the chart wouldn't rerun the query before.

In this PR it seems like we intended to also bust the cache when metrics/columns were changed (https://github.com/apache/superset/pull/8901/files#r372541748) but that doesn't seem to work. This PR addresses that oversight and adds a test to check it

### TESTING INSTRUCTIONS
CI, new unit test

create a chart, update a metric, see the chart's cache busted

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @john-bodley @villebro @dpgaspar 