### PR TITLE
fix: Pin snowflake-sqlalchemy to 1.2.4

### DIFF
--- a/docs/src/pages/docs/Connecting to Databases/snowflake.mdx
+++ b/docs/src/pages/docs/Connecting to Databases/snowflake.mdx
@@ -9,7 +9,7 @@ version: 1
 ## Snowflake
 
 The recommended connector library for Snowflake is
-[snowflake-sqlalchemy](https://pypi.org/project/snowflake-sqlalchemy/).
+[snowflake-sqlalchemy](https://pypi.org/project/snowflake-sqlalchemy/1.2.4/)<=1.2.4. (This version is required until Superset migrates to sqlalchemy>=1.4.0)
 
 The connection string for Snowflake looks like this:
 

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,9 @@ setup(
         "shillelagh": [
             "shillelagh[datasetteapi,gsheetsapi,socrata,weatherapi]>=1.0.3, <2"
         ],
-        "snowflake": ["snowflake-sqlalchemy>=1.2.4"],  # PINNED! 1.2.5 introduced breaking changes requiring sqlalchemy>=1.4.0
+        "snowflake": [
+            "snowflake-sqlalchemy>=1.2.4"
+        ],  # PINNED! 1.2.5 introduced breaking changes requiring sqlalchemy>=1.4.0
         "teradata": ["sqlalchemy-teradata==0.9.0.dev0"],
         "thumbnails": ["Pillow>=7.0.0, <8.0.0"],
         "vertica": ["sqlalchemy-vertica-python>=0.5.9, < 0.6"],

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ setup(
         "shillelagh": [
             "shillelagh[datasetteapi,gsheetsapi,socrata,weatherapi]>=1.0.3, <2"
         ],
-        "snowflake": ["snowflake-sqlalchemy>=1.2.3, <1.3"],
+        "snowflake": ["snowflake-sqlalchemy>=1.2.4"],  # PINNED! 1.2.5 introduced breaking changes requiring sqlalchemy>=1.4.0
         "teradata": ["sqlalchemy-teradata==0.9.0.dev0"],
         "thumbnails": ["Pillow>=7.0.0, <8.0.0"],
         "vertica": ["sqlalchemy-vertica-python>=0.5.9, < 0.6"],


### PR DESCRIPTION
### SUMMARY
snowflake-sqlalchemy 1.2.5 introduced breaking changes requiring sqlalchemy>=1.4.0. This PR pins the last working version of 1.2.4 until Superset migrates to sqlalchemy>=1.4.0 and updates the docs accordingly.

Reference: https://github.com/snowflakedb/snowflake-sqlalchemy/issues/235

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
