### PR TITLE
fix: fix assignment in FilterBoxViz

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -2109,7 +2109,7 @@ class FilterBoxViz(BaseViz):
                         for row in df.itertuples(index=False)
                     ]
             else:
-                df[col] = []
+                d[col] = []
         return d
 
 

--- a/tests/integration_tests/viz_tests.py
+++ b/tests/integration_tests/viz_tests.py
@@ -1498,29 +1498,13 @@ class TestFilterBoxViz(SupersetTestCase):
         test_viz = viz.FilterBoxViz(datasource, form_data)
         test_viz.dataframes = {
             "value1": pd.DataFrame(
-                data=[
-                    {"value1": "v1", "metric1": 1},
-                    {"value1": "v2", "metric1": 2},
-                ]
+                data=[{"value1": "v1", "metric1": 1}, {"value1": "v2", "metric1": 2},]
             ),
             "value2": pd.DataFrame(
-                data=[
-                    {"value2": "v3", "metric2": 3},
-                    {"value2": "v4", "metric2": 4},
-                ]
+                data=[{"value2": "v3", "metric2": 3}, {"value2": "v4", "metric2": 4},]
             ),
-            "value3": pd.DataFrame(
-                data=[
-                    {"value3": "v5"},
-                    {"value3": "v6"},
-                ]
-            ),
-            "value4": pd.DataFrame(
-                data=[
-                    {"value4": "v7"},
-                    {"value4": "v8"},
-                ]
-            ),
+            "value3": pd.DataFrame(data=[{"value3": "v5"}, {"value3": "v6"},]),
+            "value4": pd.DataFrame(data=[{"value4": "v7"}, {"value4": "v8"},]),
             "value5": pd.DataFrame(),
         }
 
@@ -1535,14 +1519,8 @@ class TestFilterBoxViz(SupersetTestCase):
                 {"id": "v3", "text": "v3", "metric": 3},
                 {"id": "v4", "text": "v4", "metric": 4},
             ],
-            "value3": [
-                {"id": "v6", "text": "v6"},
-                {"id": "v5", "text": "v5"},
-            ],
-            "value4": [
-                {"id": "v7", "text": "v7"},
-                {"id": "v8", "text": "v8"},
-            ],
+            "value3": [{"id": "v6", "text": "v6"}, {"id": "v5", "text": "v5"},],
+            "value4": [{"id": "v7", "text": "v7"}, {"id": "v8", "text": "v8"},],
             "value5": [],
             "value6": [],
         }

--- a/tests/integration_tests/viz_tests.py
+++ b/tests/integration_tests/viz_tests.py
@@ -417,9 +417,7 @@ class TestTableViz(SupersetTestCase):
                 "label": "adhoc_metric",
                 "expressionType": "SIMPLE",
                 "aggregate": "SUM",
-                "column": {
-                    "column_name": "sort_column",
-                },
+                "column": {"column_name": "sort_column",},
             }
         )
 

--- a/tests/integration_tests/viz_tests.py
+++ b/tests/integration_tests/viz_tests.py
@@ -1480,3 +1480,70 @@ class TestPivotTableViz(SupersetTestCase):
     def test_format_datetime_from_int(self):
         assert viz.PivotTableViz._format_datetime(123) == 123
         assert viz.PivotTableViz._format_datetime(123.0) == 123.0
+
+class TestFilterBoxViz(SupersetTestCase):
+    def test_get_data(self):
+        form_data = {
+            "filter_configs": [
+                {"column": "value1", "metric": "metric1"},
+                {"column": "value2", "metric": "metric2", "asc": True},
+                {"column": "value3"},
+                {"column": "value4", "asc": True},
+                {"column": "value5"},
+                {"column": "value6",},
+            ],
+        }
+        datasource = self.get_datasource_mock()
+        test_viz = viz.FilterBoxViz(datasource, form_data)
+        test_viz.dataframes = {
+            "value1": pd.DataFrame(
+                data=[
+                    {"value1": "v1", "metric1": 1},
+                    {"value1": "v2", "metric1": 2},
+                ]
+            ),
+            "value2": pd.DataFrame(
+                data=[
+                    {"value2": "v3", "metric2": 3},
+                    {"value2": "v4", "metric2": 4},
+                ]
+            ),
+            "value3": pd.DataFrame(
+                data=[
+                    {"value3": "v5"},
+                    {"value3": "v6"},
+                ]
+            ),
+            "value4": pd.DataFrame(
+                data=[
+                    {"value4": "v7"},
+                    {"value4": "v8"},
+                ]
+            ),
+            "value5": pd.DataFrame(),
+        }
+
+
+        df = pd.DataFrame()
+        data = test_viz.get_data(df)
+        expected = {
+            "value1": [
+                {"id": "v2", "text": "v2", "metric": 2},
+                {"id": "v1", "text": "v1", "metric": 1},
+            ],
+            "value2": [
+                {"id": "v3", "text": "v3", "metric": 3},
+                {"id": "v4", "text": "v4", "metric": 4},
+            ],
+            "value3": [
+                {"id": "v6", "text": "v6"},
+                {"id": "v5", "text": "v5"},
+            ],
+            "value4": [
+                {"id": "v7", "text": "v7"},
+                {"id": "v8", "text": "v8"},
+            ],
+            "value5": [],
+            "value6": [],
+        }
+        self.assertEqual(expected, data)

--- a/tests/integration_tests/viz_tests.py
+++ b/tests/integration_tests/viz_tests.py
@@ -417,7 +417,9 @@ class TestTableViz(SupersetTestCase):
                 "label": "adhoc_metric",
                 "expressionType": "SIMPLE",
                 "aggregate": "SUM",
-                "column": {"column_name": "sort_column",},
+                "column": {
+                    "column_name": "sort_column",
+                },
             }
         )
 
@@ -1481,6 +1483,7 @@ class TestPivotTableViz(SupersetTestCase):
         assert viz.PivotTableViz._format_datetime(123) == 123
         assert viz.PivotTableViz._format_datetime(123.0) == 123.0
 
+
 class TestFilterBoxViz(SupersetTestCase):
     def test_get_data(self):
         form_data = {
@@ -1490,7 +1493,7 @@ class TestFilterBoxViz(SupersetTestCase):
                 {"column": "value3"},
                 {"column": "value4", "asc": True},
                 {"column": "value5"},
-                {"column": "value6",},
+                {"column": "value6"},
             ],
         }
         datasource = self.get_datasource_mock()
@@ -1522,7 +1525,6 @@ class TestFilterBoxViz(SupersetTestCase):
             ),
             "value5": pd.DataFrame(),
         }
-
 
         df = pd.DataFrame()
         data = test_viz.get_data(df)


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Just a small fix, assigning to the right object. 
Or, it will throw `TypeError: 'NoneType' object does not support item assignment` when `df` is None.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
