### PR TITLE
chore: Make View Query Modal draggable and resizable in Dashboard

### DIFF
--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -299,6 +299,8 @@ class SliceHeaderControls extends React.PureComponent<
               modalBody={
                 <ViewQueryModal latestQueryFormData={this.props.formData} />
               }
+              draggable
+              resizable
               responsive
             />
           </Menu.Item>


### PR DESCRIPTION
### SUMMARY
It enables `resizable` and `draggable` properties for the "View query" Modal in Dashboard.

### BEFORE
![Screen Shot 2021-08-25 at 16 21 33](https://user-images.githubusercontent.com/60598000/130798166-12585447-d0bc-438a-9cc2-1278a54fd5e1.png)

### AFTER

https://user-images.githubusercontent.com/60598000/130797971-d0df2c25-38c9-4001-a221-b526c306165b.mp4

### TESTING INSTRUCTIONS
1. Open a Dashboard
2. Click on "View query" from the Chart menu
3. Drag and resize the Modal

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #16205 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
