### PR TITLE
fix(explore): show multi queries results in View query modal and data pane

### DIFF
--- a/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.test.tsx
@@ -73,7 +73,7 @@ test('Rendering DataTablesPane correctly', () => {
   expect(screen.getByRole('img', { name: 'right' })).toBeVisible();
 });
 
-test('Shoud show tabs', async () => {
+test('Should show tabs', async () => {
   const props = createProps();
   render(<DataTablesPane {...props} />, { useRedux: true });
   expect(screen.queryByText('View results')).not.toBeInTheDocument();
@@ -83,7 +83,7 @@ test('Shoud show tabs', async () => {
   expect(screen.getByText('View samples')).toBeVisible();
 });
 
-test('Shoud show tabs: View results', async () => {
+test('Should show tabs: View results', async () => {
   const props = createProps();
   render(<DataTablesPane {...props} />, {
     useRedux: true,
@@ -93,7 +93,7 @@ test('Shoud show tabs: View results', async () => {
   expect(screen.getByText('0 rows retrieved')).toBeVisible();
 });
 
-test('Shoud show tabs: View samples', async () => {
+test('Should show tabs: View samples', async () => {
   const props = createProps();
   render(<DataTablesPane {...props} />, {
     useRedux: true,

--- a/superset-frontend/src/explore/components/DataTablesPane/index.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useCallback, useEffect, useState } from 'react';
-import { JsonObject, styled, t } from '@superset-ui/core';
+import { ensureIsArray, JsonObject, styled, t } from '@superset-ui/core';
 import Collapse from 'src/components/Collapse';
 import Tabs from 'src/components/Tabs';
 import Loading from 'src/components/Loading';
@@ -155,8 +155,29 @@ export const DataTablesPane = ({
       })
         .then(({ json }) => {
           // Only displaying the first query is currently supported
-          const result = json.result[0];
-          setData(prevData => ({ ...prevData, [resultType]: result.data }));
+          const result = ensureIsArray(json.result);
+          if (result.length > 1) {
+            const data: any[] = [];
+            result.forEach(item => {
+              ensureIsArray(item.data).forEach((row, i) => {
+                if (data[i] !== undefined) {
+                  data[i] = { ...data[i], ...row };
+                } else {
+                  data[i] = row;
+                }
+              });
+            });
+            setData(prevData => ({
+              ...prevData,
+              [resultType]: data,
+            }));
+          } else {
+            setData(prevData => ({
+              ...prevData,
+              [resultType]: result[0].data,
+            }));
+          }
+
           setIsLoading(prevIsLoading => ({
             ...prevIsLoading,
             [resultType]: false,

--- a/superset-frontend/src/explore/components/DataTablesPane/index.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/index.tsx
@@ -155,11 +155,10 @@ export const DataTablesPane = ({
       })
         .then(({ json }) => {
           // Only displaying the first query is currently supported
-          const result = ensureIsArray(json.result);
-          if (result.length > 1) {
+          if (json.result.length > 1) {
             const data: any[] = [];
-            result.forEach(item => {
-              ensureIsArray(item.data).forEach((row, i) => {
+            json.result.forEach((item: { data: any[] }) => {
+              item.data.forEach((row, i) => {
                 if (data[i] !== undefined) {
                   data[i] = { ...data[i], ...row };
                 } else {
@@ -174,7 +173,7 @@ export const DataTablesPane = ({
           } else {
             setData(prevData => ({
               ...prevData,
-              [resultType]: result[0].data,
+              [resultType]: json.result[0].data,
             }));
           }
 

--- a/superset-frontend/src/explore/components/DataTablesPane/index.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useCallback, useEffect, useState } from 'react';
-import { ensureIsArray, JsonObject, styled, t } from '@superset-ui/core';
+import { JsonObject, styled, t } from '@superset-ui/core';
 import Collapse from 'src/components/Collapse';
 import Tabs from 'src/components/Tabs';
 import Loading from 'src/components/Loading';

--- a/superset-frontend/src/explore/components/controls/ViewQueryModal.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQueryModal.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useEffect, useState } from 'react';
-import { styled, t } from '@superset-ui/core';
+import { ensureIsArray, styled, t } from '@superset-ui/core';
 import SyntaxHighlighter from 'react-syntax-highlighter/dist/cjs/light';
 import github from 'react-syntax-highlighter/dist/cjs/styles/hljs/github';
 import CopyToClipboard from 'src/components/CopyToClipboard';
@@ -45,9 +45,13 @@ interface Props {
   latestQueryFormData: object;
 }
 
+type Result = {
+  query: string;
+  language: string;
+};
+
 const ViewQueryModal: React.FC<Props> = props => {
-  const [language, setLanguage] = useState(null);
-  const [query, setQuery] = useState(null);
+  const [result, setResult] = useState<Result[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -59,10 +63,7 @@ const ViewQueryModal: React.FC<Props> = props => {
       resultType,
     })
       .then(({ json }) => {
-        // Only displaying the first query is currently supported
-        const result = json.result[0];
-        setLanguage(result.language);
-        setQuery(result.query);
+        setResult(ensureIsArray(json.result));
         setIsLoading(false);
         setError(null);
       })
@@ -88,25 +89,31 @@ const ViewQueryModal: React.FC<Props> = props => {
   if (error) {
     return <pre>{error}</pre>;
   }
-  if (query) {
-    return (
-      <div>
-        <CopyToClipboard
-          text={query}
-          shouldShowText={false}
-          copyNode={
-            <CopyButtonViewQuery buttonSize="xsmall">
-              <i className="fa fa-clipboard" />
-            </CopyButtonViewQuery>
-          }
-        />
-        <SyntaxHighlighter language={language || undefined} style={github}>
-          {query}
-        </SyntaxHighlighter>
-      </div>
-    );
-  }
-  return null;
+  return (
+    <>
+      {result.map(item =>
+        item.query ? (
+          <div>
+            <CopyToClipboard
+              text={item.query}
+              shouldShowText={false}
+              copyNode={
+                <CopyButtonViewQuery buttonSize="xsmall">
+                  <i className="fa fa-clipboard" />
+                </CopyButtonViewQuery>
+              }
+            />
+            <SyntaxHighlighter
+              language={item.language || undefined}
+              style={github}
+            >
+              {item.query}
+            </SyntaxHighlighter>
+          </div>
+        ) : null,
+      )}
+    </>
+  );
 };
 
 export default ViewQueryModal;


### PR DESCRIPTION
### SUMMARY
Before, when user used a chart that sends multiple queries (such as Mixed Time Series chart), View query modal and data pane were showing results of only the first query. This PR fixes that behaviour.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see https://github.com/apache/superset/issues/15344
After:
![image](https://user-images.githubusercontent.com/15073128/126660548-fbcc56ae-c8a7-4362-860a-853562accd78.png)

### TESTING INSTRUCTIONS
1. Open Mixed Time Series chart and run queries
2. Verify that data pane shows results of metrics from both queries
3. Verify that View query modal shows both queries
4. Switch to a chart that sends only 1 query (e.g. Line chart)
5. Verify that everything works as before

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes #15344 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @junlincc @jinghua-qa