### PR TITLE
fix: Normalise `*.sh` File Endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docker/**/*.sh text eol=lf


### PR DESCRIPTION
### SUMMARY

Windows users encounter problems running the `docker-compose` commands
 to run an instance of Superset.

The reason for this is line-endings for the `*.sh` files that are
 mounted and used in the `command` sections for the superset images.

Many Windows users will check the repository out with line endings set
 to `CRLF`. When mounted in to the *nix-based containers, these line
 endings are not understood, leading to errors such as:

```text
/usr/bin/env: bash\r: No such file or directory
```

The addition of a `.gitattributes` file resolves this issue by telling
 git to always resolve these files with `LF` line endings.

fixes #10132

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
