### PR TITLE
fix: set importer as owner

### DIFF
--- a/superset/charts/commands/importers/v1/utils.py
+++ b/superset/charts/commands/importers/v1/utils.py
@@ -18,6 +18,7 @@
 import json
 from typing import Any, Dict
 
+from flask import g
 from sqlalchemy.orm import Session
 
 from superset.models.slice import Slice
@@ -38,5 +39,8 @@ def import_chart(
     chart = Slice.import_from_dict(session, config, recursive=False)
     if chart.id is None:
         session.flush()
+
+    if hasattr(g, "user") and g.user:
+        chart.owners.append(g.user)
 
     return chart

--- a/superset/dashboards/commands/importers/v1/utils.py
+++ b/superset/dashboards/commands/importers/v1/utils.py
@@ -19,6 +19,7 @@ import json
 import logging
 from typing import Any, Dict, Set
 
+from flask import g
 from sqlalchemy.orm import Session
 
 from superset.models.dashboard import Dashboard
@@ -154,5 +155,8 @@ def import_dashboard(
     dashboard = Dashboard.import_from_dict(session, config, recursive=False)
     if dashboard.id is None:
         session.flush()
+
+    if hasattr(g, "user") and g.user:
+        dashboard.owners.append(g.user)
 
     return dashboard

--- a/superset/datasets/commands/importers/v1/utils.py
+++ b/superset/datasets/commands/importers/v1/utils.py
@@ -22,7 +22,7 @@ from typing import Any, Dict
 from urllib import request
 
 import pandas as pd
-from flask import current_app
+from flask import current_app, g
 from sqlalchemy import BigInteger, Boolean, Date, DateTime, Float, String, Text
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.visitors import VisitableType
@@ -126,6 +126,9 @@ def import_dataset(
 
     if data_uri and (not table_exists or force_data):
         load_data(data_uri, dataset, example_database, session)
+
+    if hasattr(g, "user") and g.user:
+        dataset.owners.append(g.user)
 
     return dataset
 

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -1715,6 +1715,9 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         chart = db.session.query(Slice).filter_by(uuid=chart_config["uuid"]).one()
         assert chart.table == dataset
 
+        chart.owners = []
+        dataset.owners = []
+        database.owners = []
         db.session.delete(chart)
         db.session.delete(dataset)
         db.session.delete(database)
@@ -1784,6 +1787,9 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         dataset = database.tables[0]
         chart = db.session.query(Slice).filter_by(uuid=chart_config["uuid"]).one()
 
+        chart.owners = []
+        dataset.owners = []
+        database.owners = []
         db.session.delete(chart)
         db.session.delete(dataset)
         db.session.delete(database)

--- a/tests/integration_tests/charts/commands_tests.py
+++ b/tests/integration_tests/charts/commands_tests.py
@@ -226,9 +226,11 @@ class TestImportChartsCommand(SupersetTestCase):
         assert database.database_name == "imported_database"
         assert chart.table.database == database
 
-        assert dataset.owners == [mock_g.user]
         assert chart.owners == [mock_g.user]
 
+        chart.owners = []
+        dataset.owners = []
+        database.owners = []
         db.session.delete(chart)
         db.session.delete(dataset)
         db.session.delete(database)

--- a/tests/integration_tests/charts/commands_tests.py
+++ b/tests/integration_tests/charts/commands_tests.py
@@ -134,8 +134,10 @@ class TestExportChartsCommand(SupersetTestCase):
 
 
 class TestImportChartsCommand(SupersetTestCase):
-    def test_import_v1_chart(self):
+    @patch("superset.charts.commands.importers.v1.utils.g")
+    def test_import_v1_chart(self, mock_g):
         """Test that we can import a chart"""
+        mock_g.user = security_manager.find_user("admin")
         contents = {
             "metadata.yaml": yaml.safe_dump(chart_metadata_config),
             "databases/imported_database.yaml": yaml.safe_dump(database_config),
@@ -223,6 +225,9 @@ class TestImportChartsCommand(SupersetTestCase):
         )
         assert database.database_name == "imported_database"
         assert chart.table.database == database
+
+        assert dataset.owners == [mock_g.user]
+        assert chart.owners == [mock_g.user]
 
         db.session.delete(chart)
         db.session.delete(dataset)
@@ -332,7 +337,7 @@ class TestChartsUpdateCommand(SupersetTestCase):
     @patch("superset.security.manager.g")
     @pytest.mark.usefixtures("load_energy_table_with_slice")
     def test_query_context_update_command(self, mock_sm_g, mock_g):
-        """ "
+        """
         Test that a user can generate the chart query context
         payloadwithout affecting owners
         """

--- a/tests/integration_tests/dashboards/commands_tests.py
+++ b/tests/integration_tests/dashboards/commands_tests.py
@@ -546,10 +546,12 @@ class TestImportDashboardsCommand(SupersetTestCase):
         database = dataset.database
         assert str(database.uuid) == database_config["uuid"]
 
-        assert dataset.owners == [mock_g.user]
-        assert chart.owners == [mock_g.user]
         assert dashboard.owners == [mock_g.user]
 
+        dashboard.owners = []
+        chart.owners = []
+        dataset.owners = []
+        database.owners = []
         db.session.delete(dashboard)
         db.session.delete(chart)
         db.session.delete(dataset)

--- a/tests/integration_tests/dashboards/commands_tests.py
+++ b/tests/integration_tests/dashboards/commands_tests.py
@@ -463,8 +463,10 @@ class TestImportDashboardsCommand(SupersetTestCase):
         db.session.delete(dataset)
         db.session.commit()
 
-    def test_import_v1_dashboard(self):
+    @patch("superset.dashboards.commands.importers.v1.utils.g")
+    def test_import_v1_dashboard(self, mock_g):
         """Test that we can import a dashboard"""
+        mock_g.user = security_manager.find_user("admin")
         contents = {
             "metadata.yaml": yaml.safe_dump(dashboard_metadata_config),
             "databases/imported_database.yaml": yaml.safe_dump(database_config),
@@ -543,6 +545,10 @@ class TestImportDashboardsCommand(SupersetTestCase):
 
         database = dataset.database
         assert str(database.uuid) == database_config["uuid"]
+
+        assert dataset.owners == [mock_g.user]
+        assert chart.owners == [mock_g.user]
+        assert dashboard.owners == [mock_g.user]
 
         db.session.delete(dashboard)
         db.session.delete(chart)

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -1188,6 +1188,8 @@ class TestDatabaseApi(SupersetTestCase):
         assert dataset.table_name == "imported_dataset"
         assert str(dataset.uuid) == dataset_config["uuid"]
 
+        dataset.owners = []
+        database.owners = []
         db.session.delete(dataset)
         db.session.delete(database)
         db.session.commit()
@@ -1257,6 +1259,8 @@ class TestDatabaseApi(SupersetTestCase):
             db.session.query(Database).filter_by(uuid=database_config["uuid"]).one()
         )
         dataset = database.tables[0]
+        dataset.owners = []
+        database.owners = []
         db.session.delete(dataset)
         db.session.delete(database)
         db.session.commit()

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -1534,6 +1534,8 @@ class TestDatasetApi(SupersetTestCase):
         assert dataset.table_name == "imported_dataset"
         assert str(dataset.uuid) == dataset_config["uuid"]
 
+        dataset.owners = []
+        database.owners = []
         db.session.delete(dataset)
         db.session.delete(database)
         db.session.commit()
@@ -1626,6 +1628,8 @@ class TestDatasetApi(SupersetTestCase):
         )
         dataset = database.tables[0]
 
+        dataset.owners = []
+        database.owners = []
         db.session.delete(dataset)
         db.session.delete(database)
         db.session.commit()

--- a/tests/integration_tests/datasets/commands_tests.py
+++ b/tests/integration_tests/datasets/commands_tests.py
@@ -352,6 +352,8 @@ class TestImportDatasetsCommand(SupersetTestCase):
         assert column.description is None
         assert column.python_date_format is None
 
+        dataset.owners = []
+        dataset.database.owners = []
         db.session.delete(dataset)
         db.session.delete(dataset.database)
         db.session.commit()
@@ -473,6 +475,8 @@ class TestImportDatasetsCommand(SupersetTestCase):
         )
         assert len(database.tables) == 1
 
+        database.tables[0].owners = []
+        database.owners = []
         db.session.delete(database.tables[0])
         db.session.delete(database)
         db.session.commit()


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When importing a dataset, chart or dashboard, add the importer to the list of owners.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Import a dashboard.
2. Check that the user is an owner of the imported dashboard, as well as any associated charts and datasets.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
