### PR TITLE
fix(explore): remove extra filters from all adhoc_filters controls

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -940,7 +940,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
         for key, value in form_data.items():
             if ADHOC_FILTERS_REGEX.match(key):
-                form_data[key] = self.remove_extra_filters(form_data.get(key, []))
+                form_data[key] = self.remove_extra_filters(value or [])
 
         assert slc
         slc.params = json.dumps(form_data, indent=2, sort_keys=True)

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -166,6 +166,8 @@ DATABASE_KEYS = [
     "id",
 ]
 
+ADHOC_FILTERS_REGEX = re.compile("^adhoc_filters")
+
 DATASOURCE_MISSING_ERR = __("The data source seems to have been deleted")
 USER_MISSING_ERR = __("The user seems to have been deleted")
 PARAMETER_MISSING_ERR = (
@@ -936,9 +938,9 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
                 form_data.pop("slice_id")  # don't save old slice_id
             slc = Slice(owners=[g.user] if g.user else [])
 
-        form_data["adhoc_filters"] = self.remove_extra_filters(
-            form_data.get("adhoc_filters", [])
-        )
+        for key, value in form_data.items():
+            if ADHOC_FILTERS_REGEX.match(key):
+                form_data[key] = self.remove_extra_filters(form_data.get(key, []))
 
         assert slc
         slc.params = json.dumps(form_data, indent=2, sort_keys=True)


### PR DESCRIPTION
### SUMMARY
Remove `isExtra` filters from all controls that match `^adhoc_filters`. This is a prerequisite for removing extra filters from charts with multiple adhoc filter controls, such as the `MixedTimeseries` chart. See https://github.com/apache-superset/superset-ui/pull/1303 for more context.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #15858
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
