### PR TITLE
fix: dashboard url error when edit slug

### DIFF
--- a/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
@@ -166,6 +166,7 @@ function DashboardList(props: DashboardListProps) {
                 slug = '',
                 json_metadata = '',
                 changed_on_delta_humanized,
+                url = '',
               } = json.result;
               return {
                 ...dashboard,
@@ -176,6 +177,7 @@ function DashboardList(props: DashboardListProps) {
                 slug,
                 json_metadata,
                 changed_on_delta_humanized,
+                url,
               };
             }
             return dashboard;


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
closes: https://github.com/apache/superset/issues/15834
Currently, the dashboard list page is unable to update the newest URL when editing the dashboard slug. this PR is fixed this errro.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### Before

https://user-images.githubusercontent.com/81597121/126612384-55a580ac-c62f-48f5-bc1e-fc5b9998fdf4.mov

### After

https://user-images.githubusercontent.com/2016594/126938429-dcbb600c-9500-4673-873a-2c8650a56cd3.mp4


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/15834
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
