### PR TITLE
feat: send data embedded in report email

### DIFF
--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.test.jsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.test.jsx
@@ -36,7 +36,7 @@ const mockData = {
   id: 1,
   name: 'test report',
   description: 'test report description',
-  chart: { id: 1, slice_name: 'test chart' },
+  chart: { id: 1, slice_name: 'test chart', viz_type: 'table' },
   database: { id: 1, database_name: 'test database' },
   sql: 'SELECT NaN',
 };
@@ -76,7 +76,7 @@ fetchMock.get(dashboardEndpoint, {
 });
 
 fetchMock.get(chartEndpoint, {
-  result: [],
+  result: [{ text: 'table chart', value: 1 }],
 });
 
 async function mountAndWait(props = mockedProps) {
@@ -258,6 +258,22 @@ describe('AlertReportModal', () => {
   it('renders two radio buttons', () => {
     expect(wrapper.find(Radio)).toExist();
     expect(wrapper.find(Radio)).toHaveLength(2);
+  });
+
+  it('renders text option for text-based charts', async () => {
+    const props = {
+      ...mockedProps,
+      alert: mockData,
+    };
+    const textWrapper = await mountAndWait(props);
+
+    const chartOption = textWrapper.find('input[value="chart"]');
+    act(() => {
+      chartOption.props().onChange({ target: { value: 'chart' } });
+    });
+    await waitForComponentToPaint(textWrapper);
+
+    expect(textWrapper.find('input[value="TEXT"]')).toExist();
   });
 
   it('renders input element for working timeout', () => {

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -51,6 +51,12 @@ import {
 
 const SELECT_PAGE_SIZE = 2000; // temporary fix for paginated query
 const TIMEOUT_MIN = 1;
+const TEXT_BASED_VISUALIZATION_TYPES = [
+  'pivot_table',
+  'pivot_table_v2',
+  'table',
+  'paired_ttest',
+];
 
 type SelectValue = {
   value: string;
@@ -416,6 +422,9 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
   const [dashboardOptions, setDashboardOptions] = useState<MetaObject[]>([]);
   const [chartOptions, setChartOptions] = useState<MetaObject[]>([]);
 
+  // Chart metadata
+  const [chartVizType, setChartVizType] = useState<string>('');
+
   const isEditMode = alert !== null;
   const formatOptionEnabled =
     contentType === 'chart' &&
@@ -718,6 +727,19 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
     return result;
   };
 
+  const getChartVisualizationType = (chartData?: MetaObject) => {
+    const chart = chartData || currentAlert?.chart;
+    if (!chart) {
+      return;
+    }
+
+    // Fetch the visulization type, since the "text" option is only available
+    // to text-based visualizations (pivot tables, t-test table, table).
+    return SupersetClient.get({
+      endpoint: `/api/v1/chart/${chart.value}`,
+    }).then(response => setChartVizType(response.json.result.viz_type));
+  };
+
   // Updating alert/report state
   const updateAlertState = (name: string, value: any) => {
     setCurrentAlert(currentAlertData => ({
@@ -770,6 +792,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
   };
 
   const onChartChange = (chart: SelectValue) => {
+    getChartVisualizationType(chart);
     updateAlertState('chart', chart || undefined);
     updateAlertState('dashboard', null);
   };
@@ -1251,18 +1274,6 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
               <StyledRadio value="dashboard">{t('Dashboard')}</StyledRadio>
               <StyledRadio value="chart">{t('Chart')}</StyledRadio>
             </Radio.Group>
-            {formatOptionEnabled && (
-              <div className="inline-container">
-                <StyledRadioGroup
-                  onChange={onFormatChange}
-                  value={reportFormat}
-                >
-                  <StyledRadio value="PNG">{t('Send as PNG')}</StyledRadio>
-                  <StyledRadio value="CSV">{t('Send as CSV')}</StyledRadio>
-                  <StyledRadio value="TEXT">{t('Send as text')}</StyledRadio>
-                </StyledRadioGroup>
-              </div>
-            )}
             <AsyncSelect
               className={
                 contentType === 'chart'
@@ -1303,6 +1314,20 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
               cacheOptions
               onChange={onDashboardChange}
             />
+            {formatOptionEnabled && (
+              <div className="inline-container">
+                <StyledRadioGroup
+                  onChange={onFormatChange}
+                  value={reportFormat}
+                >
+                  <StyledRadio value="PNG">{t('Send as PNG')}</StyledRadio>
+                  <StyledRadio value="CSV">{t('Send as CSV')}</StyledRadio>
+                  {TEXT_BASED_VISUALIZATION_TYPES.includes(chartVizType) && (
+                    <StyledRadio value="TEXT">{t('Send as text')}</StyledRadio>
+                  )}
+                </StyledRadioGroup>
+              </div>
+            )}
             <StyledSectionTitle>
               <h4>{t('Notification method')}</h4>
               <span className="required">*</span>

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -1259,6 +1259,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                 >
                   <StyledRadio value="PNG">{t('Send as PNG')}</StyledRadio>
                   <StyledRadio value="CSV">{t('Send as CSV')}</StyledRadio>
+                  <StyledRadio value="TEXT">{t('Send as text')}</StyledRadio>
                 </StyledRadioGroup>
               </div>
             )}

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -727,18 +727,10 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
     return result;
   };
 
-  const getChartVisualizationType = (chartData?: MetaObject) => {
-    const chart = chartData || currentAlert?.chart;
-    if (!chart) {
-      return;
-    }
-
-    // Fetch the visulization type, since the "text" option is only available
-    // to text-based visualizations (pivot tables, t-test table, table).
-    return SupersetClient.get({
+  const getChartVisualizationType = (chart: SelectValue) =>
+    SupersetClient.get({
       endpoint: `/api/v1/chart/${chart.value}`,
     }).then(response => setChartVizType(response.json.result.viz_type));
-  };
 
   // Updating alert/report state
   const updateAlertState = (name: string, value: any) => {
@@ -942,6 +934,10 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
           : resource.validator_config_json;
 
       setConditionNotNull(resource.validator_type === 'not null');
+
+      if (resource.chart) {
+        setChartVizType((resource.chart as ChartObject).viz_type);
+      }
 
       setCurrentAlert({
         ...resource,

--- a/superset-frontend/src/views/CRUD/alert/types.ts
+++ b/superset-frontend/src/views/CRUD/alert/types.ts
@@ -74,7 +74,7 @@ export type AlertObject = {
   owners?: Array<Owner | MetaObject>;
   sql?: string;
   recipients?: Array<Recipient>;
-  report_format?: 'PNG' | 'CSV';
+  report_format?: 'PNG' | 'CSV' | 'TEXT';
   type?: string;
   validator_config_json?: {
     op?: Operator;

--- a/superset-frontend/src/views/CRUD/alert/types.ts
+++ b/superset-frontend/src/views/CRUD/alert/types.ts
@@ -27,6 +27,7 @@ type user = {
 export type ChartObject = {
   id: number;
   slice_name: string;
+  viz_type: string;
 };
 
 export type DashboardObject = {

--- a/superset/models/reports.py
+++ b/superset/models/reports.py
@@ -72,6 +72,7 @@ class ReportState(str, enum.Enum):
 class ReportDataFormat(str, enum.Enum):
     VISUALIZATION = "PNG"
     DATA = "CSV"
+    TEXT = "TEXT"
 
 
 class ReportCreationMethodType(str, enum.Enum):

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -83,6 +83,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
         "active",
         "chart.id",
         "chart.slice_name",
+        "chart.viz_type",
         "context_markdown",
         "creation_method",
         "crontab",

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -93,9 +93,7 @@ class BaseReportState:
         self._execution_id = execution_id
 
     def set_state_and_log(
-        self,
-        state: ReportState,
-        error_message: Optional[str] = None,
+        self, state: ReportState, error_message: Optional[str] = None,
     ) -> None:
         """
         Updates current ReportSchedule state and TS. If on final state writes the log
@@ -104,8 +102,7 @@ class BaseReportState:
         now_dttm = datetime.utcnow()
         self.set_state(state, now_dttm)
         self.create_log(
-            state,
-            error_message=error_message,
+            state, error_message=error_message,
         )
 
     def set_state(self, state: ReportState, dttm: datetime) -> None:
@@ -119,9 +116,7 @@ class BaseReportState:
         self._session.commit()
 
     def create_log(  # pylint: disable=too-many-arguments
-        self,
-        state: ReportState,
-        error_message: Optional[str] = None,
+        self, state: ReportState, error_message: Optional[str] = None,
     ) -> None:
         """
         Creates a Report execution log, uses the current computed last_value for Alerts
@@ -477,14 +472,12 @@ class ReportWorkingState(BaseReportState):
         if self.is_on_working_timeout():
             exception_timeout = ReportScheduleWorkingTimeoutError()
             self.set_state_and_log(
-                ReportState.ERROR,
-                error_message=str(exception_timeout),
+                ReportState.ERROR, error_message=str(exception_timeout),
             )
             raise exception_timeout
         exception_working = ReportSchedulePreviousWorkingError()
         self.set_state_and_log(
-            ReportState.WORKING,
-            error_message=str(exception_working),
+            ReportState.WORKING, error_message=str(exception_working),
         )
         raise exception_working
 

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -152,7 +152,6 @@ class BaseReportState:
                     "ChartRestApi.get_data",
                     pk=self._report_schedule.chart_id,
                     format="csv",
-                    type="post_processed",
                 )
             return get_url_path(
                 "Superset.slice",

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -253,7 +253,7 @@ class BaseReportState:
         """
         buf = BytesIO(self._get_csv_data())
         df = pd.read_csv(buf)
-        return df.to_html(na_rep="null")
+        return df.to_html(na_rep="", index=False)
 
     def _get_notification_content(self) -> NotificationContent:
         """

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -152,6 +152,7 @@ class BaseReportState:
                     "ChartRestApi.get_data",
                     pk=self._report_schedule.chart_id,
                     format="csv",
+                    type="post_processed",
                 )
             return get_url_path(
                 "Superset.slice",

--- a/superset/reports/notifications/base.py
+++ b/superset/reports/notifications/base.py
@@ -29,6 +29,7 @@ class NotificationContent:
     text: Optional[str] = None
     description: Optional[str] = ""
     url: Optional[str] = None  # url to chart/dashboard for this screenshot
+    embedded_data: Optional[str] = ""
 
 
 class BaseNotification:  # pylint: disable=too-few-public-methods

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 from email.utils import make_msgid, parseaddr
 from typing import Any, Dict, Optional
 
+import bleach
 from flask_babel import gettext as __
 
 from superset import app
@@ -30,6 +31,8 @@ from superset.reports.notifications.exceptions import NotificationError
 from superset.utils.core import send_email_smtp
 
 logger = logging.getLogger(__name__)
+
+TABLE_TAGS = ["table", "th", "tr", "td", "thead", "tbody", "tfoot"]
 
 
 @dataclass
@@ -68,14 +71,23 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
         csv_data = None
         domain = self._get_smtp_domain()
         msgid = make_msgid(domain)[1:-1]
+
+        # Strip any malicious HTML from the description
+        description = bleach.clean(self._content.description or "")
+
+        # Strip malicious HTML from embedded data, allowing table elements
+        embedded_data = bleach.clean(self._content.embedded_data or "", tags=TABLE_TAGS)
+
         body = __(
             """
             <p>%(description)s</p>
             <b><a href="%(url)s">Explore in Superset</a></b><p></p>
+            %(embedded_data)s
             %(img_tag)s
             """,
-            description=self._content.description or "",
+            description=description,
             url=self._content.url,
+            embedded_data=embedded_data,
             img_tag='<img width="1000px" src="cid:{}">'.format(msgid)
             if self._content.screenshot
             else "",

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -21,6 +21,7 @@ These objects represent the backend of all the visualizations that
 Superset can render.
 """
 import copy
+import inspect
 import logging
 import math
 import re
@@ -52,7 +53,7 @@ from flask_babel import lazy_gettext as _
 from geopy.point import Point
 from pandas.tseries.frequencies import to_offset
 
-from superset import app, is_feature_enabled
+from superset import app, db, is_feature_enabled
 from superset.constants import NULL_STRING
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import (
@@ -63,6 +64,7 @@ from superset.exceptions import (
     SupersetSecurityException,
 )
 from superset.extensions import cache_manager, security_manager
+from superset.models.cache import CacheKey
 from superset.models.helpers import QueryResult
 from superset.typing import Metric, QueryObjectDict, VizData, VizPayload
 from superset.utils import core as utils, csv
@@ -617,26 +619,11 @@ class BaseViz:
 
     def get_csv(self) -> Optional[str]:
         df = self.get_df_payload()["df"]  # leverage caching logic
-        df = self.post_process(df)
         include_index = not isinstance(df.index, pd.RangeIndex)
         return csv.df_to_escaped_csv(df, index=include_index, **config["CSV_EXPORT"])
 
     def get_data(self, df: pd.DataFrame) -> VizData:
         return df.to_dict(orient="records")
-
-    def post_process(self, df: pd.DataFrame) -> pd.DataFrame:
-        """
-        Post-process data to return same format as visualization.
-
-        Some visualizations post-process the data in the frontend before presenting
-        it to the user. Eg, the t-test visualization will compute p-values and
-        significance in Javascript, while the pivot table will pivot the data.
-
-        When we produce a report we want to send to the user the exact same data
-        that they see in the chart. For visualizations with post-processing we need
-        to compute the perform the same processing in Python.
-        """
-        return df
 
     @property
     def json_data(self) -> str:
@@ -909,7 +896,7 @@ class PivotTableViz(BaseViz):
         # fallback in case something incompatible is returned
         return cast(str, value)
 
-    def _pivot_data(self, df: pd.DataFrame) -> Optional[pd.DataFrame]:
+    def get_data(self, df: pd.DataFrame) -> VizData:
         if df.empty:
             return None
 
@@ -947,11 +934,6 @@ class PivotTableViz(BaseViz):
         # Display metrics side by side with each column
         if self.form_data.get("combine_metric"):
             df = df.stack(0).unstack().reindex(level=-1, columns=metrics)
-
-        return df
-
-    def get_data(self, df: pd.DataFrame) -> VizData:
-        df = self._pivot_data(df)
         return dict(
             columns=list(df.columns),
             html=df.to_html(
@@ -962,9 +944,6 @@ class PivotTableViz(BaseViz):
                 ).split(" "),
             ),
         )
-
-    def post_process(self, df: pd.DataFrame) -> pd.DataFrame:
-        return self._pivot_data(df)
 
 
 class TreemapViz(BaseViz):

--- a/tests/integration_tests/reports/api_tests.py
+++ b/tests/integration_tests/reports/api_tests.py
@@ -181,6 +181,7 @@ class TestReportSchedulesApi(SupersetTestCase):
             "chart": {
                 "id": report_schedule.chart.id,
                 "slice_name": report_schedule.chart.slice_name,
+                "viz_type": report_schedule.chart.viz_type,
             },
             "context_markdown": report_schedule.context_markdown,
             "crontab": report_schedule.crontab,

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -231,6 +231,20 @@ def create_report_email_chart_with_csv():
 
 
 @pytest.fixture()
+def create_report_email_chart_with_text():
+    with app.app_context():
+        chart = db.session.query(Slice).first()
+        chart.query_context = '{"mock": "query_context"}'
+        report_schedule = create_report_notification(
+            email_target="target@email.com",
+            chart=chart,
+            report_format=ReportDataFormat.TEXT,
+        )
+        yield report_schedule
+        cleanup_report_schedule(report_schedule)
+
+
+@pytest.fixture()
 def create_report_email_chart_with_csv_no_query_context():
     with app.app_context():
         chart = db.session.query(Slice).first()
@@ -719,6 +733,59 @@ def test_email_chart_report_schedule_with_csv_no_query_context(
 
         # verify that when query context is null we request a screenshot
         screenshot_mock.assert_called_once()
+
+
+@pytest.mark.usefixtures(
+    "load_birth_names_dashboard_with_slices", "create_report_email_chart_with_text"
+)
+@patch("superset.utils.csv.urllib.request.urlopen")
+@patch("superset.utils.csv.urllib.request.OpenerDirector.open")
+@patch("superset.reports.notifications.email.send_email_smtp")
+@patch("superset.utils.csv.get_chart_csv_data")
+def test_email_chart_report_schedule_with_text(
+    csv_mock, email_mock, mock_open, mock_urlopen, create_report_email_chart_with_text,
+):
+    """
+    ExecuteReport Command: Test chart email report schedule with CSV
+    """
+    # setup csv mock
+    response = Mock()
+    mock_open.return_value = response
+    mock_urlopen.return_value = response
+    mock_urlopen.return_value.getcode.return_value = 200
+    response.read.return_value = CSV_FILE
+
+    with freeze_time("2020-01-01T00:00:00Z"):
+        AsyncExecuteReportScheduleCommand(
+            TEST_ID, create_report_email_chart_with_text.id, datetime.utcnow()
+        ).run()
+
+        # assert that the data is embedded correctly
+        table_html = """<table>
+  <thead>
+    <tr>
+      <th>t1</th>
+      <th>t2</th>
+      <th>t3__sum</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>c11</td>
+      <td>c12</td>
+      <td>c13</td>
+    </tr>
+    <tr>
+      <td>c21</td>
+      <td>c22</td>
+      <td>c23</td>
+    </tr>
+  </tbody>
+</table>"""
+        assert table_html in email_mock.call_args[0][2]
+
+        # Assert logs are correct
+        assert_log(ReportState.SUCCESS)
 
 
 @pytest.mark.usefixtures(


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR introduces a new category of reports for charts, "TEXT":

![Screen Shot 2021-07-27 at 11 46 00 AM](https://user-images.githubusercontent.com/1534870/127210448-9e92b049-43b6-4fb2-b613-900694a65094.png)

The option shows up for a small subset of the charts types that present data in textual format: t-test, pivot table and table.

When the report is sent as text the data is embedded directly in the email as an HTML table:

![Screen Shot 2021-07-27 at 11 32 56 AM](https://user-images.githubusercontent.com/1534870/127208851-0da25213-8fd8-46e6-a4ca-73f5812a733b.png)

Finally, I also noticed that we were passing HTML from the description directly to the email without escaping it. This was fixed by using the `bleach` library.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
