### PR TITLE
chore: remove birth_names from non test environment

### DIFF
--- a/superset/cli.py
+++ b/superset/cli.py
@@ -147,9 +147,6 @@ def load_examples_run(
         print("Loading [Random long/lat data]")
         examples.load_long_lat_data(only_metadata, force)
 
-        print("Loading [Country Map data]")
-        examples.load_country_map_data(only_metadata, force)
-
         print("Loading [San Francisco population polygons]")
         examples.load_sf_population_polygons(only_metadata, force)
 

--- a/superset/examples/utils.py
+++ b/superset/examples/utils.py
@@ -52,6 +52,7 @@ def load_contents(load_test_data: bool = False) -> Dict[str, Any]:
     while queue:
         path_name = queue.pop()
         test_re = re.compile(r"\.test\.|metadata\.yaml$")
+        test_check_re = re.compile(r"\.test\.yaml$")
 
         if resource_isdir("superset", str(path_name)):
             queue.extend(
@@ -59,7 +60,11 @@ def load_contents(load_test_data: bool = False) -> Dict[str, Any]:
                 for child_name in resource_listdir("superset", str(path_name))
             )
         elif path_name.suffix.lower() in YAML_EXTENSIONS:
+            # in testing environment, only bring in files that are for test
             if load_test_data and test_re.search(str(path_name)) is None:
+                continue
+            # in non testing environment, do not bring in files that are for test
+            if not load_test_data and test_check_re.search(str(path_name)) is not None:
                 continue
             contents[path_name] = (
                 resource_stream("superset", str(path_name)).read().decode("utf-8")


### PR DESCRIPTION
### SUMMARY
This dataset is used in tests, but not very helpful for users.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
All tests that use this dataset should work, but it shouldn't show up when running superset in the browser.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
