### PR TITLE
fix: Hide Safari default tooltip

### DIFF
--- a/superset-frontend/src/components/Tooltip/index.tsx
+++ b/superset-frontend/src/components/Tooltip/index.tsx
@@ -17,17 +17,32 @@
  * under the License.
  */
 import React from 'react';
-import { useTheme } from '@superset-ui/core';
+import { useTheme, css } from '@superset-ui/core';
 import { Tooltip as AntdTooltip } from 'antd';
 import { TooltipProps } from 'antd/lib/tooltip';
+import { Global } from '@emotion/react';
 
 export const Tooltip = (props: TooltipProps) => {
   const theme = useTheme();
   return (
-    <AntdTooltip
-      overlayStyle={{ fontSize: theme.typography.sizes.s, lineHeight: '1.6' }}
-      color={`${theme.colors.grayscale.dark2}e6`}
-      {...props}
-    />
+    <>
+      {/* Safari hack to hide browser default tooltips */}
+      <Global
+        styles={css`
+          .ant-tooltip-open {
+            display: inline-block;
+            &::after {
+              content: '';
+              display: block;
+            }
+          }
+        `}
+      />
+      <AntdTooltip
+        overlayStyle={{ fontSize: theme.typography.sizes.s, lineHeight: '1.6' }}
+        color={`${theme.colors.grayscale.dark2}e6`}
+        {...props}
+      />
+    </>
   );
 };


### PR DESCRIPTION
### SUMMARY
This PR implements a small hack to prevent Safari from showing its default tooltip when a text is truncated and a custom Antdesign tooltip is already present.

### RELATED PR ON SUPERSET-UI
https://github.com/apache-superset/superset-ui/pull/1283

### BEFORE
![Screen Shot 2021-08-09 at 16 50 59](https://user-images.githubusercontent.com/60598000/128726808-419d5aa7-d15a-4a51-89d8-cf98abe19d14.png)

### AFTER
![Screen Shot 2021-08-09 at 16 48 47](https://user-images.githubusercontent.com/60598000/128726836-de53e31b-87fc-4a98-bfc5-89b902c20c51.png)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #15996
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
