### PR TITLE
fix: pivot columns with ints for name

### DIFF
--- a/superset/charts/post_processing.py
+++ b/superset/charts/post_processing.py
@@ -177,7 +177,7 @@ def pivot_table_v2(  # pylint: disable=too-many-branches
         df = df.stack(0).unstack().reindex(level=-1, columns=metrics)
 
     # flatten column names
-    df.columns = [" ".join(column) for column in df.columns]
+    df.columns = [" ".join(str(name) for name in column) for column in df.columns]
 
     return df
 

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -182,6 +182,7 @@ class BaseReportState:
         screenshot: Optional[BaseScreenshot] = None
         if self._report_schedule.chart:
             url = self._get_url(standalone="true")
+            logger.info("Screenshotting chart at %s", url)
             screenshot = ChartScreenshot(
                 url,
                 self._report_schedule.chart.digest,
@@ -190,6 +191,7 @@ class BaseReportState:
             )
         else:
             url = self._get_url()
+            logger.info("Screenshotting dashboard at %s", url)
             screenshot = DashboardScreenshot(
                 url,
                 self._report_schedule.dashboard.digest,
@@ -235,6 +237,7 @@ class BaseReportState:
                 ) from ex
 
         try:
+            logger.info("Getting chart from %s", url)
             csv_data = get_chart_csv_data(url, auth_cookies)
         except SoftTimeLimitExceeded:
             raise ReportScheduleCsvTimeout()


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The pivot column post-processing is failing because some columns have ints for their names instead of strings.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/local/lib/python3.7/site-packages/flask_appbuilder/security/decorators.py", line 67, in wraps
    return f(self, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/superset/views/base_api.py", line 85, in wraps
    raise ex
  File "/usr/local/lib/python3.7/site-packages/superset/views/base_api.py", line 82, in wraps
    duration, response = time_function(f, self, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/superset/utils/core.py", line 1428, in time_function
    response = func(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/superset/utils/log.py", line 241, in wrapper
    value = f(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/superset/charts/api.py", line 647, in get_data
    return self.get_data_response(command, form_data=form_data)
  File "/usr/local/lib/python3.7/site-packages/superset/charts/api.py", line 545, in get_data_response
    return self.send_chart_response(result, form_data)
  File "/usr/local/lib/python3.7/site-packages/superset/charts/api.py", line 509, in send_chart_response
    result = apply_post_process(result, form_data)
  File "/usr/local/lib/python3.7/site-packages/superset/charts/post_processing.py", line 204, in apply_post_process
    processed_df = post_processor(df, form_data)
  File "/usr/local/lib/python3.7/site-packages/superset/charts/post_processing.py", line 180, in pivot_table_v2
    df.columns = [" ".join(column) for column in df.columns]
  File "/usr/local/lib/python3.7/site-packages/superset/charts/post_processing.py", line 180, in <listcomp>
    df.columns = [" ".join(column) for column in df.columns]
TypeError: sequence item 1: expected str instance, int found
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
