### PR TITLE
fix: adjust initial state of report modal

### DIFF
--- a/superset-frontend/src/components/ReportModal/index.tsx
+++ b/superset-frontend/src/components/ReportModal/index.tsx
@@ -143,22 +143,23 @@ const reportReducer = (
   action: ReportActionType,
 ): Partial<ReportObject> | null => {
   const initialState = {
-    name: state?.name || 'Weekly Report',
-    ...(state || {}),
+    name: 'Weekly Report',
   };
 
   switch (action.type) {
     case ActionType.inputChange:
       return {
         ...initialState,
+        ...state,
         [action.payload.name]: action.payload.value,
       };
     case ActionType.fetched:
       return {
+        ...initialState,
         ...action.payload,
       };
     case ActionType.reset:
-      return null;
+      return { ...initialState };
     default:
       return state;
   }
@@ -178,7 +179,7 @@ const ReportModal: FunctionComponent<ReportProps> = ({
       : NOTIFICATION_FORMATS.PNG;
   const [currentReport, setCurrentReport] = useReducer<
     Reducer<Partial<ReportObject> | null, ReportActionType>
-  >(reportReducer, { report_format: defaultNotificationFormat });
+  >(reportReducer, null);
   const onChange = useCallback((type: any, payload: any) => {
     setCurrentReport({ type, payload });
   }, []);
@@ -224,7 +225,7 @@ const ReportModal: FunctionComponent<ReportProps> = ({
       type: 'Report',
       creation_method: props.props.creationMethod,
       active: true,
-      report_format: currentReport?.report_format,
+      report_format: currentReport?.report_format || defaultNotificationFormat,
       timezone: currentReport?.timezone,
     };
 


### PR DESCRIPTION
### SUMMARY
This fixes a bug where the initial state and state reset wasn't passing through the correct report format


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
n/a

### TESTING INSTRUCTIONS
Create a chart without changing anything, and it should pass in the correct initial state. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
