### PR TITLE
feat: config to customize bootstrap data overrides

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -435,6 +435,16 @@ FEATURE_FLAGS: Dict[str, bool] = {}
 #     return feature_flags_dict
 GET_FEATURE_FLAGS_FUNC: Optional[Callable[[Dict[str, bool]], Dict[str, bool]]] = None
 
+# A function that expands/overrides the frontend common bootstrap data.
+# Can be used to implement custom frontend functionality,
+# or dynamically change certain configs.
+#
+# Takes as a parameter the common bootstrap payload before transformations.
+# Returns a dict containing data that should be added or overridden to the payload.
+COMMON_BOOTSTRAP_OVERRIDES_FUNC: Callable[
+    [Dict[str, Any]], Dict[str, Any]
+] = lambda data: {}  # default: empty dict
+
 # EXTRA_CATEGORICAL_COLOR_SCHEMES is used for adding custom categorical color schemes
 # example code for "My custom warm to hot" color scheme
 # EXTRA_CATEGORICAL_COLOR_SCHEMES = [

--- a/superset/config.py
+++ b/superset/config.py
@@ -435,9 +435,13 @@ FEATURE_FLAGS: Dict[str, bool] = {}
 #     return feature_flags_dict
 GET_FEATURE_FLAGS_FUNC: Optional[Callable[[Dict[str, bool]], Dict[str, bool]]] = None
 
-# A function that expands/overrides the frontend common bootstrap data.
+# A function that expands/overrides the frontend `bootstrap_data.common` object.
 # Can be used to implement custom frontend functionality,
 # or dynamically change certain configs.
+#
+# Values in `bootstrap_data.common` should have these characteristics:
+# - They are not specific to a page the user is visiting
+# - They do not contain secrets
 #
 # Takes as a parameter the common bootstrap payload before transformations.
 # Returns a dict containing data that should be added or overridden to the payload.

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -350,7 +350,7 @@ def common_bootstrap_payload() -> Dict[str, Any]:
     messages = get_flashed_messages(with_categories=True)
     locale = str(get_locale())
 
-    return {
+    bootstrap_data = {
         "flash_messages": messages,
         "conf": {k: conf.get(k) for k in FRONTEND_CONF_KEYS},
         "locale": locale,
@@ -361,6 +361,8 @@ def common_bootstrap_payload() -> Dict[str, Any]:
         "theme_overrides": conf["THEME_OVERRIDES"],
         "menu_data": menu_data(),
     }
+    bootstrap_data.update(conf["COMMON_BOOTSTRAP_OVERRIDES_FUNC"](bootstrap_data))
+    return bootstrap_data
 
 
 # pylint: disable=invalid-name


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Motivation:
- Preset needs to add some custom sequential color palettes for specific users
- color palettes are delivered in bootstrap data, via the `extra_sequential_color_schemes` and `extra_categorical_color_schemes` fields.
- Wanted to allow general changes to common bootstrap data as well, to allow open-ended support for customizations in Superset deployments.
- Decided to add a function which can be configured to get these `bootstrap_data.common` overrides.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Set `EXTRA_SEQUENTIAL_COLOR_SCHEMES` to a function that returns a dict of `{ "foo": "bar" }`
2. Verify that Superset Frontend still renders, and that `{ "foo": "bar" }` was delivered in the bootstrap data.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
