### PR TITLE
feat: add function list to auto-complete to Clickhouse datasource

### DIFF
--- a/superset/db_engine_specs/clickhouse.py
+++ b/superset/db_engine_specs/clickhouse.py
@@ -99,7 +99,9 @@ class ClickHouseEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method
             logger.error(
                 "Payload from `%s` has the incorrect format. "
                 "Expected column `%s`, found: %s.",
-                system_functions_sql, cls._show_functions_column, ", ".join(columns),
+                system_functions_sql,
+                cls._show_functions_column,
+                ", ".join(columns),
                 exc_info=True,
             )
             # if the results have a single column, use that
@@ -107,7 +109,9 @@ class ClickHouseEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method
                 return df[columns[0]].tolist()
         except Exception as ex:  # pylint: disable=broad-except
             logger.error(
-                "Query `%s` fire error %s. ", system_functions_sql, str(ex),
+                "Query `%s` fire error %s. ",
+                system_functions_sql,
+                str(ex),
                 exc_info=True,
             )
             return []

--- a/superset/db_engine_specs/clickhouse.py
+++ b/superset/db_engine_specs/clickhouse.py
@@ -16,14 +16,14 @@
 # under the License.
 import logging
 from datetime import datetime
-from typing import Dict, Optional, Type, List, TYPE_CHECKING
+from typing import Dict, List, Optional, Type, TYPE_CHECKING
 
 from urllib3.exceptions import NewConnectionError
 
 from superset.db_engine_specs.base import BaseEngineSpec
 from superset.db_engine_specs.exceptions import SupersetDBAPIDatabaseError
-from superset.utils import core as utils
 from superset.extensions import cache_manager
+from superset.utils import core as utils
 
 if TYPE_CHECKING:
     # prevent circular imports

--- a/superset/db_engine_specs/clickhouse.py
+++ b/superset/db_engine_specs/clickhouse.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import logging
 from datetime import datetime
 from typing import Dict, Optional, Type, List, TYPE_CHECKING
 
@@ -27,6 +28,8 @@ from superset.extensions import cache_manager
 if TYPE_CHECKING:
     # prevent circular imports
     from superset.models.core import Database
+
+logger = logging.getLogger(__name__)
 
 
 class ClickHouseEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method
@@ -77,7 +80,6 @@ class ClickHouseEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method
             return f"""toDateTime('{dttm.isoformat(sep=" ", timespec="seconds")}')"""
         return None
 
-
     @classmethod
     @cache_manager.cache.memoize()
     def get_function_names(cls, database: "Database") -> List[str]:
@@ -109,7 +111,6 @@ class ClickHouseEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method
                 exc_info=True,
             )
             return []
-
 
         # otherwise, return no function names to prevent errors
         return []


### PR DESCRIPTION
### SUMMARY
add function list to auto-complete to Clickhouse datasource
Fixes #15477


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/105560/129231081-ab467886-cb10-4723-8882-0453511588e0.png)

### TESTING INSTRUCTIONS
use https://gist.github.com/Slach/ad926dfa30ceb4fe1d168c00c3da98e0#file-bootstrap-dev-sh 
`bootstrap-dev.sh` script
open https://localhost:8088
add `clickhouse+native://default@clickhouse:9000/default` as new datasource
after add, open SQLlab and try to use auto-complete
