### PR TITLE
fix: Update Add Chart modal to use new datasets api

### DIFF
--- a/superset-frontend/src/addSlice/AddSliceContainer.tsx
+++ b/superset-frontend/src/addSlice/AddSliceContainer.tsx
@@ -21,6 +21,8 @@ import Button from 'src/components/Button';
 import rison from 'rison';
 import { AutoComplete } from 'src/common/components';
 import { css, styled, t, makeApi } from '@superset-ui/core';
+import debounce from 'lodash/debounce';
+import { FAST_DEBOUNCE } from 'src/constants';
 
 import VizTypeGallery, {
   MAX_ADVISABLE_VIZ_GALLERY_WIDTH,
@@ -188,9 +190,9 @@ export default class AddSliceContainer extends React.PureComponent<
             onSelect={(_, option) => {
               this.setState({ currentDataset: option });
             }}
-            onSearch={searchTerm => {
+            onSearch={debounce(searchTerm => {
               this.getDatasets(searchTerm);
-            }}
+            }, FAST_DEBOUNCE)}
             onChange={d => {
               this.setState({ currentDataset: {} });
             }}

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm.tsx
@@ -206,9 +206,12 @@ const TableCatalog = ({
     <StyledCatalogTable>
       <div className="catalog-type-select">
         <FormLabel required>{t('Type of Google Sheets Allowed')}</FormLabel>
-        <Select style={{ width: '100%' }} defaultValue="true" disabled>
-          <Select.Option value="true" key={1}>
+        <Select style={{ width: '100%' }} defaultValue="public">
+          <Select.Option value="public" key={1}>
             {t('Publicly shared sheets only')}
+          </Select.Option>
+          <Select.Option value="private" key={2}>
+            {t('Publicly and privately shared sheets only')}
           </Select.Option>
         </Select>
       </div>


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix add chart view select to incorporate all datasets instead of just physical. To fix this we update the component to hit the api  for autocomplete functionality.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/27827808/129608295-8f5d3acf-efc0-4ea1-aedb-13ac7bd283d8.mov

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API



