### PR TITLE
chore: Bump Celery to 5.1.2

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -23,6 +23,8 @@ This file documents any backwards-incompatible changes in Superset and
 assists people when migrating to a new version.
 
 ## Next
+- [15927](https://github.com/apache/superset/pull/15927): Upgrades Celery to 5.x. Per the [upgrading](https://docs.celeryproject.org/en/stable/history/whatsnew-5.0.html#upgrading-from-celery-4-x) instructions Celery 5.0 introduces a new CLI implementation which is not completely backwards compatible. Please ensure global options are positioned before the sub-command.
+
 - [13772](https://github.com/apache/superset/pull/13772): Row level security (RLS) is now enabled by default. To activate the feature, please run `superset init` to expose the RLS menus to Admin users.
 
 - [13980](https://github.com/apache/superset/pull/13980): Data health checks no longer use the metadata database as an interim cache. Though non-breaking, deployments which implement complex logic should likely memoize the callback function. Refer to documentation in the confg.py file for more detail.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ aiohttp==3.7.2
     # via slackclient
 alembic==1.4.3
     # via flask-migrate
-amqp==2.6.1
+amqp==5.0.6
     # via kombu
 apispec[yaml]==3.3.2
     # via flask-appbuilder
@@ -25,7 +25,7 @@ babel==2.8.0
     # via flask-babel
 backoff==1.10.0
     # via apache-superset
-billiard==3.6.3.0
+billiard==3.6.4.0
     # via celery
 bleach==3.3.0
     # via apache-superset
@@ -33,7 +33,7 @@ brotli==1.0.9
     # via flask-compress
 cachelib==0.1.1
     # via apache-superset
-celery==4.4.7
+celery==5.1.2
     # via apache-superset
 cffi==1.14.3
     # via cryptography
@@ -42,8 +42,18 @@ chardet==3.0.4
 click==7.1.2
     # via
     #   apache-superset
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
     #   flask
     #   flask-appbuilder
+click-didyoumean==0.0.3
+    # via celery
+click-plugins==1.1.1
+    # via celery
+click-repl==0.2.0
+    # via celery
 colorama==0.4.4
     # via
     #   apache-superset
@@ -132,7 +142,7 @@ jinja2==2.11.3
     #   flask-babel
 jsonschema==3.2.0
     # via flask-appbuilder
-kombu==4.6.11
+kombu==5.1.0
     # via celery
 korean-lunar-calendar==0.2.1
     # via holidays
@@ -180,6 +190,8 @@ polyline==1.4.0
     # via apache-superset
 prison==0.1.3
     # via flask-appbuilder
+prompt-toolkit==3.0.19
+    # via click-repl
 pyarrow==4.0.1
     # via apache-superset
 pycparser==2.20
@@ -235,6 +247,7 @@ simplejson==3.17.2
 six==1.15.0
     # via
     #   bleach
+    #   click-repl
     #   cryptography
     #   flask-jwt-extended
     #   flask-talisman
@@ -270,10 +283,13 @@ typing-extensions==3.7.4.3
     #   apache-superset
 urllib3==1.25.11
     # via selenium
-vine==1.3.0
+vine==5.0.0
     # via
     #   amqp
     #   celery
+    #   kombu
+wcwidth==0.2.5
+    # via prompt-toolkit
 webencodings==0.5.1
     # via bleach
 werkzeug==1.0.1

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -53,8 +53,6 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-prompt-toolkit==3.0.8
-    # via ipython
 ptyprocess==0.6.0
     # via pexpect
 pyfakefs==4.4.0
@@ -80,8 +78,6 @@ statsd==3.3.0
     # via -r requirements/testing.in
 traitlets==5.0.5
     # via ipython
-wcwidth==0.2.5
-    # via prompt-toolkit
 websocket-client==0.57.0
     # via docker
 

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         "backoff>=1.8.0",
         "bleach>=3.0.2, <4.0.0",
         "cachelib>=0.1.1,<0.2",
-        "celery>=4.3.0, <5.0.0, !=4.4.1",
+        "celery>=5.0.0, <6.0.0",
         "click<8",
         "colorama",
         "croniter>=0.3.28",


### PR DESCRIPTION
### SUMMARY

At Airbnb we're testing using the `celery beat` command for dedicated reporting. The issue we're running into is the  application fails to beat after a period of time. Though there is no guarantee that this is an issue with Celery, I thought it was at least prudent to bump Celery as per the [release history](https://pypi.org/project/celery/#history) we're at least 12 months behind the latest release. 

### TESTING INSTRUCTIONS

CI and verified that our docs, scripts, etc. have [Celery 5.x compliant](https://docs.celeryproject.org/en/stable/history/whatsnew-5.0.html#step-1-adjust-your-command-line-invocation) CLI commands.  

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
