### PR TITLE
fix(sqllab): revert #15891 to fix sqllab delay

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -158,6 +158,7 @@ class SqlEditor extends React.PureComponent {
       ctas: '',
       northPercent: props.queryEditor.northPercent || INITIAL_NORTH_PERCENT,
       southPercent: props.queryEditor.southPercent || INITIAL_SOUTH_PERCENT,
+      sql: props.queryEditor.sql,
       autocompleteEnabled: true,
       showCreateAsModal: false,
       createAs: '',
@@ -255,6 +256,7 @@ class SqlEditor extends React.PureComponent {
   }
 
   onSqlChanged(sql) {
+    this.setState({ sql });
     this.setQueryEditorSqlWithDebounce(sql);
     // Request server-side validation of the query text
     if (this.canValidateQuery()) {
@@ -293,7 +295,7 @@ class SqlEditor extends React.PureComponent {
         key: 'ctrl+r',
         descr: t('Run query'),
         func: () => {
-          if (this.props.queryEditor.sql.trim() !== '') {
+          if (this.state.sql.trim() !== '') {
             this.runQuery();
           }
         },
@@ -303,7 +305,7 @@ class SqlEditor extends React.PureComponent {
         key: 'ctrl+enter',
         descr: t('Run query'),
         func: () => {
-          if (this.props.queryEditor.sql.trim() !== '') {
+          if (this.state.sql.trim() !== '') {
             this.runQuery();
           }
         },
@@ -342,7 +344,7 @@ class SqlEditor extends React.PureComponent {
       const qe = this.props.queryEditor;
       const query = {
         dbId: qe.dbId,
-        sql: qe.selectedText ? qe.selectedText : this.props.queryEditor.sql,
+        sql: qe.selectedText ? qe.selectedText : this.state.sql,
         sqlEditorId: qe.id,
         schema: qe.schema,
         templateParams: qe.templateParams,
@@ -374,7 +376,7 @@ class SqlEditor extends React.PureComponent {
       const qe = this.props.queryEditor;
       const query = {
         dbId: qe.dbId,
-        sql: this.props.queryEditor.sql,
+        sql: this.state.sql,
         sqlEditorId: qe.id,
         schema: qe.schema,
         templateParams: qe.templateParams,
@@ -407,7 +409,7 @@ class SqlEditor extends React.PureComponent {
     const qe = this.props.queryEditor;
     const query = {
       dbId: qe.dbId,
-      sql: qe.selectedText ? qe.selectedText : this.props.queryEditor.sql,
+      sql: qe.selectedText ? qe.selectedText : this.state.sql,
       sqlEditorId: qe.id,
       tab: qe.title,
       schema: qe.schema,
@@ -620,7 +622,7 @@ class SqlEditor extends React.PureComponent {
               runQuery={this.runQuery}
               selectedText={qe.selectedText}
               stopQuery={this.stopQuery}
-              sql={this.props.queryEditor.sql}
+              sql={this.state.sql}
               overlayCreateAsMenu={showMenu ? runMenuBtn : null}
             />
           </span>


### PR DESCRIPTION
This reverts commit 8c7e09e500129aaa4f52cfaabe81e4d4a6970cde.

### SUMMARY
#15891 caused some delays with the sql state in SQL Lab, resulting in the incorrect query being run if a user edited and ran a query quickly. Reverting this PR for now.

### TESTING INSTRUCTIONS
N/A, but how I tested the bug:
1. Go to sql lab
2. Type "SELECT 1"
3. Wait ~10 seconds
4. Quickly modify the query to be "SELECT 2" and click "Run"
5. Observe which query was run (1 or 2)

I confirmed that before this change, the incorrect query was run (SELECT 1), and after this change, the correct query was run (SELECT 2).

to: @graceguo-supercat 
