### PR TITLE
fix: encode rison characters when searching

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -77,7 +77,7 @@ flask==1.1.4
     #   flask-openid
     #   flask-sqlalchemy
     #   flask-wtf
-flask-appbuilder==3.3.2
+flask-appbuilder==3.3.3
     # via apache-superset
 flask-babel==1.0.0
     # via flask-appbuilder
@@ -176,7 +176,7 @@ pgsanity==0.2.9
     # via apache-superset
 polyline==1.4.0
     # via apache-superset
-prison==0.1.3
+prison==0.2.1
     # via flask-appbuilder
 pyarrow==4.0.1
     # via apache-superset

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         "cryptography>=3.3.2",
         "deprecation>=2.1.0, <2.2.0",
         "flask>=1.1.0, <2.0.0",
-        "flask-appbuilder>=3.3.2, <4.0.0",
+        "flask-appbuilder>=3.3.3, <4.0.0",
         "flask-caching>=1.10.0",
         "flask-compress",
         "flask-talisman",

--- a/superset-frontend/src/components/ListView/Filters/Search.tsx
+++ b/superset-frontend/src/components/ListView/Filters/Search.tsx
@@ -35,7 +35,8 @@ export default function SearchFilter({
   const [value, setValue] = useState(initialValue || '');
   const handleSubmit = () => {
     if (value) {
-      onSubmit(value.trim());
+      // encode plus signs to prevent them from being converted into a space
+      onSubmit(value.trim().replace(/\+/g, '%2B'));
     }
   };
   const onClear = () => {

--- a/superset-frontend/src/components/ListView/utils.ts
+++ b/superset-frontend/src/components/ListView/utils.ts
@@ -45,10 +45,11 @@ import {
   ViewModeType,
 } from './types';
 
-// Define custom RisonParam for proper encoding/decoding
+// Define custom RisonParam for proper encoding/decoding; note that
+// plus symbols should be encoded to avoid being converted into a space
 const RisonParam: QueryParamConfig<string, any> = {
   encode: (data?: any | null) =>
-    data === undefined ? undefined : rison.encode(data),
+    data === undefined ? undefined : rison.encode(data).replace(/\+/g, '%2B'),
   decode: (dataStr?: string | string[]) =>
     dataStr === undefined || Array.isArray(dataStr)
       ? undefined


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When searching for charts/dashboards/datasets we're currently getting an error if the needle has a plus symbol, eg, `/w+`. This happens because the `+` is not escaped, and gets sent as a space to the backend. Because the string `/w ` is not valid rison, the search fails.

I fixed by explicitly encoding `+`. We could use `encodeURIComponent`, but it encodes more than is needed and pollutes the URL.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

![Screenshot 2021-09-21 at 13-12-51  DEV  Superset](https://user-images.githubusercontent.com/1534870/134241600-5de285dd-8631-4584-b7ad-67ffd03b393c.png)

After:

![Screenshot 2021-09-21 at 14-14-47  DEV  Superset](https://user-images.githubusercontent.com/1534870/134248702-61daa10c-9cfc-49e7-a70b-9c73d6e3506e.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
