### PR TITLE
fix(native-filters): handle undefined control value gracefully

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
@@ -56,7 +56,7 @@ export const checkIsMissingRequiredValue = (
   const value = filterState?.value;
   // TODO: this property should be unhardcoded
   return (
-    filter.controlValues.enableEmptyFilter &&
+    filter.controlValues?.enableEmptyFilter &&
     (value === null || value === undefined)
   );
 };


### PR DESCRIPTION
### SUMMARY
If `filter.controlValues` is `undefined` (the case of metadata from when native filters wasn't yet stable), the Filter Tab will crash. This ensures that the component doesn't crash if `controlValues` isn't defined. This was the only case of `controlValues` that I was able to find where we didn't check for `?`.

Closes #16438

### TESTING INSTRUCTIONS
1. Create a native value filter in version 1.1.0.
2. Upgrade to 1.3.0.
3. watch the Filter Tab crash when in Dashboard mode.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
