### PR TITLE
perf(dashboard): decouple redux props from dashboard components

### DIFF
--- a/superset-frontend/spec/javascripts/dashboard/components/gridComponents/ChartHolder_spec.jsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/gridComponents/ChartHolder_spec.jsx
@@ -25,7 +25,7 @@ import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 
 import Chart from 'src/dashboard/containers/Chart';
-import ChartHolder from 'src/dashboard/components/gridComponents/ChartHolder';
+import ChartHolderConnected from 'src/dashboard/components/gridComponents/ChartHolder';
 import DeleteComponentButton from 'src/dashboard/components/DeleteComponentButton';
 import DragDroppable from 'src/dashboard/components/dnd/DragDroppable';
 import HoverMenu from 'src/dashboard/components/menu/HoverMenu';
@@ -71,7 +71,7 @@ describe('ChartHolder', () => {
     const wrapper = mount(
       <Provider store={mockStore}>
         <DndProvider backend={HTML5Backend}>
-          <ChartHolder {...props} {...overrideProps} />
+          <ChartHolderConnected {...props} {...overrideProps} />
         </DndProvider>
       </Provider>,
       {

--- a/superset-frontend/spec/javascripts/dashboard/components/gridComponents/Markdown_spec.jsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/gridComponents/Markdown_spec.jsx
@@ -26,7 +26,7 @@ import { HTML5Backend } from 'react-dnd-html5-backend';
 
 import { act } from 'react-dom/test-utils';
 import { MarkdownEditor } from 'src/components/AsyncAceEditor';
-import Markdown from 'src/dashboard/components/gridComponents/Markdown';
+import MarkdownConnected from 'src/dashboard/components/gridComponents/Markdown';
 import MarkdownModeDropdown from 'src/dashboard/components/menu/MarkdownModeDropdown';
 import DeleteComponentButton from 'src/dashboard/components/DeleteComponentButton';
 import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
@@ -66,7 +66,7 @@ describe('Markdown', () => {
     const wrapper = mount(
       <Provider store={mockStore}>
         <DndProvider backend={HTML5Backend}>
-          <Markdown {...props} {...overrideProps} />
+          <MarkdownConnected {...props} {...overrideProps} />
         </DndProvider>
       </Provider>,
     );

--- a/superset-frontend/src/dashboard/components/gridComponents/ChartHolder.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/ChartHolder.jsx
@@ -152,7 +152,7 @@ const FilterFocusHighlight = React.forwardRef(
   },
 );
 
-export class ChartHolder extends React.Component {
+class ChartHolder extends React.Component {
   static renderInFocusCSS(columnName) {
     return (
       <style>

--- a/superset-frontend/src/dashboard/components/gridComponents/ChartHolder.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/ChartHolder.jsx
@@ -20,7 +20,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { useTheme } from '@superset-ui/core';
-import { useSelector } from 'react-redux';
+import { useSelector, connect } from 'react-redux';
 
 import { getChartIdsInFilterScope } from 'src/dashboard/util/activeDashboardFilters';
 import Chart from '../../containers/Chart';
@@ -152,7 +152,7 @@ const FilterFocusHighlight = React.forwardRef(
   },
 );
 
-class ChartHolder extends React.Component {
+export class ChartHolder extends React.Component {
   static renderInFocusCSS(columnName) {
     return (
       <style>
@@ -381,4 +381,10 @@ class ChartHolder extends React.Component {
 ChartHolder.propTypes = propTypes;
 ChartHolder.defaultProps = defaultProps;
 
-export default ChartHolder;
+function mapStateToProps(state) {
+  return {
+    directPathToChild: state.dashboardState.directPathToChild,
+    directPathLastUpdated: state.dashboardState.directPathLastUpdated,
+  };
+}
+export default connect(mapStateToProps)(ChartHolder);

--- a/superset-frontend/src/dashboard/components/gridComponents/Markdown.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Markdown.jsx
@@ -18,8 +18,9 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-
+import { connect } from 'react-redux';
 import cx from 'classnames';
+
 import { t, SafeMarkdown } from '@superset-ui/core';
 import { Logger, LOG_ACTIONS_RENDER_CHART } from 'src/logger/LogUtils';
 import { MarkdownEditor } from 'src/components/AsyncAceEditor';
@@ -77,7 +78,7 @@ Click here to edit [markdown](https://bit.ly/1dQOfRK)`;
 
 const MARKDOWN_ERROR_MESSAGE = t('This markdown component has an error.');
 
-class Markdown extends React.PureComponent {
+export class Markdown extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
@@ -366,4 +367,10 @@ class Markdown extends React.PureComponent {
 Markdown.propTypes = propTypes;
 Markdown.defaultProps = defaultProps;
 
-export default Markdown;
+function mapStateToProps(state) {
+  return {
+    undoLength: state.dashboardLayout.past.length,
+    redoLength: state.dashboardLayout.future.length,
+  };
+}
+export default connect(mapStateToProps)(Markdown);

--- a/superset-frontend/src/dashboard/components/gridComponents/Markdown.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Markdown.jsx
@@ -78,7 +78,7 @@ Click here to edit [markdown](https://bit.ly/1dQOfRK)`;
 
 const MARKDOWN_ERROR_MESSAGE = t('This markdown component has an error.');
 
-export class Markdown extends React.PureComponent {
+class Markdown extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -405,6 +405,10 @@ Tabs.propTypes = propTypes;
 Tabs.defaultProps = defaultProps;
 
 function mapStateToProps(state) {
-  return { nativeFilters: state.nativeFilters };
+  return {
+    nativeFilters: state.nativeFilters,
+    directPathToChild: state.dashboardState.directPathToChild,
+    activeTabs: state.dashboardState.activeTabs,
+  };
 }
 export default connect(mapStateToProps)(Tabs);

--- a/superset-frontend/src/dashboard/components/gridComponents/index.js
+++ b/superset-frontend/src/dashboard/components/gridComponents/index.js
@@ -28,7 +28,7 @@ import {
 } from '../../util/componentTypes';
 
 import ChartHolderConnected from './ChartHolder';
-import Markdown from './Markdown';
+import MarkdownConnected from './Markdown';
 import Column from './Column';
 import Divider from './Divider';
 import Header from './Header';
@@ -47,7 +47,7 @@ export { default as Tabs } from './Tabs';
 
 export const componentLookup = {
   [CHART_TYPE]: ChartHolderConnected,
-  [MARKDOWN_TYPE]: Markdown,
+  [MARKDOWN_TYPE]: MarkdownConnected,
   [COLUMN_TYPE]: Column,
   [DIVIDER_TYPE]: Divider,
   [HEADER_TYPE]: Header,

--- a/superset-frontend/src/dashboard/components/gridComponents/index.js
+++ b/superset-frontend/src/dashboard/components/gridComponents/index.js
@@ -27,7 +27,7 @@ import {
   TABS_TYPE,
 } from '../../util/componentTypes';
 
-import ChartHolder from './ChartHolder';
+import ChartHolderConnected from './ChartHolder';
 import Markdown from './Markdown';
 import Column from './Column';
 import Divider from './Divider';
@@ -46,7 +46,7 @@ export { default as Tab } from './Tab';
 export { default as Tabs } from './Tabs';
 
 export const componentLookup = {
-  [CHART_TYPE]: ChartHolder,
+  [CHART_TYPE]: ChartHolderConnected,
   [MARKDOWN_TYPE]: Markdown,
   [COLUMN_TYPE]: Column,
   [DIVIDER_TYPE]: Divider,

--- a/superset-frontend/src/dashboard/components/gridComponents/index.js
+++ b/superset-frontend/src/dashboard/components/gridComponents/index.js
@@ -27,8 +27,8 @@ import {
   TABS_TYPE,
 } from '../../util/componentTypes';
 
-import ChartHolderConnected from './ChartHolder';
-import MarkdownConnected from './Markdown';
+import ChartHolder from './ChartHolder';
+import Markdown from './Markdown';
 import Column from './Column';
 import Divider from './Divider';
 import Header from './Header';
@@ -46,8 +46,8 @@ export { default as Tab } from './Tab';
 export { default as Tabs } from './Tabs';
 
 export const componentLookup = {
-  [CHART_TYPE]: ChartHolderConnected,
-  [MARKDOWN_TYPE]: MarkdownConnected,
+  [CHART_TYPE]: ChartHolder,
+  [MARKDOWN_TYPE]: Markdown,
   [COLUMN_TYPE]: Column,
   [DIVIDER_TYPE]: Divider,
   [HEADER_TYPE]: Header,

--- a/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
+++ b/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
@@ -63,8 +63,6 @@ const propTypes = {
 };
 
 const defaultProps = {
-  directPathToChild: [],
-  directPathLastUpdated: 0,
   isComponentVisible: true,
 };
 
@@ -77,15 +75,9 @@ function mapStateToProps(
   const component = dashboardLayout[id];
   const props = {
     component,
-    dashboardLayout,
     parentComponent: dashboardLayout[parentId],
     editMode: dashboardState.editMode,
-    undoLength: undoableLayout.past.length,
-    redoLength: undoableLayout.future.length,
     filters: getActiveFilters(),
-    directPathToChild: dashboardState.directPathToChild,
-    activeTabs: dashboardState.activeTabs,
-    directPathLastUpdated: dashboardState.directPathLastUpdated,
     dashboardId: dashboardInfo.id,
     fullSizeChartId: dashboardState.fullSizeChartId,
   };

--- a/superset-frontend/src/dashboard/util/activeDashboardFilters.js
+++ b/superset-frontend/src/dashboard/util/activeDashboardFilters.js
@@ -33,9 +33,7 @@ let allComponents = {};
 
 // output: { [id_column]: { values, scope } }
 export function getActiveFilters() {
-  return {
-    ...activeFilters,
-  };
+  return activeFilters;
 }
 
 // currently filter_box is a chart,


### PR DESCRIPTION
### SUMMARY
In DashboardComponent (a parent component of dashboard components such as ChartHolder, Tabs, Column etc.) we had a large mapStateToProps function, which maps redux state to props. A lot of those props were used only in some components, but since they were passed to every component, each change triggered a rerender of all components instead of the ones that actually use the changed prop. This PR decouples those props from components that don't need them.
For example - `directPathToChild` is used only by `ChartHolder` and `Tabs`, but any change of that prop triggered a rerender of all components on dashboard.
This PR is the first of a series of PRs that will come soon - all related to reducing dashboard rerenders.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No changes

### TESTING INSTRUCTIONS
Every dashboard functionality should work as it did before

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @junlincc @jinghua-qa