### PR TITLE
refactor: adopt --app as celery global option

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1465,7 +1465,7 @@ install from pip: ::
 
 and run via: ::
 
-    celery flower --app=superset.tasks.celery_app:app
+    celery --app=superset.tasks.celery_app:app flower
 
 Building from source
 ---------------------

--- a/docs/src/pages/docs/installation/async_queries_celery.mdx
+++ b/docs/src/pages/docs/installation/async_queries_celery.mdx
@@ -114,5 +114,5 @@ pip install flower
 You can run flower using:
 
 ```
-celery flower --app=superset.tasks.celery_app:app
+celery --app=superset.tasks.celery_app:app flower
 ```


### PR DESCRIPTION
### SUMMARY

This PR updates the documentation for Celery flower which was not captured in https://github.com/apache/superset/pull/15053  for ensuring that the documentation is both Celery 4.x and 5.x compliant. 

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @shawnzhu
