### PR TITLE
fix: only fetch db function when db exists in sql lab

### DIFF
--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper.tsx
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper.tsx
@@ -30,6 +30,7 @@ import {
   AceCompleterKeyword,
   FullSQLEditor as AceEditor,
 } from 'src/components/AsyncAceEditor';
+import { QueryEditor } from '../types';
 
 type HotKey = {
   key: string;
@@ -51,7 +52,7 @@ interface Props {
   tables: any[];
   functionNames: string[];
   extendedTables: Array<{ name: string; columns: any[] }>;
-  queryEditor: any;
+  queryEditor: QueryEditor;
   height: string;
   hotkeys: HotKey[];
   onChange: (sql: string) => void;
@@ -86,10 +87,12 @@ class AceEditorWrapper extends React.PureComponent<Props, State> {
   componentDidMount() {
     // Making sure no text is selected from previous mount
     this.props.actions.queryEditorSetSelectedText(this.props.queryEditor, null);
-    this.props.actions.queryEditorSetFunctionNames(
-      this.props.queryEditor,
-      this.props.queryEditor.dbId,
-    );
+    if (this.props.queryEditor.dbId) {
+      this.props.actions.queryEditorSetFunctionNames(
+        this.props.queryEditor,
+        this.props.queryEditor.dbId,
+      );
+    }
     this.setAutoCompleter(this.props);
   }
 
@@ -228,8 +231,8 @@ class AceEditorWrapper extends React.PureComponent<Props, State> {
 
   getAceAnnotations() {
     const { validationResult } = this.props.queryEditor;
-    const resultIsReady = validationResult && validationResult.completed;
-    if (resultIsReady && validationResult.errors.length > 0) {
+    const resultIsReady = validationResult?.completed;
+    if (resultIsReady && validationResult?.errors?.length) {
       const errors = validationResult.errors.map((err: any) => ({
         type: 'error',
         row: err.line_number - 1,

--- a/superset-frontend/src/SqlLab/components/ShareSqlLabQuery.tsx
+++ b/superset-frontend/src/SqlLab/components/ShareSqlLabQuery.tsx
@@ -26,16 +26,10 @@ import CopyToClipboard from 'src/components/CopyToClipboard';
 import { storeQuery } from 'src/utils/common';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 import { FeatureFlag, isFeatureEnabled } from '../../featureFlags';
+import { QueryEditor } from '../types';
 
 interface ShareSqlLabQueryPropTypes {
-  queryEditor: {
-    dbId: number;
-    title: string;
-    schema: string;
-    autorun: boolean;
-    sql: string;
-    remoteId: number | null;
-  };
+  queryEditor: QueryEditor;
   addDangerToast: (msg: string) => void;
 }
 

--- a/superset-frontend/src/SqlLab/types.ts
+++ b/superset-frontend/src/SqlLab/types.ts
@@ -69,3 +69,16 @@ export type Query = {
   queryLimit: number;
   limitingFactor: string;
 };
+
+export interface QueryEditor {
+  dbId?: number;
+  title: string;
+  schema: string;
+  autorun: boolean;
+  sql: string;
+  remoteId: number | null;
+  validationResult?: {
+    completed: boolean;
+    errors: SupersetError[];
+  };
+}


### PR DESCRIPTION
### SUMMARY
When closing multiple tabs, there would sometimes be errors because we were fetching function names with a null db. This checks that the db is present before updating. If the db is not present, the function names will fetch on the left toolbar db change method. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before: 

https://user-images.githubusercontent.com/5186919/134093911-62487bda-3467-4e05-988f-00dc8498c09b.mov


### TESTING INSTRUCTIONS
save a query, copy it and open it in a window. Open a bunch of saved queries so that you have about 4 tabs loading all at once on a page load, then close them one by one. There should be no errors, and your database should update. 


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
