### PR TITLE
feat(dashboard): Native filters - add type to native filter configuration

### DIFF
--- a/superset-frontend/spec/fixtures/mockNativeFilters.ts
+++ b/superset-frontend/spec/fixtures/mockNativeFilters.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { ExtraFormData } from '@superset-ui/core';
+import { NativeFilterType } from 'src/dashboard/components/nativeFilters/types';
 import { NativeFiltersState } from 'src/dashboard/reducers/types';
 import { DataMaskStateWithId } from '../../src/dataMask/types';
 
@@ -50,6 +51,7 @@ export const nativeFilters: NativeFiltersState = {
         enableEmptyFilter: false,
         inverseSelection: false,
       },
+      type: NativeFilterType.NATIVE_FILTER,
     },
     'NATIVE_FILTER-x9QPw0so1': {
       id: 'NATIVE_FILTER-x9QPw0so1',
@@ -78,6 +80,7 @@ export const nativeFilters: NativeFiltersState = {
         enableEmptyFilter: false,
         inverseSelection: false,
       },
+      type: NativeFilterType.NATIVE_FILTER,
     },
   },
 };

--- a/superset-frontend/spec/javascripts/dashboard/fixtures/mockNativeFilters.ts
+++ b/superset-frontend/spec/javascripts/dashboard/fixtures/mockNativeFilters.ts
@@ -16,8 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { DataMaskStateWithId } from 'src/dataMask/types';
+import { NativeFilterType } from 'src/dashboard/components/nativeFilters/types';
 import { NativeFiltersState } from 'src/dashboard/reducers/types';
+import { DataMaskStateWithId } from 'src/dataMask/types';
 
 export const mockDataMaskInfo: DataMaskStateWithId = {
   DefaultsID: {
@@ -66,6 +67,7 @@ export const nativeFiltersInfo: NativeFiltersState = {
         allowsMultipleValues: true,
         isRequired: false,
       },
+      type: NativeFilterType.NATIVE_FILTER,
     },
   },
 };

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -80,7 +80,7 @@ import {
 } from './utils';
 import { useBackendFormUpdate, useDefaultValue } from './state';
 import { getFormData } from '../../utils';
-import { Filter } from '../../types';
+import { Filter, NativeFilterType } from '../../types';
 import getControlItemsMap from './getControlItemsMap';
 import FilterScope from './FilterScope/FilterScope';
 import RemovedFilter from './RemovedFilter';
@@ -322,6 +322,8 @@ const FiltersConfigForm = (
   const formFilter =
     form.getFieldValue('filters')?.[filterId] || defaultFormFilter;
 
+  // Defaulting to NATIVE_FILTER.
+  formFilter.type = NativeFilterType.NATIVE_FILTER;
   const nativeFilterItems = getChartMetadataRegistry().items;
   const nativeFilterVizTypes = Object.entries(nativeFilterItems)
     // @ts-ignore

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -322,8 +322,6 @@ const FiltersConfigForm = (
   const formFilter =
     form.getFieldValue('filters')?.[filterId] || defaultFormFilter;
 
-  // Defaulting to NATIVE_FILTER.
-  formFilter.type = NativeFilterType.NATIVE_FILTER;
   const nativeFilterItems = getChartMetadataRegistry().items;
   const nativeFilterVizTypes = Object.entries(nativeFilterItems)
     // @ts-ignore
@@ -686,6 +684,13 @@ const FiltersConfigForm = (
         forceRender
       >
         <StyledContainer>
+          <StyledFormItem
+            name={['filters', filterId, 'type']}
+            hidden
+            initialValue={NativeFilterType.NATIVE_FILTER}
+          >
+            <Input />
+          </StyledFormItem>
           <StyledFormItem
             name={['filters', filterId, 'name']}
             label={<StyledLabel>{t('Filter name')}</StyledLabel>}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/getControlItemsMap.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/getControlItemsMap.test.tsx
@@ -16,13 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { render, screen } from 'spec/helpers/testing-library';
-import userEvent from '@testing-library/user-event';
-import { Filter } from 'src/dashboard/components/nativeFilters/types';
 import { FormInstance } from 'src/common/components';
-import { getControlItems, setNativeFilterFieldValues } from './utils';
+import {
+  Filter,
+  NativeFilterType,
+} from 'src/dashboard/components/nativeFilters/types';
 import getControlItemsMap, { ControlItemsProps } from './getControlItemsMap';
+import { getControlItems, setNativeFilterFieldValues } from './utils';
 
 jest.mock('./utils', () => ({
   getControlItems: jest.fn(),
@@ -60,6 +63,7 @@ const filterMock: Filter = {
   filterType: '',
   targets: [{}],
   controlValues: {},
+  type: NativeFilterType.NATIVE_FILTER,
 };
 
 const createProps: () => ControlItemsProps = () => ({

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/types.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { AdhocFilter, DataMask } from '@superset-ui/core';
-import { Scope } from '../types';
+import { NativeFilterType, Scope } from '../types';
 
 export interface NativeFiltersFormItem {
   scope: Scope;
@@ -44,6 +44,7 @@ export interface NativeFiltersFormItem {
   adhoc_filters?: AdhocFilter[];
   time_range?: string;
   granularity_sqla?: string;
+  type: NativeFilterType;
 }
 
 export interface NativeFiltersForm {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/utils.ts
@@ -140,6 +140,7 @@ export const createHandleSave = (
           : [],
         scope: formInputs.scope,
         sortMetric: formInputs.sortMetric,
+        type: 'NATIVE_FILTER',
       };
     });
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/utils.ts
@@ -140,7 +140,7 @@ export const createHandleSave = (
           : [],
         scope: formInputs.scope,
         sortMetric: formInputs.sortMetric,
-        type: 'NATIVE_FILTER',
+        type: formInputs.type,
       };
     });
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/types.ts
@@ -59,6 +59,7 @@ export interface Filter {
   requiredFirst?: boolean;
   tabsInScope?: string[];
   chartsInScope?: number[];
+  type: NativeFilterType;
 }
 
 export type FilterConfiguration = Filter[];

--- a/superset-frontend/src/dashboard/components/nativeFilters/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/types.ts
@@ -62,3 +62,8 @@ export interface Filter {
 }
 
 export type FilterConfiguration = Filter[];
+
+export enum NativeFilterType {
+  NATIVE_FILTER = 'NATIVE_FILTER',
+  SECTION = 'SECTION',
+}

--- a/superset-frontend/src/dashboard/components/nativeFilters/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/utils.ts
@@ -47,6 +47,7 @@ export const getFormData = ({
   adhoc_filters,
   time_range,
   granularity_sqla,
+  type,
 }: Partial<Filter> & {
   datasetId?: number;
   inputRef?: RefObject<HTMLInputElement>;
@@ -86,6 +87,7 @@ export const getFormData = ({
     inView: true,
     viz_type: filterType,
     inputRef,
+    type,
   };
 };
 

--- a/superset/migrations/versions/021b81fe4fbb_add_type_to_native_filter_configuration.py
+++ b/superset/migrations/versions/021b81fe4fbb_add_type_to_native_filter_configuration.py
@@ -89,8 +89,7 @@ def downgrade():
 
     for dashboard in session.query(Dashboard).all():
         logger.info(
-            "[RemoveTypeToNativeFilter] Updating Dashobard<pk:%s>",
-            dashboard.id,
+            "[RemoveTypeToNativeFilter] Updating Dashobard<pk:%s>", dashboard.id,
         )
         if not dashboard.json_metadata:
             logger.info(

--- a/superset/migrations/versions/021b81fe4fbb_add_type_to_native_filter_configuration.py
+++ b/superset/migrations/versions/021b81fe4fbb_add_type_to_native_filter_configuration.py
@@ -59,10 +59,21 @@ def upgrade():
                 "[AddTypeToNativeFilter] Skipping Dashboard<pk:%s> ", dashboard.id
             )
             continue
+        try:
+            json_meta = json.loads(dashboard.json_metadata)
+        except:
+            logger.exception("[AddTypeToNativeFilter] Error loading json_metadata")
+            continue
 
-        json_meta = json.loads(dashboard.json_metadata)
+        if "native_filter_configuration" not in json_meta:
+            logger.info(
+                "[AddTypeToNativeFilter] Skipping Dashboard<pk:%s>."
+                " native_filter_configuration not found.",
+                dashboard.id,
+            )
+            continue
 
-        for native_filter in json_meta.get("native_filter_configuration", []):
+        for native_filter in json_meta["native_filter_configuration"]:
             native_filter.setdefault("type", "NATIVE_FILTER")
         dashboard.json_metadata = json.dumps(json_meta)
 
@@ -78,15 +89,28 @@ def downgrade():
 
     for dashboard in session.query(Dashboard).all():
         logger.info(
-            "[RemoveTypeToNativeFilter] Updating Dashobard<pk:%s>", dashboard.id,
+            "[RemoveTypeToNativeFilter] Updating Dashobard<pk:%s>",
+            dashboard.id,
         )
         if not dashboard.json_metadata:
             logger.info(
                 "[RemoveTypeToNativeFilter] Skipping Dashboard<pk:%s> ", dashboard.id
             )
             continue
-        json_meta = json.loads(dashboard.json_metadata)
-        for native_filter in json_meta.get("native_filter_configuration", []):
+        try:
+            json_meta = json.loads(dashboard.json_metadata)
+        except:
+            logger.exception("[RemoveTypeToNativeFilter] Error loading json_metadata")
+            continue
+
+        if "native_filter_configuration" not in json_meta:
+            logger.info(
+                "[RemoveTypeToNativeFilter] Skipping Dashboard<pk:%s>."
+                " native_filter_configuration not found.",
+                dashboard.id,
+            )
+            continue
+        for native_filter in json_meta["native_filter_configuration"]:
             native_filter.pop("type", None)
         dashboard.json_metadata = json.dumps(json_meta)
     session.commit()

--- a/superset/migrations/versions/021b81fe4fbb_add_type_to_native_filter_configuration.py
+++ b/superset/migrations/versions/021b81fe4fbb_add_type_to_native_filter_configuration.py
@@ -49,7 +49,7 @@ class Dashboard(Base):
 def upgrade():
     logger.info("[AddTypeToNativeFilter] Starting upgrade")
     bind = op.get_bind()
-    session = db.session(bind=bind)
+    session = db.Session(bind=bind)
 
     for dashboard in session.query(Dashboard).all():
         logger.info("[AddTypeToNativeFilter] Updating Dashboard<pk:%s> ", dashboard.id)
@@ -74,7 +74,7 @@ def upgrade():
 def downgrade():
     logger.info("[RemoveTypeToNativeFilter] Starting downgrade")
     bind = op.get_bind()
-    session = db.session(bind=bind)
+    session = db.Session(bind=bind)
 
     for dashboard in session.query(Dashboard).all():
         logger.info(

--- a/superset/migrations/versions/021b81fe4fbb_add_type_to_native_filter_configuration.py
+++ b/superset/migrations/versions/021b81fe4fbb_add_type_to_native_filter_configuration.py
@@ -56,7 +56,9 @@ def upgrade():
 
         if not dashboard.json_metadata:
             logger.info(
-                "[AddTypeToNativeFilter] Skipping Dashboard<pk:%s> ", dashboard.id
+                "[AddTypeToNativeFilter] Skipping Dashboard<pk:%s> json_metadata is %s",
+                dashboard.id,
+                dashboard.json_metadata,
             )
             continue
         try:
@@ -74,7 +76,7 @@ def upgrade():
             continue
 
         for native_filter in json_meta["native_filter_configuration"]:
-            native_filter.setdefault("type", "NATIVE_FILTER")
+            native_filter["type"] = "NATIVE_FILTER"
         dashboard.json_metadata = json.dumps(json_meta)
 
     session.commit()
@@ -93,7 +95,9 @@ def downgrade():
         )
         if not dashboard.json_metadata:
             logger.info(
-                "[RemoveTypeToNativeFilter] Skipping Dashboard<pk:%s> ", dashboard.id
+                "[RemoveTypeToNativeFilter] Skipping Dashboard<pk:%s> json_metadata is %s",
+                dashboard.id,
+                dashboard.json_metadata,
             )
             continue
         try:

--- a/superset/migrations/versions/021b81fe4fbb_add_type_to_native_filter_configuration.py
+++ b/superset/migrations/versions/021b81fe4fbb_add_type_to_native_filter_configuration.py
@@ -1,0 +1,94 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Add type to native filter configuration
+
+Revision ID: 021b81fe4fbb
+Revises: 07071313dd52
+Create Date: 2021-08-31 11:37:40.604081
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "021b81fe4fbb"
+down_revision = "07071313dd52"
+
+import json
+import logging
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.ext.declarative.api import declarative_base
+
+from superset import db
+
+Base = declarative_base()
+
+logger = logging.getLogger("alembic")
+
+
+class Dashboard(Base):
+    __tablename__ = "dashboards"
+    id = sa.Column(sa.Integer, primary_key=True)
+    json_metadata = sa.Column(sa.Text)
+
+
+def upgrade():
+    logger.info("[AddTypeToNativeFilter] Starting upgrade")
+    bind = op.get_bind()
+    session = db.session(bind=bind)
+
+    for dashboard in session.query(Dashboard).all():
+        logger.info("[AddTypeToNativeFilter] Updating Dashboard<pk:%s> ", dashboard.id)
+
+        if not dashboard.json_metadata:
+            logger.info(
+                "[AddTypeToNativeFilter] Skipping Dashboard<pk:%s> ", dashboard.id
+            )
+            continue
+
+        json_meta = json.loads(dashboard.json_metadata)
+
+        for native_filter in json_meta.get("native_filter_configuration", []):
+            native_filter.setdefault("type", "NATIVE_FILTER")
+        dashboard.json_metadata = json.dumps(json_meta)
+
+    session.commit()
+    session.close()
+    logger.info("[AddTypeToNativeFilter] Done!")
+
+
+def downgrade():
+    logger.info("[RemoveTypeToNativeFilter] Starting downgrade")
+    bind = op.get_bind()
+    session = db.session(bind=bind)
+
+    for dashboard in session.query(Dashboard).all():
+        logger.info(
+            "[RemoveTypeToNativeFilter] Updating Dashobard<pk:%s>", dashboard.id,
+        )
+        if not dashboard.json_metadata:
+            logger.info(
+                "[RemoveTypeToNativeFilter] Skipping Dashboard<pk:%s> ", dashboard.id
+            )
+            continue
+        json_meta = json.loads(dashboard.json_metadata)
+        for native_filter in json_meta.get("native_filter_configuration", []):
+            native_filter.pop("type", None)
+        dashboard.json_metadata = json.dumps(json_meta)
+    session.commit()
+    session.close()
+    logger.info("[RemoveTypeToNativeFilter] Done!")


### PR DESCRIPTION
### SUMMARY
In a future PR, we  will add a "Section" component to the native filters. We will need a new key to distinguish between them.

### TESTING INSTRUCTIONS
**Testing existing filters**
1. Run migration using `superset db upgrade`
2. Verify in the dashboards DB table that all the filters have a type (Check `json_metadata` column in dashboards table)
**Testing new filters** 
1. Add a new filter
2. Make sure that the type key appears in the new filter (Check `json_metadata` column in dashboards table)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
