### PR TITLE
refactor: sql_json view endpoint: separate concern into ad hod method

### DIFF
--- a/superset/utils/sqllab_execution_context.py
+++ b/superset/utils/sqllab_execution_context.py
@@ -105,7 +105,7 @@ class SqlJsonExecutionContext:  # pylint: disable=too-many-instance-attributes
             limit = 0
         return limit
 
-    def _get_user_id(self) -> Optional[int]:  # pylint: disable=R0201
+    def _get_user_id(self) -> Optional[int]:  # pylint: disable=no-self-use
         try:
             return g.user.get_id() if g.user else None
         except RuntimeError:
@@ -135,7 +135,7 @@ class SqlJsonExecutionContext:  # pylint: disable=too-many-instance-attributes
         pass
 
     def create_query(self) -> Query:
-        # pylint: disable=C0301
+        # pylint: disable=line-too-long
         start_time = now_as_float()
         if self.select_as_cta:
             return Query(
@@ -167,7 +167,7 @@ class SqlJsonExecutionContext:  # pylint: disable=too-many-instance-attributes
         )
 
 
-class CreateTableAsSelect:  # pylint: disable=R0903
+class CreateTableAsSelect:  # pylint: disable=too-few-public-methods
     ctas_method: CtasMethod
     target_schema_name: Optional[str]
     target_table_name: str

--- a/tests/integration_tests/sqllab_tests.py
+++ b/tests/integration_tests/sqllab_tests.py
@@ -63,7 +63,6 @@ QUERY_2 = "SELECT * FROM NO_TABLE"
 QUERY_3 = "SELECT * FROM birth_names LIMIT 10"
 
 
-@pytest.mark.sqllab
 class TestSqlLab(SupersetTestCase):
     """Testings for Sql Lab"""
 


### PR DESCRIPTION
SUMMARY
The sql_json view code in superset core view without any "clean code" standard and it does not adopt any software development principle.
This is the fourth PR in the sequence of future PRs ([previous PR](https://github.com/apache/superset/pull/16548)) try to solve it by refactoring the code.
The PR focus of separate concern into ad hod method so the code will be cleaner 
there are no logic changes so it implies on the current tests.