### PR TITLE
chore(pylint): Reenable too-few-public-methods check

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -88,7 +88,6 @@ disable=
     import-outside-toplevel,
     raise-missing-from,
     super-with-arguments,
-    too-few-public-methods,
     too-many-locals,
     duplicate-code,
 

--- a/superset/commands/base.py
+++ b/superset/commands/base.py
@@ -43,7 +43,7 @@ class BaseCommand(ABC):
         """
 
 
-class CreateMixin:
+class CreateMixin:  # pylint: disable=too-few-public-methods
     @staticmethod
     def populate_owners(
         user: User, owner_ids: Optional[List[int]] = None
@@ -61,7 +61,7 @@ class CreateMixin:
         return populate_owners(user, owner_ids, default_to_user=True)
 
 
-class UpdateMixin:
+class UpdateMixin:  # pylint: disable=too-few-public-methods
     @staticmethod
     def populate_owners(
         user: User, owner_ids: Optional[List[int]] = None

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -214,7 +214,7 @@ def extra_validator(value: str) -> str:
     return value
 
 
-class DatabaseParametersSchemaMixin:
+class DatabaseParametersSchemaMixin:  # pylint: disable=too-few-public-methods
     """
     Allow SQLAlchemy URI to be passed as separate parameters.
 

--- a/superset/extensions.py
+++ b/superset/extensions.py
@@ -98,7 +98,7 @@ class UIManifestProcessor:
         return self.manifest.get(bundle, {}).get(asset_type, [])
 
 
-class ProfilingExtension:
+class ProfilingExtension:  # pylint: disable=too-few-public-methods
     def __init__(self, interval: float = 1e-4) -> None:
         self.interval = interval
 

--- a/superset/utils/encrypt.py
+++ b/superset/utils/encrypt.py
@@ -22,7 +22,7 @@ from sqlalchemy import TypeDecorator
 from sqlalchemy_utils import EncryptedType
 
 
-class AbstractEncryptedFieldAdapter(ABC):
+class AbstractEncryptedFieldAdapter(ABC):  # pylint: disable=too-few-public-methods
     @abstractmethod
     def create(
         self,
@@ -33,7 +33,9 @@ class AbstractEncryptedFieldAdapter(ABC):
         pass
 
 
-class SQLAlchemyUtilsAdapter(AbstractEncryptedFieldAdapter):
+class SQLAlchemyUtilsAdapter(  # pylint: disable=too-few-public-methods
+    AbstractEncryptedFieldAdapter
+):
     def create(
         self,
         app_config: Optional[Dict[str, Any]],

--- a/superset/utils/profiler.py
+++ b/superset/utils/profiler.py
@@ -21,12 +21,13 @@ from unittest import mock
 from werkzeug.wrappers import Request, Response
 
 try:
+    # pylint: disable=import-error
     from pyinstrument import Profiler
 except ModuleNotFoundError:
     Profiler = None
 
 
-class SupersetProfiler:
+class SupersetProfiler:  # pylint: disable=too-few-public-methods
     """
     WSGI middleware to instrument Superset.
 


### PR DESCRIPTION
### SUMMARY

Re-enabling the Pylint `too-few-public-methods` check.

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: https://github.com/apache/superset/issues/9953
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
