### PR TITLE
fix(explore): filter popover opening after removing a filter

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/Option.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/Option.tsx
@@ -41,10 +41,13 @@ export default function Option({
   canDelete = true,
 }: OptionProps) {
   const theme = useTheme();
-  const onClickClose = useCallback(() => clickClose(index), [
-    clickClose,
-    index,
-  ]);
+  const onClickClose = useCallback(
+    e => {
+      e.stopPropagation();
+      clickClose(index);
+    },
+    [clickClose, index],
+  );
   return (
     <OptionControlContainer data-test="option-label" withCaret={withCaret}>
       {canDelete && (


### PR DESCRIPTION
### SUMMARY
Fixes adhoc filter popover opening when user has 2 or more filters added and removes 1 of them.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see linked issue
After:
https://user-images.githubusercontent.com/15073128/127877801-05e69c2c-8769-4dea-8d05-3e6f573962da.mov

### TESTING INSTRUCTIONS
0. Enable drag and drop feature flag
1. Add 2 or more adhoc filters
2. Remove 1 adhoc filter
3. Verify that the popover doesn't open unnecessarily

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #16019
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @junlincc @jinghua-qa