### PR TITLE
fix: save DB with with query

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -525,7 +525,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
         );
       } else if (
         dbToUpdate?.parameters?.query === '' &&
-        'query' in dbModel.parameters
+        'query' in dbModel.parameters.properties
       ) {
         dbToUpdate.parameters.query = {};
       }


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Databases are not saving because we're sending `query` as a string due to the incorrect check.

This fixes the problem, but I think we should spend some cycles improving state in the frontend. Having `query` be a string sometimes, and an object other times will certainly lead to more bugs.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
