### PR TITLE
fix(native-filters): handle null values in value filter

### DIFF
--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -47,7 +47,6 @@ type PickedSelectProps = Pick<
   AntdSelectAllProps,
   | 'allowClear'
   | 'autoFocus'
-  | 'value'
   | 'disabled'
   | 'filterOption'
   | 'notFoundContent'

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -20,6 +20,7 @@
 import {
   AppSection,
   DataMask,
+  DataRecordValue,
   ensureIsArray,
   ExtraFormData,
   GenericDataType,
@@ -36,7 +37,11 @@ import { useImmerReducer } from 'use-immer';
 import { FormItemProps } from 'antd/lib/form';
 import { PluginFilterSelectProps, SelectValue } from './types';
 import { StyledFormItem, FilterPluginStyle, StatusMessage } from '../common';
-import { getDataRecordFormatter, getSelectExtraFormData } from '../../utils';
+import {
+  formatFilterValue,
+  getDataRecordFormatter,
+  getSelectExtraFormData,
+} from '../../utils';
 
 type DataMaskAction =
   | { type: 'ownState'; ownState: JsonObject }
@@ -119,7 +124,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
         filterState: {
           ...filterState,
           label: values?.length
-            ? `${(values || []).join(', ')}${suffix}`
+            ? `${(values || []).map(formatFilterValue).join(', ')}${suffix}`
             : undefined,
           value:
             appSection === AppSection.FILTER_CONFIG_MODAL && defaultToFirstItem
@@ -249,12 +254,12 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
   }
 
   const options = useMemo(() => {
-    const options: { label: string; value: string | number }[] = [];
+    const options: { label: string; value: DataRecordValue }[] = [];
     data.forEach(row => {
       const [value] = groupby.map(col => row[col]);
       options.push({
         label: labelFormatter(value, datatype),
-        value: typeof value === 'number' ? value : String(value),
+        value,
       });
     });
     return options;
@@ -286,6 +291,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
           loading={isRefreshing}
           maxTagCount={5}
           invertSelection={inverseSelection}
+          // @ts-ignore
           options={options}
         />
       </StyledFormItem>

--- a/superset-frontend/src/filters/utils.ts
+++ b/superset-frontend/src/filters/utils.ts
@@ -28,7 +28,7 @@ import { FALSE_STRING, NULL_STRING, TRUE_STRING } from 'src/utils/common';
 
 export const getSelectExtraFormData = (
   col: string,
-  value?: null | (string | number)[],
+  value?: null | (string | number | boolean | null)[],
   emptyFilter = false,
   inverseSelection = false,
 ): ExtraFormData => {
@@ -46,6 +46,7 @@ export const getSelectExtraFormData = (
       {
         col,
         op: inverseSelection ? ('NOT IN' as const) : ('IN' as const),
+        // @ts-ignore
         val: value,
       },
     ];
@@ -115,4 +116,19 @@ export function getDataRecordFormatter({
     }
     return String(value);
   };
+}
+
+export function formatFilterValue(
+  value: string | number | boolean | null,
+): string {
+  if (value === null) {
+    return NULL_STRING;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return String(value);
+  }
+  return value ? TRUE_STRING : FALSE_STRING;
 }

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -457,7 +457,7 @@ def cast_to_num(value: Optional[Union[float, int, str]]) -> Optional[Union[float
         return None
 
 
-def cast_to_boolean(value: Any) -> bool:
+def cast_to_boolean(value: Any) -> Optional[bool]:
     """Casts a value to an int/float
 
     >>> cast_to_boolean(1)
@@ -473,12 +473,14 @@ def cast_to_boolean(value: Any) -> bool:
     >>> cast_to_boolean('False')
     False
     >>> cast_to_boolean(None)
-    False
+    None
 
     :param value: value to be converted to boolean representation
     :returns: value cast to `bool`. when value is 'true' or value that are not 0
-              converte into True
+              converted into True. Return `None` if value is `None`
     """
+    if value is None:
+        return None
     if isinstance(value, (int, float)):
         return value != 0
     if isinstance(value, str):

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -473,7 +473,6 @@ def cast_to_boolean(value: Any) -> Optional[bool]:
     >>> cast_to_boolean('False')
     False
     >>> cast_to_boolean(None)
-    None
 
     :param value: value to be converted to boolean representation
     :returns: value cast to `bool`. when value is 'true' or value that are not 0


### PR DESCRIPTION
### SUMMARY
During migration of the Value filter to the new Select component, support for non-string based filter values (`number`, `boolean` and `null`) stopped working correctly. This fixes that

Known limitations: Even with this fix `null` values won't be supported in single select mode. This is due to how the native filter framework interprets the special case of a filter value being unset when the value is `null` (in the "multiple select" mode the filter value is `[null]` which is interpreted as being set). We have a potential fix for this, but it will require a slightly bigger refactor to be fully supported.

TODO: update type declarations on `superset-ui` to get rid of the `@ts-ignore`s.

Dashboard with filters unset:
![image](https://user-images.githubusercontent.com/33317356/130928197-f49cb965-759d-41ad-8029-80ceb28edf33.png)

### AFTER
![image](https://user-images.githubusercontent.com/33317356/130927234-d7d6ef39-58c9-4c0b-b1a9-2a38faf31160.png)
The query is now correctly issuing an `IS NULL` where clause:
![image](https://user-images.githubusercontent.com/33317356/130927964-ec05d849-c0ff-499c-9c1d-517f000e92e9.png)

Now the values are also formatted correctly
![image](https://user-images.githubusercontent.com/33317356/130927337-836054e3-4a80-4d7e-a073-a5a40dc9869a.png)

### BEFORE
Notice how `null` is interpreted as `false`:
![image](https://user-images.githubusercontent.com/33317356/130927537-00f3d132-ae16-40c0-85b1-0efc5242a9aa.png)
Same in the query:
![image](https://user-images.githubusercontent.com/33317356/130927612-3ef04039-56e9-499b-92e8-3486577b46f1.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
