### PR TITLE
fix: Keep chosen columns sort option when changing a column

### DIFF
--- a/superset-frontend/src/CRUD/CollectionTable.tsx
+++ b/superset-frontend/src/CRUD/CollectionTable.tsx
@@ -168,10 +168,7 @@ export default class CRUDCollection extends React.PureComponent<
       if (!newItem.id) {
         newItem = { ...newItem, id: shortid.generate() };
       }
-      this.changeCollection({
-        ...this.state.collection,
-        [newItem.id]: newItem,
-      });
+      this.changeCollection(this.state.collection, newItem);
     }
   }
 
@@ -192,12 +189,17 @@ export default class CRUDCollection extends React.PureComponent<
     return label;
   }
 
-  changeCollection(collection: any) {
+  changeCollection(collection: any, newItem?: object) {
     this.setState({ collection });
     if (this.props.onChange) {
       const collectionArray = this.state.collectionArray
         .map((c: { id: number }) => collection[c.id])
+        // filter out removed items
         .filter(c => c !== undefined);
+
+      if (newItem) {
+        collectionArray.unshift(newItem);
+      }
       this.props.onChange(collectionArray);
     }
   }


### PR DESCRIPTION
### SUMMARY
This PR keeps the existing columns sort option while the user makes changes to the columns. Previously the sort order was not kept.

Fixes: #15842

### BEFORE
https://user-images.githubusercontent.com/60598000/127232222-d7b090fe-7ba2-4885-8105-99409a65d495.mov

### AFTER

https://user-images.githubusercontent.com/60598000/127232465-59ad1f0f-471a-4ab7-9080-d2dbc2125948.mp4

### TESTING INSTRUCTIONS
1. Open a Chart in Explore
2. Edit the Dataset
3. Go to Columns
4. Check a column as Temporal, 
5. The order of columns should remain the same after the box is checked

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #15842
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
