### PR TITLE
fix: handle schemas_allowed_for_csv_upload serde

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx
@@ -372,13 +372,17 @@ const ExtraOptions = ({
             <input
               type="text"
               name="schemas_allowed_for_csv_upload"
-              value={db?.extra_json?.schemas_allowed_for_csv_upload || ''}
-              placeholder={t('Select one or multiple schemas')}
+              value={(
+                db?.extra_json?.schemas_allowed_for_csv_upload || []
+              ).join(',')}
+              placeholder="schema1,schema2"
               onChange={onExtraInputChange}
             />
           </div>
           <div className="helper">
-            {t('A list of schemas that CSVs are allowed to upload to.')}
+            {t(
+              'A comma-separated list of schemas that CSVs are allowed to upload to.',
+            )}
           </div>
         </StyledInputContainer>
         <StyledInputContainer css={{ no_margin_bottom }}>

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -222,6 +222,17 @@ function dbReducer(
           },
         };
       }
+      if (action.payload.name === 'schemas_allowed_for_csv_upload') {
+        return {
+          ...trimmedState,
+          extra_json: {
+            ...trimmedState.extra_json,
+            schemas_allowed_for_csv_upload: (action.payload.value || '').split(
+              ',',
+            ),
+          },
+        };
+      }
       return {
         ...trimmedState,
         extra_json: {
@@ -409,8 +420,9 @@ const serializeExtra = (extraJson: DatabaseObject['extra_json']) =>
     engine_params: JSON.parse(
       ((extraJson?.engine_params as unknown) as string) || '{}',
     ),
-    schemas_allowed_for_csv_upload:
-      (extraJson?.schemas_allowed_for_csv_upload as string) || '[]',
+    schemas_allowed_for_csv_upload: (
+      extraJson?.schemas_allowed_for_csv_upload || []
+    ).filter(schema => schema !== ''),
   });
 
 const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({

--- a/superset-frontend/src/views/CRUD/data/database/types.ts
+++ b/superset-frontend/src/views/CRUD/data/database/types.ts
@@ -83,7 +83,7 @@ export type DatabaseObject = {
       table_cache_timeout?: number; // in Performance
     }; // No field, holds schema and table timeout
     allows_virtual_table_explore?: boolean; // in SQL Lab
-    schemas_allowed_for_csv_upload?: [] | string; // in Security
+    schemas_allowed_for_csv_upload?: string[]; // in Security
     cancel_query_on_windows_unload?: boolean; // in Performance
     version?: string;
 

--- a/superset/migrations/versions/e323605f370a_fix_schemas_allowed_for_csv_upload.py
+++ b/superset/migrations/versions/e323605f370a_fix_schemas_allowed_for_csv_upload.py
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""fix schemas_allowed_for_csv_upload
+
+Revision ID: e323605f370a
+Revises: 31b2a1039d4a
+Create Date: 2021-08-02 16:39:45.329151
+
+"""
+import json
+import logging
+
+from alembic import op
+from sqlalchemy import Column, Integer, Text
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
+
+# revision identifiers, used by Alembic.
+revision = "e323605f370a"
+down_revision = "31b2a1039d4a"
+
+
+Base = declarative_base()
+
+
+class Database(Base):
+
+    __tablename__ = "dbs"
+    id = Column(Integer, primary_key=True)
+    extra = Column(Text)
+
+
+def upgrade():
+    """
+    Fix databases with ``schemas_allowed_for_csv_upload`` stored as string.
+    """
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for database in session.query(Database).all():
+        try:
+            extra = json.loads(database.extra)
+        except json.decoder.JSONDecodeError as ex:
+            logging.warning(str(ex))
+            continue
+
+        schemas_allowed_for_csv_upload = extra.get("schemas_allowed_for_csv_upload")
+        if not isinstance(schemas_allowed_for_csv_upload, str):
+            continue
+
+        if schemas_allowed_for_csv_upload == "[]":
+            extra["schemas_allowed_for_csv_upload"] = []
+        else:
+            extra["schemas_allowed_for_csv_upload"] = [
+                schema.strip()
+                for schema in schemas_allowed_for_csv_upload.split(",")
+                if schema.strip()
+            ]
+
+        database.extra = json.dumps(extra)
+
+    session.commit()
+    session.close()
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

We're currently storing `schemas_allowed_for_csv_upload` incorrectly in the DB:

1. When no schemas are defined we store the **string** `'[]'` in the DB, when the right value would be the **array** `[]`.
2. When one or more schemas are defined we store them as a **single string** (eg, `"schema1"` or `"schema1,schema2"`) instead of a **list of strings** (`["schema1"]`, `["schema1", "schema2"]`).

This PR is a quick fix to solve the problem. It stores `schemas_allowed_for_csv_upload` as `string[]` only, serializing and deserializing at the form interface.

I also changed the placeholder text, since there's no hint to the user how the schemas should be formatted. Ideally we'd offer a dropdown from which the user would be able to select multiple schemas, but in the meantime offering an example `schema1,schema2` should be enough.

This PR also has a DB migration that fixes the incorrect values. I tested by creating a DB in `master`, verifying that the `extra` was saved incorrectly:

```json
{
  "metadata_params": {},
  "engine_params": {},
  "metadata_cache_timeout": {},
  "schemas_allowed_for_csv_upload": "[]"
}
```

After running the migration:

```json
{
  "metadata_params": {},
  "engine_params": {},
  "metadata_cache_timeout": {},
  "schemas_allowed_for_csv_upload": []
}
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Here's how the DB is configured, and how the configuration is stored correctly with this PR:

![Screenshot 2021-08-02 at 16-02-30  DEV  Superset](https://user-images.githubusercontent.com/1534870/127934927-f568d259-ee85-4b49-8244-30ffe25070cb.png)

```
ch21223=# SELECT extra FROM dbs WHERE id=1;
                                                                                                     extra
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 {"engine_params":{"catalog":{"public_sheet":"https://docs.google.com/spreadsheets/d/1LcWZMsdCl92g7nA-D6qGRqg1T5TiHyuKJUY1u9XAnsk/edit#gid=0"}},"metadata_params":{},"schemas_allowed_for_csv_upload":["test"]}
(1 row)
```

![Screenshot 2021-08-02 at 16-03-25  DEV  Superset](https://user-images.githubusercontent.com/1534870/127934955-df922432-b052-41c3-a4c8-07e077c0afd5.png)

```
ch21223=# SELECT extra FROM dbs WHERE id=1;
                                                                                                  extra
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 {"engine_params":{"catalog":{"public_sheet":"https://docs.google.com/spreadsheets/d/1LcWZMsdCl92g7nA-D6qGRqg1T5TiHyuKJUY1u9XAnsk/edit#gid=0"}},"metadata_params":{},"schemas_allowed_for_csv_upload":[]}
(1 row)
```

![Screenshot 2021-08-02 at 16-04-38  DEV  Superset](https://user-images.githubusercontent.com/1534870/127934964-f6db3c93-2d45-40b5-884d-f39f5b8c7aa2.png)

```
ch21223=# SELECT extra FROM dbs WHERE id=1;
                                                                                                      extra
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 {"engine_params":{"catalog":{"public_sheet":"https://docs.google.com/spreadsheets/d/1LcWZMsdCl92g7nA-D6qGRqg1T5TiHyuKJUY1u9XAnsk/edit#gid=0"}},"metadata_params":{},"schemas_allowed_for_csv_upload":["a","b"]}
(1 row)
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
