### PR TITLE
fix: Ensure alerts & reports aren't schduled when flag is off

### DIFF
--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -19,7 +19,7 @@ import logging
 from celery.exceptions import SoftTimeLimitExceeded
 from dateutil import parser
 
-from superset import app
+from superset import app, is_feature_enabled
 from superset.commands.exceptions import CommandException
 from superset.extensions import celery_app
 from superset.reports.commands.exceptions import ReportScheduleUnexpectedError
@@ -37,6 +37,8 @@ def scheduler() -> None:
     """
     Celery beat main scheduler for reports
     """
+    if not is_feature_enabled("ALERT_REPORTS"):
+        return
     with session_scope(nullpool=True) as session:
         active_schedules = ReportScheduleDAO.find_active(session)
         for active_schedule in active_schedules:

--- a/tests/integration_tests/reports/scheduler_tests.py
+++ b/tests/integration_tests/reports/scheduler_tests.py
@@ -136,4 +136,3 @@ def test_scheduler_feature_flag_off(execute_mock, is_feature_enabled):
             assert len(execute_mock.call_args) == 0
         db.session.delete(report_schedule)
         db.session.commit()
-        app.config["ALERT_REPORTS_WORKING_TIME_OUT_KILL"] = True

--- a/tests/integration_tests/reports/scheduler_tests.py
+++ b/tests/integration_tests/reports/scheduler_tests.py
@@ -133,6 +133,6 @@ def test_scheduler_feature_flag_off(execute_mock, is_feature_enabled):
 
         with freeze_time("2020-01-01T09:00:00Z"):
             scheduler()
-            assert len(execute_mock.call_args) == 0
+            execute_mock.assert_not_called()
         db.session.delete(report_schedule)
         db.session.commit()

--- a/tests/integration_tests/reports/scheduler_tests.py
+++ b/tests/integration_tests/reports/scheduler_tests.py
@@ -118,7 +118,7 @@ def test_scheduler_celery_no_timeout_utc(execute_mock):
 
 @patch("superset.extensions.feature_flag_manager.is_feature_enabled")
 @patch("superset.tasks.scheduler.execute.apply_async")
-def test_scheduler_celery_no_timeout_utc(execute_mock, is_feature_enabled):
+def test_scheduler_feature_flag_off(execute_mock, is_feature_enabled):
     """
     Reports scheduler: Test scheduler with feature flag off
     """

--- a/tests/integration_tests/reports/scheduler_tests.py
+++ b/tests/integration_tests/reports/scheduler_tests.py
@@ -117,14 +117,14 @@ def test_scheduler_celery_no_timeout_utc(execute_mock):
         app.config["ALERT_REPORTS_WORKING_TIME_OUT_KILL"] = True
 
 
-@patch("superset.extensions.feature_flag_manager.is_feature_enabled")
+@patch("superset.tasks.scheduler.is_feature_enabled")
 @patch("superset.tasks.scheduler.execute.apply_async")
 def test_scheduler_feature_flag_off(execute_mock, is_feature_enabled):
     """
     Reports scheduler: Test scheduler with feature flag off
     """
-    is_feature_enabled("ALERT_REPORTS").return_value = False
     with app.app_context():
+        is_feature_enabled.return_value = False
         report_schedule = insert_report_schedule(
             type=ReportScheduleType.ALERT,
             name="report",

--- a/tests/integration_tests/reports/scheduler_tests.py
+++ b/tests/integration_tests/reports/scheduler_tests.py
@@ -116,6 +116,7 @@ def test_scheduler_celery_no_timeout_utc(execute_mock):
         db.session.commit()
         app.config["ALERT_REPORTS_WORKING_TIME_OUT_KILL"] = True
 
+
 @patch("superset.extensions.feature_flag_manager.is_feature_enabled")
 @patch("superset.tasks.scheduler.execute.apply_async")
 def test_scheduler_feature_flag_off(execute_mock, is_feature_enabled):

--- a/tests/integration_tests/reports/scheduler_tests.py
+++ b/tests/integration_tests/reports/scheduler_tests.py
@@ -122,7 +122,7 @@ def test_scheduler_feature_flag_off(execute_mock, is_feature_enabled):
     """
     Reports scheduler: Test scheduler with feature flag off
     """
-    is_feature_enabled("ALERT_REPORTS") = False
+    is_feature_enabled("ALERT_REPORTS").return_value = False
     with app.app_context():
         report_schedule = insert_report_schedule(
             type=ReportScheduleType.ALERT,


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, if there are active alerts & reports, they will be triggered even if the `ALERT_REPORTS` flag is turned off. This is a rare case, but it would make sense to stop these from triggering if the feature is off.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
