### PR TITLE
fix(dashboard): check dashboard id before calling redux methods

### DIFF
--- a/superset-frontend/src/dashboard/components/Dashboard.jsx
+++ b/superset-frontend/src/dashboard/components/Dashboard.jsx
@@ -133,6 +133,7 @@ class Dashboard extends React.PureComponent {
     const nextChartIds = getChartIdsFromLayout(nextProps.layout);
 
     if (this.props.dashboardInfo.id !== nextProps.dashboardInfo.id) {
+      // single-page-app navigation check
       return;
     }
 

--- a/superset-frontend/src/dashboard/components/Dashboard.jsx
+++ b/superset-frontend/src/dashboard/components/Dashboard.jsx
@@ -132,6 +132,10 @@ class Dashboard extends React.PureComponent {
     const currentChartIds = getChartIdsFromLayout(this.props.layout);
     const nextChartIds = getChartIdsFromLayout(nextProps.layout);
 
+    if (this.props.dashboardInfo.id !== nextProps.dashboardInfo.id) {
+      return;
+    }
+
     if (currentChartIds.length < nextChartIds.length) {
       const newChartIds = nextChartIds.filter(
         key => currentChartIds.indexOf(key) === -1,


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes an issue caused by dashboards using `UNSAFE_componentWillReceiveProps` to make changes in redux. When switching dashboards via SPA, this check doesn't work. Need to check the dashboard id.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Go to the Birth Names dashboard, then navigate to the World Health dashboard. A warning toast should not pop up.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
