### PR TITLE
feat: Add extraVolumes and extraVolumeMounts to all main containers

### DIFF
--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
   - name: craig-rueda
     email: craig@craigrueda.com
     url: https://github.com/craig-rueda
-version: 0.3.5
+version: 0.3.6
 dependencies:
 - name: postgresql
   version: 10.2.0

--- a/helm/superset/templates/deployment-beat.yaml
+++ b/helm/superset/templates/deployment-beat.yaml
@@ -86,6 +86,10 @@ spec:
             - name: superset-config
               mountPath: {{ .Values.configMountPath | quote }}
               readOnly: true
+          {{- range $volumeName, $mount := .Values.extraVolumeMounts }}
+            - name: {{ $volumeName }}
+              {{- tpl (toYaml $mount) $ | nindent 14 -}}
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}
@@ -108,4 +112,8 @@ spec:
         - name: superset-config
           secret:
             secretName: {{ tpl .Values.configFromSecret . }}
+        {{- range $volumeName, $volume := .Values.extraVolumes }}
+        - name: {{ $volumeName }}
+          {{- tpl (toYaml $volume) $ | nindent 10 -}}
+        {{- end }}
 {{- end -}}

--- a/helm/superset/templates/deployment-beat.yaml
+++ b/helm/superset/templates/deployment-beat.yaml
@@ -86,9 +86,8 @@ spec:
             - name: superset-config
               mountPath: {{ .Values.configMountPath | quote }}
               readOnly: true
-          {{- range $volumeName, $mount := .Values.extraVolumeMounts }}
-            - name: {{ $volumeName }}
-              {{- tpl (toYaml $mount) $ | nindent 14 -}}
+          {{- with .Values.extraVolumeMounts }}
+          {{- tpl (toYaml .) $ | nindent 12 -}}
           {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
@@ -112,8 +111,7 @@ spec:
         - name: superset-config
           secret:
             secretName: {{ tpl .Values.configFromSecret . }}
-        {{- range $volumeName, $volume := .Values.extraVolumes }}
-        - name: {{ $volumeName }}
-          {{- tpl (toYaml $volume) $ | nindent 10 -}}
-        {{- end }}
+      {{- with .Values.extraVolumes }}
+      {{- tpl (toYaml .) $ | nindent 8 -}}
+      {{- end }}
 {{- end -}}

--- a/helm/superset/templates/deployment-worker.yaml
+++ b/helm/superset/templates/deployment-worker.yaml
@@ -87,9 +87,8 @@ spec:
             - name: superset-config
               mountPath: {{ .Values.configMountPath | quote }}
               readOnly: true
-          {{- range $volumeName, $mount := .Values.extraVolumeMounts }}
-            - name: {{ $volumeName }}
-              {{- tpl (toYaml $mount) $ | nindent 14 -}}
+          {{- with .Values.extraVolumeMounts }}
+          {{- tpl (toYaml .) $ | nindent 12 -}}
           {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
@@ -113,7 +112,6 @@ spec:
         - name: superset-config
           secret:
             secretName: {{ tpl .Values.configFromSecret . }}
-        {{- range $volumeName, $volume := .Values.extraVolumes }}
-        - name: {{ $volumeName }}
-          {{- tpl (toYaml $volume) $ | nindent 10 -}}
-        {{- end }}
+      {{- with .Values.extraVolumes }}
+      {{- tpl (toYaml .) $ | nindent 8 -}}
+      {{- end }}

--- a/helm/superset/templates/deployment-worker.yaml
+++ b/helm/superset/templates/deployment-worker.yaml
@@ -87,6 +87,10 @@ spec:
             - name: superset-config
               mountPath: {{ .Values.configMountPath | quote }}
               readOnly: true
+          {{- range $volumeName, $mount := .Values.extraVolumeMounts }}
+            - name: {{ $volumeName }}
+              {{- tpl (toYaml $mount) $ | nindent 14 -}}
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}
@@ -109,3 +113,7 @@ spec:
         - name: superset-config
           secret:
             secretName: {{ tpl .Values.configFromSecret . }}
+        {{- range $volumeName, $volume := .Values.extraVolumes }}
+        - name: {{ $volumeName }}
+          {{- tpl (toYaml $volume) $ | nindent 10 -}}
+        {{- end }}

--- a/helm/superset/templates/deployment.yaml
+++ b/helm/superset/templates/deployment.yaml
@@ -95,6 +95,10 @@ spec:
               mountPath: {{ .Values.extraConfigMountPath | quote }}
               readOnly: true
           {{- end }}
+          {{- range $volumeName, $mount := .Values.extraVolumeMounts }}
+            - name: {{ $volumeName }}
+              {{- tpl (toYaml $mount) $ | nindent 14 -}}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
@@ -126,4 +130,8 @@ spec:
         - name: superset-extra-config
           configMap:
             name: {{ template "superset.fullname" . }}-extra-config
+        {{- end }}
+        {{- range $volumeName, $volume := .Values.extraVolumes }}
+        - name: {{ $volumeName }}
+          {{- tpl (toYaml $volume) $ | nindent 10 -}}
         {{- end }}

--- a/helm/superset/templates/deployment.yaml
+++ b/helm/superset/templates/deployment.yaml
@@ -95,9 +95,8 @@ spec:
               mountPath: {{ .Values.extraConfigMountPath | quote }}
               readOnly: true
           {{- end }}
-          {{- range $volumeName, $mount := .Values.extraVolumeMounts }}
-            - name: {{ $volumeName }}
-              {{- tpl (toYaml $mount) $ | nindent 14 -}}
+          {{- with .Values.extraVolumeMounts }}
+          {{- tpl (toYaml .) $ | nindent 12 -}}
           {{- end }}
           ports:
             - name: http
@@ -131,7 +130,6 @@ spec:
           configMap:
             name: {{ template "superset.fullname" . }}-extra-config
         {{- end }}
-        {{- range $volumeName, $volume := .Values.extraVolumes }}
-        - name: {{ $volumeName }}
-          {{- tpl (toYaml $volume) $ | nindent 10 -}}
+        {{- with .Values.extraVolumes }}
+        {{- tpl (toYaml .) $ | nindent 8 -}}
         {{- end }}

--- a/helm/superset/templates/init-job.yaml
+++ b/helm/superset/templates/init-job.yaml
@@ -60,9 +60,8 @@ spec:
             mountPath: {{ .Values.extraConfigMountPath | quote }}
             readOnly: true
         {{- end }}
-        {{- range $volumeName, $mount := .Values.extraVolumeMounts }}
-          - name: {{ $volumeName }}
-            {{- tpl (toYaml $mount) $ | nindent 12 -}}
+        {{- with .Values.extraVolumeMounts }}
+        {{- tpl (toYaml .) $ | nindent 10 -}}
         {{- end }}
         command: {{  tpl (toJson .Values.init.command) . }}
         resources:
@@ -80,9 +79,8 @@ spec:
           configMap:
             name: {{ template "superset.fullname" . }}-extra-config
         {{- end }}
-        {{- range $volumeName, $volume := .Values.extraVolumes }}
-        - name: {{ $volumeName }}
-          {{- tpl (toYaml $volume) $ | nindent 10 -}}
+        {{- with .Values.extraVolumes }}
+        {{- tpl (toYaml .) $ | nindent 8 -}}
         {{- end }}
       restartPolicy: Never
 {{- end }}

--- a/helm/superset/templates/init-job.yaml
+++ b/helm/superset/templates/init-job.yaml
@@ -60,6 +60,10 @@ spec:
             mountPath: {{ .Values.extraConfigMountPath | quote }}
             readOnly: true
         {{- end }}
+        {{- range $volumeName, $mount := .Values.extraVolumeMounts }}
+          - name: {{ $volumeName }}
+            {{- tpl (toYaml $mount) $ | nindent 12 -}}
+        {{- end }}
         command: {{  tpl (toJson .Values.init.command) . }}
         resources:
 {{ toYaml .Values.init.resources | indent 10 }}
@@ -75,6 +79,10 @@ spec:
         - name: superset-extra-config
           configMap:
             name: {{ template "superset.fullname" . }}-extra-config
+        {{- end }}
+        {{- range $volumeName, $volume := .Values.extraVolumes }}
+        - name: {{ $volumeName }}
+          {{- tpl (toYaml $volume) $ | nindent 10 -}}
         {{- end }}
       restartPolicy: Never
 {{- end }}

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -82,20 +82,20 @@ extraConfigs: {}
 
 extraSecrets: {}
 
-extraVolumes: {}
- # customConfig:
+extraVolumes: []
+ # - name: customConfig
  #   configMap:
  #     name: '{{ template "superset.fullname" . }}-custom-config'
- # additionalSecret:
+ # - name: additionalSecret
  #   secret:
  #     secretName: my-secret
  #     defaultMode: 0600
 
-extraVolumeMounts: {}
- # customConfig:
+extraVolumeMounts: []
+ # - name: customConfig
  #   mountPath: /mnt/config
  #   readOnly: true
- # additionalSecret:
+ # - name: additionalSecret:
  #   mountPath: /mnt/secret
 
 # A dictionary of overrides to append at the end of superset_config.py - the name does not matter

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -83,8 +83,20 @@ extraConfigs: {}
 extraSecrets: {}
 
 extraVolumes: {}
+ # customConfig:
+ #   configMap:
+ #     name: '{{ template "superset.fullname" . }}-custom-config'
+ # additionalSecret:
+ #   secret:
+ #     secretName: my-secret
+ #     defaultMode: 0600
 
 extraVolumeMounts: {}
+ # customConfig:
+ #   mountPath: /mnt/config
+ #   readOnly: true
+ # additionalSecret:
+ #   mountPath: /mnt/secret
 
 # A dictionary of overrides to append at the end of superset_config.py - the name does not matter
 # WARNING: the order is not guaranteed

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -82,6 +82,10 @@ extraConfigs: {}
 
 extraSecrets: {}
 
+extraVolumes: {}
+
+extraVolumeMounts: {}
+
 # A dictionary of overrides to append at the end of superset_config.py - the name does not matter
 # WARNING: the order is not guaranteed
 configOverrides: {}


### PR DESCRIPTION
### SUMMARY
Adds `extraVolumes` and `extraVolumeMounts` objects to the Helm chart. Any volumes specified will be mounted to the main containers of all deployments as well as the init-job. Use cases include mounting additional Python modules (so they don't have to be written in-line as a YAML string) and passing in CA certs that are required by our stack.

### TESTING INSTRUCTIONS
- Add one or more `extraVolumes` and `extraVolumeMounts`.
- Run `helm install --dry-run` and confirm that the pod specs contain the new volumes
- Example:
```yaml
extraVolumes:
  volume1:
    configMap:
      name: '{{ template "superset.fullname" . }}-custom-config'
  volume2:
    secret:
      secretName: my-secret
extraVolumeMounts:
  volume1:
    mountPath: /mnt/volume1
  volume2:
    mountPath: /mnt/volume2
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #16359 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
