### PR TITLE
fix: publish the new example dashboards

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard_list/filter.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard_list/filter.test.ts
@@ -59,13 +59,13 @@ describe('dashboard filters card view', () => {
     // filter by published
     cy.get('.Select__control').eq(2).click();
     cy.get('.Select__menu').contains('Published').click({ timeout: 5000 });
-    cy.get('[data-test="styled-card"]').should('have.length', 2);
+    cy.get('[data-test="styled-card"]').should('have.length', 3);
     cy.get('[data-test="styled-card"]')
       .contains('USA Births Names')
       .should('be.visible');
     cy.get('.Select__control').eq(1).click();
     cy.get('.Select__control').eq(1).type('unpub{enter}');
-    cy.get('[data-test="styled-card"]').should('have.length', 2);
+    cy.get('[data-test="styled-card"]').should('have.length', 3);
   });
 });
 
@@ -110,12 +110,12 @@ describe('dashboard filters list view', () => {
     // filter by published
     cy.get('.Select__control').eq(2).click();
     cy.get('.Select__menu').contains('Published').click();
-    cy.get('[data-test="table-row"]').should('have.length', 2);
+    cy.get('[data-test="table-row"]').should('have.length', 3);
     cy.get('[data-test="table-row"]')
       .contains('USA Births Names')
       .should('be.visible');
     cy.get('.Select__control').eq(2).click();
     cy.get('.Select__control').eq(2).type('unpub{enter}');
-    cy.get('[data-test="table-row"]').should('have.length', 2);
+    cy.get('[data-test="table-row"]').should('have.length', 3);
   });
 });

--- a/superset/commands/importers/v1/examples.py
+++ b/superset/commands/importers/v1/examples.py
@@ -125,6 +125,8 @@ class ImportExamplesCommand(ImportModelsCommand):
             if file_name.startswith("dashboards/"):
                 config = update_id_refs(config, chart_ids)
                 dashboard = import_dashboard(session, config, overwrite=overwrite)
+                dashboard.published = True
+
                 for uuid in find_chart_uuids(config["position"]):
                     chart_id = chart_ids[uuid]
                     if (dashboard.id, chart_id) not in existing_relationships:


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Make sure the new example dashboards are published when we run `load-examples`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Run `superset load-examples`, the new dashboards are now published.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
