### PR TITLE
fix: Make sheet_name into a `ValidationInputError`

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm.tsx
@@ -228,7 +228,7 @@ const TableCatalog = ({
                 validationMethods={{ onBlur: getValidation }}
                 errorMessage={catalogError[idx]?.name}
                 placeholder={t('Enter a name for this sheet')}
-                onChange={e => {
+                onChange={(e: { target: { value: any } }) => {
                   changeMethods.onParametersChange({
                     target: {
                       type: `catalog-${idx}`,

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm.tsx
@@ -19,7 +19,7 @@
 import React, { FormEvent, useState } from 'react';
 import { SupersetTheme, JsonObject, t } from '@superset-ui/core';
 import { InputProps } from 'antd/lib/input';
-import { Input, Switch, Select, Button } from 'src/common/components';
+import { Switch, Select, Button } from 'src/common/components';
 import InfoTooltip from 'src/components/InfoTooltip';
 import ValidatedInput from 'src/components/Form/LabeledErrorBoundInput';
 import FormLabel from 'src/components/Form/FormLabel';
@@ -222,8 +222,11 @@ const TableCatalog = ({
               {t('Google Sheet Name and URL')}
             </FormLabel>
             <div className="catalog-name">
-              <Input
+              <ValidatedInput
                 className="catalog-name-input"
+                required={required}
+                validationMethods={{ onBlur: getValidation }}
+                errorMessage={catalogError[idx]?.name}
                 placeholder={t('Enter a name for this sheet')}
                 onChange={e => {
                   changeMethods.onParametersChange({
@@ -236,7 +239,6 @@ const TableCatalog = ({
                 }}
                 value={sheet.name}
               />
-
               {tableCatalog?.length > 1 && (
                 <CloseOutlined
                   className="catalog-delete"
@@ -248,7 +250,7 @@ const TableCatalog = ({
               className="catalog-name-url"
               required={required}
               validationMethods={{ onBlur: getValidation }}
-              errorMessage={catalogError[sheet.name]}
+              errorMessage={catalogError[idx]?.url}
               placeholder={t('Paste the shareable Google Sheet URL here')}
               onChange={(e: { target: { value: any } }) =>
                 changeMethods.onParametersChange({

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
@@ -552,13 +552,14 @@ export const StyledCatalogTable = styled.div`
   }
 
   .catalog-label {
-    margin: 0 0 8px;
+    margin: 0 0 7px;
   }
 
   .catalog-name {
     display: flex;
     .catalog-name-input {
       width: 95%;
+      margin-bottom: 0px;
     }
   }
 
@@ -570,7 +571,7 @@ export const StyledCatalogTable = styled.div`
   .catalog-delete {
     align-self: center;
     background: ${({ theme }) => theme.colors.grayscale.light4};
-    margin: 5px;
+    margin: 5px 5px 8px 5px;
   }
 
   .catalog-add-btn {

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -691,6 +691,7 @@ export function useDatabaseValidation() {
                       if (extra.catalog.name) {
                         return {
                           ...obj,
+                          error_type,
                           [extra.catalog.idx]: {
                             name: message,
                           },
@@ -699,6 +700,7 @@ export function useDatabaseValidation() {
                       if (extra.catalog.url) {
                         return {
                           ...obj,
+                          error_type,
                           [extra.catalog.idx]: {
                             url: message,
                           },
@@ -707,6 +709,7 @@ export function useDatabaseValidation() {
 
                       return {
                         ...obj,
+                        error_type,
                         [extra.catalog.idx]: {
                           name: message,
                           url: message,

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -681,7 +681,7 @@ export function useDatabaseValidation() {
                         catalog: {
                           name: string;
                           url: string;
-                          idx: string;
+                          idx: number;
                         };
                       };
                       message: string;

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -678,21 +678,45 @@ export function useDatabaseValidation() {
                         invalid?: string[];
                         missing?: string[];
                         name: string;
+                        catalog: {
+                          name: string;
+                          url: string;
+                          idx: string;
+                        };
                       };
                       message: string;
                     },
                   ) => {
+                    if (extra.catalog) {
+                      if (extra.catalog.name) {
+                        return {
+                          ...obj,
+                          [extra.catalog.idx]: {
+                            name: message,
+                          },
+                        };
+                      }
+                      if (extra.catalog.url) {
+                        return {
+                          ...obj,
+                          [extra.catalog.idx]: {
+                            url: message,
+                          },
+                        };
+                      }
+
+                      return {
+                        ...obj,
+                        [extra.catalog.idx]: {
+                          name: message,
+                          url: message,
+                        },
+                      };
+                    }
                     // if extra.invalid doesn't exist then the
                     // error can't be mapped to a parameter
                     // so leave it alone
                     if (extra.invalid) {
-                      if (extra.invalid[0] === 'catalog') {
-                        return {
-                          ...obj,
-                          [extra.name]: message,
-                          error_type,
-                        };
-                      }
                       return {
                         ...obj,
                         [extra.invalid[0]]: message,

--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -151,14 +151,7 @@ class GSheetsEngineSpec(SqliteEngineSpec):
         table_catalog = parameters.get("catalog", {})
 
         if not table_catalog:
-            errors.append(
-                SupersetError(
-                    message="Missing required field",
-                    error_type=SupersetErrorType.CONNECTION_MISSING_PARAMETERS_ERROR,
-                    level=ErrorLevel.WARNING,
-                    extra={"catalog": {"idx": 0}},
-                ),
-            )
+            # Allowing users to submit empty catalogs
             return errors
 
         # We need a subject in case domain wide delegation is set, otherwise the

--- a/tests/unit_tests/db_engine_specs/test_gsheets.py
+++ b/tests/unit_tests/db_engine_specs/test_gsheets.py
@@ -42,13 +42,11 @@ def test_validate_parameters_simple(
     errors = GSheetsEngineSpec.validate_parameters(parameters)
     assert errors == [
         SupersetError(
-            message="URL is required",
+            message="Missing required field",
             error_type=SupersetErrorType.CONNECTION_MISSING_PARAMETERS_ERROR,
             level=ErrorLevel.WARNING,
             extra={
-                "invalid": ["catalog"],
-                "name": "",
-                "url": "",
+                "catalog": {"idx": 0},
                 "issue_codes": [
                     {
                         "code": 1018,
@@ -96,9 +94,7 @@ def test_validate_parameters_catalog(
             error_type=SupersetErrorType.TABLE_DOES_NOT_EXIST_ERROR,
             level=ErrorLevel.WARNING,
             extra={
-                "invalid": ["catalog"],
-                "name": "private_sheet",
-                "url": "https://docs.google.com/spreadsheets/d/1/edit",
+                "catalog": {"idx": 0, "url": True,},
                 "issue_codes": [
                     {
                         "code": 1003,
@@ -116,9 +112,7 @@ def test_validate_parameters_catalog(
             error_type=SupersetErrorType.TABLE_DOES_NOT_EXIST_ERROR,
             level=ErrorLevel.WARNING,
             extra={
-                "invalid": ["catalog"],
-                "name": "not_a_sheet",
-                "url": "https://www.google.com/",
+                "catalog": {"idx": 2, "url": True,},
                 "issue_codes": [
                     {
                         "code": 1003,
@@ -173,9 +167,7 @@ def test_validate_parameters_catalog_and_credentials(
             error_type=SupersetErrorType.TABLE_DOES_NOT_EXIST_ERROR,
             level=ErrorLevel.WARNING,
             extra={
-                "invalid": ["catalog"],
-                "name": "not_a_sheet",
-                "url": "https://www.google.com/",
+                "catalog": {"idx": 2, "url": True,},
                 "issue_codes": [
                     {
                         "code": 1003,

--- a/tests/unit_tests/db_engine_specs/test_gsheets.py
+++ b/tests/unit_tests/db_engine_specs/test_gsheets.py
@@ -40,22 +40,7 @@ def test_validate_parameters_simple(
         "catalog": {},
     }
     errors = GSheetsEngineSpec.validate_parameters(parameters)
-    assert errors == [
-        SupersetError(
-            message="Missing required field",
-            error_type=SupersetErrorType.CONNECTION_MISSING_PARAMETERS_ERROR,
-            level=ErrorLevel.WARNING,
-            extra={
-                "catalog": {"idx": 0},
-                "issue_codes": [
-                    {
-                        "code": 1018,
-                        "message": "Issue 1018 - One or more parameters needed to configure a database are missing.",
-                    }
-                ],
-            },
-        )
-    ]
+    assert errors == []
 
 
 def test_validate_parameters_catalog(


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Change the input type for sheet name to ValidationInputError to allow us to show specific errors for this param. We are going to allow user to create a google sheet engine if there is no catalog set.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

#### Empty URL
![Screen Shot 2021-08-04 at 1 12 54 AM](https://user-images.githubusercontent.com/27827808/128125841-eb28ca31-9a2a-4771-8161-f9d769616de9.png)

#### Empty Sheet Name
![Screen Shot 2021-08-04 at 1 18 27 AM](https://user-images.githubusercontent.com/27827808/128126245-0efa90e5-ddb7-4820-a2f4-a99341811ed6.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
