### PR TITLE
fix(explore): retain chart ownership on query context update

### DIFF
--- a/superset/charts/commands/update.py
+++ b/superset/charts/commands/update.py
@@ -84,13 +84,17 @@ class UpdateChartCommand(UpdateMixin, BaseCommand):
         if not self._model:
             raise ChartNotFoundError()
 
-        # Check ownership; when only updating query context we ignore
+        # Check and update ownership; when only updating query context we ignore
         # ownership so the update can be performed by report workers
         if not is_query_context_update(self._properties):
             try:
                 check_ownership(self._model)
+                owners = self.populate_owners(self._actor, owner_ids)
+                self._properties["owners"] = owners
             except SupersetSecurityException as ex:
                 raise ChartForbiddenError() from ex
+            except ValidationError as ex:
+                exceptions.append(ex)
 
         # Validate/Populate datasource
         if datasource_id is not None:
@@ -107,12 +111,6 @@ class UpdateChartCommand(UpdateMixin, BaseCommand):
                 exceptions.append(DashboardsNotFoundValidationError())
             self._properties["dashboards"] = dashboards
 
-        # Validate/Populate owner
-        try:
-            owners = self.populate_owners(self._actor, owner_ids)
-            self._properties["owners"] = owners
-        except ValidationError as ex:
-            exceptions.append(ex)
         if exceptions:
             exception = ChartInvalidError()
             exception.add_list(exceptions)

--- a/tests/integration_tests/charts/commands_tests.py
+++ b/tests/integration_tests/charts/commands_tests.py
@@ -321,7 +321,7 @@ class TestChartsUpdateCommand(SupersetTestCase):
         json_obj = {
             "description": "test for update",
             "cache_timeout": None,
-            "owners": [1],
+            "owners": [actor.id],
         }
         command = UpdateChartCommand(actor, model_id, json_obj)
         last_saved_before = db.session.query(Slice).get(pk).last_saved_at
@@ -329,3 +329,31 @@ class TestChartsUpdateCommand(SupersetTestCase):
         chart = db.session.query(Slice).get(pk)
         assert chart.last_saved_at != last_saved_before
         assert chart.last_saved_by == actor
+
+    @patch("superset.views.base.g")
+    @patch("superset.security.manager.g")
+    @pytest.mark.usefixtures("load_energy_table_with_slice")
+    def test_query_context_update_command(self, mock_sm_g, mock_g):
+        """"
+        Test that a user can generate the chart query context
+        payloadwithout affecting owners
+        """
+        chart = db.session.query(Slice).all()[0]
+        pk = chart.id
+        admin = security_manager.find_user(username="admin")
+        chart.owners = [admin]
+        db.session.commit()
+
+        actor = security_manager.find_user(username="alpha")
+        mock_g.user = mock_sm_g.user = actor
+        query_context = json.dumps({"foo": "bar"})
+        json_obj = {
+            "query_context_generation": True,
+            "query_context": query_context,
+        }
+        command = UpdateChartCommand(actor, pk, json_obj)
+        command.run()
+        chart = db.session.query(Slice).get(pk)
+        assert chart.query_context == query_context
+        assert len(chart.owners) == 1
+        assert chart.owners[0] == admin


### PR DESCRIPTION
### SUMMARY
A feature was recently introduced to automatically populate `query_context` in the chart metadata if it was missing. This was necessary to be able to render V1 chart reports, which require the frontend-rendered query request (not possible by the backend). However, if a non-owner triggered the chart update command, the original ownership data was lost due to the update payload not containing the `owners` property. This was due to the `self.populate_owners` method setting the owners to whichever value was passed in the request, which in this case was always `None`.

This PR changes the chart update command to not modify the `owners` property when calling the chart update command with `query_context_generation`. In addition, an integration test is added to ensure that a non-owner can update the query context payload without changing the `owners` property (test fails on master). 

### TESTING INSTRUCTIONS
1. Start a fresh installation of Superset with a newly initiated metadata database and examples data populated
2. Login as Admin
2. Go to the Charts page and change one of the Examples chart owners from empty to "Admin"
3. Open the chart into Explore view
4. Go back to Charts page and check the chart owners - notice how the owners are empty again. Set the chart owner back to Admin.
5. Reopen the chart in Explore, go to the Charts page and notice that now Admin is still an owner.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
