### PR TITLE
fix: don't send invalid URLs back to the user

### DIFF
--- a/superset/views/redirects.py
+++ b/superset/views/redirects.py
@@ -66,7 +66,7 @@ class R(BaseSupersetView):  # pylint: disable=invalid-name
         url = request.form.get("data")
         if not self._validate_url(url):
             logger.warning("Invalid URL: %s", url)
-            return Response(f"Invalid URL: {url}", 400)
+            return Response(f"Invalid URL", 400)
         obj = models.Url(url=url)
         db.session.add(obj)
         db.session.commit()

--- a/superset/views/redirects.py
+++ b/superset/views/redirects.py
@@ -66,7 +66,7 @@ class R(BaseSupersetView):  # pylint: disable=invalid-name
         url = request.form.get("data")
         if not self._validate_url(url):
             logger.warning("Invalid URL: %s", url)
-            return Response(f"Invalid URL", 400)
+            return Response("Invalid URL", 400)
         obj = models.Url(url=url)
         db.session.add(obj)
         db.session.commit()


### PR DESCRIPTION
### SUMMARY

Avoid sending a bogus URL back to the user, these can apparently cause a reflect XSS issue, yet the only possible victim is the attacker himself.
 
### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
