### PR TITLE
fix(explore): fix local development explore error

### DIFF
--- a/superset-frontend/src/explore/components/DataTablesPane/index.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/index.tsx
@@ -225,7 +225,7 @@ export const DataTablesPane = ({
 
   useEffect(() => {
     if (queriesResponse && chartStatus === 'success') {
-      const { colnames } = queriesResponse[0];
+      const { colnames = [] } = queriesResponse[0];
       setColumnNames([...colnames]);
     }
   }, [queriesResponse]);


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In local development, when directory to explore,  the colnames returns null, and can not been iterate, which will stop the rest local development steps.
### BEFORE SCREENSHOTS OR ANIMATED GIF
<img width="1405" alt="Screen Shot 2021-09-08 at 11 36 36 AM" src="https://user-images.githubusercontent.com/51693396/132442608-8497574c-3e0e-482c-9246-5161d9faa4b9.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Reproduce: chart list / welcome -> select birth_names related chart(eg: Pivot Table, Top 10 Boy Name Share).


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
