### PR TITLE
feat(config): Configurable Celery Flask Metadata passover

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -719,6 +719,25 @@ CELERY_CONFIG = CeleryConfig  # pylint: disable=invalid-name
 # Set celery config to None to disable all the above configuration
 # CELERY_CONFIG = None
 
+# A function that provides additional metadata to pass over to Celery workers.
+# The use case is mainly around having global Flask data also available in
+# async Celery calls, e.g. for DB_CONNECTION_MUTATOR to set up granular source
+# Example:
+#    def CELERY_FLASK_METADATA_EXTRACTOR() -> Dict:
+#        return {
+#            "slice_id": request.args.get("slice_id"),
+#            "dashboard_id": request.args.get("dashboard_id"),
+#        }
+CELERY_FLASK_METADATA_EXTRACTOR = None
+
+# A function that saves metadata passed by CELERY_FLASK_METADATA_EXTRACTOR on
+# the Celery worker side.
+# Example:
+#    def CELERY_FLASK_METADATA_EXTRACTOR(metadata: Dict) -> None:
+#        g.slice_id = metadata["slice_id"]
+#        g.dashboard_id = metadata["dashboard_id"]
+CELERY_FLASK_METADATA_INITIALIZER = None
+
 # Additional static HTTP headers to be served by your Superset server. Note
 # Flask-Talisman applies the relevant security HTTP headers.
 #
@@ -1273,7 +1292,7 @@ if CONFIG_PATH_ENV_VAR in os.environ:
 elif importlib.util.find_spec("superset_config") and not is_test():
     try:
         import superset_config  # pylint: disable=import-error
-        from superset_config import *  # type: ignore # pylint: disable=import-error,wildcard-import
+        from superset_config import *  # pylint: disable=import-error,wildcard-import
 
         print(f"Loaded your LOCAL configuration at [{superset_config.__file__}]")
     except Exception:


### PR DESCRIPTION
### SUMMARY
As explained in #16209, original Flask context is not present on the Celery workers. Because of that, some crucial information like granular source or access token are not reachable for establishing a proper DB connection. This PR ads two functions to the config allowing to materialize some global Flask properties into the Celery request on the requestor side and then dematerialize them back into the global environment on the Celery worker side, thus allowing DB_CONNECTION_MUTATOR to always have all required information.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
n/a

### TESTING INSTRUCTIONS
1. Define some simple metadata passover functions (e.g. `CELERY_FLASK_METADATA_EXTRACTOR` getting some field from `flask.request` and `CELERY_FLASK_METADATA_INITIALIZER` putting this data somewhere in `flask.g`)
2. Run a query from the Superset SQL Lab locally with a breakpoint on the Celery worker side.
3. Check `flask.g` contains an expected parameter.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Implements #16209
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
