### PR TITLE
fix: import dashboard w/o metadata

### DIFF
--- a/superset/dashboards/commands/importers/v1/__init__.py
+++ b/superset/dashboards/commands/importers/v1/__init__.py
@@ -67,7 +67,9 @@ class ImportDashboardsCommand(ImportModelsCommand):
         for file_name, config in configs.items():
             if file_name.startswith("dashboards/"):
                 chart_uuids.update(find_chart_uuids(config["position"]))
-                dataset_uuids.update(find_native_filter_datasets(config["metadata"]))
+                dataset_uuids.update(
+                    find_native_filter_datasets(config.get("metadata", {}))
+                )
 
         # discover datasets associated with charts
         for file_name, config in configs.items():


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Some exported dashboards don't have `metadata`, and importing them is failing.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before: can't import dash.
After: can import correctly.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Try to import this dashboard:  [dashboard_export_20210819T112813.zip](https://github.com/apache/superset/files/7017047/dashboard_export_20210819T112813.zip)


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
