### PR TITLE
fix(explore): metric label disappearing in some scenarios

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -185,6 +185,9 @@ export const DndMetricSelect = (props: any) => {
 
   const onMetricEdit = useCallback(
     (changedMetric: Metric | AdhocMetric, oldMetric: Metric | AdhocMetric) => {
+      if (oldMetric instanceof AdhocMetric && oldMetric.equals(changedMetric)) {
+        return;
+      }
       const newValue = value.map(value => {
         if (
           // compare saved metrics


### PR DESCRIPTION
### SUMMARY
When user added an adhoc metric, then opened a popover to edit that metric and clicked "Save" without doing any changes, the metric label would disappear. This PR adds a check if old and edited metric are equal - if they are, no actions are taken.

Basically what happened was that when we saved a metric without any changes, we didn't call `coerceAdhocMetrics` (which converts an object to AdhocMetric), but we did call `onChange`. The result was that we passed a normal object instead of AdhocMetric instance to value renderer, and in value renderer we checked for instanceof AdhocMetric

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see linked issue
After:
https://user-images.githubusercontent.com/15073128/129003100-1701671f-b658-49ad-bb2e-3ed13c0e5207.mov

### TESTING INSTRUCTIONS
0. Enable dnd
1. Create a chart and add an adhoc metric
2. Open a popover to edit that metric and click save without doing any changes
3. The metric label should stay as it was, no changes should happen

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes https://github.com/apache/superset/issues/16184
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @jinghua-qa @junlincc 
