### PR TITLE
fix: save query should use the correct sql 

### DIFF
--- a/superset-frontend/spec/javascripts/sqllab/actions/sqlLab_spec.js
+++ b/superset-frontend/spec/javascripts/sqllab/actions/sqlLab_spec.js
@@ -612,44 +612,44 @@ describe('async actions', () => {
     });
 
     describe('queryEditorSetSql', () => {
+      const sql = 'SELECT * ';
+      const expectedActions = [
+        {
+          type: actions.QUERY_EDITOR_SET_SQL,
+          queryEditor,
+          sql,
+        },
+      ];
       describe('with backend persistence flag on', () => {
         it('updates the tab state in the backend', () => {
           expect.assertions(2);
 
-          const sql = 'SELECT * ';
           const store = mockStore({});
 
           return store
             .dispatch(actions.queryEditorSetSql(queryEditor, sql))
             .then(() => {
-              expect(store.getActions()).toHaveLength(0);
+              expect(store.getActions()).toEqual(expectedActions);
               expect(fetchMock.calls(updateTabStateEndpoint)).toHaveLength(1);
             });
         });
       });
-    });
-    describe('with backend persistence flag off', () => {
-      it('does not update the tab state in the backend', () => {
-        const backendPersistenceOffMock = jest
-          .spyOn(featureFlags, 'isFeatureEnabled')
-          .mockImplementation(
-            feature => !(feature === 'SQLLAB_BACKEND_PERSISTENCE'),
-          );
-        const sql = 'SELECT * ';
-        const store = mockStore({});
-        const expectedActions = [
-          {
-            type: actions.QUERY_EDITOR_SET_SQL,
-            queryEditor,
-            sql,
-          },
-        ];
+      describe('with backend persistence flag off', () => {
+        it('does not update the tab state in the backend', () => {
+          const backendPersistenceOffMock = jest
+            .spyOn(featureFlags, 'isFeatureEnabled')
+            .mockImplementation(
+              feature => !(feature === 'SQLLAB_BACKEND_PERSISTENCE'),
+            );
 
-        store.dispatch(actions.queryEditorSetSql(queryEditor, sql));
+          const store = mockStore({});
 
-        expect(store.getActions()).toEqual(expectedActions);
-        expect(fetchMock.calls(updateTabStateEndpoint)).toHaveLength(0);
-        backendPersistenceOffMock.mockRestore();
+          store.dispatch(actions.queryEditorSetSql(queryEditor, sql));
+
+          expect(store.getActions()).toEqual(expectedActions);
+          expect(fetchMock.calls(updateTabStateEndpoint)).toHaveLength(0);
+          backendPersistenceOffMock.mockRestore();
+        });
       });
     });
 

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -898,6 +898,8 @@ export function updateSavedQuery(query) {
 
 export function queryEditorSetSql(queryEditor, sql) {
   return function (dispatch) {
+    // saved query and set tab state use this action
+    dispatch({ type: QUERY_EDITOR_SET_SQL, queryEditor, sql });
     if (isFeatureEnabled(FeatureFlag.SQLLAB_BACKEND_PERSISTENCE)) {
       return SupersetClient.put({
         endpoint: encodeURI(`/tabstateview/${queryEditor.id}`),
@@ -914,7 +916,7 @@ export function queryEditorSetSql(queryEditor, sql) {
         ),
       );
     }
-    return dispatch({ type: QUERY_EDITOR_SET_SQL, queryEditor, sql });
+    return Promise.resolve();
   };
 }
 


### PR DESCRIPTION
### SUMMARY
Currently, if you were to save a query without running it, the redux store does not update, and the save query button will save the old query. This updates the action to trigger the redux action in all cases. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: 


https://user-images.githubusercontent.com/5186919/134090374-7a8e63f0-3212-4e87-8722-1655432b9d0a.mp4

After: 

https://user-images.githubusercontent.com/5186919/134090396-348bbbbe-4d49-454e-a5cb-1d8a2f579c0f.mov



### TESTING INSTRUCTIONS
Write a query and then save it without hitting "run". Copy the link and paste it in a new window. The saved query should have the correct sql statement. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
