### PR TITLE
docs: Make code snippet usable with required imports in configuration doc

### DIFF
--- a/docs/src/pages/docs/installation/configuring.mdx
+++ b/docs/src/pages/docs/installation/configuring.mdx
@@ -207,7 +207,11 @@ CUSTOM_SECURITY_MANAGER = CustomSsoSecurityManager
 the app object and can alter it in any way. For example, add `FLASK_APP_MUTATOR` into your
 `superset_config.py` to setup session cookie expiration time to 24 hours:
 
-```
+```python
+from flask import session
+from flask import Flask
+
+
 def make_session_permanent():
     '''
     Enable maxAge for the cookie 'session'


### PR DESCRIPTION
### SUMMARY
This is a problem surfaced from [this thread](https://apache-superset.slack.com/archives/C0170U650CQ/p1630006496013500) in Slack

> I try to config like https://superset.apache.org/docs/installation/configuring-superset#flask-app-configuration-hook but it fail with "session" not found

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
When manually copying the code stanza under section [Flask app Configuration Hook](https://superset.apache.org/docs/installation/configuring-superset#flask-app-configuration-hook), it should not fail application starting.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
