### PR TITLE
fix(native-filters): emitted filter label format

### DIFF
--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -37,11 +37,7 @@ import { useImmerReducer } from 'use-immer';
 import { FormItemProps } from 'antd/lib/form';
 import { PluginFilterSelectProps, SelectValue } from './types';
 import { StyledFormItem, FilterPluginStyle, StatusMessage } from '../common';
-import {
-  formatFilterValue,
-  getDataRecordFormatter,
-  getSelectExtraFormData,
-} from '../../utils';
+import { getDataRecordFormatter, getSelectExtraFormData } from '../../utils';
 
 type DataMaskAction =
   | { type: 'ownState'; ownState: JsonObject }
@@ -104,6 +100,15 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
     extraFormData: {},
     filterState,
   });
+  const datatype: GenericDataType = coltypeMap[col];
+  const labelFormatter = useMemo(
+    () =>
+      getDataRecordFormatter({
+        timeFormatter: smartDateDetailedFormatter,
+      }),
+    [],
+  );
+
   const updateDataMask = useCallback(
     (values: SelectValue) => {
       const emptyFilter =
@@ -124,7 +129,9 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
         filterState: {
           ...filterState,
           label: values?.length
-            ? `${(values || []).map(formatFilterValue).join(', ')}${suffix}`
+            ? `${(values || [])
+                .map(value => labelFormatter(value, datatype))
+                .join(', ')}${suffix}`
             : undefined,
           value:
             appSection === AppSection.FILTER_CONFIG_MODAL && defaultToFirstItem
@@ -133,14 +140,17 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
         },
       });
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       appSection,
       col,
+      datatype,
       defaultToFirstItem,
       dispatchDataMask,
       enableEmptyFilter,
       inverseSelection,
       JSON.stringify(filterState),
+      labelFormatter,
     ],
   );
 
@@ -186,15 +196,6 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
     clearSuggestionSearch();
     unsetFocusedFilter();
   };
-
-  const datatype: GenericDataType = coltypeMap[col];
-  const labelFormatter = useMemo(
-    () =>
-      getDataRecordFormatter({
-        timeFormatter: smartDateDetailedFormatter,
-      }),
-    [],
-  );
 
   const handleChange = (value?: SelectValue | number | string) => {
     const values = ensureIsArray(value);

--- a/superset-frontend/src/filters/utils.ts
+++ b/superset-frontend/src/filters/utils.ts
@@ -117,18 +117,3 @@ export function getDataRecordFormatter({
     return String(value);
   };
 }
-
-export function formatFilterValue(
-  value: string | number | boolean | null,
-): string {
-  if (value === null) {
-    return NULL_STRING;
-  }
-  if (typeof value === 'string') {
-    return value;
-  }
-  if (typeof value === 'number') {
-    return String(value);
-  }
-  return value ? TRUE_STRING : FALSE_STRING;
-}


### PR DESCRIPTION
### SUMMARY
The fix in #16460 didn't address the special case of numeric filter values sometimes being temporal filters. It also introduced a new util for formatting filter values whose functionality was already covered by the much more comprehensive `getDataRecordFormatter` factory function, which also handles time and number formatting. The redundant formatter is removed and replaced by `getDataRecordFormatter` which was already being used for formatting the options in the Select component. This will ensure that the filter indicator displays identical values as the Select component.

Closes #16808

### AFTER
![image](https://user-images.githubusercontent.com/33317356/134639890-b8fbcc43-be57-4110-9714-dc073eee5034.png)

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/134640985-3ec79ea5-525d-4b65-bea6-ed237f01dd4c.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
