### PR TITLE
fix(Explore): Adjust width of cell in Time-Series Table chart

### DIFF
--- a/superset-frontend/src/components/dataViewCommon/TableCollection.tsx
+++ b/superset-frontend/src/components/dataViewCommon/TableCollection.tsx
@@ -187,7 +187,7 @@ export const Table = styled.table`
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
-    max-width: 300px;
+    max-width: 320px;
     line-height: 1;
     vertical-align: middle;
     &:first-of-type {


### PR DESCRIPTION
### SUMMARY
It adjusts the width of the cell in the Table to be just enough to show the full chart.

Fixes #15957

### BEFORE
![Screen Shot 2021-08-05 at 17 59 12](https://user-images.githubusercontent.com/60598000/128382494-cc47ed20-3307-4089-823a-0c3ceed19ad3.png)


### AFTER
![Screen Shot 2021-08-05 at 17 57 30](https://user-images.githubusercontent.com/60598000/128382180-5e597108-bfcc-4a0c-8511-845c296a1125.png)

### TESTING INSTRUCTIONS
1. Open a Time-Series Table chart in Explore
2. Configure the Time Series Columns with  type Sparkline
3. Run the query
4. Make sure the chart is appearing fully and no numbers are cut

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #15957
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
