### PR TITLE
fix: Fixes the Select unselect for object values

### DIFF
--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -310,10 +310,13 @@ const Select = ({
 
   const handleOnDeselect = (value: string | number | AntdLabeledValue) => {
     if (Array.isArray(selectValue)) {
-      const selectedValues = [
-        ...(selectValue as []).filter(opt => opt !== value),
-      ];
-      setSelectValue(selectedValues);
+      if (typeof value === 'number' || typeof value === 'string') {
+        const array = selectValue as (string | number)[];
+        setSelectValue(array.filter(element => element !== value));
+      } else {
+        const array = selectValue as AntdLabeledValue[];
+        setSelectValue(array.filter(element => element.value !== value.value));
+      }
     }
     setSearchedValue('');
   };


### PR DESCRIPTION
### SUMMARY
Fixes the `Select` unselect for object values.

@junlincc 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/128196283-01bb9df8-7c8b-4f7d-8f73-6498bff4b2dc.mov

https://user-images.githubusercontent.com/70410625/128196200-4d1d9d16-8956-467f-a77e-eadfff73f7b3.mov

### TESTING INSTRUCTIONS
See the videos for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
