### PR TITLE
fix(explore): conditional formatting value validators

### DIFF
--- a/superset-frontend/src/components/Form/Form.tsx
+++ b/superset-frontend/src/components/Form/Form.tsx
@@ -32,3 +32,5 @@ const StyledForm = styled(AntDForm)`
 export default function Form(props: FormProps) {
   return <StyledForm {...props} />;
 }
+
+export { FormProps };

--- a/superset-frontend/src/components/Form/index.tsx
+++ b/superset-frontend/src/components/Form/index.tsx
@@ -16,9 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import Form from './Form';
+import Form, { FormProps } from './Form';
 import FormItem from './FormItem';
 import FormLabel from './FormLabel';
 import LabeledErrorBoundInput from './LabeledErrorBoundInput';
 
-export { Form, FormItem, FormLabel, LabeledErrorBoundInput };
+export { Form, FormItem, FormLabel, LabeledErrorBoundInput, FormProps };

--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useCallback, useMemo } from 'react';
+import React from 'react';
 import { styled, t } from '@superset-ui/core';
 import { Form, FormItem } from 'src/components/Form';
 import { Select } from 'src/components';
@@ -57,6 +57,131 @@ const operatorOptions = [
   { value: COMPARATOR.BETWEEN_OR_RIGHT_EQUAL, label: '< x ≤' },
 ];
 
+const targetValueLeftValidator = (rightValue?: number) => (
+  _: any,
+  value?: number,
+) => {
+  if (!value || !rightValue || Number(rightValue) > Number(value)) {
+    return Promise.resolve();
+  }
+  return Promise.reject(
+    new Error(t('This value should be smaller than the right target value')),
+  );
+};
+
+const targetValueRightValidator = (leftValue?: number) => (
+  _: any,
+  value?: number,
+) => {
+  if (!value || !leftValue || Number(leftValue) < Number(value)) {
+    return Promise.resolve();
+  }
+  return Promise.reject(
+    new Error(t('This value should be greater than the left target value')),
+  );
+};
+
+const isOperatorMultiValue = (operator?: COMPARATOR) =>
+  operator && MULTIPLE_VALUE_COMPARATORS.includes(operator);
+
+const isOperatorNone = (operator?: COMPARATOR) =>
+  !operator || operator === COMPARATOR.NONE;
+
+const rulesRequired = [{ required: true, message: t('Required') }];
+
+const rulesTargetValueLeft = [
+  { required: true, message: t('Required') },
+  ({
+    getFieldValue,
+  }: {
+    getFieldValue: (name: string | number | (string | number)[]) => any;
+  }) => ({
+    validator: targetValueLeftValidator(getFieldValue('targetValueRight')),
+  }),
+];
+
+const rulesTargetValueRight = [
+  { required: true, message: t('Required') },
+  ({
+    getFieldValue,
+  }: {
+    getFieldValue: (name: string | number | (string | number)[]) => any;
+  }) => ({
+    validator: targetValueRightValidator(getFieldValue('targetValueLeft')),
+  }),
+];
+
+const targetValueLeftDeps = ['targetValueRight'];
+const targetValueRightDeps = ['targetValueLeft'];
+
+const shouldFormItemUpdate = (
+  prevValues: ConditionalFormattingConfig,
+  currentValues: ConditionalFormattingConfig,
+) =>
+  isOperatorNone(prevValues.operator) !==
+    isOperatorNone(currentValues.operator) ||
+  isOperatorMultiValue(prevValues.operator) !==
+    isOperatorMultiValue(currentValues.operator);
+
+const operatorField = (
+  <FormItem
+    name="operator"
+    label={t('Operator')}
+    rules={rulesRequired}
+    initialValue={operatorOptions[0].value}
+  >
+    <Select ariaLabel={t('Operator')} options={operatorOptions} />
+  </FormItem>
+);
+
+const renderOperatorFields = ({ getFieldValue }) =>
+  isOperatorNone(getFieldValue('operator')) ? (
+    <Row gutter={12}>
+      <Col span={6}>{operatorField}</Col>
+    </Row>
+  ) : isOperatorMultiValue(getFieldValue('operator')) ? (
+    <Row gutter={12}>
+      <Col span={9}>
+        <FormItem
+          name="targetValueLeft"
+          label={t('Left value')}
+          rules={rulesTargetValueLeft}
+          dependencies={targetValueLeftDeps}
+          validateTrigger="onBlur"
+          trigger="onBlur"
+        >
+          <FullWidthInputNumber />
+        </FormItem>
+      </Col>
+      <Col span={6}>{operatorField}</Col>
+      <Col span={9}>
+        <FormItem
+          name="targetValueRight"
+          label={t('Right value')}
+          rules={rulesTargetValueRight}
+          dependencies={targetValueRightDeps}
+          validateTrigger="onBlur"
+          trigger="onBlur"
+        >
+          <FullWidthInputNumber />
+        </FormItem>
+      </Col>
+    </Row>
+  ) : (
+    <Row gutter={12}>
+      <Col span={6}>{operatorField}</Col>
+      <Col span={18}>
+        <FormItem
+          name="targetValue"
+          label={t('Target value')}
+          rules={rulesRequired}
+        >
+          <FullWidthInputNumber />
+        </FormItem>
+      </Col>
+    </Row>
+  );
+
 export const FormattingPopoverContent = ({
   config,
   onChange,
@@ -65,167 +190,44 @@ export const FormattingPopoverContent = ({
   config?: ConditionalFormattingConfig;
   onChange: (config: ConditionalFormattingConfig) => void;
   columns: { label: string; value: string }[];
-}) => {
-  const isOperatorMultiValue = (operator?: COMPARATOR) =>
-    operator && MULTIPLE_VALUE_COMPARATORS.includes(operator);
-
-  const isOperatorNone = (operator?: COMPARATOR) =>
-    !operator || operator === COMPARATOR.NONE;
-
-  const operatorField = useMemo(
-    () => (
-      <FormItem
-        name="operator"
-        label={t('Operator')}
-        rules={[{ required: true, message: t('Required') }]}
-        initialValue={operatorOptions[0].value}
-      >
-        <Select ariaLabel={t('Operator')} options={operatorOptions} />
-      </FormItem>
-    ),
-    [],
-  );
-
-  const targetValueLeftValidator = useCallback(
-    (rightValue?: number) => (_: any, value?: number) => {
-      if (!value || !rightValue || rightValue > value) {
-        return Promise.resolve();
-      }
-      return Promise.reject(
-        new Error(
-          t('This value should be smaller than the right target value'),
-        ),
-      );
-    },
-    [],
-  );
-
-  const targetValueRightValidator = useCallback(
-    (leftValue?: number) => (_: any, value?: number) => {
-      if (!value || !leftValue || leftValue < value) {
-        return Promise.resolve();
-      }
-      return Promise.reject(
-        new Error(t('This value should be greater than the left target value')),
-      );
-    },
-    [],
-  );
-
-  return (
-    <Form
-      onFinish={onChange}
-      initialValues={config}
-      requiredMark="optional"
-      layout="vertical"
-    >
-      <Row gutter={12}>
-        <Col span={12}>
-          <FormItem
-            name="column"
-            label={t('Column')}
-            rules={[{ required: true, message: t('Required') }]}
-            initialValue={columns[0]?.value}
-          >
-            <Select ariaLabel={t('Select column')} options={columns} />
-          </FormItem>
-        </Col>
-        <Col span={12}>
-          <FormItem
-            name="colorScheme"
-            label={t('Color scheme')}
-            rules={[{ required: true, message: t('Required') }]}
-            initialValue={colorSchemeOptions[0].value}
-          >
-            <Select
-              ariaLabel={t('Color scheme')}
-              options={colorSchemeOptions}
-            />
-          </FormItem>
-        </Col>
-      </Row>
-      <FormItem
-        noStyle
-        shouldUpdate={(
-          prevValues: ConditionalFormattingConfig,
-          currentValues: ConditionalFormattingConfig,
-        ) =>
-          isOperatorNone(prevValues.operator) !==
-            isOperatorNone(currentValues.operator) ||
-          isOperatorMultiValue(prevValues.operator) !==
-            isOperatorMultiValue(currentValues.operator)
-        }
-      >
-        {({ getFieldValue }) =>
-          isOperatorNone(getFieldValue('operator')) ? (
-            <Row gutter={12}>
-              <Col span={6}>{operatorField}</Col>
-            </Row>
-          ) : isOperatorMultiValue(getFieldValue('operator')) ? (
-            <Row gutter={12}>
-              <Col span={9}>
-                <FormItem
-                  name="targetValueLeft"
-                  label={t('Left value')}
-                  rules={[
-                    { required: true, message: t('Required') },
-                    ({ getFieldValue }) => ({
-                      validator: targetValueLeftValidator(
-                        getFieldValue('targetValueRight'),
-                      ),
-                    }),
-                  ]}
-                  dependencies={['targetValueRight']}
-                  validateTrigger="onBlur"
-                  trigger="onBlur"
-                >
-                  <FullWidthInputNumber />
-                </FormItem>
-              </Col>
-              <Col span={6}>{operatorField}</Col>
-              <Col span={9}>
-                <FormItem
-                  name="targetValueRight"
-                  label={t('Right value')}
-                  rules={[
-                    { required: true, message: t('Required') },
-                    ({ getFieldValue }) => ({
-                      validator: targetValueRightValidator(
-                        getFieldValue('targetValueLeft'),
-                      ),
-                    }),
-                  ]}
-                  dependencies={['targetValueLeft']}
-                  validateTrigger="onBlur"
-                  trigger="onBlur"
-                >
-                  <FullWidthInputNumber />
-                </FormItem>
-              </Col>
-            </Row>
-          ) : (
-            <Row gutter={12}>
-              <Col span={6}>{operatorField}</Col>
-              <Col span={18}>
-                <FormItem
-                  name="targetValue"
-                  label={t('Target value')}
-                  rules={[{ required: true, message: t('Required') }]}
-                >
-                  <FullWidthInputNumber />
-                </FormItem>
-              </Col>
-            </Row>
-          )
-        }
-      </FormItem>
-      <FormItem>
-        <JustifyEnd>
-          <Button htmlType="submit" buttonStyle="primary">
-            {t('Apply')}
-          </Button>
-        </JustifyEnd>
-      </FormItem>
-    </Form>
-  );
-};
+}) => (
+  <Form
+    onFinish={onChange}
+    initialValues={config}
+    requiredMark="optional"
+    layout="vertical"
+  >
+    <Row gutter={12}>
+      <Col span={12}>
+        <FormItem
+          name="column"
+          label={t('Column')}
+          rules={rulesRequired}
+          initialValue={columns[0]?.value}
+        >
+          <Select ariaLabel={t('Select column')} options={columns} />
+        </FormItem>
+      </Col>
+      <Col span={12}>
+        <FormItem
+          name="colorScheme"
+          label={t('Color scheme')}
+          rules={rulesRequired}
+          initialValue={colorSchemeOptions[0].value}
+        >
+          <Select ariaLabel={t('Color scheme')} options={colorSchemeOptions} />
+        </FormItem>
+      </Col>
+    </Row>
+    <FormItem noStyle shouldUpdate={shouldFormItemUpdate}>
+      {renderOperatorFields}
+    </FormItem>
+    <FormItem>
+      <JustifyEnd>
+        <Button htmlType="submit" buttonStyle="primary">
+          {t('Apply')}
+        </Button>
+      </JustifyEnd>
+    </FormItem>
+  </Form>
+);

--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
@@ -84,30 +84,6 @@ const targetValueRightValidator = targetValueValidator(
   t('This value should be greater than the left target value'),
 );
 
-// const targetValueLeftValidator = (rightValue?: number) => (
-//   _: any,
-//   value?: number,
-// ) => {
-//   if (!value || !rightValue || Number(rightValue) > Number(value)) {
-//     return Promise.resolve();
-//   }
-//   return Promise.reject(
-//     new Error(t('This value should be smaller than the right target value')),
-//   );
-// };
-
-// const targetValueRightValidator = (leftValue?: number) => (
-//   _: any,
-//   value?: number,
-// ) => {
-//   if (!value || !leftValue || Number(leftValue) < Number(value)) {
-//     return Promise.resolve();
-//   }
-//   return Promise.reject(
-//     new Error(t('This value should be greater than the left target value')),
-//   );
-// };
-
 const isOperatorMultiValue = (operator?: COMPARATOR) =>
   operator && MULTIPLE_VALUE_COMPARATORS.includes(operator);
 


### PR DESCRIPTION
### SUMMARY
This PR casts  number-like strings to numbers in order to ensure correct value validation in conditional formatting.
Before, we were comparing values that were actually strings and not numbers, which caused incorrect validation errors.

I also did some refactoring to avoid unnecessary rerenders.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see linked issue
After:
https://user-images.githubusercontent.com/15073128/129187281-ab83bcde-870c-4715-a733-9448bdbd9c84.mov

### TESTING INSTRUCTIONS
1. Open Table or Pivot Table v2 chart
2. Add conditional formatter with "Between" operator and type left and right values. Verify that errors show up only if left value is larger than right. Try typing left value which is alphabetically "larger", but arithmetically smaller than right value in order to recreate the reported issue.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes #16169 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @vnnw @junlincc @jinghua-qa