### PR TITLE
fix: big number default date format

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -36,7 +36,7 @@
         "@superset-ui/legacy-plugin-chart-sunburst": "^0.17.85",
         "@superset-ui/legacy-plugin-chart-treemap": "^0.17.85",
         "@superset-ui/legacy-plugin-chart-world-map": "^0.17.85",
-        "@superset-ui/legacy-preset-chart-big-number": "^0.17.85",
+        "@superset-ui/legacy-preset-chart-big-number": "^0.17.86",
         "@superset-ui/legacy-preset-chart-deckgl": "^0.4.11",
         "@superset-ui/legacy-preset-chart-nvd3": "^0.17.85",
         "@superset-ui/plugin-chart-echarts": "^0.17.85",
@@ -12480,9 +12480,9 @@
       }
     },
     "node_modules/@superset-ui/legacy-preset-chart-big-number": {
-      "version": "0.17.85",
-      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-big-number/-/legacy-preset-chart-big-number-0.17.85.tgz",
-      "integrity": "sha512-Txuk8L/flifPESHWNpZ8vwXinHAPCXXEp2fZdB/6CRyB6TVfMs2RmKqnEyzO5xBGgqeTfdH6xeuVn+8Hfdcvrg==",
+      "version": "0.17.86",
+      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-big-number/-/legacy-preset-chart-big-number-0.17.86.tgz",
+      "integrity": "sha512-b9TZ7VJ3IK+ii6VDllfOCDujLR++rYNXcnNW/XgCZP9+ZwbHBIzGqC7APdUid7qDJM/PZwN6USXSnYf5MIYPLw==",
       "dependencies": {
         "@data-ui/xy-chart": "^0.0.84",
         "@superset-ui/chart-controls": "0.17.85",
@@ -61935,9 +61935,9 @@
       }
     },
     "@superset-ui/legacy-preset-chart-big-number": {
-      "version": "0.17.85",
-      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-big-number/-/legacy-preset-chart-big-number-0.17.85.tgz",
-      "integrity": "sha512-Txuk8L/flifPESHWNpZ8vwXinHAPCXXEp2fZdB/6CRyB6TVfMs2RmKqnEyzO5xBGgqeTfdH6xeuVn+8Hfdcvrg==",
+      "version": "0.17.86",
+      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-big-number/-/legacy-preset-chart-big-number-0.17.86.tgz",
+      "integrity": "sha512-b9TZ7VJ3IK+ii6VDllfOCDujLR++rYNXcnNW/XgCZP9+ZwbHBIzGqC7APdUid7qDJM/PZwN6USXSnYf5MIYPLw==",
       "requires": {
         "@data-ui/xy-chart": "^0.0.84",
         "@superset-ui/chart-controls": "0.17.85",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -88,7 +88,7 @@
     "@superset-ui/legacy-plugin-chart-sunburst": "^0.17.85",
     "@superset-ui/legacy-plugin-chart-treemap": "^0.17.85",
     "@superset-ui/legacy-plugin-chart-world-map": "^0.17.85",
-    "@superset-ui/legacy-preset-chart-big-number": "^0.17.85",
+    "@superset-ui/legacy-preset-chart-big-number": "^0.17.86",
     "@superset-ui/legacy-preset-chart-deckgl": "^0.4.11",
     "@superset-ui/legacy-preset-chart-nvd3": "^0.17.85",
     "@superset-ui/plugin-chart-echarts": "^0.17.85",


### PR DESCRIPTION
### SUMMARY
Pulls in the change from https://github.com/apache-superset/superset-ui/pull/1320 to allow you to change the date format for big number charts (and default it back to the smart default instead of DD-MM-YYYY)

### TESTING INSTRUCTIONS
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @ktmud @rusackas @graceguo-supercat 