### PR TITLE
refactor: re-arrange dashboard page js bundles

### DIFF
--- a/superset-frontend/src/dashboard/containers/DashboardPage.tsx
+++ b/superset-frontend/src/dashboard/containers/DashboardPage.tsx
@@ -30,7 +30,9 @@ import {
 import { hydrateDashboard } from 'src/dashboard/actions/hydrate';
 import { setDatasources } from 'src/dashboard/actions/datasources';
 import injectCustomCss from 'src/dashboard/util/injectCustomCss';
+import setupPlugins from 'src/setup/setupPlugins';
 
+setupPlugins();
 const DashboardContainer = React.lazy(
   () =>
     import(

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -32,13 +32,11 @@ import Menu from 'src/components/Menu/Menu';
 import FlashProvider from 'src/components/FlashProvider';
 import { theme } from 'src/preamble';
 import ToastPresenter from 'src/messageToasts/containers/ToastPresenter';
-import setupPlugins from 'src/setup/setupPlugins';
 import setupApp from 'src/setup/setupApp';
 import { routes, isFrontendRoute } from 'src/views/routes';
 import { store } from './store';
 
 setupApp();
-setupPlugins();
 
 const container = document.getElementById('app');
 const bootstrap = JSON.parse(container?.getAttribute('data-bootstrap') ?? '{}');

--- a/superset/templates/superset/partials/asset_bundle.html
+++ b/superset/templates/superset/partials/asset_bundle.html
@@ -21,7 +21,7 @@
      with development version #}
   <!-- Bundle js {{ filename }} START -->
   {% for entry in js_manifest(filename) %}
-    <script src="{{ entry }}"></script>
+    <script src="{{ entry }}" async></script>
   {% endfor %}
   <!-- Bundle js {{ filename }} END -->
 {% endmacro %}


### PR DESCRIPTION
### SUMMARY
I am trying to rearrange existing bundles needed by the dashboard page, make spa.js execute and route to the dashboard page quicker, so that it can start to fetch dashboard metadata earlier.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="318" alt="Screen Shot 2021-08-16 at 12 18 30 AM" src="https://user-images.githubusercontent.com/27990562/129649364-f2417d5f-c923-4986-b12f-579392313cbf.png">

<img width="1312" alt="control without cache" src="https://user-images.githubusercontent.com/27990562/129649493-5deba6d4-7e7c-4545-8ef0-6c3c66ce306b.png">


After:
<img width="308" alt="Screen Shot 2021-08-16 at 12 14 15 PM" src="https://user-images.githubusercontent.com/27990562/129649375-5f189753-ee39-4bcd-8828-9f955f5791a5.png">

<img width="1310" alt="test no cache" src="https://user-images.githubusercontent.com/27990562/129649520-b053c385-dff3-4a02-9f32-10ebe4fcfbcf.png">


### TESTING INSTRUCTIONS
CI and manual test


**Note**:
The perf improvement is hard to estimate, because I only run a few times, with same dashboard, from my own computer. I feel it might be highly impacted by my computer's performance. For example if i was in zoom meeting the page load will be slower :joy: 
Since the change is relatively small, I hope could deploy to airbnb production environment and collect some real data. If thing didn't work well, i am ok to roll it back. 

cc @nytai and @suddjian I saw you have a lot of work on spa and recent dashboard refactor, please take a look at this PR.

also cc @ktmud and @etr2460 