### PR TITLE
feat: Add disable functionality to "Add Report" button

### DIFF
--- a/superset-frontend/src/components/ReportModal/EmailReportModal.test.jsx
+++ b/superset-frontend/src/components/ReportModal/EmailReportModal.test.jsx
@@ -18,18 +18,12 @@
  */
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import {
-  render,
-  screen,
-  // within,
-  // cleanup,
-  // act,
-} from 'spec/helpers/testing-library';
+import { render, screen } from 'spec/helpers/testing-library';
 import ReportModal from '.';
 
 describe('Email Report Modal', () => {
   it('inputs respond correctly', () => {
-    render(<ReportModal show />);
+    render(<ReportModal show />, { useRedux: true });
 
     // ----- Report name textbox
     // Initial value

--- a/superset-frontend/src/components/ReportModal/index.tsx
+++ b/superset-frontend/src/components/ReportModal/index.tsx
@@ -43,6 +43,7 @@ import {
   StyledCronError,
   noBottomMargin,
   StyledFooterButton,
+  timezoneHeaderStyle,
 } from './styles';
 
 interface ReportObject {
@@ -199,7 +200,12 @@ const ReportModal: FunctionComponent<ReportProps> = ({
       <StyledFooterButton key="back" onClick={onClose}>
         Cancel
       </StyledFooterButton>
-      <StyledFooterButton key="submit" buttonStyle="primary" onClick={onSave}>
+      <StyledFooterButton
+        key="submit"
+        buttonStyle="primary"
+        onClick={onSave}
+        disabled={!currentReport?.name}
+      >
         Add
       </StyledFooterButton>
     </>
@@ -218,7 +224,8 @@ const ReportModal: FunctionComponent<ReportProps> = ({
         <LabeledErrorBoundInput
           id="name"
           name="name"
-          value={currentReport?.name || 'Weekly Report'}
+          value={currentReport?.name || ''}
+          placeholder="Weekly Report"
           required
           validationMethods={{
             onChange: ({ target }: { target: HTMLInputElement }) =>
@@ -272,10 +279,7 @@ const ReportModal: FunctionComponent<ReportProps> = ({
           }}
           onError={setError}
         />
-        <div
-          className="control-label"
-          css={(theme: SupersetTheme) => timezoneHeaderStyle(theme)}
-        >
+        <div className="control-label" css={timezoneHeaderStyle}>
           {t('Timezone')}
         </div>
         <TimezoneSelector

--- a/superset-frontend/src/components/ReportModal/index.tsx
+++ b/superset-frontend/src/components/ReportModal/index.tsx
@@ -24,7 +24,7 @@ import React, {
   Reducer,
   FunctionComponent,
 } from 'react';
-import { styled, css, t, SupersetTheme } from '@superset-ui/core';
+import { t } from '@superset-ui/core';
 import { bindActionCreators } from 'redux';
 import { connect, useDispatch } from 'react-redux';
 import { addReport } from 'src/reports/actions/reportState';

--- a/superset-frontend/src/components/ReportModal/index.tsx
+++ b/superset-frontend/src/components/ReportModal/index.tsx
@@ -105,14 +105,15 @@ const reportReducer = (
   state: Partial<ReportObject> | null,
   action: ReportActionType,
 ): Partial<ReportObject> | null => {
-  const trimmedState = {
+  const initialState = {
+    name: state?.name || 'Weekly Report',
     ...(state || {}),
   };
 
   switch (action.type) {
     case ActionType.textChange:
       return {
-        ...trimmedState,
+        ...initialState,
         [action.payload.name]: action.payload.value,
       };
     default:
@@ -166,7 +167,7 @@ const ReportModal: FunctionComponent<ReportProps> = ({
       dashboard: props.props.dashboardId,
       chart: props.props.chartId,
       description: currentReport?.description,
-      name: currentReport?.name || 'Weekly Report',
+      name: currentReport?.name,
       owners: [props.props.userId],
       recipients: [
         {

--- a/superset-frontend/src/components/ReportModal/styles.tsx
+++ b/superset-frontend/src/components/ReportModal/styles.tsx
@@ -61,3 +61,7 @@ export const noBottomMargin = css`
 export const StyledFooterButton = styled(Button)`
   width: ${({ theme }) => theme.gridUnit * 40}px;
 `;
+
+export const timezoneHeaderStyle = css`
+  width: inherit;
+`;


### PR DESCRIPTION
### SUMMARY
This PR adds disable functionality to "Add Report" button when the "Report Name" field is empty.

### ANIMATED GIF
![disableBtnn](https://user-images.githubusercontent.com/55605634/127557659-3727a072-807e-4d11-a149-0157da1dd9ad.gif)

### TESTING INSTRUCTIONS
- Click "Dashboards" in the upper navigation bar
- Navigate to any Dashboard
- Click the Calendar icon button
	- Located at the top of the chart between the "Edit dashboard" and the "..." button
- Observe the disabled "Add Report" button
- Type into the "Report Name" field
- Observe as the "Add Report" button becomes enabled

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
