### PR TITLE
fix: Multiple dashboard refresh triggers for the same session

### DIFF
--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -48,7 +48,9 @@ import {
   SAVE_TYPE_OVERWRITE,
   DASHBOARD_POSITION_DATA_LIMIT,
 } from 'src/dashboard/util/constants';
-import setPeriodicRunner from 'src/dashboard/util/setPeriodicRunner';
+import setPeriodicRunner, {
+  stopPeriodicRender,
+} from 'src/dashboard/util/setPeriodicRunner';
 import { options as PeriodicRefreshOptions } from 'src/dashboard/components/RefreshIntervalModal';
 
 const propTypes = {
@@ -196,6 +198,8 @@ class Header extends React.PureComponent {
   }
 
   componentWillUnmount() {
+    stopPeriodicRender(this.refreshTimer);
+    this.props.setRefreshFrequency(0);
     clearTimeout(this.ctrlYTimeout);
     clearTimeout(this.ctrlZTimeout);
   }

--- a/superset-frontend/src/dashboard/util/setPeriodicRunner.ts
+++ b/superset-frontend/src/dashboard/util/setPeriodicRunner.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-const stopPeriodicRender = (refreshTimer?: number) => {
+export const stopPeriodicRender = (refreshTimer?: number) => {
   if (refreshTimer) {
     clearInterval(refreshTimer);
   }


### PR DESCRIPTION
### SUMMARY
Fix: Multiple dashboard refresh triggers for the same session.

@junlincc @jinghua-qa

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/128402857-334beb22-56cb-4063-85d2-4c6dcfea3dfc.mp4

https://user-images.githubusercontent.com/70410625/128397058-dde32dbb-24ef-4035-8884-7b2412cf7a4b.mp4

### TESTING INSTRUCTIONS
Check the videos for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
