### PR TITLE
fix: Explore button not rendering after running query

### DIFF
--- a/superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx
+++ b/superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx
@@ -152,14 +152,11 @@ class ExploreResultsButton extends React.PureComponent {
   }
 
   render() {
-    const allowsSubquery =
-      this.props.database && this.props.database.allows_subquery;
     return (
       <>
         <Button
           buttonSize="small"
           onClick={this.props.onClick}
-          disabled={!allowsSubquery}
           tooltip={t('Explore the result set in the data exploration view')}
         >
           <InfoTooltipWithTrigger

--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -487,17 +487,15 @@ export default class ResultSet extends React.PureComponent<
             onChangeAutoComplete={this.handleOnChangeAutoComplete}
           />
           <ResultSetButtons>
-            {this.props.visualize &&
-              this.props.database &&
-              this.props.database.allows_virtual_table_explore && (
-                <ExploreResultsButton
-                  // @ts-ignore Redux types are difficult to work with, ignoring for now
-                  query={this.props.query}
-                  database={this.props.database}
-                  actions={this.props.actions}
-                  onClick={this.handleExploreBtnClick}
-                />
-              )}
+            {this.props.visualize && this.props.database && (
+              <ExploreResultsButton
+                // @ts-ignore Redux types are difficult to work with, ignoring for now
+                query={this.props.query}
+                database={this.props.database}
+                actions={this.props.actions}
+                onClick={this.handleExploreBtnClick}
+              />
+            )}
             {this.props.csv && (
               <Button
                 buttonSize="small"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
in sqllab, the explore button was not appearing inside the ResultSet component after query completion. The underlying database prop must have been changed in PRs before but this is currently blocking users from be able to build charts on top of virtual datasets.

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

#### Before
![Screen Shot 2021-09-23 at 2 33 39 PM](https://user-images.githubusercontent.com/27827808/134564421-1af9b817-b0a2-4e9c-922c-702468e119ab.png)

#### After
![Screen Shot 2021-09-23 at 2 36 51 PM](https://user-images.githubusercontent.com/27827808/134564501-95051d8b-0d3b-46e1-b4f7-5d26ca6fa6e6.png)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
