### PR TITLE
fix(pandas-postprocessing): percentage compare to use correct column

### DIFF
--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -508,7 +508,7 @@ def compare(  # pylint: disable=too-many-arguments
             diff_series = df[s_col] - df[c_col]
         elif compare_type == PandasPostprocessingCompare.PCT:
             diff_series = (
-                ((df[s_col] - df[c_col]) / df[s_col]).astype(float).round(precision)
+                ((df[s_col] - df[c_col]) / df[c_col]).astype(float).round(precision)
             )
         else:
             # compare_type == "ratio"

--- a/tests/integration_tests/pandas_postprocessing_tests.py
+++ b/tests/integration_tests/pandas_postprocessing_tests.py
@@ -513,7 +513,7 @@ class TestPostProcessing(SupersetTestCase):
             post_df.columns.tolist(), ["label", "y", "z", "percentage__y__z",]
         )
         self.assertListEqual(
-            series_to_list(post_df["percentage__y__z"]), [0.0, -1.0, -4.0, -3],
+            series_to_list(post_df["percentage__y__z"]), [0.0, -0.5, -0.8, -0.75],
         )
 
         # `ratio` comparison


### PR DESCRIPTION
### SUMMARY
Currently the percentage compare post processing operation is using the following formula
```
change = (new - old) / new
```

while the correct formula should most likely be
```
change = (new - old) / old
```

Example:

increase from 500 to 1000 (expected result is it should have doubled):

old:
```
change = (1000 - 500) / 1000 = 50 %
```

new:
```
change = (1000 - 500) / 500 = 100 %
```


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
