### PR TITLE
fix(helm): Exit init script immediately on error

### DIFF
--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
   - name: craig-rueda
     email: craig@craigrueda.com
     url: https://github.com/craig-rueda
-version: 0.3.8
+version: 0.3.9
 dependencies:
 - name: postgresql
   version: 10.2.0

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -302,6 +302,7 @@ init:
       command: [ "/bin/sh", "-c", "until nc -zv $DB_HOST $DB_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
   initscript: |-
     #!/bin/sh
+    set -eu
     echo "Upgrading DB schema..."
     superset db upgrade
     echo "Initializing roles..."


### PR DESCRIPTION
### SUMMARY
This adds `set -eu` to the init script. With this the script will exit immediately when it encounters an error or an unset variable.

### TESTING INSTRUCTIONS
In order to test that this works you will need a k8s environment. One way to test this is to manually add an error into the init script by including an invalid command (just make sure that the last command in the script is still a working command). Then start a helm deployment. Without this PR the init job will be marked as success despite the error. With this PR applied the init job will be marked as failed.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #16757
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### ADDITIONAL THOUGHTS
I personally think failing when an error occurs should be the default behavior. However, I could see that some people might prefer it if the script does not fail and instead tries the remaining init steps. If this is wanted I could add a flag to the init config in `values.yaml` so that users can easily select the behavior they want. Let me know if this is wanted or if this PR is ok as it is. I personally don't really think it's worth including a switch, because with the current behavior you would need to read the whole init job logs in order to know if there were any problems.