### PR TITLE
fix: can't drop column when name overlap

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/optionSelector.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/optionSelector.ts
@@ -64,7 +64,7 @@ export class OptionSelector {
   }
 
   has(value: string): boolean {
-    return !!this.getValues()?.includes(value);
+    return ensureIsArray(this.getValues()).includes(value);
   }
 
   getValues(): string[] | string | undefined {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
closes: https://github.com/apache/superset/issues/16458
Currently, OptionSelector.getValues() can return `string array`, `string` and `undefined`, the `OptionSelector.has()` method determine if it contains by `includes(value)`. If it encounter the string case, it is clearly a faulty logic.

#### After

https://user-images.githubusercontent.com/2016594/131109770-2877692f-afa9-4e5a-b560-d4e108b3bd45.mov

#### Before


https://user-images.githubusercontent.com/2016594/131110102-8bf93f0c-a19c-4157-b9cc-55c6fbebac8c.mov





### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/16458
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
