### PR TITLE
fix: example tabs filter

### DIFF
--- a/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
@@ -132,6 +132,12 @@ function ChartTable({
         operator: 'chart_is_favorite',
         value: true,
       });
+    } else if (filterName === 'Examples') {
+      filters.push({
+        id: 'created_by',
+        operator: 'rel_o_m',
+        value: 0,
+      });
     }
     return filters;
   };


### PR DESCRIPTION
### SUMMARY
This pr inputs the filters for the example tab to filter out user objects.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before

https://user-images.githubusercontent.com/17326228/129105834-4ac93ea2-d03e-4172-8409-23fbed6ad6ad.mov

after 

https://user-images.githubusercontent.com/17326228/129105863-535e9fe8-a40d-4c9e-af0c-618c0f310316.mov



### TESTING INSTRUCTIONS
Go to home page and make sure user own created charts does not show up when clicking the examples tab.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
