### PR TITLE
test: Functional RTL for email report modal

### DIFF
--- a/superset-frontend/src/components/ReportModal/index.tsx
+++ b/superset-frontend/src/components/ReportModal/index.tsx
@@ -47,7 +47,7 @@ import {
   SectionHeaderStyle,
 } from './styles';
 
-interface ReportObject {
+export interface ReportObject {
   id?: number;
   active: boolean;
   crontab: string;


### PR DESCRIPTION
### SUMMARY
Implements functional RTL testing for the email report modal

### TESTING INSTRUCTIONS
- Navigate to the following location in your terminal: `src/components/ReportModal/`
- Use the following command to observe the test suite: `npm run test -t index.test.tsx`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
