### PR TITLE
feat: Allow users to connect via legacy SQLA form

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -90,7 +90,7 @@ disable=
     super-with-arguments,
     too-few-public-methods,
     too-many-locals,
-
+    not-callable,
 
 [REPORTS]
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -90,7 +90,6 @@ disable=
     super-with-arguments,
     too-few-public-methods,
     too-many-locals,
-    not-callable,
 
 [REPORTS]
 

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -671,7 +671,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
         (db: DatabaseObject) => db.name === database_name,
       )[0];
       const { engine, parameters } = selectedDbModel;
-      const isDynamic = parameters !== undefined || database_name === 'Other';
+      const isDynamic = parameters !== undefined;
       setDB({
         type: ActionType.dbSelected,
         payload: {

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -656,21 +656,34 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
   };
 
   const setDatabaseModel = (database_name: string) => {
-    const selectedDbModel = availableDbs?.databases.filter(
-      (db: DatabaseObject) => db.name === database_name,
-    )[0];
-    const { engine, parameters } = selectedDbModel;
-    const isDynamic = parameters !== undefined;
-    setDB({
-      type: ActionType.dbSelected,
-      payload: {
-        database_name,
-        configuration_method: isDynamic
-          ? CONFIGURATION_METHOD.DYNAMIC_FORM
-          : CONFIGURATION_METHOD.SQLALCHEMY_URI,
-        engine,
-      },
-    });
+    if (database_name === 'Other') {
+      // Allow users to connect to DB via legacy SQLA form
+      setDB({
+        type: ActionType.dbSelected,
+        payload: {
+          database_name,
+          configuration_method: CONFIGURATION_METHOD.SQLALCHEMY_URI,
+          engine: undefined,
+        },
+      });
+    } else {
+      const selectedDbModel = availableDbs?.databases.filter(
+        (db: DatabaseObject) => db.name === database_name,
+      )[0];
+      const { engine, parameters } = selectedDbModel;
+      const isDynamic = parameters !== undefined || database_name === 'Other';
+      setDB({
+        type: ActionType.dbSelected,
+        payload: {
+          database_name,
+          configuration_method: isDynamic
+            ? CONFIGURATION_METHOD.DYNAMIC_FORM
+            : CONFIGURATION_METHOD.SQLALCHEMY_URI,
+          engine,
+        },
+      });
+    }
+
     setDB({ type: ActionType.addTableCatalogSheet });
   };
 
@@ -694,6 +707,10 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
               {database.name}
             </Select.Option>
           ))}
+        {/* Allow users to connect to DB via legacy SQLA form */}
+        <Select.Option value="Other" key="Other">
+          Other
+        </Select.Option>
       </Select>
       <Alert
         showIcon


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Creating an other option to allow users to get access to the legacy SQLA form to connect to DBs

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
