### PR TITLE
feat(explore): each control can define its own canDrop for dnd

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
@@ -42,7 +42,8 @@ export default function DndSelectLabel<T, O>({
       props.onDrop(item);
     },
 
-    canDrop: (item: DatasourcePanelDndItem) => props.canDrop(item),
+    canDrop: (item: DatasourcePanelDndItem) =>
+      props.canDrop(item) && (props.canDropValue?.(item.value) ?? true),
 
     collect: monitor => ({
       isOver: monitor.isOver(),

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
@@ -40,6 +40,7 @@ export default function DndSelectLabel<T, O>({
 
     drop: (item: DatasourcePanelDndItem) => {
       props.onDrop(item);
+      props.onDropValue?.(item.value);
     },
 
     canDrop: (item: DatasourcePanelDndItem) =>

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
@@ -56,7 +56,7 @@ export interface DndColumnSelectProps<
 > extends LabelProps<T> {
   onDrop: (item: DatasourcePanelDndItem) => void;
   canDrop: (item: DatasourcePanelDndItem) => boolean;
-  canDropValue: (value: DndItemValue) => boolean;
+  canDropValue?: (value: DndItemValue) => boolean;
   valuesRenderer: () => ReactNode;
   accept: DndItemType | DndItemType[];
   ghostButtonText?: string;

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
@@ -19,7 +19,10 @@
 import { ReactNode } from 'react';
 import { Metric } from '@superset-ui/core';
 import { ColumnMeta } from '@superset-ui/chart-controls';
-import { DatasourcePanelDndItem } from '../../DatasourcePanel/types';
+import {
+  DatasourcePanelDndItem,
+  DndItemValue,
+} from '../../DatasourcePanel/types';
 import { DndItemType } from '../../DndItemType';
 
 export interface OptionProps {
@@ -53,6 +56,7 @@ export interface DndColumnSelectProps<
 > extends LabelProps<T> {
   onDrop: (item: DatasourcePanelDndItem) => void;
   canDrop: (item: DatasourcePanelDndItem) => boolean;
+  canDropValue: (value: DndItemValue) => boolean;
   valuesRenderer: () => ReactNode;
   accept: DndItemType | DndItemType[];
   ghostButtonText?: string;

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
@@ -57,6 +57,7 @@ export interface DndColumnSelectProps<
   onDrop: (item: DatasourcePanelDndItem) => void;
   canDrop: (item: DatasourcePanelDndItem) => boolean;
   canDropValue?: (value: DndItemValue) => boolean;
+  onDropValue?: (value: DndItemValue) => void;
   valuesRenderer: () => ReactNode;
   accept: DndItemType | DndItemType[];
   ghostButtonText?: string;


### PR DESCRIPTION
### SUMMARY
Allows defining `canDropValue` function in `mapStateToProps` of controls in control panel (in superset-ui).
That will allow us not only to use generic `canDrop` functions for columns or adhoc metrics, but also more advanced ones - like `can drop column "gender" in "Series" control only if "Breakdown" control doesn't already have this column added`.

It's a prerequisite for fixing issue https://github.com/apache/superset/issues/16071

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No changes

### TESTING INSTRUCTIONS
0. Enable dnd
1. Verify that everything works as before

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc 