### PR TITLE
fix: benchmark_migration.py needs to close sssion

### DIFF
--- a/scripts/benchmark_migration.py
+++ b/scripts/benchmark_migration.py
@@ -172,6 +172,7 @@ def main(
         rows = session.query(model).count()
         print(f"- {model.__name__} ({rows} rows in table {model.__tablename__})")
         model_rows[model] = rows
+    session.close()
 
     print("Benchmarking migration")
     results: Dict[str, float] = {}

--- a/superset/migrations/versions/301362411006_add_execution_id_to_report_execution_.py
+++ b/superset/migrations/versions/301362411006_add_execution_id_to_report_execution_.py
@@ -32,8 +32,10 @@ from sqlalchemy_utils import UUIDType
 
 
 def upgrade():
-    op.add_column("report_execution_log", sa.Column("uuid", UUIDType(binary=True)))
+    with op.batch_alter_table("report_execution_log") as batch_op:
+        batch_op.add_column(sa.Column("uuid", UUIDType(binary=True)))
 
 
 def downgrade():
-    op.drop_column("report_execution_log", "uuid")
+    with op.batch_alter_table("report_execution_log") as batch_op:
+        batch_op.drop_column("uuid")


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

We need to close the session when running a benchmark so that the table locks get released.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
