### PR TITLE
fix: Big Query additional parameters field doesn't keep value

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -344,16 +344,21 @@ function dbReducer(
         action.payload.configuration_method ===
           CONFIGURATION_METHOD.DYNAMIC_FORM
       ) {
+        // convert query into URI params string
+        query = new URLSearchParams(
+          action?.payload?.parameters?.query as string,
+        ).toString();
+
         return {
           ...action.payload,
           engine: action.payload.backend,
           configuration_method: action.payload.configuration_method,
           extra_json: deserializeExtraJSON,
           parameters: {
-            query,
             credentials_info: JSON.stringify(
               action.payload?.parameters?.credentials_info || '',
             ),
+            query,
           },
         };
       }


### PR DESCRIPTION
### SUMMARY
This was fixed by converting the query into a URI params string.

### SCREENSHOTS
<img width="550" alt="fixedField" src="https://user-images.githubusercontent.com/55605634/128794064-7a00a440-5bfa-4faa-90de-76200041089b.png">

### TESTING INSTRUCTIONS
From the Superset home page:
- Hover over "Data" in the upper navigation bar
- Click "Database"
- Click the "+ Database" button below the navigation bar and to the right
- Create a new BigQuery database and add an additional parameter
- Click the edit button and observe that the additional parameters field now keeps the value

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
