### PR TITLE
chore: remove unnecessary deps

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -316,7 +316,7 @@ generated-members=
 # List of decorators that produce context managers, such as
 # contextlib.contextmanager. Add to this list to register other decorators that
 # produce valid context managers.
-contextmanager-decorators=contextlib.contextmanager,contextlib2.contextmanager
+contextmanager-decorators=contextlib.contextmanager
 
 
 [VARIABLES]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -48,8 +48,6 @@ colorama==0.4.4
     # via
     #   apache-superset
     #   flask-appbuilder
-contextlib2==0.6.0.post1
-    # via apache-superset
 convertdate==2.3.0
     # via holidays
 cron-descriptor==1.2.24
@@ -58,8 +56,6 @@ croniter==0.3.36
     # via apache-superset
 cryptography==3.3.2
     # via apache-superset
-decorator==4.4.2
-    # via retry
 defusedxml==0.6.0
     # via python3-openid
 deprecation==2.1.0
@@ -178,16 +174,12 @@ pandas==1.2.2
     # via apache-superset
 parsedatetime==2.6
     # via apache-superset
-pathlib2==2.3.5
-    # via apache-superset
 pgsanity==0.2.9
     # via apache-superset
 polyline==1.4.0
     # via apache-superset
 prison==0.1.3
     # via flask-appbuilder
-py==1.9.0
-    # via retry
 pyarrow==4.0.1
     # via apache-superset
 pycparser==2.20
@@ -236,8 +228,6 @@ pyyaml==5.4.1
     #   apispec
 redis==3.5.3
     # via apache-superset
-retry==0.9.2
-    # via apache-superset
 selenium==3.141.0
     # via apache-superset
 simplejson==3.17.2
@@ -252,7 +242,6 @@ six==1.15.0
     #   isodate
     #   jsonschema
     #   packaging
-    #   pathlib2
     #   polyline
     #   prison
     #   pyrsistent

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -6,39 +6,87 @@
 #    pip-compile-multi
 #
 -r base.txt
--e file:.                 # via -r requirements/base.in
-boto3==1.16.10            # via tabulator
-botocore==1.19.10         # via boto3, s3transfer
-cached-property==1.5.2    # via tableschema
-certifi==2020.6.20        # via requests
-deprecated==1.2.11        # via pygithub
-et-xmlfile==1.0.1         # via openpyxl
-flask-cors==3.0.9         # via -r requirements/development.in
-future==0.18.2            # via pyhive
-ijson==3.1.2.post0        # via tabulator
-jdcal==1.4.1              # via openpyxl
-jmespath==0.10.0          # via boto3, botocore
-jsonlines==1.2.0          # via tabulator
-linear-tsv==1.1.0         # via tabulator
-mysqlclient==1.4.2.post1  # via -r requirements/development.in
-openpyxl==3.0.5           # via tabulator
-pillow==7.2.0             # via -r requirements/development.in
-progress==1.5             # via -r requirements/development.in
-psycopg2-binary==2.8.5    # via -r requirements/development.in
-pydruid==0.6.1            # via -r requirements/development.in
-pygithub==1.54.1          # via -r requirements/development.in
-pyhive[hive]==0.6.3       # via -r requirements/development.in
-requests==2.24.0          # via pydruid, pygithub, tableschema, tabulator
-rfc3986==1.4.0            # via tableschema
-s3transfer==0.3.3         # via boto3
-sasl==0.2.1               # via pyhive, thrift-sasl
-tableschema==1.20.0       # via -r requirements/development.in
-tabulator==1.52.5         # via tableschema
-thrift-sasl==0.4.2        # via pyhive
-thrift==0.13.0            # via -r requirements/development.in, pyhive, thrift-sasl
-unicodecsv==0.14.1        # via tableschema, tabulator
-wrapt==1.12.1             # via deprecated
-xlrd==1.2.0               # via tabulator
+-e file:.
+    # via -r requirements/base.in
+boto3==1.16.10
+    # via tabulator
+botocore==1.19.10
+    # via
+    #   boto3
+    #   s3transfer
+cached-property==1.5.2
+    # via tableschema
+certifi==2020.6.20
+    # via requests
+deprecated==1.2.11
+    # via pygithub
+et-xmlfile==1.0.1
+    # via openpyxl
+flask-cors==3.0.9
+    # via -r requirements/development.in
+future==0.18.2
+    # via pyhive
+ijson==3.1.2.post0
+    # via tabulator
+jdcal==1.4.1
+    # via openpyxl
+jmespath==0.10.0
+    # via
+    #   boto3
+    #   botocore
+jsonlines==1.2.0
+    # via tabulator
+linear-tsv==1.1.0
+    # via tabulator
+mysqlclient==1.4.2.post1
+    # via -r requirements/development.in
+openpyxl==3.0.5
+    # via tabulator
+pillow==7.2.0
+    # via -r requirements/development.in
+progress==1.5
+    # via -r requirements/development.in
+psycopg2-binary==2.8.5
+    # via -r requirements/development.in
+pydruid==0.6.1
+    # via -r requirements/development.in
+pygithub==1.54.1
+    # via -r requirements/development.in
+pyhive[hive]==0.6.3
+    # via -r requirements/development.in
+requests==2.24.0
+    # via
+    #   pydruid
+    #   pygithub
+    #   tableschema
+    #   tabulator
+rfc3986==1.4.0
+    # via tableschema
+s3transfer==0.3.3
+    # via boto3
+sasl==0.2.1
+    # via
+    #   pyhive
+    #   thrift-sasl
+tableschema==1.20.0
+    # via -r requirements/development.in
+tabulator==1.52.5
+    # via tableschema
+thrift==0.13.0
+    # via
+    #   -r requirements/development.in
+    #   pyhive
+    #   thrift-sasl
+thrift-sasl==0.4.2
+    # via pyhive
+unicodecsv==0.14.1
+    # via
+    #   tableschema
+    #   tabulator
+wrapt==1.12.1
+    # via deprecated
+xlrd==1.2.0
+    # via tabulator
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -17,6 +17,8 @@ backcall==0.2.0
     # via ipython
 coverage==5.3
     # via pytest-cov
+decorator==5.0.9
+    # via ipython
 docker==4.3.1
     # via -r requirements/testing.in
 flask-testing==0.8.0

--- a/scripts/benchmark_migration.py
+++ b/scripts/benchmark_migration.py
@@ -19,6 +19,7 @@ import logging
 import re
 import time
 from collections import defaultdict
+from graphlib import TopologicalSorter  # pylint: disable=wrong-import-order
 from inspect import getsource
 from pathlib import Path
 from types import ModuleType
@@ -28,7 +29,6 @@ import click
 from flask import current_app
 from flask_appbuilder import Model
 from flask_migrate import downgrade, upgrade
-from graphlib import TopologicalSorter  # pylint: disable=wrong-import-order
 from progress.bar import ChargingBar
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.ext.automap import automap_base

--- a/scripts/benchmark_migration.py
+++ b/scripts/benchmark_migration.py
@@ -19,7 +19,6 @@ import logging
 import re
 import time
 from collections import defaultdict
-from graphlib import TopologicalSorter  # pylint: disable=wrong-import-order
 from inspect import getsource
 from pathlib import Path
 from types import ModuleType
@@ -29,6 +28,7 @@ import click
 from flask import current_app
 from flask_appbuilder import Model
 from flask_migrate import downgrade, upgrade
+from graphlib import TopologicalSorter  # pylint: disable=wrong-import-order
 from progress.bar import ChargingBar
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.ext.automap import automap_base

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ combine_as_imports = true
 include_trailing_comma = true
 line_length = 88
 known_first_party = superset
-known_third_party =alembic,apispec,backoff,bleach,cachelib,celery,click,colorama,contextlib2,cron_descriptor,croniter,cryptography,dateutil,deprecation,flask,flask_appbuilder,flask_babel,flask_caching,flask_compress,flask_jwt_extended,flask_login,flask_migrate,flask_sqlalchemy,flask_talisman,flask_testing,flask_wtf,freezegun,geohash,geopy,graphlib,holidays,humanize,isodate,jinja2,jwt,markdown,markupsafe,marshmallow,marshmallow_enum,msgpack,numpy,pandas,parameterized,parsedatetime,pathlib2,pgsanity,pkg_resources,polyline,prison,progress,pyarrow,pyhive,pyparsing,pytest,pytest_mock,pytz,redis,requests,selenium,setuptools,simplejson,slack,sqlalchemy,sqlalchemy_utils,sqlparse,typing_extensions,werkzeug,wtforms,wtforms_json,yaml
+known_third_party =alembic,apispec,backoff,bleach,cachelib,celery,click,colorama,cron_descriptor,croniter,cryptography,dateutil,deprecation,flask,flask_appbuilder,flask_babel,flask_caching,flask_compress,flask_jwt_extended,flask_login,flask_migrate,flask_sqlalchemy,flask_talisman,flask_testing,flask_wtf,freezegun,geohash,geopy,graphlib,holidays,humanize,isodate,jinja2,jwt,markdown,markupsafe,marshmallow,marshmallow_enum,msgpack,numpy,pandas,parameterized,parsedatetime,pgsanity,pkg_resources,polyline,prison,progress,pyarrow,pyhive,pyparsing,pytest,pytest_mock,pytz,redis,requests,selenium,setuptools,simplejson,slack,sqlalchemy,sqlalchemy_utils,sqlparse,typing_extensions,werkzeug,wtforms,wtforms_json,yaml
 multi_line_output = 3
 order_by_type = false
 

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,6 @@ setup(
         "celery>=4.3.0, <5.0.0, !=4.4.1",
         "click<8",
         "colorama",
-        "contextlib2",
         "croniter>=0.3.28",
         "cron-descriptor",
         "cryptography>=3.3.2",
@@ -87,13 +86,12 @@ setup(
         "gunicorn>=20.0.2, <20.1",
         "holidays==0.10.3",  # PINNED! https://github.com/dr-prodigy/python-holidays/issues/406
         "humanize",
-        "itsdangerous>=1.0.0, <2.0.0",
+        "itsdangerous>=1.0.0, <2.0.0",  # https://github.com/apache/superset/pull/14627
         "isodate",
         "markdown>=3.0",
         "msgpack>=1.0.0, <1.1",
         "pandas>=1.2.2, <1.3",
         "parsedatetime",
-        "pathlib2",
         "pgsanity",
         "polyline",
         "pyparsing>=2.4.7, <3.0.0",
@@ -112,9 +110,6 @@ setup(
         "sqlparse==0.3.0",  # PINNED! see https://github.com/andialbrecht/sqlparse/issues/562
         "typing-extensions>=3.7.4.3,<4",  # needed to support typing.Literal on py37
         "wtforms-json",
-        "pyparsing>=2.4.7, <3.0.0",
-        "holidays==0.10.3",  # PINNED! https://github.com/dr-prodigy/python-holidays/issues/406
-        "deprecation>=2.1.0, <2.2.0",
     ],
     extras_require={
         "athena": ["pyathena>=1.10.8,<1.11"],

--- a/superset/cli.py
+++ b/superset/cli.py
@@ -19,6 +19,7 @@ import json
 import logging
 import sys
 from datetime import datetime, timedelta
+from pathlib import Path
 from subprocess import Popen
 from typing import Any, Dict, List, Optional, Type, Union
 from zipfile import is_zipfile, ZipFile
@@ -30,7 +31,6 @@ from colorama import Fore, Style
 from flask import current_app, g
 from flask.cli import FlaskGroup, with_appcontext
 from flask_appbuilder import Model
-from pathlib2 import Path
 
 from superset import app, appbuilder, config, security_manager
 from superset.app import create_app

--- a/superset/utils/celery.py
+++ b/superset/utils/celery.py
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
+from contextlib import contextmanager
 from typing import Iterator
 
-from contextlib2 import contextmanager
 from sqlalchemy import create_engine
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, sessionmaker

--- a/superset/utils/decorators.py
+++ b/superset/utils/decorators.py
@@ -17,10 +17,10 @@
 from __future__ import annotations
 
 import time
+from contextlib import contextmanager
 from functools import wraps
 from typing import Any, Callable, Dict, Iterator, TYPE_CHECKING, Union
 
-from contextlib2 import contextmanager
 from flask import current_app, Response
 
 from superset import is_feature_enabled

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -15,13 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 import json
+from contextlib import contextmanager
 from datetime import datetime, timedelta
 from typing import List, Optional
 from unittest.mock import Mock, patch
 from uuid import uuid4
 
 import pytest
-from contextlib2 import contextmanager
 from flask_sqlalchemy import BaseQuery
 from freezegun import freeze_time
 from sqlalchemy.sql import func

--- a/tests/integration_tests/security/migrate_roles_tests.py
+++ b/tests/integration_tests/security/migrate_roles_tests.py
@@ -17,10 +17,10 @@
 """Unit tests for alerting in Superset"""
 import json
 import logging
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import pytest
-from contextlib2 import contextmanager
 from flask_appbuilder.security.sqla.models import Role
 
 from superset.extensions import db, security_manager


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Remove `contextlib2` and `pathlib2`, since they are backports that we no longer need.

I also cleaned up the deps in `setup.py`, we had duplicate deps.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

N/A

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
