### PR TITLE
feat: call screenshot to store `query_context`

### DIFF
--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -19,7 +19,7 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import Split from 'react-split';
-import { styled, useTheme } from '@superset-ui/core';
+import { styled, SupersetClient, useTheme } from '@superset-ui/core';
 import { useResizeDetector } from 'react-resize-detector';
 import { chartPropShape } from 'src/dashboard/util/propShapes';
 import ChartContainer from 'src/chart/ChartContainer';
@@ -29,6 +29,7 @@ import {
 } from 'src/utils/localStorageHelpers';
 import ConnectedExploreChartHeader from './ExploreChartHeader';
 import { DataTablesPane } from './DataTablesPane';
+import { buildV1ChartDataPayload } from '../exploreUtils';
 
 const propTypes = {
   actions: PropTypes.object.isRequired,
@@ -127,6 +128,34 @@ const ExploreChartPanel = props => {
   const [splitSizes, setSplitSizes] = useState(
     getFromLocalStorage(STORAGE_KEYS.sizes, INITIAL_SIZES),
   );
+
+  const { slice } = props;
+  const updateQueryContext = useCallback(
+    async function fetchChartData() {
+      if (slice.query_context === null) {
+        const queryContext = buildV1ChartDataPayload({
+          formData: slice.form_data,
+          force: false,
+          resultFormat: 'json',
+          resultType: 'full',
+          setDataMask: null,
+          ownState: null,
+        });
+
+        await SupersetClient.put({
+          endpoint: `/api/v1/chart/${slice.slice_id}`,
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            query_context: JSON.stringify(queryContext),
+          }),
+        });
+      }
+    },
+    [slice.id, slice.form_data, slice.query_context],
+  );
+  useEffect(() => {
+    updateQueryContext();
+  }, [updateQueryContext]);
 
   const calcSectionHeight = useCallback(
     percent => {

--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -151,7 +151,7 @@ const ExploreChartPanel = props => {
         });
       }
     },
-    [slice.id, slice.form_data, slice.query_context],
+    [slice.slice_id, slice.form_data, slice.query_context],
   );
   useEffect(() => {
     updateQueryContext();

--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -132,7 +132,7 @@ const ExploreChartPanel = props => {
   const { slice } = props;
   const updateQueryContext = useCallback(
     async function fetchChartData() {
-      if (slice.query_context === null) {
+      if (slice && slice.query_context === null) {
         const queryContext = buildV1ChartDataPayload({
           formData: slice.form_data,
           force: false,
@@ -151,7 +151,7 @@ const ExploreChartPanel = props => {
         });
       }
     },
-    [slice.slice_id, slice.form_data, slice.query_context],
+    [slice],
   );
   useEffect(() => {
     updateQueryContext();

--- a/superset-frontend/src/explore/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/index.tsx
@@ -23,11 +23,10 @@ import Button from 'src/components/Button';
 import { OptionsType } from 'react-select/src/types';
 import { AsyncSelect } from 'src/components/Select';
 import rison from 'rison';
-import { t, SupersetClient, QueryFormData } from '@superset-ui/core';
+import { t, SupersetClient } from '@superset-ui/core';
 import Chart, { Slice } from 'src/types/Chart';
 import { Form, FormItem } from 'src/components/Form';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
-import { buildV1ChartDataPayload } from '../../exploreUtils';
 
 type PropertiesModalProps = {
   slice: Slice;
@@ -82,26 +81,6 @@ export default function PropertiesModal({
             label: `${owner.first_name} ${owner.last_name}`,
           })),
         );
-
-        if (chart.query_context === null) {
-          // set query_context if null
-          const queryContext = buildV1ChartDataPayload({
-            formData: slice.form_data as QueryFormData,
-            force: false,
-            resultFormat: 'json',
-            resultType: 'full',
-            setDataMask: null,
-            ownState: null,
-          });
-
-          await SupersetClient.put({
-            endpoint: `/api/v1/chart/${slice.slice_id}`,
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              query_context: JSON.stringify(queryContext),
-            }),
-          });
-        }
       } catch (response) {
         const clientError = await getClientErrorObject(response);
         showError(clientError);

--- a/superset-frontend/src/types/Chart.ts
+++ b/superset-frontend/src/types/Chart.ts
@@ -47,6 +47,7 @@ export type Slice = {
   description: string | null;
   cache_timeout: number | null;
   form_data?: QueryFormData;
+  query_context?: object;
 };
 
 export default Chart;

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -193,6 +193,7 @@ class Slice(
             "description_markeddown": self.description_markeddown,
             "edit_url": self.edit_url,
             "form_data": self.form_data,
+            "query_context": self.query_context,
             "modified": self.modified(),
             "owners": [
                 f"{owner.first_name} {owner.last_name}" for owner in self.owners

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -207,11 +207,18 @@ class BaseReportState:
         return image_data
 
     def _get_csv_data(self) -> bytes:
-        if self._report_schedule.chart:
-            url = self._get_url(csv=True)
-            auth_cookies = machine_auth_provider_factory.instance.get_auth_cookies(
-                self._get_user()
-            )
+        url = self._get_url(csv=True)
+        auth_cookies = machine_auth_provider_factory.instance.get_auth_cookies(
+            self._get_user()
+        )
+
+        # To load CSV data from the endpoint the chart must have been saved
+        # with its query context. For charts without saved query context we
+        # get a screenshot to force the chart to produce and save the query
+        # context.
+        if self._report_schedule.chart.query_context is None:
+            self._get_screenshot()
+
         try:
             csv_data = get_chart_csv_data(url, auth_cookies)
         except SoftTimeLimitExceeded:

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -217,7 +217,18 @@ class BaseReportState:
         # get a screenshot to force the chart to produce and save the query
         # context.
         if self._report_schedule.chart.query_context is None:
-            self._get_screenshot()
+            logger.warning("No query context found, taking a screenshot to generate it")
+            try:
+                self._get_screenshot()
+            except (
+                ReportScheduleScreenshotFailedError,
+                ReportScheduleScreenshotTimeout,
+            ) as ex:
+                raise ReportScheduleCsvFailedError(
+                    "Unable to fetch CSV data because the chart has no query context "
+                    "saved, and an error occurred when fetching it via a screenshot. "
+                    "Please try loading the chart and saving it again."
+                ) from ex
 
         try:
             csv_data = get_chart_csv_data(url, auth_cookies)


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

https://github.com/apache/superset/pull/15830/ modified the `_get_csv_data` functionality in the reports executor to use a new chart API introduced in https://github.com/apache/superset/pull/15827/. One problem is that the new API can only be called for charts that were saved with their `query_context`, a change that was introduced in https://github.com/apache/superset/pull/15824.

Pre-existing charts have `query_context` set to null, so we can't use the new API with them. As a workaround, @hughhhh implemented logic to save `query_context` when a chart that doesn't have it saved is loaded (https://github.com/apache/superset/pull/15865). This PR leverages that work by taking a screenshot of the chart using Selenium whenever we need to call the CSV API but `query_context`  is null.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Create a chart, save.
2. Delete `query_context` of the chart (`UPDATE slices SET query_context = NULL WHERE id=XXX`)
3. Create a CSV report based on the chart
4. Report with CSV should arrive correctly, and `query_context` should be back.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
