### PR TITLE
docs: Slack integration requires "chat:write" permissions scope

### DIFF
--- a/docs/src/pages/docs/installation/alerts_reports.mdx
+++ b/docs/src/pages/docs/installation/alerts_reports.mdx
@@ -38,6 +38,7 @@ To send alerts and reports to Slack channels, you need to create a new Slack App
 3. Go to "OAuth & Permissions" section, and give the following scopes to your app:
     - `incoming-webhook`
     - `files:write`
+    - `chat:write`
 4. At the top of the "OAuth and Permissions" section, click "install to workspace".
 5. Select a default channel for your app and continue.
 (You can post to any channel by inviting your Superset app into that channel).


### PR DESCRIPTION
### SUMMARY

Slack requires `chat:write` as part of "OAuth & Permissions" for the slack integration to be able to post messages.
If the mentioned scope is not defined, one will receive following error from Slack API

```
Error: The request to the Slack API failed. The server responded with: {'ok': False, 'error': 'missing_scope', 'needed': 'chat:write:bot', 'provided': 'incoming-webhook,files:write'}
```

### TESTING INSTRUCTIONS

_**To reproduce the problem**_
1. Add slack integration as per current instructions
2. Invite the app to the target slack channel
3. Schedule an alert to be posted on specific channel
4. Error. `The request to the Slack API failed. The server responded with: {'ok': False, 'error': 'missing_scope', 'needed': 'chat:write:bot', 'provided': 'incoming-webhook,files:write'}`

_**Testing the fix**_
1. Add slack integration as per current instructions, if already done, then skip to next step
2. Add additional scope `chat:write`
3. If step 2 was done after initial installation of slack app, then reinstall the slack app on workspace
5. Invite the app to the target slack channel
6. Schedule an alert to be posted on specific channel
7. Message is posted as expected

### ADDITIONAL INFORMATION
- [x] Has associated issue: https://github.com/apache/superset/issues/15903