### PR TITLE
fix: migration downgrade references wrong column

### DIFF
--- a/superset/migrations/versions/301362411006_add_execution_id_to_report_execution_.py
+++ b/superset/migrations/versions/301362411006_add_execution_id_to_report_execution_.py
@@ -36,4 +36,4 @@ def upgrade():
 
 
 def downgrade():
-    op.drop_column("report_execution_log", "execution_id")
+    op.drop_column("report_execution_log", "uuid")


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fix the migration introduced in https://github.com/apache/superset/pull/13752/files.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
