### PR TITLE
feat(jinja): improve url parameter formatting

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -25,6 +25,9 @@ assists people when migrating to a new version.
 ## Next
 
 ### Breaking Changes
+
+- [16711](https://github.com/apache/incubator-superset/pull/16711): The `url_param` Jinja function will now by default escape the result. For instance, the value `O'Brien` will now be changed to `O''Brien`. To disable this behavior, call `url_param` with `escape_result` set to `False`: `url_param("my_key", "my default", escape_result=False)`.
+
 ### Potential Downtime
 ### Deprecations
 ### Other

--- a/tests/integration_tests/jinja_context_tests.py
+++ b/tests/integration_tests/jinja_context_tests.py
@@ -200,19 +200,35 @@ class TestJinja2Context(SupersetTestCase):
             cache = ExtraCache()
             self.assertEqual(cache.url_param("foo"), "bar")
 
-    def test_unsafe_url_param_quoted_form_data(self) -> None:
+    def test_url_param_escaped_form_data(self) -> None:
         with app.test_request_context(
             query_string={"form_data": json.dumps({"url_params": {"foo": "O'Brien"}})}
         ):
             cache = ExtraCache(dialect=dialect())
             self.assertEqual(cache.url_param("foo"), "O''Brien")
 
-    def test_unsafe_url_param_unquoted_form_data(self) -> None:
+    def test_url_param_escaped_default_form_data(self) -> None:
+        with app.test_request_context(
+            query_string={"form_data": json.dumps({"url_params": {"foo": "O'Brien"}})}
+        ):
+            cache = ExtraCache(dialect=dialect())
+            self.assertEqual(cache.url_param("bar", "O'Malley"), "O''Malley")
+
+    def test_url_param_unescaped_form_data(self) -> None:
         with app.test_request_context(
             query_string={"form_data": json.dumps({"url_params": {"foo": "O'Brien"}})}
         ):
             cache = ExtraCache(dialect=dialect())
             self.assertEqual(cache.url_param("foo", escape_result=False), "O'Brien")
+
+    def test_url_param_unescaped_default_form_data(self) -> None:
+        with app.test_request_context(
+            query_string={"form_data": json.dumps({"url_params": {"foo": "O'Brien"}})}
+        ):
+            cache = ExtraCache(dialect=dialect())
+            self.assertEqual(
+                cache.url_param("bar", "O'Malley", escape_result=False), "O'Malley"
+            )
 
     def test_safe_proxy_primitive(self) -> None:
         def func(input: Any) -> Any:


### PR DESCRIPTION
### SUMMARY

Add handling of special characters to URL param function in Jinja context to improve cross-database filter clause compatibility. This is done by adding the parameter `escape_result` to the `url_param` function which defaults to `True`. When enabled, it escapes the value of the requested url param using the relevant SQLAlchemy dialect for the selected database.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
