### PR TITLE
feat: deprecate plugins by their metadata

### DIFF
--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -398,7 +398,10 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
   const chartMetadata: VizEntry[] = useMemo(() => {
     const result = Object.entries(mountedPluginMetadata)
       .map(([key, value]) => ({ key, value }))
-      .filter(({ value }) => nativeFilterGate(value.behaviors || []));
+      .filter(
+        ({ value }) =>
+          nativeFilterGate(value.behaviors || []) && !value.deprecated,
+      );
     result.sort((a, b) => vizSortFactor(a) - vizSortFactor(b));
     return result;
   }, [mountedPluginMetadata]);


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Allows plugins to be deprecated by flipping the `deprecated` metadata flag. When a plugin is deprecated, it will still work as normal but will not show up in the viz gallery.

Currently there are no plugins shipping with Superset that have the `deprecated` flag enabled, so this will have no impact on the application except in environments that override the default configuration.

When opening the viz gallery while exploring a chart that is deprecated, the chart's viz type will not show up in the gallery list, but the detail pane will be populated with the deprecated chart's description, tags, and examples. If you change viz type from a deprecated viz to a non-deprecated viz, and save, there will not be a way to change it back.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Add a dynamic plugin or use `npm link` to register a plugin locally
2. Add `deprecated: true` to your plugin's metadata
3. The plugin will not show up in the viz gallery

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
