### PR TITLE
fix(dashboard): Add required message in the tooltip for the time range filter

### DIFF
--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -218,7 +218,7 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
         ) {
           setActualTimeRange(value);
           setTooltipTitle(
-            type === 'error'
+            type === ('error' as Type)
               ? t('Default value is required')
               : actualRange || '',
           );
@@ -230,7 +230,7 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
       }
       setLastFetchedTimeRange(value);
     });
-  }, [value, type]);
+  }, [value]);
 
   useDebouncedEffect(
     () => {

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -36,7 +36,7 @@ import {
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 import Button from 'src/components/Button';
 import ControlHeader from 'src/explore/components/ControlHeader';
-import Label from 'src/components/Label';
+import Label, { Type } from 'src/components/Label';
 import Popover from 'src/components/Popover';
 import { Divider } from 'src/common/components';
 import Icons from 'src/components/Icons';
@@ -172,6 +172,7 @@ interface DateFilterControlProps {
   onChange: (timeRange: string) => void;
   value?: string;
   endpoints?: TimeRangeEndpoints;
+  type?: Type;
 }
 
 export const DATE_FILTER_CONTROL_TEST_ID = 'date-filter-control';
@@ -180,7 +181,7 @@ export const getDateFilterControlTestId = testWithId(
 );
 
 export default function DateFilterLabel(props: DateFilterControlProps) {
-  const { value = DEFAULT_TIME_RANGE, endpoints, onChange } = props;
+  const { value = DEFAULT_TIME_RANGE, endpoints, onChange, type } = props;
   const [actualTimeRange, setActualTimeRange] = useState<string>(value);
 
   const [show, setShow] = useState<boolean>(false);
@@ -216,7 +217,11 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
           guessedFrame === 'No filter'
         ) {
           setActualTimeRange(value);
-          setTooltipTitle(actualRange || '');
+          setTooltipTitle(
+            type === 'error'
+              ? t('Default value is required')
+              : actualRange || '',
+          );
         } else {
           setActualTimeRange(actualRange || '');
           setTooltipTitle(value || '');
@@ -225,7 +230,7 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
       }
       setLastFetchedTimeRange(value);
     });
-  }, [value]);
+  }, [value, type]);
 
   useDebouncedEffect(
     () => {

--- a/superset-frontend/src/filters/components/Time/TimeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Time/TimeFilterPlugin.tsx
@@ -99,6 +99,7 @@ export default function TimeFilterPlugin(props: PluginFilterTimeProps) {
           value={filterState.value || NO_TIME_RANGE}
           name="time_range"
           onChange={handleTimeRangeChange}
+          type={filterState.validateStatus}
         />
       </ControlContainer>
     </TimeFilterStyles>

--- a/superset-frontend/src/filters/components/Time/TimeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Time/TimeFilterPlugin.tsx
@@ -31,7 +31,8 @@ const ControlContainer = styled.div<{
   validateStatus?: 'error' | 'warning' | 'info';
 }>`
   padding: 2px;
-  & > span {
+  & > span,
+  & > span:hover {
     border: 2px solid transparent;
     display: inline-block;
     border: ${({ theme, validateStatus }) =>


### PR DESCRIPTION
### SUMMARY
This PR adds a "Default value is required" message in the tooltip for a time range filter when a default value is required.

Fixes: #15375

### BEFORE
https://user-images.githubusercontent.com/81597121/123336949-6a494a80-d4fb-11eb-99db-ba0746353875.mov

### AFTER
<img width="1680" alt="Screen Shot 2021-07-29 at 11 31 14" src="https://user-images.githubusercontent.com/60598000/127468742-80846f60-25b1-40dc-8a7d-92f41aceeffc.png">

### TESTING INSTRUCTIONS
1. Create a time range filter with the 'Required ' option selected
2. Go to the dashboard and click ' Clear All'
3. Go with your mouse over the filter and check the message in the tooltip

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #15375
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
