### PR TITLE
chore: remove TerserPlugin step for build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN /frontend-mem-nag.sh \
 
 # Next, copy in the rest and let webpack do its thing
 COPY ./superset-frontend /app/superset-frontend
-# This is BY FAR the most expensive step (thanks Terser!)
+# This seems to be the most expensive step
 RUN cd /app/superset-frontend \
         && npm run ${BUILD_CMD} \
         && rm -rf node_modules

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -247,7 +247,6 @@
         "storybook-addon-jsx": "^7.3.3",
         "storybook-addon-paddings": "^3.2.0",
         "style-loader": "^1.0.0",
-        "terser-webpack-plugin": "^1.1.0",
         "thread-loader": "^1.2.0",
         "transform-loader": "^0.2.3",
         "ts-jest": "^26.4.2",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -299,7 +299,6 @@
     "storybook-addon-jsx": "^7.3.3",
     "storybook-addon-paddings": "^3.2.0",
     "style-loader": "^1.0.0",
-    "terser-webpack-plugin": "^1.1.0",
     "thread-loader": "^1.2.0",
     "transform-loader": "^0.2.3",
     "ts-jest": "^26.4.2",

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -27,7 +27,6 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const SpeedMeasurePlugin = require('speed-measure-webpack-plugin');
-const TerserPlugin = require('terser-webpack-plugin');
 const ManifestPlugin = require('webpack-manifest-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const parsedArgs = require('yargs').argv;
@@ -508,14 +507,6 @@ if (isDevMode) {
   if (hasSymlink) {
     console.log(''); // pure cosmetic new line
   }
-} else {
-  config.optimization.minimizer = [
-    new TerserPlugin({
-      cache: '.terser-plugin-cache/',
-      parallel: true,
-      extractComments: true,
-    }),
-  ];
 }
 
 // Bundle analyzer is disabled by default


### PR DESCRIPTION
### SUMMARY
Trying webpack without `TerserPlugin`, there doesn't seem to be any impact on the bundle size, yet we save a bunch of cpu time on the `npm run build` step. To be fair, when I don't remove the `.terser-plugin-cache/`, the difference is minimal, but assuming docker isn't doing anything special to keep that cache active, in that context, or in the context of a new env, the hit is pretty significant. This only affect `npm run build` but could shave a few minutes from some of our builds.


## Methodology
```
# timing with
$ time npm run build

# cleanup between steps
$ rm -rf .terser-plugin-cache/
$ rm -rf ../superset/static/assets/*
```

## With Terser
```
$ du -sh ../superset/static/assets/
 54M    ../superset/static/assets/

# first run
real    2m17.742s
user    9m2.984s
sys     0m50.677s

# second run
real    2m31.410s
user    9m16.850s
sys     0m47.766s

```

## Without Terser
```
$ rm .terser*
$ du -sh ../superset/static/assets/
 54M    ../superset/static/assets/

# first run
real    1m12.785s
user    3m50.063s
sys     0m26.636s

# second run
real    1m35.231s
user    4m54.031s
sys     0m38.375s
```