### PR TITLE
fix: remove erroneous behaviors from filter plugins

### DIFF
--- a/superset-frontend/src/filters/components/GroupBy/index.ts
+++ b/superset-frontend/src/filters/components/GroupBy/index.ts
@@ -27,7 +27,7 @@ export default class FilterGroupByPlugin extends ChartPlugin {
     const metadata = new ChartMetadata({
       name: t('Group By'),
       description: t('Group By filter plugin'),
-      behaviors: [Behavior.INTERACTIVE_CHART, Behavior.NATIVE_FILTER],
+      behaviors: [Behavior.NATIVE_FILTER],
       thumbnail,
     });
 

--- a/superset-frontend/src/filters/components/Range/index.ts
+++ b/superset-frontend/src/filters/components/Range/index.ts
@@ -27,7 +27,7 @@ export default class RangeFilterPlugin extends ChartPlugin {
     const metadata = new ChartMetadata({
       name: t('Range filter'),
       description: t('Range filter plugin using AntD'),
-      behaviors: [Behavior.INTERACTIVE_CHART, Behavior.NATIVE_FILTER],
+      behaviors: [Behavior.NATIVE_FILTER],
       thumbnail,
     });
 

--- a/superset-frontend/src/filters/components/Select/index.ts
+++ b/superset-frontend/src/filters/components/Select/index.ts
@@ -27,7 +27,7 @@ export default class FilterSelectPlugin extends ChartPlugin {
     const metadata = new ChartMetadata({
       name: t('Select filter'),
       description: t('Select filter plugin using AntD'),
-      behaviors: [Behavior.INTERACTIVE_CHART, Behavior.NATIVE_FILTER],
+      behaviors: [Behavior.NATIVE_FILTER],
       enableNoResults: false,
       thumbnail,
     });

--- a/superset-frontend/src/filters/components/Time/index.ts
+++ b/superset-frontend/src/filters/components/Time/index.ts
@@ -26,7 +26,7 @@ export default class TimeFilterPlugin extends ChartPlugin {
     const metadata = new ChartMetadata({
       name: t('Time filter'),
       description: t('Custom time filter plugin'),
-      behaviors: [Behavior.INTERACTIVE_CHART, Behavior.NATIVE_FILTER],
+      behaviors: [Behavior.NATIVE_FILTER],
       thumbnail,
       datasourceCount: 0,
     });

--- a/superset-frontend/src/filters/components/TimeColumn/index.ts
+++ b/superset-frontend/src/filters/components/TimeColumn/index.ts
@@ -27,7 +27,7 @@ export default class FilterTimeColumnPlugin extends ChartPlugin {
     const metadata = new ChartMetadata({
       name: t('Time column'),
       description: t('Time column filter plugin'),
-      behaviors: [Behavior.INTERACTIVE_CHART, Behavior.NATIVE_FILTER],
+      behaviors: [Behavior.NATIVE_FILTER],
       thumbnail,
     });
 

--- a/superset-frontend/src/filters/components/TimeGrain/index.ts
+++ b/superset-frontend/src/filters/components/TimeGrain/index.ts
@@ -27,7 +27,7 @@ export default class FilterTimeGrainPlugin extends ChartPlugin {
     const metadata = new ChartMetadata({
       name: t('Time grain'),
       description: t('Time grain filter plugin'),
-      behaviors: [Behavior.INTERACTIVE_CHART, Behavior.NATIVE_FILTER],
+      behaviors: [Behavior.NATIVE_FILTER],
       thumbnail,
     });
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Removes the filter value select plugins from the viz gallery - they were incorrectly listed as interactive charts.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #15850
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
