### PR TITLE
fix(docker): add ecpg to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,7 @@ RUN mkdir -p ${PYTHONPATH} \
             default-libmysqlclient-dev \
             libsasl2-modules-gssapi-mit \
             libpq-dev \
+            libecpg-dev \
         && rm -rf /var/lib/apt/lists/*
 
 COPY --from=superset-py /usr/local/lib/python3.8/site-packages/ /usr/local/lib/python3.8/site-packages/


### PR DESCRIPTION
### SUMMARY
When enabling the Postgres validator, the `docker-compose` returns the following error:
![image](https://user-images.githubusercontent.com/33317356/131839762-d57df9f4-8772-4fe5-a167-bae24d2aa593.png)

After adding `libecpq-dev` to the "Final lean image" (which is also installed on the pip install image), the Postgres query validator works correctly:
![image](https://user-images.githubusercontent.com/33317356/131839873-7a201e00-8a08-438f-a319-6ec8b274e725.png)

### TESTING INSTRUCTIONS
1. add the following feature flag to `docker/pythonpath_dev/superset_config_docker.py`:
```
FEATURE_FLAGS = {
    "SQL_VALIDATORS_BY_ENGINE": {"postgresql": "PostgreSQLValidator"},
}
```
2. Run `docker-compose up`
3. Open SQL Lab and write an incorrect query
4. See the validator raise an error correctly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
