### PR TITLE
chore: Mypy fix **kwargs type

### DIFF
--- a/superset/annotation_layers/annotations/api.py
+++ b/superset/annotation_layers/annotations/api.py
@@ -137,7 +137,7 @@ class AnnotationRestApi(BaseSupersetModelRestApi):
     @permission_name("get")
     @rison(get_list_schema)
     def get_list(  # pylint: disable=arguments-differ
-        self, pk: int, **kwargs: Dict[str, Any]
+        self, pk: int, **kwargs: Any
     ) -> Response:
         """Get a list of annotations
         ---
@@ -198,7 +198,7 @@ class AnnotationRestApi(BaseSupersetModelRestApi):
     @permission_name("get")
     @rison(get_item_schema)
     def get(  # pylint: disable=arguments-differ
-        self, pk: int, annotation_id: int, **kwargs: Dict[str, Any]
+        self, pk: int, annotation_id: int, **kwargs: Any
     ) -> Response:
         """Get item from Model
         ---

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -683,7 +683,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
         f".cache_screenshot",
         log_to_statsd=False,
     )
-    def cache_screenshot(self, pk: int, **kwargs: Dict[str, bool]) -> WerkzeugResponse:
+    def cache_screenshot(self, pk: int, **kwargs: Any) -> WerkzeugResponse:
         """
         ---
         get:
@@ -815,9 +815,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.thumbnail",
         log_to_statsd=False,
     )
-    def thumbnail(
-        self, pk: int, digest: str, **kwargs: Dict[str, bool]
-    ) -> WerkzeugResponse:
+    def thumbnail(self, pk: int, digest: str, **kwargs: Any) -> WerkzeugResponse:
         """Get Chart thumbnail
         ---
         get:

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -18,7 +18,7 @@ import json
 import logging
 from datetime import datetime
 from io import BytesIO
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 from zipfile import is_zipfile, ZipFile
 
 from flask import g, make_response, redirect, request, Response, send_file, url_for
@@ -755,9 +755,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.thumbnail",
         log_to_statsd=False,
     )
-    def thumbnail(
-        self, pk: int, digest: str, **kwargs: Dict[str, bool]
-    ) -> WerkzeugResponse:
+    def thumbnail(self, pk: int, digest: str, **kwargs: Any) -> WerkzeugResponse:
         """Get Dashboard thumbnail
         ---
         get:

--- a/superset/reports/logs/api.py
+++ b/superset/reports/logs/api.py
@@ -97,7 +97,7 @@ class ReportExecutionLogRestApi(BaseSupersetModelRestApi):
     @permission_name("get")
     @rison(get_list_schema)
     def get_list(  # pylint: disable=arguments-differ
-        self, pk: int, **kwargs: Dict[str, Any]
+        self, pk: int, **kwargs: Any
     ) -> Response:
         """Get a list of report schedule logs
         ---
@@ -158,7 +158,7 @@ class ReportExecutionLogRestApi(BaseSupersetModelRestApi):
     @permission_name("get")
     @rison(get_item_schema)
     def get(  # pylint: disable=arguments-differ
-        self, pk: int, log_id: int, **kwargs: Dict[str, Any]
+        self, pk: int, log_id: int, **kwargs: Any
     ) -> Response:
         """Get a report schedule log
         ---

--- a/superset/utils/decorators.py
+++ b/superset/utils/decorators.py
@@ -44,7 +44,7 @@ def stats_timing(stats_key: str, stats_logger: BaseStatsLogger) -> Iterator[floa
         stats_logger.timing(stats_key, now_as_float() - start_ts)
 
 
-def arghash(args: Any, kwargs: Dict[str, Any]) -> int:
+def arghash(args: Any, kwargs: Any) -> int:
     """Simple argument hash with kwargs sorted."""
     sorted_args = tuple(
         x if hasattr(x, "__repr__") else x for x in [*args, *sorted(kwargs.items())]


### PR DESCRIPTION
### SUMMARY

A follow up to https://github.com/apache/superset/pull/15757#discussion_r674140292, per the Mypy [documentation](https://mypy.readthedocs.io/en/stable/getting_started.html#more-function-signatures), 

> *args and **kwargs arguments can be annotated like so:
>
> ```python
> def stars(*args: int, **kwargs: float) -> None:
>    # 'args' has type 'Tuple[int, ...]' (a tuple of ints)
>    # 'kwargs' has type 'Dict[str, float]' (a dict of strs to floats)
>    for arg in args:
>        print(arg)
>    for key, value in kwargs:
>        print(key, value)
> ```

though `kwargs` is a `Dict[str, ...]` the typing of `**kwargs` is actually the dictionary value type.

### TESTING INSTRUCTIONS

CI. Found all violations by running `git grep "**kwargs: Dict"`. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
