### PR TITLE
feat: add timezone selector to alerts and reports

### DIFF
--- a/superset-frontend/src/components/CronPicker/CronPicker.tsx
+++ b/superset-frontend/src/components/CronPicker/CronPicker.tsx
@@ -31,7 +31,7 @@ export const LOCALE: Locale = {
   emptyWeekDays: t('every day of the week'),
   emptyWeekDaysShort: t('day of the week'),
   emptyHours: t('every hour'),
-  emptyMinutes: t('every minute UTC'),
+  emptyMinutes: t('every minute'),
   emptyMinutesForHourPeriod: t('every'),
   yearOption: t('year'),
   monthOption: t('month'),
@@ -48,7 +48,7 @@ export const LOCALE: Locale = {
   prefixHours: t('at'),
   prefixMinutes: t(':'),
   prefixMinutesForHourPeriod: t('at'),
-  suffixMinutesForHourPeriod: t('minute(s) UTC'),
+  suffixMinutesForHourPeriod: t('minute(s)'),
   errorInvalidCron: t('Invalid cron expression'),
   clearButtonText: t('Clear'),
   weekDays: [

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.test.jsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.test.jsx
@@ -226,12 +226,12 @@ describe('AlertReportModal', () => {
     expect(input.props().value).toEqual('SELECT NaN');
   });
 
-  it('renders one select element when in report mode', () => {
+  it('renders two select element when in report mode', () => {
     expect(wrapper.find(Select)).toExist();
-    expect(wrapper.find(Select)).toHaveLength(1);
+    expect(wrapper.find(Select)).toHaveLength(2);
   });
 
-  it('renders two select elements when in alert mode', async () => {
+  it('renders three select elements when in alert mode', async () => {
     const props = {
       ...mockedProps,
       isReport: false,
@@ -240,7 +240,7 @@ describe('AlertReportModal', () => {
     const addWrapper = await mountAndWait(props);
 
     expect(addWrapper.find(Select)).toExist();
-    expect(addWrapper.find(Select)).toHaveLength(2);
+    expect(addWrapper.find(Select)).toHaveLength(3);
   });
 
   it('renders value input element when in alert mode', async () => {

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -30,6 +30,7 @@ import { useSingleViewResource } from 'src/views/CRUD/hooks';
 import Icons from 'src/components/Icons';
 import { Switch } from 'src/components/Switch';
 import Modal from 'src/components/Modal';
+import TimezoneSelector from 'src/components/TimezoneSelector';
 import { Radio } from 'src/components/Radio';
 import { AsyncSelect, NativeGraySelect as Select } from 'src/components/Select';
 import { FeatureFlag, isFeatureEnabled } from 'src/featureFlags';
@@ -308,6 +309,7 @@ export const StyledInputContainer = styled.div`
     border-style: none;
     border: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
     border-radius: ${({ theme }) => theme.gridUnit}px;
+    width: 425px;
 
     .ant-select-selection-placeholder,
     .ant-select-selection-item {
@@ -350,6 +352,10 @@ const StyledNotificationAddButton = styled.div`
     color: ${({ theme }) => theme.colors.grayscale.light1};
     cursor: default;
   }
+`;
+
+const timezoneHeaderStyle = (theme: SupersetTheme) => css`
+  margin: ${theme.gridUnit * 3}px 0;
 `;
 
 type NotificationAddStatus = 'active' | 'disabled' | 'hidden';
@@ -806,6 +812,10 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
     updateAlertState('log_retention', retention);
   };
 
+  const onTimezoneChange = (timezone: string) => {
+    updateAlertState('timezone', timezone);
+  };
+
   const onContentTypeChange = (event: any) => {
     const { target } = event;
 
@@ -868,10 +878,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
   useEffect(() => {
     if (
       isEditMode &&
-      (!currentAlert ||
-        !currentAlert.id ||
-        (alert && alert.id !== currentAlert.id) ||
-        (isHidden && show))
+      (!currentAlert?.id || alert?.id !== currentAlert.id || (isHidden && show))
     ) {
       if (alert && alert.id !== null && !loading && !fetchError) {
         const id = alert.id || 0;
@@ -1085,7 +1092,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                   <AsyncSelect
                     name="source"
                     value={
-                      currentAlert && currentAlert.database
+                      currentAlert?.database
                         ? {
                             value: currentAlert.database.value,
                             label: currentAlert.database.label,
@@ -1176,11 +1183,19 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
               <span className="required">*</span>
             </StyledSectionTitle>
             <AlertReportCronScheduler
-              value={
-                (currentAlert && currentAlert.crontab) || DEFAULT_CRON_VALUE
-              }
+              value={currentAlert?.crontab || DEFAULT_CRON_VALUE}
               onChange={newVal => updateAlertState('crontab', newVal)}
             />
+            <div className="control-label">{t('Timezone')}</div>
+            <div
+              className="input-container"
+              css={(theme: SupersetTheme) => timezoneHeaderStyle(theme)}
+            >
+              <TimezoneSelector
+                onTimezoneChange={onTimezoneChange}
+                timezone={currentAlert?.timezone}
+              />
+            </div>
             <StyledSectionTitle>
               <h4>{t('Schedule settings')}</h4>
             </StyledSectionTitle>

--- a/superset-frontend/src/views/CRUD/alert/types.ts
+++ b/superset-frontend/src/views/CRUD/alert/types.ts
@@ -73,6 +73,7 @@ export type AlertObject = {
   name?: string;
   owners?: Array<Owner | MetaObject>;
   sql?: string;
+  timezone?: string;
   recipients?: Array<Recipient>;
   report_format?: 'PNG' | 'CSV';
   type?: string;


### PR DESCRIPTION
### SUMMARY
This PR adds a timezone selector to alerts and reports, allowing users to have a more intuitive experience as to when the reports will be triggered. The page will "guess" at the user's location/timezone and pre-populate the dropdown with that zone, or preload with the saved value on edit. Users can edit the timezone. 


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![_DEV__Superset](https://user-images.githubusercontent.com/5186919/127243976-dcca920d-ee40-4cea-a7eb-36954225bb32.png)


### TESTING INSTRUCTIONS
Go to a new alert/report or edit an existing one. Select a timezone and save the alert/report. The alert/report should fire at that timezone and not UTC (unless UTC is selected).



### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
