### PR TITLE
fix: columns/index rebuild

### DIFF
--- a/superset/charts/post_processing.py
+++ b/superset/charts/post_processing.py
@@ -296,7 +296,9 @@ def apply_post_process(
         query["coltypes"] = extract_dataframe_dtypes(processed_df)
         query["rowcount"] = len(processed_df.index)
 
-        # flatten columns/index so we can encode data as JSON
+        # Flatten hierarchical columns/index since they are represented as
+        # `Tuple[str]`. Otherwise encoding to JSON later will fail because
+        # maps cannot have tuples as their keys in JSON.
         processed_df.columns = [
             " ".join(str(name) for name in column).strip()
             if isinstance(column, tuple)

--- a/superset/utils/csv.py
+++ b/superset/utils/csv.py
@@ -96,10 +96,14 @@ def get_chart_dataframe(
 
     result = simplejson.loads(content.decode("utf-8"))
     df = pd.DataFrame.from_dict(result["result"][0]["data"])
+
+    # rebuild hierarchical columns and index
     df.columns = pd.MultiIndex.from_tuples(
-        tuple(colname) for colname in result["result"][0]["colnames"]
+        tuple(colname) if isinstance(colname, list) else (colname,)
+        for colname in result["result"][0]["colnames"]
     )
     df.index = pd.MultiIndex.from_tuples(
-        tuple(indexname) for indexname in result["result"][0]["indexnames"]
+        tuple(indexname) if isinstance(indexname, list) else (indexname,)
+        for indexname in result["result"][0]["indexnames"]
     )
     return df


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The `get_chart_dataframe` method was not building a correct dataframe when the column/index were not hierarchical. This happened with the regular table, since no post-processing is applied to it when creating a report.

With this change we handle non-hierarchical columns and indexes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before text report was broken.

Now:

![Screen Shot 2021-08-19 at 9 17 09 AM](https://user-images.githubusercontent.com/1534870/130105136-6df51478-cc81-4d3d-bfb5-0c801a83a828.png)



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Create a report from a Table chart.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
