### PR TITLE
feat: Add `long_table` example to big data script

### DIFF
--- a/superset/examples/big_data.py
+++ b/superset/examples/big_data.py
@@ -35,47 +35,50 @@ COLUMN_TYPES = [
 
 
 def load_big_data() -> None:
-    # print("Creating table `wide_table` with 100 columns")
-    # columns: List[ColumnInfo] = []
-    # for i in range(100):
-    #     column: ColumnInfo = {
-    #         "name": f"col{i}",
-    #         "type": COLUMN_TYPES[i % len(COLUMN_TYPES)],
-    #         "nullable": False,
-    #         "default": None,
-    #         "autoincrement": "auto",
-    #         "primary_key": 1 if i == 0 else 0,
-    #     }
-    #     columns.append(column)
-    # add_data(columns=columns, num_rows=1000, table_name="wide_table")
+    print("Creating table `wide_table` with 100 columns")
+    columns: List[ColumnInfo] = []
+    for i in range(100):
+        column: ColumnInfo = {
+            "name": f"col{i}",
+            "type": COLUMN_TYPES[i % len(COLUMN_TYPES)],
+            "nullable": False,
+            "default": None,
+            "autoincrement": "auto",
+            "primary_key": 1 if i == 0 else 0,
+            "group_by": False,
+        }
+        columns.append(column)
+    add_data(columns=columns, num_rows=1000, table_name="wide_table")
 
-    # print("Creating 1000 small tables")
-    # columns = [
-    #     {
-    #         "name": "id",
-    #         "type": sqlalchemy.sql.sqltypes.INTEGER(),
-    #         "nullable": False,
-    #         "default": None,
-    #         "autoincrement": "auto",
-    #         "primary_key": 1,
-    #     },
-    #     {
-    #         "name": "value",
-    #         "type": sqlalchemy.sql.sqltypes.VARCHAR(length=255),
-    #         "nullable": False,
-    #         "default": None,
-    #         "autoincrement": "auto",
-    #         "primary_key": 0,
-    #     },
-    # ]
-    # for i in range(1000):
-    #     add_data(columns=columns, num_rows=10, table_name=f"small_table_{i}")
+    print("Creating 1000 small tables")
+    columns = [
+        {
+            "name": "id",
+            "type": sqlalchemy.sql.sqltypes.INTEGER(),
+            "nullable": False,
+            "default": None,
+            "autoincrement": "auto",
+            "primary_key": 1,
+            "group_by": False,
+        },
+        {
+            "name": "value",
+            "type": sqlalchemy.sql.sqltypes.VARCHAR(length=255),
+            "nullable": False,
+            "default": None,
+            "autoincrement": "auto",
+            "primary_key": 0,
+            "group_by": False,
+        },
+    ]
+    for i in range(1000):
+        add_data(columns=columns, num_rows=10, table_name=f"small_table_{i}")
 
-    # print("Creating table with long name")
-    # name = "".join(random.choices(string.ascii_letters + string.digits, k=64))
-    # add_data(columns=columns, num_rows=10, table_name=name)
+    print("Creating table with long name")
+    name = "".join(random.choices(string.ascii_letters + string.digits, k=64))
+    add_data(columns=columns, num_rows=10, table_name=name)
 
-    columns: List[ColumnInfo] = [
+    columns = [
         {
             "name": "id",
             "type": sqlalchemy.sql.sqltypes.INTEGER(),

--- a/superset/examples/big_data.py
+++ b/superset/examples/big_data.py
@@ -74,3 +74,6 @@ def load_big_data() -> None:
     print("Creating table with long name")
     name = "".join(random.choices(string.ascii_letters + string.digits, k=64))
     add_data(columns=columns, num_rows=10, table_name=name)
+
+    print("Creating table `long_table` with 1M rows")
+    add_data(columns=columns, num_rows=1000000, table_name="long_table")

--- a/superset/examples/big_data.py
+++ b/superset/examples/big_data.py
@@ -35,29 +35,55 @@ COLUMN_TYPES = [
 
 
 def load_big_data() -> None:
-    print("Creating table `wide_table` with 100 columns")
-    columns: List[ColumnInfo] = []
-    for i in range(100):
-        column: ColumnInfo = {
-            "name": f"col{i}",
-            "type": COLUMN_TYPES[i % len(COLUMN_TYPES)],
-            "nullable": False,
-            "default": None,
-            "autoincrement": "auto",
-            "primary_key": 1 if i == 0 else 0,
-        }
-        columns.append(column)
-    add_data(columns=columns, num_rows=1000, table_name="wide_table")
+    # print("Creating table `wide_table` with 100 columns")
+    # columns: List[ColumnInfo] = []
+    # for i in range(100):
+    #     column: ColumnInfo = {
+    #         "name": f"col{i}",
+    #         "type": COLUMN_TYPES[i % len(COLUMN_TYPES)],
+    #         "nullable": False,
+    #         "default": None,
+    #         "autoincrement": "auto",
+    #         "primary_key": 1 if i == 0 else 0,
+    #     }
+    #     columns.append(column)
+    # add_data(columns=columns, num_rows=1000, table_name="wide_table")
 
-    print("Creating 1000 small tables")
-    columns = [
+    # print("Creating 1000 small tables")
+    # columns = [
+    #     {
+    #         "name": "id",
+    #         "type": sqlalchemy.sql.sqltypes.INTEGER(),
+    #         "nullable": False,
+    #         "default": None,
+    #         "autoincrement": "auto",
+    #         "primary_key": 1,
+    #     },
+    #     {
+    #         "name": "value",
+    #         "type": sqlalchemy.sql.sqltypes.VARCHAR(length=255),
+    #         "nullable": False,
+    #         "default": None,
+    #         "autoincrement": "auto",
+    #         "primary_key": 0,
+    #     },
+    # ]
+    # for i in range(1000):
+    #     add_data(columns=columns, num_rows=10, table_name=f"small_table_{i}")
+
+    # print("Creating table with long name")
+    # name = "".join(random.choices(string.ascii_letters + string.digits, k=64))
+    # add_data(columns=columns, num_rows=10, table_name=name)
+
+    columns: List[ColumnInfo] = [
         {
             "name": "id",
             "type": sqlalchemy.sql.sqltypes.INTEGER(),
             "nullable": False,
             "default": None,
             "autoincrement": "auto",
-            "primary_key": 1,
+            "primary_key": 0,
+            "group_by": False,
         },
         {
             "name": "value",
@@ -66,14 +92,18 @@ def load_big_data() -> None:
             "default": None,
             "autoincrement": "auto",
             "primary_key": 0,
+            "group_by": False,
+        },
+        {
+            "name": "groupby_this",
+            "type": sqlalchemy.sql.sqltypes.VARCHAR(length=255),
+            "nullable": False,
+            "default": None,
+            "autoincrement": "auto",
+            "primary_key": 0,
+            "group_by": True,
         },
     ]
-    for i in range(1000):
-        add_data(columns=columns, num_rows=10, table_name=f"small_table_{i}")
 
-    print("Creating table with long name")
-    name = "".join(random.choices(string.ascii_letters + string.digits, k=64))
-    add_data(columns=columns, num_rows=10, table_name=name)
-
-    print("Creating table `long_table` with 1M rows")
-    add_data(columns=columns, num_rows=1000000, table_name="long_table")
+    print("Creating table `long_table` with 5M rows")
+    add_data(columns=columns, num_rows=5000000, table_name="long_table")


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When running `superset load-examples -b` users will now have a table with 1M rows for testing

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
