### PR TITLE
[DISCUSS] - Moves the SQL Lab menu before Charts

### DIFF
--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -245,6 +245,30 @@ class SupersetAppInitializer:
             category_icon="fa-table",
         )
         appbuilder.add_separator("Data")
+        appbuilder.add_link(
+            "SQL Editor",
+            label=_("SQL Editor"),
+            href="/superset/sqllab/",
+            category_icon="fa-flask",
+            icon="fa-flask",
+            category="SQL Lab",
+            category_label=__("SQL Lab"),
+        )
+        appbuilder.add_link(
+            __("Saved Queries"),
+            href="/savedqueryview/list/",
+            icon="fa-save",
+            category="SQL Lab",
+        )
+        appbuilder.add_link(
+            "Query Search",
+            label=_("Query History"),
+            href="/superset/sqllab/history/",
+            icon="fa-search",
+            category_icon="fa-flask",
+            category="SQL Lab",
+            category_label=__("SQL Lab"),
+        )
         appbuilder.add_view(
             SliceModelView,
             "Charts",
@@ -332,30 +356,6 @@ class SupersetAppInitializer:
             cond=lambda: not feature_flag_manager.is_feature_enabled(
                 "VERSIONED_EXPORT"
             ),
-        )
-        appbuilder.add_link(
-            "SQL Editor",
-            label=_("SQL Editor"),
-            href="/superset/sqllab/",
-            category_icon="fa-flask",
-            icon="fa-flask",
-            category="SQL Lab",
-            category_label=__("SQL Lab"),
-        )
-        appbuilder.add_link(
-            __("Saved Queries"),
-            href="/savedqueryview/list/",
-            icon="fa-save",
-            category="SQL Lab",
-        )
-        appbuilder.add_link(
-            "Query Search",
-            label=_("Query History"),
-            href="/superset/sqllab/history/",
-            icon="fa-search",
-            category_icon="fa-flask",
-            category="SQL Lab",
-            category_label=__("SQL Lab"),
         )
         appbuilder.add_link(
             "Upload a CSV",


### PR DESCRIPTION
### SUMMARY
Moves the SQL Lab menu before Charts to make it workflow-oriented. Generally, the most common workflow is:
1. to connect with database in Data, Persona: Data scientist. 
2. to explore raw data, cleanup and restructure data if needed, prepare data for exploration by creating virtual datasets in SQL Lab, etc, Persona: Data scientist 
3. to explore, slice, and dice data, and to create charts for a dashboard in Explore(Chart); Persona: Data analyst
4. to view and edit dashboard in Dashboard Persona: Business analyst/business users.

The other possibility is to reorder the objects by usage, and the order would be the opposite. Dashboards -> Charts -> SQL Lab -> Data. This argument may seem counterintuitive to DS, as DS spends the majority of their time handling data. But the number of dashboard consumers is way larger than dashboard creators in large enterprises.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="495" alt="Screen Shot 2021-07-27 at 1 53 24 PM" src="https://user-images.githubusercontent.com/70410625/127211943-d3dfe888-f62e-4fe4-896c-6e035e2aac06.png">

<img width="491" alt="Screen Shot 2021-07-27 at 3 56 43 PM" src="https://user-images.githubusercontent.com/70410625/127211964-30b3ab79-79c8-46ed-8ca6-3d796c1e3d77.png">

@junlincc @rusackas 

### TESTING INSTRUCTIONS
- Login to Superset
- Check the main menu

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
