### PR TITLE
fix(SqlLab): display tooltip when disabled

### DIFF
--- a/superset-frontend/src/components/Button/index.tsx
+++ b/superset-frontend/src/components/Button/index.tsx
@@ -224,7 +224,9 @@ export default function Button(props: ButtonProps) {
         id={`${kebabCase(tooltip)}-tooltip`}
         title={tooltip}
       >
-        {button}
+        {/* this ternary wraps the button in a span so that the tooltip shows up
+        when the button is disabled.  */}
+        {disabled ? <span>{button}</span> : button}
       </Tooltip>
     );
   }


### PR DESCRIPTION
### SUMMARY

Antd button design disallows all cursor events when a button is disabled, which turns off our tooltips on disabled buttons. The easiest solution is outlined here: https://github.com/react-component/tooltip/issues/18

Summarized, you have to wrap a disabled button in a span to show the tooltip. However, if you have a span on an enabled button then you get two tooltips. This PR wraps the button in a span if it is disabled. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/48933336/134715010-0a96d60b-1e28-4fa3-9ce6-d953fad98b31.mov


### TESTING INSTRUCTIONS
Have the KV/store featureflag disabled in your superset_config. 

Write a query, hover over the copy link to see if there is a tooltip. There should be a tooltip. 
Save the query, the color should change and there should be a different tooltip. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
