### PR TITLE
fix: boolean type into SQL 'in' operator

### DIFF
--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -112,7 +112,7 @@ const ColumnButtonWrapper = styled.div`
 const checkboxGenerator = (d, onChange) => (
   <CheckboxControl value={d} onChange={onChange} />
 );
-const DATA_TYPES = ['STRING', 'NUMERIC', 'DATETIME'];
+const DATA_TYPES = ['STRING', 'NUMERIC', 'DATETIME', 'BOOLEAN'];
 
 const DATASOURCE_TYPES_ARR = [
   { key: 'physical', label: t('Physical (table or view)') },

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -374,6 +374,8 @@ class BaseDatasource(
                     return None
                 if value == "<empty string>":
                     return ""
+            if target_column_type == utils.GenericDataType.BOOLEAN:
+                return utils.cast_to_boolean(value)
             return value
 
         if isinstance(values, (list, tuple)):

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -423,6 +423,35 @@ def cast_to_num(value: Optional[Union[float, int, str]]) -> Optional[Union[float
         return None
 
 
+def cast_to_boolean(value: Any) -> bool:
+    """Casts a value to an int/float
+
+    >>> cast_to_boolean(1)
+    True
+    >>> cast_to_boolean(0)
+    False
+    >>> cast_to_boolean(0.5)
+    True
+    >>> cast_to_boolean('true')
+    True
+    >>> cast_to_boolean('false')
+    False
+    >>> cast_to_boolean('False')
+    False
+    >>> cast_to_boolean(None)
+    False
+
+    :param value: value to be converted to boolean representation
+    :returns: value cast to `bool`. when value is 'true' or value that are not 0
+              converte into True
+    """
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() == "true"
+    return False
+
+
 def list_minus(l: List[Any], minus: List[Any]) -> List[Any]:
     """Returns l without what is in minus
 

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -299,7 +299,7 @@ class TestDatabaseModel(SupersetTestCase):
         operand = "(true, false)"
 
         # override native_boolean=False behavior in MySQLCompiler
-        # https://github.com/sqlalchemy/sqlalchemy/blob/b75630cec9418ef087e7c6af0370ac6ba728a251/lib/sqlalchemy/dialects/mysql/base.py
+        # https://github.com/sqlalchemy/sqlalchemy/blob/master/lib/sqlalchemy/dialects/mysql/base.py
         if not dialect.supports_native_boolean and dialect.name != "mysql":
             operand = "(1, 0)"
         self.assertIn(f"IN {operand}", sql)

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -20,6 +20,8 @@ from typing import Any, Dict, NamedTuple, List, Pattern, Tuple, Union
 from unittest.mock import patch
 import pytest
 
+import sqlalchemy as sa
+
 from superset import db
 from superset.connectors.sqla.models import SqlaTable, TableColumn
 from superset.db_engine_specs.bigquery import BigQueryEngineSpec
@@ -295,7 +297,10 @@ class TestDatabaseModel(SupersetTestCase):
         sql = table.database.compile_sqla_query(sqla_query.sqla_query)
         dialect = table.database.get_dialect()
         operand = "(true, false)"
-        if not dialect.supports_native_boolean:
+
+        # override native_boolean=False behavior in MySQLCompiler
+        # https://github.com/sqlalchemy/sqlalchemy/blob/b75630cec9418ef087e7c6af0370ac6ba728a251/lib/sqlalchemy/dialects/mysql/base.py
+        if not dialect.supports_native_boolean and dialect.name != "mysql":
             operand = "(1, 0)"
         self.assertIn(f"IN {operand}", sql)
 

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -293,7 +293,11 @@ class TestDatabaseModel(SupersetTestCase):
         }
         sqla_query = table.get_sqla_query(**query_obj)
         sql = table.database.compile_sqla_query(sqla_query.sqla_query)
-        self.assertIn("IN (true, false)", sql)
+        dialect = table.database.get_dialect()
+        operand = "(true, false)"
+        if not dialect.supports_native_boolean:
+            operand = "(1, 0)"
+        self.assertIn(f"IN {operand}", sql)
 
     def test_incorrect_jinja_syntax_raises_correct_exception(self):
         query_obj = {

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -297,7 +297,6 @@ class TestDatabaseModel(SupersetTestCase):
         sql = table.database.compile_sqla_query(sqla_query.sqla_query)
         dialect = table.database.get_dialect()
         operand = "(true, false)"
-
         # override native_boolean=False behavior in MySQLCompiler
         # https://github.com/sqlalchemy/sqlalchemy/blob/master/lib/sqlalchemy/dialects/mysql/base.py
         if not dialect.supports_native_boolean and dialect.name != "mysql":


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
closes: https://github.com/apache/superset/issues/16081
Currently, there is an issue with filters that handle boolean values. If the database engine does not provide boolean value implicit conversion, will cause the query to fail.
Imagine SQL:
```
SELECT case
           when gender = 'boy' then True
           else False
       end AS boolean_gender,
       count(num) AS "COUNT(num)"
FROM birth_names
WHERE case
          when gender = 'boy' then True
          else False
      end IN ('false')
GROUP BY case
             when gender = 'boy' then True
             else False
         end
ORDER BY "COUNT(num)" DESC
LIMIT 10000;
```

the derived column(Calculated column in Superset) type is Boolean, and the operand is String('true')

```
case
    when gender = 'boy' then True
    else False
end IN ('false')
```


This PR introduced a conversion when the column type is boolean and operand type also is boolean.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

#### Before

https://user-images.githubusercontent.com/2016594/128458491-8c8d4e31-efb7-4445-9e2f-7ac50d246b42.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. select `birth_names` dataset
2. create a new Calculated Columns. 
name: boolean_gender
SQL expression : `case when gender = 'boy' then True else False end`
Data Type: Boolean
3. create a treemap v2. select `boolean_gender` into Group by control; select sum(num) into Metric; check `emit dashboard cross filters`; saved to new dashboard `test`
4. create a table. select `boolean_gender` into Group by control; select sum(num) into Metric; check `emit dashboard cross filters`; saved to dashboard `test`
5. goto dashboard `test`
6. select `true` or `false` in treemap v2, then the table can be filtered.
7. double-check view query in table viz, where clause like below:
```
WHERE case
          when gender = 'boy' then True
          else False
      end IN (false)
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/16081
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
