### PR TITLE
fix(Explore): "Customize" tab rendering behavior

### DIFF
--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -211,19 +211,6 @@ export class ControlPanelsContainer extends React.Component<
     this.renderControlPanelSection = this.renderControlPanelSection.bind(this);
   }
 
-  static getDerivedStateFromProps(
-    props: ControlPanelsContainerProps,
-    state: ControlPanelsContainerState,
-  ): ControlPanelsContainerState {
-    // only update the sections, not the expanded/collapsed state
-    const newState = getState(props);
-    return {
-      ...state,
-      customizeSections: newState.customizeSections,
-      querySections: newState.querySections,
-    };
-  }
-
   componentDidUpdate(prevProps: ControlPanelsContainerProps) {
     if (
       this.props.form_data.datasource !== prevProps.form_data.datasource ||

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -118,6 +118,7 @@ type ControlPanelsContainerState = {
   expandedCustomizeSections: string[];
   querySections: ControlPanelSectionConfig[];
   customizeSections: ControlPanelSectionConfig[];
+  loading: boolean;
 };
 
 const isTimeSection = (section: ControlPanelSectionConfig): boolean =>
@@ -189,6 +190,7 @@ function getState(
     expandedCustomizeSections,
     querySections,
     customizeSections,
+    loading: false,
   };
 }
 
@@ -206,6 +208,7 @@ export class ControlPanelsContainer extends React.Component<
       expandedCustomizeSections: [],
       querySections: [],
       customizeSections: [],
+      loading: false,
     };
     this.renderControl = this.renderControl.bind(this);
     this.renderControlPanelSection = this.renderControlPanelSection.bind(this);
@@ -218,6 +221,17 @@ export class ControlPanelsContainer extends React.Component<
     ) {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState(getState(this.props));
+    }
+  }
+
+  // required for an Antd bug that would otherwise malfunction re-rendering
+  // a collapsed panel after changing the datasource or viz type
+  UNSAFE_componentWillReceiveProps(nextProps: ControlPanelsContainerProps) {
+    if (
+      this.props.form_data.datasource !== nextProps.form_data.datasource ||
+      this.props.form_data.viz_type !== nextProps.form_data.viz_type
+    ) {
+      this.setState({ loading: true });
     }
   }
 
@@ -369,8 +383,9 @@ export class ControlPanelsContainer extends React.Component<
   render() {
     const controlPanelRegistry = getChartControlPanelRegistry();
     if (
-      !controlPanelRegistry.has(this.props.form_data.viz_type) &&
-      this.context.loading
+      (!controlPanelRegistry.has(this.props.form_data.viz_type) &&
+        this.context.loading) ||
+      this.state.loading
     ) {
       return <Loading />;
     }


### PR DESCRIPTION
### SUMMARY
The bug was the consequence of different issues.

#### Issue with `getDerivedStateFromProps`: 
This PR removes the `getDerivedStateFromProps` introduced by PR #14493 that was causing the Collapse to not re-render when changing viz type as the new props were not propagated down to the render phase. The removal does not seem to affect the functionality for which that PR was made. @villebro your confirmation will be appreciated here.

#### Issue with the Antdesign Collapse: 
This problem seems related to a bug with Antdesign when multiple re-renders happen while the Collapse is opening up, causing the Collapse to render invisible (0 height). By forcing the rendering of a `Loading` component after changing the viz type/datasource, Antdesign is then able to properly render the Collapse.

Fixes: #15829

### BEFORE

https://user-images.githubusercontent.com/60598000/126671260-2cd0c0ab-30aa-4e8c-8fcc-8c65a7b84c2f.mov

### AFTER

https://user-images.githubusercontent.com/60598000/126671313-c8ea5078-1baf-4e89-b961-3281ccb6548c.mp4

### TESTING INSTRUCTIONS
1. Open a chart in Explore
2. Go to the Customize tab and make sure it opens correctly
3. Change viz type
4. Go again to the Customize tab and make sure it opens correctly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #15829
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
