### PR TITLE
chore: Removes the TODOs and uses the default page size in AlertReportModal

### DIFF
--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -56,7 +56,6 @@ import {
   Recipient,
 } from './types';
 
-const SELECT_PAGE_SIZE = 2000; // temporary fix for paginated query
 const TIMEOUT_MIN = 1;
 const TEXT_BASED_VISUALIZATION_TYPES = [
   'pivot_table',
@@ -1048,10 +1047,6 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
               <Select
                 ariaLabel={t('Owners')}
                 allowClear
-                // TODO Use default page size (100). To do that, the server
-                // needs to send the total number of results. Currently, the
-                // number of results is limited to SELECT_PAGE_SIZE
-                pageSize={SELECT_PAGE_SIZE}
                 name="owners"
                 mode="multiple"
                 value={
@@ -1099,10 +1094,6 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                 <div className="input-container">
                   <Select
                     ariaLabel={t('Database')}
-                    // TODO Use default page size (100). To do that, the server
-                    // needs to send the total number of results. Currently, the
-                    // number of results is limited to SELECT_PAGE_SIZE
-                    pageSize={SELECT_PAGE_SIZE}
                     name="source"
                     value={
                       currentAlert?.database?.label &&
@@ -1267,10 +1258,6 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
               css={{
                 display: contentType === 'chart' ? 'inline' : 'none',
               }}
-              // TODO Use default page size (100). To do that, the server
-              // needs to send the total number of results. Currently, the
-              // number of results is limited to SELECT_PAGE_SIZE
-              pageSize={SELECT_PAGE_SIZE}
               name="chart"
               value={
                 currentAlert?.chart?.label && currentAlert?.chart?.value
@@ -1288,10 +1275,6 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
               css={{
                 display: contentType === 'dashboard' ? 'inline' : 'none',
               }}
-              // TODO Use default page size (100). To do that, the server
-              // needs to send the total number of results. Currently, the
-              // number of results is limited to SELECT_PAGE_SIZE
-              pageSize={SELECT_PAGE_SIZE}
               name="dashboard"
               value={
                 currentAlert?.dashboard?.label && currentAlert?.dashboard?.value


### PR DESCRIPTION
### SUMMARY
Removes the `TODOs` and uses the default page size in `AlertReportModal`.

Thanks, @villebro for fixing the endpoints.

Follow-up of https://github.com/apache/superset/pull/16144 and https://github.com/apache/superset/pull/16397

@junlincc @rusackas 

### TESTING INSTRUCTIONS
All tests should pass.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
