### PR TITLE
fix: Safari is not showing scroll bars in Explore

### DIFF
--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -81,7 +81,7 @@ const Styles = styled.div`
   text-align: left;
   position: relative;
   width: 100%;
-  height: 100%;
+  max-height: 100%;
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
@@ -448,6 +448,7 @@ function ExploreViewContainer(props) {
             margin-bottom: 0;
           }
           body {
+            height: 100vh;
             max-height: 100vh;
             overflow: hidden;
           }
@@ -458,7 +459,7 @@ function ExploreViewContainer(props) {
           #app {
             flex-basis: 100%;
             overflow: hidden;
-            height: 100vh;
+            height: 100%;
           }
           #app-menu {
             flex-shrink: 0;


### PR DESCRIPTION
### SUMMARY
Fix https://github.com/apache/superset/issues/16072

@junlincc @jinghua-qa @rusackas 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/128354308-b59a6557-f8bd-4bab-8e1b-70167adc626b.mov

https://user-images.githubusercontent.com/70410625/128354409-dda33190-f0f0-4356-b262-96782e20452d.mov

### TESTING INSTRUCTIONS
See the original issue for instructions.

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
