### PR TITLE
feat: add new field roles under advanced setting of 'Edit dataset' modal

### DIFF
--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -716,6 +716,26 @@ class DatasourceEditor extends React.PureComponent {
             control={<TextControl controlId="template_params" />}
           />
         )}
+        {isFeatureEnabled(FeatureFlag.DATASET_RBAC) && (
+          <Field
+            fieldKey="roles"
+            label={t('Roles')}
+            description={t('Roles defines access to the dataset')}
+            control={
+              <SelectAsyncControl
+                dataEndpoint="/api/v1/dashboard/related/roles"
+                multi
+                mutator={data =>
+                  data.result.map(pk => ({
+                    value: pk.value,
+                    label: `${pk.text}`,
+                  }))
+                }
+              />
+            }
+            controlProps={{}}
+          />
+        )}
       </Fieldset>
     );
   }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
It will allow granting dataset access by roles under "Edit dataset" modal.

Notice it depends on https://github.com/apache-superset/superset-ui/pull/1366 to be able to work

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Notice the new filed **ROLES** under the advanced settings:
![Screenshot from 2021-09-20 21-35-06](https://user-images.githubusercontent.com/1059372/134099029-505ca5ef-2a5e-4bf1-8eb6-60b211655916.png)



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #16557
- [x] Required feature flags: `DATASET_RBAC`
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
