### PR TITLE
fix: send CSV pivoted in reports

### DIFF
--- a/superset/common/query_actions.py
+++ b/superset/common/query_actions.py
@@ -104,6 +104,7 @@ def _get_full(
         payload["indexnames"] = list(df.index)
         payload["coltypes"] = extract_dataframe_dtypes(df)
         payload["data"] = query_context.get_data(df)
+        payload["result_format"] = query_context.result_format
     del payload["df"]
 
     filters = query_obj.filter


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

On https://github.com/apache/superset/pull/16335 I accidentally disabled sending pivoted data on CSV reports. This PR brings it back.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

![Screen Shot 2021-08-18 at 6 09 52 PM](https://user-images.githubusercontent.com/1534870/129991785-dbd9805e-0d2c-44d6-8662-4038b3c8b4f7.png)

After:

![Screen Shot 2021-08-18 at 6 11 47 PM](https://user-images.githubusercontent.com/1534870/129991917-2111480b-df7c-4961-89a8-447acfde9338.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
