### PR TITLE
fix: Select a query from History and Run

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -158,7 +158,6 @@ class SqlEditor extends React.PureComponent {
       ctas: '',
       northPercent: props.queryEditor.northPercent || INITIAL_NORTH_PERCENT,
       southPercent: props.queryEditor.southPercent || INITIAL_SOUTH_PERCENT,
-      sql: props.queryEditor.sql,
       autocompleteEnabled: true,
       showCreateAsModal: false,
       createAs: '',
@@ -222,15 +221,6 @@ class SqlEditor extends React.PureComponent {
     });
   }
 
-  static getDerivedStateFromProps(props, state) {
-    if (props.queryEditor.sql !== state.sql) {
-      return {
-        sql: props.queryEditor.sql,
-      };
-    }
-    return null;
-  }
-
   componentWillUnmount() {
     window.removeEventListener('resize', this.handleWindowResize);
     window.removeEventListener('beforeunload', this.onBeforeUnload);
@@ -265,7 +255,6 @@ class SqlEditor extends React.PureComponent {
   }
 
   onSqlChanged(sql) {
-    this.setState({ sql });
     this.setQueryEditorSqlWithDebounce(sql);
     // Request server-side validation of the query text
     if (this.canValidateQuery()) {
@@ -304,7 +293,7 @@ class SqlEditor extends React.PureComponent {
         key: 'ctrl+r',
         descr: t('Run query'),
         func: () => {
-          if (this.state.sql.trim() !== '') {
+          if (this.props.queryEditor.sql.trim() !== '') {
             this.runQuery();
           }
         },
@@ -314,7 +303,7 @@ class SqlEditor extends React.PureComponent {
         key: 'ctrl+enter',
         descr: t('Run query'),
         func: () => {
-          if (this.state.sql.trim() !== '') {
+          if (this.props.queryEditor.sql.trim() !== '') {
             this.runQuery();
           }
         },
@@ -353,7 +342,7 @@ class SqlEditor extends React.PureComponent {
       const qe = this.props.queryEditor;
       const query = {
         dbId: qe.dbId,
-        sql: qe.selectedText ? qe.selectedText : this.state.sql,
+        sql: qe.selectedText ? qe.selectedText : this.props.queryEditor.sql,
         sqlEditorId: qe.id,
         schema: qe.schema,
         templateParams: qe.templateParams,
@@ -385,7 +374,7 @@ class SqlEditor extends React.PureComponent {
       const qe = this.props.queryEditor;
       const query = {
         dbId: qe.dbId,
-        sql: this.state.sql,
+        sql: this.props.queryEditor.sql,
         sqlEditorId: qe.id,
         schema: qe.schema,
         templateParams: qe.templateParams,
@@ -418,7 +407,7 @@ class SqlEditor extends React.PureComponent {
     const qe = this.props.queryEditor;
     const query = {
       dbId: qe.dbId,
-      sql: qe.selectedText ? qe.selectedText : this.state.sql,
+      sql: qe.selectedText ? qe.selectedText : this.props.queryEditor.sql,
       sqlEditorId: qe.id,
       tab: qe.title,
       schema: qe.schema,
@@ -631,7 +620,7 @@ class SqlEditor extends React.PureComponent {
               runQuery={this.runQuery}
               selectedText={qe.selectedText}
               stopQuery={this.stopQuery}
-              sql={this.state.sql}
+              sql={this.props.queryEditor.sql}
               overlayCreateAsMenu={showMenu ? runMenuBtn : null}
             />
           </span>

--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -222,6 +222,15 @@ class SqlEditor extends React.PureComponent {
     });
   }
 
+  static getDerivedStateFromProps(props, state) {
+    if (props.queryEditor.sql !== state.sql) {
+      return {
+        sql: props.queryEditor.sql,
+      };
+    }
+    return null;
+  }
+
   componentWillUnmount() {
     window.removeEventListener('resize', this.handleWindowResize);
     window.removeEventListener('beforeunload', this.onBeforeUnload);


### PR DESCRIPTION
### SUMMARY
Fix an issue that SQL Lab didn't run correct sql after user pick a query from History. The root cause is that after update selected sql in redux store, component state is out of sync from props.

The proposed solution for this PR is to remove `sql` from component local state, and always use props which sync from redux store.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Step to reproduce:
1. open sql lab
2. run a sql statement
3. pick a query from History tab
4. you will see SQL Editor updated with the picked query
5. Click Run button
6. The query result is not correct: query result is actually from the previous sql statement.
![mIJImvnPa8](https://user-images.githubusercontent.com/27990562/126917304-014bc853-4b6b-438e-bbc9-0c4c935543b1.gif)


### TESTING INSTRUCTIONS
CI and manual test.

@jinghua-qa It's a little troublesome to add unit test for this bug. Could you add a test case for this flow?

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @etr2460 @ktmud 