### PR TITLE
feat: add Shillelagh DB engine spec

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ setup(
         "exasol": ["sqlalchemy-exasol>=2.1.0, <2.2"],
         "excel": ["xlrd>=1.2.0, <1.3"],
         "firebird": ["sqlalchemy-firebird>=0.7.0, <0.8"],
-        "gsheets": ["shillelagh[gsheetsapi]>=0.7.1, <0.8"],
+        "gsheets": ["shillelagh[gsheetsapi]>=1.0.3, <2"],
         "hana": ["hdbcli==2.4.162", "sqlalchemy_hana==0.4.0"],
         "hive": ["pyhive[hive]>=0.6.1", "tableschema", "thrift>=0.11.0, <1.0.0"],
         "impala": ["impyla>0.16.2, <0.17"],
@@ -148,6 +148,9 @@ setup(
         "prophet": ["prophet>=1.0.1, <1.1", "pystan<3.0"],
         "redshift": ["sqlalchemy-redshift>=0.8.1, < 0.9"],
         "rockset": ["rockset>=0.7.68, <0.8"],
+        "shillelagh": [
+            "shillelagh[datasetteapi,gsheetsapi,socrata,weatherapi]>=1.0.3, <2"
+        ],
         "snowflake": ["snowflake-sqlalchemy>=1.2.3, <1.3"],
         "teradata": ["sqlalchemy-teradata==0.9.0.dev0"],
         "thumbnails": ["Pillow>=7.0.0, <8.0.0"],

--- a/superset/db_engine_specs/shillelagh.py
+++ b/superset/db_engine_specs/shillelagh.py
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from superset.db_engine_specs.sqlite import SqliteEngineSpec
+
+
+class ShillelaghEngineSpec(SqliteEngineSpec):
+    """Engine for shillelagh"""
+
+    engine = "shillelagh"
+    engine_name = "Shillelagh"
+    allows_joins = True
+    allows_subqueries = True


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

[Shillelagh](https://github.com/betodealmeida/shillelagh/) is a library for querying APIs via SQL. It's currently used by Superset in order to connect to Google Sheets, but it offers more APIs:

#### Datasette

[Datasette](https://datasette.io/) is an open-source tool for exploring and publishing data, developed by one of the creators of Django. "Datasettes" are self-hosted micro web apps that serve a few tables, with a friendly UI. For example, [this list of trees in SF](https://san-francisco.datasettes.com/sf-trees/Street_Tree_List).

Shillelagh can query any Datasette table directly:

```sql
% shillelagh
sql> SELECT * FROM "https://san-francisco.datasettes.com/sf-trees/Street_Tree_List" LIMIT 5;
  TreeID    qLegalStatus    qSpecies  qAddress             SiteOrder    qSiteInfo    PlantType    qCaretaker  qCareAssistant    PlantDate                 DBH  PlotSize    PermitNotes                XCoord       YCoord    Latitude    Longitude  Location
--------  --------------  ----------  -----------------  -----------  -----------  -----------  ------------  ----------------  ----------------------  -----  ----------  --------------------  -----------  -----------  ----------  -----------  -------------------------------------
  141565               1           1  501X Baker St                1            1            1             1                    07/21/1988 12:00:00 AM     21  Width 0ft   Permit Number 25401   6.00061e+06  2.11083e+06     37.776      -122.441  (37.7759676911831, -122.441396661871)
  232565               2           2  940 Elizabeth St             1            2            1             1                    03/20/2017 12:00:00 AM      3  Width 4ft   Permit Number 779625  6.0004e+06   2.102e+06       37.7517     -122.441  (37.7517102172731, -122.441498017841)
  119263               3           3  495X Lakeshore Dr            1            3            1             2                                                   10x30
  207368               2           4  920 Kirkham St               1            1            1             1                                                6  Width 1ft                         5.99201e+06  2.10527e+06     37.7602     -122.471  (37.760210314285, -122.47073935813)
  188702               3           5  1501 Evans Ave               2            4            1             2                                               17  Width 4ft                         6.01599e+06  2.09822e+06     37.7422     -122.387  (37.7422086702947, -122.387293152263)
sql>
```

We can create a dataset in Superset and make a map of red maple trees in SF:

![Screenshot 2021-08-23 at 21-12-41  DEV  Red maple trees in SF](https://user-images.githubusercontent.com/1534870/130554644-8e1549b3-5660-4664-a228-c3999ece7d78.png)

#### Socrata

The [Socrata Open Data API](https://dev.socrata.com/) is a simple API used by many governments, non-profits, and NGOs around the world, including the CDC. Shillelagh can connect directly to any Socrata dataset by using its API URL. Here's an example showing the [percentage of adults partially vaccinated for COVID-19 in the US](https://data.cdc.gov/resource/unsk-b7fc):

![Screen Shot 2021-08-24 at 8 13 40 AM](https://user-images.githubusercontent.com/1534870/130642774-f52ffce5-660f-4d92-8f5c-b5c71b864f24.png)


```sql
% shillelagh
sql> SELECT date, administered_dose1_recip_4 FROM "https://data.cdc.gov/resource/unsk-b7fc.json" WHERE location='US' LIMIT 5;
date          administered_dose1_recip_4
----------  ----------------------------
2021-08-23                          73.1
2021-08-22                          73
2021-08-21                          72.9
2021-08-20                          72.7
2021-08-19                          72.5
sql>
```

We can also create a dataset in Superset and make a time series:

![Screenshot 2021-08-23 at 21-21-45  DEV  % adults partially vaccinated US](https://user-images.githubusercontent.com/1534870/130555300-d7a5e0ff-d029-47a7-b0a1-cac75acf4573.png)

#### WeatherAPI

This adapter offers access to historical weather data from [WeatherAPI](https://www.weatherapi.com/). It requires signing up and an API key, but there's a free account.

Here's an example chart showing the perceived temperature in Fahrenheit in Bodega Bay:

```sql
% shillelagh
sql> SELECT AVG(feelslike_f) AS "AVG(feelslike_f)"
FROM "https://api.weatherapi.com/v1/history.json?q=94923"
LIMIT 10000
OFFSET 0;
  AVG(feelslike_f)
------------------
           57.6054
sql>
```

![Screenshot 2021-08-24 at 08-40-19  DEV  Explore - https api weatherapi com v1 history json q=94923](https://user-images.githubusercontent.com/1534870/130647161-a167fc13-465d-4bbf-aaf4-ca3948bfadbe.png)


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Shillelagh supports two dialects, `shillelagh://` and `shillelagh+safe://`. The former is disabled in Superset if `PREVENT_UNSAFE_DB_CONNECTIONS` is true, since it can read and write to disk. The latter allows only safe adapters to be loaded, and they have to be listed explicitly:

<img src="https://user-images.githubusercontent.com/1534870/130652237-3629a1ff-de4d-4fff-9bbc-d4ddecf253c8.png" width="60%" />

<img src="https://user-images.githubusercontent.com/1534870/130651792-e43e5f10-a28f-49fd-a9ef-eade3728c7d1.png" width="60%" style="box-shadow:5px 5px 5px #999;" />

An API key is needed for WeatherAPI:

<img src="https://user-images.githubusercontent.com/1534870/130651768-71c4cafd-54f8-4d36-984b-09c14612c863.png" width="60%" />

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
