### PR TITLE
fix: Sort Metrics by ID DESC (order of creation) in the Datasource Editor

### DIFF
--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -902,7 +902,7 @@ class DatasourceEditor extends React.PureComponent {
   renderMetricCollection() {
     const { datasource } = this.state;
     const { metrics } = datasource;
-    const sortedMetrics = this.sortMetrics(metrics);
+    const sortedMetrics = metrics?.length ? this.sortMetrics(metrics) : [];
 
     return (
       <CollectionTable
@@ -1036,7 +1036,7 @@ class DatasourceEditor extends React.PureComponent {
   render() {
     const { datasource, activeTabKey } = this.state;
     const { metrics } = datasource;
-    const sortedMetrics = this.sortMetrics(metrics);
+    const sortedMetrics = metrics?.length ? this.sortMetrics(metrics) : [];
 
     return (
       <DatasourceContainer>

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -557,6 +557,10 @@ class DatasourceEditor extends React.PureComponent {
     this.setState({ activeTabKey });
   }
 
+  sortMetrics(metrics) {
+    return metrics.sort(({ id: a }, { id: b }) => b - a);
+  }
+
   renderSettingsFieldset() {
     const { datasource } = this.state;
     return (
@@ -896,6 +900,10 @@ class DatasourceEditor extends React.PureComponent {
   }
 
   renderMetricCollection() {
+    const { datasource } = this.state;
+    const { metrics } = datasource;
+    const sortedMetrics = this.sortMetrics(metrics);
+
     return (
       <CollectionTable
         tableColumns={['metric_name', 'verbose_name', 'expression']}
@@ -969,7 +977,7 @@ class DatasourceEditor extends React.PureComponent {
             </Fieldset>
           </FormContainer>
         }
-        collection={this.state.datasource.metrics}
+        collection={sortedMetrics}
         allowAddItem
         onChange={this.onDatasourcePropChange.bind(this, 'metrics')}
         itemGenerator={() => ({
@@ -1027,6 +1035,9 @@ class DatasourceEditor extends React.PureComponent {
 
   render() {
     const { datasource, activeTabKey } = this.state;
+    const { metrics } = datasource;
+    const sortedMetrics = this.sortMetrics(metrics);
+
     return (
       <DatasourceContainer>
         {this.renderErrors()}
@@ -1056,7 +1067,7 @@ class DatasourceEditor extends React.PureComponent {
           <Tabs.TabPane
             tab={
               <CollectionTabTitle
-                collection={datasource.metrics}
+                collection={sortedMetrics}
                 title={t('Metrics')}
               />
             }


### PR DESCRIPTION
### SUMMARY
This PR changes the order of the Metrics in the Datasource Editor to show at the top the most recently created items.

Fixes: #12802

### BEFORE
https://user-images.githubusercontent.com/67837651/106104741-aff21a80-60f7-11eb-9f5d-4d874b1bd152.mov

### AFTER
https://user-images.githubusercontent.com/60598000/127626161-e2fe4319-1b54-4bc8-a82f-35036f016ff0.mp4

### TESTING INSTRUCTIONS
1. Go to Explore
2. Open the Edit Dataset modal
3. Go to metrics and add a new or update an existing one
4. Save
5. Open the Edit Dataset modal again and observe the order of the Metrics

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #12802
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
