### PR TITLE
feat(homepage): conditionally render viewed tab and move examples to chart and dashboard table

### DIFF
--- a/superset-frontend/src/views/CRUD/types.ts
+++ b/superset-frontend/src/views/CRUD/types.ts
@@ -43,7 +43,7 @@ export interface DashboardTableProps {
   mine: Array<Dashboard>;
   showThumbnails?: boolean;
   featureFlag?: boolean;
-  examples: Array<object>;
+  examples: Array<Dashboard>;
 }
 
 export interface Dashboard {

--- a/superset-frontend/src/views/CRUD/types.ts
+++ b/superset-frontend/src/views/CRUD/types.ts
@@ -26,6 +26,7 @@ export type FavoriteStatus = {
 export enum TableTabTypes {
   FAVORITE = 'Favorite',
   MINE = 'Mine',
+  EXAMPLES = 'Examples',
 }
 
 export type Filters = {
@@ -42,6 +43,7 @@ export interface DashboardTableProps {
   mine: Array<Dashboard>;
   showThumbnails?: boolean;
   featureFlag?: boolean;
+  examples: Array<object>;
 }
 
 export interface Dashboard {

--- a/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
@@ -176,7 +176,6 @@ export default function ActivityTable({
   const [editedObjs, setEditedObjs] = useState<Array<ActivityData>>();
   const [loadingState, setLoadingState] = useState(false);
 
-  console.log('activityData ActivtyTbl', activityData)
   const getEditedCards = () => {
     setLoadingState(true);
     getEditedObjects(user.userId).then(r => {

--- a/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
@@ -176,6 +176,7 @@ export default function ActivityTable({
   const [editedObjs, setEditedObjs] = useState<Array<ActivityData>>();
   const [loadingState, setLoadingState] = useState(false);
 
+  console.log('activityData ActivtyTbl', activityData)
   const getEditedCards = () => {
     setLoadingState(true);
     getEditedObjects(user.userId).then(r => {
@@ -219,17 +220,7 @@ export default function ActivityTable({
         setInLocalStorage(HOMEPAGE_ACTIVITY_FILTER, SetTabType.VIEWED);
       },
     });
-  } else {
-    tabs.unshift({
-      name: 'Examples',
-      label: t('Examples'),
-      onClick: () => {
-        setActiveChild('Examples');
-        setInLocalStorage(HOMEPAGE_ACTIVITY_FILTER, SetTabType.EXAMPLE);
-      },
-    });
   }
-
   const renderActivity = () =>
     (activeChild !== 'Edited' ? activityData[activeChild] : editedObjs).map(
       (entity: ActivityObject) => {

--- a/superset-frontend/src/views/CRUD/welcome/ChartTable.test.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ChartTable.test.tsx
@@ -85,7 +85,7 @@ describe('ChartTable', () => {
       }
     });
     await waitForComponentToPaint(wrapper);
-    expect(fetchMock.calls(chartsEndpoint)).toHaveLength(3);
+    expect(fetchMock.calls(chartsEndpoint)).toHaveLength(1);
     expect(wrapper.find('ChartCard')).toExist();
   });
 

--- a/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
@@ -66,10 +66,11 @@ function ChartTable({
 }: ChartTableProps) {
   const history = useHistory();
   const filterStore = getFromLocalStorage(HOMEPAGE_CHART_FILTER, null);
-  const initialFilter =
-    !examples && filterStore === TableTabTypes.EXAMPLES
-      ? TableTabTypes.MINE
-      : filterStore || TableTabTypes.MINE;
+  let initialFilter = filterStore || TableTabTypes.EXAMPLES;
+
+  if (!examples && filterStore === TableTabTypes.EXAMPLES) {
+    initialFilter = TableTabTypes.MINE;
+  }
 
   const filteredExamples = filter(examples, obj => 'viz_type' in obj);
 

--- a/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
@@ -52,6 +52,7 @@ interface ChartTableProps {
   user?: User;
   mine: Array<any>;
   showThumbnails: boolean;
+  examples?: Array<object>;
 }
 
 function ChartTable({
@@ -60,6 +61,7 @@ function ChartTable({
   addSuccessToast,
   mine,
   showThumbnails,
+  examples,
 }: ChartTableProps) {
   const history = useHistory();
   const filterStore = getFromLocalStorage(HOMEPAGE_CHART_FILTER, null);
@@ -128,6 +130,36 @@ function ChartTable({
     return filters;
   };
 
+  const menuTabs = [
+    {
+      name: 'Favorite',
+      label: t('Favorite'),
+      onClick: () => {
+        setChartFilter('Favorite');
+        setInLocalStorage(HOMEPAGE_CHART_FILTER, TableTabTypes.FAVORITE);
+      },
+    },
+    {
+      name: 'Mine',
+      label: t('Mine'),
+      onClick: () => {
+        setChartFilter('Mine');
+        setInLocalStorage(HOMEPAGE_CHART_FILTER, TableTabTypes.MINE);
+      },
+    },
+  ];
+
+  if (examples) {
+    menuTabs.push({
+      name: 'Examples',
+      label: t('Examples'),
+      onClick: () => {
+        setChartFilter('Mine');
+        setInLocalStorage(HOMEPAGE_CHART_FILTER, TableTabTypes.EXAMPLES);
+      },
+    });
+  }
+
   const getData = (filter: string) =>
     fetchData({
       pageIndex: 0,
@@ -156,24 +188,7 @@ function ChartTable({
       <SubMenu
         activeChild={chartFilter}
         // eslint-disable-next-line react/no-children-prop
-        tabs={[
-          {
-            name: 'Favorite',
-            label: t('Favorite'),
-            onClick: () => {
-              setChartFilter('Favorite');
-              setInLocalStorage(HOMEPAGE_CHART_FILTER, TableTabTypes.FAVORITE);
-            },
-          },
-          {
-            name: 'Mine',
-            label: t('Mine'),
-            onClick: () => {
-              setChartFilter('Mine');
-              setInLocalStorage(HOMEPAGE_CHART_FILTER, TableTabTypes.MINE);
-            },
-          },
-        ]}
+        tabs={menuTabs}
         buttons={[
           {
             name: (

--- a/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
@@ -18,7 +18,7 @@
  */
 import React, { useState, useMemo, useEffect } from 'react';
 import { t } from '@superset-ui/core';
-import { reject } from 'lodash';
+import { filter } from 'lodash';
 import {
   useListViewResource,
   useChartEditModal,
@@ -68,11 +68,7 @@ function ChartTable({
   const filterStore = getFromLocalStorage(HOMEPAGE_CHART_FILTER, null);
   const initialFilter = filterStore || TableTabTypes.MINE;
 
-  // @ts-ignore
-  // eslint-disable-next-line consistent-return
-  const filteredExamples = reject(examples, obj => {
-    if (!('viz_type' in obj)) return obj;
-  }).map(r => r);
+  const filteredExamples = filter(examples, obj => 'viz_type' in obj);
 
   const {
     state: { loading, resourceCollection: charts, bulkSelectEnabled },

--- a/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
@@ -66,7 +66,10 @@ function ChartTable({
 }: ChartTableProps) {
   const history = useHistory();
   const filterStore = getFromLocalStorage(HOMEPAGE_CHART_FILTER, null);
-  const initialFilter = filterStore || TableTabTypes.MINE;
+  const initialFilter =
+    !examples && filterStore === TableTabTypes.EXAMPLES
+      ? TableTabTypes.MINE
+      : filterStore || TableTabTypes.MINE;
 
   const filteredExamples = filter(examples, obj => 'viz_type' in obj);
 

--- a/superset-frontend/src/views/CRUD/welcome/DashboardTable.test.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/DashboardTable.test.tsx
@@ -72,7 +72,7 @@ describe('DashboardTable', () => {
   it('render a submenu with clickable tabs and buttons', async () => {
     expect(wrapper.find('SubMenu')).toExist();
     expect(wrapper.find('li.no-router')).toHaveLength(2);
-    expect(wrapper.find('Button')).toHaveLength(4);
+    expect(wrapper.find('Button')).toHaveLength(6);
     act(() => {
       const handler = wrapper.find('li.no-router a').at(0).prop('onClick');
       if (handler) {

--- a/superset-frontend/src/views/CRUD/welcome/DashboardTable.test.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/DashboardTable.test.tsx
@@ -74,7 +74,7 @@ describe('DashboardTable', () => {
     expect(wrapper.find('li.no-router')).toHaveLength(2);
     expect(wrapper.find('Button')).toHaveLength(4);
     act(() => {
-      const handler = wrapper.find('li.no-router a').at(1).prop('onClick');
+      const handler = wrapper.find('li.no-router a').at(0).prop('onClick');
       if (handler) {
         handler({} as any);
       }

--- a/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
@@ -18,7 +18,7 @@
  */
 import React, { useState, useMemo, useEffect } from 'react';
 import { SupersetClient, t } from '@superset-ui/core';
-import { reject } from 'lodash';
+import { filter } from 'lodash';
 import { useListViewResource, useFavoriteStatus } from 'src/views/CRUD/hooks';
 import {
   Dashboard,
@@ -61,11 +61,10 @@ function DashboardTable({
   const filterStore = getFromLocalStorage(HOMEPAGE_DASHBOARD_FILTER, null);
   const defaultFilter = filterStore || TableTabTypes.EXAMPLES;
 
-  // @ts-ignore
-  // eslint-disable-next-line consistent-return
-  const filteredExamples: Array<Dashboard> = reject(examples, obj => {
-    if ('viz_type' in obj) return obj;
-  }).map(r => r);
+  const filteredExamples: Array<Dashboard> = filter<Dashboard>(
+    examples,
+    (obj: Dashboard) => !('viz_type' in obj),
+  );
 
   const {
     state: { loading, resourceCollection: dashboards },

--- a/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
@@ -59,7 +59,10 @@ function DashboardTable({
 }: DashboardTableProps) {
   const history = useHistory();
   const filterStore = getFromLocalStorage(HOMEPAGE_DASHBOARD_FILTER, null);
-  const defaultFilter = filterStore || TableTabTypes.EXAMPLES;
+  const defaultFilter =
+    !examples && filterStore === TableTabTypes.EXAMPLES
+      ? TableTabTypes.MINE
+      : filterStore || TableTabTypes.MINE;
 
   const filteredExamples: Array<Dashboard> = filter<any>(
     examples,

--- a/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
@@ -61,7 +61,7 @@ function DashboardTable({
   const filterStore = getFromLocalStorage(HOMEPAGE_DASHBOARD_FILTER, null);
   const defaultFilter = filterStore || TableTabTypes.EXAMPLES;
 
-  const filteredExamples: Array<Dashboard> = filter<Dashboard>(
+  const filteredExamples: Array<Dashboard> = filter<any>(
     examples,
     (obj: Dashboard) => !('viz_type' in obj),
   );

--- a/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
@@ -59,10 +59,11 @@ function DashboardTable({
 }: DashboardTableProps) {
   const history = useHistory();
   const filterStore = getFromLocalStorage(HOMEPAGE_DASHBOARD_FILTER, null);
-  const defaultFilter =
-    !examples && filterStore === TableTabTypes.EXAMPLES
-      ? TableTabTypes.MINE
-      : filterStore || TableTabTypes.MINE;
+  let defaultFilter = filterStore || TableTabTypes.EXAMPLES;
+
+  if (!examples && filterStore === TableTabTypes.EXAMPLES) {
+    defaultFilter = TableTabTypes.MINE;
+  }
 
   const filteredExamples = filter(examples, obj => !('viz_type' in obj));
 

--- a/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
@@ -18,6 +18,7 @@
  */
 import React, { useState, useMemo, useEffect } from 'react';
 import { SupersetClient, t } from '@superset-ui/core';
+import { reject } from 'lodash';
 import { useListViewResource, useFavoriteStatus } from 'src/views/CRUD/hooks';
 import {
   Dashboard,
@@ -54,11 +55,13 @@ function DashboardTable({
   addSuccessToast,
   mine,
   showThumbnails,
+  examples,
 }: DashboardTableProps) {
   const history = useHistory();
   const filterStore = getFromLocalStorage(HOMEPAGE_DASHBOARD_FILTER, null);
   const defaultFilter = filterStore || TableTabTypes.MINE;
 
+  console.log('examples top of', examples);
   const {
     state: { loading, resourceCollection: dashboards },
     setResourceCollection: setDashboards,
@@ -87,6 +90,9 @@ function DashboardTable({
 
   useEffect(() => {
     getData(dashboardFilter);
+    console.log('examples', examples);
+    const filtered = reject(examples, ['viz_type', undefined]).map(r => r);
+    console.log('filtered', filtered);
   }, [dashboardFilter]);
 
   const handleBulkDashboardExport = (dashboardsToExport: Dashboard[]) => {
@@ -136,6 +142,36 @@ function DashboardTable({
     return filters;
   };
 
+  const menuTabs = [
+    {
+      name: 'Favorite',
+      label: t('Favorite'),
+      onClick: () => {
+        setDashboardFilter(TableTabTypes.FAVORITE);
+        setInLocalStorage(HOMEPAGE_DASHBOARD_FILTER, TableTabTypes.FAVORITE);
+      },
+    },
+    {
+      name: 'Mine',
+      label: t('Mine'),
+      onClick: () => {
+        setDashboardFilter(TableTabTypes.MINE);
+        setInLocalStorage(HOMEPAGE_DASHBOARD_FILTER, TableTabTypes.MINE);
+      },
+    },
+  ];
+
+  if (examples) {
+    menuTabs.push({
+      name: 'Examples',
+      label: t('Examples'),
+      onClick: () => {
+        setDashboardFilter('Mine');
+        setInLocalStorage(HOMEPAGE_DASHBOARD_FILTER, TableTabTypes.EXAMPLES);
+      },
+    });
+  }
+
   const getData = (filter: string) =>
     fetchData({
       pageIndex: 0,
@@ -154,27 +190,7 @@ function DashboardTable({
     <>
       <SubMenu
         activeChild={dashboardFilter}
-        tabs={[
-          {
-            name: 'Favorite',
-            label: t('Favorite'),
-            onClick: () => {
-              setDashboardFilter(TableTabTypes.FAVORITE);
-              setInLocalStorage(
-                HOMEPAGE_DASHBOARD_FILTER,
-                TableTabTypes.FAVORITE,
-              );
-            },
-          },
-          {
-            name: 'Mine',
-            label: t('Mine'),
-            onClick: () => {
-              setDashboardFilter(TableTabTypes.MINE);
-              setInLocalStorage(HOMEPAGE_DASHBOARD_FILTER, TableTabTypes.MINE);
-            },
-          },
-        ]}
+        tabs={menuTabs}
         buttons={[
           {
             name: (

--- a/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
@@ -64,7 +64,7 @@ function DashboardTable({
       ? TableTabTypes.MINE
       : filterStore || TableTabTypes.MINE;
 
- const filteredExamples = filter(examples, obj => !('viz_type' in obj));
+  const filteredExamples = filter(examples, obj => !('viz_type' in obj));
 
   const {
     state: { loading, resourceCollection: dashboards },

--- a/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
@@ -64,10 +64,7 @@ function DashboardTable({
       ? TableTabTypes.MINE
       : filterStore || TableTabTypes.MINE;
 
-  const filteredExamples: Array<Dashboard> = filter<any>(
-    examples,
-    (obj: Dashboard) => !('viz_type' in obj),
-  );
+ const filteredExamples = filter(examples, obj => !('viz_type' in obj));
 
   const {
     state: { loading, resourceCollection: dashboards },

--- a/superset-frontend/src/views/CRUD/welcome/Welcome.test.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/Welcome.test.tsx
@@ -132,10 +132,10 @@ describe('Welcome', () => {
     const savedQueryCall = fetchMock.calls(/saved_query\/\?q/);
     const recentCall = fetchMock.calls(/superset\/recent_activity\/*/);
     const dashboardCall = fetchMock.calls(/dashboard\/\?q/);
-    expect(chartCall).toHaveLength(2);
+    expect(chartCall).toHaveLength(1);
     expect(recentCall).toHaveLength(1);
     expect(savedQueryCall).toHaveLength(1);
-    expect(dashboardCall).toHaveLength(2);
+    expect(dashboardCall).toHaveLength(1);
   });
 });
 

--- a/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
@@ -114,11 +114,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
     null,
   );
   const [loadedCount, setLoadedCount] = useState(0);
-  const [activeState, setActiveState] = useState<Array<string>>([
-    '1',
-    '2',
-    '3',
-  ]);
+  const [activeState, setActiveState] = useState<Array<string>>(['2', '3']);
   const userid = user.userId;
   const id = userid.toString();
 
@@ -141,6 +137,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
           } else setActiveChild(activeTab);
         } else {
           data.Examples = res.examples;
+          console.log('data', data)
           if (activeTab === 'Viewed' || !activeTab) {
             setActiveChild('Examples');
           } else setActiveChild(activeTab);
@@ -200,9 +197,14 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
   };
 
   useEffect(() => {
-    if (queryData?.length) {
-      setActiveState(['1', '2', '3', '4']);
+    const defaultArr = ['2', '3'];
+    if (activityData?.Viewed || activityData?.Examples) {
+      defaultArr.push('1');
     }
+    if (queryData?.length) {
+      defaultArr.push('4');
+    }
+    setActiveState(defaultArr);
     setActivityData(activityData => ({
       ...activityData,
       Created: [
@@ -211,6 +213,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
         ...(queryData || []),
       ],
     }));
+    console.log('chartData', chartData)
   }, [chartData, queryData, dashboardData]);
 
   return (
@@ -250,6 +253,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
               user={user}
               mine={dashboardData}
               showThumbnails={checked}
+              examples={activityData?.Examples}
             />
           )}
         </Collapse.Panel>
@@ -257,7 +261,12 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
           {!chartData ? (
             <Loading position="inline" />
           ) : (
-            <ChartTable showThumbnails={checked} user={user} mine={chartData} />
+            <ChartTable
+              showThumbnails={checked}
+              user={user}
+              mine={chartData}
+              examples={activityData?.Examples}
+            />
           )}
         </Collapse.Panel>
         <Collapse.Panel header={t('Saved queries')} key="4">

--- a/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
@@ -54,6 +54,8 @@ export interface ActivityData {
   Examples?: Array<object>;
 }
 
+const DEFAULT_TAB_ARR = ['2', '3'];
+
 const WelcomeContainer = styled.div`
   background-color: ${({ theme }) => theme.colors.grayscale.light4};
   .ant-row.menu {
@@ -114,7 +116,9 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
     null,
   );
   const [loadedCount, setLoadedCount] = useState(0);
-  const [activeState, setActiveState] = useState<Array<string>>(['2', '3']);
+  const [activeState, setActiveState] = useState<Array<string>>(
+    DEFAULT_TAB_ARR,
+  );
   const userid = user.userId;
   const id = userid.toString();
 
@@ -197,7 +201,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
   };
 
   useEffect(() => {
-    const defaultArr = ['2', '3'];
+    const defaultArr = DEFAULT_TAB_ARR;
     if (activityData?.Viewed) {
       defaultArr.push('1');
     }

--- a/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
@@ -137,7 +137,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
           } else setActiveChild(activeTab);
         } else {
           data.Examples = res.examples;
-          console.log('data', data)
+          console.log('data', data);
           if (activeTab === 'Viewed' || !activeTab) {
             setActiveChild('Examples');
           } else setActiveChild(activeTab);
@@ -213,7 +213,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
         ...(queryData || []),
       ],
     }));
-    console.log('chartData', chartData)
+    // console.log('chartData', chartData)
   }, [chartData, queryData, dashboardData]);
 
   return (

--- a/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
@@ -132,15 +132,15 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
         if (res.viewed) {
           const filtered = reject(res.viewed, ['item_url', null]).map(r => r);
           data.Viewed = filtered;
-          if (!activeTab) {
+          if (!activeTab && data.Viewed) {
             setActiveChild('Viewed');
+          } else if (!activeTab && !data.Viewed) {
+            setActiveChild('Created');
           } else setActiveChild(activeTab);
         } else {
+          if (!activeTab) setActiveChild('Created');
+          else setActiveChild(activeTab);
           data.Examples = res.examples;
-          console.log('data', data);
-          if (activeTab === 'Viewed' || !activeTab) {
-            setActiveChild('Examples');
-          } else setActiveChild(activeTab);
         }
         setActivityData(activityData => ({ ...activityData, ...data }));
       })
@@ -198,7 +198,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
 
   useEffect(() => {
     const defaultArr = ['2', '3'];
-    if (activityData?.Viewed || activityData?.Examples) {
+    if (activityData?.Viewed) {
       defaultArr.push('1');
     }
     if (queryData?.length) {
@@ -213,9 +213,10 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
         ...(queryData || []),
       ],
     }));
-    // console.log('chartData', chartData)
   }, [chartData, queryData, dashboardData]);
 
+  const isRecentActivityLoading =
+    !activityData?.Examples && !activityData?.Viewed;
   return (
     <WelcomeContainer>
       <WelcomeNav>
@@ -246,7 +247,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
           )}
         </Collapse.Panel>
         <Collapse.Panel header={t('Dashboards')} key="2">
-          {!dashboardData ? (
+          {!dashboardData || isRecentActivityLoading ? (
             <Loading position="inline" />
           ) : (
             <DashboardTable
@@ -258,7 +259,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
           )}
         </Collapse.Panel>
         <Collapse.Panel header={t('Charts')} key="3">
-          {!chartData ? (
+          {!chartData || isRecentActivityLoading ? (
             <Loading position="inline" />
           ) : (
             <ChartTable


### PR DESCRIPTION
### SUMMARY
This Pr conditionally renders the viewed tab if there is viewed data, and splits the example dashboards and charts into the their respective tables.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before
https://user-images.githubusercontent.com/17326228/126246854-5d36d140-0637-4437-a8a7-97638e325f19.mov

after with viewed data

https://user-images.githubusercontent.com/17326228/126246854-5d36d140-0637-4437-a8a7-97638e325f19.mov

after with just examples

https://user-images.githubusercontent.com/17326228/126249400-5764a7c9-aff9-4b89-9149-1e66c92fb0e7.mov

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
