### PR TITLE
refactor: sql_json view endpoint: extract methods

### DIFF
--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -19,7 +19,7 @@ import logging
 from celery.exceptions import SoftTimeLimitExceeded
 from dateutil import parser
 
-from superset import app
+from superset import app, is_feature_enabled
 from superset.commands.exceptions import CommandException
 from superset.extensions import celery_app
 from superset.reports.commands.exceptions import ReportScheduleUnexpectedError
@@ -37,6 +37,8 @@ def scheduler() -> None:
     """
     Celery beat main scheduler for reports
     """
+    if not is_feature_enabled("ALERT_REPORTS"):
+        return
     with session_scope(nullpool=True) as session:
         active_schedules = ReportScheduleDAO.find_active(session)
         for active_schedule in active_schedules:

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=comparison-with-callable, line-too-long
+from __future__ import annotations
+
 import dataclasses
 import logging
 import re
@@ -173,6 +175,8 @@ PARAMETER_MISSING_ERR = (
     "they match across your SQL query and Set Parameters. Then, try running "
     "your query again."
 )
+
+SqlResults = Optional[Dict[str, Any]]
 
 
 class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
@@ -2410,14 +2414,249 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
                 return json_error_response(f"{msg}", status=400)
             return json_error_response(f"{msg}")
 
+    @has_access_api
+    @handle_api_exception
+    @event_logger.log_this
+    @expose("/sql_json/", methods=["POST"])
+    def sql_json(self) -> FlaskResponse:
+        log_params = {
+            "user_agent": cast(Optional[str], request.headers.get("USER_AGENT"))
+        }
+        execution_context = SqlJsonExecutionContext(request.json)
+        return self.sql_json_exec(execution_context, log_params)
+
+    def sql_json_exec(  # pylint: disable=too-many-statements,useless-suppression
+        self,
+        execution_context: SqlJsonExecutionContext,
+        log_params: Optional[Dict[str, Any]] = None,
+    ) -> FlaskResponse:
+        """Runs arbitrary sql and returns data as json"""
+
+        session = db.session()
+
+        query = self._get_existing_query(execution_context, session)
+
+        if self.is_query_handled(query):
+            payload = self._convert_query_to_payload(cast(Query, query))
+            return json_success(payload)
+
+        return self._run_sql_json_exec_from_scratch(
+            execution_context, session, log_params
+        )
+
+    @classmethod
+    def _get_existing_query(
+        cls, execution_context: SqlJsonExecutionContext, session: Session
+    ) -> Optional[Query]:
+        query = (
+            session.query(Query)
+            .filter_by(
+                client_id=execution_context.client_id,
+                user_id=execution_context.user_id,
+                sql_editor_id=execution_context.sql_editor_id,
+            )
+            .one_or_none()
+        )
+        return query
+
+    @classmethod
+    def is_query_handled(cls, query: Optional[Query]) -> bool:
+        return query is not None and query.status in [
+            QueryStatus.RUNNING,
+            QueryStatus.PENDING,
+            QueryStatus.TIMED_OUT,
+        ]
+
+    @staticmethod
+    def _convert_query_to_payload(query: Query) -> str:
+        return json.dumps(
+            {"query": query.to_dict()},
+            default=utils.json_int_dttm_ser,
+            ignore_nan=True,
+        )
+
+    def _run_sql_json_exec_from_scratch(
+        self,
+        execution_context: SqlJsonExecutionContext,
+        session: Session,
+        log_params: Optional[Dict[str, Any]] = None,
+    ) -> FlaskResponse:
+        execution_context.set_database(
+            self._get_the_query_db(execution_context, session)
+        )
+        query = execution_context.create_query()
+        self._save_new_query(query, session)
+        logger.info("Triggering query_id: %i", query.id)
+        self._validate_access(query, session)
+        rendered_query = self._render_query(query, execution_context, session)
+
+        self._set_query_limit_if_required(execution_context, query, rendered_query)
+
+        return self._execute_query(
+            query, execution_context, rendered_query, session, log_params
+        )
+
+    @classmethod
+    def _get_the_query_db(
+        cls, execution_context: SqlJsonExecutionContext, session: Session
+    ) -> Database:
+        mydb = session.query(Database).get(execution_context.database_id)
+        cls._validate_query_db(mydb)
+        return mydb
+
+    @classmethod
+    def _validate_query_db(cls, database: Optional[Database]) -> None:
+        if not database:
+            raise SupersetGenericErrorException(
+                __(
+                    "The database referenced in this query was not found. Please "
+                    "contact an administrator for further assistance or try again."
+                )
+            )
+
+    def _save_new_query(  # pylint: disable=no-self-use
+        self, query: Query, session: Session
+    ) -> None:
+        try:
+            session.add(query)
+            session.flush()
+            session.commit()  # shouldn't be necessary
+        except SQLAlchemyError as ex:
+            logger.error("Errors saving query details %s", str(ex), exc_info=True)
+            session.rollback()
+        if not query.id:
+            raise SupersetGenericErrorException(
+                __(
+                    "The query record was not created as expected. Please "
+                    "contact an administrator for further assistance or try again."
+                )
+            )
+
+    def _validate_access(  # pylint: disable=no-self-use
+        self, query: Query, session: Session
+    ) -> None:
+        try:
+            query.raise_for_access()
+        except SupersetSecurityException as ex:
+            query.set_extra_json_key("errors", [dataclasses.asdict(ex.error)])
+            query.status = QueryStatus.FAILED
+            query.error_message = ex.error.message
+            session.commit()
+            raise SupersetErrorException(ex.error, status=403) from ex
+
+    def _render_query(  # pylint: disable=no-self-use
+        self, query: Query, execution_context: SqlJsonExecutionContext, session: Session
+    ) -> str:
+        def validate(
+            rendered_query: str, template_processor: BaseTemplateProcessor
+        ) -> None:
+            if is_feature_enabled("ENABLE_TEMPLATE_PROCESSING"):
+                # pylint: disable=protected-access
+                ast = template_processor._env.parse(rendered_query)
+                undefined_parameters = find_undeclared_variables(ast)  # type: ignore
+                if undefined_parameters:
+                    query.status = QueryStatus.FAILED
+                    session.commit()
+                    raise SupersetTemplateParamsErrorException(
+                        message=ngettext(
+                            "The parameter %(parameters)s in your query is undefined.",
+                            "The following parameters in your query are undefined: %(parameters)s.",
+                            len(undefined_parameters),
+                            parameters=utils.format_list(undefined_parameters),
+                        )
+                        + " "
+                        + PARAMETER_MISSING_ERR,
+                        error=SupersetErrorType.MISSING_TEMPLATE_PARAMS_ERROR,
+                        extra={
+                            "undefined_parameters": list(undefined_parameters),
+                            "template_parameters": execution_context.template_params,
+                        },
+                    )
+
+        try:
+            template_processor = get_template_processor(
+                database=query.database, query=query
+            )
+            rendered_query = template_processor.process_template(
+                query.sql, **execution_context.template_params
+            )
+            validate(rendered_query, template_processor)
+        except TemplateError as ex:
+            query.status = QueryStatus.FAILED
+            session.commit()
+            raise SupersetTemplateParamsErrorException(
+                message=__(
+                    'The query contains one or more malformed template parameters. Please check your query and confirm that all template parameters are surround by double braces, for example, "{{ ds }}". Then, try running your query again.'
+                ),
+                error=SupersetErrorType.INVALID_TEMPLATE_PARAMS_ERROR,
+            ) from ex
+
+        return rendered_query
+
+    def _set_query_limit_if_required(
+        self,
+        execution_context: SqlJsonExecutionContext,
+        query: Query,
+        rendered_query: str,
+    ) -> None:
+        if self._is_required_to_set_limit(execution_context):
+            self._set_query_limit(rendered_query, query, execution_context)
+
+    def _is_required_to_set_limit(  # pylint: disable=no-self-use
+        self, execution_context: SqlJsonExecutionContext
+    ) -> bool:
+        return not (
+            config.get("SQLLAB_CTAS_NO_LIMIT") and execution_context.select_as_cta
+        )
+
+    def _set_query_limit(  # pylint: disable=no-self-use
+        self,
+        rendered_query: str,
+        query: Query,
+        execution_context: SqlJsonExecutionContext,
+    ) -> None:
+        db_engine_spec = execution_context.database.db_engine_spec  # type: ignore
+        limits = [
+            db_engine_spec.get_limit_from_sql(rendered_query),
+            execution_context.limit,
+        ]
+        if limits[0] is None or limits[0] > limits[1]:  # type: ignore
+            query.limiting_factor = LimitingFactor.DROPDOWN
+        elif limits[1] > limits[0]:  # type: ignore
+            query.limiting_factor = LimitingFactor.QUERY
+        else:  # limits[0] == limits[1]
+            query.limiting_factor = LimitingFactor.QUERY_AND_DROPDOWN
+        query.limit = min(lim for lim in limits if lim is not None)
+
+    def _execute_query(  # pylint: disable=too-many-arguments
+        self,
+        query: Query,
+        execution_context: SqlJsonExecutionContext,
+        rendered_query: str,
+        session: Session,
+        log_params: Optional[Dict[str, Any]],
+    ) -> FlaskResponse:
+        # Flag for whether or not to expand data
+        # (feature that will expand Presto row objects and arrays)
+        expand_data: bool = execution_context.expand_data
+        # Async request.
+        if execution_context.is_run_asynchronous():
+            return self._sql_json_async(
+                query, rendered_query, expand_data, session, log_params
+            )
+        # Sync request.
+        return self._sql_json_sync(
+            query, rendered_query, expand_data, session, log_params
+        )
+
     @classmethod
     def _sql_json_async(  # pylint: disable=too-many-arguments
         cls,
-        session: Session,
-        rendered_query: str,
         query: Query,
+        rendered_query: str,
         expand_data: bool,
-        log_params: Optional[Dict[str, Any]] = None,
+        session: Session,
+        log_params: Optional[Dict[str, Any]],
     ) -> FlaskResponse:
         """
         Send SQL JSON query to celery workers.
@@ -2481,11 +2720,11 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @classmethod
     def _sql_json_sync(
         cls,
-        _session: Session,
-        rendered_query: str,
         query: Query,
+        rendered_query: str,
         expand_data: bool,
-        log_params: Optional[Dict[str, Any]] = None,
+        _session: Session,
+        log_params: Optional[Dict[str, Any]],
     ) -> FlaskResponse:
         """
         Execute SQL query (sql json).
@@ -2498,35 +2737,15 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         try:
             timeout = config["SQLLAB_TIMEOUT"]
             timeout_msg = f"The query exceeded the {timeout} seconds timeout."
-            store_results = (
-                is_feature_enabled("SQLLAB_BACKEND_PERSISTENCE")
-                and not query.select_as_cta
-            )
             query_id = query.id
-            with utils.timeout(seconds=timeout, error_message=timeout_msg):
-                # pylint: disable=no-value-for-parameter
-                data = sql_lab.get_sql_results(
-                    query.id,
-                    rendered_query,
-                    return_results=True,
-                    store_results=store_results,
-                    user_name=g.user.username
-                    if g.user and hasattr(g.user, "username")
-                    else None,
-                    expand_data=expand_data,
-                    log_params=log_params,
-                )
-
+            data = cls._get_sql_results_with_timeout(
+                query, timeout, rendered_query, expand_data, timeout_msg, log_params
+            )
             # Update saved query if needed
             QueryDAO.update_saved_query_exec_info(query_id)
 
             # TODO: set LimitingFactor to display?
-            payload = json.dumps(
-                apply_display_max_row_limit(data),
-                default=utils.pessimistic_json_iso_dttm_ser,
-                ignore_nan=True,
-                encoding=None,
-            )
+            payload = cls._convert_sql_result_to_payload(data)
         except SupersetTimeoutException as ex:
             # re-raise exception for api exception handler
             raise ex
@@ -2536,7 +2755,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
                 utils.error_msg_from_exception(ex)
             ) from ex
 
-        if data.get("status") == QueryStatus.FAILED:
+        if data is not None and data.get("status") == QueryStatus.FAILED:
             # new error payload with rich context
             if data["errors"]:
                 raise SupersetErrorsException(
@@ -2547,229 +2766,44 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
         return json_success(payload)
 
-    @has_access_api
-    @handle_api_exception
-    @event_logger.log_this
-    @expose("/sql_json/", methods=["POST"])
-    def sql_json(self) -> FlaskResponse:
-        log_params = {
-            "user_agent": cast(Optional[str], request.headers.get("USER_AGENT"))
-        }
-        execution_context = SqlJsonExecutionContext(request.json)
-        return self.sql_json_exec(execution_context, log_params)
+    @classmethod
+    def _get_sql_results_with_timeout(  # pylint: disable=too-many-arguments
+        cls,
+        query: Query,
+        timeout: int,
+        rendered_query: str,
+        expand_data: bool,
+        timeout_msg: str,
+        log_params: Optional[Dict[str, Any]],
+    ) -> SqlResults:
+        with utils.timeout(seconds=timeout, error_message=timeout_msg):
+            # pylint: disable=no-value-for-parameter
+            return sql_lab.get_sql_results(
+                query.id,
+                rendered_query,
+                return_results=True,
+                store_results=cls._is_store_results(query),
+                user_name=g.user.username
+                if g.user and hasattr(g.user, "username")
+                else None,
+                expand_data=expand_data,
+                log_params=log_params,
+            )
 
     @classmethod
-    def is_query_handled(cls, query: Optional[Query]) -> bool:
-        return query is not None and query.status in [
-            QueryStatus.RUNNING,
-            QueryStatus.PENDING,
-            QueryStatus.TIMED_OUT,
-        ]
-
-    def sql_json_exec(  # pylint: disable=too-many-statements,useless-suppression
-        self,
-        execution_context: SqlJsonExecutionContext,
-        log_params: Optional[Dict[str, Any]] = None,
-    ) -> FlaskResponse:
-        """Runs arbitrary sql and returns data as json"""
-
-        session = db.session()
-
-        query = self._get_existing_query(execution_context, session)
-
-        if self.is_query_handled(query):
-            payload = self._convert_query_to_payload(cast(Query, query))
-            return json_success(payload)
-
-        return self._run_sql_json_exec_from_scratch(
-            execution_context, session, log_params
+    def _is_store_results(cls, query: Query) -> bool:
+        return (
+            is_feature_enabled("SQLLAB_BACKEND_PERSISTENCE") and not query.select_as_cta
         )
 
-    def _run_sql_json_exec_from_scratch(
-        self,
-        execution_context: SqlJsonExecutionContext,
-        session: Session,
-        log_params: Optional[Dict[str, Any]] = None,
-    ) -> FlaskResponse:
-        execution_context.set_database(
-            self._get_the_query_db(execution_context, session)
-        )
-        query = execution_context.create_query()
-        self._save_new_query(query, session)
-        logger.info("Triggering query_id: %i", query.id)
-        self._validate_access(query, session)
-        rendered_query = self._render_query(execution_context, query, session)
-
-        self._set_query_limit_if_required(execution_context, query, rendered_query)
-
-        # Flag for whether or not to expand data
-        # (feature that will expand Presto row objects and arrays)
-        expand_data: bool = execution_context.expand_data
-
-        # Async request.
-        if execution_context.is_run_asynchronous():
-            return self._sql_json_async(
-                session, rendered_query, query, expand_data, log_params
-            )
-        # Sync request.
-        return self._sql_json_sync(
-            session, rendered_query, query, expand_data, log_params
-        )
-
-    def _set_query_limit_if_required(
-        self,
-        execution_context: SqlJsonExecutionContext,
-        query: Query,
-        rendered_query: str,
-    ) -> None:
-        if self._is_required_to_set_limit(execution_context):
-            self._set_query_limit(execution_context, query, rendered_query)
-
-    def _set_query_limit(  # pylint: disable=no-self-use
-        self,
-        execution_context: SqlJsonExecutionContext,
-        query: Query,
-        rendered_query: str,
-    ) -> None:
-        db_engine_spec = execution_context.database.db_engine_spec  # type: ignore
-        limits = [
-            db_engine_spec.get_limit_from_sql(rendered_query),
-            execution_context.limit,
-        ]
-        if limits[0] is None or limits[0] > limits[1]:  # type: ignore
-            query.limiting_factor = LimitingFactor.DROPDOWN
-        elif limits[1] > limits[0]:  # type: ignore
-            query.limiting_factor = LimitingFactor.QUERY
-        else:  # limits[0] == limits[1]
-            query.limiting_factor = LimitingFactor.QUERY_AND_DROPDOWN
-        query.limit = min(lim for lim in limits if lim is not None)
-
-    def _is_required_to_set_limit(  # pylint: disable=no-self-use
-        self, execution_context: SqlJsonExecutionContext
-    ) -> bool:
-        return not (
-            config.get("SQLLAB_CTAS_NO_LIMIT") and execution_context.select_as_cta
-        )
-
-    def _render_query(  # pylint: disable=no-self-use
-        self, execution_context: SqlJsonExecutionContext, query: Query, session: Session
-    ) -> str:
-        def validate(
-            rendered_query: str, template_processor: BaseTemplateProcessor
-        ) -> None:
-            if is_feature_enabled("ENABLE_TEMPLATE_PROCESSING"):
-                # pylint: disable=protected-access
-                ast = template_processor._env.parse(rendered_query)
-                undefined_parameters = find_undeclared_variables(ast)  # type: ignore
-                if undefined_parameters:
-                    query.status = QueryStatus.FAILED
-                    session.commit()
-                    raise SupersetTemplateParamsErrorException(
-                        message=ngettext(
-                            "The parameter %(parameters)s in your query is undefined.",
-                            "The following parameters in your query are undefined: %(parameters)s.",
-                            len(undefined_parameters),
-                            parameters=utils.format_list(undefined_parameters),
-                        )
-                        + " "
-                        + PARAMETER_MISSING_ERR,
-                        error=SupersetErrorType.MISSING_TEMPLATE_PARAMS_ERROR,
-                        extra={
-                            "undefined_parameters": list(undefined_parameters),
-                            "template_parameters": execution_context.template_params,
-                        },
-                    )
-
-        try:
-            template_processor = get_template_processor(
-                database=query.database, query=query
-            )
-            rendered_query = template_processor.process_template(
-                query.sql, **execution_context.template_params
-            )
-            validate(rendered_query, template_processor)
-        except TemplateError as ex:
-            query.status = QueryStatus.FAILED
-            session.commit()
-            raise SupersetTemplateParamsErrorException(
-                message=__(
-                    'The query contains one or more malformed template parameters. Please check your query and confirm that all template parameters are surround by double braces, for example, "{{ ds }}". Then, try running your query again.'
-                ),
-                error=SupersetErrorType.INVALID_TEMPLATE_PARAMS_ERROR,
-            ) from ex
-
-        return rendered_query
-
-    def _validate_access(  # pylint: disable=no-self-use
-        self, query: Query, session: Session
-    ) -> None:
-        try:
-            query.raise_for_access()
-        except SupersetSecurityException as ex:
-            query.set_extra_json_key("errors", [dataclasses.asdict(ex.error)])
-            query.status = QueryStatus.FAILED
-            query.error_message = ex.error.message
-            session.commit()
-            raise SupersetErrorException(ex.error, status=403) from ex
-
-    def _save_new_query(  # pylint: disable=no-self-use
-        self, query: Query, session: Session
-    ) -> None:
-        try:
-            session.add(query)
-            session.flush()
-            session.commit()  # shouldn't be necessary
-        except SQLAlchemyError as ex:
-            logger.error("Errors saving query details %s", str(ex), exc_info=True)
-            session.rollback()
-        if not query.id:
-            raise SupersetGenericErrorException(
-                __(
-                    "The query record was not created as expected. Please "
-                    "contact an administrator for further assistance or try again."
-                )
-            )
-
-    @staticmethod
-    def _convert_query_to_payload(query: Query) -> str:
+    @classmethod
+    def _convert_sql_result_to_payload(cls, sql_results: SqlResults) -> str:
         return json.dumps(
-            {"query": query.to_dict()},
-            default=utils.json_int_dttm_ser,
+            apply_display_max_row_limit(sql_results),  # type: ignore
+            default=utils.pessimistic_json_iso_dttm_ser,
             ignore_nan=True,
+            encoding=None,
         )
-
-    @classmethod
-    def _get_the_query_db(
-        cls, execution_context: SqlJsonExecutionContext, session: Session
-    ) -> Database:
-        mydb = session.query(Database).get(execution_context.database_id)
-        cls._validate_query_db(mydb)
-        return mydb
-
-    @classmethod
-    def _validate_query_db(cls, database: Optional[Database]) -> None:
-        if not database:
-            raise SupersetGenericErrorException(
-                __(
-                    "The database referenced in this query was not found. Please "
-                    "contact an administrator for further assistance or try again."
-                )
-            )
-
-    @classmethod
-    def _get_existing_query(
-        cls, execution_context: SqlJsonExecutionContext, session: Session
-    ) -> Optional[Query]:
-        query = (
-            session.query(Query)
-            .filter_by(
-                client_id=execution_context.client_id,
-                user_id=execution_context.user_id,
-                sql_editor_id=execution_context.sql_editor_id,
-            )
-            .one_or_none()
-        )
-        return query
 
     @has_access
     @event_logger.log_this


### PR DESCRIPTION
The sql_json view code in superset core view without any "clean code" standard and it does not adopt any software development principle.
This is the ninth PR in the sequence of future PRs ([previous PR](https://github.com/apache/superset/pull/16653)) try to solve it by refactoring the code.
The PR focus of extract code to methods and arrange the code by flow ordering 