### PR TITLE
fix: Adding report bug

### DIFF
--- a/superset-frontend/src/components/ReportModal/HeaderReportActionsDropdown/index.tsx
+++ b/superset-frontend/src/components/ReportModal/HeaderReportActionsDropdown/index.tsx
@@ -18,7 +18,7 @@
  */
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
-import { t, SupersetTheme, css } from '@superset-ui/core';
+import { t, SupersetTheme, css, useTheme } from '@superset-ui/core';
 import Icons from 'src/components/Icons';
 import { Switch } from 'src/components/Switch';
 import { AlertObject } from 'src/views/CRUD/alert/types';
@@ -47,6 +47,7 @@ export default function HeaderReportActionsDropDown({
     currentReportDeleting,
     setCurrentReportDeleting,
   ] = useState<AlertObject | null>(null);
+  const theme = useTheme();
 
   const toggleActiveKey = async (data: AlertObject, checked: boolean) => {
     if (data?.id) {
@@ -68,7 +69,7 @@ export default function HeaderReportActionsDropDown({
           checked={report?.active}
           onClick={(checked: boolean) => toggleActiveKey(report, checked)}
           size="small"
-          css={{ marginLeft: '8px' }}
+          css={{ marginLeft: theme.gridUnit * 2 }}
         />
       </Menu.Item>
       <Menu.Item onClick={showReportModal}>{t('Edit email report')}</Menu.Item>

--- a/superset-frontend/src/components/ReportModal/HeaderReportActionsDropdown/index.tsx
+++ b/superset-frontend/src/components/ReportModal/HeaderReportActionsDropdown/index.tsx
@@ -60,7 +60,7 @@ export default function HeaderReportActionsDropDown({
   };
 
   const menu = () => (
-    <Menu selectable={false}>
+    <Menu selectable={false} css={{ width: '200px' }}>
       <Menu.Item>
         {t('Email reports active')}
         <Switch
@@ -68,6 +68,7 @@ export default function HeaderReportActionsDropDown({
           checked={report?.active}
           onClick={(checked: boolean) => toggleActiveKey(report, checked)}
           size="small"
+          css={{ marginLeft: '8px' }}
         />
       </Menu.Item>
       <Menu.Item onClick={showReportModal}>{t('Edit email report')}</Menu.Item>

--- a/superset-frontend/src/reports/actions/reports.js
+++ b/superset-frontend/src/reports/actions/reports.js
@@ -102,8 +102,8 @@ export const addReport = report => dispatch => {
     endpoint: `/api/v1/report/`,
     jsonPayload: report,
   })
-    .then(() => {
-      dispatch({ type: ADD_REPORT, report });
+    .then(({ json }) => {
+      dispatch({ type: ADD_REPORT, json });
       dispatch(addSuccessToast(t('The report has been created')));
     })
     .catch(() =>


### PR DESCRIPTION
### SUMMARY
The reducer for the add reports feature was being sent the wrong information, this fixes it. It also adds margin left to the toggle active button. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/48933336/128210724-ec8e6123-9ce4-4c89-b0b2-f05e6a4f58ab.mov

![Screen Shot 2021-08-04 at 12 14 41 PM](https://user-images.githubusercontent.com/48933336/128216757-39c97762-de7e-4e91-bf99-501033e9f9f9.png)
![Screen Shot 2021-08-04 at 12 14 22 PM](https://user-images.githubusercontent.com/48933336/128216763-a483166d-c094-4fee-b930-4dfeba74122d.png)


### TESTING INSTRUCTIONS
Go to dashboards with ALERT_REPORTS set to true, and a role that has admin. Add a report. 
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
