### PR TITLE
fix: call external metadata endpoint with correct rison object

### DIFF
--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -493,11 +493,14 @@ class DatasourceEditor extends React.PureComponent {
       schema_name: datasource.schema,
       table_name: datasource.table_name,
     };
-    const endpoint = `/datasource/external_metadata_by_name/?q=${rison.encode(
+    Object.entries(params).forEach(([key, value]) => {
       // rison can't encode the undefined value
-      Object.keys(params).map(key =>
-        params[key] === undefined ? null : params[key],
-      ),
+      if (value === undefined) {
+        params[key] = null;
+      }
+    });
+    const endpoint = `/datasource/external_metadata_by_name/?q=${rison.encode(
+      params,
     )}`;
     this.setState({ metadataLoading: true });
 


### PR DESCRIPTION
### SUMMARY
A recent PR #16193 replaced the external metadata endpoint from using path based parameters to using a rison encoded object. As the backend expects key-value pairs, the requests were failing due to the request being sent as an array instead of an object.

### AFTER
When changing a table reference in the dataset modal, the metadata now updates correctly:
![image](https://user-images.githubusercontent.com/33317356/130199901-bfb2051b-90b7-4557-91c8-91288148193b.png)

### BEFORE
Previously the marshmallow load failed due to deserialization being performed with a list of values, rather than a dict of key-value pairs:
![image](https://user-images.githubusercontent.com/33317356/130200006-47941459-8aa6-4d1f-b525-7dffcc8761bd.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
