### PR TITLE
fix: migration script can't drop constraint

### DIFF
--- a/scripts/benchmark_migration.py
+++ b/scripts/benchmark_migration.py
@@ -30,7 +30,7 @@ from flask_appbuilder import Model
 from flask_migrate import downgrade, upgrade
 from graphlib import TopologicalSorter  # pylint: disable=wrong-import-order
 from progress.bar import ChargingBar
-from sqlalchemy import create_engine, inspect, Table
+from sqlalchemy import create_engine, inspect
 from sqlalchemy.ext.automap import automap_base
 
 from superset import db
@@ -160,7 +160,6 @@ def main(
         rows = session.query(model).count()
         print(f"- {model.__name__} ({rows} rows in table {model.__tablename__})")
         model_rows[model] = rows
-    session.close()
 
     print("Benchmarking migration")
     results: Dict[str, float] = {}

--- a/superset/migrations/versions/49b5a32daba5_add_report_schedules.py
+++ b/superset/migrations/versions/49b5a32daba5_add_report_schedules.py
@@ -28,6 +28,7 @@ down_revision = "96e99fb176a0"
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.exc import OperationalError
 
 
@@ -119,13 +120,17 @@ def upgrade():
     )
 
 
+def has_unique_constraint(constraint_name: str, table_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = Inspector.from_engine(bind)
+    unique_constraints = inspector.get_unique_constraints(table_name)
+    return constraint_name in {constraint["name"] for constraint in unique_constraints}
+
+
 def downgrade():
     op.drop_index(op.f("ix_report_schedule_active"), table_name="report_schedule")
-    try:
+    if has_unique_constraint("uq_report_schedule_name", "report_schedule"):
         op.drop_constraint("uq_report_schedule_name", "report_schedule", type_="unique")
-    except Exception:
-        # Expected to fail on SQLite
-        pass
 
     op.drop_table("report_execution_log")
     op.drop_table("report_recipient")


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

We're trying to run the `downgrade` from `49b5a32daba5_add_report_schedules.py`, but the migration errors because the unique constraint `uq_report_schedule_name` is not found. The `upgrade` function in the migration has the creation of the constraint inside a permissive `try/except` block, so I'm assuming the upgrade partially failed for some reason and now we can't downgrade.

I modified the migration to check if the constraint exists before deleting it. The change should be harmless, because in theory the constraint should always exist. But maybe we should adopt this as a more conservative approach for `downgrade`s in migrations.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

I was able to benchmark the migration:

```
Identifying models used in the migration:
- dbs (2 rows in table dbs)
- slices (114 rows in table slices)
- tables (27 rows in table tables)
Benchmarking migration
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade f9a30386bd74 -> 620241d1153f, update time_grain_sqla
Migration on current DB took: 0.25 seconds
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade 620241d1153f -> f9a30386bd74, update time_grain_sqla
Running with at least 10 entities of each model
- Adding 8 entities to the dbs model
Processing ████████████████████████████████ 100%
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade f9a30386bd74 -> 620241d1153f, update time_grain_sqla
Migration for 10+ entities took: 0.39 seconds
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade 620241d1153f -> f9a30386bd74, update time_grain_sqla
Running with at least 100 entities of each model
- Adding 90 entities to the dbs model
Processing ████████████████████████████████ 100%
- Adding 73 entities to the tables model
Processing ████████████████████████████████ 100%
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade f9a30386bd74 -> 620241d1153f, update time_grain_sqla
Migration for 100+ entities took: 0.38 seconds
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade 620241d1153f -> f9a30386bd74, update time_grain_sqla
Running with at least 1000 entities of each model
- Adding 900 entities to the dbs model
Processing ████████████████████████████████ 100%
- Adding 886 entities to the slices model
Processing ████████████████████████████████ 100%
- Adding 900 entities to the tables model
Processing ████████████████████████████████ 100%
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade f9a30386bd74 -> 620241d1153f, update time_grain_sqla
Migration for 1000+ entities took: 0.31 seconds
Cleaning up DB

Revert DB to 620241d1153f? [y/N]: y
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
Reverted

Results:

Current: 0.25 s
10+: 0.39 s
100+: 0.38 s
1000+: 0.31 s
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
