### PR TITLE
fix: Show cross filter option only when cross filter is enabled

### DIFF
--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -88,6 +88,7 @@ export interface SliceHeaderControlsProps {
     slice_name: string;
     slice_id: number;
     slice_description: string;
+    form_data?: { emit_filter?: boolean };
   };
 
   componentId: string;
@@ -229,6 +230,7 @@ class SliceHeaderControls extends React.PureComponent<
         value.behaviors?.includes(Behavior.INTERACTIVE_CHART),
       )
       .find(([key]) => key === slice.viz_type);
+    const canEmitCrossFilter = slice.form_data?.emit_filter;
 
     const cachedWhen = (cachedDttm || []).map(itemCachedDttm =>
       moment.utc(itemCachedDttm).fromNow(),
@@ -335,7 +337,8 @@ class SliceHeaderControls extends React.PureComponent<
             </Menu.Item>
           )}
         {isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS) &&
-          isCrossFilter && (
+          isCrossFilter &&
+          canEmitCrossFilter && (
             <Menu.Item key={MENU_KEYS.CROSS_FILTER_SCOPING}>
               {t('Cross-filter scoping')}
             </Menu.Item>


### PR DESCRIPTION
### SUMMARY
Fixes https://github.com/apache/superset/issues/16341

@junlincc @jinghua-qa @rusackas 

### AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/130330118-f7ea77c8-01e8-4edf-8715-7ce6002df0a7.mov

### TESTING INSTRUCTIONS
Check the original issue for instructions.

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
