### PR TITLE
fix: Remove Advanced Analytics tag for 2 charts

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -39,7 +39,7 @@
         "@superset-ui/legacy-preset-chart-big-number": "^0.17.82",
         "@superset-ui/legacy-preset-chart-deckgl": "^0.4.10",
         "@superset-ui/legacy-preset-chart-nvd3": "^0.17.81",
-        "@superset-ui/plugin-chart-echarts": "^0.17.81",
+        "@superset-ui/plugin-chart-echarts": "^0.17.83",
         "@superset-ui/plugin-chart-pivot-table": "^0.17.81",
         "@superset-ui/plugin-chart-table": "^0.17.82",
         "@superset-ui/plugin-chart-word-cloud": "^0.17.81",
@@ -12685,9 +12685,9 @@
       }
     },
     "node_modules/@superset-ui/plugin-chart-echarts": {
-      "version": "0.17.81",
-      "resolved": "https://registry.npmjs.org/@superset-ui/plugin-chart-echarts/-/plugin-chart-echarts-0.17.81.tgz",
-      "integrity": "sha512-pQ91Y7ZzmMkRs8XdMMyP/tq2t431MQnlDFiQv5XUkoBtOhWqVH2KVm9dk7AYwufuuwcLcm48Ab4vRDT8oQKKNw==",
+      "version": "0.17.83",
+      "resolved": "https://registry.npmjs.org/@superset-ui/plugin-chart-echarts/-/plugin-chart-echarts-0.17.83.tgz",
+      "integrity": "sha512-Xrq+90LV3twY68pTMU8kwibecwozEY8gYzEOOIMDS+Ccnh6pVXpec/585ne5i2CL4KGVLFoNXBUyJ0cXk6BUvw==",
       "dependencies": {
         "@superset-ui/chart-controls": "0.17.81",
         "@superset-ui/core": "0.17.81",
@@ -62116,9 +62116,9 @@
       }
     },
     "@superset-ui/plugin-chart-echarts": {
-      "version": "0.17.81",
-      "resolved": "https://registry.npmjs.org/@superset-ui/plugin-chart-echarts/-/plugin-chart-echarts-0.17.81.tgz",
-      "integrity": "sha512-pQ91Y7ZzmMkRs8XdMMyP/tq2t431MQnlDFiQv5XUkoBtOhWqVH2KVm9dk7AYwufuuwcLcm48Ab4vRDT8oQKKNw==",
+      "version": "0.17.83",
+      "resolved": "https://registry.npmjs.org/@superset-ui/plugin-chart-echarts/-/plugin-chart-echarts-0.17.83.tgz",
+      "integrity": "sha512-Xrq+90LV3twY68pTMU8kwibecwozEY8gYzEOOIMDS+Ccnh6pVXpec/585ne5i2CL4KGVLFoNXBUyJ0cXk6BUvw==",
       "requires": {
         "@superset-ui/chart-controls": "0.17.81",
         "@superset-ui/core": "0.17.81",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -91,7 +91,7 @@
     "@superset-ui/legacy-preset-chart-big-number": "^0.17.82",
     "@superset-ui/legacy-preset-chart-deckgl": "^0.4.10",
     "@superset-ui/legacy-preset-chart-nvd3": "^0.17.81",
-    "@superset-ui/plugin-chart-echarts": "^0.17.81",
+    "@superset-ui/plugin-chart-echarts": "^0.17.83",
     "@superset-ui/plugin-chart-pivot-table": "^0.17.81",
     "@superset-ui/plugin-chart-table": "^0.17.82",
     "@superset-ui/plugin-chart-word-cloud": "^0.17.81",

--- a/superset-frontend/src/visualizations/TimeTable/TimeTableChartPlugin.js
+++ b/superset-frontend/src/visualizations/TimeTable/TimeTableChartPlugin.js
@@ -27,7 +27,6 @@ const metadata = new ChartMetadata({
     'Compare multiple time series charts (as sparklines) and related metrics quickly.',
   ),
   tags: [
-    t('Advanced-Analytics'),
     t('Multi-Variables'),
     t('Comparison'),
     t('Legacy'),


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Two charts (**Timeseries Table** and **Mixed Timeseries** (via ECharts)) do not currently have Advanced Analytics, but were tagged as though they do. This PR removes the tag for Timeseries Table in two spots - in the repo (why is this even here?) and in the superset-ui plugin (why is this not the one we're using?). It also removes it from the relevant part of the ECharts plugin.

Brings in the 0.17.83 release for [this change](https://github.com/apache-superset/superset-ui/pull/1306/files).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
**Before:**
![image](https://user-images.githubusercontent.com/812905/129265241-2ef0b672-53de-4c78-8657-30e6401204eb.png)

**After:**
![image](https://user-images.githubusercontent.com/812905/129264764-1990800e-d684-45ca-8ac5-49e57671ff12.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Go to the viz gallery, select the Advanced analytics tag, and make sure these two don't show up.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
