### PR TITLE
chore: add stats logging to thumbnail api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,6 +118,9 @@ services:
     depends_on: *superset-depends-on
     user: *superset-user
     volumes: *superset-volumes
+    # Bump memory limit if processing selenium / thumbails on superset-worker
+    # mem_limit: 2038m
+    # mem_reservation: 128M
 
   superset-worker-beat:
     image: *superset-image

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -29440,6 +29440,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -48774,6 +48775,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -989,6 +989,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
         )
         # If not screenshot then send request to compute thumb to celery
         if not screenshot:
+            self.incr_stats("async", self.thumbnail.__name__)
             logger.info(
                 "Triggering thumbnail compute (chart id: %s) ASYNC", str(chart.id)
             )
@@ -996,11 +997,13 @@ class ChartRestApi(BaseSupersetModelRestApi):
             return self.response(202, message="OK Async")
         # If digests
         if chart.digest != digest:
+            self.incr_stats("redirect", self.thumbnail.__name__)
             return redirect(
                 url_for(
                     f"{self.__class__.__name__}.thumbnail", pk=pk, digest=chart.digest
                 )
             )
+        self.incr_stats("from_cache", self.thumbnail.__name__)
         return Response(
             FileWrapper(screenshot), mimetype="image/png", direct_passthrough=True
         )

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -820,10 +820,12 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         ).get_from_cache(cache=thumbnail_cache)
         # If the screenshot does not exist, request one from the workers
         if not screenshot:
+            self.incr_stats("async", self.thumbnail.__name__)
             cache_dashboard_thumbnail.delay(dashboard_url, dashboard.digest, force=True)
             return self.response(202, message="OK Async")
         # If digests
         if dashboard.digest != digest:
+            self.incr_stats("redirect", self.thumbnail.__name__)
             return redirect(
                 url_for(
                     f"{self.__class__.__name__}.thumbnail",
@@ -831,6 +833,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
                     digest=dashboard.digest,
                 )
             )
+        self.incr_stats("from_cache", self.thumbnail.__name__)
         return Response(
             FileWrapper(screenshot), mimetype="image/png", direct_passthrough=True
         )


### PR DESCRIPTION
### SUMMARY
Adding a few events to related to thumbnail generation. The main driver here is to be able to compute a `thumbnail_cache_hit_rate`
- `DashboardRestApi.thumbnail.async`: endpoint is hit, 202 is returned and async process is triggered
- `DashboardRestApi.thumbnail.redirect`: thumbnail exists for dashboard, redirecting to the right hash (digest)
- `DashboardRestApi.thumbnail.from_cache`: indicates the thumbnail was loaded from cache (following the redirect)

All equivalent events for `ChartRestApi` are also logged the same way.

Logically `cache_hit_rate = from_cache/(async+from_cache)`



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1550" alt="Screen Shot 2021-08-07 at 10 03 57 AM" src="https://user-images.githubusercontent.com/487433/128608900-5fb71572-dc5d-4320-ba22-0caae5f6a761.png">


### TESTING INSTRUCTIONS
Tested thoroughly on docker-compose locally, made sure all the events logged through the dummy stats logger looked as expected
