### PR TITLE
fix: Fix table height in Change dataset modal when pagination is off

### DIFF
--- a/superset-frontend/src/components/TableView/TableView.tsx
+++ b/superset-frontend/src/components/TableView/TableView.tsx
@@ -56,14 +56,15 @@ const EmptyWrapper = styled.div`
 `;
 
 const TableViewStyles = styled.div<{
+  hasPagination?: boolean;
   isPaginationSticky?: boolean;
   scrollTable?: boolean;
   small?: boolean;
 }>`
-  ${({ scrollTable, theme }) =>
+  ${({ hasPagination, scrollTable, theme }) =>
     scrollTable &&
     `
-    height: 300px;
+    height: ${hasPagination ? '300px' : '380px'};
     margin-bottom: ${theme.gridUnit * 4}px;
     overflow: auto;
   `}
@@ -191,10 +192,11 @@ const TableView = ({
   }
 
   const isEmpty = !loading && content.length === 0;
+  const hasPagination = pageCount > 1 && withPagination;
 
   return (
     <>
-      <TableViewStyles {...props}>
+      <TableViewStyles hasPagination={hasPagination} {...props}>
         <TableCollection
           getTableProps={getTableProps}
           getTableBodyProps={getTableBodyProps}
@@ -217,7 +219,7 @@ const TableView = ({
           </EmptyWrapperComponent>
         )}
       </TableViewStyles>
-      {pageCount > 1 && withPagination && (
+      {hasPagination && (
         <PaginationStyles
           className="pagination-container"
           isPaginationSticky={props.isPaginationSticky}


### PR DESCRIPTION
### SUMMARY
This PR fixes an issue with the height of the table inside the Change dataset modal when the pagination is off, which was causing a blank space to appear.

### BEFORE

https://user-images.githubusercontent.com/60598000/129256458-4a582b35-11d2-42a0-afb0-c3911b5957d8.mp4

### AFTER

https://user-images.githubusercontent.com/60598000/129588511-5cba6d93-938a-4407-96e1-8a92ca96f213.mp4

### TESTING INSTRUCTIONS
1. Open a chart in Explore
2. Click on Change dataset
3. Observe the table height and make sure there is no blank space at the bottom

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #16249
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
