### PR TITLE
fix: change listivew card layouts to the new homepage card layout

### DIFF
--- a/superset-frontend/src/components/ListView/CardCollection.tsx
+++ b/superset-frontend/src/components/ListView/CardCollection.tsx
@@ -27,12 +27,21 @@ interface CardCollectionProps {
   prepareRow: TableInstance['prepareRow'];
   renderCard?: (row: any) => React.ReactNode;
   rows: TableInstance['rows'];
+  showThumbnails?: boolean;
 }
 
-const CardContainer = styled.div`
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(459px, 1fr));
-  grid-gap: ${({ theme }) => theme.gridUnit * 8}px;
+const CardContainer = styled.div<{ showThumbnails?: boolean }>`
+  ${({ theme, showThumbnails }) => `
+    display: grid;
+    grid-gap: ${theme.gridUnit * 12}px ${theme.gridUnit * 4}px;
+    grid-template-columns: repeat(auto-fit, 300px);
+    margin-top: ${theme.gridUnit * -6}px;
+    padding: ${
+      showThumbnails
+        ? `${theme.gridUnit * 8 + 3}px ${theme.gridUnit * 9}px`
+        : `${theme.gridUnit * 8 + 1}px ${theme.gridUnit * 9}px`
+    };
+  `}
 `;
 
 const CardWrapper = styled.div`
@@ -51,6 +60,7 @@ export default function CardCollection({
   prepareRow,
   renderCard,
   rows,
+  showThumbnails,
 }: CardCollectionProps) {
   function handleClick(
     event: React.MouseEvent<HTMLDivElement, MouseEvent>,
@@ -65,7 +75,7 @@ export default function CardCollection({
 
   if (!renderCard) return null;
   return (
-    <CardContainer>
+    <CardContainer showThumbnails={showThumbnails}>
       {loading &&
         rows.length === 0 &&
         [...new Array(25)].map((e, i) => (

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -221,6 +221,7 @@ export interface ListViewProps<T extends object = any> {
   cardSortSelectOptions?: Array<CardSortSelectOption>;
   defaultViewMode?: ViewModeType;
   highlightRowId?: number;
+  showThumbnails?: boolean;
   emptyState?: {
     message?: string;
     slot?: React.ReactNode;
@@ -242,6 +243,7 @@ function ListView<T extends object = any>({
   disableBulkSelect = () => {},
   renderBulkSelectCopy = selected => t('%s Selected', selected.length),
   renderCard,
+  showThumbnails,
   cardSortSelectOptions,
   defaultViewMode = 'card',
   highlightRowId,
@@ -376,6 +378,7 @@ function ListView<T extends object = any>({
               renderCard={renderCard}
               rows={rows}
               loading={loading}
+              showThumbnails={showThumbnails}
             />
           )}
           {viewMode === 'table' && (

--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -30,7 +30,6 @@ import {
   createErrorHandler,
   createFetchRelated,
   handleChartDelete,
-  CardStylesOverrides,
 } from 'src/views/CRUD/utils';
 import {
   useChartEditModal,
@@ -159,6 +158,9 @@ function ChartList(props: ChartListProps) {
   const [importingChart, showImportModal] = useState<boolean>(false);
   const [passwordFields, setPasswordFields] = useState<string[]>([]);
   const [preparingExport, setPreparingExport] = useState<boolean>(false);
+
+  const { userId } = props.user;
+  const userKey = getFromLocalStorage(userId.toString(), null);
 
   const openChartImportModal = () => {
     showImportModal(true);
@@ -532,29 +534,25 @@ function ChartList(props: ChartListProps) {
   ];
 
   function renderCard(chart: Chart) {
-    const { userId } = props.user;
-    const userKey = getFromLocalStorage(userId.toString(), null);
     return (
-      <CardStylesOverrides>
-        <ChartCard
-          chart={chart}
-          showThumbnails={
-            userKey
-              ? userKey.thumbnails
-              : isFeatureEnabled(FeatureFlag.THUMBNAILS)
-          }
-          hasPerm={hasPerm}
-          openChartEditModal={openChartEditModal}
-          bulkSelectEnabled={bulkSelectEnabled}
-          addDangerToast={addDangerToast}
-          addSuccessToast={addSuccessToast}
-          refreshData={refreshData}
-          loading={loading}
-          favoriteStatus={favoriteStatus[chart.id]}
-          saveFavoriteStatus={saveFavoriteStatus}
-          handleBulkChartExport={handleBulkChartExport}
-        />
-      </CardStylesOverrides>
+      <ChartCard
+        chart={chart}
+        showThumbnails={
+          userKey
+            ? userKey.thumbnails
+            : isFeatureEnabled(FeatureFlag.THUMBNAILS)
+        }
+        hasPerm={hasPerm}
+        openChartEditModal={openChartEditModal}
+        bulkSelectEnabled={bulkSelectEnabled}
+        addDangerToast={addDangerToast}
+        addSuccessToast={addSuccessToast}
+        refreshData={refreshData}
+        loading={loading}
+        favoriteStatus={favoriteStatus[chart.id]}
+        saveFavoriteStatus={saveFavoriteStatus}
+        handleBulkChartExport={handleBulkChartExport}
+      />
     );
   }
   const subMenuButtons: SubMenuProps['buttons'] = [];
@@ -644,6 +642,11 @@ function ChartList(props: ChartListProps) {
               loading={loading}
               pageSize={PAGE_SIZE}
               renderCard={renderCard}
+              showThumbnails={
+                userKey
+                  ? userKey.thumbnails
+                  : isFeatureEnabled(FeatureFlag.THUMBNAILS)
+              }
               defaultViewMode={
                 isFeatureEnabled(FeatureFlag.LISTVIEWS_DEFAULT_CARD_VIEW)
                   ? 'card'

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
@@ -25,7 +25,6 @@ import {
   createFetchRelated,
   createErrorHandler,
   handleDashboardDelete,
-  CardStylesOverrides,
 } from 'src/views/CRUD/utils';
 import { useListViewResource, useFavoriteStatus } from 'src/views/CRUD/hooks';
 import ConfirmStatusChange from 'src/components/ConfirmStatusChange';
@@ -139,6 +138,9 @@ function DashboardList(props: DashboardListProps) {
     showImportModal(false);
     refreshData();
   };
+
+  const { userId } = props.user;
+  const userKey = getFromLocalStorage(userId.toString(), null);
 
   const canCreate = hasPerm('can_write');
   const canEdit = hasPerm('can_write');
@@ -499,29 +501,25 @@ function DashboardList(props: DashboardListProps) {
   ];
 
   function renderCard(dashboard: Dashboard) {
-    const { userId } = props.user;
-    const userKey = getFromLocalStorage(userId.toString(), null);
     return (
-      <CardStylesOverrides>
-        <DashboardCard
-          dashboard={dashboard}
-          hasPerm={hasPerm}
-          bulkSelectEnabled={bulkSelectEnabled}
-          refreshData={refreshData}
-          showThumbnails={
-            userKey
-              ? userKey.thumbnails
-              : isFeatureEnabled(FeatureFlag.THUMBNAILS)
-          }
-          loading={loading}
-          addDangerToast={addDangerToast}
-          addSuccessToast={addSuccessToast}
-          openDashboardEditModal={openDashboardEditModal}
-          saveFavoriteStatus={saveFavoriteStatus}
-          favoriteStatus={favoriteStatus[dashboard.id]}
-          handleBulkDashboardExport={handleBulkDashboardExport}
-        />
-      </CardStylesOverrides>
+      <DashboardCard
+        dashboard={dashboard}
+        hasPerm={hasPerm}
+        bulkSelectEnabled={bulkSelectEnabled}
+        refreshData={refreshData}
+        showThumbnails={
+          userKey
+            ? userKey.thumbnails
+            : isFeatureEnabled(FeatureFlag.THUMBNAILS)
+        }
+        loading={loading}
+        addDangerToast={addDangerToast}
+        addSuccessToast={addSuccessToast}
+        openDashboardEditModal={openDashboardEditModal}
+        saveFavoriteStatus={saveFavoriteStatus}
+        favoriteStatus={favoriteStatus[dashboard.id]}
+        handleBulkDashboardExport={handleBulkDashboardExport}
+      />
     );
   }
 
@@ -614,6 +612,11 @@ function DashboardList(props: DashboardListProps) {
                 initialSort={initialSort}
                 loading={loading}
                 pageSize={PAGE_SIZE}
+                showThumbnails={
+                  userKey
+                    ? userKey.thumbnails
+                    : isFeatureEnabled(FeatureFlag.THUMBNAILS)
+                }
                 renderCard={renderCard}
                 defaultViewMode={
                   isFeatureEnabled(FeatureFlag.LISTVIEWS_DEFAULT_CARD_VIEW)

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -275,12 +275,6 @@ export const loadingCardCount = 5;
 const breakpoints = [576, 768, 992, 1200];
 export const mq = breakpoints.map(bp => `@media (max-width: ${bp}px)`);
 
-export const CardStylesOverrides = styled.div`
-  .ant-card-cover > div {
-    height: 264px;
-  }
-`;
-
 export const CardContainer = styled.div<{
   showThumbnails?: boolean | undefined;
 }>`


### PR DESCRIPTION
### SUMMARY
This pr updates the listview cards layout to the new the homepage cards layout with smaller fit to screen cards.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

before
<img width="1394" alt="Screen Shot 2021-08-10 at 9 46 10 AM" src="https://user-images.githubusercontent.com/17326228/128900096-dc6f856e-f666-43d5-83e8-3d6fa0f22958.png">

after
https://user-images.githubusercontent.com/17326228/128899471-dab2b6c2-7b2f-4667-be34-558b283cc581.mov


### TESTING INSTRUCTIONS
Go to listviews and change to card view to explore the new layout

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x ] Has associated issue: fixes https://github.com/apache/superset/issues/16155, 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
