### PR TITLE
fix: Stop the scrollbar in the Change Dataset modal from scrolling down to the pagination component

### DIFF
--- a/superset-frontend/src/components/TableView/TableView.tsx
+++ b/superset-frontend/src/components/TableView/TableView.tsx
@@ -63,7 +63,7 @@ const TableViewStyles = styled.div<{
   ${({ scrollTable, theme }) =>
     scrollTable &&
     `
-    height: 380px;
+    height: 300px;
     margin-bottom: ${theme.gridUnit * 4}px;
     overflow: auto;
   `}
@@ -88,22 +88,24 @@ const TableViewStyles = styled.div<{
       `${theme.gridUnit - 2}px solid ${theme.colors.grayscale.light2}`};
     ${({ small }) => small && `padding-bottom: 0;`}
   }
+`;
 
-  .pagination-container {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    background-color: ${({ theme }) => theme.colors.grayscale.light5};
+const PaginationStyles = styled.div<{
+  isPaginationSticky?: boolean;
+}>`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background-color: ${({ theme }) => theme.colors.grayscale.light5};
 
-    ${({ isPaginationSticky }) =>
-      isPaginationSticky &&
-      `
+  ${({ isPaginationSticky }) =>
+    isPaginationSticky &&
+    `
         position: sticky;
         bottom: 0;
         left: 0;
     `};
-  }
 
   .row-count-container {
     margin-top: ${({ theme }) => theme.gridUnit * 2}px;
@@ -191,30 +193,35 @@ const TableView = ({
   const isEmpty = !loading && content.length === 0;
 
   return (
-    <TableViewStyles {...props}>
-      <TableCollection
-        getTableProps={getTableProps}
-        getTableBodyProps={getTableBodyProps}
-        prepareRow={prepareRow}
-        headerGroups={headerGroups}
-        rows={content}
-        columns={columns}
-        loading={loading}
-      />
-      {isEmpty && (
-        <EmptyWrapperComponent>
-          {noDataText ? (
-            <Empty
-              image={Empty.PRESENTED_IMAGE_SIMPLE}
-              description={noDataText}
-            />
-          ) : (
-            <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
-          )}
-        </EmptyWrapperComponent>
-      )}
+    <>
+      <TableViewStyles {...props}>
+        <TableCollection
+          getTableProps={getTableProps}
+          getTableBodyProps={getTableBodyProps}
+          prepareRow={prepareRow}
+          headerGroups={headerGroups}
+          rows={content}
+          columns={columns}
+          loading={loading}
+        />
+        {isEmpty && (
+          <EmptyWrapperComponent>
+            {noDataText ? (
+              <Empty
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                description={noDataText}
+              />
+            ) : (
+              <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
+            )}
+          </EmptyWrapperComponent>
+        )}
+      </TableViewStyles>
       {pageCount > 1 && withPagination && (
-        <div className="pagination-container">
+        <PaginationStyles
+          className="pagination-container"
+          isPaginationSticky={props.isPaginationSticky}
+        >
           <Pagination
             totalPages={pageCount || 0}
             currentPage={pageCount ? pageIndex + 1 : 0}
@@ -232,9 +239,9 @@ const TableView = ({
                 )}
             </div>
           )}
-        </div>
+        </PaginationStyles>
       )}
-    </TableViewStyles>
+    </>
   );
 };
 


### PR DESCRIPTION
### SUMMARY

This PR only solves the most perceivable issue with the scrollbar going all the way to the bottom, down to the pagination component. Read [this comment](https://github.com/apache/superset/issues/15935#issuecomment-897699534) for context 

### BEFORE

<img width="878" alt="Screen Shot 2021-07-28 at 10 41 38 AM" src="https://user-images.githubusercontent.com/67837651/127398200-713c6564-496b-4bbf-b82b-bcf05401ba26.png">

### AFTER

https://user-images.githubusercontent.com/60598000/129215292-6d07c6b7-f6d9-4c74-8133-90c45ac59a7f.mp4

### TESTING INSTRUCTIONS
1. Open Explore
2. Click on "Change dataset"
3. Observe the table and scroll
4. Make sure the scrollbar does not appear down to the pagination

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #15935
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
