### PR TITLE
[wip]fix: Select a query from History and Run -- 2nd try

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -222,6 +222,15 @@ class SqlEditor extends React.PureComponent {
     });
   }
 
+  static getDerivedStateFromProps(props, state) {
+    if (props.queryEditor.sql !== state.sql) {
+      return {
+        sql: props.queryEditor.sql,
+      };
+    }
+    return null;
+  }
+
   componentWillUnmount() {
     window.removeEventListener('resize', this.handleWindowResize);
     window.removeEventListener('beforeunload', this.onBeforeUnload);

--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -78,7 +78,7 @@ const LIMIT_DROPDOWN = [10, 100, 1000, 10000, 100000];
 const SQL_EDITOR_PADDING = 10;
 const INITIAL_NORTH_PERCENT = 30;
 const INITIAL_SOUTH_PERCENT = 70;
-const SET_QUERY_EDITOR_SQL_DEBOUNCE_MS = 2000;
+const SET_QUERY_EDITOR_SQL_DEBOUNCE_MS = 1000;
 const VALIDATION_DEBOUNCE_MS = 600;
 const WINDOW_RESIZE_THROTTLE_MS = 100;
 
@@ -776,8 +776,10 @@ SqlEditor.propTypes = propTypes;
 
 function mapStateToProps(state, props) {
   const { sqlLab } = state;
+  const activeQueryEditorId =
+    sqlLab.tabHistory.slice(-1).pop() || props.queryEditorId;
   const queryEditor = sqlLab.queryEditors.find(
-    editor => editor.id === props.queryEditorId,
+    editor => editor.id === activeQueryEditorId,
   );
 
   return { sqlLab, ...props, queryEditor };


### PR DESCRIPTION
### SUMMARY
This PR add extra fix for #15891. After #15891, in airbnb some user found SQL Lab was running old SQL query after they update. it happens more often when open a new tab in sql lab. See #15992.

I found there are few issues:
1. when new query tab is added, which triggered redux store change, there are many re-render for every existed query tabs, even if the tab is not the top active one. 
2. when user update sql, there is a race condition: trigger in-component callback function runQuery vs global redux store update with new Sql statement.
3. there is a 2-seconds debounce for Sql Editor to response sql change. this debounce make global redux update almost never win local call runQuery.

So I added few fixes:
1. add logic to only render active tab
2. remove some of change introduced in #15891. keep a copy of current sql statement in local state.
3. reduce debounce from 2 seconds to 1 second.


### TESTING INSTRUCTIONS
CI and manual test.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #15891 #15992 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @serenajiang @etr2460 