### PR TITLE
fix: move watermark to about section

### DIFF
--- a/superset-frontend/src/components/Menu/MenuRight.tsx
+++ b/superset-frontend/src/components/Menu/MenuRight.tsx
@@ -69,15 +69,6 @@ const StyledAnchor = styled.a`
   padding-left: ${({ theme }) => theme.gridUnit}px;
 `;
 
-const WaterMark = styled.span`
-  font-size: 13px;
-  color: #b0b4c3;
-  margin: 0 ${({ theme }) => theme.gridUnit * 4}px;
-  @media (max-width: 1070px) {
-    display: none;
-  }
-`;
-
 const { SubMenu } = Menu;
 
 interface RightMenuProps {
@@ -95,9 +86,6 @@ const RightMenu = ({
 }: RightMenuProps) => (
   <StyledDiv align={align}>
     <Menu mode="horizontal">
-      {navbarRight.show_watermark && (
-        <WaterMark>{t('Powered by Apache Superset')}</WaterMark>
-      )}
       {!navbarRight.user_is_anonymous && (
         <SubMenu
           data-test="new-dropdown"
@@ -160,6 +148,11 @@ const RightMenu = ({
           <Menu.Divider key="version-info-divider" />,
           <Menu.ItemGroup key="about-section" title={t('About')}>
             <div className="about-section">
+              {navbarRight.show_watermark && (
+                <div css={versionInfoStyles}>
+                  {t('Powered by Apache Superset')}
+                </div>
+              )}
               {navbarRight.version_string && (
                 <div css={versionInfoStyles}>
                   Version: {navbarRight.version_string}


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Moving the "Powered by Apache Superset" watermark to the About section in the menu


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
After:
<img width="495" alt="Screen Shot 2021-08-05 at 3 37 19 PM" src="https://user-images.githubusercontent.com/10255196/128430658-62805fc2-22c5-47f8-823b-14f5e71e48fe.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
👀 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
