### PR TITLE
refactor: sql lab: handling command exceptions 

### DIFF
--- a/superset/errors.py
+++ b/superset/errors.py
@@ -218,3 +218,10 @@ class SupersetError:
                     ]
                 }
             )
+
+    def to_dict(self) -> Dict[str, Any]:
+        rv = {"message": self.message,
+              "error_type": self.error_type}
+        if self.extra:
+            rv["extra"] = self.extra
+        return rv

--- a/superset/errors.py
+++ b/superset/errors.py
@@ -220,8 +220,7 @@ class SupersetError:
             )
 
     def to_dict(self) -> Dict[str, Any]:
-        rv = {"message": self.message,
-              "error_type": self.error_type}
+        rv = {"message": self.message, "error_type": self.error_type}
         if self.extra:
-            rv["extra"] = self.extra
+            rv["extra"] = self.extra  # type: ignore
         return rv

--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -54,7 +54,7 @@ class SupersetException(Exception):
         if self.error_type:
             rv["error_type"] = self.error_type
         if self.exception is not None and hasattr(self.exception, "to_dict"):
-            rv = {**rv, **self.exception.to_dict()}
+            rv = {**rv, **self.exception.to_dict()}  # type: ignore
         return rv
 
 

--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -28,16 +28,34 @@ class SupersetException(Exception):
     message = ""
 
     def __init__(
-        self, message: str = "", exception: Optional[Exception] = None,
+        self,
+        message: str = "",
+        exception: Optional[Exception] = None,
+        error_type: Optional[SupersetErrorType] = None,
     ) -> None:
         if message:
             self.message = message
         self._exception = exception
+        self._error_type = error_type
         super().__init__(self.message)
 
     @property
     def exception(self) -> Optional[Exception]:
         return self._exception
+
+    @property
+    def error_type(self) -> Optional[SupersetErrorType]:
+        return self._error_type
+
+    def to_dict(self) -> Dict[str, Any]:
+        rv = {}
+        if hasattr(self, "message"):
+            rv["message"] = self.message
+        if self.error_type:
+            rv["error_type"] = self.error_type
+        if self.exception is not None and hasattr(self.exception, "to_dict"):
+            rv = {**rv, **self.exception.to_dict()}
+        return rv
 
 
 class SupersetErrorException(SupersetException):
@@ -48,6 +66,9 @@ class SupersetErrorException(SupersetException):
         self.error = error
         if status is not None:
             self.status = status
+
+    def to_dict(self) -> Dict[str, Any]:
+        return self.error.to_dict()
 
 
 class SupersetGenericErrorException(SupersetErrorException):

--- a/superset/sqllab/exceptions.py
+++ b/superset/sqllab/exceptions.py
@@ -1,0 +1,83 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import os
+from typing import Optional, TYPE_CHECKING
+
+from superset.errors import SupersetError, SupersetErrorType
+from superset.exceptions import SupersetException
+
+MSG_FORMAT = "Failed to execute {}"
+
+if TYPE_CHECKING:
+    from superset.utils.sqllab_execution_context import SqlJsonExecutionContext
+
+
+class SqlLabException(SupersetException):
+    sql_json_execution_context: SqlJsonExecutionContext
+    failed_reason_msg: str
+    suggestion_help_msg: Optional[str]
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        sql_json_execution_context: SqlJsonExecutionContext,
+        error_type: Optional[SupersetErrorType] = None,
+        reason_message: Optional[str] = None,
+        exception: Optional[Exception] = None,
+        suggestion_help_msg: Optional[str] = None,
+    ) -> None:
+        self.sql_json_execution_context = sql_json_execution_context
+        self.failed_reason_msg = self._get_reason(reason_message, exception)
+        self.suggestion_help_msg = suggestion_help_msg
+        if error_type is None:
+            if exception is not None:
+                if (
+                    hasattr(exception, "error_type")
+                    and exception.error_type is not None  # type: ignore
+                ):
+                    error_type = exception.error_type  # type: ignore
+                elif hasattr(exception, "error") and isinstance(
+                    exception.error, SupersetError  # type: ignore
+                ):
+                    error_type = exception.error.error_type  # type: ignore
+            else:
+                error_type = SupersetErrorType.GENERIC_BACKEND_ERROR
+
+        super().__init__(self._generate_message(), exception, error_type)
+
+    def _generate_message(self) -> str:
+        msg = MSG_FORMAT.format(self.sql_json_execution_context.get_query_details())
+        if self.failed_reason_msg:
+            msg = msg + self.failed_reason_msg
+        if self.suggestion_help_msg is not None:
+            msg = "{} {} {}".format(msg, os.linesep, self.suggestion_help_msg)
+        return msg
+
+    @classmethod
+    def _get_reason(
+        cls, reason_message: Optional[str] = None, exception: Optional[Exception] = None
+    ) -> str:
+        if reason_message is not None:
+            return ": {}".format(reason_message)
+        if exception is not None:
+            if hasattr(exception, "get_message"):
+                return ": {}".format(exception.get_message())  # type: ignore
+            if hasattr(exception, "message"):
+                return ": {}".format(exception.message)  # type: ignore
+            return ": {}".format(str(exception))
+        return ""

--- a/superset/utils/sqllab_execution_context.py
+++ b/superset/utils/sqllab_execution_context.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from typing import Any, cast, Dict, Optional, TYPE_CHECKING
 
 from flask import g
+from sqlalchemy.orm.exc import DetachedInstanceError
 
 from superset import is_feature_enabled
 from superset.models.sql_lab import Query
@@ -176,6 +177,15 @@ class SqlJsonExecutionContext:  # pylint: disable=too-many-instance-attributes
             user_id=self.user_id,
             client_id=self.client_id_or_short_id,
         )
+
+    def get_query_details(self) -> str:
+        try:
+            if self.query:
+                if self.query.id:
+                    return "query '{}' - '{}'".format(self.query.id, self.query.sql)
+        except DetachedInstanceError:
+            pass
+        return "query '{}'".format(self.sql)
 
 
 class CreateTableAsSelect:  # pylint: disable=too-few-public-methods


### PR DESCRIPTION
SUMMARY
The sql_json view code in superset core view without any "clean code" standard and it does not adopt any software development principle.

This is the fifteenth PR in the sequence of future PRs ([previous PR](refactor: sql_json view endpoint: move all logic from view to Command class)) try to solve it by refactoring the code.

The PR focus on organizing the command exception handling 

actually, there are no logic changes so it implies on the current tests.