### PR TITLE
feat: send report data to Slack

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -264,6 +264,8 @@ sqlalchemy-utils==0.36.8
     #   flask-appbuilder
 sqlparse==0.3.0
     # via apache-superset
+tabulate==0.8.9
+    # via apache-superset
 typing-extensions==3.7.4.3
     # via
     #   aiohttp

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ combine_as_imports = true
 include_trailing_comma = true
 line_length = 88
 known_first_party = superset
-known_third_party =alembic,apispec,backoff,bleach,cachelib,celery,click,colorama,cron_descriptor,croniter,cryptography,dateutil,deprecation,flask,flask_appbuilder,flask_babel,flask_caching,flask_compress,flask_jwt_extended,flask_login,flask_migrate,flask_sqlalchemy,flask_talisman,flask_testing,flask_wtf,freezegun,geohash,geopy,graphlib,holidays,humanize,isodate,jinja2,jwt,markdown,markupsafe,marshmallow,marshmallow_enum,msgpack,numpy,pandas,parameterized,parsedatetime,pgsanity,pkg_resources,polyline,prison,progress,pyarrow,pyhive,pyparsing,pytest,pytest_mock,pytz,redis,requests,selenium,setuptools,simplejson,slack,sqlalchemy,sqlalchemy_utils,sqlparse,typing_extensions,werkzeug,wtforms,wtforms_json,yaml
+known_third_party =alembic,apispec,backoff,bleach,cachelib,celery,click,colorama,cron_descriptor,croniter,cryptography,dateutil,deprecation,flask,flask_appbuilder,flask_babel,flask_caching,flask_compress,flask_jwt_extended,flask_login,flask_migrate,flask_sqlalchemy,flask_talisman,flask_testing,flask_wtf,freezegun,geohash,geopy,holidays,humanize,isodate,jinja2,jwt,markdown,markupsafe,marshmallow,marshmallow_enum,msgpack,numpy,pandas,parameterized,parsedatetime,pgsanity,pkg_resources,polyline,prison,progress,pyarrow,pyhive,pyparsing,pytest,pytest_mock,pytz,redis,requests,selenium,setuptools,simplejson,slack,sqlalchemy,sqlalchemy_utils,sqlparse,tabulate,typing_extensions,werkzeug,wtforms,wtforms_json,yaml
 multi_line_output = 3
 order_by_type = false
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ combine_as_imports = true
 include_trailing_comma = true
 line_length = 88
 known_first_party = superset
-known_third_party =alembic,apispec,backoff,bleach,cachelib,celery,click,colorama,cron_descriptor,croniter,cryptography,dateutil,deprecation,flask,flask_appbuilder,flask_babel,flask_caching,flask_compress,flask_jwt_extended,flask_login,flask_migrate,flask_sqlalchemy,flask_talisman,flask_testing,flask_wtf,freezegun,geohash,geopy,holidays,humanize,isodate,jinja2,jwt,markdown,markupsafe,marshmallow,marshmallow_enum,msgpack,numpy,pandas,parameterized,parsedatetime,pgsanity,pkg_resources,polyline,prison,progress,pyarrow,pyhive,pyparsing,pytest,pytest_mock,pytz,redis,requests,selenium,setuptools,simplejson,slack,sqlalchemy,sqlalchemy_utils,sqlparse,tabulate,typing_extensions,werkzeug,wtforms,wtforms_json,yaml
+known_third_party =alembic,apispec,backoff,bleach,cachelib,celery,click,colorama,cron_descriptor,croniter,cryptography,dateutil,deprecation,flask,flask_appbuilder,flask_babel,flask_caching,flask_compress,flask_jwt_extended,flask_login,flask_migrate,flask_sqlalchemy,flask_talisman,flask_testing,flask_wtf,freezegun,geohash,geopy,graphlib,holidays,humanize,isodate,jinja2,jwt,markdown,markupsafe,marshmallow,marshmallow_enum,msgpack,numpy,pandas,parameterized,parsedatetime,pgsanity,pkg_resources,polyline,prison,progress,pyarrow,pyhive,pyparsing,pytest,pytest_mock,pytz,redis,requests,selenium,setuptools,simplejson,slack,sqlalchemy,sqlalchemy_utils,sqlparse,tabulate,typing_extensions,werkzeug,wtforms,wtforms_json,yaml
 multi_line_output = 3
 order_by_type = false
 

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ setup(
         "sqlalchemy>=1.3.16, <1.4, !=1.3.21",
         "sqlalchemy-utils>=0.36.6,<0.37",
         "sqlparse==0.3.0",  # PINNED! see https://github.com/andialbrecht/sqlparse/issues/562
+        "tabulate==0.8.9",
         "typing-extensions>=3.7.4.3,<4",  # needed to support typing.Literal on py37
         "wtforms-json",
     ],

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -93,9 +93,7 @@ class BaseReportState:
         self._execution_id = execution_id
 
     def set_state_and_log(
-        self,
-        state: ReportState,
-        error_message: Optional[str] = None,
+        self, state: ReportState, error_message: Optional[str] = None,
     ) -> None:
         """
         Updates current ReportSchedule state and TS. If on final state writes the log
@@ -104,8 +102,7 @@ class BaseReportState:
         now_dttm = datetime.utcnow()
         self.set_state(state, now_dttm)
         self.create_log(
-            state,
-            error_message=error_message,
+            state, error_message=error_message,
         )
 
     def set_state(self, state: ReportState, dttm: datetime) -> None:
@@ -119,9 +116,7 @@ class BaseReportState:
         self._session.commit()
 
     def create_log(  # pylint: disable=too-many-arguments
-        self,
-        state: ReportState,
-        error_message: Optional[str] = None,
+        self, state: ReportState, error_message: Optional[str] = None,
     ) -> None:
         """
         Creates a Report execution log, uses the current computed last_value for Alerts
@@ -477,14 +472,12 @@ class ReportWorkingState(BaseReportState):
         if self.is_on_working_timeout():
             exception_timeout = ReportScheduleWorkingTimeoutError()
             self.set_state_and_log(
-                ReportState.ERROR,
-                error_message=str(exception_timeout),
+                ReportState.ERROR, error_message=str(exception_timeout),
             )
             raise exception_timeout
         exception_working = ReportSchedulePreviousWorkingError()
         self.set_state_and_log(
-            ReportState.WORKING,
-            error_message=str(exception_working),
+            ReportState.WORKING, error_message=str(exception_working),
         )
         raise exception_working
 

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -152,7 +152,6 @@ class BaseReportState:
                     "ChartRestApi.get_data",
                     pk=self._report_schedule.chart_id,
                     format="csv",
-                    type="post_processed",
                 )
             return get_url_path(
                 "Superset.slice",

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -152,6 +152,7 @@ class BaseReportState:
                     "ChartRestApi.get_data",
                     pk=self._report_schedule.chart_id,
                     format="csv",
+                    type="post_processed",
                 )
             return get_url_path(
                 "Superset.slice",

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -93,9 +93,7 @@ class BaseReportState:
         self._execution_id = execution_id
 
     def set_state_and_log(
-        self,
-        state: ReportState,
-        error_message: Optional[str] = None,
+        self, state: ReportState, error_message: Optional[str] = None,
     ) -> None:
         """
         Updates current ReportSchedule state and TS. If on final state writes the log
@@ -104,8 +102,7 @@ class BaseReportState:
         now_dttm = datetime.utcnow()
         self.set_state(state, now_dttm)
         self.create_log(
-            state,
-            error_message=error_message,
+            state, error_message=error_message,
         )
 
     def set_state(self, state: ReportState, dttm: datetime) -> None:
@@ -119,9 +116,7 @@ class BaseReportState:
         self._session.commit()
 
     def create_log(  # pylint: disable=too-many-arguments
-        self,
-        state: ReportState,
-        error_message: Optional[str] = None,
+        self, state: ReportState, error_message: Optional[str] = None,
     ) -> None:
         """
         Creates a Report execution log, uses the current computed last_value for Alerts
@@ -247,7 +242,7 @@ class BaseReportState:
             raise ReportScheduleCsvFailedError()
         return csv_data
 
-    def _get_embedded_data(self) -> str:
+    def _get_embedded_data(self) -> pd.DataFrame:
         """
         Return data as an HTML table, to embed in the email.
         """
@@ -477,14 +472,12 @@ class ReportWorkingState(BaseReportState):
         if self.is_on_working_timeout():
             exception_timeout = ReportScheduleWorkingTimeoutError()
             self.set_state_and_log(
-                ReportState.ERROR,
-                error_message=str(exception_timeout),
+                ReportState.ERROR, error_message=str(exception_timeout),
             )
             raise exception_timeout
         exception_working = ReportSchedulePreviousWorkingError()
         self.set_state_and_log(
-            ReportState.WORKING,
-            error_message=str(exception_working),
+            ReportState.WORKING, error_message=str(exception_working),
         )
         raise exception_working
 

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -93,7 +93,9 @@ class BaseReportState:
         self._execution_id = execution_id
 
     def set_state_and_log(
-        self, state: ReportState, error_message: Optional[str] = None,
+        self,
+        state: ReportState,
+        error_message: Optional[str] = None,
     ) -> None:
         """
         Updates current ReportSchedule state and TS. If on final state writes the log
@@ -102,7 +104,8 @@ class BaseReportState:
         now_dttm = datetime.utcnow()
         self.set_state(state, now_dttm)
         self.create_log(
-            state, error_message=error_message,
+            state,
+            error_message=error_message,
         )
 
     def set_state(self, state: ReportState, dttm: datetime) -> None:
@@ -116,7 +119,9 @@ class BaseReportState:
         self._session.commit()
 
     def create_log(  # pylint: disable=too-many-arguments
-        self, state: ReportState, error_message: Optional[str] = None,
+        self,
+        state: ReportState,
+        error_message: Optional[str] = None,
     ) -> None:
         """
         Creates a Report execution log, uses the current computed last_value for Alerts
@@ -472,12 +477,14 @@ class ReportWorkingState(BaseReportState):
         if self.is_on_working_timeout():
             exception_timeout = ReportScheduleWorkingTimeoutError()
             self.set_state_and_log(
-                ReportState.ERROR, error_message=str(exception_timeout),
+                ReportState.ERROR,
+                error_message=str(exception_timeout),
             )
             raise exception_timeout
         exception_working = ReportSchedulePreviousWorkingError()
         self.set_state_and_log(
-            ReportState.WORKING, error_message=str(exception_working),
+            ReportState.WORKING,
+            error_message=str(exception_working),
         )
         raise exception_working
 

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -93,7 +93,9 @@ class BaseReportState:
         self._execution_id = execution_id
 
     def set_state_and_log(
-        self, state: ReportState, error_message: Optional[str] = None,
+        self,
+        state: ReportState,
+        error_message: Optional[str] = None,
     ) -> None:
         """
         Updates current ReportSchedule state and TS. If on final state writes the log
@@ -102,7 +104,8 @@ class BaseReportState:
         now_dttm = datetime.utcnow()
         self.set_state(state, now_dttm)
         self.create_log(
-            state, error_message=error_message,
+            state,
+            error_message=error_message,
         )
 
     def set_state(self, state: ReportState, dttm: datetime) -> None:
@@ -116,7 +119,9 @@ class BaseReportState:
         self._session.commit()
 
     def create_log(  # pylint: disable=too-many-arguments
-        self, state: ReportState, error_message: Optional[str] = None,
+        self,
+        state: ReportState,
+        error_message: Optional[str] = None,
     ) -> None:
         """
         Creates a Report execution log, uses the current computed last_value for Alerts
@@ -248,7 +253,7 @@ class BaseReportState:
         """
         buf = BytesIO(self._get_csv_data())
         df = pd.read_csv(buf)
-        return df.to_html(na_rep="", index=False)
+        return df
 
     def _get_notification_content(self) -> NotificationContent:
         """
@@ -472,12 +477,14 @@ class ReportWorkingState(BaseReportState):
         if self.is_on_working_timeout():
             exception_timeout = ReportScheduleWorkingTimeoutError()
             self.set_state_and_log(
-                ReportState.ERROR, error_message=str(exception_timeout),
+                ReportState.ERROR,
+                error_message=str(exception_timeout),
             )
             raise exception_timeout
         exception_working = ReportSchedulePreviousWorkingError()
         self.set_state_and_log(
-            ReportState.WORKING, error_message=str(exception_working),
+            ReportState.WORKING,
+            error_message=str(exception_working),
         )
         raise exception_working
 

--- a/superset/reports/notifications/base.py
+++ b/superset/reports/notifications/base.py
@@ -18,6 +18,8 @@
 from dataclasses import dataclass
 from typing import Any, List, Optional, Type
 
+import pandas as pd
+
 from superset.models.reports import ReportRecipients, ReportRecipientType
 
 
@@ -29,7 +31,7 @@ class NotificationContent:
     text: Optional[str] = None
     description: Optional[str] = ""
     url: Optional[str] = None  # url to chart/dashboard for this screenshot
-    embedded_data: Optional[str] = ""
+    embedded_data: Optional[pd.DataFrame] = None
 
 
 class BaseNotification:  # pylint: disable=too-few-public-methods

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -75,19 +75,25 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
         # Strip any malicious HTML from the description
         description = bleach.clean(self._content.description or "")
 
-        # Strip malicious HTML from embedded data, allowing table elements
-        embedded_data = bleach.clean(self._content.embedded_data or "", tags=TABLE_TAGS)
+        # Strip malicious HTML from embedded data, allowing only table elements
+        if self._content.embedded_data is not None:
+            df = self._content.embedded_data
+            html_table = bleach.clean(
+                df.to_html(na_rep="", index=False), tags=TABLE_TAGS
+            )
+        else:
+            html_table = ""
 
         body = __(
             """
             <p>%(description)s</p>
             <b><a href="%(url)s">Explore in Superset</a></b><p></p>
-            %(embedded_data)s
+            %(html_table)s
             %(img_tag)s
             """,
             description=description,
             url=self._content.url,
-            embedded_data=embedded_data,
+            html_table=html_table,
             img_tag='<img width="1000px" src="cid:{}">'.format(msgid)
             if self._content.screenshot
             else "",

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -21,6 +21,7 @@ These objects represent the backend of all the visualizations that
 Superset can render.
 """
 import copy
+import inspect
 import logging
 import math
 import re
@@ -52,7 +53,7 @@ from flask_babel import lazy_gettext as _
 from geopy.point import Point
 from pandas.tseries.frequencies import to_offset
 
-from superset import app, is_feature_enabled
+from superset import app, db, is_feature_enabled
 from superset.constants import NULL_STRING
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import (
@@ -63,6 +64,7 @@ from superset.exceptions import (
     SupersetSecurityException,
 )
 from superset.extensions import cache_manager, security_manager
+from superset.models.cache import CacheKey
 from superset.models.helpers import QueryResult
 from superset.typing import Metric, QueryObjectDict, VizData, VizPayload
 from superset.utils import core as utils, csv
@@ -617,26 +619,11 @@ class BaseViz:
 
     def get_csv(self) -> Optional[str]:
         df = self.get_df_payload()["df"]  # leverage caching logic
-        df = self.post_process(df)
         include_index = not isinstance(df.index, pd.RangeIndex)
         return csv.df_to_escaped_csv(df, index=include_index, **config["CSV_EXPORT"])
 
     def get_data(self, df: pd.DataFrame) -> VizData:
         return df.to_dict(orient="records")
-
-    def post_process(self, df: pd.DataFrame) -> pd.DataFrame:
-        """
-        Post-process data to return same format as visualization.
-
-        Some visualizations post-process the data in the frontend before presenting
-        it to the user. Eg, the t-test visualization will compute p-values and
-        significance in Javascript, while the pivot table will pivot the data.
-
-        When we produce a report we want to send to the user the exact same data
-        that they see in the chart. For visualizations with post-processing we need
-        to compute the perform the same processing in Python.
-        """
-        return df
 
     @property
     def json_data(self) -> str:
@@ -909,7 +896,7 @@ class PivotTableViz(BaseViz):
         # fallback in case something incompatible is returned
         return cast(str, value)
 
-    def _pivot_data(self, df: pd.DataFrame) -> Optional[pd.DataFrame]:
+    def get_data(self, df: pd.DataFrame) -> VizData:
         if df.empty:
             return None
 
@@ -947,11 +934,6 @@ class PivotTableViz(BaseViz):
         # Display metrics side by side with each column
         if self.form_data.get("combine_metric"):
             df = df.stack(0).unstack().reindex(level=-1, columns=metrics)
-
-        return df
-
-    def get_data(self, df: pd.DataFrame) -> VizData:
-        df = self._pivot_data(df)
         return dict(
             columns=list(df.columns),
             html=df.to_html(
@@ -962,9 +944,6 @@ class PivotTableViz(BaseViz):
                 ).split(" "),
             ),
         )
-
-    def post_process(self, df: pd.DataFrame) -> pd.DataFrame:
-        return self._pivot_data(df)
 
 
 class TreemapViz(BaseViz):


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Send embedded report data (see https://github.com/apache/superset/pull/15805) to Slack when user selects "TEXT" as the format.

When the user selects "TEXT" format and Slack delivery for a chart on a report, we send a truncated table to the channel. Slack limits the pre-formatted text to approximately 25 rows, so the table is truncated at 19 rows.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

<img width="1459" alt="Screen Shot 2021-07-20 at 4 22 59 PM" src="https://user-images.githubusercontent.com/1534870/126407901-d1a80c5f-2a36-4224-b1fa-3a701312b689.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
