### PR TITLE
fix: ensure created user entities do not show inside examples

### DIFF
--- a/superset-frontend/src/views/CRUD/types.ts
+++ b/superset-frontend/src/views/CRUD/types.ts
@@ -32,7 +32,7 @@ export enum TableTabTypes {
 export type Filters = {
   col: string;
   opr: string;
-  value: string;
+  value: string | number;
 };
 
 export interface DashboardTableProps {

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -138,9 +138,9 @@ export const getRecentAcitivtyObjs = (
           col: 'created_by',
           opr: 'rel_o_m',
           value: 0,
-        }
-      ]
-    }
+        },
+      ],
+    };
     const newBatch = [
       SupersetClient.get({
         endpoint: `/api/v1/chart/?q=${getParams(filters.examples)}`,

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -132,10 +132,21 @@ export const getRecentAcitivtyObjs = (
 ) =>
   SupersetClient.get({ endpoint: recent }).then(recentsRes => {
     const res: any = {};
+    const filters = {
+      examples: [
+        {
+          col: 'created_by',
+          opr: 'rel_o_m',
+          value: 0,
+        }
+      ]
+    }
     const newBatch = [
-      SupersetClient.get({ endpoint: `/api/v1/chart/?q=${getParams()}` }),
       SupersetClient.get({
-        endpoint: `/api/v1/dashboard/?q=${getParams()}`,
+        endpoint: `/api/v1/chart/?q=${getParams(filters.examples)}`,
+      }),
+      SupersetClient.get({
+        endpoint: `/api/v1/dashboard/?q=${getParams(filters.examples)}`,
       }),
     ];
     return Promise.all(newBatch)

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -146,7 +146,7 @@ export const getRecentAcitivtyObjs = (
         endpoint: `/api/v1/chart/?q=${getParams(filters.examples)}`,
       }),
       SupersetClient.get({
-        endpoint: `/api/v1/dashboard/?q=${getParams(filters.examples)}`,
+        endpoint: `/api/v1/dashboard/?q=${getParams(filters)}`,
       }),
     ];
     return Promise.all(newBatch)

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -132,15 +132,13 @@ export const getRecentAcitivtyObjs = (
 ) =>
   SupersetClient.get({ endpoint: recent }).then(recentsRes => {
     const res: any = {};
-    const filters = {
-      examples: [
-        {
-          col: 'created_by',
-          opr: 'rel_o_m',
-          value: 0,
-        },
-      ],
-    };
+    const filters = [
+      {
+        col: 'created_by',
+        opr: 'rel_o_m',
+        value: 0,
+      },
+    ];
     const newBatch = [
       SupersetClient.get({
         endpoint: `/api/v1/chart/?q=${getParams(filters)}`,

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -143,7 +143,7 @@ export const getRecentAcitivtyObjs = (
     };
     const newBatch = [
       SupersetClient.get({
-        endpoint: `/api/v1/chart/?q=${getParams(filters.examples)}`,
+        endpoint: `/api/v1/chart/?q=${getParams(filters)}`,
       }),
       SupersetClient.get({
         endpoint: `/api/v1/dashboard/?q=${getParams(filters)}`,


### PR DESCRIPTION
### SUMMARY
This pr ensures that created user objects do not show in examples on homescreen. The api uses the changed on delta humanized where in some env would return users owned created charts and dashboards. The change filtere ensures the users entities are not returned.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
go to homescreen to make sure user data is not being populated inside of examples charts and dashboards

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x ] Has associated issue: closes https://github.com/apache/superset/issues/16069
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
