### PR TITLE
fix: Remove export CSV in old filter box

### DIFF
--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
@@ -36,7 +36,7 @@ jest.mock('src/common/components', () => {
   };
 });
 
-const createProps = () => ({
+const createProps = (viz_type = 'sunburst') => ({
   addDangerToast: jest.fn(),
   addSuccessToast: jest.fn(),
   exploreChart: jest.fn(),
@@ -67,9 +67,9 @@ const createProps = () => ({
       time_range: 'No filter',
       time_range_endpoints: ['inclusive', 'exclusive'],
       url_params: {},
-      viz_type: 'sunburst',
+      viz_type,
     },
-    viz_type: 'sunburst',
+    viz_type,
     datasource: '58__table',
     description: 'test-description',
     description_markeddown: '',
@@ -152,25 +152,30 @@ test('Should "export to CSV"', () => {
   expect(props.exportCSV).toBeCalledWith(371);
 });
 
+test('Should not show "Export to CSV" if slice is filter box', () => {
+  const props = createProps('filter_box');
+  render(<SliceHeaderControls {...props} />, { useRedux: true });
+  expect(screen.queryByRole('menuitem', { name: 'Export CSV' })).toBe(null);
+});
+
 test('Export full CSV is under featureflag', () => {
   // @ts-ignore
   global.featureFlags = {
     [FeatureFlag.ALLOW_FULL_CSV_EXPORT]: false,
   };
-  const props = createProps();
-  props.slice.viz_type = 'table';
+  const props = createProps('table');
   render(<SliceHeaderControls {...props} />, { useRedux: true });
   expect(screen.queryByRole('menuitem', { name: 'Export full CSV' })).toBe(
     null,
   );
 });
+
 test('Should "export full CSV"', () => {
   // @ts-ignore
   global.featureFlags = {
     [FeatureFlag.ALLOW_FULL_CSV_EXPORT]: true,
   };
-  const props = createProps();
-  props.slice.viz_type = 'table';
+  const props = createProps('table');
   render(<SliceHeaderControls {...props} />, { useRedux: true });
   expect(screen.queryByRole('menuitem', { name: 'Export full CSV' })).not.toBe(
     null,
@@ -187,6 +192,18 @@ test('Should not show export full CSV if report is not table', () => {
     [FeatureFlag.ALLOW_FULL_CSV_EXPORT]: true,
   };
   const props = createProps();
+  render(<SliceHeaderControls {...props} />, { useRedux: true });
+  expect(screen.queryByRole('menuitem', { name: 'Export full CSV' })).toBe(
+    null,
+  );
+});
+
+test('Should not show export full CSV if slice is filter box', () => {
+  // @ts-ignore
+  global.featureFlags = {
+    [FeatureFlag.ALLOW_FULL_CSV_EXPORT]: true,
+  };
+  const props = createProps('filter_box');
   render(<SliceHeaderControls {...props} />, { useRedux: true });
   expect(screen.queryByRole('menuitem', { name: 'Export full CSV' })).toBe(
     null,

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -328,16 +328,20 @@ class SliceHeaderControls extends React.PureComponent<
           {t('Download as image')}
         </Menu.Item>
 
-        {this.props.supersetCanCSV && (
-          <Menu.Item key={MENU_KEYS.EXPORT_CSV}>{t('Export CSV')}</Menu.Item>
-        )}
-        {isFeatureEnabled(FeatureFlag.ALLOW_FULL_CSV_EXPORT) &&
+        {this.props.slice.viz_type !== 'filter_box' &&
+          this.props.supersetCanCSV && (
+            <Menu.Item key={MENU_KEYS.EXPORT_CSV}>{t('Export CSV')}</Menu.Item>
+          )}
+
+        {this.props.slice.viz_type !== 'filter_box' &&
+          isFeatureEnabled(FeatureFlag.ALLOW_FULL_CSV_EXPORT) &&
           this.props.supersetCanCSV &&
           isTable && (
             <Menu.Item key={MENU_KEYS.EXPORT_FULL_CSV}>
               {t('Export full CSV')}
             </Menu.Item>
           )}
+
         {isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS) &&
           isCrossFilter &&
           canEmitCrossFilter && (


### PR DESCRIPTION
### SUMMARY
There is no reason to export Filter box to CSV, we should remove Export CSV link as well as Export Full CSV link in filter box.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before
![image](https://user-images.githubusercontent.com/7106179/132113659-60587bae-d03d-497f-93c5-84f2751c7166.png)

After
![image](https://user-images.githubusercontent.com/7106179/132113674-118b07e7-7b7c-4673-b6a2-c7fb19b091f7.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #14189
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
