### PR TITLE
fix(explore): revert dnd column dependency array change to fix infinite rerenders

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
@@ -45,6 +45,8 @@ export const DndColumnSelect = (props: LabelProps) => {
     [multi, options, value],
   );
 
+  console.log("DND COLUMN SELECT")
+
   // synchronize values in case of dataset changes
   const handleOptionsChange = useCallback(() => {
     const optionSelectorValues = optionSelector.getValues();
@@ -68,7 +70,7 @@ export const DndColumnSelect = (props: LabelProps) => {
     }
     // when options change, that means that the dataset has changed
     // so we have to check if values are still applicable.
-  }, [options, value, optionSelector]);
+  }, [JSON.stringify(value), JSON.stringify(optionSelector.getValues())]);
 
   // useComponentDidUpdate to avoid running this for the first render, to avoid
   // calling onChange when the initial value is not valid for the dataset

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
@@ -45,8 +45,6 @@ export const DndColumnSelect = (props: LabelProps) => {
     [multi, options, value],
   );
 
-  console.log("DND COLUMN SELECT")
-
   // synchronize values in case of dataset changes
   const handleOptionsChange = useCallback(() => {
     const optionSelectorValues = optionSelector.getValues();

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
@@ -66,8 +66,6 @@ export const DndColumnSelect = (props: LabelProps) => {
     ) {
       onChange(optionSelectorValues);
     }
-    // when options change, that means that the dataset has changed
-    // so we have to check if values are still applicable.
   }, [JSON.stringify(value), JSON.stringify(optionSelector.getValues())]);
 
   // useComponentDidUpdate to avoid running this for the first render, to avoid


### PR DESCRIPTION
### SUMMARY
Revert change in dependency array in `DndColumnSelect` introduced in https://github.com/apache/superset/pull/16073 - it causes infinite rerenders and page freeze when interacting with the component.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/15073128/128518892-8349a8e4-e365-42f0-84e3-4d418fcbe297.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
