### PR TITLE
chore: simplify chart permissions

### DIFF
--- a/superset/constants.py
+++ b/superset/constants.py
@@ -119,12 +119,13 @@ MODEL_API_RW_METHOD_PERMISSION_MAP = {
     "refresh": "write",
     "cache_screenshot": "read",
     "screenshot": "read",
-    "data": "read",
     "data_from_cache": "read",
     "get_charts": "read",
     "get_datasets": "read",
     "function_names": "read",
     "available": "read",
+    "post_data": "read",  # used to fetch chart data, so "read"
+    "get_data": "read",
 }
 
 EXTRA_FORM_DATA_APPEND_KEYS = {

--- a/superset/migrations/versions/f6196627326f_update_chart_permissions.py
+++ b/superset/migrations/versions/f6196627326f_update_chart_permissions.py
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""update chart permissions
+
+Revision ID: f6196627326f
+Revises: 143b6f2815da
+Create Date: 2021-08-04 17:16:47.714866
+
+"""
+
+from alembic import op
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from superset.migrations.shared.security_converge import (
+    add_pvms,
+    get_reversed_new_pvms,
+    get_reversed_pvm_map,
+    migrate_roles,
+    Pvm,
+)
+
+# revision identifiers, used by Alembic.
+revision = "f6196627326f"
+down_revision = "143b6f2815da"
+
+PVM_MAP = {
+    Pvm("Chart", "can_get_data"): (Pvm("Chart", "can_read"),),
+    Pvm("Chart", "can_post_data"): (Pvm("Chart", "can_read"),),
+}
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = Session(bind=bind)
+
+    # Add the new permissions on the migration itself
+    migrate_roles(session, PVM_MAP)
+    try:
+        session.commit()
+    except SQLAlchemyError as ex:
+        print(f"An error occurred while upgrading permissions: {ex}")
+        session.rollback()
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = Session(bind=bind)
+
+    # Add the old permissions on the migration itself
+    add_pvms(session, get_reversed_new_pvms(PVM_MAP))
+    migrate_roles(session, get_reversed_pvm_map(PVM_MAP))
+    try:
+        session.commit()
+    except SQLAlchemyError as ex:
+        print(f"An error occurred while downgrading permissions: {ex}")
+        session.rollback()

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -187,9 +187,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         data = json.loads(rv.data.decode("utf-8"))
         assert rv.status_code == 200
         assert set(data["permissions"]) == {
-            "can_get_data",
             "can_read",
-            "can_post_data",
             "can_write",
         }
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Move `cat_post_data` and `can_get_data` (in `Charts`) to `can_read`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

N/A

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
