### PR TITLE
feat: Success toast added to report modal

### DIFF
--- a/superset-frontend/src/components/ReportModal/index.tsx
+++ b/superset-frontend/src/components/ReportModal/index.tsx
@@ -135,6 +135,7 @@ const reportReducer = (
 
 const ReportModal: FunctionComponent<ReportProps> = ({
   // addDangerToast,
+  addSuccessToast,
   onReportAdd,
   onHide,
   show = false,
@@ -169,6 +170,7 @@ const ReportModal: FunctionComponent<ReportProps> = ({
   const onClose = () => {
     // setLoading(false);
     onHide();
+    addSuccessToast(t('The report has been created'));
   };
   const onSave = async () => {
     // Create new Report

--- a/superset-frontend/src/components/ReportModal/index.tsx
+++ b/superset-frontend/src/components/ReportModal/index.tsx
@@ -134,8 +134,6 @@ const reportReducer = (
 };
 
 const ReportModal: FunctionComponent<ReportProps> = ({
-  // addDangerToast,
-  addSuccessToast,
   onReportAdd,
   onHide,
   show = false,
@@ -170,7 +168,6 @@ const ReportModal: FunctionComponent<ReportProps> = ({
   const onClose = () => {
     // setLoading(false);
     onHide();
-    addSuccessToast(t('The report has been created'));
   };
   const onSave = async () => {
     // Create new Report

--- a/superset-frontend/src/reports/actions/reports.js
+++ b/superset-frontend/src/reports/actions/reports.js
@@ -102,9 +102,9 @@ export const addReport = report => dispatch => {
     endpoint: `/api/v1/report/`,
     jsonPayload: report,
   })
-    .then(response => {
-      const { json } = response;
-      dispatch({ type: ADD_REPORT, json });
+    .then(() => {
+      dispatch({ type: ADD_REPORT, report });
+      dispatch(addSuccessToast(t('The report has been created')));
     })
     .catch(() =>
       dispatch(


### PR DESCRIPTION
### SUMMARY
Success toast now appears when report modal is created.

### TESTING INSTRUCTIONS
- Click "Dashboards" in the upper navigation bar
- Navigate to any Dashboard
- Click the Calendar icon button
	- Located at the top of the chart between the "Edit dashboard" and the "..." button
- Create a new report
- Observe the success toast

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
