### PR TITLE
feat: Begin incorporation of email report modal to Charts

### DIFF
--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -523,7 +523,7 @@ class Header extends React.PureComponent {
                 className="action-button"
                 onClick={this.showReportModal}
               >
-                <Icon name="calendar" />
+                <Icons.Calendar />
               </span>
             </>
           )}

--- a/superset-frontend/src/explore/components/ExploreChartHeader.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader.jsx
@@ -84,7 +84,8 @@ const StyledHeader = styled.div`
   }
 
   .action-button {
-    margin: 0 6px 0 4px;
+    margin: 0 ${({ theme }) => theme.gridUnit * 1.5}px 0
+      ${({ theme }) => theme.gridUnit}px;
   }
 `;
 

--- a/superset-frontend/src/explore/components/ExploreChartHeader.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader.jsx
@@ -20,8 +20,10 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
+import Icons from 'src/components/Icons';
 import { styled, t } from '@superset-ui/core';
 import { Tooltip } from 'src/components/Tooltip';
+import ReportModal from 'src/components/ReportModal';
 import { chartPropShape } from '../../dashboard/util/propShapes';
 import ExploreActionButtons from './ExploreActionButtons';
 import RowCountLabel from './RowCountLabel';
@@ -80,6 +82,10 @@ const StyledHeader = styled.div`
       margin-left: ${({ theme }) => theme.gridUnit}px;
     }
   }
+
+  .action-button {
+    margin: 0 6px 0 4px;
+  }
 `;
 
 const StyledButtons = styled.span`
@@ -92,9 +98,12 @@ export class ExploreChartHeader extends React.PureComponent {
     super(props);
     this.state = {
       isPropertiesModalOpen: false,
+      showingReportModal: false,
     };
     this.openPropertiesModal = this.openPropertiesModal.bind(this);
     this.closePropertiesModal = this.closePropertiesModal.bind(this);
+    this.showReportModal = this.showReportModal.bind(this);
+    this.hideReportModal = this.hideReportModal.bind(this);
   }
 
   getSliceName() {
@@ -121,6 +130,14 @@ export class ExploreChartHeader extends React.PureComponent {
     this.setState({
       isPropertiesModalOpen: false,
     });
+  }
+
+  showReportModal() {
+    this.setState({ showingReportModal: true });
+  }
+
+  hideReportModal() {
+    this.setState({ showingReportModal: false });
   }
 
   render() {
@@ -204,6 +221,19 @@ export class ExploreChartHeader extends React.PureComponent {
             endTime={chartUpdateEndTime}
             isRunning={chartStatus === 'loading'}
             status={CHART_STATUS_MAP[chartStatus]}
+          />
+          <span
+            role="button"
+            title={t('Schedule email report')}
+            tabIndex={0}
+            className="action-button"
+            onClick={this.showReportModal}
+          >
+            <Icons.Calendar />
+          </span>
+          <ReportModal
+            show={this.state.showingReportModal}
+            onHide={this.hideReportModal}
           />
           <ExploreActionButtons
             actions={{


### PR DESCRIPTION
### SUMMARY
This is the beginning of incorporation of the email report modal into Charts.

### SCREENSHOTS
#### Chart entry point
<img width="544" alt="Screen Shot 2021-07-19 at 11 27 36 PM" src="https://user-images.githubusercontent.com/55605634/126262894-3af7a33c-ed55-4d69-a5b9-9ed51150a2b5.png">

#### Report modal
<img width="608" alt="Screen Shot 2021-07-19 at 11 31 48 PM" src="https://user-images.githubusercontent.com/55605634/126262917-ae3b355c-e703-4231-8b62-177195a0c1e3.png">

### TESTING INSTRUCTIONS
- Click "Charts" in the upper navigation bar
- Navigate to any Chart
- Click the Calendar icon button
	- Located at the top of the chart between the timer and the "Copy chart URL to clipboard" button
- Observe the email report modal

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
