### PR TITLE
fix: Cancel alert is not appearing to all native filters modal fields

### DIFF
--- a/superset-frontend/spec/javascripts/dashboard/components/nativeFilters/NativeFiltersModal_spec.tsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/nativeFilters/NativeFiltersModal_spec.tsx
@@ -119,22 +119,12 @@ describe('FiltersConfigModal', () => {
       expect(onCancel.mock.calls).toHaveLength(1);
     });
 
-    it('shows correct alert message for an unsaved filter', async () => {
+    it('shows correct alert message for unsaved filters', async () => {
       addFilter();
       await clickCancel();
       expect(onCancel.mock.calls).toHaveLength(0);
       expect(wrapper.find(Alert).text()).toContain(
-        'Are you sure you want to cancel? "New filter" will not be saved.',
-      );
-    });
-
-    it('shows correct alert message for 2 unsaved filters', async () => {
-      addFilter();
-      addFilter();
-      await clickCancel();
-      expect(onCancel.mock.calls).toHaveLength(0);
-      expect(wrapper.find(Alert).text()).toContain(
-        'Are you sure you want to cancel? "New filter" and "New filter" will not be saved.',
+        'There are unsaved changes.',
       );
     });
   });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
@@ -171,7 +171,7 @@ export function FiltersConfigModal({
     setCurrentFilterId(initialCurrentFilterId);
     setRemovedFilters({});
     setSaveAlertVisible(false);
-    setFormValues({ filters: {} });
+    setFormValues({ filters: {}, changed: false });
   };
 
   const getFilterTitle = (id: string) =>
@@ -212,6 +212,7 @@ export function FiltersConfigModal({
         onSave,
         values,
       )();
+      resetForm();
     } else {
       configFormRef.current.changeTab('configuration');
     }
@@ -223,7 +224,8 @@ export function FiltersConfigModal({
   };
 
   const handleCancel = () => {
-    if (unsavedFiltersIds.length > 0) {
+    const changed = form.getFieldValue('changed');
+    if (unsavedFiltersIds.length > 0 || form.isFieldsTouched() || changed) {
       setSaveAlertVisible(true);
     } else {
       handleConfirmCancel();
@@ -245,10 +247,8 @@ export function FiltersConfigModal({
         <Footer
           onDismiss={() => setSaveAlertVisible(false)}
           onCancel={handleCancel}
-          getFilterTitle={getFilterTitle}
           handleSave={handleSave}
           saveAlertVisible={saveAlertVisible}
-          unsavedFiltersIds={unsavedFiltersIds}
           onConfirmCancel={handleConfirmCancel}
         />
       }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/Footer/Footer.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/Footer/Footer.tsx
@@ -27,8 +27,6 @@ type FooterProps = {
   onConfirmCancel: OnClickHandler;
   onDismiss: OnClickHandler;
   saveAlertVisible: boolean;
-  getFilterTitle: (id: string) => string;
-  unsavedFiltersIds: string[];
 };
 
 const Footer: FC<FooterProps> = ({
@@ -36,38 +34,17 @@ const Footer: FC<FooterProps> = ({
   handleSave,
   onDismiss,
   onConfirmCancel,
-  getFilterTitle,
-  unsavedFiltersIds,
   saveAlertVisible,
 }) => {
-  const getUnsavedFilterNames = (): string => {
-    const unsavedFiltersNames = unsavedFiltersIds.map(
-      id => `"${getFilterTitle(id)}"`,
-    );
-
-    if (unsavedFiltersNames.length === 0) {
-      return '';
-    }
-
-    if (unsavedFiltersNames.length === 1) {
-      return unsavedFiltersNames[0];
-    }
-
-    const lastFilter = unsavedFiltersNames.pop();
-
-    return `${unsavedFiltersNames.join(', ')} ${t('and')} ${lastFilter}`;
-  };
-
   if (saveAlertVisible) {
     return (
       <CancelConfirmationAlert
         key="cancel-confirm"
-        title={`${unsavedFiltersIds.length} ${t('unsaved filters')}`}
+        title={t('There are unsaved changes.')}
         onConfirm={onConfirmCancel}
         onDismiss={onDismiss}
       >
-        {t(`Are you sure you want to cancel?`)} {getUnsavedFilterNames()}{' '}
-        {t(`will not be saved.`)}
+        {t(`Are you sure you want to cancel?`)}
       </CancelConfirmationAlert>
     );
   }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/types.ts
@@ -48,6 +48,7 @@ export interface NativeFiltersFormItem {
 
 export interface NativeFiltersForm {
   filters: Record<string, NativeFiltersFormItem>;
+  changed?: boolean;
 }
 
 export type FilterRemoval =


### PR DESCRIPTION
### SUMMARY
Monitors changes to all fields of the native filters modal. Previously, the cancel alert was not shown when some fields changed.

@junlincc @jinghua-qa @adam-stasiak 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/127343289-ed972bf9-cdb3-4093-a2bd-94b7576d6ad6.mp4

https://user-images.githubusercontent.com/70410625/127343173-8e007962-30ac-4482-8e2d-539ffa6b7809.mp4

### TESTING INSTRUCTIONS
- Go to the native filters modal
- Create, edit, delete filters
- Check if the cancel alert is displayed consistently

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
