### PR TITLE
fix: sync columns in explore page

### DIFF
--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -487,9 +487,9 @@ class DatasourceEditor extends React.PureComponent {
     const { datasource } = this.state;
     const endpoint = `/datasource/external_metadata_by_name/${
       datasource.type || datasource.datasource_type
-    }/${datasource.database.database_name}/${datasource.schema}/${
-      datasource.table_name
-    }/`;
+    }/${datasource.database.database_name || datasource.database.name}/${
+      datasource.schema
+    }/${datasource.table_name}/`;
     this.setState({ metadataLoading: true });
 
     SupersetClient.get({ endpoint })


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
DatasetEditor can't sync columns in explore page.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### Before


https://user-images.githubusercontent.com/2016594/127957792-267f25a4-c40e-4c2e-bdde-82cb74407ef8.mov



### After

https://user-images.githubusercontent.com/2016594/127956935-0461cd5e-214b-499d-810a-798279353493.mov



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
tested in local environment


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
