### PR TITLE
fix: Adds a loading message when needed in the Select component

### DIFF
--- a/superset-frontend/src/components/Select/Select.stories.tsx
+++ b/superset-frontend/src/components/Select/Select.stories.tsx
@@ -300,6 +300,7 @@ const USERS = [
 ];
 
 export const AsyncSelect = ({
+  fetchOnlyOnSearch,
   withError,
   withInitialValue,
   responseTime,
@@ -381,7 +382,9 @@ export const AsyncSelect = ({
       >
         <Select
           {...rest}
+          fetchOnlyOnSearch={fetchOnlyOnSearch}
           options={withError ? fetchUserListError : fetchUserListPage}
+          placeholder={fetchOnlyOnSearch ? 'Type anything' : 'Select...'}
           value={
             withInitialValue
               ? { label: 'Valentina', value: 'Valentina' }


### PR DESCRIPTION
### SUMMARY
Adds a loading message when needed in the Select component. Previously, we displayed the 'No data' message while the select was still loading the items.

### AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/131564780-36434a76-c7c5-434f-9a13-91ecf7b2a4e5.mov

### TESTING INSTRUCTIONS
- Open the Select Storybook
- Check for the loading indicator while applying different combinations of the controls

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
