### PR TITLE
fix: sorting on "Modified By" in chart table

### DIFF
--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -285,7 +285,7 @@ function ChartList(props: ChartListProps) {
           </a>
         ),
         Header: t('Modified by'),
-        accessor: 'last_saved_by',
+        accessor: 'last_saved_by.id',
         size: 'xl',
       },
       {

--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -285,7 +285,7 @@ function ChartList(props: ChartListProps) {
           </a>
         ),
         Header: t('Modified by'),
-        accessor: 'last_saved_by.id',
+        accessor: 'last_saved_by.first_name',
         size: 'xl',
       },
       {


### PR DESCRIPTION
### SUMMARY
This pr fixes sorting problem for last_saved_by in the chartlist view. The accessor was set to the wrong key.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

before
https://user-images.githubusercontent.com/17326228/129097514-0cdb53d5-27ca-4a86-914e-45cd147d19d3.mov

after

https://user-images.githubusercontent.com/17326228/129101047-c289eb56-6587-4764-b827-014e670e5851.mov



### TESTING INSTRUCTIONS
Go to the chart listview page and clicked the modified by sorting button to test out proper sorting.




### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
