### PR TITLE
refactor: external metadata fetch API

### DIFF
--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -488,11 +488,14 @@ class DatasourceEditor extends React.PureComponent {
     const { datasource } = this.state;
     const params = {
       datasource_type: datasource.type || datasource.datasource_type,
-      database_name: datasource.database.database_name || datasource.database.name,
+      database_name:
+        datasource.database.database_name || datasource.database.name,
       schema_name: datasource.schema,
       table_name: datasource.table_name,
-    }
-    const endpoint = `/datasource/external_metadata_by_name/?q=${rison.encode(params)}`;
+    };
+    const endpoint = `/datasource/external_metadata_by_name/?q=${rison.encode(
+      params,
+    )}`;
     this.setState({ metadataLoading: true });
 
     SupersetClient.get({ endpoint })

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import rison from 'rison';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Row, Col } from 'src/common/components';
@@ -485,11 +486,13 @@ class DatasourceEditor extends React.PureComponent {
 
   syncMetadata() {
     const { datasource } = this.state;
-    const endpoint = `/datasource/external_metadata_by_name/${
-      datasource.type || datasource.datasource_type
-    }/${datasource.database.database_name || datasource.database.name}/${
-      datasource.schema
-    }/${datasource.table_name}/`;
+    const params = {
+      datasource_type: datasource.type || datasource.datasource_type,
+      database_name: datasource.database.database_name || datasource.database.name,
+      schema_name: datasource.schema,
+      table_name: datasource.table_name,
+    }
+    const endpoint = `/datasource/external_metadata_by_name/?q=${rison.encode(params)}`;
     this.setState({ metadataLoading: true });
 
     SupersetClient.get({ endpoint })

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -494,7 +494,10 @@ class DatasourceEditor extends React.PureComponent {
       table_name: datasource.table_name,
     };
     const endpoint = `/datasource/external_metadata_by_name/?q=${rison.encode(
-      params,
+      // rison can't encode the undefined value
+      Object.keys(params).map(key =>
+        params[key] === undefined ? null : params[key],
+      ),
     )}`;
     this.setState({ metadataLoading: true });
 

--- a/superset/connectors/sqla/utils.py
+++ b/superset/connectors/sqla/utils.py
@@ -18,6 +18,7 @@ from contextlib import closing
 from typing import Dict, List, Optional, TYPE_CHECKING
 
 from flask_babel import lazy_gettext as _
+from sqlalchemy.exc import NoSuchTableError
 from sqlalchemy.sql.type_api import TypeEngine
 
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
@@ -41,6 +42,10 @@ def get_physical_table_metadata(
     db_dialect = database.get_dialect()
     # ensure empty schema
     _schema_name = schema_name if schema_name else None
+    # Table does not exist or is not visible to a connection.
+    if not database.has_table_by_name(table_name, schema=_schema_name):
+        raise NoSuchTableError
+
     cols = database.get_columns(table_name, schema=_schema_name)
     for col in cols:
         try:

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -172,7 +172,7 @@ class SupersetAppInitializer:
             DatabaseView,
             ExcelToDatabaseView,
         )
-        from superset.views.datasource import Datasource
+        from superset.views.datasource.views import Datasource
         from superset.views.dynamic_plugins import DynamicPluginsView
         from superset.views.key_value import KV
         from superset.views.log.api import LogRestApi

--- a/superset/views/datasource/__init__.py
+++ b/superset/views/datasource/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/superset/views/datasource/schemas.py
+++ b/superset/views/datasource/schemas.py
@@ -36,10 +36,10 @@ get_external_metadata_schema = {
 
 
 class ExternalMetadataSchema(Schema):
-    datasource_type = fields.Str()
-    database_name = fields.Str()
+    datasource_type = fields.Str(required=True)
+    database_name = fields.Str(required=True)
     schema_name = fields.Str(allow_none=True)
-    table_name = fields.Str()
+    table_name = fields.Str(required=True)
 
     # pylint: disable=no-self-use,unused-argument
     @post_load
@@ -49,6 +49,6 @@ class ExternalMetadataSchema(Schema):
         return ExternalMetadataParams(
             datasource_type=data["datasource_type"],
             database_name=data["database_name"],
-            schema_name=data["schema_name"] or "",
+            schema_name=data.get("schema_name", ""),
             table_name=data["table_name"],
         )

--- a/superset/views/datasource/schemas.py
+++ b/superset/views/datasource/schemas.py
@@ -14,9 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Any, TypedDict
+from typing import Any
 
 from marshmallow import fields, post_load, Schema
+from typing_extensions import TypedDict
 
 
 class ExternalMetadataParams(TypedDict):

--- a/superset/views/datasource/schemas.py
+++ b/superset/views/datasource/schemas.py
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Any, TypedDict
+
+from marshmallow import fields, post_load, Schema
+
+
+class ExternalMetadataParams(TypedDict):
+    datasource_type: str
+    database_name: str
+    schema_name: str
+    table_name: str
+
+
+get_external_metadata_schema = {
+    "datasource_type": "string",
+    "database_name": "string",
+    "schema_name": "string",
+    "table_name": "string",
+}
+
+
+class ExternalMetadataSchema(Schema):
+    datasource_type = fields.Str()
+    database_name = fields.Str()
+    schema_name = fields.Str(allow_none=True)
+    table_name = fields.Str()
+
+    # pylint: disable=no-self-use,unused-argument
+    @post_load
+    def normalize(
+        self, data: ExternalMetadataParams, **kwargs: Any,
+    ) -> ExternalMetadataParams:
+        return ExternalMetadataParams(
+            datasource_type=data["datasource_type"],
+            database_name=data["database_name"],
+            schema_name=data["schema_name"] or "",
+            table_name=data["table_name"],
+        )

--- a/superset/views/datasource/views.py
+++ b/superset/views/datasource/views.py
@@ -24,11 +24,16 @@ from flask_appbuilder.api import rison
 from flask_appbuilder.security.decorators import has_access_api
 from flask_babel import _
 from marshmallow import ValidationError
+from sqlalchemy.exc import NoSuchTableError
+from sqlalchemy.orm.exc import NoResultFound
 
 from superset import app, db, event_logger
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.connectors.sqla.utils import get_physical_table_metadata
-from superset.datasets.commands.exceptions import DatasetForbiddenError
+from superset.datasets.commands.exceptions import (
+    DatasetForbiddenError,
+    DatasetNotFoundError,
+)
 from superset.exceptions import SupersetException, SupersetSecurityException
 from superset.models.core import Database
 from superset.typing import FlaskResponse
@@ -170,6 +175,6 @@ class Datasource(BaseSupersetView):
                     table_name=params["table_name"],
                     schema_name=params["schema_name"],
                 )
-        except SupersetException as ex:
-            return json_error_response(str(ex), status=400)
+        except (NoResultFound, NoSuchTableError):
+            raise DatasetNotFoundError
         return self.json_response(external_metadata)

--- a/superset/views/datasource/views.py
+++ b/superset/views/datasource/views.py
@@ -156,7 +156,7 @@ class Datasource(BaseSupersetView):
         )
         try:
             if datasource is not None:
-                # Get external from Superset metadata
+                # Get columns from Superset metadata
                 external_metadata = datasource.external_metadata()
             else:
                 # Use the SQLAlchemy inspector to get columns

--- a/superset/views/datasource/views.py
+++ b/superset/views/datasource/views.py
@@ -16,11 +16,14 @@
 # under the License.
 import json
 from collections import Counter
+from typing import Any
 
 from flask import request
 from flask_appbuilder import expose
+from flask_appbuilder.api import rison
 from flask_appbuilder.security.decorators import has_access_api
 from flask_babel import _
+from marshmallow import ValidationError
 
 from superset import app, db, event_logger
 from superset.connectors.connector_registry import ConnectorRegistry
@@ -29,10 +32,18 @@ from superset.datasets.commands.exceptions import DatasetForbiddenError
 from superset.exceptions import SupersetException, SupersetSecurityException
 from superset.models.core import Database
 from superset.typing import FlaskResponse
-from superset.views.base import check_ownership
-
-from ..utils.core import parse_js_uri_path_item
-from .base import api, BaseSupersetView, handle_api_exception, json_error_response
+from superset.views.base import (
+    api,
+    BaseSupersetView,
+    check_ownership,
+    handle_api_exception,
+    json_error_response,
+)
+from superset.views.datasource.schemas import (
+    ExternalMetadataParams,
+    ExternalMetadataSchema,
+    get_external_metadata_schema,
+)
 
 
 class Datasource(BaseSupersetView):
@@ -122,44 +133,42 @@ class Datasource(BaseSupersetView):
             return json_error_response(str(ex), status=400)
         return self.json_response(external_metadata)
 
-    @expose(
-        "/external_metadata_by_name/<datasource_type>/<database_name>/"
-        "<schema_name>/<table_name>/"
-    )
+    @expose("/external_metadata_by_name/")
     @has_access_api
     @api
     @handle_api_exception
-    def external_metadata_by_name(
-        self,
-        datasource_type: str,
-        database_name: str,
-        schema_name: str,
-        table_name: str,
-    ) -> FlaskResponse:
+    @rison(get_external_metadata_schema)
+    def external_metadata_by_name(self, **kwargs: Any) -> FlaskResponse:
         """Gets table metadata from the source system and SQLAlchemy inspector"""
-        database_name = parse_js_uri_path_item(database_name) or ""
-        schema_name = parse_js_uri_path_item(schema_name, eval_undefined=True) or ""
-        table_name = parse_js_uri_path_item(table_name) or ""
+        try:
+            params: ExternalMetadataParams = (
+                ExternalMetadataSchema().load(kwargs.get("rison"))
+            )
+        except ValidationError as err:
+            return json_error_response(str(err), status=400)
 
         datasource = ConnectorRegistry.get_datasource_by_name(
             session=db.session,
-            datasource_type=datasource_type,
-            database_name=database_name,
-            schema=schema_name,
-            datasource_name=table_name,
+            datasource_type=params["datasource_type"],
+            database_name=params["database_name"],
+            schema=params["schema_name"],
+            datasource_name=params["table_name"],
         )
         try:
             if datasource is not None:
+                # Get external from Superset metadata
                 external_metadata = datasource.external_metadata()
             else:
                 # Use the SQLAlchemy inspector to get columns
                 database = (
                     db.session.query(Database)
-                    .filter_by(database_name=database_name)
+                    .filter_by(database_name=params["database_name"])
                     .one()
                 )
                 external_metadata = get_physical_table_metadata(
-                    database=database, table_name=table_name, schema_name=schema_name,
+                    database=database,
+                    table_name=params["table_name"],
+                    schema_name=params["schema_name"],
                 )
         except SupersetException as ex:
             return json_error_response(str(ex), status=400)


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
closes: https://github.com/apache/superset/issues/16172
When special characters("/") are encountered, the API `/datasource/external_metadata_by_name/<datasouce_type>/<database_name>/<schema_name>/<table_name>` cannot be called.

This PR refactor this API to `/datasource/external_metadata_by_name/?q=<rison string>`


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### After

https://user-images.githubusercontent.com/2016594/129010851-5bdf76fa-f54a-4185-8862-b41d3e1f9d7f.mov



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Create a virtual dataset from SQLLab, ensure that dataset's name contains "/" and "space"
2. Goto dataset List
3. Sync columns from source



### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/16172
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
