### PR TITLE
perf(dashboard): reduce number of rerenders of Charts

### DIFF
--- a/superset-frontend/src/dashboard/actions/hydrate.js
+++ b/superset-frontend/src/dashboard/actions/hydrate.js
@@ -371,8 +371,8 @@ export const hydrateDashboard = (dashboardData, chartData) => (
         // only persistent refreshFrequency will be saved to backend
         shouldPersistRefreshFrequency: false,
         css: dashboardData.css || '',
-        colorNamespace: metadata?.color_namespace ?? undefined,
-        colorScheme: metadata?.color_scheme ?? undefined,
+        colorNamespace: metadata?.color_namespace,
+        colorScheme: metadata?.color_scheme,
         editMode: canEdit && editMode,
         isPublished: dashboardData.published,
         hasUnsavedChanges: false,

--- a/superset-frontend/src/dashboard/actions/hydrate.js
+++ b/superset-frontend/src/dashboard/actions/hydrate.js
@@ -371,8 +371,8 @@ export const hydrateDashboard = (dashboardData, chartData) => (
         // only persistent refreshFrequency will be saved to backend
         shouldPersistRefreshFrequency: false,
         css: dashboardData.css || '',
-        colorNamespace: metadata?.color_namespace || null,
-        colorScheme: metadata?.color_scheme || null,
+        colorNamespace: metadata?.color_namespace ?? undefined,
+        colorScheme: metadata?.color_scheme ?? undefined,
         editMode: canEdit && editMode,
         isPublished: dashboardData.published,
         hasUnsavedChanges: false,

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -87,7 +87,8 @@ const defaultProps = {
 // resizing across all slices on a dashboard on every update
 const RESIZE_TIMEOUT = 350;
 const SHOULD_UPDATE_ON_PROP_CHANGES = Object.keys(propTypes).filter(
-  prop => prop !== 'width' && prop !== 'height',
+  prop =>
+    prop !== 'width' && prop !== 'height' && prop !== 'isComponentVisible',
 );
 const OVERFLOWABLE_VIZ_TYPES = new Set(['filter_box']);
 const DEFAULT_HEADER_HEIGHT = 22;
@@ -100,6 +101,8 @@ const ChartOverlay = styled.div`
 `;
 
 export default class Chart extends React.Component {
+  static whyDidYouRender = true;
+
   constructor(props) {
     super(props);
     this.state = {

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -101,8 +101,6 @@ const ChartOverlay = styled.div`
 `;
 
 export default class Chart extends React.Component {
-  static whyDidYouRender = true;
-
   constructor(props) {
     super(props);
     this.state = {

--- a/superset-frontend/src/dashboard/containers/Chart.jsx
+++ b/superset-frontend/src/dashboard/containers/Chart.jsx
@@ -37,7 +37,7 @@ import getFormDataWithExtraFilters from '../util/charts/getFormDataWithExtraFilt
 import Chart from '../components/gridComponents/Chart';
 import { PLACEHOLDER_DATASOURCE } from '../constants';
 
-const EMPTY_FILTERS = {};
+const EMPTY_OBJECT = {};
 
 function mapStateToProps(
   {
@@ -54,7 +54,7 @@ function mapStateToProps(
   ownProps,
 ) {
   const { id } = ownProps;
-  const chart = chartQueries[id] || {};
+  const chart = chartQueries[id] || EMPTY_OBJECT;
   const datasource =
     (chart && chart.form_data && datasources[chart.form_data.datasource]) ||
     PLACEHOLDER_DATASOURCE;
@@ -82,7 +82,7 @@ function mapStateToProps(
     datasource,
     slice: sliceEntities.slices[id],
     timeout: dashboardInfo.common.conf.SUPERSET_WEBSERVER_TIMEOUT,
-    filters: getActiveFilters() || EMPTY_FILTERS,
+    filters: getActiveFilters() || EMPTY_OBJECT,
     formData,
     editMode: dashboardState.editMode,
     isExpanded: !!dashboardState.expandedSlices[id],

--- a/superset-frontend/src/dashboard/util/charts/getFormDataWithExtraFilters.ts
+++ b/superset-frontend/src/dashboard/util/charts/getFormDataWithExtraFilters.ts
@@ -25,6 +25,7 @@ import {
 import { ChartQueryPayload, Charts, LayoutItem } from 'src/dashboard/types';
 import { getExtraFormData } from 'src/dashboard/components/nativeFilters/utils';
 import { DataMaskStateWithId } from 'src/dataMask/types';
+import { areObjectsEqual } from 'src/reduxUtils';
 import getEffectiveExtraFilters from './getEffectiveExtraFilters';
 import { ChartConfiguration, NativeFiltersState } from '../../reducers/types';
 import { getAllActiveFilters } from '../activeAllDashboardFilters';
@@ -68,13 +69,15 @@ export default function getFormDataWithExtraFilters({
 
   // if dashboard metadata + filters have not changed, use cache if possible
   if (
-    (cachedFiltersByChart[sliceId] || {}) === filters &&
-    (colorScheme == null ||
-      cachedFormdataByChart[sliceId].color_scheme === colorScheme) &&
-    cachedFormdataByChart[sliceId].color_namespace === colorNamespace &&
-    isEqual(cachedFormdataByChart[sliceId].label_colors, labelColors) &&
+    cachedFiltersByChart[sliceId] === filters &&
+    (colorScheme === null ||
+      cachedFormdataByChart[sliceId]?.color_scheme === colorScheme) &&
+    cachedFormdataByChart[sliceId]?.color_namespace === colorNamespace &&
+    isEqual(cachedFormdataByChart[sliceId]?.label_colors, labelColors) &&
     !!cachedFormdataByChart[sliceId] &&
-    dataMask === undefined
+    areObjectsEqual(cachedFormdataByChart[sliceId]?.dataMask, dataMask, {
+      ignoreUndefined: true,
+    })
   ) {
     return cachedFormdataByChart[sliceId];
   }

--- a/superset-frontend/src/dashboard/util/charts/getFormDataWithExtraFilters.ts
+++ b/superset-frontend/src/dashboard/util/charts/getFormDataWithExtraFilters.ts
@@ -68,18 +68,18 @@ export default function getFormDataWithExtraFilters({
   const labelColors = scale.getColorMap();
 
   // if dashboard metadata + filters have not changed, use cache if possible
+  const cachedFormData = cachedFormdataByChart[sliceId];
   if (
     cachedFiltersByChart[sliceId] === filters &&
-    (colorScheme === null ||
-      cachedFormdataByChart[sliceId]?.color_scheme === colorScheme) &&
-    cachedFormdataByChart[sliceId]?.color_namespace === colorNamespace &&
-    isEqual(cachedFormdataByChart[sliceId]?.label_colors, labelColors) &&
-    !!cachedFormdataByChart[sliceId] &&
-    areObjectsEqual(cachedFormdataByChart[sliceId]?.dataMask, dataMask, {
+    cachedFormData?.color_scheme === colorScheme &&
+    cachedFormData?.color_namespace === colorNamespace &&
+    isEqual(cachedFormData?.label_colors, labelColors) &&
+    !!cachedFormData &&
+    areObjectsEqual(cachedFormData?.dataMask, dataMask, {
       ignoreUndefined: true,
     })
   ) {
-    return cachedFormdataByChart[sliceId];
+    return cachedFormData;
   }
 
   let extraData: { extra_form_data?: JsonObject } = {};


### PR DESCRIPTION
### SUMMARY
We generate formData, which is passed through props to Chart, with a function `getFormDataWithExtraFilters`. The idea is to generate formData, save it in a cache object, and on each subsequent render use the cached version. However, due to incorrect equality checks, we never used the cached version and created a new formData object each time. That resulted not only in recalculating the same logic many times, but also triggered Chart's rerender, as formData object's reference was changing.
Moreover, in Chart component's `shouldComponentUpdate` function we triggered rerender each time chart's visibility changed - in other words, we rerendered all charts every time we changed a tab.
This PR fixes both of those behaviours.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No changes

### TESTING INSTRUCTIONS
Everything should work as it did before.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @junlincc @jinghua-qa