### PR TITLE
fix(datasets): add support for removing owners

### DIFF
--- a/superset/views/datasource/views.py
+++ b/superset/views/datasource/views.py
@@ -18,7 +18,7 @@ import json
 from collections import Counter
 from typing import Any
 
-from flask import request
+from flask import g, request
 from flask_appbuilder import expose
 from flask_appbuilder.api import rison
 from flask_appbuilder.security.decorators import has_access_api
@@ -28,6 +28,7 @@ from sqlalchemy.exc import NoSuchTableError
 from sqlalchemy.orm.exc import NoResultFound
 
 from superset import app, db, event_logger
+from superset.commands.utils import populate_owners
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.connectors.sqla.utils import get_physical_table_metadata
 from superset.datasets.commands.exceptions import (
@@ -35,6 +36,7 @@ from superset.datasets.commands.exceptions import (
     DatasetNotFoundError,
 )
 from superset.exceptions import SupersetException, SupersetSecurityException
+from superset.extensions import security_manager
 from superset.models.core import Database
 from superset.typing import FlaskResponse
 from superset.views.base import (
@@ -76,22 +78,31 @@ class Datasource(BaseSupersetView):
         )
         orm_datasource.database_id = database_id
 
-        owners = datasource_dict.get("owners")
-        if owners and orm_datasource.owner_class is not None:
+        if "owners" in datasource_dict and orm_datasource.owner_class is not None:
             # Check ownership
             if app.config["OLD_API_CHECK_DATASET_OWNERSHIP"]:
+                # mimic the behavior of the new dataset command that
+                # checks ownership and ensures that non-admins aren't locked out
+                # of the object
                 try:
                     check_ownership(orm_datasource)
                 except SupersetSecurityException as ex:
                     raise DatasetForbiddenError() from ex
-
-            datasource_dict["owners"] = (
-                db.session.query(orm_datasource.owner_class)
-                .filter(orm_datasource.owner_class.id.in_(owners))
-                .all()
-            )
-        else:
-            datasource_dict["owners"] = []
+                user = security_manager.get_user_by_id(g.user.id)
+                datasource_dict["owners"] = populate_owners(
+                    user, datasource_dict["owners"], default_to_user=False
+                )
+            else:
+                # legacy behavior
+                datasource_dict["owners"] = (
+                    db.session.query(orm_datasource.owner_class)
+                    .filter(
+                        orm_datasource.owner_class.id.in_(
+                            datasource_dict["owners"] or []
+                        )
+                    )
+                    .all()
+                )
 
         duplicates = [
             name

--- a/superset/views/datasource/views.py
+++ b/superset/views/datasource/views.py
@@ -76,7 +76,8 @@ class Datasource(BaseSupersetView):
         )
         orm_datasource.database_id = database_id
 
-        if "owners" in datasource_dict and orm_datasource.owner_class is not None:
+        owners = datasource_dict.get("owners")
+        if owners and orm_datasource.owner_class is not None:
             # Check ownership
             if app.config["OLD_API_CHECK_DATASET_OWNERSHIP"]:
                 try:
@@ -86,9 +87,11 @@ class Datasource(BaseSupersetView):
 
             datasource_dict["owners"] = (
                 db.session.query(orm_datasource.owner_class)
-                .filter(orm_datasource.owner_class.id.in_(datasource_dict["owners"]))
+                .filter(orm_datasource.owner_class.id.in_(owners))
                 .all()
             )
+        else:
+            datasource_dict["owners"] = []
 
         duplicates = [
             name


### PR DESCRIPTION
### SUMMARY
Currently removing all owners from the datasets modal raises the following error:
![image](https://user-images.githubusercontent.com/33317356/130931659-a9ce9094-1d78-465c-a33e-43d582d16e95.png)

This makes the following changes to the endpoint:
- When `OLD_API_CHECK_DATASET_OWNERSHIP` config is set to the default value (`True`), we both check ownership and make sure the user doesn't lock themselves out of the object. See #15149 for more details on how this works for Admin vs regular users
- When the `OLD_API_CHECK_DATASET_OWNERSHIP` config flag is set to `False`, the behavior is unchanged (other than fixing the error when `datasource_dict["owners"] == None`). Note that in this scenario, a user is able to both edit datasets that they don't own and also save without adding themselves to the list of owners. See #16461 for context on this FF.

### AFTER
![image](https://user-images.githubusercontent.com/33317356/130931505-fdba81db-f0ca-403b-8d9b-44aade90ff1c.png)

### TESTING INSTRUCTIONS
1. Login as Admin
2. Open the dataset modal for a dataset you own
3. Remove yourself as owner
4. See the error

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
