### PR TITLE
fix(Explore): Show the tooltip only when label does not fit the container in the Dataset panel

### DIFF
--- a/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanelDragOption/DatasourcePanelDragOption.test.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanelDragOption/DatasourcePanelDragOption.test.tsx
@@ -21,37 +21,33 @@ import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { render, screen } from 'spec/helpers/testing-library';
 import { DndItemType } from 'src/explore/components/DndItemType';
-import DatasourcePanelDragWrapper from '.';
+import DatasourcePanelDragOption from '.';
 
 test('should render', () => {
   render(
     <DndProvider backend={HTML5Backend}>
-      <DatasourcePanelDragWrapper
+      <DatasourcePanelDragOption
         value={{ metric_name: 'test' }}
         type={DndItemType.Metric}
-      >
-        <div data-test="children" />
-      </DatasourcePanelDragWrapper>
+      />
     </DndProvider>,
   );
 
-  expect(screen.getByTestId('DatasourcePanelDragWrapper')).toBeInTheDocument();
-  expect(screen.getByTestId('children')).toBeInTheDocument();
+  expect(screen.getByTestId('DatasourcePanelDragOption')).toBeInTheDocument();
+  expect(screen.getByText('test')).toBeInTheDocument();
 });
 
 test('should have attribute draggable:true', () => {
   render(
     <DndProvider backend={HTML5Backend}>
-      <DatasourcePanelDragWrapper
+      <DatasourcePanelDragOption
         value={{ metric_name: 'test' }}
         type={DndItemType.Metric}
-      >
-        <div data-test="children" />
-      </DatasourcePanelDragWrapper>
+      />
     </DndProvider>,
   );
 
-  expect(screen.getByTestId('DatasourcePanelDragWrapper')).toHaveAttribute(
+  expect(screen.getByTestId('DatasourcePanelDragOption')).toHaveAttribute(
     'draggable',
     'true',
   );

--- a/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanelDragOption/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanelDragOption/index.tsx
@@ -16,9 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { useDrag } from 'react-dnd';
-import { styled } from '@superset-ui/core';
+import { Metric, styled } from '@superset-ui/core';
+import { DndItemType } from 'src/explore/components/DndItemType';
+import {
+  StyledColumnOption,
+  StyledMetricOption,
+} from 'src/explore/components/optionRenderers';
+import { ColumnMeta } from '@superset-ui/chart-controls';
 import { DatasourcePanelDndItem } from '../types';
 
 const DatasourceItemContainer = styled.div`
@@ -37,23 +43,42 @@ const DatasourceItemContainer = styled.div`
   }
 `;
 
-interface DatasourcePanelDragWrapperProps extends DatasourcePanelDndItem {
-  children?: ReactNode;
+interface DatasourcePanelDragOptionProps extends DatasourcePanelDndItem {
+  labelRef?: React.RefObject<any>;
+  showTooltip?: boolean;
 }
 
-export default function DatasourcePanelDragWrapper(
-  props: DatasourcePanelDragWrapperProps,
+type MetricOption = Omit<Metric, 'id'> & {
+  label?: string;
+};
+
+export default function DatasourcePanelDragOption(
+  props: DatasourcePanelDragOptionProps,
 ) {
-  const [, drag] = useDrag({
+  const { labelRef, showTooltip, type, value } = props;
+  const [{ isDragging }, drag] = useDrag({
     item: {
       value: props.value,
       type: props.type,
     },
+    collect: monitor => ({
+      isDragging: monitor.isDragging(),
+    }),
   });
 
+  const optionProps = {
+    labelRef,
+    showTooltip: !isDragging && showTooltip,
+    showType: true,
+  };
+
   return (
-    <DatasourceItemContainer data-test="DatasourcePanelDragWrapper" ref={drag}>
-      {props.children}
+    <DatasourceItemContainer data-test="DatasourcePanelDragOption" ref={drag}>
+      {type === DndItemType.Column ? (
+        <StyledColumnOption column={value as ColumnMeta} {...optionProps} />
+      ) : (
+        <StyledMetricOption metric={value as MetricOption} {...optionProps} />
+      )}
     </DatasourceItemContainer>
   );
 }


### PR DESCRIPTION
### SUMMARY
This PR makes the tooltip appear only when the label does not fit the container in the Dataset panel. Also, it hides the tooltip when the drag event starts.

### BEFORE

https://user-images.githubusercontent.com/60598000/129005898-a3b9a073-355d-41d2-9627-fc77f1083238.mp4

### AFTER NO DRAG AND DROP

https://user-images.githubusercontent.com/60598000/129004634-224d4f17-8a2a-4c00-9376-0b70005b6f67.mp4

### AFTER DRAG AND DROP ON

https://user-images.githubusercontent.com/60598000/129004722-337326ca-d255-4203-ae7c-f95502067803.mp4

### TESTING INSTRUCTIONS
1. Visit Explore
2. Observe the labels with long text in the Dataset panel and make sure they are truncated with ellipsis
3. Hover the labels and check the tooltip
4. Expand the panel until the text isn't truncated and hover the labels
5. Make sure the tooltip isn't appearing
6. Drag an item
7. Make sure the tooltip isn't appearing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #15996
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
