### PR TITLE
fix(jinja): Fixed issue with filters when Jina templating is turned on

### DIFF
--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -297,7 +297,7 @@ class ExtraCache:
 
         for flt in form_data.get("adhoc_filters", []):
             val: Union[Any, List[Any]] = flt.get("comparator")
-            op: str = flt["operator"].upper() if "operator" in flt else None
+            op: str = flt["operator"].upper() if "operator" in flt and flt["operator"] is not None else None
             # fltOpName: str = flt.get("filterOptionName")
             if (
                 flt.get("expressionType") == "SIMPLE"


### PR DESCRIPTION
### SUMMARY
Fix a crash when filtering in 1.3.0 with Jinja templates turned on

### TESTING INSTRUCTIONS
Although not a 100% sure, I think this is related to Custom SQL filters. Create a complex filter (mine looked like
(A = 'B' AND time <> '00:00:00' AND C = 'D') OR (A = 'B' AND C <> 'E').

Without the fix, the error I got is:
```
Traceback (most recent call last):
File "/app/superset/viz.py", line 540, in get_df_payload
df = self.get_df(query_obj)
File "/app/superset/viz.py", line 276, in get_df
self.results = self.datasource.query(query_obj)
File "/app/superset/connectors/sqla/models.py", line 1439, in query
query_str_ext = self.get_query_str_extended(query_obj)
File "/app/superset/connectors/sqla/models.py", line 766, in get_query_str_extended
sqlaq = self.get_sqla_query(**query_obj)
File "/app/superset/connectors/sqla/models.py", line 1011, in get_sqla_query
metrics_exprs.append(metrics_by_name[metric].get_sqla_col())
File "/app/superset/connectors/sqla/models.py", line 415, in get_sqla_col
sqla_col: ColumnClause = literal_column(tp.process_template(self.expression))
File "/app/superset/jinja_context.py", line 424, in process_template
return template.render(context)
File "/usr/local/lib/python3.7/site-packages/jinja2/environment.py", line 1090, in render
self.environment.handle_exception()
File "/usr/local/lib/python3.7/site-packages/jinja2/environment.py", line 832, in handle_exception
reraise(*rewrite_traceback_stack(source=source))
File "/usr/local/lib/python3.7/site-packages/jinja2/_compat.py", line 28, in reraise
raise value.with_traceback(tb)
File "", line 1, in top-level template code
File "/usr/local/lib/python3.7/site-packages/jinja2/sandbox.py", line 462, in call
return __context.call(__obj, *args, **kwargs)
File "/app/superset/jinja_context.py", line 321, in safe_proxy
return_value = func(*args, **kwargs)
File "/app/superset/jinja_context.py", line 210, in filter_values
filters = self.get_filters(column, remove_filter)
File "/app/superset/jinja_context.py", line 298, in get_filters
op: str = flt["operator"].upper() if "operator" in flt else None
AttributeError: 'NoneType' object has no attribute 'upper'
```
### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
