### PR TITLE
fix(native-filters): add support for versioned import/export

### DIFF
--- a/superset/charts/commands/export.py
+++ b/superset/charts/commands/export.py
@@ -54,7 +54,7 @@ class ExportChartsCommand(ExportModelsCommand):
             export_uuids=True,
         )
         # TODO (betodealmeida): move this logic to export_to_dict once this
-        # becomes the default export endpoint
+        #  becomes the default export endpoint
         for key in REMOVE_KEYS:
             del payload[key]
         if payload.get("params"):

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -1205,7 +1205,7 @@ class ImportV1ChartSchema(Schema):
     slice_name = fields.String(required=True)
     viz_type = fields.String(required=True)
     params = fields.Dict()
-    query_context = fields.Dict()
+    query_context = fields.String()
     cache_timeout = fields.Integer(allow_none=True)
     uuid = fields.UUID(required=True)
     version = fields.String(required=True)

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -1205,7 +1205,7 @@ class ImportV1ChartSchema(Schema):
     slice_name = fields.String(required=True)
     viz_type = fields.String(required=True)
     params = fields.Dict()
-    query_context = fields.String()
+    query_context = fields.String(allow_none=True, validate=utils.validate_json)
     cache_timeout = fields.Integer(allow_none=True)
     uuid = fields.UUID(required=True)
     version = fields.String(required=True)

--- a/superset/commands/importers/v1/examples.py
+++ b/superset/commands/importers/v1/examples.py
@@ -130,7 +130,7 @@ class ImportExamplesCommand(ImportModelsCommand):
         dashboard_chart_ids: List[Tuple[int, int]] = []
         for file_name, config in configs.items():
             if file_name.startswith("dashboards/"):
-                config = update_id_refs(config, chart_ids)
+                config = update_id_refs(config, chart_ids, dataset_info)
                 dashboard = import_dashboard(session, config, overwrite=overwrite)
                 dashboard.published = True
 

--- a/superset/dashboards/commands/export.py
+++ b/superset/dashboards/commands/export.py
@@ -130,7 +130,9 @@ class ExportDashboardsCommand(ExportModelsCommand):
 
         # Extract all native filter datasets and replace native
         # filter dataset references with uuid
-        for native_filter in payload["metadata"].get("native_filter_configuration", []):
+        for native_filter in payload.get("metadata", {}).get(
+            "native_filter_configuration", []
+        ):
             for target in native_filter.get("targets", []):
                 dataset_id = target.pop("datasetId", None)
                 if dataset_id is not None:

--- a/superset/dashboards/commands/export.py
+++ b/superset/dashboards/commands/export.py
@@ -30,6 +30,8 @@ from superset.dashboards.commands.exceptions import DashboardNotFoundError
 from superset.dashboards.commands.importers.v1.utils import find_chart_uuids
 from superset.dashboards.dao import DashboardDAO
 from superset.commands.export import ExportModelsCommand
+from superset.datasets.commands.export import ExportDatasetsCommand
+from superset.datasets.dao import DatasetDAO
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.utils.dict_import_export import EXPORT_VERSION
@@ -116,7 +118,7 @@ class ExportDashboardsCommand(ExportModelsCommand):
             export_uuids=True,
         )
         # TODO (betodealmeida): move this logic to export_to_dict once this
-        # becomes the default export endpoint
+        #  becomes the default export endpoint
         for key, new_name in JSON_KEYS.items():
             value: Optional[str] = payload.pop(key, None)
             if value:
@@ -125,6 +127,16 @@ class ExportDashboardsCommand(ExportModelsCommand):
                 except (TypeError, json.decoder.JSONDecodeError):
                     logger.info("Unable to decode `%s` field: %s", key, value)
                     payload[new_name] = {}
+
+        # Extract all native filter datasets and replace native
+        # filter dataset references with uuid
+        for native_filter in payload["metadata"].get("native_filter_configuration", []):
+            for target in native_filter.get("targets", []):
+                dataset_id = target.pop("datasetId", None)
+                if dataset_id is not None:
+                    dataset = DatasetDAO.find_by_id(dataset_id)
+                    target["datasetUuid"] = str(dataset.uuid)
+                    yield from ExportDatasetsCommand([dataset_id]).run()
 
         # the mapping between dashboard -> charts is inferred from the position
         # attribute, so if it's not present we need to add a default config

--- a/superset/dashboards/commands/importers/v1/__init__.py
+++ b/superset/dashboards/commands/importers/v1/__init__.py
@@ -27,6 +27,7 @@ from superset.commands.importers.v1 import ImportModelsCommand
 from superset.dashboards.commands.exceptions import DashboardImportError
 from superset.dashboards.commands.importers.v1.utils import (
     find_chart_uuids,
+    find_native_filter_dataset_uuids,
     import_dashboard,
     update_id_refs,
 )
@@ -60,14 +61,17 @@ class ImportDashboardsCommand(ImportModelsCommand):
     def _import(
         session: Session, configs: Dict[str, Any], overwrite: bool = False
     ) -> None:
-        # discover charts associated with dashboards
+        # discover charts and datasets associated with dashboards
         chart_uuids: Set[str] = set()
+        dataset_uuids: Set[str] = set()
         for file_name, config in configs.items():
             if file_name.startswith("dashboards/"):
                 chart_uuids.update(find_chart_uuids(config["position"]))
+                dataset_uuids.update(
+                    find_native_filter_dataset_uuids(config["metadata"])
+                )
 
         # discover datasets associated with charts
-        dataset_uuids: Set[str] = set()
         for file_name, config in configs.items():
             if file_name.startswith("charts/") and config["uuid"] in chart_uuids:
                 dataset_uuids.add(config["dataset_uuid"])
@@ -96,7 +100,7 @@ class ImportDashboardsCommand(ImportModelsCommand):
                 dataset = import_dataset(session, config, overwrite=False)
                 dataset_info[str(dataset.uuid)] = {
                     "datasource_id": dataset.id,
-                    "datasource_type": "view" if dataset.is_sqllab_view else "table",
+                    "datasource_type": dataset.datasource_type,
                     "datasource_name": dataset.table_name,
                 }
 
@@ -121,7 +125,7 @@ class ImportDashboardsCommand(ImportModelsCommand):
         dashboard_chart_ids: List[Tuple[int, int]] = []
         for file_name, config in configs.items():
             if file_name.startswith("dashboards/"):
-                config = update_id_refs(config, chart_ids)
+                config = update_id_refs(config, chart_ids, dataset_info)
                 dashboard = import_dashboard(session, config, overwrite=overwrite)
                 for uuid in find_chart_uuids(config["position"]):
                     if uuid not in chart_ids:

--- a/superset/dashboards/commands/importers/v1/__init__.py
+++ b/superset/dashboards/commands/importers/v1/__init__.py
@@ -27,7 +27,7 @@ from superset.commands.importers.v1 import ImportModelsCommand
 from superset.dashboards.commands.exceptions import DashboardImportError
 from superset.dashboards.commands.importers.v1.utils import (
     find_chart_uuids,
-    find_native_filter_dataset_uuids,
+    find_native_filter_datasets,
     import_dashboard,
     update_id_refs,
 )
@@ -67,9 +67,7 @@ class ImportDashboardsCommand(ImportModelsCommand):
         for file_name, config in configs.items():
             if file_name.startswith("dashboards/"):
                 chart_uuids.update(find_chart_uuids(config["position"]))
-                dataset_uuids.update(
-                    find_native_filter_dataset_uuids(config["metadata"])
-                )
+                dataset_uuids.update(find_native_filter_datasets(config["metadata"]))
 
         # discover datasets associated with charts
         for file_name, config in configs.items():

--- a/superset/dashboards/commands/importers/v1/utils.py
+++ b/superset/dashboards/commands/importers/v1/utils.py
@@ -33,7 +33,7 @@ def find_chart_uuids(position: Dict[str, Any]) -> Set[str]:
     return set(build_uuid_to_id_map(position))
 
 
-def find_native_filter_dataset_uuids(metadata: Dict[str, Any]) -> Set[str]:
+def find_native_filter_datasets(metadata: Dict[str, Any]) -> Set[str]:
     uuids: Set[str] = set()
     for native_filter in metadata.get("native_filter_configuration", []):
         targets = native_filter.get("targets", [])

--- a/superset/dashboards/commands/importers/v1/utils.py
+++ b/superset/dashboards/commands/importers/v1/utils.py
@@ -33,6 +33,17 @@ def find_chart_uuids(position: Dict[str, Any]) -> Set[str]:
     return set(build_uuid_to_id_map(position))
 
 
+def find_native_filter_dataset_uuids(metadata: Dict[str, Any]) -> Set[str]:
+    uuids: Set[str] = set()
+    for native_filter in metadata.get("native_filter_configuration", []):
+        targets = native_filter.get("targets", [])
+        for target in targets:
+            dataset_uuid = target.get("datasetUuid")
+            if dataset_uuid:
+                uuids.add(dataset_uuid)
+    return uuids
+
+
 def build_uuid_to_id_map(position: Dict[str, Any]) -> Dict[str, int]:
     return {
         child["meta"]["uuid"]: child["meta"]["chartId"]
@@ -45,7 +56,11 @@ def build_uuid_to_id_map(position: Dict[str, Any]) -> Dict[str, int]:
     }
 
 
-def update_id_refs(config: Dict[str, Any], chart_ids: Dict[str, int]) -> Dict[str, Any]:
+def update_id_refs(
+    config: Dict[str, Any],
+    chart_ids: Dict[str, int],
+    dataset_info: Dict[str, Dict[str, Any]],
+) -> Dict[str, Any]:
     """Update dashboard metadata to use new IDs"""
     fixed = config.copy()
 
@@ -102,6 +117,17 @@ def update_id_refs(config: Dict[str, Any], chart_ids: Dict[str, int]) -> Dict[st
             and child["meta"]["uuid"] in chart_ids
         ):
             child["meta"]["chartId"] = chart_ids[child["meta"]["uuid"]]
+
+    # fix native filter references
+    native_filter_configuration = fixed["metadata"].get(
+        "native_filter_configuration", []
+    )
+    for native_filter in native_filter_configuration:
+        targets = native_filter.get("targets", [])
+        for target in targets:
+            dataset_uuid = target.pop("datasetUuid", None)
+            if dataset_uuid:
+                target["datasetId"] = dataset_info[dataset_uuid]["datasource_id"]
 
     return fixed
 


### PR DESCRIPTION
### SUMMARY
This PR fixes native filter metadata in versioned import/export of dashboards by doing the following:
- export all datasets referenced in native filters, even those not referenced by charts in dashboard.
- replaces `datasetId` with `datasetUuid` in native filter targets to ensure that dataset reference is based on UUID, not numeric id.

Other bycatch fixes that were found while testing:
- Fix datatype of `query_context` in `ImportV1ChartSchema`, which should be `String`, not `Dict` (caused a marshmallow schema validation exception). Also make it accept `None` values and add JSON validation.
- `datasource_type` in `dataset_info` was set as `view` if the table was a virtual table, which caused an exception when importing virtual datasets. Since virtual datasets are in fact regular `table` datasources, we just reference the `datasource_type` of the imported dataset.

### SCREENSHOT
Now native filter targets are referencing `datasetUuid` instead of `datasetId`:
![image](https://user-images.githubusercontent.com/33317356/127825419-d0e82a8e-19c3-4afa-87c0-77ee4bd2f4ce.png)

### TESTING INSTRUCTIONS

1. enable the "VERSIONED_EXPORT" feature flag
2. export a dashboard that had only one chart and two native filters, one referencing the same dataset as the chart and another not referenced by the chart
3. check that the native filter configurations in the dashboard metadata contain `datasetUuid` instead of `datasetId` references
4. delete the exported dashboard, chart and dataset only referenced by the native filter
5. import the exported bundle
6. make sure the imported dashboard works correctly, and that both datasets are imported correctly and native filter configurations are correct

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #15484 , closes #15531
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
