### PR TITLE
fix: 500s uniqueness issue on updates

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1671,7 +1671,7 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
             return None
 
         if not DatasetDAO.validate_uniqueness(
-            target.database_id, target.schema, target.table_name
+            target.database_id, target.schema, target.table_name, check_count=True
         ):
             raise Exception(get_dataset_exist_error_msg(target.full_name))
 

--- a/superset/datasets/dao.py
+++ b/superset/datasets/dao.py
@@ -105,18 +105,6 @@ class DatasetDAO(BaseDAO):  # pylint: disable=too-many-public-methods
         return not db.session.query(dataset_query.exists()).scalar()
 
     @staticmethod
-    def validate_duplicate_uniqueness(
-        database_id: int, schema: Optional[str], name: str
-    ) -> bool:
-        dataset_query = db.session.query(SqlaTable).filter(
-            SqlaTable.table_name == name,
-            SqlaTable.schema == schema,
-            SqlaTable.database_id == database_id,
-        )
-
-        return not db.session.query(dataset_query.exists()).scalar()
-
-    @staticmethod
     def validate_update_uniqueness(
         database_id: int, dataset_id: int, name: str
     ) -> bool:

--- a/superset/datasets/dao.py
+++ b/superset/datasets/dao.py
@@ -100,7 +100,7 @@ class DatasetDAO(BaseDAO):  # pylint: disable=too-many-public-methods
         if check_count:
             # Make sure there is only one dataset
             # Using this test to allow for overwrite
-            return dataset_query.count() == 1
+            return not dataset_query.count() == 1
 
         return not db.session.query(dataset_query.exists()).scalar()
 

--- a/superset/datasets/dao.py
+++ b/superset/datasets/dao.py
@@ -85,12 +85,35 @@ class DatasetDAO(BaseDAO):  # pylint: disable=too-many-public-methods
             return False
 
     @staticmethod
-    def validate_uniqueness(database_id: int, schema: Optional[str], name: str) -> bool:
+    def validate_uniqueness(
+        database_id: int,
+        schema: Optional[str],
+        name: str,
+        check_count: Optional[bool] = False,
+    ) -> bool:
         dataset_query = db.session.query(SqlaTable).filter(
             SqlaTable.table_name == name,
             SqlaTable.schema == schema,
             SqlaTable.database_id == database_id,
         )
+
+        if check_count:
+            # Make sure there is only one dataset
+            # Using this test to allow for overwrite
+            return dataset_query.count() == 1
+
+        return not db.session.query(dataset_query.exists()).scalar()
+
+    @staticmethod
+    def validate_duplicate_uniqueness(
+        database_id: int, schema: Optional[str], name: str
+    ) -> bool:
+        dataset_query = db.session.query(SqlaTable).filter(
+            SqlaTable.table_name == name,
+            SqlaTable.schema == schema,
+            SqlaTable.database_id == database_id,
+        )
+
         return not db.session.query(dataset_query.exists()).scalar()
 
     @staticmethod


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Users would intermittently get Fatal Error 500 errors when trying to update datasets from SQLLab. The issue is happening
with `if history.has_changes()` coming back as true and `DatasetDAO.validate_uniqueness` failing. Users should be able to overwrite 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
