### PR TITLE
chore: db migrate timeseries_limit_metric to legacy_order_by

### DIFF
--- a/superset/migrations/versions/60dc453f4e2e_migrate_timeseries_limit_metric_to_.py
+++ b/superset/migrations/versions/60dc453f4e2e_migrate_timeseries_limit_metric_to_.py
@@ -1,0 +1,74 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""migrate timeseries_limit_metric to legacy_order_by in pivot_table_v2
+
+Revision ID: 60dc453f4e2e
+Revises: 3ebe0993c770
+Create Date: 2021-09-27 11:31:53.453164
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "60dc453f4e2e"
+down_revision = "3ebe0993c770"
+
+import json
+import re
+
+from alembic import op
+from sqlalchemy import and_, Column, Integer, String, Text
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
+
+Base = declarative_base()
+
+
+class Slice(Base):
+    __tablename__ = "slices"
+
+    id = Column(Integer, primary_key=True)
+    slice_name = Column(Text)
+    viz_type = Column(String(250))
+    params = Column(Text)
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    where_clause = and_(
+        Slice.viz_type == "pivot_table_v2",
+        Slice.params.like('%"timeseries_limit_metric%'),
+    )
+    slices = session.query(Slice).filter(where_clause)
+    total = slices.count()
+    idx = 0
+    for slc in slices.yield_per(100):
+        idx += 1
+        print(f"Upgrading ({idx}/{total}): {slc.slice_name}#{slc.id}")
+        params = json.loads(slc.params)
+        params["legacy_order_by"] = params.pop("timeseries_limit_metric", None)
+        slc.params = json.dumps(params, sort_keys=True, indent=4)
+        session.commit()
+
+    session.close()
+
+
+def downgrade():
+    # slices can't be downgraded
+    pass


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Frontend changes at: https://github.com/apache-superset/superset-ui/pull/1364

currently, Superset use timeseries_limit_metric control for main query orderby. While this is actually prepared for the inner query when viz is timeseries-like.

To fix the original incorrect use, so this PR introduce a legacy_order_by control.

This PR only migrate pivot table v2.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
