### PR TITLE
fix(query): handle Infinity in query results

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ combine_as_imports = true
 include_trailing_comma = true
 line_length = 88
 known_first_party = superset
-known_third_party =alembic,apispec,backoff,bleach,cachelib,celery,click,colorama,cron_descriptor,croniter,cryptography,dateutil,deprecation,flask,flask_appbuilder,flask_babel,flask_caching,flask_compress,flask_jwt_extended,flask_login,flask_migrate,flask_sqlalchemy,flask_talisman,flask_testing,flask_wtf,freezegun,geohash,geopy,graphlib,holidays,humanize,isodate,jinja2,jwt,markdown,markupsafe,marshmallow,marshmallow_enum,msgpack,numpy,pandas,parameterized,parsedatetime,pgsanity,pkg_resources,polyline,prison,progress,pyarrow,pyhive,pyparsing,pytest,pytest_mock,pytz,redis,requests,selenium,setuptools,simplejson,slack,sqlalchemy,sqlalchemy_utils,sqlparse,typing_extensions,urllib3,werkzeug,wtforms,wtforms_json,yaml
+known_third_party =alembic,apispec,backoff,bleach,cachelib,celery,click,colorama,cron_descriptor,croniter,cryptography,dateutil,deprecation,flask,flask_appbuilder,flask_babel,flask_caching,flask_compress,flask_jwt_extended,flask_login,flask_migrate,flask_sqlalchemy,flask_talisman,flask_testing,flask_wtf,freezegun,geohash,geopy,holidays,humanize,isodate,jinja2,jwt,markdown,markupsafe,marshmallow,marshmallow_enum,msgpack,numpy,pandas,parameterized,parsedatetime,pgsanity,pkg_resources,polyline,prison,progress,pyarrow,pyhive,pyparsing,pytest,pytest_mock,pytz,redis,requests,selenium,setuptools,simplejson,slack,sqlalchemy,sqlalchemy_utils,sqlparse,typing_extensions,urllib3,werkzeug,wtforms,wtforms_json,yaml
 multi_line_output = 3
 order_by_type = false
 

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -125,9 +125,7 @@ class QueryContext:
         return df
 
     def processing_time_offsets(  # pylint: disable=too-many-locals
-        self,
-        df: pd.DataFrame,
-        query_object: QueryObject,
+        self, df: pd.DataFrame, query_object: QueryObject,
     ) -> CachedTimeOffset:
         # ensure query_object is immutable
         query_object_clone = copy.copy(query_object)
@@ -140,8 +138,7 @@ class QueryContext:
         for offset in time_offsets:
             try:
                 query_object_clone.from_dttm = get_past_or_future(
-                    offset,
-                    outer_from_dttm,
+                    offset, outer_from_dttm,
                 )
                 query_object_clone.to_dttm = get_past_or_future(offset, outer_to_dttm)
             except ValueError as ex:
@@ -293,10 +290,7 @@ class QueryContext:
                     errors="ignore",
                 )
 
-    def get_data(
-        self,
-        df: pd.DataFrame,
-    ) -> Union[str, List[Dict[str, Any]]]:
+    def get_data(self, df: pd.DataFrame,) -> Union[str, List[Dict[str, Any]]]:
         if self.result_format == ChartDataResultFormat.CSV:
             include_index = not isinstance(df.index, pd.RangeIndex)
             result = csv.df_to_escaped_csv(
@@ -307,9 +301,7 @@ class QueryContext:
         return df.to_dict(orient="records")
 
     def get_payload(
-        self,
-        cache_query_context: Optional[bool] = False,
-        force_cached: bool = False,
+        self, cache_query_context: Optional[bool] = False, force_cached: bool = False,
     ) -> Dict[str, Any]:
         """Returns the query results with both metadata and data"""
 
@@ -454,17 +446,12 @@ class QueryContext:
         return annotation_data
 
     def get_df_payload(
-        self,
-        query_obj: QueryObject,
-        force_cached: Optional[bool] = False,
+        self, query_obj: QueryObject, force_cached: Optional[bool] = False,
     ) -> Dict[str, Any]:
         """Handles caching around the df payload retrieval"""
         cache_key = self.query_cache_key(query_obj)
         cache = QueryCacheManager.get(
-            cache_key,
-            CacheRegion.DATA,
-            self.force,
-            force_cached,
+            cache_key, CacheRegion.DATA, self.force, force_cached,
         )
 
         if query_obj and cache_key and not cache.is_loaded:

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -125,7 +125,9 @@ class QueryContext:
         return df
 
     def processing_time_offsets(  # pylint: disable=too-many-locals
-        self, df: pd.DataFrame, query_object: QueryObject,
+        self,
+        df: pd.DataFrame,
+        query_object: QueryObject,
     ) -> CachedTimeOffset:
         # ensure query_object is immutable
         query_object_clone = copy.copy(query_object)
@@ -138,7 +140,8 @@ class QueryContext:
         for offset in time_offsets:
             try:
                 query_object_clone.from_dttm = get_past_or_future(
-                    offset, outer_from_dttm,
+                    offset,
+                    outer_from_dttm,
                 )
                 query_object_clone.to_dttm = get_past_or_future(offset, outer_to_dttm)
             except ValueError as ex:
@@ -289,10 +292,11 @@ class QueryContext:
                     .replace(NEGATIVE_INFINITY_LITERALS, -np.inf),
                     errors="ignore",
                 )
-                print(df[col])
-                print(df)
 
-    def get_data(self, df: pd.DataFrame,) -> Union[str, List[Dict[str, Any]]]:
+    def get_data(
+        self,
+        df: pd.DataFrame,
+    ) -> Union[str, List[Dict[str, Any]]]:
         if self.result_format == ChartDataResultFormat.CSV:
             include_index = not isinstance(df.index, pd.RangeIndex)
             result = csv.df_to_escaped_csv(
@@ -303,7 +307,9 @@ class QueryContext:
         return df.to_dict(orient="records")
 
     def get_payload(
-        self, cache_query_context: Optional[bool] = False, force_cached: bool = False,
+        self,
+        cache_query_context: Optional[bool] = False,
+        force_cached: bool = False,
     ) -> Dict[str, Any]:
         """Returns the query results with both metadata and data"""
 
@@ -448,12 +454,17 @@ class QueryContext:
         return annotation_data
 
     def get_df_payload(
-        self, query_obj: QueryObject, force_cached: Optional[bool] = False,
+        self,
+        query_obj: QueryObject,
+        force_cached: Optional[bool] = False,
     ) -> Dict[str, Any]:
         """Handles caching around the df payload retrieval"""
         cache_key = self.query_cache_key(query_obj)
         cache = QueryCacheManager.get(
-            cache_key, CacheRegion.DATA, self.force, force_cached,
+            cache_key,
+            CacheRegion.DATA,
+            self.force,
+            force_cached,
         )
 
         if query_obj and cache_key and not cache.is_loaded:

--- a/superset/constants.py
+++ b/superset/constants.py
@@ -174,3 +174,20 @@ class CacheRegion(str, Enum):
     DEFAULT = "default"
     DATA = "data"
     THUMBNAIL = "thumbnail"
+
+
+# Possible SQL literal representation for `Infinity`
+INFINITY_LITERALS = [
+    "Infinity",
+    '"Infinity"',
+    "Inf",
+    '"Inf"',
+]
+
+
+NEGATIVE_INFINITY_LITERALS = [
+    "-Infinity",
+    '"-Infinity"',
+    "-Inf",
+    '"-Inf"',
+]


### PR DESCRIPTION
### SUMMARY

More explicitly handle `Infinity` values in query results and improve type inference related to infinity values.

Previously we treat `Infinity` as `N/A` since JSON cannot handle infinity values. This PR explicitly retains infinity values in Pandas dataframes and adds two fields in data response (`infs` and `-infs`) to return to the client side which `null`s in the data records are actually infinities. The client side can then convert them back into JavaScript `Infinity/-Infinity` (not the scope of this PR).

More unit tests to come.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
