### PR TITLE
fix(explore): fix undefined error when using dnd

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   FeatureFlag,
   isFeatureEnabled,
@@ -50,10 +50,19 @@ import {
 } from 'src/explore/components/DatasourcePanel/types';
 import { DndItemType } from 'src/explore/components/DndItemType';
 
+const DND_ACCEPTED_TYPES = [
+  DndItemType.Column,
+  DndItemType.Metric,
+  DndItemType.MetricOption,
+  DndItemType.AdhocMetricOption,
+];
+
 const isDictionaryForAdhocFilter = (value: OptionValueType) =>
   !(value instanceof AdhocFilter) && value?.expressionType;
 
 export const DndFilterSelect = (props: DndFilterSelectProps) => {
+  const { datasource, onChange } = props;
+
   const propsValues = Array.from(props.value ?? []);
   const [values, setValues] = useState(
     propsValues.map((filter: OptionValueType) =>
@@ -117,7 +126,6 @@ export const DndFilterSelect = (props: DndFilterSelectProps) => {
   );
 
   useEffect(() => {
-    const { datasource } = props;
     if (datasource && datasource.type === 'table') {
       const dbId = datasource.database?.id;
       const {
@@ -149,7 +157,7 @@ export const DndFilterSelect = (props: DndFilterSelectProps) => {
           });
       }
     }
-  }, []);
+  }, [datasource]);
 
   useEffect(() => {
     setOptions(optionsForSelect(props.columns, props.formData));
@@ -163,138 +171,167 @@ export const DndFilterSelect = (props: DndFilterSelectProps) => {
     );
   }, [props.value]);
 
-  const onClickClose = (index: number) => {
-    const valuesCopy = [...values];
-    valuesCopy.splice(index, 1);
-    setValues(valuesCopy);
-    props.onChange(valuesCopy);
-  };
+  const onClickClose = useCallback(
+    (index: number) => {
+      const valuesCopy = [...values];
+      valuesCopy.splice(index, 1);
+      setValues(valuesCopy);
+      onChange(valuesCopy);
+    },
+    [onChange, values],
+  );
 
-  const onShiftOptions = (dragIndex: number, hoverIndex: number) => {
-    const newValues = [...values];
-    [newValues[hoverIndex], newValues[dragIndex]] = [
-      newValues[dragIndex],
-      newValues[hoverIndex],
-    ];
-    setValues(newValues);
-  };
-
-  const getMetricExpression = (savedMetricName: string) =>
-    props.savedMetrics.find(
-      (savedMetric: Metric) => savedMetric.metric_name === savedMetricName,
-    )?.expression;
-
-  const mapOption = (option: OptionValueType) => {
-    // already a AdhocFilter, skip
-    if (option instanceof AdhocFilter) {
-      return option;
-    }
-    const filterOptions = option as Record<string, any>;
-    // via datasource saved metric
-    if (filterOptions.saved_metric_name) {
-      return new AdhocFilter({
-        expressionType:
-          props.datasource.type === 'druid'
-            ? EXPRESSION_TYPES.SIMPLE
-            : EXPRESSION_TYPES.SQL,
-        subject:
-          props.datasource.type === 'druid'
-            ? filterOptions.saved_metric_name
-            : getMetricExpression(filterOptions.saved_metric_name),
-        operator:
-          OPERATOR_ENUM_TO_OPERATOR_TYPE[Operators.GREATER_THAN].operation,
-        operatorId: Operators.GREATER_THAN,
-        comparator: 0,
-        clause: CLAUSES.HAVING,
-      });
-    }
-    // has a custom label, meaning it's custom column
-    if (filterOptions.label) {
-      return new AdhocFilter({
-        expressionType:
-          props.datasource.type === 'druid'
-            ? EXPRESSION_TYPES.SIMPLE
-            : EXPRESSION_TYPES.SQL,
-        subject:
-          props.datasource.type === 'druid'
-            ? filterOptions.label
-            : new AdhocMetric(option).translateToSql(),
-        operator:
-          OPERATOR_ENUM_TO_OPERATOR_TYPE[Operators.GREATER_THAN].operation,
-        operatorId: Operators.GREATER_THAN,
-        comparator: 0,
-        clause: CLAUSES.HAVING,
-      });
-    }
-    // add a new filter item
-    if (filterOptions.column_name) {
-      return new AdhocFilter({
-        expressionType: EXPRESSION_TYPES.SIMPLE,
-        subject: filterOptions.column_name,
-        operator: OPERATOR_ENUM_TO_OPERATOR_TYPE[Operators.EQUALS].operation,
-        operatorId: Operators.EQUALS,
-        comparator: '',
-        clause: CLAUSES.WHERE,
-        isNew: true,
-      });
-    }
-    return null;
-  };
-
-  const onFilterEdit = (changedFilter: AdhocFilter) => {
-    props.onChange(
-      values.map((value: AdhocFilter) => {
-        if (value.filterOptionName === changedFilter.filterOptionName) {
-          return changedFilter;
-        }
-        return value;
-      }),
-    );
-  };
-
-  const onNewFilter = (newFilter: AdhocFilter) => {
-    const mappedOption = mapOption(newFilter);
-    if (mappedOption) {
-      const newValues = [...values, mappedOption];
+  const onShiftOptions = useCallback(
+    (dragIndex: number, hoverIndex: number) => {
+      const newValues = [...values];
+      [newValues[hoverIndex], newValues[dragIndex]] = [
+        newValues[dragIndex],
+        newValues[hoverIndex],
+      ];
       setValues(newValues);
-      props.onChange(newValues);
-    }
-  };
+    },
+    [values],
+  );
 
-  const togglePopover = (visible: boolean) => {
-    setNewFilterPopoverVisible(visible);
-  };
+  const getMetricExpression = useCallback(
+    (savedMetricName: string) =>
+      props.savedMetrics.find(
+        (savedMetric: Metric) => savedMetric.metric_name === savedMetricName,
+      )?.expression,
+    [props.savedMetrics],
+  );
 
-  const closePopover = () => {
-    togglePopover(false);
-  };
+  const mapOption = useCallback(
+    (option: OptionValueType) => {
+      // already a AdhocFilter, skip
+      if (option instanceof AdhocFilter) {
+        return option;
+      }
+      const filterOptions = option as Record<string, any>;
+      // via datasource saved metric
+      if (filterOptions.saved_metric_name) {
+        return new AdhocFilter({
+          expressionType:
+            datasource.type === 'druid'
+              ? EXPRESSION_TYPES.SIMPLE
+              : EXPRESSION_TYPES.SQL,
+          subject:
+            datasource.type === 'druid'
+              ? filterOptions.saved_metric_name
+              : getMetricExpression(filterOptions.saved_metric_name),
+          operator:
+            OPERATOR_ENUM_TO_OPERATOR_TYPE[Operators.GREATER_THAN].operation,
+          operatorId: Operators.GREATER_THAN,
+          comparator: 0,
+          clause: CLAUSES.HAVING,
+        });
+      }
+      // has a custom label, meaning it's custom column
+      if (filterOptions.label) {
+        return new AdhocFilter({
+          expressionType:
+            datasource.type === 'druid'
+              ? EXPRESSION_TYPES.SIMPLE
+              : EXPRESSION_TYPES.SQL,
+          subject:
+            datasource.type === 'druid'
+              ? filterOptions.label
+              : new AdhocMetric(option).translateToSql(),
+          operator:
+            OPERATOR_ENUM_TO_OPERATOR_TYPE[Operators.GREATER_THAN].operation,
+          operatorId: Operators.GREATER_THAN,
+          comparator: 0,
+          clause: CLAUSES.HAVING,
+        });
+      }
+      // add a new filter item
+      if (filterOptions.column_name) {
+        return new AdhocFilter({
+          expressionType: EXPRESSION_TYPES.SIMPLE,
+          subject: filterOptions.column_name,
+          operator: OPERATOR_ENUM_TO_OPERATOR_TYPE[Operators.EQUALS].operation,
+          operatorId: Operators.EQUALS,
+          comparator: '',
+          clause: CLAUSES.WHERE,
+          isNew: true,
+        });
+      }
+      return null;
+    },
+    [datasource.type, getMetricExpression],
+  );
 
-  const valuesRenderer = () =>
-    values.map((adhocFilter: AdhocFilter, index: number) => {
-      const label = adhocFilter.getDefaultLabel();
-      return (
-        <AdhocFilterPopoverTrigger
-          key={index}
-          adhocFilter={adhocFilter}
-          options={options}
-          datasource={props.datasource}
-          onFilterEdit={onFilterEdit}
-          partitionColumn={partitionColumn}
-        >
-          <OptionWrapper
-            key={index}
-            index={index}
-            clickClose={onClickClose}
-            onShiftOptions={onShiftOptions}
-            type={DndItemType.FilterOption}
-            withCaret
-            isExtra={adhocFilter.isExtra}
-          >
-            <Tooltip title={label}>{label}</Tooltip>
-          </OptionWrapper>
-        </AdhocFilterPopoverTrigger>
+  const onFilterEdit = useCallback(
+    (changedFilter: AdhocFilter) => {
+      onChange(
+        values.map((value: AdhocFilter) => {
+          if (value.filterOptionName === changedFilter.filterOptionName) {
+            return changedFilter;
+          }
+          return value;
+        }),
       );
-    });
+    },
+    [onChange, values],
+  );
+
+  const onNewFilter = useCallback(
+    (newFilter: AdhocFilter) => {
+      const mappedOption = mapOption(newFilter);
+      if (mappedOption) {
+        const newValues = [...values, mappedOption];
+        setValues(newValues);
+        onChange(newValues);
+      }
+    },
+    [mapOption, onChange, values],
+  );
+
+  const togglePopover = useCallback((visible: boolean) => {
+    setNewFilterPopoverVisible(visible);
+  }, []);
+
+  const closePopover = useCallback(() => {
+    togglePopover(false);
+  }, [togglePopover]);
+
+  const valuesRenderer = useCallback(
+    () =>
+      values.map((adhocFilter: AdhocFilter, index: number) => {
+        const label = adhocFilter.getDefaultLabel();
+        return (
+          <AdhocFilterPopoverTrigger
+            key={index}
+            adhocFilter={adhocFilter}
+            options={options}
+            datasource={datasource}
+            onFilterEdit={onFilterEdit}
+            partitionColumn={partitionColumn}
+          >
+            <OptionWrapper
+              key={index}
+              index={index}
+              clickClose={onClickClose}
+              onShiftOptions={onShiftOptions}
+              type={DndItemType.FilterOption}
+              withCaret
+              isExtra={adhocFilter.isExtra}
+            >
+              <Tooltip title={label}>{label}</Tooltip>
+            </OptionWrapper>
+          </AdhocFilterPopoverTrigger>
+        );
+      }),
+    [
+      onClickClose,
+      onFilterEdit,
+      onShiftOptions,
+      options,
+      partitionColumn,
+      datasource,
+      values,
+    ],
+  );
 
   const adhocFilter = useMemo(() => {
     if (droppedItem?.metric_name) {
@@ -321,28 +358,29 @@ export const DndFilterSelect = (props: DndFilterSelectProps) => {
     return new AdhocFilter(config);
   }, [droppedItem]);
 
+  const canDrop = useCallback(() => true, []);
+  const handleDrop = useCallback(
+    (item: DatasourcePanelDndItem) => {
+      setDroppedItem(item.value);
+      togglePopover(true);
+    },
+    [togglePopover],
+  );
+
   return (
     <>
       <DndSelectLabel<OptionValueType, OptionValueType[]>
-        onDrop={(item: DatasourcePanelDndItem) => {
-          setDroppedItem(item.value);
-          togglePopover(true);
-        }}
-        canDrop={() => true}
+        onDrop={handleDrop}
+        canDrop={canDrop}
         valuesRenderer={valuesRenderer}
-        accept={[
-          DndItemType.Column,
-          DndItemType.Metric,
-          DndItemType.MetricOption,
-          DndItemType.AdhocMetricOption,
-        ]}
+        accept={DND_ACCEPTED_TYPES}
         ghostButtonText={t('Drop columns or metrics')}
         {...props}
       />
       <AdhocFilterPopoverTrigger
         adhocFilter={adhocFilter}
         options={options}
-        datasource={props.datasource}
+        datasource={datasource}
         onFilterEdit={onNewFilter}
         partitionColumn={partitionColumn}
         isControlledComponent

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/Option.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/Option.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
+import React, { useCallback } from 'react';
 import { styled, t, useTheme } from '@superset-ui/core';
 import Icons from 'src/components/Icons';
 import {
@@ -41,13 +41,17 @@ export default function Option({
   canDelete = true,
 }: OptionProps) {
   const theme = useTheme();
+  const onClickClose = useCallback(() => clickClose(index), [
+    clickClose,
+    index,
+  ]);
   return (
     <OptionControlContainer data-test="option-label" withCaret={withCaret}>
       {canDelete && (
         <CloseContainer
           role="button"
           data-test="remove-control-button"
-          onClick={() => clickClose(index)}
+          onClick={onClickClose}
         >
           <Icons.XSmall iconColor={theme.colors.grayscale.light1} />
         </CloseContainer>

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/OptionWrapper.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/OptionWrapper.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useRef } from 'react';
+import React, { useMemo, useRef } from 'react';
 import {
   useDrag,
   useDrop,
@@ -24,7 +24,6 @@ import {
   DragSourceMonitor,
 } from 'react-dnd';
 import { DragContainer } from 'src/explore/components/controls/OptionControls';
-import { DndItemType } from 'src/explore/components/DndItemType';
 import {
   OptionProps,
   OptionItemInterface,
@@ -33,7 +32,7 @@ import Option from './Option';
 
 export default function OptionWrapper(
   props: OptionProps & {
-    type: DndItemType;
+    type: string;
     onShiftOptions: (dragIndex: number, hoverIndex: number) => void;
   },
 ) {
@@ -50,10 +49,13 @@ export default function OptionWrapper(
   } = props;
   const ref = useRef<HTMLDivElement>(null);
 
-  const item: OptionItemInterface = {
-    dragIndex: index,
-    type,
-  };
+  const item: OptionItemInterface = useMemo(
+    () => ({
+      dragIndex: index,
+      type,
+    }),
+    [index, type],
+  );
   const [, drag] = useDrag({
     item,
     collect: (monitor: DragSourceMonitor) => ({

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
@@ -44,6 +44,7 @@ export interface LabelProps<T = string[] | string> {
   multi?: boolean;
   canDelete?: boolean;
   ghostButtonText?: string;
+  label?: string;
 }
 
 export interface DndColumnSelectProps<

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricOption.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricOption.jsx
@@ -36,6 +36,7 @@ const propTypes = {
   onMoveLabel: PropTypes.func,
   onDropLabel: PropTypes.func,
   index: PropTypes.number,
+  type: PropTypes.string,
 };
 
 class AdhocMetricOption extends React.PureComponent {
@@ -46,7 +47,7 @@ class AdhocMetricOption extends React.PureComponent {
 
   onRemoveMetric(e) {
     e.stopPropagation();
-    this.props.onRemoveMetric();
+    this.props.onRemoveMetric(this.props.index);
   }
 
   render() {
@@ -60,6 +61,7 @@ class AdhocMetricOption extends React.PureComponent {
       onMoveLabel,
       onDropLabel,
       index,
+      type,
     } = this.props;
 
     return (
@@ -79,7 +81,7 @@ class AdhocMetricOption extends React.PureComponent {
           onMoveLabel={onMoveLabel}
           onDropLabel={onDropLabel}
           index={index}
-          type={DndItemType.AdhocMetricOption}
+          type={type ?? DndItemType.AdhocMetricOption}
           withCaret
           isFunction
         />

--- a/superset-frontend/src/explore/components/controls/MetricControl/MetricDefinitionValue.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/MetricDefinitionValue.jsx
@@ -48,6 +48,7 @@ export default function MetricDefinitionValue({
   onMoveLabel,
   onDropLabel,
   index,
+  type,
 }) {
   const getSavedMetricByName = metricName =>
     savedMetrics.find(metric => metric.metric_name === metricName);
@@ -74,6 +75,7 @@ export default function MetricDefinitionValue({
       onDropLabel,
       index,
       savedMetric: savedMetric ?? {},
+      type,
     };
 
     return <AdhocMetricOption {...metricOptionProps} />;

--- a/superset-frontend/src/explore/components/controls/MetricControl/MetricsControl.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/MetricsControl.jsx
@@ -142,7 +142,7 @@ class MetricsControl extends React.PureComponent {
         index={index}
         option={option}
         onMetricEdit={this.onMetricEdit}
-        onRemoveMetric={() => this.onRemoveMetric(index)}
+        onRemoveMetric={this.onRemoveMetric}
         columns={this.props.columns}
         datasource={this.props.datasource}
         savedMetrics={this.props.savedMetrics}


### PR DESCRIPTION
### SUMMARY
When user tried to drag and drop value from a control to a different control of the same type, an undefined error occurred. The root of the issue was in reordering logic - in order the rearrange values, control's dnd handler had to accept a given drag item type. However if there were more controls of the same type in control panel, user could drag them to the other control, which wasn't handled in any way. This PR fixes the issue by changing control's dnd type from a generic one (like "Column", "Metric" etc.) to a more specific one (old type concatenated with control's name and label to ensure uniqueness).
In the future, we'll enhance the DnD experience by allowing user to drag and drop items across different controls (instead of prohibiting it). However, that will require deeper, riskier changes, so for now let's just fix the "undefined" error with this PR.
While I was at it, I introduced a few simple performance improvements - mostly wrapping stuff in useCallbacks and useMemos.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see https://github.com/apache/superset/issues/16009

After:
https://user-images.githubusercontent.com/15073128/127839347-f0e4e9af-c10c-4e8c-a426-03987e8180d7.mov

### TESTING INSTRUCTIONS
0. Enable drag and drop
1. Create a chart which has multiple controls of the same type, for example table or pivot table
2. Add values to controls of the same type (e.g Metric and Percentage Metric in Table, or Columns and Rows in Pivot Table)
3. Try to drag a value from 1 control to the other.
4. Verify that nothing happened and no "undefined" error is shown

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #16009, closes #16007 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @jinghua-qa @junlincc 