### PR TITLE
fix: Drag inner tab to outer tab while editing a dashboard will show an error

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -244,7 +244,7 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
           onDrop={dropResult => dispatch(handleComponentDrop(dropResult))}
           editMode={editMode}
           // you cannot drop on/displace tabs if they already exist
-          disableDragdrop={!!topLevelTabs}
+          disableDragDrop={!!topLevelTabs}
           style={{
             marginLeft: dashboardFiltersOpen || editMode ? 0 : -32,
           }}

--- a/superset-frontend/src/dashboard/components/dnd/DragDroppable.jsx
+++ b/superset-frontend/src/dashboard/components/dnd/DragDroppable.jsx
@@ -37,7 +37,7 @@ const propTypes = {
   component: componentShape.isRequired,
   parentComponent: componentShape,
   depth: PropTypes.number.isRequired,
-  disableDragdrop: PropTypes.bool,
+  disableDragDrop: PropTypes.bool,
   orientation: PropTypes.oneOf(['row', 'column']),
   index: PropTypes.number.isRequired,
   style: PropTypes.object,
@@ -58,7 +58,7 @@ const defaultProps = {
   className: null,
   style: null,
   parentComponent: null,
-  disableDragdrop: false,
+  disableDragDrop: false,
   children() {},
   onDrop() {},
   orientation: 'row',
@@ -104,6 +104,7 @@ export class UnwrappedDragDroppable extends React.Component {
       className,
       orientation,
       dragSourceRef,
+      disableDragDrop,
       isDragging,
       isDraggingOver,
       style,
@@ -112,7 +113,7 @@ export class UnwrappedDragDroppable extends React.Component {
 
     const { dropIndicator } = this.state;
     const dropIndicatorProps =
-      isDraggingOver && dropIndicator
+      isDraggingOver && dropIndicator && !disableDragDrop
         ? {
             className: cx(
               'drop-indicator',

--- a/superset-frontend/src/dashboard/components/dnd/dragDroppableConfig.js
+++ b/superset-frontend/src/dashboard/components/dnd/dragDroppableConfig.js
@@ -54,6 +54,9 @@ export const dragConfig = [
 export const dropConfig = [
   TYPE,
   {
+    canDrop(props) {
+      return !props.disableDragDrop;
+    },
     hover(props, monitor, component) {
       if (component && component.mounted) {
         handleHover(props, monitor, component);

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -34,7 +34,7 @@ import getLeafComponentIdFromPath from '../../util/getLeafComponentIdFromPath';
 import { componentShape } from '../../util/propShapes';
 import { NEW_TAB_ID, DASHBOARD_ROOT_ID } from '../../util/constants';
 import { RENDER_TAB, RENDER_TAB_CONTENT } from './Tab';
-import { TAB_TYPE } from '../../util/componentTypes';
+import { TABS_TYPE, TAB_TYPE } from '../../util/componentTypes';
 
 const propTypes = {
   id: PropTypes.string.isRequired,
@@ -315,7 +315,11 @@ export class Tabs extends React.PureComponent {
         orientation="row"
         index={index}
         depth={depth}
-        onDrop={handleComponentDrop}
+        onDrop={dropResult => {
+          if (dropResult.dragging.type !== TABS_TYPE) {
+            handleComponentDrop(dropResult);
+          }
+        }}
         editMode={editMode}
       >
         {({


### PR DESCRIPTION
### SUMMARY
Fixes https://github.com/apache/superset/issues/15726

### AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/127516508-43fccacb-065c-4b83-9517-d5abb7003a44.mov

@junlincc @jinghua-qa

### TESTING INSTRUCTIONS
Check the original issue for instructions.

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
