### PR TITLE
fix: Fix parsing onSaving reports toast when user hasn't saved chart

### DIFF
--- a/superset-frontend/src/reports/actions/reports.js
+++ b/superset-frontend/src/reports/actions/reports.js
@@ -17,7 +17,6 @@
  * under the License.
  */
 /* eslint camelcase: 0 */
-import { ConsoleSqlOutlined } from '@ant-design/icons';
 import { t, SupersetClient } from '@superset-ui/core';
 import rison from 'rison';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';

--- a/superset-frontend/src/reports/actions/reports.js
+++ b/superset-frontend/src/reports/actions/reports.js
@@ -17,6 +17,7 @@
  * under the License.
  */
 /* eslint camelcase: 0 */
+import { ConsoleSqlOutlined } from '@ant-design/icons';
 import { t, SupersetClient } from '@superset-ui/core';
 import rison from 'rison';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
@@ -110,12 +111,11 @@ export const addReport = report => dispatch => {
     .catch(async e => {
       const parsedError = await getClientErrorObject(e);
       const errorMessage = parsedError.message;
-      // Do we need this?
-      // const errorArr = Object.keys(errorMessage);
-      // const error = errorMessage[errorArr[0]][0];
+      const errorArr = Object.keys(errorMessage);
+      const error = errorMessage[errorArr[0]];
       dispatch(
         addDangerToast(
-          t('An error occurred while editing this report: %s', errorMessage),
+          t('An error occurred while editing this report: %s', error),
         ),
       );
     });

--- a/superset-frontend/src/reports/actions/reports.js
+++ b/superset-frontend/src/reports/actions/reports.js
@@ -110,11 +110,12 @@ export const addReport = report => dispatch => {
     .catch(async e => {
       const parsedError = await getClientErrorObject(e);
       const errorMessage = parsedError.message;
-      const errorArr = Object.keys(errorMessage);
-      const error = errorMessage[errorArr[0]][0];
+      // Do we need this?
+      // const errorArr = Object.keys(errorMessage);
+      // const error = errorMessage[errorArr[0]][0];
       dispatch(
         addDangerToast(
-          t('An error occurred while editing this report: %s', error),
+          t('An error occurred while editing this report: %s', errorMessage),
         ),
       );
     });

--- a/superset/reports/commands/base.py
+++ b/superset/reports/commands/base.py
@@ -60,5 +60,8 @@ class BaseReportScheduleCommand(BaseCommand):
             if not dashboard:
                 exceptions.append(DashboardNotFoundValidationError())
             self._properties["dashboard"] = dashboard
-        elif not update:
+        elif dashboard_id is None and not chart_id:
+            # User hasn't saved the chart in explore yet
             exceptions.append(ChartNotSavedValidationError())
+        elif not update:
+            exceptions.append(ReportScheduleChartOrDashboardValidationError())

--- a/superset/reports/commands/base.py
+++ b/superset/reports/commands/base.py
@@ -24,6 +24,7 @@ from superset.commands.base import BaseCommand
 from superset.dashboards.dao import DashboardDAO
 from superset.reports.commands.exceptions import (
     ChartNotFoundValidationError,
+    ChartNotSavedValidationError,
     DashboardNotFoundValidationError,
     ReportScheduleChartOrDashboardValidationError,
 )
@@ -60,4 +61,4 @@ class BaseReportScheduleCommand(BaseCommand):
                 exceptions.append(DashboardNotFoundValidationError())
             self._properties["dashboard"] = dashboard
         elif not update:
-            exceptions.append(ReportScheduleChartOrDashboardValidationError())
+            exceptions.append(ChartNotSavedValidationError())

--- a/superset/reports/commands/base.py
+++ b/superset/reports/commands/base.py
@@ -22,10 +22,12 @@ from marshmallow import ValidationError
 from superset.charts.dao import ChartDAO
 from superset.commands.base import BaseCommand
 from superset.dashboards.dao import DashboardDAO
+from superset.models.reports import ReportCreationMethodType
 from superset.reports.commands.exceptions import (
     ChartNotFoundValidationError,
     ChartNotSavedValidationError,
     DashboardNotFoundValidationError,
+    DashboardNotSavedValidationError,
     ReportScheduleChartOrDashboardValidationError,
 )
 
@@ -48,6 +50,15 @@ class BaseReportScheduleCommand(BaseCommand):
         """ Validate chart or dashboard relation """
         chart_id = self._properties.get("chart")
         dashboard_id = self._properties.get("dashboard")
+        creation_method = self._properties.get("creation_method")
+
+        if creation_method == ReportCreationMethodType.CHARTS and not chart_id:
+            # User has not saved chart yet in Explore view
+            exceptions.append(ChartNotSavedValidationError())
+
+        if creation_method == ReportCreationMethodType.DASHBOARDS and not dashboard_id:
+            exceptions.append(DashboardNotSavedValidationError())
+
         if chart_id and dashboard_id:
             exceptions.append(ReportScheduleChartOrDashboardValidationError())
         if chart_id:
@@ -60,8 +71,5 @@ class BaseReportScheduleCommand(BaseCommand):
             if not dashboard:
                 exceptions.append(DashboardNotFoundValidationError())
             self._properties["dashboard"] = dashboard
-        elif dashboard_id is None and not chart_id:
-            # User hasn't saved the chart in explore yet
-            exceptions.append(ChartNotSavedValidationError())
         elif not update:
             exceptions.append(ReportScheduleChartOrDashboardValidationError())

--- a/superset/reports/commands/base.py
+++ b/superset/reports/commands/base.py
@@ -55,9 +55,11 @@ class BaseReportScheduleCommand(BaseCommand):
         if creation_method == ReportCreationMethodType.CHARTS and not chart_id:
             # User has not saved chart yet in Explore view
             exceptions.append(ChartNotSavedValidationError())
+            return
 
         if creation_method == ReportCreationMethodType.DASHBOARDS and not dashboard_id:
             exceptions.append(DashboardNotSavedValidationError())
+            return
 
         if chart_id and dashboard_id:
             exceptions.append(ReportScheduleChartOrDashboardValidationError())

--- a/superset/reports/commands/exceptions.py
+++ b/superset/reports/commands/exceptions.py
@@ -87,7 +87,8 @@ class ChartNotSavedValidationError(ValidationError):
 
     def __init__(self) -> None:
         super().__init__(
-            _("Chart needs to be saved before creating schedule"), field_name="chart"
+            _("Please save your chart first, then try creating a new email report."),
+            field_name="chart",
         )
 
 

--- a/superset/reports/commands/exceptions.py
+++ b/superset/reports/commands/exceptions.py
@@ -80,6 +80,17 @@ class ReportScheduleChartOrDashboardValidationError(ValidationError):
         super().__init__(_("Choose a chart or dashboard not both"), field_name="chart")
 
 
+class ChartNotSavedValidationError(ValidationError):
+    """
+    Marshmallow validation error for charts that haven't been saved yet
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            _("Chart needs to be saved before creating schedule"), field_name="chart"
+        )
+
+
 class ReportScheduleInvalidError(CommandInvalidError):
     message = _("Report Schedule parameters are invalid.")
 

--- a/superset/reports/commands/exceptions.py
+++ b/superset/reports/commands/exceptions.py
@@ -92,6 +92,20 @@ class ChartNotSavedValidationError(ValidationError):
         )
 
 
+class DashboardNotSavedValidationError(ValidationError):
+    """
+    Marshmallow validation error for dashboards that haven't been saved yet
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            _(
+                "Please save your dashboard first, then try creating a new email report."
+            ),
+            field_name="dashboard",
+        )
+
+
 class ReportScheduleInvalidError(CommandInvalidError):
     message = _("Report Schedule parameters are invalid.")
 

--- a/tests/integration_tests/reports/api_tests.py
+++ b/tests/integration_tests/reports/api_tests.py
@@ -739,7 +739,7 @@ class TestReportSchedulesApi(SupersetTestCase):
     )
     def test_unsaved_report_schedule_schema(self):
         """
-        ReportSchedule Api: Test create report schedule schema check
+        ReportSchedule Api: Test create report schedule with unsaved chart
         """
         self.login(username="admin")
         chart = db.session.query(Slice).first()
@@ -763,6 +763,31 @@ class TestReportSchedulesApi(SupersetTestCase):
             data["message"]["chart"]
             == "Please save your chart first, then try creating a new email report."
         )
+
+    @pytest.mark.usefixtures(
+        "load_birth_names_dashboard_with_slices", "create_report_schedules"
+    )
+    def test_no_dashboard_report_schedule_schema(self):
+        """
+        ReportSchedule Api: Test create report schedule with not dashboard id
+        """
+        self.login(username="admin")
+        chart = db.session.query(Slice).first()
+        dashboard = db.session.query(Dashboard).first()
+        example_db = get_example_database()
+
+        # Check that a report does not have a database reference
+        report_schedule_data = {
+            "type": ReportScheduleType.REPORT,
+            "name": "name3",
+            "description": "description",
+            "creation_method": ReportCreationMethodType.DASHBOARDS,
+            "crontab": "0 9 * * *",
+        }
+        uri = "api/v1/report/"
+        rv = self.client.post(uri, json=report_schedule_data)
+        data = json.loads(rv.data.decode("utf-8"))
+        assert rv.status_code == 422
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_create_report_schedule_chart_dash_validation(self):

--- a/tests/integration_tests/reports/api_tests.py
+++ b/tests/integration_tests/reports/api_tests.py
@@ -746,7 +746,6 @@ class TestReportSchedulesApi(SupersetTestCase):
         dashboard = db.session.query(Dashboard).first()
         example_db = get_example_database()
 
-        # Check that a report does not have a database reference
         report_schedule_data = {
             "type": ReportScheduleType.REPORT,
             "name": "name3",
@@ -775,8 +774,6 @@ class TestReportSchedulesApi(SupersetTestCase):
         chart = db.session.query(Slice).first()
         dashboard = db.session.query(Dashboard).first()
         example_db = get_example_database()
-
-        # Check that a report does not have a database reference
         report_schedule_data = {
             "type": ReportScheduleType.REPORT,
             "name": "name3",
@@ -788,6 +785,10 @@ class TestReportSchedulesApi(SupersetTestCase):
         rv = self.client.post(uri, json=report_schedule_data)
         data = json.loads(rv.data.decode("utf-8"))
         assert rv.status_code == 422
+        assert (
+            data["message"]["dashboard"]
+            == "Please save your dashboard first, then try creating a new email report."
+        )
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_create_report_schedule_chart_dash_validation(self):


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove extra index when parsing errors to render to user. This was specfically happening when users would try to create a report without saving the chart

<img width="638" alt="Screen Shot 2021-08-18 at 1 32 50 PM" src="https://user-images.githubusercontent.com/27827808/129945130-e7a60e28-6684-40f8-ad74-4a3970991f79.png">

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

