### PR TITLE
feat: add support for JOIN in Druid

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -334,6 +334,8 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     # Experimental feature introducing a client (browser) cache
     "CLIENT_CACHE": False,
     "DISABLE_DATASET_SOURCE_EDIT": False,
+    # When using a recent version of Druid that supports JOINs turn this on
+    "DRUID_JOINS": False,
     "DYNAMIC_PLUGINS": False,
     # For some security concerns, you may need to enforce CSRF protection on
     # all query request to explore_json endpoint. In Superset, we use

--- a/superset/db_engine_specs/druid.py
+++ b/superset/db_engine_specs/druid.py
@@ -19,6 +19,7 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, Optional, TYPE_CHECKING
 
+from superset import is_feature_enabled
 from superset.db_engine_specs.base import BaseEngineSpec
 from superset.exceptions import SupersetException
 from superset.utils import core as utils
@@ -35,7 +36,7 @@ class DruidEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method
 
     engine = "druid"
     engine_name = "Apache Druid"
-    allows_joins = False
+    allows_joins = is_feature_enabled("DRUID_JOINS")
     allows_subqueries = True
 
     _time_grain_expressions = {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Druid has supported `JOIN` for a quite a while. I added a feature flag to turn it on, and hopefully in 2.0 we can make it on by default.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

With the flag off we get 2 queries (1 to get top groups, the other filtering on top groups) in a line chart:

![Screenshot 2021-09-21 at 15-01-30  DEV  Explore - wikipedia](https://user-images.githubusercontent.com/1534870/134253715-c21a77d8-23ed-4282-bcaa-8448b72d3fa7.png)


With the flag on we get a join:

![Screenshot 2021-09-21 at 14-58-07  DEV  Explore - wikipedia](https://user-images.githubusercontent.com/1534870/134253586-316f0935-8489-40e4-9a9b-4a6d2db92413.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
