### PR TITLE
fix: Download as image of dashboard chart did not work

### DIFF
--- a/superset-frontend/src/utils/downloadAsImage.ts
+++ b/superset-frontend/src/utils/downloadAsImage.ts
@@ -64,15 +64,23 @@ export default function downloadAsImage(
       );
     }
 
+    // Mapbox controls are loaded from different origin, causing CORS error
+    // See https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL#exceptions
+    const filter = (node: Element) => {
+      if (typeof node.className === 'string') {
+        return (
+          node.className !== 'mapboxgl-control-container' &&
+          !node.className.includes('ant-dropdown')
+        );
+      }
+      return true;
+    };
+
     return domToImage
       .toJpeg(elementToPrint, {
         quality: 0.95,
         bgcolor: GRAY_BACKGROUND_COLOR,
-        // Mapbox controls are loaded from different origin, causing CORS error
-        // See https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL#exceptions
-        filter: (node: Element) =>
-          node.className !== 'mapboxgl-control-container',
-        ...domToImageOptions,
+        filter,
       })
       .then(dataUrl => {
         const link = document.createElement('a');


### PR DESCRIPTION
### SUMMARY
Fixes https://github.com/apache/superset/issues/15872

@junlincc @jinghua-qa

### AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/127008106-8580ded6-957a-471e-8b72-98bf789a1480.mp4

### TESTING INSTRUCTIONS
Check the original issue for instructions.

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
