### PR TITLE
fix: Charts sort by in edit mode gets cut off

### DIFF
--- a/superset-frontend/spec/javascripts/dashboard/components/SliceAdder_spec.jsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/SliceAdder_spec.jsx
@@ -155,10 +155,10 @@ describe('SliceAdder', () => {
     });
 
     it('handleSelect', () => {
-      const newSortBy = { value: 'viz_type' };
+      const newSortBy = 'viz_type';
       wrapper.instance().handleSelect(newSortBy);
       expect(spy.calledOnce).toBe(true);
-      expect(spy.lastCall.args[1]).toBe(newSortBy.value);
+      expect(spy.lastCall.args[1]).toBe(newSortBy);
     });
 
     it('handleKeyPress', () => {

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -97,6 +97,12 @@ const StyledSelect = styled(AntdSelect, {
     && .ant-select-selector {
       border-radius: ${theme.gridUnit}px;
     }
+
+    // Open the dropdown when clicking on the suffix
+    // This is fixed in version 4.16
+    .ant-select-arrow .anticon:not(.ant-select-suffix) {
+      pointer-events: none;
+    }
   `}
 `;
 

--- a/superset-frontend/src/dashboard/components/SliceAdder.jsx
+++ b/superset-frontend/src/dashboard/components/SliceAdder.jsx
@@ -23,7 +23,7 @@ import { List } from 'react-virtualized';
 import { createFilter } from 'react-search-input';
 import { t, styled } from '@superset-ui/core';
 import { Input } from 'src/common/components';
-import Select from 'src/components/Select';
+import { Select } from 'src/components';
 import Loading from 'src/components/Loading';
 import {
   CHART_TYPE,
@@ -168,8 +168,7 @@ class SliceAdder extends React.Component {
     }));
   }
 
-  handleSelect(object) {
-    const sortBy = object.value;
+  handleSelect(sortBy) {
     this.setState(prevState => ({
       sortBy,
       filteredSlices: this.getFilteredSortedSlices(


### PR DESCRIPTION
### SUMMARY
Fixes https://github.com/apache/superset/issues/14799

@junlincc @jinghua-qa

### AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/126987492-a368a5fd-c51f-4fba-8477-3adcbe62a16f.mov

### TESTING INSTRUCTIONS
See the original issue for instructions.

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
