### PR TITLE
refactor: Update async query init to support runtime feature flags

### DIFF
--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -718,8 +718,7 @@ class SupersetAppInitializer:
                 csrf.exempt(ex)
 
     def configure_async_queries(self) -> None:
-        if feature_flag_manager.is_feature_enabled("GLOBAL_ASYNC_QUERIES"):
-            async_query_manager.init_app(self.superset_app)
+        async_query_manager.init_app(self.superset_app)
 
     def register_blueprints(self) -> None:
         for bp in self.config["BLUEPRINTS"]:

--- a/tests/integration_tests/async_events/api_tests.py
+++ b/tests/integration_tests/async_events/api_tests.py
@@ -20,6 +20,7 @@ from unittest import mock
 
 from superset.extensions import async_query_manager
 from tests.integration_tests.base_tests import SupersetTestCase
+from tests.integration_tests.conftest import with_feature_flags
 from tests.integration_tests.test_app import app
 
 
@@ -31,6 +32,7 @@ class TestAsyncEventApi(SupersetTestCase):
         uri = f"{base_uri}?last_id={last_id}" if last_id else base_uri
         return self.client.get(uri)
 
+    @with_feature_flags(GLOBAL_ASYNC_QUERIES=True)
     @mock.patch("uuid.uuid4", return_value=UUID)
     def test_events(self, mock_uuid4):
         async_query_manager.init_app(app)
@@ -44,6 +46,7 @@ class TestAsyncEventApi(SupersetTestCase):
         mock_xrange.assert_called_with(channel_id, "-", "+", 100)
         self.assertEqual(response, {"result": []})
 
+    @with_feature_flags(GLOBAL_ASYNC_QUERIES=True)
     @mock.patch("uuid.uuid4", return_value=UUID)
     def test_events_last_id(self, mock_uuid4):
         async_query_manager.init_app(app)
@@ -57,6 +60,7 @@ class TestAsyncEventApi(SupersetTestCase):
         mock_xrange.assert_called_with(channel_id, "1607471525180-1", "+", 100)
         self.assertEqual(response, {"result": []})
 
+    @with_feature_flags(GLOBAL_ASYNC_QUERIES=True)
     @mock.patch("uuid.uuid4", return_value=UUID)
     def test_events_results(self, mock_uuid4):
         async_query_manager.init_app(app)
@@ -106,11 +110,13 @@ class TestAsyncEventApi(SupersetTestCase):
         }
         self.assertEqual(response, expected)
 
+    @with_feature_flags(GLOBAL_ASYNC_QUERIES=True)
     def test_events_no_login(self):
         async_query_manager.init_app(app)
         rv = self.fetch_events()
         assert rv.status_code == 401
 
+    @with_feature_flags(GLOBAL_ASYNC_QUERIES=True)
     def test_events_no_token(self):
         self.login(username="admin")
         self.client.set_cookie(


### PR DESCRIPTION
### SUMMARY
Refactors and updates the initialization of `GLOBAL_ASYNC_QUERIES` to support dynamic feature flags set at runtime.

Net impact is the addition of the no-op `after_request` hook when the flag is disabled.

### TESTING INSTRUCTIONS
Superset should function normally with the `GLOBAL_ASYNC_QUERIES` feature flag enabled and disabled.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
