### PR TITLE
chore: Changes the RefreshIntervalModal component to use the new select component

### DIFF
--- a/superset-frontend/spec/javascripts/dashboard/components/RefreshIntervalModal_spec.jsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/RefreshIntervalModal_spec.jsx
@@ -54,7 +54,7 @@ describe('RefreshIntervalModal', () => {
   });
   it('should change refreshFrequency with edit mode', () => {
     const wrapper = getMountWrapper(mockedProps);
-    wrapper.instance().handleFrequencyChange({ value: 30 });
+    wrapper.instance().handleFrequencyChange(30);
     wrapper.instance().onSave();
     expect(mockedProps.onChange).toHaveBeenCalled();
     expect(mockedProps.onChange).toHaveBeenCalledWith(30, mockedProps.editMode);
@@ -69,11 +69,11 @@ describe('RefreshIntervalModal', () => {
     const wrapper = getMountWrapper(props);
     wrapper.find('span[role="button"]').simulate('click');
 
-    wrapper.instance().handleFrequencyChange({ value: 30 });
+    wrapper.instance().handleFrequencyChange(30);
     wrapper.update();
     expect(wrapper.find(ModalTrigger).find(Alert)).toExist();
 
-    wrapper.instance().handleFrequencyChange({ value: 3601 });
+    wrapper.instance().handleFrequencyChange(3601);
     wrapper.update();
     expect(wrapper.find(ModalTrigger).find(Alert)).not.toExist();
   });

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -217,7 +217,7 @@ const Select = ({
   const handleTopOptions = useCallback(
     (selectedValue: AntdSelectValue | undefined) => {
       // bringing selected options to the top of the list
-      if (selectedValue) {
+      if (selectedValue !== undefined && selectedValue !== null) {
         const topOptions: OptionsType = [];
         const otherOptions: OptionsType = [];
 

--- a/superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx
+++ b/superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { RefObject } from 'react';
-import Select from 'src/components/Select';
+import { Select } from 'src/components';
 import { t, styled } from '@superset-ui/core';
 import Alert from 'src/components/Alert';
 import Button from 'src/components/Button';
@@ -36,7 +36,7 @@ export const options = [
   [21600, t('6 hours')],
   [43200, t('12 hours')],
   [86400, t('24 hours')],
-].map(o => ({ value: o[0], label: o[1] }));
+].map(o => ({ value: o[0] as number, label: o[1] }));
 
 const StyledModalTrigger = styled(ModalTrigger)`
   .ant-modal-body {
@@ -95,10 +95,9 @@ class RefreshIntervalModal extends React.PureComponent<
     this.modalRef.current?.close();
   }
 
-  handleFrequencyChange(opt: Record<string, any>) {
-    const value = opt ? opt.value : options[0].value;
+  handleFrequencyChange(value: number) {
     this.setState({
-      refreshFrequency: value,
+      refreshFrequency: value || options[0].value,
     });
   }
 
@@ -117,10 +116,10 @@ class RefreshIntervalModal extends React.PureComponent<
           <div>
             <FormLabel>{t('Refresh frequency')}</FormLabel>
             <Select
+              ariaLabel={t('Refresh interval')}
               options={options}
-              value={{ value: refreshFrequency }}
+              value={refreshFrequency}
               onChange={this.handleFrequencyChange}
-              forceOverflow
             />
             {showRefreshWarning && (
               <RefreshWarningContainer>


### PR DESCRIPTION
### SUMMARY
Changes the `RefreshIntervalModal` component to use the new select component.

@junlincc @jinghua-qa @rusackas 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/128062197-60bdeed8-cef5-4484-8d64-acfdb61315e9.mov

https://user-images.githubusercontent.com/70410625/128061876-48964645-1792-4bcc-8ef8-b8a0beaa7103.mov

### TESTING INSTRUCTIONS
Check the videos for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
