### PR TITLE
chore: upgrade to Node 16

### DIFF
--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -55,8 +55,6 @@ npm-install() {
   cd "$GITHUB_WORKSPACE/superset-frontend"
 
   # cache-restore npm
-  say "::group::Install npm@7"
-  sudo npm i -g npm@7 --registry=https://registry.npmjs.org
   say "::group::Install npm packages"
   echo "npm: $(npm --version)"
   echo "node: $(node --version)"

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -72,8 +72,7 @@ jobs:
         if: steps.check.outcome == 'failure'
         uses: ./.github/actions/cached-dependencies
         with:
-          run: |
-            apt-get-install
+          run: apt-get-install
       - name: Install python dependencies
         if: steps.check.outcome == 'failure'
         uses: ./.github/actions/cached-dependencies
@@ -85,32 +84,31 @@ jobs:
         if: steps.check.outcome == 'failure'
         uses: ./.github/actions/cached-dependencies
         with:
-          run: |
-            setup-postgres
+          run: setup-postgres
       - name: Import test data
         if: steps.check.outcome == 'failure'
         uses: ./.github/actions/cached-dependencies
         with:
-          run: |
-            testdata
+          run: testdata
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version:  '16'
       - name: Install npm dependencies
         if: steps.check.outcome == 'failure'
         uses: ./.github/actions/cached-dependencies
         with:
-          run: |
-            npm-install
+          run: npm-install
       - name: Build javascript packages
         if: steps.check.outcome == 'failure'
         uses: ./.github/actions/cached-dependencies
         with:
-          run: |
-            build-instrumented-assets
+          run: build-instrumented-assets
       - name: Install cypress
         if: steps.check.outcome == 'failure'
         uses: ./.github/actions/cached-dependencies
         with:
-          run: |
-            cypress-install
+          run: cypress-install
       - name: Run Cypress
         if: steps.check.outcome == 'failure'
         uses: ./.github/actions/cached-dependencies

--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -25,6 +25,10 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         continue-on-error: true
         run: ./scripts/ci_check_no_file_changes.sh frontend
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version:  '16'
       - name: Install dependencies
         if: steps.check.outcome == 'failure'
         uses: ./.github/actions/cached-dependencies

--- a/.github/workflows/superset-translations.yml
+++ b/.github/workflows/superset-translations.yml
@@ -17,6 +17,10 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version:  '16'
       - name: Install dependencies
         uses: ./.github/actions/cached-dependencies
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -522,7 +522,11 @@ Frontend assets (TypeScript, JavaScript, CSS, and images) must be compiled in or
 
 ##### nvm and node
 
-First, be sure you are using recent versions of Node.js and npm. We recommend using [nvm](https://github.com/nvm-sh/nvm) to manage your node environment:
+First, be sure you are using the following versions of Node.js and npm:
+- `Node.js`: Version 16
+- `npm`: Version 7
+
+We recommend using [nvm](https://github.com/nvm-sh/nvm) to manage your node environment:
 
 ```bash
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.0/install.sh | bash
@@ -539,12 +543,6 @@ sh -c "$(curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.0/install
 ```
 
 For those interested, you may also try out [avn](https://github.com/nvm-sh/nvm#deeper-shell-integration) to automatically switch to the node version that is required to run Superset frontend.
-
-We have upgraded our `package-lock.json` to use `lockfileversion: 2` from npm 7, so please make sure you have installed npm 7, too:
-
-```bash
-npm install -g npm@7
-```
 
 #### Install dependencies
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN cd /app \
 ######################################################################
 # Node stage to deal with static asset construction
 ######################################################################
-FROM node:14 AS superset-node
+FROM node:16 AS superset-node
 
 ARG NPM_VER=7
 RUN npm install -g npm@${NPM_VER}

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -35,6 +35,8 @@ assists people when migrating to a new version.
 
 ### Other
 
+- [16809](https://github.com/apache/incubator-superset/pull/16809): When building the superset frontend assets manually, you should now use Node 16 (previously Node 14 was required/recommended). Node 14 will most likely still work for at least some time, but is no longer actively tested for on CI.
+
 ## 1.3.0
 
 ### Breaking Changes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       CYPRESS_CONFIG: "${CYPRESS_CONFIG}"
 
   superset-node:
-    image: node:14
+    image: node:16
     container_name: superset_node
     command: ["/app/docker/docker-frontend.sh"]
     env_file: docker/.env

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -56,7 +56,7 @@
     "last 3 edge versions"
   ],
   "engines": {
-    "node": "^14.15.5",
+    "node": "^16.9.1",
     "npm": "^7.5.4"
   },
   "homepage": "https://superset.apache.org/",

--- a/superset-frontend/spec/javascripts/dashboard/components/PropertiesModal_spec.jsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/PropertiesModal_spec.jsx
@@ -150,8 +150,9 @@ describe('PropertiesModal', () => {
       const wrapper = setup();
       const modalInstance = wrapper.find('PropertiesModal').instance();
       const spy = jest.spyOn(modalInstance, 'updateFormState');
-      modalInstance.onOwnersChange('foo');
-      expect(spy).toHaveBeenCalledWith('owners', 'foo');
+      const newOwners = [{ value: 1, label: 'foo' }];
+      modalInstance.onOwnersChange(newOwners);
+      expect(spy).toHaveBeenCalledWith('owners', newOwners);
     });
   });
   describe('onMetadataChange', () => {

--- a/superset-frontend/spec/javascripts/sqllab/ResultSet_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/ResultSet_spec.jsx
@@ -26,6 +26,7 @@ import Alert from 'src/components/Alert';
 import ProgressBar from 'src/components/ProgressBar';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import fetchMock from 'fetch-mock';
 import FilterableTable from 'src/components/FilterableTable/FilterableTable';
 import ExploreResultsButton from 'src/SqlLab/components/ExploreResultsButton';
 import ResultSet from 'src/SqlLab/components/ResultSet';
@@ -80,6 +81,7 @@ const newProps = {
     },
   },
 };
+fetchMock.get('glob:*/api/v1/dataset?*', { result: [] });
 
 test('is valid', () => {
   expect(React.isValidElement(<ResultSet {...mockedProps} />)).toBe(true);

--- a/superset-frontend/spec/javascripts/sqllab/SqlEditorLeftBar_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/SqlEditorLeftBar_spec.jsx
@@ -46,8 +46,7 @@ const mockedProps = {
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
 const store = mockStore(initialState);
-const DATABASE_ENDPOINT = 'glob:*/api/v1/database/?*';
-fetchMock.get(DATABASE_ENDPOINT, []);
+fetchMock.get('glob:*/api/v1/database/*/schemas/?*', { result: [] });
 describe('SqlEditorLeftBar', () => {
   let wrapper;
 

--- a/superset-frontend/src/components/AlteredSliceTag/AlteredSliceTag.test.jsx
+++ b/superset-frontend/src/components/AlteredSliceTag/AlteredSliceTag.test.jsx
@@ -129,7 +129,7 @@ describe('AlteredSliceTag', () => {
       const th = getTableWrapperFromModalBody(modalBody).find('th');
       expect(th).toHaveLength(3);
       ['Control', 'Before', 'After'].forEach(async (v, i) => {
-        await expect(th.find('span').get(i).props.children[0]).toBe(v);
+        await expect(th.at(i).find('span').get(0).props.children[0]).toBe(v);
       });
     });
 

--- a/superset-frontend/src/dashboard/components/Header/Header.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/Header.test.tsx
@@ -23,7 +23,6 @@ import sinon from 'sinon';
 import fetchMock from 'fetch-mock';
 import * as actions from 'src/reports/actions/reports';
 import * as featureFlags from 'src/featureFlags';
-import { ReportObject } from 'src/components/ReportModal';
 import mockState from 'spec/fixtures/mockStateWithoutUser';
 import { HeaderProps } from './types';
 import Header from '.';
@@ -345,24 +344,27 @@ describe('Email Report Modal', () => {
     render(setup(mockedProps), { useRedux: true });
 
     const reportValues = {
-      active: true,
-      creation_method: 'dashboards',
-      crontab: '0 12 * * 1',
-      dashboard: mockedProps.dashboardInfo.id,
-      name: 'Weekly Report',
-      owners: [mockedProps.user.userId],
-      recipients: [
-        {
-          recipient_config_json: {
-            target: mockedProps.user.email,
+      id: 1,
+      result: {
+        active: true,
+        creation_method: 'dashboards',
+        crontab: '0 12 * * 1',
+        dashboard: mockedProps.dashboardInfo.id,
+        name: 'Weekly Report',
+        owners: [mockedProps.user.userId],
+        recipients: [
+          {
+            recipient_config_json: {
+              target: mockedProps.user.email,
+            },
+            type: 'Email',
           },
-          type: 'Email',
-        },
-      ],
-      type: 'Report',
+        ],
+        type: 'Report',
+      },
     };
     // This is needed to structure the reportValues to match the fetchMock return
-    const stringyReportValues = `{"active":true,"creation_method":"dashboards","crontab":"0 12 * * 1","dashboard":${mockedProps.dashboardInfo.id},"name":"Weekly Report","owners":[${mockedProps.user.userId}],"recipients":[{"recipient_config_json":{"target":"${mockedProps.user.email}"},"type":"Email"}],"type":"Report"}`;
+    const stringyReportValues = `{"id":1,"result":{"active":true,"creation_method":"dashboards","crontab":"0 12 * * 1","dashboard":${mockedProps.dashboardInfo.id},"name":"Weekly Report","owners":[${mockedProps.user.userId}],"recipients":[{"recipient_config_json":{"target":"${mockedProps.user.email}"},"type":"Email"}],"type":"Report"}}`;
     // Watch for report POST
     fetchMock.post(REPORT_ENDPOINT, reportValues);
 
@@ -380,7 +382,7 @@ describe('Email Report Modal', () => {
 
     // Mock addReport from Redux
     const makeRequest = () => {
-      const request = actions.addReport(reportValues as ReportObject);
+      const request = actions.addReport(reportValues);
       return request(dispatch);
     };
 

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.test.jsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.test.jsx
@@ -42,6 +42,8 @@ const dbProps = {
 const DATABASE_FETCH_ENDPOINT = 'glob:*/api/v1/database/10';
 // const DATABASE_POST_ENDPOINT = 'glob:*/api/v1/database/';
 const AVAILABLE_DB_ENDPOINT = 'glob:*/api/v1/database/available*';
+const VALIDATE_PARAMS_ENDPOINT = 'glob:*/api/v1/database/validate_parameters*';
+
 fetchMock.config.overwriteRoutes = true;
 fetchMock.get(DATABASE_FETCH_ENDPOINT, {
   result: {
@@ -193,6 +195,9 @@ fetchMock.mock(AVAILABLE_DB_ENDPOINT, {
       sqlalchemy_uri_placeholder: 'bigquery://{project_id}',
     },
   ],
+});
+fetchMock.post(VALIDATE_PARAMS_ENDPOINT, {
+  message: 'OK',
 });
 
 describe('DatabaseModal', () => {

--- a/superset-websocket/Dockerfile
+++ b/superset-websocket/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM node:14.16.1
+FROM node:16
 
 WORKDIR /home/superset-websocket
 


### PR DESCRIPTION
### SUMMARY
With Node 16 being the currently recommended version since 2021-04-20 and becoming the LTS supported version on 2021-10-26, it makes sense to migrate to this version to get all the benefits available in the new release:
https://medium.com/the-node-js-collection/node-js-16-available-now-7f5099a97e70
Also removes the workaround for pulling in `npm@7` in #16748 (npm 7 ships by default with Node 16)

This PR also fixes some tests that were previously passing but contained unhandled promise rejections. Previously these only emitted warnings, but as of Node 15 these caused errors. 

### TESTING INSTRUCTIONS
1. Make sure the application works as expected - done (running on the new build):
![image](https://user-images.githubusercontent.com/33317356/134489123-53cf68b3-a880-45d5-a69b-f2e40dde3d37.png)
2. Make sure CI is reporting the correct versions - done:
![image](https://user-images.githubusercontent.com/33317356/134488990-aa1493e9-f29b-454f-8d91-d157542818a6.png)


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
