### PR TITLE
fix: revert data endpoint name

### DIFF
--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -132,7 +132,7 @@ const ExploreChartPanel = props => {
   const { slice } = props;
   const updateQueryContext = useCallback(
     async function fetchChartData() {
-      if (slice && slice.query_context === null) {
+      if (props.can_overwrite && slice && slice.query_context === null) {
         const queryContext = buildV1ChartDataPayload({
           formData: slice.form_data,
           force: false,

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -107,7 +107,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
         RouteMethod.IMPORT,
         RouteMethod.RELATED,
         "bulk_delete",  # not using RouteMethod since locally defined
-        "post_data",
+        "data",
         "get_data",
         "data_from_cache",
         "viz_types",
@@ -641,7 +641,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.data",
         log_to_statsd=False,
     )
-    def post_data(self) -> Response:
+    def data(self) -> Response:
         """
         Takes a query context constructed in the client and returns payload
         data response for the given query.

--- a/superset/constants.py
+++ b/superset/constants.py
@@ -119,12 +119,12 @@ MODEL_API_RW_METHOD_PERMISSION_MAP = {
     "refresh": "write",
     "cache_screenshot": "read",
     "screenshot": "read",
+    "data": "read",
     "data_from_cache": "read",
     "get_charts": "read",
     "get_datasets": "read",
     "function_names": "read",
     "available": "read",
-    "post_data": "read",  # used to fetch chart data, so "read"
     "get_data": "read",
 }
 

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -1051,7 +1051,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         """
         self.login(username="admin")
         request_payload = get_query_context("birth_names")
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         self.assertEqual(rv.status_code, 200)
         data = json.loads(rv.data.decode("utf-8"))
         expected_row_count = self.get_expected_row_count("client_id_1")
@@ -1125,7 +1125,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
             "__time_range": "100 years ago : now",
             "__time_origin": "now",
         }
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         self.assertEqual(rv.status_code, 200)
         data = json.loads(rv.data.decode("utf-8"))
         self.assertEqual(
@@ -1154,7 +1154,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         request_payload["queries"][0]["row_limit"] = 5
         request_payload["queries"][0]["row_offset"] = 0
         request_payload["queries"][0]["orderby"] = [["name", True]]
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         response_payload = json.loads(rv.data.decode("utf-8"))
         result = response_payload["result"][0]
         self.assertEqual(result["rowcount"], 5)
@@ -1167,7 +1167,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         offset = 2
         expected_name = result["data"][offset]["name"]
         request_payload["queries"][0]["row_offset"] = offset
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         response_payload = json.loads(rv.data.decode("utf-8"))
         result = response_payload["result"][0]
         self.assertEqual(result["rowcount"], 5)
@@ -1184,7 +1184,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         self.login(username="admin")
         request_payload = get_query_context("birth_names")
         del request_payload["queries"][0]["row_limit"]
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         response_payload = json.loads(rv.data.decode("utf-8"))
         result = response_payload["result"][0]
         self.assertEqual(result["rowcount"], 7)
@@ -1201,7 +1201,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         request_payload = get_query_context("birth_names")
         request_payload["result_type"] = utils.ChartDataResultType.SAMPLES
         request_payload["queries"][0]["row_limit"] = 10
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         response_payload = json.loads(rv.data.decode("utf-8"))
         result = response_payload["result"][0]
         self.assertEqual(result["rowcount"], 5)
@@ -1213,7 +1213,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         self.login(username="admin")
         request_payload = get_query_context("birth_names")
         request_payload["result_type"] = "qwerty"
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         self.assertEqual(rv.status_code, 400)
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
@@ -1224,7 +1224,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         self.login(username="admin")
         request_payload = get_query_context("birth_names")
         request_payload["result_format"] = "qwerty"
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         self.assertEqual(rv.status_code, 400)
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
@@ -1250,7 +1250,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         self.login(username="admin")
         request_payload = get_query_context("birth_names")
         request_payload["result_type"] = utils.ChartDataResultType.QUERY
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         self.assertEqual(rv.status_code, 200)
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
@@ -1261,7 +1261,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         self.login(username="admin")
         request_payload = get_query_context("birth_names")
         request_payload["result_format"] = "csv"
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         self.assertEqual(rv.status_code, 200)
 
     # Test chart csv without permission
@@ -1274,7 +1274,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         request_payload = get_query_context("birth_names")
         request_payload["result_format"] = "csv"
 
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         self.assertEqual(rv.status_code, 403)
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
@@ -1286,7 +1286,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         request_payload = get_query_context("birth_names")
         request_payload["queries"][0]["filters"][0]["op"] = "In"
         request_payload["queries"][0]["row_limit"] = 10
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         response_payload = json.loads(rv.data.decode("utf-8"))
         result = response_payload["result"][0]
         self.assertEqual(result["rowcount"], 10)
@@ -1312,7 +1312,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
             "op": "!=",
             "val": ms_epoch,
         }
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         response_payload = json.loads(rv.data.decode("utf-8"))
         result = response_payload["result"][0]
 
@@ -1354,7 +1354,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
                 },
             }
         ]
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         self.assertEqual(rv.status_code, 200)
         response_payload = json.loads(rv.data.decode("utf-8"))
         result = response_payload["result"][0]
@@ -1377,7 +1377,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
             {"col": "non_existent_filter", "op": "==", "val": "foo"},
         ]
         request_payload["result_type"] = utils.ChartDataResultType.QUERY
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         self.assertEqual(rv.status_code, 200)
         response_payload = json.loads(rv.data.decode("utf-8"))
         assert "non_existent_filter" not in response_payload["result"][0]["query"]
@@ -1392,7 +1392,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         request_payload["queries"][0]["filters"] = [
             {"col": "gender", "op": "==", "val": "foo"}
         ]
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         self.assertEqual(rv.status_code, 200)
         response_payload = json.loads(rv.data.decode("utf-8"))
         result = response_payload["result"][0]
@@ -1408,7 +1408,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         request_payload["queries"][0]["filters"] = []
         # erroneus WHERE-clause
         request_payload["queries"][0]["extras"]["where"] = "(gender abc def)"
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         self.assertEqual(rv.status_code, 400)
 
     def test_chart_data_with_invalid_datasource(self):
@@ -1418,7 +1418,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         self.login(username="admin")
         payload = get_query_context("birth_names")
         payload["datasource"] = "abc"
-        rv = self.post_assert_metric(CHART_DATA_URI, payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, payload, "data")
         self.assertEqual(rv.status_code, 400)
 
     def test_chart_data_with_invalid_enum_value(self):
@@ -1440,7 +1440,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         """
         self.login(username="gamma")
         payload = get_query_context("birth_names")
-        rv = self.post_assert_metric(CHART_DATA_URI, payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, payload, "data")
         self.assertEqual(rv.status_code, 401)
         response_payload = json.loads(rv.data.decode("utf-8"))
         assert (
@@ -1462,7 +1462,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         request_payload["queries"][0]["extras"][
             "where"
         ] = "('boy' = '{{ filter_values('gender', 'xyz' )[0] }}')"
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         response_payload = json.loads(rv.data.decode("utf-8"))
         result = response_payload["result"][0]["query"]
         if get_example_database().backend != "presto":
@@ -1477,7 +1477,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         async_query_manager.init_app(app)
         self.login(username="admin")
         request_payload = get_query_context("birth_names")
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         self.assertEqual(rv.status_code, 202)
         data = json.loads(rv.data.decode("utf-8"))
         keys = list(data.keys())
@@ -1509,7 +1509,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         ) as patched_run:
             request_payload = get_query_context("birth_names")
             request_payload["result_type"] = utils.ChartDataResultType.FULL
-            rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+            rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
             self.assertEqual(rv.status_code, 200)
             data = json.loads(rv.data.decode("utf-8"))
             patched_run.assert_called_once_with(force_cached=True)
@@ -1525,7 +1525,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         self.login(username="admin")
         request_payload = get_query_context("birth_names")
         request_payload["result_type"] = "results"
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         self.assertEqual(rv.status_code, 200)
 
     @with_feature_flags(GLOBAL_ASYNC_QUERIES=True)
@@ -1856,7 +1856,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         event["value"] = event_layer.id
         annotation_layers.append(event)
 
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         self.assertEqual(rv.status_code, 200)
         data = json.loads(rv.data.decode("utf-8"))
         # response should only contain interval and event data, not formula
@@ -1900,7 +1900,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         request_payload = get_query_context("birth_names")
         request_payload["queries"][0]["is_rowcount"] = True
         request_payload["queries"][0]["groupby"] = ["name"]
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         response_payload = json.loads(rv.data.decode("utf-8"))
         result = response_payload["result"][0]
         expected_row_count = self.get_expected_row_count("client_id_4")
@@ -1917,7 +1917,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
             {"result_type": utils.ChartDataResultType.TIMEGRAINS},
             {"result_type": utils.ChartDataResultType.COLUMNS},
         ]
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         response_payload = json.loads(rv.data.decode("utf-8"))
         timegrain_result = response_payload["result"][0]
         column_result = response_payload["result"][1]

--- a/tests/integration_tests/dashboards/security/security_rbac_tests.py
+++ b/tests/integration_tests/dashboards/security/security_rbac_tests.py
@@ -90,7 +90,7 @@ class TestDashboardRoleBasedSecurity(BaseTestDashboardSecurity):
         response = self.get_dashboard_view_response(dashboard_to_access)
 
         request_payload = get_query_context("birth_names")
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         self.assertEqual(rv.status_code, 401)
 
         # assert
@@ -140,7 +140,7 @@ class TestDashboardRoleBasedSecurity(BaseTestDashboardSecurity):
         self.assert200(response)
 
         request_payload = get_query_context("birth_names")
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "post_data")
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         self.assertEqual(rv.status_code, 200)
 
         # post


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Rename `post_data` back to `data`, since it's giving permission errors.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
