### PR TITLE
feat: show nice error page in prod

### DIFF
--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -437,6 +437,10 @@ def show_http_exception(ex: HTTPException) -> FlaskResponse:
 @superset_app.errorhandler(CommandException)
 def show_command_errors(ex: CommandException) -> FlaskResponse:
     logger.warning(ex)
+    if "text/html" in request.accept_mimetypes and not config["DEBUG"]:
+        path = resource_filename("superset", "static/assets/500.html")
+        return send_file(path), 500
+
     extra = ex.normalized_messages() if isinstance(ex, CommandInvalidError) else {}
     return json_errors_response(
         errors=[
@@ -455,6 +459,10 @@ def show_command_errors(ex: CommandException) -> FlaskResponse:
 @superset_app.errorhandler(Exception)
 def show_unexpected_exception(ex: Exception) -> FlaskResponse:
     logger.exception(ex)
+    if "text/html" in request.accept_mimetypes and not config["DEBUG"]:
+        path = resource_filename("superset", "static/assets/500.html")
+        return send_file(path), 500
+
     return json_errors_response(
         errors=[
             SupersetError(


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

With SIP-40 and SIP-41 we introduced an error handler to Flask to format exceptions in a standard JSON payload. One problem with this approach is that users are seeing JSON payloads in production when a generic error occurs.

We already had some logic to show a nice 404/500 page when catching an `HTTPException` error. I extended the logic to uncaught exceptions as well.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

WIP, still haven't been able to trigger an error.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
