### PR TITLE
docs: update install-from-scratch instructions for CentOS

### DIFF
--- a/docs/src/pages/docs/installation/installing_scratch.mdx
+++ b/docs/src/pages/docs/installation/installing_scratch.mdx
@@ -36,6 +36,18 @@ Install the following packages using the `yum` package manager:
 sudo yum install gcc gcc-c++ libffi-devel python-devel python-pip python-wheel openssl-devel cyrus-sasl-devel openldap-devel
 ```
 
+In more recent versions of CentOS and Fedora, you may need to install a slightly different set of packages using `dnf`:
+
+```
+sudo dnf install gcc gcc-c++ libffi-devel python3-devel python3-pip python3-wheel openssl-devel cyrus-sasl-devel openldap-devel
+```
+
+Also, on CentOS, you may need to upgrade pip for the install to work:
+
+```
+pip3 install --upgrade pip
+```
+
 **Mac OS X**
 
 If you're not on the latest version of OS X, we recommend upgrading because we've found that many


### PR DESCRIPTION
### SUMMARY

Update install-from-scratch instructions for current CentOS stream, based on doing a test install today.  CentOS stream python packages are now named after the version ("python3") and current Superset code requires updating Pip to a more current version.

### TESTING INSTRUCTIONS

Try following instructions on a current CentOS 8 or CentOS Stream server.

### ADDITIONAL INFORMATION
