### PR TITLE
fix: list Db2 as supported databases

### DIFF
--- a/superset/db_engine_specs/__init__.py
+++ b/superset/db_engine_specs/__init__.py
@@ -147,6 +147,15 @@ def get_available_engine_specs() -> Dict[Type[BaseEngineSpec], Set[str]]:
 
     available_engines = {}
     for engine_spec in load_engine_specs():
-        available_engines[engine_spec] = drivers[engine_spec.engine]
+        driver = drivers[engine_spec.engine]
+
+        # lookup driver by engine aliases.
+        if not driver and engine_spec.engine_aliases:
+            for alias in engine_spec.engine_aliases:
+                driver = drivers[alias]
+                if driver:
+                    break
+
+        available_engines[engine_spec] = driver
 
     return available_engines


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This PR will make sure Superset can still lookup the db engine by engine alias when failed to locate installed dialect by engine name.

Take db2 for example, It still uses legacy name `ibm_db_sa` within the SQLAlchemy dialect for Db2 while it has start to use latest name `db2` when connecting to Db2 via SQLAlchemy connection URL. So if using engine name `db2` only, it will not list Db2 as available databases from API `GET /api/v1/database/available`. This PR will fix this case.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Install SQLAlchemy dialect for db2 by running `pip3 install apache-superset[db2]`
2. Follow reproduce step of #16796
3. Make sure `IBM Db2` is listed under supported databases.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #16796 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
