### PR TITLE
fix(dashboard): unset empty time filter indicator

### DIFF
--- a/superset/common/query_actions.py
+++ b/superset/common/query_actions.py
@@ -27,6 +27,7 @@ from superset.utils.core import (
     ChartDataResultType,
     extract_column_dtype,
     extract_dataframe_dtypes,
+    ExtraFiltersReasonType,
     get_time_filter_status,
     QueryStatus,
 )
@@ -114,7 +115,7 @@ def _get_full(
         {"column": col} for col in filter_columns if col in columns
     ] + applied_time_columns
     payload["rejected_filters"] = [
-        {"reason": "not_in_datasource", "column": col}
+        {"reason": ExtraFiltersReasonType.COL_NOT_IN_DATASOURCE, "column": col}
         for col in filter_columns
         if col not in columns
     ] + rejected_time_columns

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -122,6 +122,8 @@ logger = logging.getLogger(__name__)
 
 DTTM_ALIAS = "__timestamp"
 
+NO_TIME_RANGE = "No filter"
+
 TIME_COMPARISION = "__"
 
 JS_MAX_INTEGER = 9007199254740991  # Largest int Java Script can handle 2^53-1
@@ -221,6 +223,12 @@ class ExtraFiltersTimeColumnType(str, Enum):
     TIME_GRAIN = "__time_grain"
     TIME_ORIGIN = "__time_origin"
     TIME_RANGE = "__time_range"
+
+
+class ExtraFiltersReasonType(str, Enum):
+    NO_TEMPORAL_COLUMN = "no_temporal_column"
+    COL_NOT_IN_DATASOURCE = "not_in_datasource"
+    NOT_DRUID_DATASOURCE = "not_druid_datasource"
 
 
 class FilterOperator(str, Enum):
@@ -1620,7 +1628,7 @@ def get_time_filter_status(  # pylint: disable=too-many-branches
         else:
             rejected.append(
                 {
-                    "reason": "not_in_datasource",
+                    "reason": ExtraFiltersReasonType.COL_NOT_IN_DATASOURCE,
                     "column": ExtraFiltersTimeColumnType.TIME_COL,
                 }
             )
@@ -1632,19 +1640,20 @@ def get_time_filter_status(  # pylint: disable=too-many-branches
         else:
             rejected.append(
                 {
-                    "reason": "no_temporal_column",
+                    "reason": ExtraFiltersReasonType.NO_TEMPORAL_COLUMN,
                     "column": ExtraFiltersTimeColumnType.TIME_GRAIN,
                 }
             )
 
-    if ExtraFiltersTimeColumnType.TIME_RANGE in applied_time_extras:
+    time_range = applied_time_extras.get(ExtraFiltersTimeColumnType.TIME_RANGE)
+    if time_range and time_range != NO_TIME_RANGE:
         # are there any temporal columns to assign the time grain to?
         if temporal_columns:
             applied.append({"column": ExtraFiltersTimeColumnType.TIME_RANGE})
         else:
             rejected.append(
                 {
-                    "reason": "no_temporal_column",
+                    "reason": ExtraFiltersReasonType.NO_TEMPORAL_COLUMN,
                     "column": ExtraFiltersTimeColumnType.TIME_RANGE,
                 }
             )
@@ -1655,7 +1664,7 @@ def get_time_filter_status(  # pylint: disable=too-many-branches
         else:
             rejected.append(
                 {
-                    "reason": "not_druid_datasource",
+                    "reason": ExtraFiltersReasonType.NOT_DRUID_DATASOURCE,
                     "column": ExtraFiltersTimeColumnType.TIME_ORIGIN,
                 }
             )
@@ -1666,7 +1675,7 @@ def get_time_filter_status(  # pylint: disable=too-many-branches
         else:
             rejected.append(
                 {
-                    "reason": "not_druid_datasource",
+                    "reason": ExtraFiltersReasonType.NOT_DRUID_DATASOURCE,
                     "column": ExtraFiltersTimeColumnType.GRANULARITY,
                 }
             )

--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -44,6 +44,7 @@ from superset.charts.commands.exceptions import (
     TimeRangeAmbiguousError,
     TimeRangeParseFailError,
 )
+from superset.utils.core import NO_TIME_RANGE
 from superset.utils.memoized import memoized
 
 ParserElement.enablePackrat()
@@ -174,7 +175,7 @@ def get_since_until(
     _relative_start = relative_start if relative_start else "today"
     _relative_end = relative_end if relative_end else "today"
 
-    if time_range == "No filter":
+    if time_range == NO_TIME_RANGE:
         return None, None
 
     if time_range and time_range.startswith("Last") and separator not in time_range:

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -71,6 +71,7 @@ from superset.utils import core as utils, csv
 from superset.utils.cache import set_and_log_cache
 from superset.utils.core import (
     DTTM_ALIAS,
+    ExtraFiltersReasonType,
     JS_MAX_INTEGER,
     merge_extra_filters,
     QueryMode,
@@ -477,7 +478,7 @@ class BaseViz:
             if col in columns or col in filter_values_columns
         ] + applied_time_columns
         payload["rejected_filters"] = [
-            {"reason": "not_in_datasource", "column": col}
+            {"reason": ExtraFiltersReasonType.COL_NOT_IN_DATASOURCE, "column": col}
             for col in filter_columns
             if col not in columns and col not in filter_values_columns
         ] + rejected_time_columns

--- a/tests/unit_tests/fixtures/datasets.py
+++ b/tests/unit_tests/fixtures/datasets.py
@@ -1,0 +1,206 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Any, Dict
+from unittest.mock import Mock
+
+
+def get_column_mock(params: Dict[str, Any]) -> Mock:
+    mock = Mock()
+    mock.id = params["id"]
+    mock.column_name = params["column_name"]
+    mock.verbose_name = params["verbose_name"]
+    mock.description = params["description"]
+    mock.expression = params["expression"]
+    mock.filterable = params["filterable"]
+    mock.groupby = params["groupby"]
+    mock.is_dttm = params["is_dttm"]
+    mock.type = params["type"]
+    return mock
+
+
+def get_metric_mock(params: Dict[str, Any]) -> Mock:
+    mock = Mock()
+    mock.id = params["id"]
+    mock.metric_name = params["metric_name"]
+    mock.metric_name = params["verbose_name"]
+    mock.description = params["description"]
+    mock.expression = params["expression"]
+    mock.warning_text = params["warning_text"]
+    mock.d3format = params["d3format"]
+    return mock
+
+
+def get_dataset_mock() -> Mock:
+    mock = Mock()
+    mock.id = None
+    mock.column_formats = {"ratio": ".2%"}
+    mock.database = {"id": 1}
+    mock.description = "Adding a DESCRip"
+    mock.default_endpoint = ""
+    mock.filter_select_enabled = True
+    mock.name = "birth_names"
+    mock.table_name = "birth_names"
+    mock.datasource_name = "birth_names"
+    mock.type = "table"
+    mock.schema = None
+    mock.offset = 66
+    mock.cache_timeout = 55
+    mock.sql = ""
+    mock.columns = [
+        get_column_mock(
+            {
+                "id": 504,
+                "column_name": "ds",
+                "verbose_name": "",
+                "description": None,
+                "expression": "",
+                "filterable": True,
+                "groupby": True,
+                "is_dttm": True,
+                "type": "DATETIME",
+            }
+        ),
+        get_column_mock(
+            {
+                "id": 505,
+                "column_name": "gender",
+                "verbose_name": None,
+                "description": None,
+                "expression": "",
+                "filterable": True,
+                "groupby": True,
+                "is_dttm": False,
+                "type": "VARCHAR(16)",
+            }
+        ),
+        get_column_mock(
+            {
+                "id": 506,
+                "column_name": "name",
+                "verbose_name": None,
+                "description": None,
+                "expression": None,
+                "filterable": True,
+                "groupby": True,
+                "is_dttm": None,
+                "type": "VARCHAR(255)",
+            }
+        ),
+        get_column_mock(
+            {
+                "id": 508,
+                "column_name": "state",
+                "verbose_name": None,
+                "description": None,
+                "expression": None,
+                "filterable": True,
+                "groupby": True,
+                "is_dttm": None,
+                "type": "VARCHAR(10)",
+            }
+        ),
+        get_column_mock(
+            {
+                "id": 509,
+                "column_name": "num_boys",
+                "verbose_name": None,
+                "description": None,
+                "expression": None,
+                "filterable": True,
+                "groupby": True,
+                "is_dttm": None,
+                "type": "BIGINT(20)",
+            }
+        ),
+        get_column_mock(
+            {
+                "id": 510,
+                "column_name": "num_girls",
+                "verbose_name": None,
+                "description": None,
+                "expression": "",
+                "filterable": False,
+                "groupby": False,
+                "is_dttm": False,
+                "type": "BIGINT(20)",
+            }
+        ),
+        get_column_mock(
+            {
+                "id": 532,
+                "column_name": "num",
+                "verbose_name": None,
+                "description": None,
+                "expression": None,
+                "filterable": True,
+                "groupby": True,
+                "is_dttm": None,
+                "type": "BIGINT(20)",
+            }
+        ),
+        get_column_mock(
+            {
+                "id": 522,
+                "column_name": "num_california",
+                "verbose_name": None,
+                "description": None,
+                "expression": "CASE WHEN state = 'CA' THEN num ELSE 0 END",
+                "filterable": False,
+                "groupby": False,
+                "is_dttm": False,
+                "type": "NUMBER",
+            }
+        ),
+    ]
+    mock.metrics = (
+        [
+            get_metric_mock(
+                {
+                    "id": 824,
+                    "metric_name": "sum__num",
+                    "verbose_name": "Babies",
+                    "description": "",
+                    "expression": "SUM(num)",
+                    "warning_text": "",
+                    "d3format": "",
+                }
+            ),
+            get_metric_mock(
+                {
+                    "id": 836,
+                    "metric_name": "count",
+                    "verbose_name": "",
+                    "description": None,
+                    "expression": "count(1)",
+                    "warning_text": None,
+                    "d3format": None,
+                }
+            ),
+            get_metric_mock(
+                {
+                    "id": 843,
+                    "metric_name": "ratio",
+                    "verbose_name": "Ratio Boys/Girls",
+                    "description": "This represents the ratio of boys/girls",
+                    "expression": "sum(num_boys) / sum(num_girls)",
+                    "warning_text": "no warning",
+                    "d3format": ".2%",
+                }
+            ),
+        ],
+    )
+    return mock


### PR DESCRIPTION
### SUMMARY
Currently the time filter indicator shows filter box time filters as being applied despite being set to "No filter". This PR changes the chart data endpoint (both legacy and VI) to not add the time filter to "applied columns" if the time filter is set to "No filter". In addition, unit tests are added for all non-Druid functionality in `get_time_filter_status` as the function didn't have any unit tests, along with a dataset fixture that can be used with the new unit tests (=faster than the integration tests).

### AFTER
Notice how now the indicator doesn't show the filter box time range as being applied when set to "No filter":
![image](https://user-images.githubusercontent.com/33317356/129561408-a24c5820-cc65-4be8-8122-5c34927aae95.png)
However, when set to something else, it's now showing up correctly:
![image](https://user-images.githubusercontent.com/33317356/129562533-9a44ec1a-b828-4955-80cb-3c022f783671.png)

### BEFORE
Notice how both V1 (left) and legacy (middle) chart indicators previously showed the filter as being applied: 
![image](https://user-images.githubusercontent.com/33317356/129561310-7db74cb6-ff5b-470d-ab75-7a3bab40be11.png)

### TESTING INSTRUCTIONS
1. Create a filter box with a "No filter" time range and create a dashboard with it
2. Add a legacy chart to the dashboard
3. Notice the filter indicator showing the time range as applied.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
