### PR TITLE
feat(explore): new datasets have autocomplete filters enabled if UX_BETA is set

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
@@ -306,6 +306,8 @@ export const DndFilterSelect = (props: DndFilterSelectProps) => {
     }
     return new AdhocFilter({
       subject: (droppedItem as ColumnMeta)?.column_name,
+      operator: OPERATOR_ENUM_TO_OPERATOR_TYPE[Operators.IN].operation,
+      operatorId: Operators.IN,
     });
   }, [droppedItem]);
 

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
@@ -17,12 +17,19 @@
  * under the License.
  */
 import React, { useEffect, useMemo, useState } from 'react';
-import { logging, SupersetClient, t, Metric } from '@superset-ui/core';
+import {
+  FeatureFlag,
+  isFeatureEnabled,
+  logging,
+  Metric,
+  SupersetClient,
+  t,
+} from '@superset-ui/core';
 import { ColumnMeta } from '@superset-ui/chart-controls';
 import { Tooltip } from 'src/components/Tooltip';
 import {
-  Operators,
   OPERATOR_ENUM_TO_OPERATOR_TYPE,
+  Operators,
 } from 'src/explore/constants';
 import { OptionSortType } from 'src/explore/types';
 import {
@@ -304,11 +311,14 @@ export const DndFilterSelect = (props: DndFilterSelectProps) => {
         sqlExpression: (droppedItem as AdhocMetric)?.translateToSql(),
       });
     }
-    return new AdhocFilter({
+    const config: Partial<AdhocFilter> = {
       subject: (droppedItem as ColumnMeta)?.column_name,
-      operator: OPERATOR_ENUM_TO_OPERATOR_TYPE[Operators.IN].operation,
-      operatorId: Operators.IN,
-    });
+    };
+    if (isFeatureEnabled(FeatureFlag.UX_BETA)) {
+      config.operator = OPERATOR_ENUM_TO_OPERATOR_TYPE[Operators.IN].operation;
+      config.operatorId = Operators.IN;
+    }
+    return new AdhocFilter(config);
   }, [droppedItem]);
 
   return (

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
@@ -427,7 +427,7 @@ const AdhocFilterEditPopoverSimpleTabContent: React.FC<Props> = props => {
         >
           {suggestions.map((suggestion: string) => (
             <Select.Option value={suggestion} key={suggestion}>
-              {suggestion}
+              {String(suggestion)}
             </Select.Option>
           ))}
 

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -24,7 +24,7 @@ from sqlalchemy import and_, Boolean, Column, Integer, String, Text
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import foreign, Query, relationship, RelationshipProperty, Session
 
-from superset import security_manager
+from superset import security_manager, is_feature_enabled
 from superset.constants import NULL_STRING
 from superset.models.helpers import AuditMixinNullable, ImportExportMixin, QueryResult
 from superset.models.slice import Slice
@@ -103,7 +103,7 @@ class BaseDatasource(
     description = Column(Text)
     default_endpoint = Column(Text)
     is_featured = Column(Boolean, default=False)  # TODO deprecating
-    filter_select_enabled = Column(Boolean, default=False)
+    filter_select_enabled = Column(Boolean, default=is_feature_enabled("UX_BETA"))
     offset = Column(Integer, default=0)
     cache_timeout = Column(Integer)
     params = Column(String(1000))

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -24,7 +24,7 @@ from sqlalchemy import and_, Boolean, Column, Integer, String, Text
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import foreign, Query, relationship, RelationshipProperty, Session
 
-from superset import security_manager, is_feature_enabled
+from superset import is_feature_enabled, security_manager
 from superset.constants import NULL_STRING
 from superset.models.helpers import AuditMixinNullable, ImportExportMixin, QueryResult
 from superset.models.slice import Slice

--- a/superset/examples/bart_lines.py
+++ b/superset/examples/bart_lines.py
@@ -59,6 +59,7 @@ def load_bart_lines(only_metadata: bool = False, force: bool = False) -> None:
         tbl = table(table_name=tbl_name)
     tbl.description = "BART lines"
     tbl.database = database
+    tbl.filter_select_enabled = True
     db.session.merge(tbl)
     db.session.commit()
     tbl.fetch_metadata()

--- a/superset/examples/configs/datasets/examples/FCC_2018_Survey.yaml
+++ b/superset/examples/configs/datasets/examples/FCC_2018_Survey.yaml
@@ -24,7 +24,7 @@ schema: null
 sql: ''
 params: null
 template_params: null
-filter_select_enabled: false
+filter_select_enabled: true
 fetch_values_predicate: null
 extra: null
 uuid: d95a2865-53ce-1f82-a53d-8e3c89331469

--- a/superset/examples/configs/datasets/examples/channel_members.yaml
+++ b/superset/examples/configs/datasets/examples/channel_members.yaml
@@ -24,7 +24,7 @@ schema: null
 sql: null
 params: null
 template_params: null
-filter_select_enabled: false
+filter_select_enabled: true
 fetch_values_predicate: null
 extra: null
 uuid: 3e8130eb-0831-d568-b531-c3ce6d68d3d8

--- a/superset/examples/configs/datasets/examples/channels.yaml
+++ b/superset/examples/configs/datasets/examples/channels.yaml
@@ -24,7 +24,7 @@ schema: null
 sql: null
 params: null
 template_params: null
-filter_select_enabled: false
+filter_select_enabled: true
 fetch_values_predicate: null
 extra: null
 uuid: f7db6d45-7056-f395-d24a-6c805fb4c97d

--- a/superset/examples/configs/datasets/examples/cleaned_sales_data.yaml
+++ b/superset/examples/configs/datasets/examples/cleaned_sales_data.yaml
@@ -24,7 +24,7 @@ schema: null
 sql: null
 params: null
 template_params: null
-filter_select_enabled: false
+filter_select_enabled: true
 fetch_values_predicate: null
 extra: null
 uuid: e8623bb9-5e00-f531-506a-19607f5f8005

--- a/superset/examples/configs/datasets/examples/covid_vaccines.yaml
+++ b/superset/examples/configs/datasets/examples/covid_vaccines.yaml
@@ -24,7 +24,7 @@ schema: null
 sql: ''
 params: null
 template_params: null
-filter_select_enabled: false
+filter_select_enabled: true
 fetch_values_predicate: null
 extra: null
 uuid: 974b7a1c-22ea-49cb-9214-97b7dbd511e0

--- a/superset/examples/configs/datasets/examples/exported_stats.yaml
+++ b/superset/examples/configs/datasets/examples/exported_stats.yaml
@@ -24,7 +24,7 @@ schema: null
 sql: ''
 params: null
 template_params: null
-filter_select_enabled: false
+filter_select_enabled: true
 fetch_values_predicate: null
 extra: null
 uuid: 0bd5d01c-b7d8-471b-b3a5-366ce6c920d4

--- a/superset/examples/configs/datasets/examples/members_channels_2.yaml
+++ b/superset/examples/configs/datasets/examples/members_channels_2.yaml
@@ -25,7 +25,7 @@ sql: SELECT c.name AS channel_name, u.name AS member_name FROM channel_members c
   JOIN channels c ON cm.channel_id = c.id JOIN users u ON cm.user_id = u.id
 params: null
 template_params: null
-filter_select_enabled: false
+filter_select_enabled: true
 fetch_values_predicate: null
 extra: null
 uuid: 3d9c0054-b31b-4102-92de-b1ef9f9e5e77

--- a/superset/examples/configs/datasets/examples/messages.yaml
+++ b/superset/examples/configs/datasets/examples/messages.yaml
@@ -24,7 +24,7 @@ schema: null
 sql: null
 params: null
 template_params: null
-filter_select_enabled: false
+filter_select_enabled: true
 fetch_values_predicate: null
 extra: null
 uuid: e032c69e-716e-d700-eff7-07800d0f9989

--- a/superset/examples/configs/datasets/examples/messages_channels.yaml
+++ b/superset/examples/configs/datasets/examples/messages_channels.yaml
@@ -25,7 +25,7 @@ sql: SELECT m.ts, c.name, m.text FROM messages m JOIN channels c ON m.channel_id
   c.id
 params: null
 template_params: null
-filter_select_enabled: false
+filter_select_enabled: true
 fetch_values_predicate: null
 extra: null
 uuid: 6e533506-fce6-4f6a-b116-d139df6dbdea

--- a/superset/examples/configs/datasets/examples/new_members_daily.yaml
+++ b/superset/examples/configs/datasets/examples/new_members_daily.yaml
@@ -25,7 +25,7 @@ sql: SELECT date, total_membership - lag(total_membership) OVER (ORDER BY date) 
   new_members FROM exported_stats
 params: null
 template_params: null
-filter_select_enabled: false
+filter_select_enabled: true
 fetch_values_predicate: null
 extra: null
 uuid: 9dd99cda-ff6b-4575-9a74-684d06e871ab

--- a/superset/examples/configs/datasets/examples/threads.yaml
+++ b/superset/examples/configs/datasets/examples/threads.yaml
@@ -24,7 +24,7 @@ schema: null
 sql: null
 params: null
 template_params: null
-filter_select_enabled: false
+filter_select_enabled: true
 fetch_values_predicate: null
 extra: null
 uuid: d7438be6-6078-17dd-cf9a-56f0ef546c80

--- a/superset/examples/configs/datasets/examples/unicode_test.test.yaml
+++ b/superset/examples/configs/datasets/examples/unicode_test.test.yaml
@@ -24,7 +24,7 @@ schema: null
 sql: null
 params: null
 template_params: null
-filter_select_enabled: false
+filter_select_enabled: true
 fetch_values_predicate: null
 extra: null
 uuid: a6771c73-96fc-44c6-8b6e-9d303955ea48

--- a/superset/examples/configs/datasets/examples/users.yaml
+++ b/superset/examples/configs/datasets/examples/users.yaml
@@ -24,7 +24,7 @@ schema: null
 sql: null
 params: null
 template_params: null
-filter_select_enabled: false
+filter_select_enabled: true
 fetch_values_predicate: null
 extra: null
 uuid: 7195db6b-2d17-7619-b7c7-26b15378df8c

--- a/superset/examples/configs/datasets/examples/users_channels-uzooNNtSRO.yaml
+++ b/superset/examples/configs/datasets/examples/users_channels-uzooNNtSRO.yaml
@@ -28,7 +28,7 @@ sql: 'SELECT uc1.name as channel_1, uc2.name as channel_2, count(*) AS cnt
   HAVING uc1.name <> uc2.name'
 params: null
 template_params: null
-filter_select_enabled: false
+filter_select_enabled: true
 fetch_values_predicate: null
 extra: null
 uuid: 473d6113-b44a-48d8-a6ae-e0ef7e2aebb0

--- a/superset/examples/configs/datasets/examples/users_channels.yaml
+++ b/superset/examples/configs/datasets/examples/users_channels.yaml
@@ -24,7 +24,7 @@ schema: null
 sql: null
 params: null
 template_params: null
-filter_select_enabled: false
+filter_select_enabled: true
 fetch_values_predicate: null
 extra: null
 uuid: 29b18573-c9d6-40bc-b8cb-f70c9a1b6244

--- a/superset/examples/configs/datasets/examples/video_game_sales.yaml
+++ b/superset/examples/configs/datasets/examples/video_game_sales.yaml
@@ -27,7 +27,7 @@ params:
   database_name: examples
   import_time: 1606677834
 template_params: null
-filter_select_enabled: false
+filter_select_enabled: true
 fetch_values_predicate: null
 extra: null
 uuid: 53d47c0c-c03d-47f0-b9ac-81225f808283

--- a/superset/examples/country_map.py
+++ b/superset/examples/country_map.py
@@ -79,6 +79,7 @@ def load_country_map_data(only_metadata: bool = False, force: bool = False) -> N
         obj = table(table_name=tbl_name)
     obj.main_dttm_col = "dttm"
     obj.database = database
+    obj.filter_select_enabled = True
     if not any(col.metric_name == "avg__2004" for col in obj.metrics):
         col = str(column("2004").compile(db.engine))
         obj.metrics.append(SqlMetric(metric_name="avg__2004", expression=f"AVG({col})"))

--- a/superset/examples/energy.py
+++ b/superset/examples/energy.py
@@ -63,6 +63,7 @@ def load_energy(
         tbl = table(table_name=tbl_name)
     tbl.description = "Energy consumption"
     tbl.database = database
+    tbl.filter_select_enabled = True
 
     if not any(col.metric_name == "sum__value" for col in tbl.metrics):
         col = str(column("value").compile(db.engine))

--- a/superset/examples/flights.py
+++ b/superset/examples/flights.py
@@ -63,6 +63,7 @@ def load_flights(only_metadata: bool = False, force: bool = False) -> None:
         tbl = table(table_name=tbl_name)
     tbl.description = "Random set of flights in the US"
     tbl.database = database
+    tbl.filter_select_enabled = True
     db.session.merge(tbl)
     db.session.commit()
     tbl.fetch_metadata()

--- a/superset/examples/long_lat.py
+++ b/superset/examples/long_lat.py
@@ -88,6 +88,7 @@ def load_long_lat_data(only_metadata: bool = False, force: bool = False) -> None
         obj = table(table_name=tbl_name)
     obj.main_dttm_col = "datetime"
     obj.database = database
+    obj.filter_select_enabled = True
     db.session.merge(obj)
     db.session.commit()
     obj.fetch_metadata()

--- a/superset/examples/multiformat_time_series.py
+++ b/superset/examples/multiformat_time_series.py
@@ -80,6 +80,7 @@ def load_multiformat_time_series(
         obj = table(table_name=tbl_name)
     obj.main_dttm_col = "ds"
     obj.database = database
+    obj.filter_select_enabled = True
     dttm_and_expr_dict: Dict[str, Tuple[Optional[str], None]] = {
         "ds": (None, None),
         "ds2": (None, None),

--- a/superset/examples/paris.py
+++ b/superset/examples/paris.py
@@ -56,6 +56,7 @@ def load_paris_iris_geojson(only_metadata: bool = False, force: bool = False) ->
         tbl = table(table_name=tbl_name)
     tbl.description = "Map of Paris"
     tbl.database = database
+    tbl.filter_select_enabled = True
     db.session.merge(tbl)
     db.session.commit()
     tbl.fetch_metadata()

--- a/superset/examples/random_time_series.py
+++ b/superset/examples/random_time_series.py
@@ -65,6 +65,7 @@ def load_random_time_series_data(
         obj = table(table_name=tbl_name)
     obj.main_dttm_col = "ds"
     obj.database = database
+    obj.filter_select_enabled = True
     db.session.merge(obj)
     db.session.commit()
     obj.fetch_metadata()

--- a/superset/examples/sf_population_polygons.py
+++ b/superset/examples/sf_population_polygons.py
@@ -58,6 +58,7 @@ def load_sf_population_polygons(
         tbl = table(table_name=tbl_name)
     tbl.description = "Population density of San Francisco"
     tbl.database = database
+    tbl.filter_select_enabled = True
     db.session.merge(tbl)
     db.session.commit()
     tbl.fetch_metadata()


### PR DESCRIPTION
### SUMMARY
If `UX_BETA` feature flag is set to True, all new datasets will have autocomplete filters enabled by default. The existing datasets will not be modified.
The existing datasets have been set to use autocompleting feature regardless of the feature flag value.
Also, adhoc filters in drag and drop mode have "IN" selected as a if UX_BETA is enabled.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/15073128/126776554-078ca129-964f-4e6a-8973-442a62d8cbb5.mov

https://user-images.githubusercontent.com/15073128/126975341-a7db9ac7-b2ee-45ca-b3de-193ba214c054.mov

### TESTING INSTRUCTIONS
0. Enable `UX_BETA` feature flag
1. Create a new dataset and verify that it has "Autocomplete filters" enabled by default
2. Create an adhoc filter and verify that after selecting column you can select a value from suggestions. Also, if you're using drag and drop, "IN" operator should be selected by default.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #15694 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @junlincc @graceguo-supercat 
