### PR TITLE
fix(viz): deduce metric name if empty

### DIFF
--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -177,7 +177,7 @@ class QueryObject:
         #   2. { label: 'label_name' }  - legacy format for a predefined metric
         #   3. { expressionType: 'SIMPLE' | 'SQL', ... } - adhoc metric
         self.metrics = metrics and [
-            x if isinstance(x, str) or is_adhoc_metric(x) else x["label"]
+            x if isinstance(x, str) or is_adhoc_metric(x) else x["label"]  # type: ignore
             for x in metrics
         ]
 

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -60,6 +60,7 @@ from superset.models.core import Database
 from superset.models.helpers import AuditMixinNullable, ImportExportMixin, QueryResult
 from superset.typing import (
     AdhocMetric,
+    AdhocMetricColumn,
     FilterValues,
     Granularity,
     Metric,
@@ -93,7 +94,13 @@ except ImportError:
     pass
 
 try:
-    from superset.utils.core import DimSelector, DTTM_ALIAS, FilterOperator, flasher
+    from superset.utils.core import (
+        DimSelector,
+        DTTM_ALIAS,
+        FilterOperator,
+        flasher,
+        get_metric_name,
+    )
 except ImportError:
     pass
 
@@ -1021,7 +1028,7 @@ class DruidDatasource(Model, BaseDatasource):
 
     @staticmethod
     def druid_type_from_adhoc_metric(adhoc_metric: AdhocMetric) -> str:
-        column_type = adhoc_metric["column"]["type"].lower()
+        column_type = adhoc_metric["column"]["type"].lower()  # type: ignore
         aggregate = adhoc_metric["aggregate"].lower()
 
         if aggregate == "count":
@@ -1063,11 +1070,13 @@ class DruidDatasource(Model, BaseDatasource):
                 _("Metric(s) {} must be aggregations.").format(invalid_metric_names)
             )
         for adhoc_metric in adhoc_metrics:
-            aggregations[adhoc_metric["label"]] = {
-                "fieldName": adhoc_metric["column"]["column_name"],
-                "fieldNames": [adhoc_metric["column"]["column_name"]],
+            label = get_metric_name(adhoc_metric)
+            column = cast(AdhocMetricColumn, adhoc_metric["column"])
+            aggregations[label] = {
+                "fieldName": column["column_name"],
+                "fieldNames": [column["column_name"]],
                 "type": DruidDatasource.druid_type_from_adhoc_metric(adhoc_metric),
-                "name": adhoc_metric["label"],
+                "name": label,
             }
         return aggregations
 

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -845,7 +845,8 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
         label = utils.get_metric_name(metric)
 
         if expression_type == utils.AdhocMetricExpressionType.SIMPLE:
-            column_name = cast(str, metric["column"].get("column_name"))
+            metric_column = metric.get("column") or {}
+            column_name = cast(str, metric_column.get("column_name"))
             table_column: Optional[TableColumn] = columns_by_name.get(column_name)
             if table_column:
                 sqla_column = table_column.get_sqla_col()

--- a/superset/typing.py
+++ b/superset/typing.py
@@ -15,24 +15,50 @@
 # specific language governing permissions and limitations
 # under the License.
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TYPE_CHECKING,
+    Union,
+)
 
 from flask import Flask
 from flask_caching import Cache
 from typing_extensions import TypedDict
 from werkzeug.wrappers import Response
 
+if TYPE_CHECKING:
+    from superset.utils.core import GenericDataType
 
-class AdhocMetricColumn(TypedDict):
+
+class LegacyMetric(TypedDict):
+    label: Optional[str]
+
+
+class AdhocMetricColumn(TypedDict, total=False):
     column_name: Optional[str]
+    description: Optional[str]
+    expression: Optional[str]
+    filterable: bool
+    groupby: bool
+    id: int
+    is_dttm: bool
+    python_date_format: Optional[str]
     type: str
+    type_generic: "GenericDataType"
+    verbose_name: Optional[str]
 
 
-class AdhocMetric(TypedDict):
+class AdhocMetric(TypedDict, total=False):
     aggregate: str
-    column: AdhocMetricColumn
+    column: Optional[AdhocMetricColumn]
     expressionType: str
-    label: str
+    label: Optional[str]
     sqlExpression: Optional[str]
 
 

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -96,7 +96,14 @@ from superset.exceptions import (
     SupersetException,
     SupersetTimeoutException,
 )
-from superset.typing import AdhocMetric, FilterValues, FlaskResponse, FormData, Metric
+from superset.typing import (
+    AdhocMetric,
+    AdhocMetricColumn,
+    FilterValues,
+    FlaskResponse,
+    FormData,
+    Metric,
+)
 from superset.utils.dates import datetime_to_epoch, EPOCH
 from superset.utils.hashing import md5_sha_from_dict, md5_sha_from_str
 
@@ -1268,12 +1275,47 @@ def backend() -> str:
     return get_example_database().backend
 
 
+def is_legacy_metric(metric: Metric) -> bool:
+    return (
+        isinstance(metric, dict)
+        and "label" in metric
+        and "expressionType" not in metric
+    )
+
+
 def is_adhoc_metric(metric: Metric) -> bool:
     return isinstance(metric, dict) and "expressionType" in metric
 
 
 def get_metric_name(metric: Metric) -> str:
-    return metric["label"] if is_adhoc_metric(metric) else metric  # type: ignore
+    """
+    Extract label from metric
+
+    :param metric: object to extract label from
+    :return: String representation of metric
+    :raises ValueError: if metric object is invalid
+    """
+    if isinstance(metric, str):
+        return cast(str, metric)
+    if is_adhoc_metric(metric):
+        metric = cast(AdhocMetric, metric)
+        label = metric.get("label")
+        if label:
+            return label
+        expression_type = metric.get("expressionType")
+        if expression_type == "SQL":
+            sql_expression = metric.get("sqlExpression")
+            if sql_expression:
+                return sql_expression
+        elif expression_type == "SIMPLE":
+            column: AdhocMetricColumn = metric.get("column") or {}
+            column_name = column.get("column_name")
+            aggregate = metric.get("aggregate")
+            if column and aggregate:
+                return f"{aggregate}({column_name})"
+            if column_name:
+                return column_name
+    raise ValueError(__("Invalid metric object"))
 
 
 def get_metric_names(metrics: Sequence[Metric]) -> List[str]:

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1275,14 +1275,6 @@ def backend() -> str:
     return get_example_database().backend
 
 
-def is_legacy_metric(metric: Metric) -> bool:
-    return (
-        isinstance(metric, dict)
-        and "label" in metric
-        and "expressionType" not in metric
-    )
-
-
 def is_adhoc_metric(metric: Metric) -> bool:
     return isinstance(metric, dict) and "expressionType" in metric
 
@@ -1295,8 +1287,6 @@ def get_metric_name(metric: Metric) -> str:
     :return: String representation of metric
     :raises ValueError: if metric object is invalid
     """
-    if isinstance(metric, str):
-        return cast(str, metric)
     if is_adhoc_metric(metric):
         metric = cast(AdhocMetric, metric)
         label = metric.get("label")
@@ -1315,7 +1305,8 @@ def get_metric_name(metric: Metric) -> str:
                 return f"{aggregate}({column_name})"
             if column_name:
                 return column_name
-    raise ValueError(__("Invalid metric object"))
+        raise ValueError(__("Invalid metric object"))
+    return cast(str, metric)
 
 
 def get_metric_names(metrics: Sequence[Metric]) -> List[str]:

--- a/tests/unit_tests/core_tests.py
+++ b/tests/unit_tests/core_tests.py
@@ -1,0 +1,96 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from copy import deepcopy
+
+import pytest
+
+from superset.utils.core import (
+    AdhocMetric,
+    GenericDataType,
+    get_metric_name,
+    get_metric_names,
+)
+
+STR_METRIC = "my_metric"
+SIMPLE_SUM_ADHOC_METRIC: AdhocMetric = {
+    "aggregate": "SUM",
+    "column": {
+        "column_name": "my_col",
+        "type": "INT",
+        "type_generic": GenericDataType.NUMERIC,
+    },
+    "expressionType": "SIMPLE",
+    "label": "my SUM",
+}
+SQL_ADHOC_METRIC: AdhocMetric = {
+    "expressionType": "SQL",
+    "label": "my_sql",
+    "sqlExpression": "SUM(my_col)",
+}
+
+
+def test_get_metric_name_saved_metric():
+    assert get_metric_name(STR_METRIC) == "my_metric"
+
+
+def test_get_metric_name_adhoc():
+    metric = deepcopy(SIMPLE_SUM_ADHOC_METRIC)
+    assert get_metric_name(metric) == "my SUM"
+    del metric["label"]
+    assert get_metric_name(metric) == "SUM(my_col)"
+    metric["label"] = ""
+    assert get_metric_name(metric) == "SUM(my_col)"
+    del metric["aggregate"]
+    assert get_metric_name(metric) == "my_col"
+    metric["aggregate"] = ""
+    assert get_metric_name(metric) == "my_col"
+
+    metric = deepcopy(SQL_ADHOC_METRIC)
+    assert get_metric_name(metric) == "my_sql"
+    del metric["label"]
+    assert get_metric_name(metric) == "SUM(my_col)"
+    metric["label"] = ""
+    assert get_metric_name(metric) == "SUM(my_col)"
+
+
+def test_get_metric_name_invalid_metric():
+    with pytest.raises(ValueError):
+        get_metric_name({})
+
+    metric = deepcopy(SIMPLE_SUM_ADHOC_METRIC)
+    del metric["label"]
+    del metric["column"]
+    with pytest.raises(ValueError):
+        get_metric_name(metric)
+
+    metric = deepcopy(SIMPLE_SUM_ADHOC_METRIC)
+    del metric["label"]
+    metric["expressionType"] = "FOO"
+    with pytest.raises(ValueError):
+        get_metric_name(metric)
+
+    metric = deepcopy(SQL_ADHOC_METRIC)
+    del metric["label"]
+    metric["expressionType"] = "FOO"
+    with pytest.raises(ValueError):
+        get_metric_name(metric)
+
+
+def test_get_metric_names():
+    assert get_metric_names(
+        [STR_METRIC, SIMPLE_SUM_ADHOC_METRIC, SQL_ADHOC_METRIC]
+    ) == ["my_metric", "my SUM", "my_sql"]

--- a/tests/unit_tests/core_tests.py
+++ b/tests/unit_tests/core_tests.py
@@ -68,9 +68,6 @@ def test_get_metric_name_adhoc():
 
 
 def test_get_metric_name_invalid_metric():
-    with pytest.raises(ValueError):
-        get_metric_name({})
-
     metric = deepcopy(SIMPLE_SUM_ADHOC_METRIC)
     del metric["label"]
     del metric["column"]


### PR DESCRIPTION
### SUMMARY
This is part 1 of a fix for #16067 to make the backend more resilient to incomplete chart metadata. If an adhoc metric is missing the `label` property, the backend can in most cases deduce what the label should be. Since the util `get_metric_name` is used in quite a few places in the backend and didn't have a single unit test, this PR also adds tests to ensure that the function works as expected. In addition, related types are improved and affected code updated.

### AFTER
![image](https://user-images.githubusercontent.com/33317356/129022590-f27c7f42-99a5-404a-ba96-63f10efd1a65.png)

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/129022683-9737685e-5fe2-49f8-b7c0-3163f5c7e467.png)


### TESTING INSTRUCTIONS
1. create an adhoc metric that either has a missing or empty label
2. make a chart data request
3. notice how the request fails

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
