### PR TITLE
feat: Add new dev commands to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ update-py:
 
 update-js:
 	# Install js packages
-	cd superset-frontend; npm install
+	cd superset-frontend; npm ci
 
 venv:
 	# Create a virtual environment and activate it (recommended)
@@ -81,3 +81,9 @@ py-lint: pre-commit
 
 js-format:
 	cd superset-frontend; npm run prettier
+
+flask-app:
+	flask run -p 8088 --with-threads --reload --debugger
+
+node-app:
+	cd superset-frontend; npm run dev-server -- --devserverPort=9001

--- a/Makefile
+++ b/Makefile
@@ -86,4 +86,4 @@ flask-app:
 	flask run -p 8088 --with-threads --reload --debugger
 
 node-app:
-	cd superset-frontend; npm run dev-server -- --devserverPort=9001
+	cd superset-frontend; npm run dev-server


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added 2 commands to allow users to spin up the node (FE) and flask app (BE) for development. Also change `make update` to use npm ci instead

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
