### PR TITLE
fix(api): return total count on related endpoint

### DIFF
--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -494,7 +494,7 @@ class BaseSupersetModelRestApi(ModelRestApi):
         ids = args.get("include_ids")
         if page and ids:
             # pagination with forced ids is not supported
-            return self.response_400()
+            return self.response_422()
 
         try:
             datamodel = self.datamodel.get_related_interface(column_name)

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -490,6 +490,12 @@ class BaseSupersetModelRestApi(ModelRestApi):
 
         # handle pagination
         page, page_size = self._handle_page_args(args)
+
+        ids = args.get("include_ids")
+        if page and ids:
+            # pagination with forced ids is not supported
+            return self.response_400()
+
         try:
             datamodel = self.datamodel.get_related_interface(column_name)
         except KeyError:
@@ -504,7 +510,7 @@ class BaseSupersetModelRestApi(ModelRestApi):
         # handle filters
         filters = self._get_related_filter(datamodel, column_name, args.get("filter"))
         # Make the query
-        _, rows = datamodel.query(
+        total_rows, rows = datamodel.query(
             filters, order_column, order_direction, page=page, page_size=page_size
         )
 
@@ -512,10 +518,11 @@ class BaseSupersetModelRestApi(ModelRestApi):
         result = self._get_result_from_rows(datamodel, rows, column_name)
 
         # If ids are specified make sure we fetch and include them on the response
-        ids = args.get("include_ids")
-        self._add_extra_ids_to_result(datamodel, column_name, ids, result)
+        if ids:
+            self._add_extra_ids_to_result(datamodel, column_name, ids, result)
+            total_rows = len(result)
 
-        return self.response(200, count=len(result), result=result)
+        return self.response(200, count=total_rows, result=result)
 
     @expose("/distinct/<column_name>", methods=["GET"])
     @protect()

--- a/tests/integration_tests/base_api_tests.py
+++ b/tests/integration_tests/base_api_tests.py
@@ -228,13 +228,13 @@ class ApiOwnersTestCaseMixin:
 
     def test_get_ids_related_owners_paginated(self):
         """
-        API: Test get related owners with pagination returns 400
+        API: Test get related owners with pagination returns 422
         """
         self.login(username="admin")
         argument = {"page": 1, "page_size": 1, "include_ids": [2]}
         uri = f"api/v1/{self.resource_name}/related/owners?q={prison.dumps(argument)}"
         rv = self.client.get(uri)
-        assert rv.status_code == 400
+        assert rv.status_code == 422
 
     def test_get_filter_related_owners(self):
         """

--- a/tests/integration_tests/base_api_tests.py
+++ b/tests/integration_tests/base_api_tests.py
@@ -202,6 +202,40 @@ class ApiOwnersTestCaseMixin:
         for expected_user in expected_users:
             assert expected_user in response_users
 
+    def test_get_related_owners_paginated(self):
+        """
+        API: Test get related owners with pagination
+        """
+        self.login(username="admin")
+        page_size = 1
+        argument = {"page_size": page_size}
+        uri = f"api/v1/{self.resource_name}/related/owners?q={prison.dumps(argument)}"
+        rv = self.client.get(uri)
+        assert rv.status_code == 200
+        response = json.loads(rv.data.decode("utf-8"))
+        users = db.session.query(security_manager.user_model).all()
+
+        # the count should correspond with the total number of users
+        assert response["count"] == len(users)
+
+        # the length of the result should be at most equal to the page size
+        assert len(response["result"]) == min(page_size, len(users))
+
+        # make sure all received users are included in the full set of users
+        all_users = [str(user) for user in users]
+        for received_user in [result["text"] for result in response["result"]]:
+            assert received_user in all_users
+
+    def test_get_ids_related_owners_paginated(self):
+        """
+        API: Test get related owners with pagination returns 400
+        """
+        self.login(username="admin")
+        argument = {"page": 1, "page_size": 1, "include_ids": [2]}
+        uri = f"api/v1/{self.resource_name}/related/owners?q={prison.dumps(argument)}"
+        rv = self.client.get(uri)
+        assert rv.status_code == 400
+
     def test_get_filter_related_owners(self):
         """
         API: Test get filter related owners


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
While reviewing/testing #16144 , I came across a TODO related to the `/related` endpoints not returning total object count, but rather the count of results on the requested page. 

This PR makes the following changes:
- When `include_ids` is undefined, always return the total number of objects as the `count` parameter as opposed to the actual number of objects in `result`.
- When `include_ids` is defined, behavior is unchanged, i.e. `count` equals the length of `result`.
- When `include_ids` is defined and `page > 0`, a 400 is returned due to pagination of mixed results not being possible.

### BEFORE
Currently the `count` parameter in the response is equal to the length of the `result` array (in this example, the total number of objects is in fact two, not just one):
![image](https://user-images.githubusercontent.com/33317356/130430642-68136936-76da-4a47-ada2-854dcbf34cf3.png)

### AFTER
Now the `count` parameter shows the total number of objects, despite the page size being less:
![image](https://user-images.githubusercontent.com/33317356/130430128-c6efd9c4-862a-432a-97e4-2086992b46ab.png)

When sending the request with `include_ids` and `page=0`, the result is the same as before (notice how `page_size` only affects the values not included in `include_ids`):
![image](https://user-images.githubusercontent.com/33317356/130431296-34112eaf-f5ff-41b8-afb3-fd66237dbc1f.png)

Now requesting other than the first page with defined `include_ids` will result in a 400:
![image](https://user-images.githubusercontent.com/33317356/130430204-7b9c2cf8-f683-4f03-b375-647a991e980d.png)


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
