### PR TITLE
fix: ensure certified fields are populated in metrics

### DIFF
--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -325,14 +325,18 @@ class DatasourceEditor extends React.PureComponent {
         ...props.datasource,
         metrics: props.datasource.metrics?.map(metric => {
           const {
+            certified_by: certifiedByMetric,
+            certification_details: certificationDetails,
+          } = metric;
+          const {
             certification: { details, certified_by: certifiedBy } = {},
             warning_markdown: warningMarkdown,
           } = JSON.parse(metric.extra || '{}') || {};
           return {
             ...metric,
-            certification_details: details || '',
+            certification_details: certificationDetails || details,
             warning_markdown: warningMarkdown || '',
-            certified_by: certifiedBy,
+            certified_by: certifiedBy || certifiedByMetric,
           };
         }),
       },
@@ -935,7 +939,6 @@ class DatasourceEditor extends React.PureComponent {
     const { datasource } = this.state;
     const { metrics } = datasource;
     const sortedMetrics = metrics?.length ? this.sortMetrics(metrics) : [];
-
     return (
       <CollectionTable
         tableColumns={['metric_name', 'verbose_name', 'expression']}


### PR DESCRIPTION
### SUMMARY
This pr fixes an issue where the certified fields are not populated after saving them in the metrics tab in the edit dataset modal.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
existing certified metric

https://user-images.githubusercontent.com/17326228/130295158-2238b9bb-8e73-4ff5-b191-583051467710.mov

adding metrics with certified fields 

Uploading Screen Recording 2021-08-20 at 2.23.11 PM.mov…



### TESTING INSTRUCTIONS
Go to edit dataset modal within explore. Add info to the certified fields under the metrics tab and save. Test they are still populated when reopening the modal

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x ] Has associated issue: Fixes https://github.com/apache/superset/issues/16368
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
