### PR TITLE
refactor: remove unnecessary dataset queries from dashboard requests

### DIFF
--- a/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
@@ -113,8 +113,6 @@ fetchMock.get('http://localhost/api/v1/dashboard/26', {
       published: false,
       roles: [],
       slug: null,
-      table_names:
-        '[examples].[covid_vaccines], [examples].[covid_vaccines], [examples].[covid_vaccines], [examples].[covid_vaccines], [examples].[covid_vaccines], [examples].[covid_vaccines], [examples].[covid_vaccines], [examples].[covid_vaccines]',
       thumbnail_url:
         '/api/v1/dashboard/26/thumbnail/b24805e98d90116da8c0974d24f5c533/',
       url: '/superset/dashboard/26/',

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -145,7 +145,6 @@ class ChartEntityResponseSchema(Schema):
     cache_timeout = fields.Integer(description=cache_timeout_description)
     changed_on = fields.String(description=changed_on_description)
     modified = fields.String()
-    datasource = fields.String(description=datasource_name_description)
     description = fields.String(description=description_description)
     description_markeddown = fields.String(
         description=description_markeddown_description

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -158,7 +158,6 @@ class DashboardGetResponseSchema(Schema):
     charts = fields.List(fields.String(description=charts_description))
     owners = fields.List(fields.Nested(UserSchema))
     roles = fields.List(fields.Nested(RolesSchema))
-    table_names = fields.String()  # legacy nonsense
     changed_on_humanized = fields.String(data_key="changed_on_delta_humanized")
 
 

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -162,11 +162,6 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
         return f"Dashboard<{self.id or self.slug}>"
 
     @property
-    def table_names(self) -> str:
-        # pylint: disable=no-member
-        return ", ".join(str(s.datasource.full_name) for s in self.slices)
-
-    @property
     def url(self) -> str:
         return f"/superset/dashboard/{self.slug or self.id}/"
 

--- a/superset/views/dashboard/mixin.py
+++ b/superset/views/dashboard/mixin.py
@@ -39,7 +39,7 @@ class DashboardMixin:  # pylint: disable=too-few-public-methods
         "json_metadata",
         "published",
     ]
-    show_columns = edit_columns + ["table_names", "charts"]
+    show_columns = edit_columns + ["charts"]
     search_columns = ("dashboard_title", "slug", "owners", "published")
     add_columns = edit_columns
     base_order = ("changed_on", "desc")

--- a/superset/views/dashboard/mixin.py
+++ b/superset/views/dashboard/mixin.py
@@ -87,7 +87,6 @@ class DashboardMixin:  # pylint: disable=too-few-public-methods
         "position_json": _("Position JSON"),
         "css": _("CSS"),
         "json_metadata": _("JSON Metadata"),
-        "table_names": _("Underlying Tables"),
     }
 
     def pre_delete(self, item: "DashboardMixin") -> None:  # pylint: disable=no-self-use

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -339,7 +339,6 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
             "published": False,
             "url": "/superset/dashboard/slug1/",
             "slug": "slug1",
-            "table_names": "",
             "thumbnail_url": dashboard.thumbnail_url,
         }
         data = json.loads(rv.data.decode("utf-8"))


### PR DESCRIPTION
### SUMMARY
In airbnb we did some investigation for server-side processing time for dashboard requests, try to find perf bottleneck and improve the dashboard performance, especially for those large ones with multiple datasets and tabs. 

Currently when user opens a dashboard we need 3 different API to fetch data:
- `GET /api/v1/dashboard/<id_or_slug>`: to get dashboard metadata
- `GET /api/v1/dashboard/<id_or_slug>/charts`: to get charts metadata for a given dashboard id
- `GET /api/v1/dashboard/<id_or_slug>/datasets`: to get dataset metadata for a given dashboard id

Since [this PR](#15688), we found the queries to `tables` is perf bottleneck, so we already made datasets request non-blocking for dashboard render. And given we already split big blob of dashboard data into 3 different APIs, it seems not necessary for each of request to query `tables`. This PR is to remove unnecessary dataset queries from these 2 requests.

We run some profiling for `/dashboard/id` and `/dashboard/id/charts` requests in `Datadog`. I used a heavy dashboard in airbnb as example, which has 80 datasets and about 300 charts.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: 
<img width="941" alt="Screen Shot 2021-08-06 at 5 53 10 PM" src="https://user-images.githubusercontent.com/27990562/128583911-8a997963-2253-46ff-bdcd-182464acb49f.png">

<img width="1062" alt="Screen Shot 2021-08-06 at 6 42 02 PM" src="https://user-images.githubusercontent.com/27990562/128584078-62c86ff4-4c19-433b-8fe3-6efffc39e956.png">

You will see that even each query to `tables` table only takes 1.2 ~ 1.9 ms, but the queries was called a few hundred times, it cause the overall response time took ~ 1 seconds (for both dashboard and dashboard/charts request)


After: 
<img width="967" alt="Screen Shot 2021-08-06 at 6 47 18 PM" src="https://user-images.githubusercontent.com/27990562/128584211-51963c8d-9294-456a-ab6d-44875098ea39.png">
<img width="962" alt="Screen Shot 2021-08-06 at 6 47 36 PM" src="https://user-images.githubusercontent.com/27990562/128584212-c29e8045-2bee-4329-a34e-6a81e59df724.png">

After removing unnecessary queries to datasets, `pymysql.query` operation is reduced a lot.  


### TESTING INSTRUCTIONS
CI and manual test.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
