### PR TITLE
feat: apply post processing to chart data

### DIFF
--- a/superset/charts/post_processing.py
+++ b/superset/charts/post_processing.py
@@ -1,0 +1,100 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Functions to reproduce the post-processing of data on text charts.
+
+Some text-based charts (pivot tables and t-test table) perform
+post-processing of the data in Javascript. When sending the data
+to users in reports we want to show the same data they would see
+on Explore.
+
+In order to do that, we reproduce the post-processing in Python
+for these chart types.
+"""
+
+from typing import Any, Callable, Dict, List, Optional, Union
+
+import pandas as pd
+
+from superset.utils.core import DTTM_ALIAS, extract_dataframe_dtypes, get_metric_name
+
+
+def pivot_table(
+    result: Dict[Any, Any], form_data: Optional[Dict[str, Any]] = None
+) -> Dict[Any, Any]:
+    """
+    Pivot table.
+    """
+    for query in result["queries"]:
+        data = query["data"]
+        df = pd.DataFrame(data)
+        form_data = form_data or {}
+
+        if form_data.get("granularity") == "all" and DTTM_ALIAS in df:
+            del df[DTTM_ALIAS]
+
+        metrics = [get_metric_name(m) for m in form_data["metrics"]]
+        aggfuncs: Dict[str, Union[str, Callable[[Any], Any]]] = {}
+        for metric in metrics:
+            aggfunc = form_data.get("pandas_aggfunc") or "sum"
+            if pd.api.types.is_numeric_dtype(df[metric]):
+                if aggfunc == "sum":
+                    aggfunc = lambda x: x.sum(min_count=1)
+            elif aggfunc not in {"min", "max"}:
+                aggfunc = "max"
+            aggfuncs[metric] = aggfunc
+
+        groupby = form_data.get("groupby") or []
+        columns = form_data.get("columns") or []
+        if form_data.get("transpose_pivot"):
+            groupby, columns = columns, groupby
+
+        df = df.pivot_table(
+            index=groupby,
+            columns=columns,
+            values=metrics,
+            aggfunc=aggfuncs,
+            margins=form_data.get("pivot_margins"),
+        )
+
+        # Re-order the columns adhering to the metric ordering.
+        df = df[metrics]
+
+        # Display metrics side by side with each column
+        if form_data.get("combine_metric"):
+            df = df.stack(0).unstack().reindex(level=-1, columns=metrics)
+
+        # flatten column names
+        df.columns = [" ".join(column) for column in df.columns]
+
+        # re-arrange data into a list of dicts
+        data = []
+        for i in df.index:
+            d = {col: df[col][i] for col in df.columns}
+            d[df.index.name] = i
+            data.append(d)
+        query["data"] = data
+        query["colnames"] = list(df.columns)
+        query["coltypes"] = extract_dataframe_dtypes(df)
+        query["rowcount"] = len(df.index)
+
+    return result
+
+
+post_processors = {
+    "pivot_table": pivot_table,
+}

--- a/superset/charts/post_processing.py
+++ b/superset/charts/post_processing.py
@@ -84,9 +84,9 @@ def pivot_table(
         # re-arrange data into a list of dicts
         data = []
         for i in df.index:
-            d = {col: df[col][i] for col in df.columns}
-            d[df.index.name] = i
-            data.append(d)
+            row = {col: df[col][i] for col in df.columns}
+            row[df.index.name] = i
+            data.append(row)
         query["data"] = data
         query["colnames"] = list(df.columns)
         query["coltypes"] = extract_dataframe_dtypes(df)

--- a/superset/charts/post_processing.py
+++ b/superset/charts/post_processing.py
@@ -26,7 +26,7 @@ In order to do that, we reproduce the post-processing in Python
 for these chart types.
 """
 
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 
 import pandas as pd
 

--- a/superset/common/query_actions.py
+++ b/superset/common/query_actions.py
@@ -157,6 +157,10 @@ _result_type_functions: Dict[
     ChartDataResultType.SAMPLES: _get_samples,
     ChartDataResultType.FULL: _get_full,
     ChartDataResultType.RESULTS: _get_results,
+    # for requests for post-processed data we return the full results,
+    # and post-process it later where we have the chart context, since
+    # post-processing is unique to each visualization type
+    ChartDataResultType.POST_PROCESSED: _get_full,
 }
 
 
@@ -180,5 +184,5 @@ def get_query_results(
     if result_func:
         return result_func(query_context, query_obj, force_cached)
     raise QueryObjectValidationError(
-        _("Invalid result type: %(result_type)", result_type=result_type)
+        _("Invalid result type: %(result_type)s", result_type=result_type)
     )

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -178,6 +178,7 @@ class ChartDataResultType(str, Enum):
     RESULTS = "results"
     SAMPLES = "samples"
     TIMEGRAINS = "timegrains"
+    POST_PROCESSED = "post_processed"
 
 
 class DatasourceDict(TypedDict):

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -1498,6 +1498,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
 
         class QueryContext:
             result_format = ChartDataResultFormat.JSON
+            result_type = utils.ChartDataResultType.FULL
 
         cmd_run_val = {
             "query_context": QueryContext(),
@@ -1508,6 +1509,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
             ChartDataCommand, "run", return_value=cmd_run_val
         ) as patched_run:
             request_payload = get_query_context("birth_names")
+            request_payload["result_type"] = utils.ChartDataResultType.FULL
             rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
             self.assertEqual(rv.status_code, 200)
             data = json.loads(rv.data.decode("utf-8"))


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR introduces a new `ChartDataResultType`, `ChartDataResultType.POST_PROCESSED`. It allows us to request the data for a given chart post-processed in the same way the visualization does in Javascript.

Eg, for this pivot table:

![Screenshot 2021-07-22 at 12-00-06  DEV  Pivot Table](https://user-images.githubusercontent.com/1534870/126694587-791beb7a-fcd6-40cd-aa0a-f8acfd720feb.png)

Normally if we request the data for the chart we get the pre-processed (**unpivoted**) data.

Doing a `GET` on "http://localhost:9000/api/v1/chart/72/data/?format=json" returns:

```json
{
  "result": [
    {
      "cache_key": "d432a37512f63a88562744f4da62021e",
      "cached_dttm": null,
      "cache_timeout": 86400,
      "annotation_data": {},
      "error": null,
      "is_cached": false,
      "query": "SELECT gender AS gender,\n       state AS state,\n       sum(num) AS \"Births\"\nFROM birth_names\nWHERE ds >= TO_TIMESTAMP('1921-07-22 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')\n  AND ds < TO_TIMESTAMP('2021-07-22 11:56:04.000000', 'YYYY-MM-DD HH24:MI:SS.US')\nGROUP BY gender,\n         state\nLIMIT 100",
      "status": "success",
      "stacktrace": null,
      "rowcount": 22,
      "colnames": [
        "gender",
        "state",
        "Births"
      ],
      "coltypes": [
        1,
        1,
        0
      ],
      "data": [
        {
          "gender": "boy",
          "state": "PA",
          "Births": 2390275
        },
        {
          "gender": "girl",
          "state": "PA",
          "Births": 1615383
        },
        {
          "gender": "boy",
          "state": "OH",
          "Births": 2376385
        },
        {
          "gender": "girl",
          "state": "MI",
          "Births": 1326229
        },
        {
          "gender": "girl",
          "state": "FL",
          "Births": 1312593
        },
        {
          "gender": "boy",
          "state": "CA",
          "Births": 5430796
        },
        {
          "gender": "boy",
          "state": "other",
          "Births": 22044909
        },
        {
          "gender": "girl",
          "state": "OH",
          "Births": 1622814
        },
        {
          "gender": "girl",
          "state": "TX",
          "Births": 2313186
        },
        {
          "gender": "boy",
          "state": "NY",
          "Births": 3543961
        },
        {
          "gender": "boy",
          "state": "IL",
          "Births": 2357411
        },
        {
          "gender": "girl",
          "state": "CA",
          "Births": 3567754
        },
        {
          "gender": "girl",
          "state": "NY",
          "Births": 2280733
        },
        {
          "gender": "girl",
          "state": "IL",
          "Births": 1614427
        },
        {
          "gender": "girl",
          "state": "other",
          "Births": 15058341
        },
        {
          "gender": "boy",
          "state": "TX",
          "Births": 3311985
        },
        {
          "gender": "boy",
          "state": "FL",
          "Births": 1968060
        },
        {
          "gender": "boy",
          "state": "MA",
          "Births": 1285126
        },
        {
          "gender": "boy",
          "state": "MI",
          "Births": 1938321
        },
        {
          "gender": "boy",
          "state": "NJ",
          "Births": 1486126
        },
        {
          "gender": "girl",
          "state": "NJ",
          "Births": 992702
        },
        {
          "gender": "girl",
          "state": "MA",
          "Births": 842146
        }
      ],
      "applied_filters": [],
      "rejected_filters": []
    }
  ]
}
```

Note that the results above have 22 rows and 3 columns: "gender", "state", and "Birth" (the metric).

With this PR we can do a `GET` request to "http://localhost:9000/api/v1/chart/72/data/?format=json&type=post_processed" to get:

```json
{
  "result": [
    {
      "cache_key": "d432a37512f63a88562744f4da62021e",
      "cached_dttm": null,
      "cache_timeout": 86400,
      "annotation_data": {},
      "error": null,
      "is_cached": false,
      "query": "SELECT gender AS gender,\n       state AS state,\n       sum(num) AS \"Births\"\nFROM birth_names\nWHERE ds >= TO_TIMESTAMP('1921-07-22 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')\n  AND ds < TO_TIMESTAMP('2021-07-22 12:03:21.000000', 'YYYY-MM-DD HH24:MI:SS.US')\nGROUP BY gender,\n         state\nLIMIT 100",
      "status": "success",
      "stacktrace": null,
      "rowcount": 3,
      "colnames": [
        "Births CA",
        "Births FL",
        "Births IL",
        "Births MA",
        "Births MI",
        "Births NJ",
        "Births NY",
        "Births OH",
        "Births PA",
        "Births TX",
        "Births other",
        "Births All"
      ],
      "coltypes": [
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0
      ],
      "data": [
        {
          "Births CA": 5430796,
          "Births FL": 1968060,
          "Births IL": 2357411,
          "Births MA": 1285126,
          "Births MI": 1938321,
          "Births NJ": 1486126,
          "Births NY": 3543961,
          "Births OH": 2376385,
          "Births PA": 2390275,
          "Births TX": 3311985,
          "Births other": 22044909,
          "Births All": 22044909,
          "gender": "boy"
        },
        {
          "Births CA": 3567754,
          "Births FL": 1312593,
          "Births IL": 1614427,
          "Births MA": 842146,
          "Births MI": 1326229,
          "Births NJ": 992702,
          "Births NY": 2280733,
          "Births OH": 1622814,
          "Births PA": 1615383,
          "Births TX": 2313186,
          "Births other": 15058341,
          "Births All": 15058341,
          "gender": "girl"
        },
        {
          "Births CA": 5430796,
          "Births FL": 1968060,
          "Births IL": 2357411,
          "Births MA": 1285126,
          "Births MI": 1938321,
          "Births NJ": 1486126,
          "Births NY": 3543961,
          "Births OH": 2376385,
          "Births PA": 2390275,
          "Births TX": 3311985,
          "Births other": 22044909,
          "Births All": 22044909,
          "gender": "All"
        }
      ],
      "applied_filters": [],
      "rejected_filters": []
    }
  ]
}
```

Note that we now get the correct results, with 3 rows and many columns from the pivot.

This functionality was added to support a very small subset of visualization types:

1. Pivot tables (v1)
2. Pivot tables (v2)
3. T-test tables

Because of the small number of visualization types, I opted to do this by reimplementing the chart logic in Python. The alternative would be to run the visualization under Selenium and scrape the data, which is inefficient and still requires keeping the scraping logic up-to-date with the plugins.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Create and save a pivot chart (not v2). Check the data at "http://localhost:9000/api/v1/chart/{chartid}/data/?format=json&type=post_processed" and "http://localhost:9000/api/v1/chart/{chartid}/data/?format=json&type=full".

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
