### PR TITLE
fix(tests): make parquet select deterministic with order by

### DIFF
--- a/tests/integration_tests/csv_upload_tests.py
+++ b/tests/integration_tests/csv_upload_tests.py
@@ -420,7 +420,7 @@ def test_import_parquet(setup_csv_upload, create_columnar_files):
     data = (
         get_upload_db()
         .get_sqla_engine()
-        .execute(f"SELECT * from {PARQUET_UPLOAD_TABLE}")
+        .execute(f"SELECT * from {PARQUET_UPLOAD_TABLE} ORDER BY b")
         .fetchall()
     )
     assert data == [("john", 1), ("paul", 2)]
@@ -435,7 +435,7 @@ def test_import_parquet(setup_csv_upload, create_columnar_files):
     data = (
         get_upload_db()
         .get_sqla_engine()
-        .execute(f"SELECT * from {PARQUET_UPLOAD_TABLE}")
+        .execute(f"SELECT * from {PARQUET_UPLOAD_TABLE} ORDER BY b")
         .fetchall()
     )
     assert data == [("john", 1), ("paul", 2), ("max", 3), ("bob", 4)]


### PR DESCRIPTION
### SUMMARY
A recently added unit test is causing flaky test results due to non-deterministic ordering of results.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
