### PR TITLE
fix: virtual dataset wont work

### DIFF
--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -390,7 +390,7 @@ class DatasourceEditor extends React.PureComponent {
     this.setState(prevState => ({ isEditMode: !prevState.isEditMode }));
   }
 
-  onDatasourceChange(datasource, callback) {
+  onDatasourceChange(datasource, callback = this.validateAndChange) {
     this.setState({ datasource }, callback);
   }
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
closes: https://github.com/apache/superset/issues/16124
fix that dataset modal is unable to save settings and virtual SQL.
@graceguo-supercat @yousoph @junlincc 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### After

https://user-images.githubusercontent.com/2016594/128590412-6e921ede-d01e-4880-ab98-85af5f8a47d9.mov



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. create a virtual dataset
2. open explore page and use virtual dataset
3. change virtual dataset SQL, ensure that SQL is modified correctly
5. change dataset settings, ensure that settings are modified correctly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/16124
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
