### PR TITLE
fix: Blank space in Change dataset modal without warning message

### DIFF
--- a/superset-frontend/src/components/TableView/TableView.tsx
+++ b/superset-frontend/src/components/TableView/TableView.tsx
@@ -56,15 +56,14 @@ const EmptyWrapper = styled.div`
 `;
 
 const TableViewStyles = styled.div<{
-  hasPagination?: boolean;
   isPaginationSticky?: boolean;
   scrollTable?: boolean;
   small?: boolean;
 }>`
-  ${({ hasPagination, scrollTable, theme }) =>
+  ${({ scrollTable, theme }) =>
     scrollTable &&
     `
-    height: ${hasPagination ? '300px' : '380px'};
+    flex: 1 1 auto;
     margin-bottom: ${theme.gridUnit * 4}px;
     overflow: auto;
   `}
@@ -196,7 +195,7 @@ const TableView = ({
 
   return (
     <>
-      <TableViewStyles hasPagination={hasPagination} {...props}>
+      <TableViewStyles {...props}>
         <TableCollection
           getTableProps={getTableProps}
           getTableBodyProps={getTableBodyProps}

--- a/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
+++ b/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
@@ -277,7 +277,6 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
         {!confirmChange && (
           <>
             <Alert
-              closable={false}
               roomBelow
               type="warning"
               css={theme => ({ marginBottom: theme.gridUnit * 4 })}

--- a/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
+++ b/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
@@ -67,6 +67,13 @@ interface ChangeDatasourceModalProps {
   show: boolean;
 }
 
+const Modal = styled(StyledModal)`
+  .ant-modal-body {
+    display: flex;
+    flex-direction: column;
+  }
+`;
+
 const ConfirmModalStyled = styled.div`
   .btn-container {
     display: flex;
@@ -239,7 +246,7 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
   };
 
   return (
-    <StyledModal
+    <Modal
       show={show}
       onHide={onHide}
       responsive
@@ -270,6 +277,7 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
         {!confirmChange && (
           <>
             <Alert
+              closable={false}
               roomBelow
               type="warning"
               css={theme => ({ marginBottom: theme.gridUnit * 4 })}
@@ -307,7 +315,7 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
         )}
         {confirmChange && <>{CONFIRM_WARNING_MESSAGE}</>}
       </>
-    </StyledModal>
+    </Modal>
   );
 };
 


### PR DESCRIPTION
### SUMMARY
This PR should definitely fix a problem with a blank space appearing at the bottom of the Change dataset modal when closing the top warning whether pagination is on or off.

### BEFORE

https://user-images.githubusercontent.com/60598000/129912683-3efe2209-268f-4985-ba54-8368536e54d3.mp4

### AFTER WITHOUT PAGINATION

https://user-images.githubusercontent.com/60598000/129912800-bb62a10e-1fe9-4f6d-bfaf-366b60cc452f.mp4

### AFTER WITH PAGINATION

https://user-images.githubusercontent.com/60598000/129912887-61e8525d-88e3-4b57-b774-1b9a7c16a822.mp4

### TESTING INSTRUCTIONS
1. Open Explore
2. Open the Change Dataset modal
3. Close the top warning
4. Make sure no excessive blank space appears at the bottom

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #16291 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
