### PR TITLE
fix(dashboard): Show the filters popover behind the dashboard header when scrolling

### DIFF
--- a/superset-frontend/src/common/components/index.tsx
+++ b/superset-frontend/src/common/components/index.tsx
@@ -232,13 +232,11 @@ export const TextArea = styled(AntdInput.TextArea)`
   border-radius: ${({ theme }) => theme.borderRadius}px;
 `;
 
+// @z-index-below-dashboard-header (100) - 1 = 99
 export const NoAnimationDropdown = (
   props: DropDownProps & { children?: React.ReactNode },
 ) => (
-  <Dropdown
-    overlayStyle={{ zIndex: 4000, animationDuration: '0s' }}
-    {...props}
-  />
+  <Dropdown overlayStyle={{ zIndex: 99, animationDuration: '0s' }} {...props} />
 );
 
 export const ThinSkeleton = styled(Skeleton)`

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -19,7 +19,7 @@
 /* eslint-env browser */
 import cx from 'classnames';
 import React, { FC } from 'react';
-import { JsonObject, styled } from '@superset-ui/core';
+import { JsonObject, styled, css } from '@superset-ui/core';
 import ErrorBoundary from 'src/components/ErrorBoundary';
 import BuilderComponentPane from 'src/dashboard/components/BuilderComponentPane';
 import DashboardHeader from 'src/dashboard/containers/DashboardHeader';
@@ -48,6 +48,7 @@ import {
 } from 'src/dashboard/util/constants';
 import FilterBar from 'src/dashboard/components/nativeFilters/FilterBar';
 import Loading from 'src/components/Loading';
+import { Global } from '@emotion/react';
 import { shouldFocusTabs, getRootLevelTabsComponent } from './utils';
 import DashboardContainer from './DashboardContainer';
 import { useNativeFilters } from './state';
@@ -284,6 +285,13 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
         </DragDroppable>
       </StyledHeader>
       <StyledContent fullSizeChartId={fullSizeChartId}>
+        <Global
+          styles={css`
+            // @z-index-above-dashboard-header (100) + 1 = 101
+            ${fullSizeChartId &&
+            `div > .filterStatusPopover.ant-popover{z-index: 101}`}
+          `}
+        />
         <div
           data-test="dashboard-content"
           className={cx('dashboard', editMode && 'dashboard--editing')}

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -83,13 +83,13 @@ const StickyPanel = styled.div<{ width: number }>`
   flex: 0 0 ${({ width }) => width}px;
 `;
 
-// @z-index-above-dashboard-charts + 1 = 11
+// @z-index-above-dashboard-popovers (99) + 1 = 100
 const StyledHeader = styled.div`
   grid-column: 2;
   grid-row: 1;
   position: sticky;
   top: 0px;
-  z-index: 11;
+  z-index: 100;
 `;
 
 const StyledContent = styled.div<{
@@ -97,7 +97,8 @@ const StyledContent = styled.div<{
 }>`
   grid-column: 2;
   grid-row: 2;
-  ${({ fullSizeChartId }) => fullSizeChartId && `z-index: 1000;`}
+  // @z-index-above-dashboard-header (100) + 1 = 101
+  ${({ fullSizeChartId }) => fullSizeChartId && `z-index: 101;`}
 `;
 
 const StyledDashboardContent = styled.div<{


### PR DESCRIPTION
### SUMMARY
This PR fixes the z-index of the dashboard header to make sure that the Filters Popover does not show over the Dashboard header.

Fixes: #15873

### BEFORE
<img width="1490" alt="Screen Shot 2021-07-23 at 11 06 09 AM" src="https://user-images.githubusercontent.com/81597121/126823332-4bb59efa-6f48-4f86-9735-b4eb2d678e91.png">

<img width="1672" alt="Screen Shot 2021-07-28 at 23 18 47" src="https://user-images.githubusercontent.com/60598000/127397454-2dd0ff56-0f71-477f-96a8-06c33568e740.png">

### AFTER

https://user-images.githubusercontent.com/60598000/127392326-1514fc13-2b79-4632-83d6-6833ffbac9e6.mp4

### TESTING INSTRUCTIONS
1. Open a dashboard
2. Open the filters of a chart
3. Scroll down
4. Make sure the filters popover does not appear over the dashboard header

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #15873
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
