### PR TITLE
fix(sqlite): week grain refer to day of week

### DIFF
--- a/superset/db_engine_specs/sqlite.py
+++ b/superset/db_engine_specs/sqlite.py
@@ -44,7 +44,7 @@ class SqliteEngineSpec(BaseEngineSpec):
         "PT1M": "DATETIME(STRFTIME('%Y-%m-%dT%H:%M:00', {col}))",
         "PT1H": "DATETIME(STRFTIME('%Y-%m-%dT%H:00:00', {col}))",
         "P1D": "DATE({col})",
-        "P1W": "DATE({col}, -strftime('%W', {col}) || ' days')",
+        "P1W": "DATE({col}, -strftime('%w', {col}) || ' days')",
         "P1M": "DATE({col}, -strftime('%d', {col}) || ' days', '+1 day')",
         "P0.25Y": (
             "DATETIME(STRFTIME('%Y-', {col}) || "  # year


### PR DESCRIPTION
### SUMMARY
Currently the weekly grain subtracts the week of year (`%W`) from the date, not the day of week (`%w`). See docs for reference: https://www.sqlite.org/lang_datefunc.html

### AFTER
Here we can see that there is 7 nowdays between time increments:
![image](https://user-images.githubusercontent.com/33317356/129719110-01368455-6489-4dc6-9fdc-7dd634ba2658.png)

### BEFORE
Currently there is intraweek data, as the week of year is the same for all days within the week:
![image](https://user-images.githubusercontent.com/33317356/129719161-6688e06a-7779-42af-bbc8-5a9ada2ec6e0.png)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
