### PR TITLE
fix: stop endless loading when dataset no longer exist

### DIFF
--- a/superset-frontend/src/chart/Chart.jsx
+++ b/superset-frontend/src/chart/Chart.jsx
@@ -178,7 +178,12 @@ class Chart extends React.PureComponent {
     const message = chartAlert || queryResponse?.message;
 
     // if datasource is still loading, don't render JS errors
-    if (chartAlert && datasource === PLACEHOLDER_DATASOURCE) {
+    if (
+      chartAlert !== undefined &&
+      chartAlert !==
+        'The dataset associated with this chart no longer exists' &&
+      datasource === PLACEHOLDER_DATASOURCE
+    ) {
       return (
         <Styles
           data-ui-anchor="chart"

--- a/superset-frontend/src/chart/Chart.jsx
+++ b/superset-frontend/src/chart/Chart.jsx
@@ -68,8 +68,9 @@ const propTypes = {
 };
 
 const BLANK = {};
-const NONEXISTENT_DATASET =
-  'The dataset associated with this chart no longer exists';
+const NONEXISTENT_DATASET = t(
+  'The dataset associated with this chart no longer exists',
+);
 
 const defaultProps = {
   addFilter: () => BLANK,

--- a/superset-frontend/src/chart/Chart.jsx
+++ b/superset-frontend/src/chart/Chart.jsx
@@ -68,6 +68,8 @@ const propTypes = {
 };
 
 const BLANK = {};
+const NONEXISTENT_DATASET =
+  'The dataset associated with this chart no longer exists';
 
 const defaultProps = {
   addFilter: () => BLANK,
@@ -180,8 +182,7 @@ class Chart extends React.PureComponent {
     // if datasource is still loading, don't render JS errors
     if (
       chartAlert !== undefined &&
-      chartAlert !==
-        'The dataset associated with this chart no longer exists' &&
+      chartAlert !== NONEXISTENT_DATASET &&
       datasource === PLACEHOLDER_DATASOURCE
     ) {
       return (


### PR DESCRIPTION
### SUMMARY
This pr stops the endless loading in the dashboards when a dataset no longer exists and returns proper error info to the user. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before

https://user-images.githubusercontent.com/17326228/131378812-5f92c50a-434c-48b3-857b-47b52c567976.mov

after

https://user-images.githubusercontent.com/17326228/131379074-cf9d01df-79c1-490e-81a2-9fd49dde63dc.mov



### TESTING INSTRUCTIONS
Delete a dataset that has associated chart in a a dashboard.
Go to the dashboard and ensure that the charts do no endlessly load.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x ] Has associated issue: Fixes https://github.com/apache/superset/issues/16431
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
