### PR TITLE
fix: envFromSecrets spacing in helm chart

### DIFF
--- a/helm/superset/templates/deployment-worker.yaml
+++ b/helm/superset/templates/deployment-worker.yaml
@@ -80,9 +80,9 @@ spec:
             - secretRef:
                 name: {{ tpl .Values.envFromSecret . | quote }}
             {{- range .Values.envFromSecrets }}
-          - secretRef:
-              name: {{ tpl . $ | quote }}
-          {{- end }}
+            - secretRef:
+                name: {{ tpl . $ | quote }}
+            {{- end }}
           volumeMounts:
             - name: superset-config
               mountPath: {{ .Values.configMountPath | quote }}

--- a/helm/superset/templates/deployment.yaml
+++ b/helm/superset/templates/deployment.yaml
@@ -83,9 +83,9 @@ spec:
             - secretRef:
                 name: {{ tpl .Values.envFromSecret . | quote }}
             {{- range .Values.envFromSecrets }}
-          - secretRef:
-              name: {{ tpl . $ | quote }}
-          {{- end }}
+            - secretRef:
+                name: {{ tpl . $ | quote }}
+            {{- end }}
           volumeMounts:
             - name: superset-config
               mountPath: {{ .Values.configMountPath | quote }}


### PR DESCRIPTION
Previous, the spacing in the in the envFromSecrets caused a problem in yaml > json conversion and errored when attempting to use: 

```shell
Error: UPGRADE FAILED: YAML parse error on superset/templates/deployment-worker.yaml: error converting YAML to JSON: yaml: line 71: did not find expected key
```

Fixing the spacing seems to have solved the issue. 

Cheers! 