### PR TITLE
chore(pylint): Reenable ungrouped-imports check

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -84,7 +84,6 @@ confidence=
 disable=
     missing-docstring,
     too-many-lines,
-    ungrouped-imports,
     import-outside-toplevel,
     raise-missing-from,
     super-with-arguments,

--- a/scripts/ci_check_no_file_changes.sh
+++ b/scripts/ci_check_no_file_changes.sh
@@ -34,7 +34,7 @@ REGEXES=()
 for CHECK in "$@"
 do
   if [[ ${CHECK} == "python" ]]; then
-    REGEX="(^\.github\/workflows\/.*python|^tests\/|^superset\/|^setup\.py|^requirements\/.+\.txt)"
+    REGEX="(^\.github\/workflows\/.*python|^tests\/|^superset\/|^setup\.py|^requirements\/.+\.txt|^\.pylintrc)"
     echo "Searching for changes in python files"
   elif [[ ${CHECK} == "frontend" ]]; then
     REGEX="(^\.github\/workflows\/.*(frontend|e2e)|^superset-frontend\/)"


### PR DESCRIPTION
### SUMMARY

Re-enabling the Pylint `ungrouped-imports` check. This is a no-op since https://github.com/apache/superset/pull/16146 which bumped the version of Pylint to resolve a number of false positive `ungrouped-imports` errors related to `TYPE_CHECKING`. See https://github.com/PyCQA/pylint/issues/3382 for more details. 

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: https://github.com/apache/superset/issues/9953
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
