### PR TITLE
fix(15482): Propagate SupersetSecurityException error

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2685,23 +2685,11 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         try:
             query.raise_for_access()
         except SupersetSecurityException as ex:
-            message = __(
-                "You are not authorized to see this query. If you think this "
-                "is an error, please reach out to your administrator."
-            )
-            error = SupersetError(
-                message=message,
-                error_type=SupersetErrorType.QUERY_SECURITY_ACCESS_ERROR,
-                level=ErrorLevel.ERROR,
-            )
-            error_payload = dataclasses.asdict(error)
-
-            query.set_extra_json_key("errors", [error_payload])
+            query.set_extra_json_key("errors", [dataclasses.asdict(ex.error)])
             query.status = QueryStatus.FAILED
-            query.error_message = message
+            query.error_message = ex.error.message
             session.commit()
-
-            raise SupersetErrorException(error, status=403) from ex
+            raise SupersetErrorException(ex.error, status=403) from ex
 
         try:
             template_processor = get_template_processor(


### PR DESCRIPTION
### SUMMARY

I'm not sure why in https://github.com/apache/superset/pull/15482 we construct a new `SupersetError` (with corresponding message, error type, and level) rather than merely leveraging the mandatory `SupersetError` which raised as part of the `SupersetSecurityException`. 

These errors contain specifics (message, error type, etc.) which differ depending on the type of exception ([example](https://github.com/apache/superset/blob/master/superset/security/manager.py#L410-L418))—which also may be custom for security manager overrides—and thus should be preserved.

This PR merely uses the previous `SupersetError` (which is guaranteed to exist per the [SupersetSecurityException](https://github.com/apache/superset/blob/02032ee8a478ab9578cf6e13a7645a8b4106be58/superset/exceptions.py#L130-L137) signature) rather than constructing a new error.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
