### PR TITLE
fix: reset perf logger timer for soft navigation for SPA pages

### DIFF
--- a/superset-frontend/src/dashboard/components/Dashboard.jsx
+++ b/superset-frontend/src/dashboard/components/Dashboard.jsx
@@ -101,7 +101,7 @@ class Dashboard extends React.PureComponent {
     const bootstrapData = appContainer?.getAttribute('data-bootstrap') || '';
     const { dashboardState, layout } = this.props;
     const eventData = {
-      is_soft_navigation: Logger.softNavigationStart > 0,
+      is_soft_navigation: Logger.timeOriginOffset > 0,
       is_edit_mode: dashboardState.editMode,
       mount_duration: Logger.getTimestamp(),
       is_empty: isDashboardEmpty(layout),

--- a/superset-frontend/src/dashboard/components/Dashboard.jsx
+++ b/superset-frontend/src/dashboard/components/Dashboard.jsx
@@ -101,6 +101,7 @@ class Dashboard extends React.PureComponent {
     const bootstrapData = appContainer?.getAttribute('data-bootstrap') || '';
     const { dashboardState, layout } = this.props;
     const eventData = {
+      is_soft_navigation: Logger.softNavigationStart > 0,
       is_edit_mode: dashboardState.editMode,
       mount_duration: Logger.getTimestamp(),
       is_empty: isDashboardEmpty(layout),

--- a/superset-frontend/src/logger/LogUtils.ts
+++ b/superset-frontend/src/logger/LogUtils.ts
@@ -59,8 +59,14 @@ export const LOG_EVENT_TYPE_USER = new Set([
 ]);
 
 export const Logger = {
+  softNavigationStart: 0,
+
+  resetStartTime() {
+    this.softNavigationStart = window.performance.now();
+  },
+
   // note that this returns ms since page load, NOT ms since epoch
   getTimestamp() {
-    return Math.round(window.performance.now());
+    return Math.round(window.performance.now() - this.softNavigationStart);
   },
 };

--- a/superset-frontend/src/logger/LogUtils.ts
+++ b/superset-frontend/src/logger/LogUtils.ts
@@ -65,7 +65,7 @@ export const Logger = {
     this.softNavigationStart = window.performance.now();
   },
 
-  // note that this returns ms since page load, NOT ms since epoch
+  // note that this returns ms since last navigation, NOT ms since epoch
   getTimestamp() {
     return Math.round(window.performance.now() - this.softNavigationStart);
   },

--- a/superset-frontend/src/logger/LogUtils.ts
+++ b/superset-frontend/src/logger/LogUtils.ts
@@ -59,14 +59,14 @@ export const LOG_EVENT_TYPE_USER = new Set([
 ]);
 
 export const Logger = {
-  softNavigationStart: 0,
+  timeOriginOffset: 0,
 
-  resetStartTime() {
-    this.softNavigationStart = window.performance.now();
+  markTimeOrigin() {
+    this.timeOriginOffset = window.performance.now();
   },
 
   // note that this returns ms since last navigation, NOT ms since epoch
   getTimestamp() {
-    return Math.round(window.performance.now() - this.softNavigationStart);
+    return Math.round(window.performance.now() - this.timeOriginOffset);
   },
 };

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -58,7 +58,7 @@ const RootContextProviders: React.FC = ({ children }) => {
     // reset performance logger timer start point to avoid soft navigation
     // cause dashboard perf measurement problem
     if (lastLocationPathname && lastLocationPathname !== location.pathname) {
-      Logger.resetStartTime();
+      Logger.markTimeOrigin();
     }
     lastLocationPathname = location.pathname;
   }, [location.pathname]);

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -39,7 +39,7 @@ import { theme } from 'src/preamble';
 import ToastPresenter from 'src/messageToasts/containers/ToastPresenter';
 import setupApp from 'src/setup/setupApp';
 import { routes, isFrontendRoute } from 'src/views/routes';
-import { Logger } from '../logger/LogUtils';
+import { Logger } from 'src/logger/LogUtils';
 import { store } from './store';
 
 setupApp();
@@ -49,7 +49,7 @@ const bootstrap = JSON.parse(container?.getAttribute('data-bootstrap') ?? '{}');
 const user = { ...bootstrap.user };
 const menu = { ...bootstrap.common.menu_data };
 const common = { ...bootstrap.common };
-let lastLocation: string;
+let lastLocationPathname: string;
 initFeatureFlags(bootstrap.common.feature_flags);
 
 const RootContextProviders: React.FC = ({ children }) => {
@@ -57,10 +57,10 @@ const RootContextProviders: React.FC = ({ children }) => {
   useEffect(() => {
     // reset performance logger timer start point to avoid soft navigation
     // cause dashboard perf measurement problem
-    if (lastLocation && lastLocation !== location.pathname) {
+    if (lastLocationPathname && lastLocationPathname !== location.pathname) {
       Logger.resetStartTime();
     }
-    lastLocation = location.pathname;
+    lastLocationPathname = location.pathname;
   }, [location.pathname]);
 
   return (

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -16,10 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { Suspense } from 'react';
+import React, { Suspense, useEffect } from 'react';
 import { hot } from 'react-hot-loader/root';
 import { Provider as ReduxProvider } from 'react-redux';
-import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
+import {
+  BrowserRouter as Router,
+  Switch,
+  Route,
+  useLocation,
+} from 'react-router-dom';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { QueryParamProvider } from 'use-query-params';
@@ -34,6 +39,7 @@ import { theme } from 'src/preamble';
 import ToastPresenter from 'src/messageToasts/containers/ToastPresenter';
 import setupApp from 'src/setup/setupApp';
 import { routes, isFrontendRoute } from 'src/views/routes';
+import { Logger } from '../logger/LogUtils';
 import { store } from './store';
 
 setupApp();
@@ -43,26 +49,39 @@ const bootstrap = JSON.parse(container?.getAttribute('data-bootstrap') ?? '{}');
 const user = { ...bootstrap.user };
 const menu = { ...bootstrap.common.menu_data };
 const common = { ...bootstrap.common };
+let lastLocation: string;
 initFeatureFlags(bootstrap.common.feature_flags);
 
-const RootContextProviders: React.FC = ({ children }) => (
-  <ThemeProvider theme={theme}>
-    <ReduxProvider store={store}>
-      <DndProvider backend={HTML5Backend}>
-        <FlashProvider messages={common.flash_messages}>
-          <DynamicPluginProvider>
-            <QueryParamProvider
-              ReactRouterRoute={Route}
-              stringifyOptions={{ encode: false }}
-            >
-              {children}
-            </QueryParamProvider>
-          </DynamicPluginProvider>
-        </FlashProvider>
-      </DndProvider>
-    </ReduxProvider>
-  </ThemeProvider>
-);
+const RootContextProviders: React.FC = ({ children }) => {
+  const location = useLocation();
+  useEffect(() => {
+    // reset performance logger timer start point to avoid soft navigation
+    // cause dashboard perf measurement problem
+    if (lastLocation && lastLocation !== location.pathname) {
+      Logger.resetStartTime();
+    }
+    lastLocation = location.pathname;
+  }, [location.pathname]);
+
+  return (
+    <ThemeProvider theme={theme}>
+      <ReduxProvider store={store}>
+        <DndProvider backend={HTML5Backend}>
+          <FlashProvider messages={common.flash_messages}>
+            <DynamicPluginProvider>
+              <QueryParamProvider
+                ReactRouterRoute={Route}
+                stringifyOptions={{ encode: false }}
+              >
+                {children}
+              </QueryParamProvider>
+            </DynamicPluginProvider>
+          </FlashProvider>
+        </DndProvider>
+      </ReduxProvider>
+    </ThemeProvider>
+  );
+};
 
 const App = () => (
   <Router>


### PR DESCRIPTION
### SUMMARY
We used some features from [HTML5 Performance API](https://developer.mozilla.org/en-US/docs/Web/API/Performance_API/Using_the_Performance_API) to track dashboard page load performance. After we started to use SPA to generate and soft navigate between pages, "navigation" is any subsequent route change. Performance API's start point is based on `onload` event, so if user switch between chart list, dash list and dashboard (these pages are built from SPA structure), the old measurement for dashboard page load time is not accurate anymore.

This PR uses location to detect soft navigation and reset logging time start point.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**BEFORE SPA**
<img width="723" alt="Screen Shot 2021-09-10 at 11 05 50 AM" src="https://user-images.githubusercontent.com/27990562/132898025-90d8c345-90df-4baf-82dc-683b9064b10f.png">



**AFTER FIX**
<img width="764" alt="Screen Shot 2021-09-11 at 3 53 43 PM" src="https://user-images.githubusercontent.com/27990562/132963482-a169f533-fcc7-40e4-b1e2-35bec3db7650.png">






### TESTING INSTRUCTIONS
CI and manual test

### ADDITIONAL INFORMATION
cc @etr2460 @ktmud 
