### PR TITLE
fix(dashboard): Refresh Native Filters when Dashboard refreshes

### DIFF
--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -241,6 +241,11 @@ export function saveDashboardRequest(data, id, saveType) {
   };
 }
 
+export const ON_REFRESH_SUCCESS = 'ON_REFRESH_SUCCESS';
+export function onRefreshSuccess() {
+  return { type: ON_REFRESH_SUCCESS };
+}
+
 export function fetchCharts(
   chartList = [],
   force = false,
@@ -272,6 +277,27 @@ export function fetchCharts(
         delay * i,
       );
     });
+  };
+}
+
+const refreshCharts = (chartList, force, interval, dashboardId, dispatch) =>
+  new Promise(resolve => {
+    dispatch(fetchCharts(chartList, force, interval, dashboardId));
+    resolve();
+  });
+
+export const ON_REFRESH = 'ON_REFRESH';
+export function onRefresh(
+  chartList = [],
+  force = false,
+  interval = 0,
+  dashboardId,
+) {
+  return dispatch => {
+    dispatch({ type: ON_REFRESH });
+    refreshCharts(chartList, force, interval, dashboardId, dispatch).then(() =>
+      dispatch({ type: ON_REFRESH_SUCCESS }),
+    );
   };
 }
 

--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -241,11 +241,6 @@ export function saveDashboardRequest(data, id, saveType) {
   };
 }
 
-export const ON_REFRESH_SUCCESS = 'ON_REFRESH_SUCCESS';
-export function onRefreshSuccess() {
-  return { type: ON_REFRESH_SUCCESS };
-}
-
 export function fetchCharts(
   chartList = [],
   force = false,
@@ -285,6 +280,11 @@ const refreshCharts = (chartList, force, interval, dashboardId, dispatch) =>
     dispatch(fetchCharts(chartList, force, interval, dashboardId));
     resolve();
   });
+
+export const ON_REFRESH_SUCCESS = 'ON_REFRESH_SUCCESS';
+export function onRefreshSuccess() {
+  return { type: ON_REFRESH_SUCCESS };
+}
 
 export const ON_REFRESH = 'ON_REFRESH';
 export function onRefresh(

--- a/superset-frontend/src/dashboard/actions/hydrate.js
+++ b/superset-frontend/src/dashboard/actions/hydrate.js
@@ -378,6 +378,7 @@ export const hydrateDashboard = (dashboardData, chartData) => (
         hasUnsavedChanges: false,
         maxUndoHistoryExceeded: false,
         lastModifiedTime: dashboardData.changed_on,
+        isRefreshing: false,
         activeTabs: [],
       },
       dashboardLayout,

--- a/superset-frontend/src/dashboard/components/Header/Header.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/Header.test.tsx
@@ -54,6 +54,7 @@ const createProps = () => ({
   onChange: jest.fn(),
   fetchFaveStar: jest.fn(),
   fetchCharts: jest.fn(),
+  onRefresh: jest.fn(),
   saveFaveStar: jest.fn(),
   savePublished: jest.fn(),
   isPublished: false,
@@ -301,5 +302,5 @@ test('should refresh the charts', async () => {
   render(setup(mockedProps));
   await openActionsDropdown();
   userEvent.click(screen.getByText('Refresh dashboard'));
-  expect(mockedProps.fetchCharts).toHaveBeenCalledTimes(1);
+  expect(mockedProps.onRefresh).toHaveBeenCalledTimes(1);
 });

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -217,7 +217,12 @@ class Header extends React.PureComponent {
         interval: 0,
         chartCount: chartList.length,
       });
-      this.props.onRefresh(chartList, true, 0, this.props.dashboardInfo.id);
+      return this.props.onRefresh(
+        chartList,
+        true,
+        0,
+        this.props.dashboardInfo.id,
+      );
     }
     return false;
   }

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -82,6 +82,7 @@ const propTypes = {
   lastModifiedTime: PropTypes.number.isRequired,
 
   // redux
+  onRefresh: PropTypes.func.isRequired,
   onUndo: PropTypes.func.isRequired,
   onRedo: PropTypes.func.isRequired,
   undoLength: PropTypes.number.isRequired,
@@ -216,13 +217,7 @@ class Header extends React.PureComponent {
         interval: 0,
         chartCount: chartList.length,
       });
-
-      return this.props.fetchCharts(
-        chartList,
-        true,
-        0,
-        this.props.dashboardInfo.id,
-      );
+      this.props.onRefresh(chartList, true, 0, this.props.dashboardInfo.id);
     }
     return false;
   }

--- a/superset-frontend/src/dashboard/components/Header/types.ts
+++ b/superset-frontend/src/dashboard/components/Header/types.ts
@@ -48,7 +48,6 @@ export interface HeaderDropdownProps {
   onSave: () => void;
   refreshFrequency: number;
   setRefreshFrequency: () => void;
-  onRefresh: () => void;
   shouldPersistRefreshFrequency: boolean;
   showPropertiesModal: () => void;
   startPeriodicRender: () => void;
@@ -88,6 +87,7 @@ export interface HeaderProps {
   lastModifiedTime: number;
   onUndo: () => void;
   onRedo: () => void;
+  onRefresh: () => void;
   undoLength: number;
   redoLength: number;
   setMaxUndoHistoryExceeded: () => void;

--- a/superset-frontend/src/dashboard/components/Header/types.ts
+++ b/superset-frontend/src/dashboard/components/Header/types.ts
@@ -48,6 +48,7 @@ export interface HeaderDropdownProps {
   onSave: () => void;
   refreshFrequency: number;
   setRefreshFrequency: () => void;
+  onRefresh: () => void;
   shouldPersistRefreshFrequency: boolean;
   showPropertiesModal: () => void;
   startPeriodicRender: () => void;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
@@ -28,7 +28,7 @@ import {
   JsonObject,
   getChartMetadataRegistry,
 } from '@superset-ui/core';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { areObjectsEqual } from 'src/reduxUtils';
 import { getChartDataRequest } from 'src/chart/chartAction';
 import Loading from 'src/components/Loading';
@@ -36,6 +36,7 @@ import BasicErrorAlert from 'src/components/ErrorMessage/BasicErrorAlert';
 import { FeatureFlag, isFeatureEnabled } from 'src/featureFlags';
 import { waitForAsyncData } from 'src/middleware/asyncEvent';
 import { ClientErrorObject } from 'src/utils/getClientErrorObject';
+import { RootState } from 'src/dashboard/types';
 import { dispatchFocusAction } from './utils';
 import { FilterProps } from './types';
 import { getFormData } from '../../utils';
@@ -62,6 +63,9 @@ const FilterValue: React.FC<FilterProps> = ({
   const { id, targets, filterType, adhoc_filters, time_range } = filter;
   const metadata = getChartMetadataRegistry().get(filterType);
   const cascadingFilters = useCascadingFilters(id, dataMaskSelected);
+  const isDashboardRefreshing = useSelector<RootState, boolean>(
+    state => state.dashboardState.isRefreshing,
+  );
   const [state, setState] = useState<ChartDataResponseResult[]>([]);
   const [error, setError] = useState<string>('');
   const [formData, setFormData] = useState<Partial<QueryFormData>>({
@@ -78,7 +82,7 @@ const FilterValue: React.FC<FilterProps> = ({
   const { name: groupby } = column;
   const hasDataSource = !!datasetId;
   const [isLoading, setIsLoading] = useState<boolean>(hasDataSource);
-  const [isRefreshing, setIsRefreshing] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -102,8 +106,10 @@ const FilterValue: React.FC<FilterProps> = ({
     });
     const filterOwnState = filter.dataMask?.ownState || {};
     if (
-      !areObjectsEqual(formData, newFormData) ||
-      !areObjectsEqual(ownState, filterOwnState)
+      !isRefreshing &&
+      (!areObjectsEqual(formData, newFormData) ||
+        !areObjectsEqual(ownState, filterOwnState) ||
+        isDashboardRefreshing)
     ) {
       setFormData(newFormData);
       setOwnState(filterOwnState);
@@ -165,6 +171,7 @@ const FilterValue: React.FC<FilterProps> = ({
     groupby,
     JSON.stringify(filter),
     hasDataSource,
+    isDashboardRefreshing,
   ]);
 
   useEffect(() => {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
@@ -171,6 +171,7 @@ const FilterValue: React.FC<FilterProps> = ({
     groupby,
     JSON.stringify(filter),
     hasDataSource,
+    isRefreshing,
     isDashboardRefreshing,
   ]);
 

--- a/superset-frontend/src/dashboard/containers/DashboardHeader.jsx
+++ b/superset-frontend/src/dashboard/containers/DashboardHeader.jsx
@@ -39,6 +39,7 @@ import {
   setMaxUndoHistoryExceeded,
   maxUndoHistoryToast,
   setRefreshFrequency,
+  onRefresh,
 } from '../actions/dashboardState';
 
 import {
@@ -120,6 +121,7 @@ function mapDispatchToProps(dispatch) {
       maxUndoHistoryToast,
       logEvent,
       setRefreshFrequency,
+      onRefresh,
       dashboardInfoChanged,
       dashboardTitleChanged,
       updateDataMask,

--- a/superset-frontend/src/dashboard/reducers/dashboardState.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.js
@@ -32,6 +32,8 @@ import {
   TOGGLE_PUBLISHED,
   UPDATE_CSS,
   SET_REFRESH_FREQUENCY,
+  ON_REFRESH,
+  ON_REFRESH_SUCCESS,
   SET_DIRECT_PATH,
   SET_FOCUSED_FILTER_FIELD,
   UNSET_FOCUSED_FILTER_FIELD,
@@ -126,6 +128,18 @@ export default function dashboardStateReducer(state = {}, action) {
         refreshFrequency: action.refreshFrequency,
         shouldPersistRefreshFrequency: action.isPersistent,
         hasUnsavedChanges: action.isPersistent,
+      };
+    },
+    [ON_REFRESH]() {
+      return {
+        ...state,
+        isRefreshing: true,
+      };
+    },
+    [ON_REFRESH_SUCCESS]() {
+      return {
+        ...state,
+        isRefreshing: false,
       };
     },
     [SET_DIRECT_PATH]() {

--- a/superset-frontend/src/dashboard/types.ts
+++ b/superset-frontend/src/dashboard/types.ts
@@ -60,6 +60,7 @@ export type DashboardState = {
   directPathToChild: string[];
   activeTabs: ActiveTabs;
   fullSizeChartId: number | null;
+  isRefreshing: boolean;
 };
 export type DashboardInfo = {
   common: {


### PR DESCRIPTION
### SUMMARY
This PR implements a `onRefresh` action to let the native filters reload when the dashboard reloads.

Fixes #15808 

### BEFORE

https://user-images.githubusercontent.com/60598000/126914237-12917206-08a0-4b38-a23f-65c372e13979.mp4

### AFTER

https://user-images.githubusercontent.com/60598000/126914243-1c75f6f6-8bb5-42eb-8b0e-da83b6953eb0.mp4

### TESTING INSTRUCTIONS
1. Open a dashboard with Native Filters ON
2. Add a filter
3. Remove any of the options from the dataset
4. Refresh the dashboard
5. Observe that the option is not appearing in the filter

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #15808 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
