### PR TITLE
fix(dashboard): 500 error caused by data_for_slices API

### DIFF
--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -282,10 +282,9 @@ class BaseDatasource(
         column_names = set()
         for slc in slices:
             form_data = slc.form_data
-
             # pull out all required metrics from the form_data
-            for param in METRIC_FORM_DATA_PARAMS:
-                for metric in utils.get_iterable(form_data.get(param) or []):
+            for metric_param in METRIC_FORM_DATA_PARAMS:
+                for metric in utils.get_iterable(form_data.get(metric_param) or []):
                     metric_names.add(utils.get_metric_name(metric))
                     if utils.is_adhoc_metric(metric):
                         column_names.add(
@@ -308,8 +307,8 @@ class BaseDatasource(
 
             column_names.update(
                 column
-                for column in utils.get_iterable(form_data.get(param) or [])
-                for param in COLUMN_FORM_DATA_PARAMS
+                for column_param in COLUMN_FORM_DATA_PARAMS
+                for column in utils.get_iterable(form_data.get(column_param) or [])
             )
 
         filtered_metrics = [

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1217,10 +1217,10 @@ def get_metric_name(metric: Metric) -> str:
 
 
 def get_metric_names(metrics: Sequence[Metric]) -> List[str]:
-    return [get_metric_name(metric) for metric in metrics]
+    return [metric for metric in map(get_metric_name, metrics) if metric]
 
 
-def get_main_metric_name(metrics: Sequence[Metric]) -> Optional[str]:
+def get_first_metric_name(metrics: Sequence[Metric]) -> Optional[str]:
     metric_labels = get_metric_names(metrics)
     return metric_labels[0] if metric_labels else None
 
@@ -1427,7 +1427,6 @@ def get_iterable(x: Any) -> List[Any]:
     :param x: The object
     :returns: An iterable representation
     """
-
     return x if isinstance(x, list) else [x]
 
 
@@ -1464,12 +1463,7 @@ def get_column_names_from_metrics(metrics: List[Metric]) -> List[str]:
     :param metrics: Ad-hoc metric
     :return: column name if simple metric, otherwise None
     """
-    columns: List[str] = []
-    for metric in metrics:
-        column_name = get_column_name_from_metric(metric)
-        if column_name:
-            columns.append(column_name)
-    return columns
+    return [col for col in map(get_column_name_from_metric, metrics) if col]
 
 
 def extract_dataframe_dtypes(df: pd.DataFrame) -> List[GenericDataType]:

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1230,7 +1230,7 @@ class NVD3TimeSeriesViz(NVD3Viz):
         d = super().query_obj()
         sort_by = self.form_data.get(
             "timeseries_limit_metric"
-        ) or utils.get_main_metric_name(d.get("metrics") or [])
+        ) or utils.get_first_metric_name(d.get("metrics") or [])
         is_asc = not self.form_data.get("order_desc")
         if sort_by:
             sort_by_label = utils.get_metric_name(sort_by)

--- a/tests/integration_tests/model_tests.py
+++ b/tests/integration_tests/model_tests.py
@@ -497,13 +497,15 @@ class TestSqlaTableModel(SupersetTestCase):
         slc = (
             metadata_db.session.query(Slice)
             .filter_by(
-                datasource_id=tbl.id,
-                datasource_type=tbl.type,
-                slice_name="Participants",
+                datasource_id=tbl.id, datasource_type=tbl.type, slice_name="Genders",
             )
             .first()
         )
         data_for_slices = tbl.data_for_slices([slc])
-        self.assertEqual(len(data_for_slices["columns"]), 0)
-        self.assertEqual(len(data_for_slices["metrics"]), 1)
-        self.assertEqual(len(data_for_slices["verbose_map"].keys()), 2)
+        assert len(data_for_slices["metrics"]) == 1
+        assert len(data_for_slices["columns"]) == 1
+        assert data_for_slices["metrics"][0]["metric_name"] == "sum__num"
+        assert data_for_slices["columns"][0]["column_name"] == "gender"
+        assert set(data_for_slices["verbose_map"].keys()) == set(
+            ["__timestamp", "sum__num", "gender",]
+        )


### PR DESCRIPTION
### SUMMARY

Fix a 500 error on the `/dashboard/<dashboardId>/datasets` API caused by an incorrect nested list comprehension introduced by https://github.com/apache/superset/pull/15993 .

```python
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/flask_appbuilder/api/__init__.py", line 85, in wraps
    return f(self, *args, **kwargs)
  File "superset/views/base_api.py", line 85, in wraps
    raise ex
  File "superset/views/base_api.py", line 82, in wraps
    duration, response = time_function(f, self, *args, **kwargs)
  File "superset/utils/core.py", line 1367, in time_function
    response = func(*args, **kwargs)
  File "superset/utils/log.py", line 241, in wrapper
    value = f(*args, **kwargs)
  File "superset/dashboards/api.py", line 334, in get_datasets
    datasets = DashboardDAO.get_datasets_for_dashboard(id_or_slug)
  File "superset/dashboards/dao.py", line 52, in get_datasets_for_dashboard
    return dashboard.datasets_trimmed_for_slices()
  File "/usr/local/lib/python3.8/dist-packages/flask_caching/__init__.py", line 905, in decorated_function
    return f(*args, **kwargs)
  File "superset/models/dashboard.py", line 280, in datasets_trimmed_for_slices
    result.append(datasource.data_for_slices(slices))
  File "superset/connectors/base/models.py", line 309, in data_for_slices
    column_names.update(
TypeError: unhashable type: 'dict'
```

Updated the test case to cover this case.

In dashboards where a slice has the `y` metric set (e.g. a NVD3 timeseries chart), the `/datasets` API will return 500. However, most of the time if will not break the dashboard, since this API is almost only used in FilterBox and filter indicators.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

1. Test adding a NVD3 Timeseries chart to the dashboard
2. You may see 500 error in base but not error after the fix

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
