### PR TITLE
fix: Render value immediately on SQL Editor for Calculated Columns in Edit Dataset modal

### DIFF
--- a/superset-frontend/src/explore/components/controls/TextAreaControl.jsx
+++ b/superset-frontend/src/explore/components/controls/TextAreaControl.jsx
@@ -62,21 +62,27 @@ const defaultProps = {
 export default class TextAreaControl extends React.Component {
   constructor() {
     super();
+    this.state = {
+      value: '',
+    };
     this.onAceChangeDebounce = debounce(value => {
       this.onAceChange(value);
     }, FAST_DEBOUNCE);
   }
 
   onControlChange(event) {
-    this.props.onChange(event.target.value);
+    const { value } = event.target;
+    this.setState({ value });
+    this.props.onChange(value);
   }
 
   onAceChange(value) {
+    this.setState({ value });
     this.props.onChange(value);
   }
 
   renderEditor(inModal = false) {
-    const value = this.props.value || '';
+    const value = this.state.value || this.props.value;
     const minLines = inModal ? 40 : this.props.minLines || 12;
     if (this.props.language) {
       const style = { border: '1px solid #CCC' };


### PR DESCRIPTION
### SUMMARY

It renders the typed value immediately to avoid a glitch with the cursor moving backward. It would also avoid delays with rendering the value while typing.

Fixes: #15675
Fixes: #13251

### BEFORE

![125559494-147c4889-34d4-4e6d-ac76-c64f9d1d1afc](https://user-images.githubusercontent.com/60598000/126493397-45611cf0-49ab-4ea2-be79-6b598310a1f7.png)

### AFTER

https://user-images.githubusercontent.com/60598000/126493445-7456ea07-5660-4a1e-932d-75f6205a2b53.mp4

### TESTING INSTRUCTIONS
1. Open a chart in Explore and open the Edit Dataset modal
2. Click on 'Calculated Columns' 
3. Click on 'Add Item'
4. Expand the dropdown
5. Start typing in 'SQL Expression'
6. Make sure the text is typed immediately and the cursor does not move backward

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #15675 #13251
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
