### PR TITLE
feat: use new API endpoint to build CSV reports

### DIFF
--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -142,9 +142,9 @@ class BaseReportState:
         if self._report_schedule.chart:
             if csv:
                 return get_url_path(
-                    "Superset.explore_json",
-                    csv="true",
-                    form_data=json.dumps({"slice_id": self._report_schedule.chart_id}),
+                    "ChartRestApi.get_data",
+                    pk=self._report_schedule.chart_id,
+                    format="csv",
                 )
             return get_url_path(
                 "Superset.slice",

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -889,11 +889,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         # test filtering on datasource_name
         arguments = {
             "filters": [
-                {
-                    "col": "slice_name",
-                    "opr": "chart_all_text",
-                    "value": "energy",
-                }
+                {"col": "slice_name", "opr": "chart_all_text", "value": "energy",}
             ],
             "keys": ["none"],
             "columns": ["slice_name"],
@@ -911,11 +907,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         # test filtering on datasource_name
         arguments = {
             "filters": [
-                {
-                    "col": "slice_name",
-                    "opr": "chart_all_text",
-                    "value": "energy",
-                }
+                {"col": "slice_name", "opr": "chart_all_text", "value": "energy",}
             ],
             "keys": ["none"],
             "columns": ["slice_name"],
@@ -1063,7 +1055,6 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
         self.assertEqual(rv.status_code, 200)
         data = json.loads(rv.data.decode("utf-8"))
-        print(data)
         expected_row_count = self.get_expected_row_count("client_id_1")
         self.assertEqual(data["result"][0]["rowcount"], expected_row_count)
 
@@ -1149,9 +1140,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         )
         self.assertEqual(
             data["result"][0]["rejected_filters"],
-            [
-                {"column": "__time_origin", "reason": "not_druid_datasource"},
-            ],
+            [{"column": "__time_origin", "reason": "not_druid_datasource"},],
         )
         expected_row_count = self.get_expected_row_count("client_id_2")
         self.assertEqual(data["result"][0]["rowcount"], expected_row_count)
@@ -1187,8 +1176,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     @mock.patch(
-        "superset.common.query_object.config",
-        {**app.config, "ROW_LIMIT": 7},
+        "superset.common.query_object.config", {**app.config, "ROW_LIMIT": 7},
     )
     def test_chart_data_default_row_limit(self):
         """
@@ -1204,8 +1192,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     @mock.patch(
-        "superset.common.query_actions.config",
-        {**app.config, "SAMPLES_ROW_LIMIT": 5},
+        "superset.common.query_actions.config", {**app.config, "SAMPLES_ROW_LIMIT": 5},
     )
     def test_chart_data_default_sample_limit(self):
         """
@@ -1340,8 +1327,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
                 dttm_col = col
         if dttm_col:
             dttm_expression = table.database.db_engine_spec.convert_dttm(
-                dttm_col.type,
-                dttm,
+                dttm_col.type, dttm,
             )
             self.assertIn(dttm_expression, result["query"])
         else:
@@ -1621,9 +1607,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
             return orig_run(self, force_cached=False)
 
         with mock.patch.object(ChartDataCommand, "run", new=mock_run):
-            rv = self.client.get(
-                f"{CHART_DATA_URI}/test-cache-key",
-            )
+            rv = self.client.get(f"{CHART_DATA_URI}/test-cache-key",)
 
         self.assertEqual(rv.status_code, 401)
 

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -889,7 +889,11 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         # test filtering on datasource_name
         arguments = {
             "filters": [
-                {"col": "slice_name", "opr": "chart_all_text", "value": "energy",}
+                {
+                    "col": "slice_name",
+                    "opr": "chart_all_text",
+                    "value": "energy",
+                }
             ],
             "keys": ["none"],
             "columns": ["slice_name"],
@@ -907,7 +911,11 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         # test filtering on datasource_name
         arguments = {
             "filters": [
-                {"col": "slice_name", "opr": "chart_all_text", "value": "energy",}
+                {
+                    "col": "slice_name",
+                    "opr": "chart_all_text",
+                    "value": "energy",
+                }
             ],
             "keys": ["none"],
             "columns": ["slice_name"],
@@ -1055,6 +1063,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
         self.assertEqual(rv.status_code, 200)
         data = json.loads(rv.data.decode("utf-8"))
+        print(data)
         expected_row_count = self.get_expected_row_count("client_id_1")
         self.assertEqual(data["result"][0]["rowcount"], expected_row_count)
 
@@ -1140,7 +1149,9 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         )
         self.assertEqual(
             data["result"][0]["rejected_filters"],
-            [{"column": "__time_origin", "reason": "not_druid_datasource"},],
+            [
+                {"column": "__time_origin", "reason": "not_druid_datasource"},
+            ],
         )
         expected_row_count = self.get_expected_row_count("client_id_2")
         self.assertEqual(data["result"][0]["rowcount"], expected_row_count)
@@ -1176,7 +1187,8 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     @mock.patch(
-        "superset.common.query_object.config", {**app.config, "ROW_LIMIT": 7},
+        "superset.common.query_object.config",
+        {**app.config, "ROW_LIMIT": 7},
     )
     def test_chart_data_default_row_limit(self):
         """
@@ -1192,7 +1204,8 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     @mock.patch(
-        "superset.common.query_actions.config", {**app.config, "SAMPLES_ROW_LIMIT": 5},
+        "superset.common.query_actions.config",
+        {**app.config, "SAMPLES_ROW_LIMIT": 5},
     )
     def test_chart_data_default_sample_limit(self):
         """
@@ -1327,7 +1340,8 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
                 dttm_col = col
         if dttm_col:
             dttm_expression = table.database.db_engine_spec.convert_dttm(
-                dttm_col.type, dttm,
+                dttm_col.type,
+                dttm,
             )
             self.assertIn(dttm_expression, result["query"])
         else:
@@ -1607,7 +1621,9 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
             return orig_run(self, force_cached=False)
 
         with mock.patch.object(ChartDataCommand, "run", new=mock_run):
-            rv = self.client.get(f"{CHART_DATA_URI}/test-cache-key",)
+            rv = self.client.get(
+                f"{CHART_DATA_URI}/test-cache-key",
+            )
 
         self.assertEqual(rv.status_code, 401)
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR changes the reports executor to use the new CSV endpoint introduced in https://github.com/apache/superset/pull/15827. This allows us to produce CSV reports from visualization types not defined in `viz.py`, like pie charts and the new pivot table.

Before the executor was using the `explore_json` endpoint, which is not supported for the new visualization types.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

![Screenshot 2021-07-21 at 17-10-19  DEV  Superset](https://user-images.githubusercontent.com/1534870/126575038-b090b2e6-007a-40f4-8c36-bb2200456681.png)

![Screenshot 2021-07-21 at 17-09-09  Report  Test new CSV endpoint Pivot Table v2 - ralmeida gmail com - Gmail](https://user-images.githubusercontent.com/1534870/126575047-0e52fa0d-11ed-4a7c-b17d-3acd2dc15665.png)

![Screenshot 2021-07-21 at 17-09-45  Report  Test new CSV endpoint Pivot Table v2 - ralmeida gmail com - Gmail](https://user-images.githubusercontent.com/1534870/126575049-4914d049-7a7c-4da2-ae09-fa0991cae25d.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
