### PR TITLE
chore(pylint): Reenable too-many-locals check

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -89,7 +89,6 @@ disable=
     raise-missing-from,
     super-with-arguments,
     too-few-public-methods,
-    too-many-locals,
     duplicate-code,
 
 [REPORTS]

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -120,7 +120,7 @@ class QueryContext:
         df.reset_index(level=0, inplace=True)
         return df
 
-    def processing_time_offsets(
+    def processing_time_offsets(  # pylint: disable=too-many-locals
         self, df: pd.DataFrame, query_object: QueryObject,
     ) -> CachedTimeOffset:
         # ensure query_object is immutable

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -671,7 +671,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.export",
         log_to_statsd=False,
-    )
+    )  # pylint: disable=too-many-locals
     def export(self, **kwargs: Any) -> Response:
         """Export dashboards
         ---

--- a/superset/dashboards/commands/importers/v1/utils.py
+++ b/superset/dashboards/commands/importers/v1/utils.py
@@ -56,7 +56,7 @@ def build_uuid_to_id_map(position: Dict[str, Any]) -> Dict[str, int]:
     }
 
 
-def update_id_refs(
+def update_id_refs(  # pylint: disable=too-many-locals
     config: Dict[str, Any],
     chart_ids: Dict[str, int],
     dataset_info: Dict[str, Dict[str, Any]],

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -415,7 +415,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.export",
         log_to_statsd=False,
-    )
+    )  # pylint: disable=too-many-locals
     def export(self, **kwargs: Any) -> Response:
         """Export datasets
         ---

--- a/superset/examples/multiformat_time_series.py
+++ b/superset/examples/multiformat_time_series.py
@@ -32,7 +32,7 @@ from .helpers import (
 )
 
 
-def load_multiformat_time_series(
+def load_multiformat_time_series(  # pylint: disable=too-many-locals
     only_metadata: bool = False, force: bool = False
 ) -> None:
     """Loading time series data from a zip file in the repo"""

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -211,7 +211,7 @@ def _append_columns(
 
 
 @validate_column_args("index", "columns")
-def pivot(  # pylint: disable=too-many-arguments
+def pivot(  # pylint: disable=too-many-arguments,too-many-locals
     df: DataFrame,
     index: List[str],
     aggregates: Dict[str, Dict[str, Any]],

--- a/superset/utils/profiler.py
+++ b/superset/utils/profiler.py
@@ -21,6 +21,7 @@ from unittest import mock
 from werkzeug.wrappers import Request, Response
 
 try:
+    # pylint: disable=import-error
     from pyinstrument import Profiler
 except ModuleNotFoundError:
     Profiler = None


### PR DESCRIPTION
### SUMMARY

Re-enabling the Pylint `too-many-locals` check.

Note the goal is not to remedy existing code, i.e., I merely have added disabled checks locally, but rather to enforce future changes from using too many local variables which often makes the code difficult to grok.

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: https://github.com/apache/superset/issues/9953
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
