### PR TITLE
fix(dashboard): Add z-index to dashboard only when maximizing chart

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -95,7 +95,7 @@ const StyledContent = styled.div<{
 }>`
   grid-column: 2;
   grid-row: 2;
-  z-index: ${({ fullSizeChartId }) => (fullSizeChartId ? 1000 : 1)};
+  ${({ fullSizeChartId }) => fullSizeChartId && `z-index: 1000;`}
 `;
 
 const StyledDashboardContent = styled.div<{


### PR DESCRIPTION
### SUMMARY
It adds the `z-index `to the dashboard only when maximizing charts in order to avoid display issues of overlapping items.

Fixes #15689

### BEFORE
<img width="1791" alt="125673168-0c518bee-7ce7-4801-97fc-e905fb5e76cf" src="https://user-images.githubusercontent.com/60598000/126340383-73efbcb5-796b-4310-998f-981f8824fa40.png">

### AFTER
https://user-images.githubusercontent.com/60598000/126340664-5b199d76-284a-47cc-a095-5c2873a30ee3.mp4

### TESTING INSTRUCTIONS
1. Open a dashboard in edit mode
2. Add a header component at the top and click on it
3. Make sure the options are appearing properly
4. Add a chart, save the dashboard and maximize the chart
5. Make sure the chart is taking all the available space

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #15689
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
