### PR TITLE
fix(Explore): Cell height and spacing for Data panel 

### DIFF
--- a/superset-frontend/src/components/TableView/TableView.tsx
+++ b/superset-frontend/src/components/TableView/TableView.tsx
@@ -48,6 +48,7 @@ export interface TableViewProps {
   isPaginationSticky?: boolean;
   showRowCount?: boolean;
   scrollTable?: boolean;
+  small?: boolean;
 }
 
 const EmptyWrapper = styled.div`
@@ -57,6 +58,7 @@ const EmptyWrapper = styled.div`
 const TableViewStyles = styled.div<{
   isPaginationSticky?: boolean;
   scrollTable?: boolean;
+  small?: boolean;
 }>`
   ${({ scrollTable, theme }) =>
     scrollTable &&
@@ -67,11 +69,30 @@ const TableViewStyles = styled.div<{
   `}
 
   .table-row {
-    height: 43px;
+    ${({ theme, small }) => !small && `height: ${theme.gridUnit * 11 - 1}px;`}
+
+    .table-cell {
+      ${({ theme, small }) =>
+        small &&
+        `
+        padding-top: ${theme.gridUnit + 1}px;
+        padding-bottom: ${theme.gridUnit + 1}px;
+        line-height: 1.45;
+      `}
+    }
   }
 
   th[role='columnheader'] {
     z-index: 1;
+    border-bottom: ${({ theme }) =>
+      `${theme.gridUnit - 2}px solid ${theme.colors.grayscale.light2}`};
+
+    ${({ theme, small }) =>
+      small &&
+      `
+        padding-top: ${theme.gridUnit - 1}px;
+        padding-bottom: 0;
+      `}
   }
 
   .pagination-container {
@@ -81,7 +102,7 @@ const TableViewStyles = styled.div<{
     align-items: center;
     background-color: ${({ theme }) => theme.colors.grayscale.light5};
 
-    ${({ theme, isPaginationSticky }) =>
+    ${({ isPaginationSticky }) =>
       isPaginationSticky &&
       `
         position: sticky;

--- a/superset-frontend/src/components/TableView/TableView.tsx
+++ b/superset-frontend/src/components/TableView/TableView.tsx
@@ -86,13 +86,7 @@ const TableViewStyles = styled.div<{
     z-index: 1;
     border-bottom: ${({ theme }) =>
       `${theme.gridUnit - 2}px solid ${theme.colors.grayscale.light2}`};
-
-    ${({ theme, small }) =>
-      small &&
-      `
-        padding-top: ${theme.gridUnit - 1}px;
-        padding-bottom: 0;
-      `}
+    ${({ small }) => small && `padding-bottom: 0;`}
   }
 
   .pagination-container {

--- a/superset-frontend/src/explore/components/DataTablesPane/index.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/index.tsx
@@ -101,6 +101,10 @@ const CollapseWrapper = styled.div`
   }
 `;
 
+const Error = styled.pre`
+  margin-top: ${({ theme }) => `${theme.gridUnit * 4}px`};
+`;
+
 export const DataTablesPane = ({
   queryFormData,
   tableSectionHeight,
@@ -263,7 +267,7 @@ export const DataTablesPane = ({
       return <Loading />;
     }
     if (error[type]) {
-      return <pre>{error[type]}</pre>;
+      return <Error>{error[type]}</Error>;
     }
     if (data[type]) {
       if (data[type]?.length === 0) {
@@ -279,11 +283,12 @@ export const DataTablesPane = ({
           className="table-condensed"
           isPaginationSticky
           showRowCount={false}
+          small
         />
       );
     }
     if (errorMessage) {
-      return <pre>{errorMessage}</pre>;
+      return <Error>{errorMessage}</Error>;
     }
     return null;
   };


### PR DESCRIPTION
### SUMMARY
Makes the height of the cells consistent and improves spacing.

Fixes: #15691

### BEFORE
<img width="818" alt="125676605-429bf2ec-d153-4be1-a8fc-48fd237fa546" src="https://user-images.githubusercontent.com/60598000/126515859-8e4613b4-c989-43d0-8255-4f7abeb64202.png">
<img width="819" alt="125677475-ec7b35f4-5927-4181-9e2e-159895030ecf" src="https://user-images.githubusercontent.com/60598000/126515856-6fb5b6ad-4d1a-4b0b-ae41-2620cbfb8d1b.png">

### AFTER

<img width="1062" alt="Screen Shot 2021-07-21 at 17 38 10" src="https://user-images.githubusercontent.com/60598000/126517672-f004e4a2-0ad1-4743-97ed-dd53f9177cde.png">
<img width="1055" alt="Screen Shot 2021-07-21 at 17 25 30" src="https://user-images.githubusercontent.com/60598000/126515947-29a7e605-0dd0-4180-830e-8ee57d5f56e2.png">


### TESTING INSTRUCTIONS
1. Open a Table chart in Explore
2. Observe the layout of the Data panel and spacing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #15691
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
