### PR TITLE
fix(explore): let admin overwrite slice

### DIFF
--- a/superset-frontend/src/explore/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/index.tsx
@@ -175,7 +175,7 @@ export default function PropertiesModal({
             buttonStyle="primary"
             // @ts-ignore
             onClick={onSubmit}
-            disabled={!owners || submitting || !name}
+            disabled={submitting || !name}
             cta
           >
             {t('Save')}

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -122,6 +122,7 @@ from superset.views.base import (
     get_error_msg,
     get_user_roles,
     handle_api_exception,
+    is_user_admin,
     json_error_response,
     json_errors_response,
     json_success,
@@ -787,7 +788,9 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
         # slc perms
         slice_add_perm = security_manager.can_access("can_write", "Chart")
-        slice_overwrite_perm = is_owner(slc, g.user) if slc else False
+        slice_overwrite_perm = (
+            is_owner(slc, g.user) or is_user_admin() if slc else False
+        )
         slice_download_perm = security_manager.can_access("can_csv", "Superset")
 
         form_data["datasource"] = str(datasource_id) + "__" + cast(str, datasource_type)


### PR DESCRIPTION
### SUMMARY
Currently Explore doesn't let Admins overwrite a slice if they don't belong to the owners group. This changes this so that admins have the `can_overwrite` property on bootstrap data set to `True` if the user is an owner OR they are an Admin. In addition, the Edit Chart metadata modal is changed so that it is possible to save even if the owner list is empty. This is to align the behavior of the Chart metadata modal with the Dashboard metadata modal. See #15149 for more context on this change.

### AFTER
As an admin, the user can now overwrite the chart if they are an Admin:
![image](https://user-images.githubusercontent.com/33317356/129674266-71e0ef88-e649-4ac5-99ce-5aed695d433b.png)
In addition, the Chart metadata modal is now saveable even if the owners list is empty:
![image](https://user-images.githubusercontent.com/33317356/129674320-8d967421-0f8e-4b8c-92f5-14e0f6e6dd91.png)

### BEFORE
Currently the overwrite option is disabled for admins that aren't set as owners of a chart:
![image](https://user-images.githubusercontent.com/33317356/129674430-29976a79-01ea-4b09-83ad-48cd65579f15.png)
In addition, the Save button in the Chart metadata modal is disabled when empty:
![image](https://user-images.githubusercontent.com/33317356/129674552-b15a5dc9-c0ed-405a-a26f-d0605bf724b2.png)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
