### PR TITLE
feat: add resample operator in post processing

### DIFF
--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -749,6 +749,7 @@ class ChartDataPostProcessingOperationSchema(Schema):
                 "sort",
                 "diff",
                 "compare",
+                "resample",
             )
         ),
         example="aggregate",

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -923,7 +923,7 @@ def resample(
     rule: str,
     method: str,
     time_column: str,
-    fill_value: Optional[Union[float, int]],
+    fill_value: Optional[Union[float, int]] = None,
 ) -> DataFrame:
     """
     resample a timeseries dataframe.

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -919,7 +919,11 @@ def boxplot(
 
 
 def resample(
-    df: DataFrame, resample_rule: str, resample_method: str, time_column: str,
+    df: DataFrame,
+    resample_rule: str,
+    resample_method: str,
+    time_column: str,
+    resample_fill_zero: bool = False,
 ) -> DataFrame:
     """
     resample a timeseries dataframe.
@@ -928,10 +932,13 @@ def resample(
     :param resample_rule: The offset string representing target conversion.
     :param resample_method: How to fill the NaN value after resample.
     :param time_column: existing columns in DataFrame.
+    :param resample_fill_zero: fill missing values with zero.
     :return: DataFrame after resample
     :raises QueryObjectValidationError: If the request in incorrect
     """
-    df.set_index(time_column, inplace=True)
-    df = getattr(df.resample(resample_rule), resample_method)()
-    df.reset_index(inplace=True)
-    return df
+    df = df.set_index(time_column)
+    if resample_method == "asfreq" and resample_fill_zero:
+        df = df.resample(resample_rule).asfreq(fill_value=0)
+    else:
+        df = getattr(df.resample(resample_rule), resample_method)()
+    return df.reset_index()

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -920,25 +920,25 @@ def boxplot(
 
 def resample(
     df: DataFrame,
-    resample_rule: str,
-    resample_method: str,
+    rule: str,
+    method: str,
     time_column: str,
-    resample_fill_zero: bool = False,
+    fill_value: Optional[Union[float, int]],
 ) -> DataFrame:
     """
     resample a timeseries dataframe.
 
     :param df: DataFrame to resample.
-    :param resample_rule: The offset string representing target conversion.
-    :param resample_method: How to fill the NaN value after resample.
+    :param rule: The offset string representing target conversion.
+    :param method: How to fill the NaN value after resample.
     :param time_column: existing columns in DataFrame.
-    :param resample_fill_zero: fill missing values with zero.
+    :param fill_value: What values do fill missing.
     :return: DataFrame after resample
     :raises QueryObjectValidationError: If the request in incorrect
     """
     df = df.set_index(time_column)
-    if resample_method == "asfreq" and resample_fill_zero:
-        df = df.resample(resample_rule).asfreq(fill_value=0)
+    if method == "asfreq" and fill_value is not None:
+        df = df.resample(rule).asfreq(fill_value=fill_value)
     else:
-        df = getattr(df.resample(resample_rule), resample_method)()
+        df = getattr(df.resample(rule), method)()
     return df.reset_index()

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -916,3 +916,22 @@ def boxplot(
         for metric in metrics
     }
     return aggregate(df, groupby=groupby, aggregates=aggregates)
+
+
+def resample(
+    df: DataFrame, resample_rule: str, resample_method: str, time_column: str,
+) -> DataFrame:
+    """
+    resample a timeseries dataframe.
+
+    :param df: DataFrame to resample.
+    :param resample_rule: The offset string representing target conversion.
+    :param resample_method: How to fill the NaN value after resample.
+    :param time_column: existing columns in DataFrame.
+    :return: DataFrame after resample
+    :raises QueryObjectValidationError: If the request in incorrect
+    """
+    df.set_index(time_column, inplace=True)
+    df = getattr(df.resample(resample_rule), resample_method)()
+    df.reset_index(inplace=True)
+    return df

--- a/tests/integration_tests/pandas_postprocessing_tests.py
+++ b/tests/integration_tests/pandas_postprocessing_tests.py
@@ -886,3 +886,13 @@ class TestPostProcessing(SupersetTestCase):
             post_df["label"].tolist(), ["x", "y", "y", "y", "z", "z", "q"]
         )
         self.assertListEqual(post_df["y"].tolist(), [1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 4.0])
+
+        post_df = proc.resample(
+            df=df,
+            resample_rule="1D",
+            resample_method="asfreq",
+            time_column="time_column",
+            resample_fill_zero=True,
+        )
+        self.assertListEqual(post_df["label"].tolist(), ["x", "y", 0, 0, "z", 0, "q"])
+        self.assertListEqual(post_df["y"].tolist(), [1.0, 2.0, 0, 0, 3.0, 0, 4.0])

--- a/tests/integration_tests/pandas_postprocessing_tests.py
+++ b/tests/integration_tests/pandas_postprocessing_tests.py
@@ -872,11 +872,12 @@ class TestPostProcessing(SupersetTestCase):
             )
 
     def test_resample(self):
-        timeseries_df.index.name = "time_column"
-        timeseries_df.reset_index(inplace=True)
+        df = timeseries_df.copy()
+        df.index.name = "time_column"
+        df.reset_index(inplace=True)
 
         post_df = proc.resample(
-            df=timeseries_df,
+            df=df,
             resample_rule="1D",
             resample_method="ffill",
             time_column="time_column",

--- a/tests/integration_tests/pandas_postprocessing_tests.py
+++ b/tests/integration_tests/pandas_postprocessing_tests.py
@@ -877,10 +877,7 @@ class TestPostProcessing(SupersetTestCase):
         df.reset_index(inplace=True)
 
         post_df = proc.resample(
-            df=df,
-            resample_rule="1D",
-            resample_method="ffill",
-            time_column="time_column",
+            df=df, rule="1D", method="ffill", time_column="time_column",
         )
         self.assertListEqual(
             post_df["label"].tolist(), ["x", "y", "y", "y", "z", "z", "q"]
@@ -888,11 +885,7 @@ class TestPostProcessing(SupersetTestCase):
         self.assertListEqual(post_df["y"].tolist(), [1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 4.0])
 
         post_df = proc.resample(
-            df=df,
-            resample_rule="1D",
-            resample_method="asfreq",
-            time_column="time_column",
-            resample_fill_zero=True,
+            df=df, rule="1D", method="asfreq", time_column="time_column", fill_value=0,
         )
         self.assertListEqual(post_df["label"].tolist(), ["x", "y", 0, 0, "z", 0, "q"])
         self.assertListEqual(post_df["y"].tolist(), [1.0, 2.0, 0, 0, 3.0, 0, 4.0])

--- a/tests/integration_tests/pandas_postprocessing_tests.py
+++ b/tests/integration_tests/pandas_postprocessing_tests.py
@@ -870,3 +870,18 @@ class TestPostProcessing(SupersetTestCase):
                 metrics=["cars"],
                 percentiles=[10, 90, 10],
             )
+
+    def test_resample(self):
+        timeseries_df.index.name = "time_column"
+        timeseries_df.reset_index(inplace=True)
+
+        post_df = proc.resample(
+            df=timeseries_df,
+            resample_rule="1D",
+            resample_method="ffill",
+            time_column="time_column",
+        )
+        self.assertListEqual(
+            post_df["label"].tolist(), ["x", "y", "y", "y", "z", "z", "q"]
+        )
+        self.assertListEqual(post_df["y"].tolist(), [1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 4.0])


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
introduce resample operator in post processing
frontend codes at: https://github.com/apache-superset/superset-ui/pull/1349

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### After
<img width="1472" alt="image" src="https://user-images.githubusercontent.com/2016594/132201953-55a04ea6-e1a9-45b4-be0d-59e055bf4c79.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Select `Time-series Line Chart`
1. Select `birth_names` dataset
2. `time grain` set to `Year`; `Time rang` set to `2000 - 2005`
3. Resample rule set to `1D`
4. Resample method set to `ffill`
5. Run query




### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
