### PR TITLE
chore: Bump Flask-OpenID to 1.3.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -91,7 +91,7 @@ flask-login==0.4.1
     # via flask-appbuilder
 flask-migrate==3.1.0
     # via apache-superset
-flask-openid==1.2.5
+flask-openid==1.3.0
     # via flask-appbuilder
 flask-sqlalchemy==2.5.1
     # via


### PR DESCRIPTION
### SUMMARY
`setuptools` release 58.0.2 removed `use_2to3` and that broke Flask-OpenID that is a dependency on Flask-AppBuilder.
This caused Apache Superset installations with setuptools >= 58.0.2 to fail with:
```
error in Flask-OpenID setup command: use_2to3 is invalid.
```
Latest Flask-OpenID 1.3.0 removed `use_2to3` dependency and updated the code to python3.

More details here: https://github.com/mitsuhiko/flask-openid/issues/59 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
