### PR TITLE
chore: Update OpenAPI definition /database/available

### DIFF
--- a/docs/src/resources/openapi.json
+++ b/docs/src/resources/openapi.json
@@ -9984,43 +9984,45 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "properties": {
-                      "available_drivers": {
-                        "description": "Installed drivers for the engine",
-                        "items": {
+                  "databases": {
+                    "items": {
+                      "properties": {
+                        "available_drivers": {
+                          "description": "Installed drivers for the engine",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "default_driver": {
+                          "description": "Default driver for the engine",
                           "type": "string"
                         },
-                        "type": "array"
+                        "engine": {
+                          "description": "Name of the SQLAlchemy engine",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the database",
+                          "type": "string"
+                        },
+                        "parameters": {
+                          "description": "JSON schema defining the needed parameters",
+                          "type": "object"
+                        },
+                        "preferred": {
+                          "description": "Is the database preferred?",
+                          "type": "boolean"
+                        },
+                        "sqlalchemy_uri_placeholder": {
+                          "description": "Example placeholder for the SQLAlchemy URI",
+                          "type": "string"
+                        }
                       },
-                      "default_driver": {
-                        "description": "Default driver for the engine",
-                        "type": "string"
-                      },
-                      "engine": {
-                        "description": "Name of the SQLAlchemy engine",
-                        "type": "string"
-                      },
-                      "name": {
-                        "description": "Name of the database",
-                        "type": "string"
-                      },
-                      "parameters": {
-                        "description": "JSON schema defining the needed parameters",
-                        "type": "object"
-                      },
-                      "preferred": {
-                        "description": "Is the database preferred?",
-                        "type": "boolean"
-                      },
-                      "sqlalchemy_uri_placeholder": {
-                        "description": "Example placeholder for the SQLAlchemy URI",
-                        "type": "string"
-                      }
+                      "type": "object"
                     },
-                    "type": "object"
-                  },
-                  "type": "array"
+                    "type": "array"
+                  }
                 }
               }
             },


### PR DESCRIPTION
### SUMMARY
Update OpenAPI definition for the latest API response for database available. In previous spec, it is list of object expected but from the API response it is dict that is the key "databases" followed by a list of objects. Example:
```json
{
  "databases": [
    {
      "available_drivers": [
        "psycopg2"
      ],
      "default_driver": "psycopg2",
      "engine": "postgresql",
      "name": "PostgreSQL",
      "parameters": {
        "properties": {
          "database": {
            "description": "Database name",
            "type": "string"
          },
          "encryption": {
            "description": "Use an encrypted connection to the database",
            "type": "boolean"
          },
          "host": {
            "description": "Hostname or IP address",
            "type": "string"
          },
          "password": {
            "description": "Password",
            "nullable": true,
            "type": "string"
          },
          "port": {
            "description": "Database port",
            "format": "int32",
            "maximum": 65536,
            "minimum": 0,
            "type": "integer"
          },
          "query": {
            "additionalProperties": {},
            "description": "Additional parameters",
            "type": "object"
          },
          "username": {
            "description": "Username",
            "nullable": true,
            "type": "string"
          }
        },
        "required": [
          "database",
          "host",
          "port",
          "username"
        ],
        "type": "object"
      },
      "preferred": true,
      "sqlalchemy_uri_placeholder": "postgresql://user:password@host:port/dbname[?key=value&key=value...]"
    },
    {
      "available_drivers": [
        "rest"
      ],
      "engine": "presto",
      "name": "Presto",
      "preferred": true
    },
    {
      "available_drivers": [
        "mysqldb"
      ],
      "default_driver": "mysqldb",
      "engine": "mysql",
      "name": "MySQL",
      "parameters": {
        "properties": {
          "database": {
            "description": "Database name",
            "type": "string"
          },
          "encryption": {
            "description": "Use an encrypted connection to the database",
            "type": "boolean"
          },
          "host": {
            "description": "Hostname or IP address",
            "type": "string"
          },
          "password": {
            "description": "Password",
            "nullable": true,
            "type": "string"
          },
          "port": {
            "description": "Database port",
            "format": "int32",
            "maximum": 65536,
            "minimum": 0,
            "type": "integer"
          },
          "query": {
            "additionalProperties": {},
            "description": "Additional parameters",
            "type": "object"
          },
          "username": {
            "description": "Username",
            "nullable": true,
            "type": "string"
          }
        },
        "required": [
          "database",
          "host",
          "port",
          "username"
        ],
        "type": "object"
      },
      "preferred": true,
      "sqlalchemy_uri_placeholder": "mysql://user:password@host:port/dbname[?key=value&key=value...]"
    },
    {
      "available_drivers": [
        "pysqlite"
      ],
      "engine": "sqlite",
      "name": "SQLite",
      "preferred": true
    },
    {
      "available_drivers": [
        "rest"
      ],
      "engine": "druid",
      "name": "Apache Druid",
      "preferred": false
    },
    {
      "available_drivers": [
        "thrift"
      ],
      "engine": "hive",
      "name": "Apache Hive",
      "preferred": false
    },
    {
      "available_drivers": [
        "thrift"
      ],
      "engine": "hive",
      "name": "Apache Spark SQL",
      "preferred": false
    }
  ]
}

```

### TESTING INSTRUCTIONS
Download the OpenAPI spec from http://localhost:8088/api/v1/_openapi
Generate client
```shell
java -jar openapi-generator-cli.jar generate -i ./openapi.json -g python -o ./superset_py/ --skip-validate-spec
```
Test code
```python
import openapi_client
from openapi_client.api.dashboards_api import DashboardsApi
from openapi_client.api.database_api import DatabaseApi

configuration = openapi_client.Configuration(
    host= "http://localhost:8088/api/v1",
    username="admin",
    password="admin")
api_client = openapi_client.ApiClient(configuration)
database_api = DatabaseApi(api_client)
databases = database_api.database_available_get()
print(databases)
```
