### PR TITLE
fix(viz): apply temporal adhoc filter on non-ts charts

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1156,7 +1156,7 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
             op = flt["op"].upper()
             col_obj = (
                 dttm_col
-                if col == utils.DTTM_ALIAS and is_timeseries and dttm_col
+                if col == utils.DTTM_ALIAS and dttm_col
                 else columns_by_name.get(col)
             )
             filter_grain = flt.get("grain")


### PR DESCRIPTION
### SUMMARY
Currently temporal adhoc native/cross filters only apply to charts that are marked as `is_temporal`. This changes the logic so that they apply to any chart that is referencing a dataset that has a temporal column defined.

### AFTER
After the change, the filter applies to the temporal column of the dataset:
https://user-images.githubusercontent.com/33317356/129598864-1d76210e-a824-4c27-94fe-b959aacf01b0.mp4

### BEFORE
Currently temporal cross filters only apply to temporal charts, even if the underlying dataset has a temporal column:
https://user-images.githubusercontent.com/33317356/129582205-21daef29-c7bb-4dfd-b804-688a34b41140.mp4



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
