### PR TITLE
ci: bump npm to version 7

### DIFF
--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -55,7 +55,8 @@ npm-install() {
   cd "$GITHUB_WORKSPACE/superset-frontend"
 
   # cache-restore npm
-
+  say "::group::Install npm@7"
+  sudo npm i -g npm@7 --registry=https://registry.npmjs.org
   say "::group::Install npm packages"
   echo "npm: $(npm --version)"
   echo "node: $(node --version)"

--- a/scripts/ci_check_no_file_changes.sh
+++ b/scripts/ci_check_no_file_changes.sh
@@ -37,7 +37,7 @@ do
     REGEX="(^\.github\/workflows\/.*python|^tests\/|^superset\/|^setup\.py|^requirements\/.+\.txt|^\.pylintrc)"
     echo "Searching for changes in python files"
   elif [[ ${CHECK} == "frontend" ]]; then
-    REGEX="(^\.github\/workflows\/.*(frontend|e2e)|^superset-frontend\/)"
+    REGEX="(^\.github\/workflows\/.*(bashlib|frontend|e2e)|^superset-frontend\/)"
     echo "Searching for changes in frontend files"
   else
     echo "Invalid check: \"${CHECK}\". Falling back to exiting with FAILURE code"


### PR DESCRIPTION
While the docs state `npm@7` to be a requirement for running Superset (see #13100 which migrated to then new lockfile format), CI is still running version 6. It turns out running `npm@7` with `node@14` isn't very well supported: https://github.com/actions/setup-node/issues/213 . Long term, we should probably bump to `node@16` to get rid of this workaround.

When running `npm ci` on #16701 using `npm@6` we get the following error:
```
$ npm i -g npm@6
$ npm --version
6.14.15
$ npm ci

npm WARN prepare removing existing node_modules/ before installation
npm ERR! watchpack-chokidar2 not accessible from watchpack

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/ville/.npm/_logs/2021-09-20T11_10_20_593Z-debug.log
```

This is fixed by simply bumping to version 7:
```
$ npm i -g npm@7
$ npm ci
...
added 3599 packages, and audited 3600 packages in 3m

248 packages are looking for funding
  run `npm fund` for details

79 vulnerabilities (11 low, 22 moderate, 46 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues possible (including breaking changes), run:
  npm audit fix --force

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.
```

After this update, CI uses `npm@7`:
![image](https://user-images.githubusercontent.com/33317356/133996307-a7b21fbe-1cf7-44b4-b594-21cc5a6177eb.png)

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
