### PR TITLE
fix: Dataset field required 2 clicks to select when dashboard was empty

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -510,7 +510,8 @@ const FiltersConfigForm = (
     setHasDefaultValue,
   ] = useDefaultValue(formFilter, filterToEdit);
 
-  const showDataset = !datasetId || datasetDetails;
+  const showDataset =
+    !datasetId || datasetDetails || formFilter?.dataset?.label;
 
   useEffect(() => {
     if (hasDataset && hasFilledDataset && hasDefaultValue && isDataDirty) {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
@@ -171,7 +171,8 @@ export function FiltersConfigModal({
     setCurrentFilterId(initialCurrentFilterId);
     setRemovedFilters({});
     setSaveAlertVisible(false);
-    setFormValues({ filters: {}, changed: false });
+    setFormValues({ filters: {} });
+    form.setFieldsValue({ changed: false });
   };
 
   const getFilterTitle = (id: string) =>


### PR DESCRIPTION
### SUMMARY
Fix a bug where the dataset field required 2 clicks to select when the dashboard was empty.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/127702142-2a5956ff-3716-4c51-b4ca-b66d5858c21d.mov

https://user-images.githubusercontent.com/70410625/127701842-db9d5e93-dee4-4b13-819f-42cde88d9808.mov

### TESTING INSTRUCTIONS
- Create an empty dashboard
- Add a native filter
- Select the dataset
- It should only require one click to select the dataset

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
