### PR TITLE
feat(sqla): apply time grain to all temporal groupbys

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1069,12 +1069,12 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
             columns = groupby or columns
             for selected in columns:
                 # if groupby field/expr equals granularity field/expr
-                if selected == granularity:
-                    sqla_col = columns_by_name[selected]
-                    outer = sqla_col.get_timestamp_expression(time_grain, selected)
+                table_col = columns_by_name.get(selected)
+                if table_col and table_col.type_generic == GenericDataType.TEMPORAL:
+                    outer = table_col.get_timestamp_expression(time_grain, selected)
                 # if groupby field equals a selected column
-                elif selected in columns_by_name:
-                    outer = columns_by_name[selected].get_sqla_col()
+                elif table_col:
+                    outer = table_col.get_sqla_col()
                 else:
                     outer = literal_column(f"({selected})")
                     outer = self.make_sqla_column_compatible(outer, selected)


### PR DESCRIPTION
### SUMMARY

Currently the time grain only applies to the main temporal column, making it impossible to have multiple time grained groupbys in the same chart. This PR changes the SqlAlchemy model to apply the time grain to all selected temporal columns. By applying this change it will no longer be possible to mix time grains and original values from two different temporal columns. However, it is unlikely that anyone would prefer that behavior over the proposed new flow, given that in the old flow it was impossible to apply a time grain to other than the main temporal column. 

### AFTER
Table chart:
![image](https://user-images.githubusercontent.com/33317356/129858123-b2cb3994-0574-4dfe-97da-3b4d3a47376c.png)
![image](https://user-images.githubusercontent.com/33317356/129858167-ee217dcd-885a-46af-af39-8d105f8d8623.png)

Pivot table v2:
![image](https://user-images.githubusercontent.com/33317356/129858314-6981a0e0-a79c-482c-947e-5a65b9f20f70.png)
![image](https://user-images.githubusercontent.com/33317356/129858345-f903fe79-463f-407a-bee6-937f1fcb3f82.png)

### BEFORE
Table chart:
![image](https://user-images.githubusercontent.com/33317356/129858421-936899c4-ae74-4256-81cc-8cb0adeeb3fb.png)
![image](https://user-images.githubusercontent.com/33317356/129858906-17fb7859-6367-4f69-9504-b5da32396ca4.png)

Pivot table v2:
![image](https://user-images.githubusercontent.com/33317356/129858626-21e6eea7-ed34-4a1b-a2a3-63dc68cb6cdf.png)
![image](https://user-images.githubusercontent.com/33317356/129858861-d21e5341-973c-444e-8640-529d0a844dcb.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
