### PR TITLE
fix: make chart rerender on timeseries columns change

### DIFF
--- a/superset-frontend/src/explore/controlPanels/TimeTable.js
+++ b/superset-frontend/src/explore/controlPanels/TimeTable.js
@@ -36,6 +36,7 @@ export default {
             config: {
               type: 'CollectionControl',
               label: t('Time series columns'),
+              renderTrigger: true,
               validators: [validateNonEmpty],
               controlName: 'TimeSeriesColumnControl',
             },


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/17326228/130512997-9096e6cb-3e4f-4617-bb3c-c1000dd78467.mov



### TESTING INSTRUCTIONS
Go to time series chart and change metric in time series column. The chart should rerender without running the run button.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
