### PR TITLE
fix: remove mergepoint from past migration

### DIFF
--- a/superset/migrations/versions/6d20ba9ecb33_add_last_saved_at_to_slice_model.py
+++ b/superset/migrations/versions/6d20ba9ecb33_add_last_saved_at_to_slice_model.py
@@ -17,14 +17,14 @@
 """add_last_saved_at_to_slice_model
 
 Revision ID: 6d20ba9ecb33
-Revises: ('ae1ed299413b', 'f6196627326f')
+Revises: 'f6196627326f'
 Create Date: 2021-08-02 21:14:58.200438
 
 """
 
 # revision identifiers, used by Alembic.
 revision = "6d20ba9ecb33"
-down_revision = ("ae1ed299413b", "f6196627326f")
+down_revision = "f6196627326f"
 
 import sqlalchemy as sa
 from alembic import op


### PR DESCRIPTION
### SUMMARY
We try to keep a single branch of all migrations, and this specific migration refers to 2 different down revisions. `ae1ed299413b` was merged multiple weeks before this migration, and also has a child migration already, so removing it from the chain here should be safe

### TESTING INSTRUCTIONS
CI. CI should go through a `superset db upgrade` and will error if something is broken here

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @betodealmeida @pkdotson @john-bodley 
cc: @michellethomas 