### PR TITLE
fix: copy to Clipboard order

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -190,6 +190,7 @@ export default class ResultSet extends React.PureComponent<
       this,
     );
     this.handleExploreBtnClick = this.handleExploreBtnClick.bind(this);
+    this.orderResultsData = this.orderResultsData.bind(this);
   }
 
   async componentDidMount() {
@@ -442,13 +443,34 @@ export default class ResultSet extends React.PureComponent<
     }
   }
 
+  orderResultsData(data: Record<string, unknown>[]) {
+    // orders the data from results based on the columns.
+    const { columns } = this.props.query.results;
+    const orderedData = [];
+    for (let i = 0; i < data.length; i += 1) {
+      const row = {};
+      for (let j = 0; j < columns.length; j += 1) {
+        const key = columns[j].name;
+        if (data[i][key]) {
+          row[j] = data[i][key];
+        } else {
+          row[j] = data[i][parseFloat(key)];
+        }
+      }
+      orderedData.push(row);
+    }
+    return orderedData;
+  }
+
   renderControls() {
     if (this.props.search || this.props.visualize || this.props.csv) {
       let { data } = this.props.query.results;
       if (this.props.cache && this.props.query.cached) {
         ({ data } = this.state);
       }
-
+      // JavaScript does not mantain the order of a mixed set of keys (i.e integers and strings)
+      // the below function orders the keys based on the column names.
+      const orderedData = this.orderResultsData(data);
       // Added compute logic to stop user from being able to Save & Explore
       const {
         saveDatasetRadioBtnState,
@@ -508,7 +530,7 @@ export default class ResultSet extends React.PureComponent<
             )}
 
             <CopyToClipboard
-              text={prepareCopyToClipboardTabularData(data)}
+              text={prepareCopyToClipboardTabularData(orderedData)}
               wrapped={false}
               copyNode={
                 <Button buttonSize="small">

--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -190,7 +190,6 @@ export default class ResultSet extends React.PureComponent<
       this,
     );
     this.handleExploreBtnClick = this.handleExploreBtnClick.bind(this);
-    this.orderResultsData = this.orderResultsData.bind(this);
   }
 
   async componentDidMount() {
@@ -443,34 +442,13 @@ export default class ResultSet extends React.PureComponent<
     }
   }
 
-  orderResultsData(data: Record<string, unknown>[]) {
-    // orders the data from results based on the columns.
-    const { columns } = this.props.query.results;
-    const orderedData = [];
-    for (let i = 0; i < data.length; i += 1) {
-      const row = {};
-      for (let j = 0; j < columns.length; j += 1) {
-        const key = columns[j].name;
-        if (data[i][key]) {
-          row[j] = data[i][key];
-        } else {
-          row[j] = data[i][parseFloat(key)];
-        }
-      }
-      orderedData.push(row);
-    }
-    return orderedData;
-  }
-
   renderControls() {
     if (this.props.search || this.props.visualize || this.props.csv) {
       let { data } = this.props.query.results;
       if (this.props.cache && this.props.query.cached) {
         ({ data } = this.state);
       }
-      // JavaScript does not mantain the order of a mixed set of keys (i.e integers and strings)
-      // the below function orders the keys based on the column names.
-      const orderedData = this.orderResultsData(data);
+      const { columns } = this.props.query.results;
       // Added compute logic to stop user from being able to Save & Explore
       const {
         saveDatasetRadioBtnState,
@@ -530,7 +508,7 @@ export default class ResultSet extends React.PureComponent<
             )}
 
             <CopyToClipboard
-              text={prepareCopyToClipboardTabularData(orderedData)}
+              text={prepareCopyToClipboardTabularData(data, columns)}
               wrapped={false}
               copyNode={
                 <Button buttonSize="small">

--- a/superset-frontend/src/components/TableView/TableView.tsx
+++ b/superset-frontend/src/components/TableView/TableView.tsx
@@ -156,7 +156,6 @@ const TableView = ({
     useSortBy,
     usePagination,
   );
-
   useEffect(() => {
     if (serverPagination && pageIndex !== initialState.pageIndex) {
       onServerPagination({

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -55,11 +55,13 @@ const CopyNode = (
 
 export const CopyToClipboardButton = ({
   data,
+  columns,
 }: {
   data?: Record<string, any>;
+  columns?: string[];
 }) => (
   <CopyToClipboard
-    text={data ? prepareCopyToClipboardTabularData(data) : ''}
+    text={data ? prepareCopyToClipboardTabularData(data, columns) : ''}
     wrapped={false}
     copyNode={CopyNode}
   />

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -61,7 +61,9 @@ export const CopyToClipboardButton = ({
   columns?: string[];
 }) => (
   <CopyToClipboard
-    text={data ? prepareCopyToClipboardTabularData(data, columns) : ''}
+    text={
+      data && columns ? prepareCopyToClipboardTabularData(data, columns) : ''
+    }
     wrapped={false}
     copyNode={CopyNode}
   />
@@ -115,14 +117,14 @@ export const useFilteredTableData = (
   }, [data, filterText]);
 
 export const useTableColumns = (
-  all_columns: string[],
+  colnames?: string[],
   data?: Record<string, any>[],
   moreConfigs?: { [key: string]: Partial<Column> },
 ) =>
   useMemo(
     () =>
-      data?.length
-        ? all_columns
+      colnames && data?.length
+        ? colnames
             .filter((column: string) => Object.keys(data[0]).includes(column))
             .map(
               key =>

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -122,23 +122,25 @@ export const useTableColumns = (
   useMemo(
     () =>
       data?.length
-        ? all_columns.map(
-            key =>
-              ({
-                accessor: row => row[key],
-                Header: key,
-                Cell: ({ value }) => {
-                  if (value === true) {
-                    return BOOL_TRUE_DISPLAY;
-                  }
-                  if (value === false) {
-                    return BOOL_FALSE_DISPLAY;
-                  }
-                  return String(value);
-                },
-                ...moreConfigs?.[key],
-              } as Column),
-          )
+        ? all_columns
+            .filter((column: string) => Object.keys(data[0]).includes(column))
+            .map(
+              key =>
+                ({
+                  accessor: row => row[key],
+                  Header: key,
+                  Cell: ({ value }) => {
+                    if (value === true) {
+                      return BOOL_TRUE_DISPLAY;
+                    }
+                    if (value === false) {
+                      return BOOL_FALSE_DISPLAY;
+                    }
+                    return String(value);
+                  },
+                  ...moreConfigs?.[key],
+                } as Column),
+            )
         : [],
     [data, moreConfigs],
   );

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -115,13 +115,14 @@ export const useFilteredTableData = (
   }, [data, filterText]);
 
 export const useTableColumns = (
+  all_columns: string[],
   data?: Record<string, any>[],
   moreConfigs?: { [key: string]: Partial<Column> },
 ) =>
   useMemo(
     () =>
       data?.length
-        ? Object.keys(data[0]).map(
+        ? all_columns.map(
             key =>
               ({
                 accessor: row => row[key],

--- a/superset-frontend/src/explore/components/DataTableControl/useTableColumns.test.ts
+++ b/superset-frontend/src/explore/components/DataTableControl/useTableColumns.test.ts
@@ -30,6 +30,7 @@ for (let i = 32; i < 127; i += 1) {
 const asciiKey = asciiChars.join('');
 const unicodeKey = '你好. 吃了吗?';
 
+const all_columns = ['col01', 'col02'];
 const data = [
   { col01: true, col02: false, [asciiKey]: asciiKey, [unicodeKey]: unicodeKey },
   { col01: true, col02: false, [asciiKey]: asciiKey, [unicodeKey]: unicodeKey },
@@ -44,7 +45,7 @@ const data = [
 ];
 
 test('useTableColumns with no options', () => {
-  const hook = renderHook(() => useTableColumns(data));
+  const hook = renderHook(() => useTableColumns(all_columns, data));
   expect(hook.result.current).toEqual([
     {
       Cell: expect.any(Function),
@@ -83,7 +84,7 @@ test('useTableColumns with no options', () => {
 
 test('use only the first record columns', () => {
   const newData = [data[3], data[0]];
-  const hook = renderHook(() => useTableColumns(newData));
+  const hook = renderHook(() => useTableColumns(all_columns, newData));
   expect(hook.result.current).toEqual([
     {
       Cell: expect.any(Function),
@@ -134,7 +135,9 @@ test('use only the first record columns', () => {
 });
 
 test('useTableColumns with options', () => {
-  const hook = renderHook(() => useTableColumns(data, { col01: { id: 'ID' } }));
+  const hook = renderHook(() =>
+    useTableColumns(all_columns, data, { col01: { id: 'ID' } }),
+  );
   expect(hook.result.current).toEqual([
     {
       Cell: expect.any(Function),

--- a/superset-frontend/src/explore/components/DataTableControl/useTableColumns.test.ts
+++ b/superset-frontend/src/explore/components/DataTableControl/useTableColumns.test.ts
@@ -30,7 +30,6 @@ for (let i = 32; i < 127; i += 1) {
 const asciiKey = asciiChars.join('');
 const unicodeKey = '你好. 吃了吗?';
 
-const all_columns = ['col01', 'col02'];
 const data = [
   { col01: true, col02: false, [asciiKey]: asciiKey, [unicodeKey]: unicodeKey },
   { col01: true, col02: false, [asciiKey]: asciiKey, [unicodeKey]: unicodeKey },
@@ -43,6 +42,7 @@ const data = [
     [unicodeKey]: unicodeKey,
   },
 ];
+const all_columns = ['col01', 'col02', 'col03', asciiKey, unicodeKey];
 
 test('useTableColumns with no options', () => {
   const hook = renderHook(() => useTableColumns(all_columns, data));

--- a/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.test.tsx
@@ -58,6 +58,11 @@ const createProps = () => ({
   tableSectionHeight: 156.9,
   chartStatus: 'rendered',
   onCollapseChange: jest.fn(),
+  queriesResponse: [
+    {
+      colnames: [],
+    },
+  ],
 });
 
 afterAll(() => {

--- a/superset-frontend/src/explore/components/DataTablesPane/index.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/index.tsx
@@ -112,6 +112,7 @@ export const DataTablesPane = ({
   chartStatus,
   ownState,
   errorMessage,
+  queriesResponse,
 }: {
   queryFormData: Record<string, any>;
   tableSectionHeight: number;
@@ -119,6 +120,7 @@ export const DataTablesPane = ({
   ownState?: JsonObject;
   onCollapseChange: (openPanelName: string) => void;
   errorMessage?: JSX.Element;
+  queriesResponse: Record<string, any>;
 }) => {
   const [data, setData] = useState<{
     [RESULT_TYPES.results]?: Record<string, any>[];
@@ -128,6 +130,7 @@ export const DataTablesPane = ({
     [RESULT_TYPES.results]: true,
     [RESULT_TYPES.samples]: true,
   });
+  const [columnNames, setColumnNames] = useState<string[]>([]);
   const [error, setError] = useState(NULLISH_RESULTS_STATE);
   const [filterText, setFilterText] = useState('');
   const [activeTabKey, setActiveTabKey] = useState<string>(
@@ -221,6 +224,13 @@ export const DataTablesPane = ({
   }, [queryFormData.adhoc_filters, queryFormData.datasource]);
 
   useEffect(() => {
+    if (queriesResponse) {
+      const { colnames } = queriesResponse[0];
+      setColumnNames([...colnames]);
+    }
+  }, [queriesResponse]);
+
+  useEffect(() => {
     if (panelOpen && isRequestPending[RESULT_TYPES.results]) {
       if (errorMessage) {
         setIsRequestPending(prevState => ({
@@ -277,16 +287,15 @@ export const DataTablesPane = ({
     ),
   };
 
-  const { all_columns } = queryFormData;
   // this is to preserve the order of the columns, even if there are integer values,
   // while also only grabbing the first column's keys
   const columns = {
     [RESULT_TYPES.results]: useTableColumns(
-      all_columns,
+      columnNames,
       data[RESULT_TYPES.results],
     ),
     [RESULT_TYPES.samples]: useTableColumns(
-      all_columns,
+      columnNames,
       data[RESULT_TYPES.samples],
     ),
   };
@@ -325,7 +334,7 @@ export const DataTablesPane = ({
   const TableControls = (
     <TableControlsWrapper>
       <RowCount data={data[activeTabKey]} loading={isLoading[activeTabKey]} />
-      <CopyToClipboardButton data={data[activeTabKey]} columns={all_columns} />
+      <CopyToClipboardButton data={data[activeTabKey]} columns={columnNames} />
       <FilterInput onChangeHandler={setFilterText} />
     </TableControlsWrapper>
   );

--- a/superset-frontend/src/explore/components/DataTablesPane/index.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/index.tsx
@@ -281,6 +281,7 @@ export const DataTablesPane = ({
     [RESULT_TYPES.results]: useTableColumns(data[RESULT_TYPES.results]),
     [RESULT_TYPES.samples]: useTableColumns(data[RESULT_TYPES.samples]),
   };
+  const { all_columns } = queryFormData;
 
   const renderDataTable = (type: string) => {
     if (isLoading[type]) {
@@ -316,7 +317,7 @@ export const DataTablesPane = ({
   const TableControls = (
     <TableControlsWrapper>
       <RowCount data={data[activeTabKey]} loading={isLoading[activeTabKey]} />
-      <CopyToClipboardButton data={data[activeTabKey]} />
+      <CopyToClipboardButton data={data[activeTabKey]} columns={all_columns} />
       <FilterInput onChangeHandler={setFilterText} />
     </TableControlsWrapper>
   );

--- a/superset-frontend/src/explore/components/DataTablesPane/index.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/index.tsx
@@ -276,12 +276,17 @@ export const DataTablesPane = ({
       data[RESULT_TYPES.samples],
     ),
   };
-
-  const columns = {
-    [RESULT_TYPES.results]: useTableColumns(data[RESULT_TYPES.results]),
-    [RESULT_TYPES.samples]: useTableColumns(data[RESULT_TYPES.samples]),
-  };
   const { all_columns } = queryFormData;
+  const columns = {
+    [RESULT_TYPES.results]: useTableColumns(
+      all_columns,
+      data[RESULT_TYPES.results],
+    ),
+    [RESULT_TYPES.samples]: useTableColumns(
+      all_columns,
+      data[RESULT_TYPES.samples],
+    ),
+  };
 
   const renderDataTable = (type: string) => {
     if (isLoading[type]) {

--- a/superset-frontend/src/explore/components/DataTablesPane/index.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/index.tsx
@@ -276,7 +276,10 @@ export const DataTablesPane = ({
       data[RESULT_TYPES.samples],
     ),
   };
+
   const { all_columns } = queryFormData;
+  // this is to preserve the order of the columns, even if there are integer values,
+  // while also only grabbing the first column's keys
   const columns = {
     [RESULT_TYPES.results]: useTableColumns(
       all_columns,

--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -116,7 +116,6 @@ const ExploreChartPanel = props => {
   const theme = useTheme();
   const gutterMargin = theme.gridUnit * GUTTER_SIZE_FACTOR;
   const gutterHeight = theme.gridUnit * GUTTER_SIZE_FACTOR;
-
   const { height: hHeight, ref: headerRef } = useResizeDetector({
     refreshMode: 'debounce',
     refreshRate: 300,

--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -127,7 +127,6 @@ const ExploreChartPanel = props => {
   const [splitSizes, setSplitSizes] = useState(
     getFromLocalStorage(STORAGE_KEYS.sizes, INITIAL_SIZES),
   );
-
   const { slice } = props;
   const updateQueryContext = useCallback(
     async function fetchChartData() {
@@ -210,7 +209,6 @@ const ExploreChartPanel = props => {
     }
     setSplitSizes(splitSizes);
   };
-
   const renderChart = useCallback(() => {
     const { chart, vizType } = props;
     const newHeight =
@@ -316,6 +314,7 @@ const ExploreChartPanel = props => {
             onCollapseChange={onCollapseChange}
             chartStatus={props.chart.chartStatus}
             errorMessage={props.errorMessage}
+            queriesResponse={props.chart.queriesResponse}
           />
         </Split>
       )}

--- a/superset-frontend/src/utils/common.js
+++ b/superset-frontend/src/utils/common.js
@@ -87,10 +87,21 @@ export function optionFromValue(opt) {
   return { value: optionValue(opt), label: optionLabel(opt) };
 }
 
-export function prepareCopyToClipboardTabularData(data) {
+export function prepareCopyToClipboardTabularData(data, columns) {
   let result = '';
   for (let i = 0; i < data.length; i += 1) {
-    result += `${Object.values(data[i]).join('\t')}\n`;
+    const row = {};
+    for (let j = 0; j < columns.length; j += 1) {
+      // JavaScript does not mantain the order of a mixed set of keys (i.e integers and strings)
+      // the below function orders the keys based on the column names.
+      const key = columns[j].name || columns[j];
+      if (data[i][key]) {
+        row[j] = data[i][key];
+      } else {
+        row[j] = data[i][parseFloat(key)];
+      }
+    }
+    result += `${Object.values(row).join('\t')}\n`;
   }
   return result;
 }

--- a/superset-frontend/src/utils/common.test.jsx
+++ b/superset-frontend/src/utils/common.test.jsx
@@ -46,15 +46,18 @@ describe('utils/common', () => {
   describe('prepareCopyToClipboardTabularData', () => {
     it('converts empty array', () => {
       const array = [];
-      expect(prepareCopyToClipboardTabularData(array)).toEqual('');
+      const column = [];
+      expect(prepareCopyToClipboardTabularData(array, column)).toEqual('');
     });
     it('converts non empty array', () => {
       const array = [
         { column1: 'lorem', column2: 'ipsum' },
         { column1: 'dolor', column2: 'sit', column3: 'amet' },
       ];
-      expect(prepareCopyToClipboardTabularData(array)).toEqual(
-        'lorem\tipsum\ndolor\tsit\tamet\n',
+      const column = ['column1', 'column2', 'column3'];
+      console.log(prepareCopyToClipboardTabularData(array, column));
+      expect(prepareCopyToClipboardTabularData(array, column)).toEqual(
+        'lorem\tipsum\t\ndolor\tsit\tamet\n',
       );
     });
   });

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -449,7 +449,7 @@ class BaseViz:
 
         payload = self.get_df_payload(query_obj)
 
-        df = pd.DataFrame()
+        df = payload.get("df") or pd.DataFrame()
 
         if self.status != utils.QueryStatus.FAILED:
             payload["data"] = self.get_data(df)

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -449,7 +449,7 @@ class BaseViz:
 
         payload = self.get_df_payload(query_obj)
 
-        df = payload.get("df")
+        df = pd.DataFrame()
 
         if self.status != utils.QueryStatus.FAILED:
             payload["data"] = self.get_data(df)
@@ -481,7 +481,8 @@ class BaseViz:
             for col in filter_columns
             if col not in columns and col not in filter_values_columns
         ] + rejected_time_columns
-
+        if hasattr(df, "columns"):
+            payload["colnames"] = list(df.columns)
         return payload
 
     def get_df_payload(

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -449,7 +449,8 @@ class BaseViz:
 
         payload = self.get_df_payload(query_obj)
 
-        df = payload.get("df") or pd.DataFrame()
+        # if payload does not have a df, we are raising an error here.
+        df = cast(Optional[pd.DataFrame], payload["df"])
 
         if self.status != utils.QueryStatus.FAILED:
             payload["data"] = self.get_data(df)
@@ -481,7 +482,7 @@ class BaseViz:
             for col in filter_columns
             if col not in columns and col not in filter_values_columns
         ] + rejected_time_columns
-        if hasattr(df, "columns"):
+        if df is not None:
             payload["colnames"] = list(df.columns)
         return payload
 


### PR DESCRIPTION
### SUMMARY
This fixes this issue: https://github.com/apache/superset/issues/16149

The reason for this issue occurring is that Javascript orders objects based on integer and integer-like keys first, and then all strings: https://2ality.com/2015/10/property-traversal-order-es6.html

Therefore to prep the data for copyToClipboard, this code goes through and orders the keys based on the column names. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Also fixed the table order, which was previously wrong. 
Before: 
![Screen Shot 2021-08-20 at 10 20 21 AM](https://user-images.githubusercontent.com/48933336/130247700-9132b338-76ba-41c9-9416-db0bb6a207f6.png)

After:
![Screen Shot 2021-08-19 at 11 39 13 AM](https://user-images.githubusercontent.com/48933336/130098980-6347890a-b2d4-43a0-a8d4-a5ad5bc242ca.png)

### TESTING INSTRUCTIONS
To test:
1) Create a google sheet/database that has a mix of integers and strings as columns
2) run a query on the database
3) Use the copy to clipboard feature. 
4) Go into explore, use the copy to clipboard feature. 

Also-
1) Go to charts
2) make sure the different visualization types have the south data pane rendering 


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ x] Has associated issue:  https://github.com/apache/superset/issues/16149
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
