### PR TITLE
fix: show run button when time series column is updated.

### DIFF
--- a/superset-frontend/src/explore/components/controls/CollectionControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/CollectionControl/index.jsx
@@ -80,8 +80,9 @@ class CollectionControl extends React.Component {
   }
 
   onChange(i, value) {
-    Object.assign(this.props.value[i], value);
-    this.props.onChange(this.props.value);
+    const newValue = [...this.props.value];
+    newValue[i] = { ...this.props.value[i], ...value };
+    this.props.onChange(newValue);
   }
 
   onAdd() {


### PR DESCRIPTION
### SUMMARY
This fix ensure that the state change is detected when collection control is updated. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/17326228/130167636-4ee163e4-7a05-4dd1-a8ef-1121ebd1c042.mov



### TESTING INSTRUCTIONS
Go to time series chart and add a metric in the time series column. Add some metric properties and ensure that run button state is updated.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ x] Has associated issue: Fixes https://github.com/apache/superset/issues/16319
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
