### PR TITLE
fix(native-filters): filter indicator stale state

### DIFF
--- a/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
@@ -212,7 +212,7 @@ export const selectIndicatorsForChart = (
 };
 
 const cachedNativeIndicatorsForChart = {};
-let cachedNativeFilterDataForChart: any = {};
+const cachedNativeFilterDataForChart: any = {};
 const defaultChartConfig = {};
 export const selectNativeIndicatorsForChart = (
   nativeFilters: Filters,
@@ -230,10 +230,10 @@ export const selectNativeIndicatorsForChart = (
     cachedNativeIndicatorsForChart[chartId] &&
     areObjectsEqual(cachedFilterData?.appliedColumns, appliedColumns) &&
     areObjectsEqual(cachedFilterData?.rejectedColumns, rejectedColumns) &&
-    cachedNativeFilterDataForChart?.nativeFilters === nativeFilters &&
-    cachedNativeFilterDataForChart?.dashboardLayout === dashboardLayout &&
-    cachedNativeFilterDataForChart?.chartConfiguration === chartConfiguration &&
-    cachedNativeFilterDataForChart?.dataMask === dataMask
+    cachedFilterData?.nativeFilters === nativeFilters &&
+    cachedFilterData?.dashboardLayout === dashboardLayout &&
+    cachedFilterData?.chartConfiguration === chartConfiguration &&
+    cachedFilterData?.dataMask === dataMask
   ) {
     return cachedNativeIndicatorsForChart[chartId];
   }
@@ -326,14 +326,11 @@ export const selectNativeIndicatorsForChart = (
   }
   const indicators = crossFilterIndicators.concat(nativeFilterIndicators);
   cachedNativeIndicatorsForChart[chartId] = indicators;
-  cachedNativeFilterDataForChart = {
-    ...cachedNativeFilterDataForChart,
+  cachedNativeFilterDataForChart[chartId] = {
     nativeFilters,
     dashboardLayout,
     chartConfiguration,
     dataMask,
-  };
-  cachedNativeFilterDataForChart[chartId] = {
     appliedColumns,
     rejectedColumns,
   };


### PR DESCRIPTION
### SUMMARY
The recent perf improvement PR #16545 introduced a regression where some chart indicators didn't update correctly after applying filters. This was caused by all indicators sharing the same state that was used to check if the relevant data had changed. This changes the logic so that all indicators have their own set of "previous" objects to ensure that the result is recalculated when a relevant change has occurred.

When checking if this was also a problem with the legacy indicators I noticed that the logic there mostly resembles the proposed solution here, so this shouldn't be a problem there.

Fixes: #16806

### AFTER
When applying new filters, all filter indicators are now updated correctly:
![image](https://user-images.githubusercontent.com/33317356/134664630-3b976327-839a-462a-8c0f-9b7531387d4b.png)

### BEFORE
Previously only the first few charts' indicators were updated; the later ones always hit the cache due to the shared state having already been updated and hence satisfying the equality checks:
![image](https://user-images.githubusercontent.com/33317356/134664733-1af9ec65-a23f-463f-9b4e-f03ef3cc3612.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
