### PR TITLE
feat(explore): default aggregate for string/numeric columns when creating metric

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -269,7 +269,7 @@ export const DndMetricSelect = (props: any) => {
       return new AdhocMetric(config);
     }
     return new AdhocMetric({ isNew: true });
-  }, [droppedItem?.type, droppedItem?.value]);
+  }, [droppedItem]);
 
   return (
     <div className="metrics-select">

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -18,7 +18,14 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { ensureIsArray, GenericDataType, Metric, tn } from '@superset-ui/core';
+import {
+  ensureIsArray,
+  FeatureFlag,
+  GenericDataType,
+  isFeatureEnabled,
+  Metric,
+  tn,
+} from '@superset-ui/core';
 import { ColumnMeta } from '@superset-ui/chart-controls';
 import { isEqual } from 'lodash';
 import { usePrevious } from 'src/common/hooks/usePrevious';
@@ -258,13 +265,16 @@ export const DndMetricSelect = (props: any) => {
       const config: Partial<AdhocMetric> = {
         column: { column_name: itemValue?.column_name },
       };
-      if (itemValue.type_generic === GenericDataType.NUMERIC) {
-        config.aggregate = AGGREGATES.SUM;
-      } else if (
-        itemValue.type_generic === GenericDataType.STRING ||
-        itemValue.type_generic === GenericDataType.BOOLEAN
-      ) {
-        config.aggregate = AGGREGATES.COUNT_DISTINCT;
+      if (isFeatureEnabled(FeatureFlag.UX_BETA)) {
+        if (itemValue.type_generic === GenericDataType.NUMERIC) {
+          config.aggregate = AGGREGATES.SUM;
+        } else if (
+          itemValue.type_generic === GenericDataType.STRING ||
+          itemValue.type_generic === GenericDataType.BOOLEAN ||
+          itemValue.type_generic === GenericDataType.TEMPORAL
+        ) {
+          config.aggregate = AGGREGATES.COUNT_DISTINCT;
+        }
       }
       return new AdhocMetric(config);
     }

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
@@ -76,6 +76,26 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
     };
   }
 
+  componentDidUpdate(
+    prevProps: Readonly<AdhocMetricPopoverTriggerProps>,
+    prevState: Readonly<AdhocMetricPopoverTriggerState>,
+    snapshot?: any,
+  ) {
+    if (
+      prevProps.adhocMetric.optionName !== this.props.adhocMetric.optionName
+    ) {
+      // eslint-disable-next-line react/no-did-update-set-state
+      this.setState({
+        title: {
+          label: this.props.adhocMetric.label,
+          hasCustomLabel: this.props.adhocMetric.hasCustomLabel,
+        },
+        currentLabel: '',
+        labelModified: false,
+      });
+    }
+  }
+
   onLabelChange(e: any) {
     const { verbose_name, metric_name } = this.props.savedMetric;
     const defaultMetricLabel = this.props.adhocMetric?.getDefaultLabel();

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
@@ -43,6 +43,7 @@ export type AdhocMetricPopoverTriggerProps = {
 };
 
 export type AdhocMetricPopoverTriggerState = {
+  adhocMetric: AdhocMetric;
   popoverVisible: boolean;
   title: { label: string; hasCustomLabel: boolean };
   currentLabel: string;
@@ -65,6 +66,7 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
     this.onChange = this.onChange.bind(this);
 
     this.state = {
+      adhocMetric: props.adhocMetric,
       popoverVisible: false,
       title: {
         label: props.adhocMetric.label,
@@ -76,24 +78,24 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
     };
   }
 
-  componentDidUpdate(
-    prevProps: Readonly<AdhocMetricPopoverTriggerProps>,
-    prevState: Readonly<AdhocMetricPopoverTriggerState>,
-    snapshot?: any,
+  static getDerivedStateFromProps(
+    nextProps: AdhocMetricPopoverTriggerProps,
+    prevState: AdhocMetricPopoverTriggerState,
   ) {
-    if (
-      prevProps.adhocMetric.optionName !== this.props.adhocMetric.optionName
-    ) {
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({
+    if (prevState.adhocMetric.optionName !== nextProps.adhocMetric.optionName) {
+      return {
+        adhocMetric: nextProps.adhocMetric,
         title: {
-          label: this.props.adhocMetric.label,
-          hasCustomLabel: this.props.adhocMetric.hasCustomLabel,
+          label: nextProps.adhocMetric.label,
+          hasCustomLabel: nextProps.adhocMetric.hasCustomLabel,
         },
         currentLabel: '',
         labelModified: false,
-      });
+      };
     }
+    return {
+      adhocMetric: nextProps.adhocMetric,
+    };
   }
 
   onLabelChange(e: any) {

--- a/superset/config.py
+++ b/superset/config.py
@@ -399,6 +399,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     # Allow users to export full CSV of table viz type.
     # This could cause the server to run out of memory or compute.
     "ALLOW_FULL_CSV_EXPORT": False,
+    "UX_BETA": False,
 }
 
 # Feature flags may also be set via 'SUPERSET_FEATURE_' prefixed environment vars.


### PR DESCRIPTION
### SUMMARY
When user creates a new adhoc metric with drag and dropping a column into metrics control, auto fill default aggregate in metric popover.
If column's generic type is numeric, set `SUM` aggregate as default.
if column's generic type is string or boolean, set `COUNT_DISTINCT` aggregate as default.
Otherwise, don't set a default aggregate.

Also, this PR fixes a bug metrics popover - when user created a metric with a custom label and then tried to create next metric, previous label was set instead of a default label. Now it should work as expected.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/15073128/126321084-c75a8fc2-40fa-4d66-bf32-3be7eefa6f4d.mov

### TESTING INSTRUCTIONS
0. Set `ENABLE_EXPLORE_DRAG_AND_DROP` and `UX_BETA` feature flags to True
1. Drag numeric column to metrics control. The default aggregate should be `SUM`
2. Drag string or boolean column to metrics control. The default aggregate should be `COUNT_DISTINCT`
3. Drag other type of column to metrics control. Aggregate should be unset.
4. Click Run and make sure the metrics work properly
5. Edit the default label of some metric and then try to add a new one. A default label in the new metric popover should match column's name and selected aggregate. Previously set label shouldn't be shown here

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: fixes #12364 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @junlincc 