### PR TITLE
fix: eliminate cartesian product columns in pivot operator

### DIFF
--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -269,12 +269,10 @@ def pivot(  # pylint: disable=too-many-arguments
     # https://github.com/apache/superset/issues/15956
     # https://github.com/pandas-dev/pandas/issues/18030
     series_set = set()
-    lst_to_str: Callable[[List[Any]], str] = lambda lst: "_".join(str(_) for _ in lst)
     if not drop_missing_columns and columns:
         for row in df[columns].itertuples():
-            metrics_and_series = list(aggfunc.keys()) + list(row[1:])
-            series_set.add(lst_to_str(metrics_and_series))
-
+            metrics_and_series = tuple(aggfunc.keys()) + tuple(row[1:])
+            series_set.add(str(metrics_and_series))
     df = df.pivot_table(
         values=aggfunc.keys(),
         index=index,
@@ -288,7 +286,7 @@ def pivot(  # pylint: disable=too-many-arguments
 
     if not drop_missing_columns and len(series_set) > 0 and not df.empty:
         for col in df.columns:
-            series = lst_to_str(col)
+            series = str(col)
             if series not in series_set:
                 df = df.drop(col, axis=PandasAxis.COLUMN)
 

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -264,6 +264,16 @@ def pivot(  # pylint: disable=too-many-arguments
     #  Remove once/if support is added.
     aggfunc = {na.column: na.aggfunc for na in aggregate_funcs.values()}
 
+    # When dropna = False, the pivot_table function will calculate cartesian-product
+    # for MultiIndex.
+    # https://github.com/apache/superset/issues/15956
+    # https://github.com/pandas-dev/pandas/issues/18030
+    series_set = set()
+    if not drop_missing_columns and columns:
+        for row in df[columns].itertuples():
+            metrics_and_series = list(aggfunc.keys()) + list(row[1:])
+            series_set.add("".join([str(_) for _ in metrics_and_series]))
+
     df = df.pivot_table(
         values=aggfunc.keys(),
         index=index,
@@ -274,6 +284,12 @@ def pivot(  # pylint: disable=too-many-arguments
         margins=marginal_distributions,
         margins_name=marginal_distribution_name,
     )
+
+    if not drop_missing_columns and len(series_set) > 0 and not df.empty:
+        for col in df.columns:
+            series = "".join([str(_) for _ in col])
+            if series not in series_set:
+                df = df.drop(col, axis=PandasAxis.COLUMN)
 
     if combine_value_with_metric:
         df = df.stack(0).unstack()

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -269,11 +269,11 @@ def pivot(  # pylint: disable=too-many-arguments
     # https://github.com/apache/superset/issues/15956
     # https://github.com/pandas-dev/pandas/issues/18030
     series_set = set()
-    to_string_list: Callable[[List[Any]], List[str]] = lambda lst: [str(_) for _ in lst]
+    lst_to_str: Callable[[List[Any]], str] = lambda lst: "_".join(str(_) for _ in lst)
     if not drop_missing_columns and columns:
         for row in df[columns].itertuples():
             metrics_and_series = list(aggfunc.keys()) + list(row[1:])
-            series_set.add("_".join(to_string_list(metrics_and_series)))
+            series_set.add(lst_to_str(metrics_and_series))
 
     df = df.pivot_table(
         values=aggfunc.keys(),
@@ -288,7 +288,7 @@ def pivot(  # pylint: disable=too-many-arguments
 
     if not drop_missing_columns and len(series_set) > 0 and not df.empty:
         for col in df.columns:
-            series = "_".join(to_string_list(col))
+            series = lst_to_str(col)
             if series not in series_set:
                 df = df.drop(col, axis=PandasAxis.COLUMN)
 

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -269,10 +269,11 @@ def pivot(  # pylint: disable=too-many-arguments
     # https://github.com/apache/superset/issues/15956
     # https://github.com/pandas-dev/pandas/issues/18030
     series_set = set()
+    to_string_list: Callable[[List[Any]], List[str]] = lambda lst: [str(_) for _ in lst]
     if not drop_missing_columns and columns:
         for row in df[columns].itertuples():
             metrics_and_series = list(aggfunc.keys()) + list(row[1:])
-            series_set.add("".join([str(_) for _ in metrics_and_series]))
+            series_set.add("_".join(to_string_list(metrics_and_series)))
 
     df = df.pivot_table(
         values=aggfunc.keys(),
@@ -287,7 +288,7 @@ def pivot(  # pylint: disable=too-many-arguments
 
     if not drop_missing_columns and len(series_set) > 0 and not df.empty:
         for col in df.columns:
-            series = "".join([str(_) for _ in col])
+            series = "_".join(to_string_list(col))
             if series not in series_set:
                 df = df.drop(col, axis=PandasAxis.COLUMN)
 

--- a/tests/integration_tests/pandas_postprocessing_tests.py
+++ b/tests/integration_tests/pandas_postprocessing_tests.py
@@ -20,7 +20,8 @@ from importlib.util import find_spec
 import math
 from typing import Any, List, Optional
 
-from pandas import DataFrame, Series, Timestamp
+import numpy as np
+from pandas import DataFrame, Series, Timestamp, to_datetime
 import pytest
 
 from superset.exceptions import QueryObjectValidationError
@@ -255,6 +256,29 @@ class TestPostProcessing(SupersetTestCase):
             columns=["category"],
             aggregates={"idx_nulls": {}},
         )
+
+    def test_pivot_eliminate_cartesian_product_columns(self):
+        mock_df = DataFrame(
+            {
+                "dttm": to_datetime(["2019-01-01", "2019-01-01"]),
+                "a": [0, 1],
+                "b": [0, 1],
+                "metric": [9, np.NAN],
+            }
+        )
+
+        df = proc.pivot(
+            df=mock_df,
+            index=["dttm"],
+            columns=["a", "b"],
+            aggregates={"metric": {"operator": "mean"}},
+            drop_missing_columns=False,
+        )
+        print(df)
+        self.assertEqual(df.columns[1], "0, 0")
+        self.assertEqual(df.columns[2], "1, 1")
+        self.assertEqual(len(df.columns), 3)
+        self.assertTrue(np.isnan(df["1, 1"][0]))
 
     def test_aggregate(self):
         aggregates = {

--- a/tests/integration_tests/pandas_postprocessing_tests.py
+++ b/tests/integration_tests/pandas_postprocessing_tests.py
@@ -274,10 +274,7 @@ class TestPostProcessing(SupersetTestCase):
             aggregates={"metric": {"operator": "mean"}},
             drop_missing_columns=False,
         )
-        print(df)
-        self.assertEqual(df.columns[1], "0, 0")
-        self.assertEqual(df.columns[2], "1, 1")
-        self.assertEqual(len(df.columns), 3)
+        self.assertEqual(list(df.columns), ["dttm", "0, 0", "1, 1"])
         self.assertTrue(np.isnan(df["1, 1"][0]))
 
     def test_aggregate(self):


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
closes: https://github.com/apache/superset/issues/15956

eliminate cartesian product columns in pivot operator

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### After
<img width="1324" alt="image" src="https://user-images.githubusercontent.com/2016594/127643485-7e3d286e-5306-4579-aa61-446e8307aad6.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
added test in integrated test


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/15956
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
