### PR TITLE
fix(native-filters): ignore unset filter box time range

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1175,7 +1175,7 @@ def merge_extra_filters(form_data: Dict[str, Any]) -> None:
             time_extra = date_options.get(filter_column)
             if time_extra:
                 time_extra_value = filtr.get("val")
-                if time_extra_value:
+                if time_extra_value and time_extra_value != NO_TIME_RANGE:
                     form_data[time_extra] = time_extra_value
                     applied_time_extras[filter_column] = time_extra_value
             elif filtr["val"]:
@@ -1640,7 +1640,7 @@ def get_time_filter_status(
             )
 
     time_range = applied_time_extras.get(ExtraFiltersTimeColumnType.TIME_RANGE)
-    if time_range and time_range != NO_TIME_RANGE:
+    if time_range:
         # are there any temporal columns to assign the time grain to?
         if temporal_columns:
             applied.append({"column": ExtraFiltersTimeColumnType.TIME_RANGE})

--- a/tests/integration_tests/utils_tests.py
+++ b/tests/integration_tests/utils_tests.py
@@ -47,6 +47,7 @@ from superset.utils.core import (
     convert_legacy_filters_into_adhoc,
     create_ssl_cert_file,
     DTTM_ALIAS,
+    extract_dataframe_dtypes,
     format_timedelta,
     GenericDataType,
     get_form_data_token,
@@ -60,10 +61,10 @@ from superset.utils.core import (
     merge_extra_filters,
     merge_extra_form_data,
     merge_request_params,
+    NO_TIME_RANGE,
     normalize_dttm_col,
     parse_ssl_cert,
     parse_js_uri_path_item,
-    extract_dataframe_dtypes,
     split,
     TimeRangeEndpoint,
     validate_json,
@@ -848,6 +849,47 @@ class TestUtils(SupersetTestCase):
         merge_extra_form_data(form_data)
         self.assertEqual(
             form_data, {"time_range": "Last 10 days", "adhoc_filters": [],},
+        )
+
+    def test_merge_extra_filters_with_unset_legacy_time_range(self):
+        """
+        Make sure native filter is applied if filter box time range is unset.
+        """
+        form_data = {
+            "time_range": "Last 10 days",
+            "extra_filters": [
+                {"col": "__time_range", "op": "==", "val": NO_TIME_RANGE},
+            ],
+            "extra_form_data": {"time_range": "Last year"},
+        }
+        merge_extra_filters(form_data)
+        self.assertEqual(
+            form_data,
+            {
+                "time_range": "Last year",
+                "applied_time_extras": {},
+                "adhoc_filters": [],
+            },
+        )
+
+    def test_merge_extra_filters_with_conflicting_time_ranges(self):
+        """
+        Make sure filter box takes precedence if both native filter and filter box
+        time ranges are set.
+        """
+        form_data = {
+            "time_range": "Last 10 days",
+            "extra_filters": [{"col": "__time_range", "op": "==", "val": "Last week"}],
+            "extra_form_data": {"time_range": "Last year",},
+        }
+        merge_extra_filters(form_data)
+        self.assertEqual(
+            form_data,
+            {
+                "time_range": "Last week",
+                "applied_time_extras": {"__time_range": "Last week"},
+                "adhoc_filters": [],
+            },
         )
 
     def test_merge_extra_filters_with_extras(self):

--- a/tests/unit_tests/core_tests.py
+++ b/tests/unit_tests/core_tests.py
@@ -117,10 +117,6 @@ def test_get_time_filter_status_time_range():
     dataset = get_dataset_mock()
 
     assert get_time_filter_status(
-        dataset, {ExtraFiltersTimeColumnType.TIME_RANGE: NO_TIME_RANGE}
-    ) == ([], [])
-
-    assert get_time_filter_status(
         dataset, {ExtraFiltersTimeColumnType.TIME_RANGE: "1 year ago"}
     ) == ([{"column": ExtraFiltersTimeColumnType.TIME_RANGE}], [])
 


### PR DESCRIPTION
### SUMMARY
When a dashboard has both a native time range filter AND a filter box with a date filter, the native time range filter won't apply to charts, even if the filter box is set to "No filter". This is due to the filter box taking precedence over the native filter without evaluating if it's set or not.

This PR changes this so that the filter box doesn't override the value of the native filter if its value is "No filter" (the constant `NO_TIME_RANGE`). This is done by checking that the filter box time range is set earlier in the code flow. This check was previously done when setting the filter indicator status - this logic and associated unit tests were removed as they're now handled upstream. However, if both are set, the filter box takes precedence as before. Unit tests are added to handle both cases.

Closes #16839

### AFTER
After this change the native time range filter applies properly:
![image](https://user-images.githubusercontent.com/33317356/134904062-2e212dd3-0c24-4d1d-8012-1f39d92d929f.png)


### BEFORE
Currently the native time range filter doesn't apply to a chart if the dashboard has a filter box with a date filter (see the missing `year >= 1971` in the query):
![image](https://user-images.githubusercontent.com/33317356/134904152-8b097d0c-02c9-454b-9ac0-32e525dcfc48.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
