### PR TITLE
fix: add percent sign in like/ilike clause

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1232,9 +1232,9 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
                     elif op == utils.FilterOperator.LESS_THAN_OR_EQUALS.value:
                         where_clause_and.append(sqla_col <= eq)
                     elif op == utils.FilterOperator.LIKE.value:
-                        where_clause_and.append(sqla_col.like(eq))
+                        where_clause_and.append(sqla_col.like(f"%{eq}%"))
                     elif op == utils.FilterOperator.ILIKE.value:
-                        where_clause_and.append(sqla_col.ilike(eq))
+                        where_clause_and.append(sqla_col.ilike(f"%{eq}%"))
                     else:
                         raise QueryObjectValidationError(
                             _("Invalid filter operation type: %(op)s", op=op)

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -472,6 +472,8 @@ def cast_to_boolean(value: Any) -> bool:
     False
     >>> cast_to_boolean('False')
     False
+    >>> cast_to_boolean('True')
+    False
     >>> cast_to_boolean(None)
     False
 

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -473,7 +473,7 @@ def cast_to_boolean(value: Any) -> bool:
     >>> cast_to_boolean('False')
     False
     >>> cast_to_boolean('True')
-    False
+    True
     >>> cast_to_boolean(None)
     False
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add percent sign in ends of like/ilike clause
closes: https://github.com/apache/superset/issues/16277



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### After
<img width="1247" alt="image" src="https://user-images.githubusercontent.com/2016594/130412309-f450294d-0245-4d8a-9d14-2ada2125c7dd.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. goto explore page
2. select table viz
3. select a column to groupby, select a metric
4. select column to filter control, and select `LIKE` operator in filter modal, input some chars to operand input area.
5. click run button
6. obvious SQL, percent sign in like clause


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/16277
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
