### PR TITLE
fix(sqla): support for date adhoc filter

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -250,7 +250,11 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
             types.DateTime(),
             GenericDataType.TEMPORAL,
         ),
-        (re.compile(r"^date", re.IGNORECASE), types.Date(), GenericDataType.TEMPORAL,),
+        (
+            re.compile(r"^date", re.IGNORECASE),
+            types.DateTime(),
+            GenericDataType.TEMPORAL,
+        ),
         (
             re.compile(r"^timestamp", re.IGNORECASE),
             types.TIMESTAMP(),

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -508,7 +508,7 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
         ),
         (
             re.compile(r"^date.*", re.IGNORECASE),
-            types.DATE(),
+            types.DATETIME(),
             utils.GenericDataType.TEMPORAL,
         ),
         (


### PR DESCRIPTION
### SUMMARY
When sending a temporal Native Value Filter to a chart with a `DATE` column, the query errors out. This is due all temporal filters being encoded as `datetime.datetime` objects, irrespective of the target column being `DATE`, `DATETIME` or `TIMESTAMP` (we handle formatting of the temporal value in `BaseEngineSpec.convert_dttm`). This error is due to the SqlAlchemy `Date` and `Datetime` column types not being able to handle `datetime` and `date` objects respectively.

This PR replaces the SqlAlchemy `Date` type with `DateTime`, making it compatible with the logic in `sqla/models.py`.

### AFTER
![image](https://user-images.githubusercontent.com/33317356/132498010-79fddec4-4d76-4fd3-a2ab-bc289dbf2f2e.png)

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/132498160-b35c03f8-f927-47c3-8760-2d492f534564.png)
![image](https://user-images.githubusercontent.com/33317356/132498177-1898cebc-06bc-43b0-8a45-c6fd53dc15cf.png)

### TESTING INSTRUCTIONS
1. create a chart from a datasource that has a temporal column with `DATE` type
2. Add it to a dashboard and create a Value Filter referencing the `DATE` column
3. Emit a filter
4. See error

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
