### PR TITLE
chore: move repro steps up in issue template 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,13 @@ labels: "#bug"
 
 A clear and concise description of what the bug is.
 
+#### How to reproduce the bug
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
 ### Expected results
 
 what you expected to happen.
@@ -19,12 +26,6 @@ what actually happens.
 
 If applicable, add screenshots to help explain your problem.
 
-#### How to reproduce the bug
-
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
 
 ### Environment
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
After filing near 300 and triaged near 1000 issues in Superset repo, I found that having reproduce steps right after the 'one sentence issue description', following with Expected Results and Actual Results is more logical. 
- The 'What' and 'How' should stay close, which help ticket assignee to grab the context easier
- People often forget to provide repro steps( which is the most important info) as the section was not in a prominent section. 
- The info in Issue description and Expected results seem repetitive. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
