### PR TITLE
fix: TemporalWrapperType string representation

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1295,7 +1295,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
             # using datetimes
             if generic_type == GenericDataType.TEMPORAL:
                 column_type = literal_dttm_type_factory(
-                    type(column_type), cls, native_type or ""
+                    column_type, cls, native_type or ""
                 )
             is_dttm = generic_type == GenericDataType.TEMPORAL
             return ColumnSpec(

--- a/superset/models/sql_types/base.py
+++ b/superset/models/sql_types/base.py
@@ -26,10 +26,8 @@ if TYPE_CHECKING:
 
 
 def literal_dttm_type_factory(
-    sqla_type: Type[types.TypeEngine],
-    db_engine_spec: Type["BaseEngineSpec"],
-    col_type: str,
-) -> Type[types.TypeEngine]:
+    sqla_type: types.TypeEngine, db_engine_spec: Type["BaseEngineSpec"], col_type: str,
+) -> types.TypeEngine:
     """
     Create a custom SQLAlchemy type that supports datetime literal binds.
 
@@ -39,7 +37,7 @@ def literal_dttm_type_factory(
     :return: SQLAlchemy type that supports using datetima as literal bind
     """
     # pylint: disable=too-few-public-methods
-    class TemporalWrapperType(sqla_type):  # type: ignore
+    class TemporalWrapperType(type(sqla_type)):  # type: ignore
         # pylint: disable=unused-argument
         def literal_processor(self, dialect: Dialect) -> Callable[[Any], Any]:
             def process(value: Any) -> Any:
@@ -58,4 +56,4 @@ def literal_dttm_type_factory(
 
             return process
 
-    return TemporalWrapperType
+    return TemporalWrapperType()

--- a/tests/integration_tests/db_engine_specs/presto_tests.py
+++ b/tests/integration_tests/db_engine_specs/presto_tests.py
@@ -561,11 +561,13 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
         self.assertEqual(column_spec.generic_type, GenericDataType.NUMERIC)
 
         column_spec = PrestoEngineSpec.get_column_spec("time")
-        assert issubclass(column_spec.sqla_type, types.Time)
+        assert isinstance(column_spec.sqla_type, types.Time)
+        assert type(column_spec.sqla_type).__name__ == "TemporalWrapperType"
         self.assertEqual(column_spec.generic_type, GenericDataType.TEMPORAL)
 
         column_spec = PrestoEngineSpec.get_column_spec("timestamp")
-        assert issubclass(column_spec.sqla_type, types.TIMESTAMP)
+        assert isinstance(column_spec.sqla_type, types.TIMESTAMP)
+        assert type(column_spec.sqla_type).__name__ == "TemporalWrapperType"
         self.assertEqual(column_spec.generic_type, GenericDataType.TEMPORAL)
 
         sqla_type = PrestoEngineSpec.get_sqla_column_type(None)

--- a/tests/integration_tests/model_tests.py
+++ b/tests/integration_tests/model_tests.py
@@ -24,11 +24,14 @@ from tests.integration_tests.fixtures.birth_names_dashboard import (
 
 import pytest
 from sqlalchemy.engine.url import make_url
+from sqlalchemy.types import DateTime
 
 import tests.integration_tests.test_app
 from superset import app, db as metadata_db
+from superset.db_engine_specs.postgres import PostgresEngineSpec
 from superset.models.core import Database
 from superset.models.slice import Slice
+from superset.models.sql_types.base import literal_dttm_type_factory
 from superset.utils.core import get_example_database, QueryStatus
 
 from .base_tests import SupersetTestCase
@@ -516,3 +519,10 @@ class TestSqlaTableModel(SupersetTestCase):
         assert set(data_for_slices["verbose_map"].keys()) == set(
             ["__timestamp", "sum__num", "gender",]
         )
+
+
+def test_literal_dttm_type_factory():
+    orig_type = DateTime()
+    new_type = literal_dttm_type_factory(orig_type, PostgresEngineSpec, "TIMESTAMP")
+    assert type(new_type).__name__ == "TemporalWrapperType"
+    assert str(new_type) == str(orig_type)


### PR DESCRIPTION
### SUMMARY

Currently the temporal wrapper class used by the sqla model returns `Type[TypeEngine]`, although it should be returning an instantiated `TypeEngine`, which results in an incorrect string representation of the type object. This doesn't affect regular query generation (the types and instances can mostly be used interchangeably when writing SqlAlchemy code), but causes trouble in the Presto db engine spec here:
https://github.com/apache/superset/blob/3fe2e6ec731529ae228904b9b5e39baec073ae8d/superset/db_engine_specs/presto.py#L385-L407

and more specifically here (notice how the expected data type for `data_type` is `types.TypeEngine`, not `Type[types.TypeEngine]`):
https://github.com/apache/superset/blob/3fe2e6ec731529ae228904b9b5e39baec073ae8d/superset/db_engine_specs/presto.py#L293-L303

Without this fix the new test fails with the following error:

```
>       assert str(new_type) == str(orig_type)
E       assert "<class 'supe...WrapperType'>" == 'DATETIME'
E         - DATETIME
E         + <class 'superset.models.sql_types.base.literal_dttm_type_factory.<locals>.TemporalWrapperType'>
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #16258
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
