### PR TITLE
fix: downgrade pivot-table because of breaking changes

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -40,7 +40,7 @@
         "@superset-ui/legacy-preset-chart-deckgl": "^0.4.7",
         "@superset-ui/legacy-preset-chart-nvd3": "^0.17.74",
         "@superset-ui/plugin-chart-echarts": "^0.17.74",
-        "@superset-ui/plugin-chart-pivot-table": "^0.17.74",
+        "@superset-ui/plugin-chart-pivot-table": "^0.17.67",
         "@superset-ui/plugin-chart-table": "^0.17.74",
         "@superset-ui/plugin-chart-word-cloud": "^0.17.74",
         "@superset-ui/preset-chart-xy": "^0.17.74",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -92,7 +92,7 @@
     "@superset-ui/legacy-preset-chart-deckgl": "^0.4.7",
     "@superset-ui/legacy-preset-chart-nvd3": "^0.17.74",
     "@superset-ui/plugin-chart-echarts": "^0.17.74",
-    "@superset-ui/plugin-chart-pivot-table": "^0.17.74",
+    "@superset-ui/plugin-chart-pivot-table": "^0.17.67",
     "@superset-ui/plugin-chart-table": "^0.17.74",
     "@superset-ui/plugin-chart-word-cloud": "^0.17.74",
     "@superset-ui/preset-chart-xy": "^0.17.74",


### PR DESCRIPTION
### SUMMARY
I'm downgrading pivot-table back to version 0.17.67 because we have people using this visualization reporting breaking changes with conditional formatting from https://github.com/apache/superset/pull/15742 and superset-ui has been too active for me to fix forward in this case.

It seems as if there's still a lot of development on this visualization, however since it's not behind a feature flag we had people actively using it in production, and therefore need to prevent regressions here. I'm hoping that we can merge fixes into superset-ui and then upgrade back to a fully functional version that either migrates the old charts to use the new controls properly or fixes the regression. Thanks!

### TESTING INSTRUCTIONS
CI, use the test env

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: https://github.com/apache/superset/issues/15961
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @kgabryje @villebro 
cc: @graceguo-supercat @serenajiang @junlincc 