### PR TITLE
fix(dataset): retain is_dttm if set on metadata sync

### DIFF
--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -464,13 +464,13 @@ class DatasourceEditor extends React.PureComponent {
         results.added.push(col.name);
       } else if (
         currentCol.type !== col.type ||
-        currentCol.is_dttm !== col.is_dttm
+        (!currentCol.is_dttm && col.is_dttm)
       ) {
         // modified column
         finalColumns.push({
           ...currentCol,
           type: col.type,
-          is_dttm: col.is_dttm,
+          is_dttm: currentCol.is_dttm || col.is_dttm,
         });
         results.modified.push(col.name);
       } else {


### PR DESCRIPTION
### SUMMARY
When syncing dataset metadata, the `is_dttm` flag is reset for columns that are not natively temporal (like `VARCHAR` that has a datetime format). This changes the logic so that `is_dttm` is only reset if it is unset and the new datatype would be natively identified as being temporal.

Closes #16774

### AFTER

https://user-images.githubusercontent.com/33317356/134282249-6c83c718-5c2a-4856-8ed0-32dd2d2c2334.mp4

### BEFORE

https://user-images.githubusercontent.com/33317356/134282263-809bc38e-583a-490a-a371-fd8a495ee26c.mp4


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
