### PR TITLE
chore: Changes the main menu order as defined in SIP-34

### DIFF
--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -227,37 +227,18 @@ class SupersetAppInitializer:
             category_icon="",
         )
         appbuilder.add_view(
-            DatabaseView,
-            "Databases",
-            label=__("Databases"),
-            icon="fa-database",
-            category="Data",
-            category_label=__("Data"),
-            category_icon="fa-database",
+            DashboardModelView,
+            "Dashboards",
+            label=__("Dashboards"),
+            icon="fa-dashboard",
+            category="",
+            category_icon="",
         )
-        appbuilder.add_link(
-            "Datasets",
-            label=__("Datasets"),
-            href="/tablemodelview/list/",
-            icon="fa-table",
-            category="Data",
-            category_label=__("Data"),
-            category_icon="fa-table",
-        )
-        appbuilder.add_separator("Data")
         appbuilder.add_view(
             SliceModelView,
             "Charts",
             label=__("Charts"),
             icon="fa-bar-chart",
-            category="",
-            category_icon="",
-        )
-        appbuilder.add_view(
-            DashboardModelView,
-            "Dashboards",
-            label=__("Dashboards"),
-            icon="fa-dashboard",
             category="",
             category_icon="",
         )
@@ -357,6 +338,25 @@ class SupersetAppInitializer:
             category="SQL Lab",
             category_label=__("SQL Lab"),
         )
+        appbuilder.add_view(
+            DatabaseView,
+            "Databases",
+            label=__("Databases"),
+            icon="fa-database",
+            category="Data",
+            category_label=__("Data"),
+            category_icon="fa-database",
+        )
+        appbuilder.add_link(
+            "Datasets",
+            label=__("Datasets"),
+            href="/tablemodelview/list/",
+            icon="fa-table",
+            category="Data",
+            category_label=__("Data"),
+            category_icon="fa-table",
+        )
+        appbuilder.add_separator("Data")
         appbuilder.add_link(
             "Upload a CSV",
             label=__("Upload a CSV"),


### PR DESCRIPTION
### SUMMARY
This PR is a follow-up of https://github.com/apache/superset/pull/15915 where we discussed the possibility of ordering the main menu items according to user workflows or usage. We decided to change the main menu order as defined in [SIP-34](https://github.com/apache/superset/issues/8976).

The order defined was Dashboards -> Charts -> SQL Lab -> Data as you can see in the following screenshot from [SIP-34](https://github.com/apache/superset/issues/8976):

![72392712-8a10f800-36e5-11ea-95a1-3d9c1b60719f](https://user-images.githubusercontent.com/70410625/127369817-7c931771-7df6-4d37-908d-57c28a7b9c6f.png)

Thanks @junlincc @ktmud @graceguo-supercat @john-bodley @srinify for the valuable discussion.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="495" alt="127211943-d3dfe888-f62e-4fe4-896c-6e035e2aac06" src="https://user-images.githubusercontent.com/70410625/127370147-829c6021-e5e5-4762-ae7c-32eb0db8792a.png">

<img width="521" alt="Screen Shot 2021-07-28 at 2 37 22 PM" src="https://user-images.githubusercontent.com/70410625/127370085-85ab3621-02e3-4cb6-acad-be9ca2bfe2dd.png">

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
