### PR TITLE
docs: 14520, corrected referenced name in extraConfigs in sample values.yaml and documentation

### DIFF
--- a/docs/src/pages/docs/installation/kubernetes.mdx
+++ b/docs/src/pages/docs/installation/kubernetes.mdx
@@ -183,7 +183,7 @@ Data source definitions can be automatically declared by providing key/value yam
 
 ```yaml
 extraConfigs:
-  datasources-init.yaml: |
+  import_datasources.yaml: |
     databases:
     - allow_csv_upload: true
       allow_ctas: true

--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
   - name: craig-rueda
     email: craig@craigrueda.com
     url: https://github.com/craig-rueda
-version: 0.3.5
+version: 0.3.6
 dependencies:
 - name: postgresql
   version: 10.2.0

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -68,7 +68,7 @@ extraSecretEnv: {}
   # GOOGLE_SECRET: ...
 
 extraConfigs: {}
-  # datasources-init.yaml: |
+  # import_datasources.yaml: |
   #     databases:
   #     - allow_csv_upload: true
   #       allow_ctas: true


### PR DESCRIPTION
### SUMMARY
Fixes Issue #14520 

extraConfigs do not work for adding databases. This fixes that problem by adjusting the name of the yaml-file to-be-created 
 (configured in extraConfigs)  to match the filename mentioned by the initscript.

This PR alligns them so that they are referencing the same name: **import_datasources.yaml**.

### TESTING INSTRUCTIONS
Tested using Kind 0.11.1

Add these lines in the values.yaml file.
The configuration might fail if the trino database does not exist. Which means that the configuration value is actually read and processed.

```
extraConfigs:
  import_datasources.yaml: |
    databases:
    - allow_csv_upload: true
      allow_ctas: true
      allow_cvas: true
      database_name: trino
      extra: "{\r\n    \"metadata_params\": {},\r\n    \"engine_params\": {},\r\n    \"\
        metadata_cache_timeout\": {},\r\n    \"schemas_allowed_for_csv_upload\": []\r\n\
        }"
      sqlalchemy_uri: trino://trino:8080/hive/default
      tables: []
```


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ X] Has associated issue: 14520 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
