### PR TITLE
feat: add config to hide some user menu items

### DIFF
--- a/superset-frontend/src/components/Menu/MenuRight.tsx
+++ b/superset-frontend/src/components/Menu/MenuRight.tsx
@@ -136,9 +136,11 @@ const RightMenu = ({
                 <a href={navbarRight.user_profile_url}>{t('Profile')}</a>
               </Menu.Item>
             )}
-            <Menu.Item key="info">
-              <a href={navbarRight.user_info_url}>{t('Info')}</a>
-            </Menu.Item>
+            {navbarRight.user_info_url && (
+              <Menu.Item key="info">
+                <a href={navbarRight.user_info_url}>{t('Info')}</a>
+              </Menu.Item>
+            )}
             <Menu.Item key="logout">
               <a href={navbarRight.user_logout_url}>{t('Logout')}</a>
             </Menu.Item>

--- a/superset/config.py
+++ b/superset/config.py
@@ -1233,6 +1233,9 @@ GLOBAL_ASYNC_QUERIES_WEBSOCKET_URL = "ws://127.0.0.1:8080/"
 #
 DATASET_HEALTH_CHECK: Optional[Callable[["SqlaTable"], str]] = None
 
+# Do not show user info or profile in the menu
+MENU_HIDE_USER_INFO = False
+
 # SQLalchemy link doc reference
 SQLALCHEMY_DOCS_URL = "https://docs.sqlalchemy.org/en/13/core/engines.html"
 SQLALCHEMY_DISPLAY_TEXT = "SQLAlchemy docs"

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -332,11 +332,13 @@ def menu_data() -> Dict[str, Any]:
             "languages": languages,
             "show_language_picker": len(languages.keys()) > 1,
             "user_is_anonymous": g.user.is_anonymous,
-            "user_info_url": appbuilder.get_url_for_userinfo,
+            "user_info_url": None
+            if appbuilder.app.config["MENU_HIDE_USER_INFO"]
+            else appbuilder.get_url_for_userinfo,
             "user_logout_url": appbuilder.get_url_for_logout,
             "user_login_url": appbuilder.get_url_for_login,
             "user_profile_url": None
-            if g.user.is_anonymous
+            if g.user.is_anonymous or appbuilder.app.config["MENU_HIDE_USER_INFO"]
             else f"/superset/profile/{g.user.username}",
             "locale": session.get("locale", "en"),
         },


### PR DESCRIPTION
### SUMMARY
Adding a config flag that allows admins to hide some menu items for users. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: 
![Superset](https://user-images.githubusercontent.com/5186919/128785492-087f625b-7c86-4a33-be06-5a5079a41638.png)

After:
<img width="374" alt="_DEV__Superset" src="https://user-images.githubusercontent.com/5186919/128785421-13d07139-2759-4a83-afca-955d3391c5a2.png">



### TESTING INSTRUCTIONS
Add flag to config and test that the menu items are gone. With the flag the menu items should be there and the links should still work. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
