### PR TITLE
fix: report with timeout chart

### DIFF
--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -141,6 +141,7 @@ class WebDriverProxy:
             img = element.screenshot_as_png
         except TimeoutException:
             logger.warning("Selenium timed out requesting url %s", url, exc_info=True)
+            img = element.screenshot_as_png
         except StaleElementReferenceException:
             logger.error(
                 "Selenium got a stale element while requesting url %s",


### PR DESCRIPTION
### SUMMARY
A user schedule may an email report for a dashboard in the future time. When webdriver takes screeshot of the dashboard, one or more of its charts may not well cached, and may take pretty long time to query. Current webdriver wait timeout is 60 seconds. If one of charts didn't get rendered after timeout, currently Superset will report an email with following error message but no screenshot of dashboard.
```
Error: Report Schedule execution failed when generating a screenshot.
```

To most of dashboard report users, a report with a couple of timeout chart (showing spinner) is still acceptable, much better than an error message without report. Could we still send report with timeout chart? @dpgaspar @betodealmeida @eschutho 

### TESTING INSTRUCTIONS
CI and manual test


