### PR TITLE
feat: use UUID for uniqueness in import_from_dict

### DIFF
--- a/superset/commands/importers/v1/examples.py
+++ b/superset/commands/importers/v1/examples.py
@@ -107,20 +107,6 @@ class ImportExamplesCommand(ImportModelsCommand):
                 dataset = import_dataset(
                     session, config, overwrite=overwrite, force_data=force_data
                 )
-
-                try:
-                    dataset = import_dataset(
-                        session, config, overwrite=overwrite, force_data=force_data
-                    )
-                except MultipleResultsFound:
-                    # Multiple result can be found for datasets. There was a bug in
-                    # load-examples that resulted in datasets being loaded with a NULL
-                    # schema. Users could then add a new dataset with the same name in
-                    # the correct schema, resulting in duplicates, since the uniqueness
-                    # constraint was not enforced correctly in the application logic.
-                    # See https://github.com/apache/superset/issues/16051.
-                    continue
-
                 dataset_info[str(dataset.uuid)] = {
                     "datasource_id": dataset.id,
                     "datasource_type": "view" if dataset.is_sqllab_view else "table",


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

All models in the `importExportMixin` now have a UUID column. This code simplifies the logic in `import_from_dict` to use the UUID column to identify the imported object.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
