### PR TITLE
feat(explore): make dnd controls clickable

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -139,20 +139,15 @@ const ColumnSelectPopover = ({
   );
 
   return (
-    <Form
-      layout="vertical"
-      id="metrics-edit-popover"
-      data-test="metrics-edit-popover"
-    >
+    <Form layout="vertical" id="metrics-edit-popover">
       <Tabs
         id="adhoc-metric-edit-tabs"
-        data-test="adhoc-metric-edit-tabs"
         defaultActiveKey={defaultActiveTabKey}
         className="adhoc-metric-edit-tabs"
         allowOverflow
       >
         <Tabs.TabPane key="saved" tab={t('Saved')}>
-          <FormItem label={t('Calculated column')}>
+          <FormItem label={t('Saved expressions')}>
             <StyledSelect
               value={selectedCalculatedColumn?.column_name}
               getPopupContainer={getPopupContainer}
@@ -206,12 +201,7 @@ const ColumnSelectPopover = ({
         </Tabs.TabPane>
       </Tabs>
       <div>
-        <Button
-          buttonSize="small"
-          onClick={onResetStateAndClose}
-          data-test="AdhocMetricEdit#cancel"
-          cta
-        >
+        <Button buttonSize="small" onClick={onResetStateAndClose} cta>
           {t('Close')}
         </Button>
         <Button
@@ -220,7 +210,6 @@ const ColumnSelectPopover = ({
             hasUnsavedChanges && stateIsValid ? 'primary' : 'default'
           }
           buttonSize="small"
-          data-test="AdhocMetricEdit#save"
           onClick={onSave}
           cta
         >

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -1,0 +1,234 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/* eslint-disable camelcase */
+import React, { useCallback, useMemo, useState } from 'react';
+import Tabs from 'src/components/Tabs';
+import Button from 'src/components/Button';
+import { NativeSelect as Select } from 'src/components/Select';
+import { t, styled } from '@superset-ui/core';
+
+import { Form, FormItem } from 'src/components/Form';
+import { StyledColumnOption } from 'src/explore/components/optionRenderers';
+import { ColumnMeta } from '@superset-ui/chart-controls';
+
+const StyledSelect = styled(Select)`
+  .metric-option {
+    & > svg {
+      min-width: ${({ theme }) => `${theme.gridUnit * 4}px`};
+    }
+    & > .option-label {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+`;
+
+interface ColumnSelectPopoverProps {
+  columns: ColumnMeta[];
+  editedColumn?: ColumnMeta;
+  onChange: (column: ColumnMeta) => void;
+  onClose: () => void;
+}
+
+const ColumnSelectPopover = ({
+  columns,
+  editedColumn,
+  onChange,
+  onClose,
+}: ColumnSelectPopoverProps) => {
+  const [
+    initialCalculatedColumn,
+    initialSimpleColumn,
+  ] = editedColumn?.expression
+    ? [editedColumn, undefined]
+    : [undefined, editedColumn];
+  const [selectedCalculatedColumn, setSelectedCalculatedColumn] = useState(
+    initialCalculatedColumn,
+  );
+  const [selectedSimpleColumn, setSelectedSimpleColumn] = useState(
+    initialSimpleColumn,
+  );
+
+  const [calculatedColumns, simpleColumns] = useMemo(
+    () =>
+      columns?.reduce(
+        (acc: [ColumnMeta[], ColumnMeta[]], column: ColumnMeta) => {
+          if (column.expression) {
+            acc[0].push(column);
+          } else {
+            acc[1].push(column);
+          }
+          return acc;
+        },
+        [[], []],
+      ),
+    [columns],
+  );
+
+  const onCalculatedColumnChange = useCallback(
+    selectedColumnName => {
+      const selectedColumn = calculatedColumns.find(
+        col => col.column_name === selectedColumnName,
+      );
+      setSelectedCalculatedColumn(selectedColumn);
+      setSelectedSimpleColumn(undefined);
+    },
+    [calculatedColumns],
+  );
+
+  const onSimpleColumnChange = useCallback(
+    selectedColumnName => {
+      const selectedColumn = simpleColumns.find(
+        col => col.column_name === selectedColumnName,
+      );
+      setSelectedCalculatedColumn(undefined);
+      setSelectedSimpleColumn(selectedColumn);
+    },
+    [simpleColumns],
+  );
+
+  const defaultActiveTabKey =
+    initialSimpleColumn || calculatedColumns.length === 0 ? 'simple' : 'saved';
+
+  const onSave = useCallback(() => {
+    const selectedColumn = selectedCalculatedColumn || selectedSimpleColumn;
+    if (!selectedColumn) {
+      return;
+    }
+    onChange(selectedColumn);
+    onClose();
+  }, [onChange, onClose, selectedCalculatedColumn, selectedSimpleColumn]);
+
+  const onResetStateAndClose = useCallback(() => {
+    setSelectedCalculatedColumn(initialCalculatedColumn);
+    setSelectedSimpleColumn(initialSimpleColumn);
+    onClose();
+  }, [initialCalculatedColumn, initialSimpleColumn, onClose]);
+
+  const stateIsValid = selectedCalculatedColumn || selectedSimpleColumn;
+  const hasUnsavedChanges =
+    selectedCalculatedColumn?.column_name !==
+      initialCalculatedColumn?.column_name ||
+    selectedSimpleColumn?.column_name !== initialSimpleColumn?.column_name;
+
+  const filterOption = useCallback(
+    (input, option) =>
+      option?.filterBy.toLowerCase().indexOf(input.toLowerCase()) >= 0,
+    [],
+  );
+
+  const getPopupContainer = useCallback(
+    (triggerNode: any) => triggerNode.parentNode,
+    [],
+  );
+
+  return (
+    <Form
+      layout="vertical"
+      id="metrics-edit-popover"
+      data-test="metrics-edit-popover"
+    >
+      <Tabs
+        id="adhoc-metric-edit-tabs"
+        data-test="adhoc-metric-edit-tabs"
+        defaultActiveKey={defaultActiveTabKey}
+        className="adhoc-metric-edit-tabs"
+        allowOverflow
+      >
+        <Tabs.TabPane key="saved" tab={t('Saved')}>
+          <FormItem label={t('Calculated column')}>
+            <StyledSelect
+              value={selectedCalculatedColumn?.column_name}
+              getPopupContainer={getPopupContainer}
+              onChange={onCalculatedColumnChange}
+              allowClear
+              showSearch
+              autoFocus={!selectedCalculatedColumn}
+              filterOption={filterOption}
+              placeholder={t('%s column(s)', calculatedColumns.length)}
+            >
+              {calculatedColumns.map(calculatedColumn => (
+                <Select.Option
+                  value={calculatedColumn.column_name}
+                  filterBy={
+                    calculatedColumn.verbose_name ||
+                    calculatedColumn.column_name
+                  }
+                  key={calculatedColumn.column_name}
+                >
+                  <StyledColumnOption column={calculatedColumn} showType />
+                </Select.Option>
+              ))}
+            </StyledSelect>
+          </FormItem>
+        </Tabs.TabPane>
+        <Tabs.TabPane key="simple" tab={t('Simple')}>
+          <FormItem label={t('Column')}>
+            <Select
+              value={selectedSimpleColumn?.column_name}
+              getPopupContainer={getPopupContainer}
+              onChange={onSimpleColumnChange}
+              allowClear
+              showSearch
+              autoFocus={!selectedSimpleColumn}
+              filterOption={filterOption}
+              placeholder={t('%s column(s)', simpleColumns.length)}
+            >
+              {simpleColumns.map(simpleColumn => (
+                <Select.Option
+                  value={simpleColumn.column_name}
+                  filterBy={
+                    simpleColumn.verbose_name || simpleColumn.column_name
+                  }
+                  key={simpleColumn.column_name}
+                >
+                  <StyledColumnOption column={simpleColumn} showType />
+                </Select.Option>
+              ))}
+            </Select>
+          </FormItem>
+        </Tabs.TabPane>
+      </Tabs>
+      <div>
+        <Button
+          buttonSize="small"
+          onClick={onResetStateAndClose}
+          data-test="AdhocMetricEdit#cancel"
+          cta
+        >
+          {t('Close')}
+        </Button>
+        <Button
+          disabled={!stateIsValid}
+          buttonStyle={
+            hasUnsavedChanges && stateIsValid ? 'primary' : 'default'
+          }
+          buttonSize="small"
+          data-test="AdhocMetricEdit#save"
+          onClick={onSave}
+          cta
+        >
+          {t('Save')}
+        </Button>
+      </div>
+    </Form>
+  );
+};
+
+export default ColumnSelectPopover;

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.tsx
@@ -26,6 +26,10 @@ interface ColumnSelectPopoverTriggerProps {
   columns: ColumnMeta[];
   editedColumn?: ColumnMeta;
   onColumnEdit: (editedColumn: ColumnMeta) => void;
+  isControlledComponent?: boolean;
+  visible?: boolean;
+  togglePopover?: (visible: boolean) => void;
+  closePopover?: () => void;
   children: React.ReactNode;
 }
 
@@ -33,7 +37,9 @@ const ColumnSelectPopoverTrigger = ({
   columns,
   editedColumn,
   onColumnEdit,
+  isControlledComponent,
   children,
+  ...props
 }: ColumnSelectPopoverTriggerProps) => {
   const [popoverVisible, setPopoverVisible] = useState(false);
 
@@ -45,18 +51,34 @@ const ColumnSelectPopoverTrigger = ({
     setPopoverVisible(false);
   }, []);
 
+  const {
+    visible,
+    handleTogglePopover,
+    handleClosePopover,
+  } = isControlledComponent
+    ? {
+        visible: props.visible,
+        handleTogglePopover: props.togglePopover!,
+        handleClosePopover: props.closePopover!,
+      }
+    : {
+        visible: popoverVisible,
+        handleTogglePopover: togglePopover,
+        handleClosePopover: closePopover,
+      };
+
   const overlayContent = useMemo(
     () => (
       <ExplorePopoverContent>
         <ColumnSelectPopover
           editedColumn={editedColumn}
           columns={columns}
-          onClose={closePopover}
+          onClose={handleClosePopover}
           onChange={onColumnEdit}
         />
       </ExplorePopoverContent>
     ),
-    [closePopover, columns, editedColumn, onColumnEdit],
+    [columns, editedColumn, handleClosePopover, onColumnEdit],
   );
 
   return (
@@ -64,9 +86,9 @@ const ColumnSelectPopoverTrigger = ({
       placement="right"
       trigger="click"
       content={overlayContent}
-      defaultVisible={popoverVisible}
-      visible={popoverVisible}
-      onVisibleChange={togglePopover}
+      defaultVisible={visible}
+      visible={visible}
+      onVisibleChange={handleTogglePopover}
       destroyTooltipOnHide
     >
       {children}

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.tsx
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { useCallback, useMemo, useState } from 'react';
+import { ColumnMeta } from '@superset-ui/chart-controls';
+import Popover from 'src/components/Popover';
+import { ExplorePopoverContent } from 'src/explore/components/ExploreContentPopover';
+import ColumnSelectPopover from './ColumnSelectPopover';
+
+interface ColumnSelectPopoverTriggerProps {
+  columns: ColumnMeta[];
+  editedColumn?: ColumnMeta;
+  onColumnEdit: (editedColumn: ColumnMeta) => void;
+  children: React.ReactNode;
+}
+
+const ColumnSelectPopoverTrigger = ({
+  columns,
+  editedColumn,
+  onColumnEdit,
+  children,
+}: ColumnSelectPopoverTriggerProps) => {
+  const [popoverVisible, setPopoverVisible] = useState(false);
+
+  const togglePopover = useCallback((visible: boolean) => {
+    setPopoverVisible(visible);
+  }, []);
+
+  const closePopover = useCallback(() => {
+    setPopoverVisible(false);
+  }, []);
+
+  const overlayContent = useMemo(
+    () => (
+      <ExplorePopoverContent>
+        <ColumnSelectPopover
+          editedColumn={editedColumn}
+          columns={columns}
+          onClose={closePopover}
+          onChange={onColumnEdit}
+        />
+      </ExplorePopoverContent>
+    ),
+    [closePopover, columns, editedColumn, onColumnEdit],
+  );
+
+  return (
+    <Popover
+      placement="right"
+      trigger="click"
+      content={overlayContent}
+      defaultVisible={popoverVisible}
+      visible={popoverVisible}
+      onVisibleChange={togglePopover}
+      destroyTooltipOnHide
+    >
+      {children}
+    </Popover>
+  );
+};
+
+export default ColumnSelectPopoverTrigger;

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
@@ -27,6 +27,7 @@ import { OptionSelector } from 'src/explore/components/controls/DndColumnSelectC
 import { DatasourcePanelDndItem } from 'src/explore/components/DatasourcePanel/types';
 import { DndItemType } from 'src/explore/components/DndItemType';
 import { useComponentDidUpdate } from 'src/common/hooks/useComponentDidUpdate';
+import ColumnSelectPopoverTrigger from './ColumnSelectPopoverTrigger';
 
 export const DndColumnSelect = (props: LabelProps) => {
   const {
@@ -113,23 +114,35 @@ export const DndColumnSelect = (props: LabelProps) => {
   const valuesRenderer = useCallback(
     () =>
       optionSelector.values.map((column, idx) => (
-        <OptionWrapper
-          key={idx}
-          index={idx}
-          clickClose={onClickClose}
-          onShiftOptions={onShiftOptions}
-          type={`${DndItemType.ColumnOption}_${name}_${label}`}
-          canDelete={canDelete}
-          column={column}
-        />
+        <ColumnSelectPopoverTrigger
+          columns={Object.values(options)}
+          onColumnEdit={newColumn => {
+            optionSelector.replace(idx, newColumn.column_name);
+            onChange(optionSelector.getValues());
+          }}
+          editedColumn={column}
+        >
+          <OptionWrapper
+            key={idx}
+            index={idx}
+            clickClose={onClickClose}
+            onShiftOptions={onShiftOptions}
+            type={`${DndItemType.ColumnOption}_${name}_${label}`}
+            canDelete={canDelete}
+            column={column}
+            withCaret
+          />
+        </ColumnSelectPopoverTrigger>
       )),
     [
       canDelete,
       label,
       name,
+      onChange,
       onClickClose,
       onShiftOptions,
-      optionSelector.values,
+      optionSelector,
+      options,
     ],
   );
 

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
@@ -143,10 +143,9 @@ export const DndColumnSelect = (props: LabelProps) => {
               onShiftOptions={onShiftOptions}
               type={`${DndItemType.ColumnOption}_${name}_${label}`}
               canDelete={canDelete}
+              column={column}
               withCaret
-            >
-              <StyledColumnOption column={column} showType />
-            </OptionWrapper>
+            />
           </ColumnSelectPopoverTrigger>
         ) : (
           <OptionWrapper
@@ -159,6 +158,7 @@ export const DndColumnSelect = (props: LabelProps) => {
             column={column}
             withCaret
           />
+        ),
       ),
     [
       canDelete,
@@ -192,6 +192,16 @@ export const DndColumnSelect = (props: LabelProps) => {
     togglePopover(true);
   }, [togglePopover]);
 
+  const defaultGhostButtonText = isFeatureEnabled(
+    FeatureFlag.ENABLE_DND_WITH_CLICK_UX,
+  )
+    ? tn(
+        'Drop a column here or click',
+        'Drop columns here or click',
+        multi ? 2 : 1,
+      )
+    : tn('Drop column here', 'Drop columns here', multi ? 2 : 1);
+
   return (
     <div>
       <DndSelectLabel<string | string[], ColumnMeta[]>
@@ -200,10 +210,7 @@ export const DndColumnSelect = (props: LabelProps) => {
         valuesRenderer={valuesRenderer}
         accept={DndItemType.Column}
         displayGhostButton={multi || optionSelector.values.length === 0}
-        ghostButtonText={
-          ghostButtonText ||
-          tn('Drop column here', 'Drop columns here', multi ? 2 : 1)
-        }
+        ghostButtonText={ghostButtonText || defaultGhostButtonText}
         onClickGhostButton={
           isFeatureEnabled(FeatureFlag.ENABLE_DND_WITH_CLICK_UX)
             ? openPopover

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
@@ -156,7 +156,6 @@ export const DndColumnSelect = (props: LabelProps) => {
             type={`${DndItemType.ColumnOption}_${name}_${label}`}
             canDelete={canDelete}
             column={column}
-            withCaret
           />
         ),
       ),

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
@@ -188,7 +188,8 @@ export const DndColumnSelect = (props: LabelProps) => {
         accept={DndItemType.Column}
         displayGhostButton={multi || optionSelector.values.length === 0}
         ghostButtonText={
-          ghostButtonText || tn('Drop column here', 'Drop columns here', multi ? 2 : 1)
+          ghostButtonText ||
+          tn('Drop column here', 'Drop columns here', multi ? 2 : 1)
         }
         onClickGhostButton={openPopover}
         {...props}

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
@@ -356,7 +356,7 @@ export const DndFilterSelect = (props: DndFilterSelectProps) => {
     const config: Partial<AdhocFilter> = {
       subject: (droppedItem as ColumnMeta)?.column_name,
     };
-    if (isFeatureEnabled(FeatureFlag.UX_BETA)) {
+    if (config.subject && isFeatureEnabled(FeatureFlag.UX_BETA)) {
       config.operator = OPERATOR_ENUM_TO_OPERATOR_TYPE[Operators.IN].operation;
       config.operatorId = Operators.IN;
     }

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
@@ -333,6 +333,11 @@ export const DndFilterSelect = (props: DndFilterSelectProps) => {
     ],
   );
 
+  const handleClickGhostButton = useCallback(() => {
+    setDroppedItem(null);
+    togglePopover(true);
+  }, [togglePopover]);
+
   const adhocFilter = useMemo(() => {
     if (droppedItem?.metric_name) {
       return new AdhocFilter({
@@ -375,6 +380,7 @@ export const DndFilterSelect = (props: DndFilterSelectProps) => {
         valuesRenderer={valuesRenderer}
         accept={DND_ACCEPTED_TYPES}
         ghostButtonText={t('Drop columns or metrics here')}
+        onClickGhostButton={handleClickGhostButton}
         {...props}
       />
       <AdhocFilterPopoverTrigger

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
@@ -380,7 +380,11 @@ export const DndFilterSelect = (props: DndFilterSelectProps) => {
         valuesRenderer={valuesRenderer}
         accept={DND_ACCEPTED_TYPES}
         ghostButtonText={t('Drop columns or metrics here')}
-        onClickGhostButton={handleClickGhostButton}
+        onClickGhostButton={
+          isFeatureEnabled(FeatureFlag.ENABLE_DND_WITH_CLICK_UX)
+            ? handleClickGhostButton
+            : undefined
+        }
         {...props}
       />
       <AdhocFilterPopoverTrigger

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
@@ -372,6 +372,10 @@ export const DndFilterSelect = (props: DndFilterSelectProps) => {
     [togglePopover],
   );
 
+  const ghostButtonText = isFeatureEnabled(FeatureFlag.ENABLE_DND_WITH_CLICK_UX)
+    ? t('Drop columns/metrics here or click')
+    : t('Drop columns or metrics here');
+
   return (
     <>
       <DndSelectLabel<OptionValueType, OptionValueType[]>
@@ -379,7 +383,7 @@ export const DndFilterSelect = (props: DndFilterSelectProps) => {
         canDrop={canDrop}
         valuesRenderer={valuesRenderer}
         accept={DND_ACCEPTED_TYPES}
-        ghostButtonText={t('Drop columns or metrics here')}
+        ghostButtonText={ghostButtonText}
         onClickGhostButton={
           isFeatureEnabled(FeatureFlag.ENABLE_DND_WITH_CLICK_UX)
             ? handleClickGhostButton

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -312,6 +312,11 @@ export const DndMetricSelect = (props: any) => {
     [onNewMetric, togglePopover],
   );
 
+  const handleClickGhostButton = useCallback(() => {
+    setDroppedItem(null);
+    togglePopover(true);
+  }, [togglePopover]);
+
   const adhocMetric = useMemo(() => {
     if (droppedItem?.type === DndItemType.Column) {
       const itemValue = droppedItem?.value as ColumnMeta;
@@ -347,6 +352,7 @@ export const DndMetricSelect = (props: any) => {
           multi ? 2 : 1,
         )}
         displayGhostButton={multi || value.length === 0}
+        onClickGhostButton={handleClickGhostButton}
         {...props}
       />
       <AdhocMetricPopoverTrigger

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -352,7 +352,11 @@ export const DndMetricSelect = (props: any) => {
           multi ? 2 : 1,
         )}
         displayGhostButton={multi || value.length === 0}
-        onClickGhostButton={handleClickGhostButton}
+        onClickGhostButton={
+          isFeatureEnabled(FeatureFlag.ENABLE_DND_WITH_CLICK_UX)
+            ? handleClickGhostButton
+            : undefined
+        }
         {...props}
       />
       <AdhocMetricPopoverTrigger

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -339,6 +339,18 @@ export const DndMetricSelect = (props: any) => {
     return new AdhocMetric({ isNew: true });
   }, [droppedItem]);
 
+  const ghostButtonText = isFeatureEnabled(FeatureFlag.ENABLE_DND_WITH_CLICK_UX)
+    ? tn(
+        'Drop a column/metric here or click',
+        'Drop columns/metrics here or click',
+        multi ? 2 : 1,
+      )
+    : tn(
+        'Drop column or metric here',
+        'Drop columns or metrics here',
+        multi ? 2 : 1,
+      );
+
   return (
     <div className="metrics-select">
       <DndSelectLabel<OptionValueType, OptionValueType[]>
@@ -346,11 +358,7 @@ export const DndMetricSelect = (props: any) => {
         canDrop={canDrop}
         valuesRenderer={valuesRenderer}
         accept={DND_ACCEPTED_TYPES}
-        ghostButtonText={tn(
-          'Drop column or metric here',
-          'Drop columns or metrics here',
-          multi ? 2 : 1,
-        )}
+        ghostButtonText={ghostButtonText}
         displayGhostButton={multi || value.length === 0}
         onClickGhostButton={
           isFeatureEnabled(FeatureFlag.ENABLE_DND_WITH_CLICK_UX)

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
@@ -55,7 +55,10 @@ export default function DndSelectLabel<T, O>({
 
   function renderGhostButton() {
     return (
-      <AddControlLabel cancelHover>
+      <AddControlLabel
+        cancelHover={!props.onClickGhostButton}
+        onClick={props.onClickGhostButton}
+      >
         <Icons.PlusSmall iconColor={theme.colors.grayscale.light1} />
         {t(props.ghostButtonText || 'Drop columns here')}
       </AddControlLabel>

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
@@ -65,6 +65,7 @@ export interface DndColumnSelectProps<
   accept: DndItemType | DndItemType[];
   ghostButtonText?: string;
   displayGhostButton?: boolean;
+  onClickGhostButton?: () => void;
 }
 
 export type OptionValueType = Record<string, any>;

--- a/superset/config.py
+++ b/superset/config.py
@@ -388,6 +388,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     "OMNIBAR": False,
     "DASHBOARD_RBAC": False,
     "ENABLE_EXPLORE_DRAG_AND_DROP": False,
+    "ENABLE_DND_WITH_CLICK_UX": False,
     # Enabling ALERTS_ATTACH_REPORTS, the system sends email and slack message
     # with screenshot and link
     # Disables ALERTS_ATTACH_REPORTS, the system DOES NOT generate screenshot


### PR DESCRIPTION
### SUMMARY
Changes:
* Clickable ghost button for metrics and filters controls. Clicking a ghost button opens a popover without any fields pre-filled, which means user opts out of UX improvements introduced with drag and drop. Dnd works exactly as before.
* A new popover for columns control, similar to a popover for metrics and filters. Contains 2 tabs - "Saved" with a select button for choosing calculated columns and "Simple" with a button for selecting normal columns.
* Clickable ghost button and clickable labels in columns control. Clicking a ghost button opens an empty popover in which user can select a column. Clicking a label opens a popover prefilled with that label. Dnd works as before - column is added without using popover. Dnd is the preferred way of adding columns as it requires much less user input - 1 drag versus 4 clicks (open popover, click select button, select column, click save).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/15073128/128537355-321742e4-069f-467a-a553-87b879f3ccae.mov

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @junlincc @mistercrunch 