### PR TITLE
fix: remove encryption from db params

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1410,7 +1410,8 @@ class BasicParametersMixin:
         parameters: BasicParametersType,
         encryted_extra: Optional[Dict[str, str]] = None,
     ) -> str:
-        query = parameters.get("query", {})
+        # make a copy so that we don't update the original
+        query = dict(parameters.get("query", {}))
         if parameters.get("encryption"):
             if not cls.encryption_parameters:
                 raise Exception("Unable to build a URL with encryption enabled")
@@ -1433,6 +1434,11 @@ class BasicParametersMixin:
         cls, uri: str, encrypted_extra: Optional[Dict[str, Any]] = None
     ) -> BasicParametersType:
         url = make_url(uri)
+        query = {
+            key: value
+            for (key, value) in url.query.items()
+            if (key, value) not in cls.encryption_parameters.items()
+        }
         encryption = all(
             item in url.query.items() for item in cls.encryption_parameters.items()
         )
@@ -1442,7 +1448,7 @@ class BasicParametersMixin:
             "host": url.host,
             "port": url.port,
             "database": url.database,
-            "query": url.query,
+            "query": query,
             "encryption": encryption,
         }
 

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1411,7 +1411,7 @@ class BasicParametersMixin:
         encryted_extra: Optional[Dict[str, str]] = None,
     ) -> str:
         # make a copy so that we don't update the original
-        query = dict(parameters.get("query", {}))
+        query = parameters.get("query", {}).copy()
         if parameters.get("encryption"):
             if not cls.encryption_parameters:
                 raise Exception("Unable to build a URL with encryption enabled")


### PR DESCRIPTION
### SUMMARY
There are some errors on db connection ui when toggling on encryption, it would also get returned in the params field, and then would error when trying to turn off ssl with the toggle. 


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: 
https://user-images.githubusercontent.com/5186919/129117204-42cd6021-647d-4c33-a4d1-eff56130b63c.mov

After:
https://user-images.githubusercontent.com/5186919/129117801-eb56b5fb-4767-427a-9f1d-3096fd353eab.mov



### TESTING INSTRUCTIONS
edit a database, and toggle on/off ssl

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
