### PR TITLE
fix: missing mulitiple metrics on pivot operator

### DIFF
--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -271,8 +271,12 @@ def pivot(  # pylint: disable=too-many-arguments
     series_set = set()
     if not drop_missing_columns and columns:
         for row in df[columns].itertuples():
-            metrics_and_series = tuple(aggfunc.keys()) + tuple(row[1:])
-            series_set.add(str(metrics_and_series))
+            metrics_and_series = []
+            for metric in aggfunc.keys():
+                metrics_and_series.append(tuple([metric]) + tuple(row[1:]))
+            for m_series in metrics_and_series:
+                series_set.add(str(m_series))
+
     df = df.pivot_table(
         values=aggfunc.keys(),
         index=index,

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -271,11 +271,8 @@ def pivot(  # pylint: disable=too-many-arguments
     series_set = set()
     if not drop_missing_columns and columns:
         for row in df[columns].itertuples():
-            metrics_and_series = []
             for metric in aggfunc.keys():
-                metrics_and_series.append(tuple([metric]) + tuple(row[1:]))
-            for m_series in metrics_and_series:
-                series_set.add(str(m_series))
+                series_set.add(str(tuple([metric]) + tuple(row[1:])))
 
     df = df.pivot_table(
         values=aggfunc.keys(),


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fixes: https://github.com/apache/superset/issues/16023
closes: https://github.com/apache/superset/issues/16023

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### After
![image](https://user-images.githubusercontent.com/2016594/127882853-695cb18c-3737-4f18-9063-81e0e26820b9.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

UT converage

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
