### PR TITLE
fix: Revert "fix(explore): let admin overwrite slice"

### DIFF
--- a/superset-frontend/src/explore/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/index.tsx
@@ -175,7 +175,7 @@ export default function PropertiesModal({
             buttonStyle="primary"
             // @ts-ignore
             onClick={onSubmit}
-            disabled={submitting || !name}
+            disabled={!owners || submitting || !name}
             cta
           >
             {t('Save')}

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -122,7 +122,6 @@ from superset.views.base import (
     get_error_msg,
     get_user_roles,
     handle_api_exception,
-    is_user_admin,
     json_error_response,
     json_errors_response,
     json_success,
@@ -788,9 +787,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
         # slc perms
         slice_add_perm = security_manager.can_access("can_write", "Chart")
-        slice_overwrite_perm = (
-            is_owner(slc, g.user) or is_user_admin() if slc else False
-        )
+        slice_overwrite_perm = is_owner(slc, g.user) if slc else False
         slice_download_perm = security_manager.can_access("can_csv", "Superset")
 
         form_data["datasource"] = str(datasource_id) + "__" + cast(str, datasource_type)


### PR DESCRIPTION
Reverts apache/superset#16290

This PR gives Admin users a capability they did not have before, to meddle with another users' work. I think we need to discuss this a little more broadly and gain some degree of consensus before merging it, that we want to allow Admin users to have these added capabilities/privileges.