### PR TITLE
perf(dashboard): native filter select will be stuck if there has a filter box.

### DIFF
--- a/superset-frontend/src/components/Select/DeprecatedSelect.tsx
+++ b/superset-frontend/src/components/Select/DeprecatedSelect.tsx
@@ -249,8 +249,15 @@ function styled<
     if (forceOverflow) {
       Object.assign(restProps, {
         closeMenuOnScroll: (e: Event) => {
+          // ensure menu is open
+          const menuIsOpen = (stateManager as BasicSelect<OptionType>)?.state
+            ?.menuIsOpen;
           const target = e.target as HTMLElement;
-          return target && !target.classList?.contains('Select__menu-list');
+          return (
+            menuIsOpen &&
+            target &&
+            !target.classList?.contains('Select__menu-list')
+          );
         },
         menuPosition: 'fixed',
       });


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes the case that if the dashboard has a filterbox, native filter select will be very stuck.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### before

https://user-images.githubusercontent.com/11830681/133277989-df4526ae-4cc6-449c-9a8e-a787dd737199.mov



### after


https://user-images.githubusercontent.com/11830681/133278009-d151f362-ce46-49f9-8b71-38762075a83e.mov



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
