### PR TITLE
chore(explore): remove unnecessary favstar redirect

### DIFF
--- a/superset-frontend/src/explore/actions/exploreActions.ts
+++ b/superset-frontend/src/explore/actions/exploreActions.ts
@@ -70,7 +70,7 @@ export const FETCH_FAVE_STAR = 'FETCH_FAVE_STAR';
 export function fetchFaveStar(sliceId: string) {
   return function (dispatch: Dispatch) {
     SupersetClient.get({
-      endpoint: `${FAVESTAR_BASE_URL}/${sliceId}/count`,
+      endpoint: `${FAVESTAR_BASE_URL}/${sliceId}/count/`,
     }).then(({ json }) => {
       if (json.count > 0) {
         dispatch(toggleFaveStar(true));


### PR DESCRIPTION
### SUMMARY
Remove an unnecessary 308 redirect for the `/superset/favstar/slice/<pk>/count` endpoint in the Explore view.

### AFTER
Notice no redirects:
![image](https://user-images.githubusercontent.com/33317356/129669937-419e8127-83cf-45f4-b50b-dc94dde67524.png)

### BEFORE
Notice the 308 redirect
![image](https://user-images.githubusercontent.com/33317356/129670037-27a13fa7-7e7a-4b92-889f-c3b25077a2d5.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
