### PR TITLE
chore(explore): change dnd placeholders

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.test.tsx
@@ -29,7 +29,7 @@ const defaultProps: LabelProps = {
 
 test('renders with default props', () => {
   render(<DndColumnSelect {...defaultProps} />, { useDnd: true });
-  expect(screen.getByText('Drop columns')).toBeInTheDocument();
+  expect(screen.getByText('Drop columns here')).toBeInTheDocument();
 });
 
 test('renders with value', () => {

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
@@ -145,7 +145,8 @@ export const DndColumnSelect = (props: LabelProps) => {
       accept={DndItemType.Column}
       displayGhostButton={multi || optionSelector.values.length === 0}
       ghostButtonText={
-        ghostButtonText || tn('Drop column here', 'Drop columns here', multi ? 2 : 1)
+        ghostButtonText ||
+        tn('Drop column here', 'Drop columns here', multi ? 2 : 1)
       }
       {...props}
     />

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
@@ -145,7 +145,7 @@ export const DndColumnSelect = (props: LabelProps) => {
       accept={DndItemType.Column}
       displayGhostButton={multi || optionSelector.values.length === 0}
       ghostButtonText={
-        ghostButtonText || tn('Drop column', 'Drop columns', multi ? 2 : 1)
+        ghostButtonText || tn('Drop column here', 'Drop columns here', multi ? 2 : 1)
       }
       {...props}
     />

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.test.tsx
@@ -38,7 +38,7 @@ const defaultProps = {
 
 test('renders with default props', () => {
   render(<DndFilterSelect {...defaultProps} />, { useDnd: true });
-  expect(screen.getByText('Drop columns or metrics')).toBeInTheDocument();
+  expect(screen.getByText('Drop columns or metrics here')).toBeInTheDocument();
 });
 
 test('renders with value', () => {
@@ -56,7 +56,7 @@ test('renders options with saved metric', () => {
   render(<DndFilterSelect {...defaultProps} formData={['saved_metric']} />, {
     useDnd: true,
   });
-  expect(screen.getByText('Drop columns or metrics')).toBeInTheDocument();
+  expect(screen.getByText('Drop columns or metrics here')).toBeInTheDocument();
 });
 
 test('renders options with column', () => {
@@ -76,7 +76,7 @@ test('renders options with column', () => {
       useDnd: true,
     },
   );
-  expect(screen.getByText('Drop columns or metrics')).toBeInTheDocument();
+  expect(screen.getByText('Drop columns or metrics here')).toBeInTheDocument();
 });
 
 test('renders options with adhoc metric', () => {
@@ -87,5 +87,5 @@ test('renders options with adhoc metric', () => {
   render(<DndFilterSelect {...defaultProps} formData={[adhocMetric]} />, {
     useDnd: true,
   });
-  expect(screen.getByText('Drop columns or metrics')).toBeInTheDocument();
+  expect(screen.getByText('Drop columns or metrics here')).toBeInTheDocument();
 });

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
@@ -374,7 +374,7 @@ export const DndFilterSelect = (props: DndFilterSelectProps) => {
         canDrop={canDrop}
         valuesRenderer={valuesRenderer}
         accept={DND_ACCEPTED_TYPES}
-        ghostButtonText={t('Drop columns or metrics')}
+        ghostButtonText={t('Drop columns or metrics here')}
         {...props}
       />
       <AdhocFilterPopoverTrigger

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
@@ -31,10 +31,10 @@ const defaultProps = {
 
 test('renders with default props', () => {
   render(<DndMetricSelect {...defaultProps} />, { useDnd: true });
-  expect(screen.getByText('Drop column or metric')).toBeInTheDocument();
+  expect(screen.getByText('Drop column or metric here')).toBeInTheDocument();
 });
 
 test('renders with default props and multi = true', () => {
   render(<DndMetricSelect {...defaultProps} multi />, { useDnd: true });
-  expect(screen.getByText('Drop columns or metrics')).toBeInTheDocument();
+  expect(screen.getByText('Drop columns or metrics here')).toBeInTheDocument();
 });

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -334,8 +334,8 @@ export const DndMetricSelect = (props: any) => {
         valuesRenderer={valuesRenderer}
         accept={DND_ACCEPTED_TYPES}
         ghostButtonText={tn(
-          'Drop column or metric',
-          'Drop columns or metrics',
+          'Drop column or metric here',
+          'Drop columns or metrics here',
           multi ? 2 : 1,
         )}
         displayGhostButton={multi || value.length === 0}

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.test.tsx
@@ -33,7 +33,7 @@ const defaultProps = {
 
 test('renders with default props', async () => {
   render(<DndSelectLabel {...defaultProps} />, { useDnd: true });
-  expect(await screen.findByText('Drop columns')).toBeInTheDocument();
+  expect(await screen.findByText('Drop columns here')).toBeInTheDocument();
 });
 
 test('renders ghost button when empty', async () => {

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
@@ -55,7 +55,7 @@ export default function DndSelectLabel<T, O>({
     return (
       <AddControlLabel cancelHover>
         <Icons.PlusSmall iconColor={theme.colors.grayscale.light1} />
-        {t(props.ghostButtonText || 'Drop columns')}
+        {t(props.ghostButtonText || 'Drop columns here')}
       </AddControlLabel>
     );
   }


### PR DESCRIPTION
### SUMMARY
Add "here" suffix to drag and drop controls placeholders.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://user-images.githubusercontent.com/15073128/128524674-374ef50b-0d88-41a2-bfbd-d8e314aba3fe.png)

After: 
![image](https://user-images.githubusercontent.com/15073128/128524429-dffc66c3-059f-4826-a16a-3f2150247161.png)

### TESTING INSTRUCTIONS
Enable dnd and verify that all controls placeholders have "here" suffix

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @junlincc @srinify 