### PR TITLE
fix: remove useless-suppression for pylint

### DIFF
--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -53,7 +53,7 @@ slice_user = Table(
 logger = logging.getLogger(__name__)
 
 
-class Slice(  # pylint: disable=too-many-public-methods, too-many-instance-attributes
+class Slice(  # pylint: disable=too-many-public-methods
     Model, AuditMixinNullable, ImportExportMixin
 ):
     """A slice is essentially a report or a view on data"""

--- a/superset/sqllab/command.py
+++ b/superset/sqllab/command.py
@@ -383,7 +383,7 @@ class ExecuteSqlCommand(BaseCommand):
         )
 
     def _create_payload_from_execution_context(
-        # pylint: disable=invalid-name, no-self-use
+        # pylint: disable=invalid-name
         self,
         status: SqlJsonExecutionStatus,
     ) -> str:


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
CI has been stuck with `useless-suppression` rule on pylint checking. This PR fixed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
