### PR TITLE
chore(pylint): Reenable too-many-lines check

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -84,7 +84,6 @@ enable=
 # --disable=W"
 disable=
     missing-docstring,
-    too-many-lines,
     duplicate-code,
     unspecified-encoding,
     # re-enable once this no longer raises false positives

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=too-many-lines
 import json
 import logging
 from datetime import datetime

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=too-many-lines
 from typing import Any, Dict
 
 from flask_babel import gettext as _

--- a/superset/config.py
+++ b/superset/config.py
@@ -20,6 +20,7 @@ All configuration in this file can be overridden by providing a superset_config
 in your PYTHONPATH as there is a ``from superset_config import *``
 at the end of this file.
 """
+# pylint: disable=too-many-lines
 import imp  # pylint: disable=deprecated-module
 import importlib.util
 import json

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=too-many-lines
 import dataclasses
 import json
 import logging

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=too-many-lines
 import json
 import logging
 from datetime import datetime

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=unused-argument
+# pylint: disable=too-many-lines,unused-argument
 import json
 import logging
 import re

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=too-many-lines
 import logging
 import re
 import textwrap

--- a/superset/examples/countries.py
+++ b/superset/examples/countries.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """This module contains data related to countries and is used for geo mapping"""
+# pylint: disable=too-many-lines
 from typing import Any, Dict, List, Optional
 
 countries: List[Dict[str, Any]] = [

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=too-few-public-methods
+# pylint: disable=too-few-public-methods,too-many-lines
 """A set of constants and methods to manage permissions and security"""
 import logging
 import re

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Utility functions used across Superset"""
+# pylint: disable=too-many-lines
 import collections
 import decimal
 import errno

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=comparison-with-callable, line-too-long
+# pylint: disable=comparison-with-callable,line-too-long,too-many-lines
 from __future__ import annotations
 
 import logging

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=C,R,W,useless-suppression
+# pylint: disable=C,R,W,too-many-lines,useless-suppression
 """This module contains the 'Viz' objects
 
 These objects represent the backend of all the visualizations that


### PR DESCRIPTION
### SUMMARY

Re-enabling the `Pylint too-many-lines` check.

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: https://github.com/apache/superset/issues/9953
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
