### PR TITLE
chore(viz): bump deckgl plugin to 0.4.11

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -37,7 +37,7 @@
         "@superset-ui/legacy-plugin-chart-treemap": "^0.17.85",
         "@superset-ui/legacy-plugin-chart-world-map": "^0.17.85",
         "@superset-ui/legacy-preset-chart-big-number": "^0.17.85",
-        "@superset-ui/legacy-preset-chart-deckgl": "^0.4.10",
+        "@superset-ui/legacy-preset-chart-deckgl": "^0.4.11",
         "@superset-ui/legacy-preset-chart-nvd3": "^0.17.85",
         "@superset-ui/plugin-chart-echarts": "^0.17.85",
         "@superset-ui/plugin-chart-pivot-table": "^0.17.85",
@@ -12497,9 +12497,9 @@
       }
     },
     "node_modules/@superset-ui/legacy-preset-chart-deckgl": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-deckgl/-/legacy-preset-chart-deckgl-0.4.10.tgz",
-      "integrity": "sha512-UGgzzDjy6N+vZvHlaSbihEyblm41jS2eL/41RWAEAABrn8g27V33a1VdVR/5zLUAtjqvP/dZqqkebF0h4ebmXA==",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-deckgl/-/legacy-preset-chart-deckgl-0.4.11.tgz",
+      "integrity": "sha512-N4l8zavJ3kQUyoPFqG6zXQT8EELFcXtD/GNRy3aJzSgHObRhK8+aqFaWIn3ncQrBuEiUzGDnHLNni/LRAxz7vA==",
       "dependencies": {
         "@math.gl/web-mercator": "^3.2.2",
         "@types/d3-array": "^2.0.0",
@@ -61949,9 +61949,9 @@
       }
     },
     "@superset-ui/legacy-preset-chart-deckgl": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-deckgl/-/legacy-preset-chart-deckgl-0.4.10.tgz",
-      "integrity": "sha512-UGgzzDjy6N+vZvHlaSbihEyblm41jS2eL/41RWAEAABrn8g27V33a1VdVR/5zLUAtjqvP/dZqqkebF0h4ebmXA==",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-deckgl/-/legacy-preset-chart-deckgl-0.4.11.tgz",
+      "integrity": "sha512-N4l8zavJ3kQUyoPFqG6zXQT8EELFcXtD/GNRy3aJzSgHObRhK8+aqFaWIn3ncQrBuEiUzGDnHLNni/LRAxz7vA==",
       "requires": {
         "@math.gl/web-mercator": "^3.2.2",
         "@types/d3-array": "^2.0.0",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -89,7 +89,7 @@
     "@superset-ui/legacy-plugin-chart-treemap": "^0.17.85",
     "@superset-ui/legacy-plugin-chart-world-map": "^0.17.85",
     "@superset-ui/legacy-preset-chart-big-number": "^0.17.85",
-    "@superset-ui/legacy-preset-chart-deckgl": "^0.4.10",
+    "@superset-ui/legacy-preset-chart-deckgl": "^0.4.11",
     "@superset-ui/legacy-preset-chart-nvd3": "^0.17.85",
     "@superset-ui/plugin-chart-echarts": "^0.17.85",
     "@superset-ui/plugin-chart-pivot-table": "^0.17.85",

--- a/superset/examples/deck.py
+++ b/superset/examples/deck.py
@@ -287,6 +287,7 @@ def load_deck_dash() -> None:
     slices.append(slc)
 
     slice_data = {
+        "autozoom": False,
         "spatial": {"type": "latlong", "lonCol": "LON", "latCol": "LAT"},
         "row_limit": 5000,
         "mapbox_style": "mapbox://styles/mapbox/satellite-streets-v9",


### PR DESCRIPTION
### SUMMARY
Pull in the following fixes to the deckgl viz plugin:
- https://github.com/apache-superset/superset-ui-plugins-deckgl/pull/43
- https://github.com/apache-superset/superset-ui-plugins-deckgl/pull/42

Also update the examples data to support the autozoom control in the Hex chart type.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
