### PR TITLE
fix(native-filters): add support for boolean cols to select

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils.ts
@@ -30,6 +30,7 @@ export const FILTER_SUPPORTED_TYPES = {
   filter_timegrain: [GenericDataType.TEMPORAL],
   filter_timecolumn: [GenericDataType.TEMPORAL],
   filter_select: [
+    GenericDataType.BOOLEAN,
     GenericDataType.STRING,
     GenericDataType.NUMERIC,
     GenericDataType.TEMPORAL,


### PR DESCRIPTION
### SUMMARY
Add boolean type support to select filter.

### AFTER
Now boolean fields show up in the filter config modal:
![image](https://user-images.githubusercontent.com/33317356/128195743-94654ef1-c7e2-4e3d-ab7c-394b242e3455.png)

...and work:
![image](https://user-images.githubusercontent.com/33317356/128195680-dfeb1524-495e-48f0-aec2-393e52a64247.png)
![image](https://user-images.githubusercontent.com/33317356/128197595-996f252f-93d7-4e9f-908e-684ad4ab60b1.png)

### BEFORE
the boolean field didn't show up in the column selector:
![image](https://user-images.githubusercontent.com/33317356/128196102-30e33261-00e9-4520-93a3-dded16cd1596.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #15746
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
