### PR TITLE
fix: Name change is not lost in left side of modal when return to edition after aborting changes

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
@@ -171,6 +171,7 @@ export function FiltersConfigModal({
     setCurrentFilterId(initialCurrentFilterId);
     setRemovedFilters({});
     setSaveAlertVisible(false);
+    setFormValues({ filters: {} });
   };
 
   const getFilterTitle = (id: string) =>


### PR DESCRIPTION
### SUMMARY
Fixes https://github.com/apache/superset/issues/15684

PS: The cancel alert fix is here https://github.com/apache/superset/pull/15925

@junlincc @adam-stasiak 

### AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/127547291-5c11bde8-d3c8-4761-ba23-6f4cc9ea640c.mov

### TESTING INSTRUCTIONS
See the original issue for instructions.

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
