### PR TITLE
fix: DB exported with incorrect type

### DIFF
--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -552,6 +552,25 @@ class DatabaseFunctionNamesResponse(Schema):
 
 
 class ImportV1DatabaseExtraSchema(Schema):
+    # pylint: disable=no-self-use, unused-argument
+    @pre_load
+    def fix_schemas_allowed_for_csv_upload(
+        self, data: Dict[str, Any], **kwargs: Any
+    ) -> Dict[str, Any]:
+        """
+        Fix ``schemas_allowed_for_csv_upload`` being a string.
+
+        Due to a bug in the database modal, some databases might have been
+        saved and exported with a string for ``schemas_allowed_for_csv_upload``.
+        """
+        schemas_allowed_for_csv_upload = data.get("schemas_allowed_for_csv_upload")
+        if isinstance(schemas_allowed_for_csv_upload, str):
+            data["schemas_allowed_for_csv_upload"] = json.loads(
+                schemas_allowed_for_csv_upload
+            )
+
+        return data
+
     metadata_params = fields.Dict(keys=fields.Str(), values=fields.Raw())
     engine_params = fields.Dict(keys=fields.Str(), values=fields.Raw())
     metadata_cache_timeout = fields.Dict(keys=fields.Str(), values=fields.Integer())


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Some databases were saved with `schemas_allowed_for_csv_upload` as a JSON string, instead of a JSON object. When these databases are exported the ZIP payload has the incorrect schema, and can't be imported.

This PR fixes the export, so that these databases are exported with the correct schema; and the import, so that any databases that were eventually exported can be imported.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Before applying this PR, create a DB using the new custom form. Check that the DB is saved with incorrect `extra`:

```json
 {"metadata_params":{},"engine_params":{},"schemas_allowed_for_csv_upload":"[]"}
```

Note that the payload is incorrect becase `schemas_allowed_for_csv_upload` should be an array, not a string. One way to save a DB with the incorrect format like above is to add a schema, save the DB, remove the schema, and save the DB again.

Export the DB, the YAML will look like this:

```yaml
database_name: MySQL
sqlalchemy_uri: mysql+mysqldb://root@localhost:3306/MySQL
cache_timeout: null
expose_in_sqllab: true
allow_run_async: false
allow_ctas: false
allow_cvas: false
allow_csv_upload: false
extra:
  metadata_params: {}
  engine_params: {}
  schemas_allowed_for_csv_upload: '[]'
uuid: 8bf58f76-c884-49d2-8612-d94d3ca1d1aa
version: 1.0.0
```

When importing the file it will fail the validation, because `schemas_allowed_for_csv_upload` is a string.

With this PR, the import will work. Additionally, when exporting the incorrectly saved database the output YAML will look like this:

```yaml
database_name: MySQL
sqlalchemy_uri: mysql+mysqldb://root@localhost:3306/MySQL
cache_timeout: null
expose_in_sqllab: true
allow_run_async: false
allow_ctas: false
allow_cvas: false
allow_csv_upload: false
extra:
  metadata_params: {}
  engine_params: {}
  schemas_allowed_for_csv_upload: []
uuid: 8bf58f76-c884-49d2-8612-d94d3ca1d1aa
version: 1.0.0
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
