### PR TITLE
fix(gallery): Hide the bottom info section when no chart is being selected

### DIFF
--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -125,17 +125,23 @@ const RECOMMENDED_TAGS = [t('Popular'), t('ECharts'), t('Advanced-Analytics')];
 
 export const VIZ_TYPE_CONTROL_TEST_ID = 'viz-type-control';
 
-const VizPickerLayout = styled.div`
-  display: grid;
-  grid-template-rows: auto minmax(100px, 1fr) minmax(200px, 35%);
-  // em is used here because the sidebar should be sized to fit the longest standard tag
-  grid-template-columns: minmax(14em, auto) 5fr;
-  grid-template-areas:
-    'sidebar search'
-    'sidebar main'
-    'details details';
-  height: 70vh;
-  overflow: auto;
+const VizPickerLayout = styled.div<{ isSelectedVizMetadata: boolean }>`
+  ${({ isSelectedVizMetadata }) => `
+    display: grid;
+    grid-template-rows: ${
+      isSelectedVizMetadata
+        ? `auto minmax(100px, 1fr) minmax(200px, 35%)`
+        : 'auto minmax(100px, 1fr)'
+    };
+    // em is used here because the sidebar should be sized to fit the longest standard tag
+    grid-template-columns: minmax(14em, auto) 5fr;
+    grid-template-areas:
+      'sidebar search'
+      'sidebar main'
+      'details details';
+    height: 70vh;
+    overflow: auto;
+  `}
 `;
 
 const SectionTitle = styled.h3`
@@ -267,15 +273,6 @@ const DetailsPopulated = (theme: SupersetTheme) => css`
     'viz-name examples-header'
     'viz-tags examples'
     'description examples';
-`;
-
-const DetailsEmpty = (theme: SupersetTheme) => css`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-  font-style: italic;
-  color: ${theme.colors.grayscale.light1};
 `;
 
 // overflow hidden on the details pane and overflow auto on the description
@@ -642,7 +639,10 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
   };
 
   return (
-    <VizPickerLayout className={className}>
+    <VizPickerLayout
+      className={className}
+      isSelectedVizMetadata={Boolean(selectedVizMetadata)}
+    >
       <LeftPane>
         <Selector
           css={({ gridUnit }) =>
@@ -769,16 +769,7 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
             </Examples>
           </>
         </div>
-      ) : (
-        <div
-          css={(theme: SupersetTheme) => [
-            DetailsPane(theme),
-            DetailsEmpty(theme),
-          ]}
-        >
-          {t('Select a visualization type')}
-        </div>
-      )}
+      ) : null}
     </VizPickerLayout>
   );
 }


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR improve the viz gallery that hide the bottom info section when no chart is being selected.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### after

https://user-images.githubusercontent.com/11830681/134765553-13b95eb2-3f6a-47bf-8a80-7ebcc88c604a.mov



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:  #16771 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
