### PR TITLE
fix(explore): update overwrite button on perm change

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/SaveModal_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/SaveModal_spec.jsx
@@ -42,14 +42,16 @@ describe('SaveModal', () => {
       dashboards: [],
     },
     explore: {
-      can_overwrite: true,
-      user_id: '1',
       datasource: {},
       slice: {
         slice_id: 1,
         slice_name: 'title',
+        owners: [1],
       },
       alert: null,
+      user: {
+        userId: 1,
+      },
     },
   };
   const store = mockStore(initialState);
@@ -104,7 +106,7 @@ describe('SaveModal', () => {
 
   it('disable overwrite option for non-owner', () => {
     const wrapperForNonOwner = getWrapper();
-    wrapperForNonOwner.setProps({ can_overwrite: false });
+    wrapperForNonOwner.setProps({ userId: 2 });
     const overwriteRadio = wrapperForNonOwner.find('#overwrite-radio');
     expect(overwriteRadio).toHaveLength(1);
     expect(overwriteRadio.prop('disabled')).toBe(true);

--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -620,7 +620,6 @@ function mapStateToProps(state) {
     timeout: explore.common.conf.SUPERSET_WEBSERVER_TIMEOUT,
     ownState: dataMask[form_data.slice_id ?? 0]?.ownState, // 0 - unsaved chart
     impressionId,
-    userId: explore.user_id,
     user: explore.user,
     reports,
   };

--- a/superset-frontend/src/explore/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/index.tsx
@@ -175,7 +175,7 @@ export default function PropertiesModal({
             buttonStyle="primary"
             // @ts-ignore
             onClick={onSubmit}
-            disabled={!owners || submitting || !name}
+            disabled={submitting || !name}
             cta
           >
             {t('Save')}

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -34,11 +34,10 @@ const SK_DASHBOARD_ID = 'save_chart_recent_dashboard';
 const SELECT_PLACEHOLDER = t('**Select** a dashboard OR **create** a new one');
 
 type SaveModalProps = {
-  can_overwrite?: boolean;
   onHide: () => void;
   actions: Record<string, any>;
   form_data?: Record<string, any>;
-  userId: string;
+  userId: number;
   dashboards: Array<any>;
   alert?: string;
   sliceName?: string;
@@ -70,12 +69,16 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
       saveToDashboardId: null,
       newSliceName: props.sliceName,
       alert: null,
-      action: props.can_overwrite ? 'overwrite' : 'saveas',
+      action: this.canOverwriteSlice() ? 'overwrite' : 'saveas',
     };
     this.onDashboardSelectChange = this.onDashboardSelectChange.bind(this);
     this.onSliceNameChange = this.onSliceNameChange.bind(this);
     this.changeAction = this.changeAction.bind(this);
     this.saveOrOverwrite = this.saveOrOverwrite.bind(this);
+  }
+
+  canOverwriteSlice(): boolean {
+    return this.props.slice?.owners?.includes(this.props.userId);
   }
 
   componentDidMount() {
@@ -196,7 +199,7 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
               disabled={!this.state.newSliceName}
               data-test="btn-modal-save"
             >
-              {!this.props.can_overwrite && this.props.slice
+              {!this.canOverwriteSlice() && this.props.slice
                 ? t('Save as new chart')
                 : t('Save')}
             </Button>
@@ -225,7 +228,7 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
           <FormItem data-test="radio-group">
             <Radio
               id="overwrite-radio"
-              disabled={!(this.props.can_overwrite && this.props.slice)}
+              disabled={!this.canOverwriteSlice()}
               checked={this.state.action === 'overwrite'}
               onChange={() => this.changeAction('overwrite')}
               data-test="save-overwrite-radio"
@@ -289,8 +292,7 @@ function mapStateToProps({
   return {
     datasource: explore.datasource,
     slice: explore.slice,
-    can_overwrite: explore.can_overwrite,
-    userId: explore.user_id,
+    userId: explore.user?.userId,
     dashboards: saveModal.dashboards,
     alert: saveModal.saveModalAlert,
   };

--- a/superset-frontend/src/explore/reducers/exploreReducer.js
+++ b/superset-frontend/src/explore/reducers/exploreReducer.js
@@ -219,6 +219,7 @@ export default function exploreReducer(state = {}, action) {
         slice: {
           ...state.slice,
           ...action.slice,
+          owners: action.slice.owners ?? null,
         },
         sliceName: action.slice.slice_name ?? state.sliceName,
       };

--- a/superset-frontend/src/explore/reducers/getInitialState.ts
+++ b/superset-frontend/src/explore/reducers/getInitialState.ts
@@ -22,7 +22,7 @@ import {
   ControlStateMapping,
   DatasourceMeta,
 } from '@superset-ui/chart-controls';
-import { CommonBootstrapData } from 'src/types/bootstrapTypes';
+import { CommonBootstrapData, User } from 'src/types/bootstrapTypes';
 import getToastsFromPyFlashMessages from 'src/messageToasts/utils/getToastsFromPyFlashMessages';
 
 import { ChartState, Slice } from 'src/explore/types';
@@ -37,14 +37,15 @@ export interface ExlorePageBootstrapData extends JsonObject {
   can_add: boolean;
   can_download: boolean;
   can_overwrite: boolean;
+  common: CommonBootstrapData;
   datasource: DatasourceMeta;
-  form_data: QueryFormData;
   datasource_id: number;
   datasource_type: DatasourceType;
+  forced_height: string | null;
+  form_data: QueryFormData;
   slice: Slice | null;
   standalone: boolean;
-  forced_height: string | null;
-  common: CommonBootstrapData;
+  user: User;
 }
 
 export default function getInitialState(

--- a/superset-frontend/src/explore/reducers/getInitialState.ts
+++ b/superset-frontend/src/explore/reducers/getInitialState.ts
@@ -43,7 +43,6 @@ export interface ExlorePageBootstrapData extends JsonObject {
   datasource_type: DatasourceType;
   slice: Slice | null;
   standalone: boolean;
-  user_id: number;
   forced_height: string | null;
   common: CommonBootstrapData;
 }

--- a/superset-frontend/src/explore/reducers/getInitialState.ts
+++ b/superset-frontend/src/explore/reducers/getInitialState.ts
@@ -22,7 +22,10 @@ import {
   ControlStateMapping,
   DatasourceMeta,
 } from '@superset-ui/chart-controls';
-import { CommonBootstrapData, User } from 'src/types/bootstrapTypes';
+import {
+  CommonBootstrapData,
+  UserWithPermissionsAndRoles,
+} from 'src/types/bootstrapTypes';
 import getToastsFromPyFlashMessages from 'src/messageToasts/utils/getToastsFromPyFlashMessages';
 
 import { ChartState, Slice } from 'src/explore/types';
@@ -45,7 +48,7 @@ export interface ExlorePageBootstrapData extends JsonObject {
   form_data: QueryFormData;
   slice: Slice | null;
   standalone: boolean;
-  user: User;
+  user: UserWithPermissionsAndRoles;
 }
 
 export default function getInitialState(

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -471,7 +471,9 @@ sqlatable_user = Table(
 )
 
 
-class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-methods
+class SqlaTable(
+    Model, BaseDatasource
+):  # pylint: disable=too-many-instance-attributes,too-many-public-methods
     """An ORM object for SqlAlchemy table references"""
 
     type = "table"

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -471,9 +471,7 @@ sqlatable_user = Table(
 )
 
 
-class SqlaTable(  # pylint: disable=too-many-instance-attributes,too-many-public-methods
-    Model, BaseDatasource
-):
+class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-methods
     """An ORM object for SqlAlchemy table references"""
 
     type = "table"

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -201,9 +201,7 @@ class Slice(  # pylint: disable=too-many-public-methods
             "form_data": self.form_data,
             "query_context": self.query_context,
             "modified": self.modified(),
-            "owners": [
-                f"{owner.first_name} {owner.last_name}" for owner in self.owners
-            ],
+            "owners": [owner.id for owner in self.owners],
             "slice_id": self.id,
             "slice_name": self.slice_name,
             "slice_url": self.slice_url,

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -53,7 +53,7 @@ slice_user = Table(
 logger = logging.getLogger(__name__)
 
 
-class Slice(  # pylint: disable=too-many-instance-attributes,too-many-public-methods
+class Slice(  # pylint: disable=too-many-public-methods
     Model, AuditMixinNullable, ImportExportMixin
 ):
     """A slice is essentially a report or a view on data"""

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -53,7 +53,7 @@ slice_user = Table(
 logger = logging.getLogger(__name__)
 
 
-class Slice(  # pylint: disable=too-many-public-methods
+class Slice(  # pylint: disable=too-many-instance-attributes,too-many-public-methods
     Model, AuditMixinNullable, ImportExportMixin
 ):
     """A slice is essentially a report or a view on data"""

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -715,7 +715,6 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     def explore(  # pylint: disable=too-many-locals
         self, datasource_type: Optional[str] = None, datasource_id: Optional[int] = None
     ) -> FlaskResponse:
-        user_id = g.user.get_id() if g.user else None
         form_data, slc = get_form_data(use_slice_data=True)
         query_context = request.form.get("query_context")
         # Flash the SIP-15 message if the slice is owned by the current user and has not
@@ -848,7 +847,6 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             "datasource_type": datasource_type,
             "slice": slc.data if slc else None,
             "standalone": standalone_mode,
-            "user_id": user_id,
             "user": bootstrap_user_data(g.user, include_perms=True),
             "forced_height": request.args.get("height"),
             "common": common_bootstrap_payload(),

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -842,7 +842,6 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         bootstrap_data = {
             "can_add": slice_add_perm,
             "can_download": slice_download_perm,
-            "can_overwrite": slice_overwrite_perm,
             "datasource": datasource_data,
             "form_data": form_data,
             "datasource_id": datasource_id,
@@ -1019,7 +1018,6 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         response = {
             "can_add": slice_add_perm,
             "can_download": slice_download_perm,
-            "can_overwrite": is_owner(slc, g.user),
             "form_data": slc.form_data,
             "slice": slc.data,
             "dashboard_url": dash.url if dash else None,


### PR DESCRIPTION
### SUMMARY
Currently the Explore view does not update the "can_overwrite" permission when the user updates the chart ownership, as it's populated from bootstrap data (rendered server-side when page is loaded). In addition, the "Save" button in the chart metadata modal is enabled when the owners array is initially empty, but after adding and removing a user the save button gets disabled.

This removes the `can_overwrite` property from the Explore bootstrap data and replaces it with state from Redux, making it possible to change the disabled state of the "Save (Overwrite)" button in the Save modal. In addition, the `slice.owners` property in bootstrap data is changed to provide numeric ids instead of "firstname lastname" (most other models were already returning owners in this format; it appears the "firstname lastname" results weren't being used anywhere in Explore). Also update some types and remove redundant `user_id` property from bootstrap data.

### AFTER
https://user-images.githubusercontent.com/33317356/130752708-1ed4a830-f2d6-487d-a3d4-10a1fe283539.mp4

### BEFORE
https://user-images.githubusercontent.com/33317356/130752813-aeaa593c-94e2-48a8-9705-397048386cc2.mp4

### TESTING INSTRUCTIONS
1. Login as Admin
2. Open the Charts page and edit the metadata of an example dataset that doesn't have any owners
3. Add and remove yourself as owner and notice how the Save button goes from being enabled to disabled without the owners changing. Click cancel.
4. Open an example chart in Explore that doesn't have any owners
5. Add yourself as an owner
6. Try to overwrite the chart - notice that the "Save (Overwrite)" radio button is disabled

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
