### PR TITLE
fix: Ensure DatabaseErrorMessage works when extra is undefined

### DIFF
--- a/superset-frontend/src/components/ErrorMessage/DatabaseErrorMessage.tsx
+++ b/superset-frontend/src/components/ErrorMessage/DatabaseErrorMessage.tsx
@@ -41,7 +41,7 @@ function DatabaseErrorMessage({
 
   const isVisualization = ['dashboard', 'explore'].includes(source);
 
-  const body = (
+  const body = extra && (
     <>
       <p>
         {t('This may be triggered by:')}
@@ -75,13 +75,16 @@ function DatabaseErrorMessage({
     </>
   );
 
-  const copyText = `${message}
+  const copyText =
+    extra && extra.issue_codes
+      ? `${message}
 ${t('This may be triggered by:')}
-${extra.issue_codes.map(issueCode => issueCode.message).join('\n')}`;
+${extra.issue_codes.map(issueCode => issueCode.message).join('\n')}`
+      : message;
 
   return (
     <ErrorAlert
-      title={t('%s Error', extra.engine_name || t('DB engine'))}
+      title={t('%s Error', (extra && extra.engine_name) || t('DB engine'))}
       subtitle={subtitle}
       level={level}
       source={source}

--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -189,7 +189,6 @@ class InvalidPayloadFormatError(SupersetErrorException):
             message=message,
             error_type=SupersetErrorType.INVALID_PAYLOAD_FORMAT_ERROR,
             level=ErrorLevel.ERROR,
-            extra={},
         )
         super().__init__(error)
 

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -412,7 +412,6 @@ def show_http_exception(ex: HTTPException) -> FlaskResponse:
                 message=utils.error_msg_from_exception(ex),
                 error_type=SupersetErrorType.GENERIC_BACKEND_ERROR,
                 level=ErrorLevel.ERROR,
-                extra={},
             ),
         ],
         status=ex.code or 500,
@@ -449,7 +448,6 @@ def show_unexpected_exception(ex: Exception) -> FlaskResponse:
                 message=utils.error_msg_from_exception(ex),
                 error_type=SupersetErrorType.GENERIC_BACKEND_ERROR,
                 level=ErrorLevel.ERROR,
-                extra={},
             ),
         ],
     )

--- a/tests/integration_tests/databases/commands_tests.py
+++ b/tests/integration_tests/databases/commands_tests.py
@@ -587,7 +587,7 @@ class TestTestConnectionDatabaseCommand(SupersetTestCase):
         connection exc is raised"""
         database = get_example_database()
         mock_get_sqla_engine.side_effect = SupersetSecurityException(
-            SupersetError(error_type=500, message="test", level="info", extra={})
+            SupersetError(error_type=500, message="test", level="info")
         )
         db_uri = database.sqlalchemy_uri_decrypted
         json_payload = {"sqlalchemy_uri": db_uri}


### PR DESCRIPTION
### SUMMARY

At Airbnb we have custom error types and thus `SupersetError.extra` field may be undefined (or underdefined) per [here](https://github.com/apache/superset/blob/master/superset/errors.py#L206) whereas the [DatabaseErrorMessage](https://github.com/apache/superset/blob/master/superset-frontend/src/components/ErrorMessage/DatabaseErrorMessage.tsx) expects it to be well defined.  This resulted in the application crashing when a custom error was thrown.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

![sql-lab-error](https://user-images.githubusercontent.com/4567245/126694862-64ec5881-f5d3-4f4c-aa5d-5c5f5cb32803.gif)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
