### PR TITLE
feat(sqla): add time grain and time column to jinja params

### DIFF
--- a/docs/src/pages/docs/installation/sql_templating.mdx
+++ b/docs/src/pages/docs/installation/sql_templating.mdx
@@ -10,10 +10,33 @@ version: 1
 
 ### Jinja Templates
 
-SQL Lab supports [Jinja templating](https://jinja.palletsprojects.com/en/2.11.x/) in queries. You'll
-need to to overload the default Jinja context in your environment by defining the
-JINJA_CONTEXT_ADDONS in your superset configuration (`superset_config.py`). Objects referenced in
-this dictionary are made available for users to use in their SQL code.
+SQL Lab and Explore supports [Jinja templating](https://jinja.palletsprojects.com/en/2.11.x/) in queries.
+To enable templating, the `ENABLE_TEMPLATE_PROCESSING` feature flag needs to be enabled in
+`superset_config.py`. When templating is enabled, python code can be embedded in virtual datasets and
+in Custom SQL in the filter and metric controls in Explore. By default, the following variables are
+made available in the Jinja context:
+
+- `columns`: columns available in the dataset
+- `filter`: filters applied in the query
+- `from_dttm`: start `datetime` value from the selected time range (`None` if undefined)
+- `to_dttm`: end `datetime` value from the selected time range (`None` if undefined)
+- `groupby`: columns which to group by in the query
+- `metrics`: aggregate expressions in the query
+- `row_limit`: row limit of the query
+- `row_offset`: row offset of the query
+- `time_column`: temporal column of the query (`None` if undefined)
+- `time_grain`: selected time grain (`None` if undefined)
+
+For example, to add a time range to a virtual dataset, you can write the following:
+
+```sql
+SELECT * from tbl where dttm_col > '{{ from_dttm }}' and dttm_col < '{{ to_dttm }}'
+```
+
+To add custom functionality to the Jinja context, you need to to to overload the default Jinja
+context in your environment by defining the `JINJA_CONTEXT_ADDONS` in your superset configuration
+(`superset_config.py`). Objects referenced in this dictionary are made available for users to use
+where the Jinja context is made available.
 
 ```python
 JINJA_CONTEXT_ADDONS = {
@@ -174,7 +197,7 @@ You can retrieve the value for a specific filter as a list using `{{ filter_valu
 
 This is useful if:
 - you want to use a filter component to filter a query where the name of filter component column doesn't match the one in the select statement
-- you want to have the ability for filter inside the main query for speed purposes
+- you want to have the ability for filter inside the main query for performance purposes
 
 Here's a concrete example:
 
@@ -185,11 +208,6 @@ WHERE
     action in ({{ "'" + "','".join(filter_values('action_type')) + "'" }})
 GROUP BY action
 ```
-
-You can use thisfeature to reference the start & end datetimes from a time filter using:
-
-- `{{ from_dttm }}`: start datetime value
-- `{{ to_dttm }}`: end datetime value
 
 **Filters for a Specific Column**
 


### PR DESCRIPTION
### SUMMARY
Add `time_grain` and `time_column` variables to the default Jinja context. Also add default Jinja variables to the documentation.

### With the following virtual dataset:
![image](https://user-images.githubusercontent.com/33317356/133030360-75a212b9-9d32-4f90-8b93-b05a8e8bddc9.png)

The generated query looks as follows:
![image](https://user-images.githubusercontent.com/33317356/133030409-2085e397-18d6-4463-9585-9a240f755865.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
