### PR TITLE
fix: Incorrect translations in Chinese in messages.po

### DIFF
--- a/superset/translations/zh/LC_MESSAGES/messages.po
+++ b/superset/translations/zh/LC_MESSAGES/messages.po
@@ -3058,7 +3058,7 @@ msgstr "在 SQL 编辑器中允许 CREATE TABLE AS 选项"
 #: superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx:493
 #: superset/views/database/mixins.py:113
 msgid "Allow CREATE VIEW AS option in SQL Lab"
-msgstr "在 SQL 编辑器中允许 CREATE TABLE AS 选项"
+msgstr "在 SQL 编辑器中允许 CREATE VIEW AS 选项"
 
 #: superset/views/database/mixins.py:114
 msgid ""
@@ -3125,7 +3125,7 @@ msgstr "允许 CREATE TABLE AS"
 #: superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx:491
 #: superset/views/database/mixins.py:187
 msgid "Allow CREATE VIEW AS"
-msgstr "允许 CREATE TABLE AS"
+msgstr "允许 CREATE VIEW AS"
 
 #: superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx:505
 #: superset/views/database/mixins.py:188
@@ -3893,7 +3893,7 @@ msgstr "允许 CREATE TABLE AS"
 
 #: superset-frontend/src/SqlLab/components/SqlEditor.jsx:610
 msgid "CREATE VIEW AS"
-msgstr "允许 CREATE TABLE AS"
+msgstr "允许 CREATE VIEW AS"
 
 #: superset-frontend/src/SqlLab/components/SqlEditor.jsx:645
 msgid "Estimate the cost before running a query"


### PR DESCRIPTION
### SUMMARY
Chinese translation and English translation do not match，"CREATE VIEW AS" should correspond to "CREATE VIEW AS", not "CREATE TABLE AS"

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
