### PR TITLE
fix: handle CTEs with comments on is_select

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -131,13 +131,17 @@ class ParsedQuery:
         return self._limit
 
     def is_select(self) -> bool:
-        return self._parsed[0].get_type() == "SELECT"
+        # make sure we strip comments; prevents a bug with coments in the CTE
+        parsed = sqlparse.parse(self.strip_comments())
+        return parsed[0].get_type() == "SELECT"
 
     def is_valid_ctas(self) -> bool:
-        return self._parsed[-1].get_type() == "SELECT"
+        parsed = sqlparse.parse(self.strip_comments())
+        return parsed[-1].get_type() == "SELECT"
 
     def is_valid_cvas(self) -> bool:
-        return len(self._parsed) == 1 and self._parsed[0].get_type() == "SELECT"
+        parsed = sqlparse.parse(self.strip_comments())
+        return len(parsed) == 1 and parsed[0].get_type() == "SELECT"
 
     def is_explain(self) -> bool:
         # Remove comments

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from superset.sql_parse import ParsedQuery
+
+
+def test_cte_with_comments():
+    sql = ParsedQuery(
+        """WITH blah AS
+  (SELECT * FROM core_dev.manager_team),
+
+blah2 AS
+  (SELECT * FROM core_dev.manager_workspace)
+
+SELECT * FROM blah
+INNER JOIN blah2 ON blah2.team_id = blah.team_id"""
+    )
+    assert sql.is_select()
+
+    sql = ParsedQuery(
+        """WITH blah AS
+/*blahblahbalh*/
+  (SELECT * FROM core_dev.manager_team),
+--blahblahbalh
+
+blah2 AS
+  (SELECT * FROM core_dev.manager_workspace)
+
+SELECT * FROM blah
+INNER JOIN blah2 ON blah2.team_id = blah.team_id"""
+    )
+    assert sql.is_select()


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

CTEs with comments on them were not correctly identified as a `SELECT`, eg:

```sql
WITH blah AS 
/*blahblahbalh*/
  (SELECT * FROM core_dev.manager_team), 
--blahblahbalh

blah2 AS 
  (SELECT * FROM core_dev.manager_workspace)

SELECT * FROM blah 
INNER JOIN blah2 ON blah2.team_id = blah.team_id 
```

Removing the comments before running `is_select()` fixes it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
