### PR TITLE
chore(security): Remove obsolete FAB metric_access permission

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -193,7 +193,6 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         "database_access",
         "schema_access",
         "datasource_access",
-        "metric_access",
     }
 
     ACCESSIBLE_PERMS = {"can_userinfo", "resetmypassword"}

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -93,7 +93,6 @@ class SupersetRoleListWidget(ListWidget):  # pylint: disable=too-few-public-meth
     """
 
     template = "superset/fab_overrides/list_role.html"
-
     
     def __init__(self, **kwargs: Any) -> None:
         kwargs["appbuilder"] = current_app.appbuilder

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -93,7 +93,7 @@ class SupersetRoleListWidget(ListWidget):  # pylint: disable=too-few-public-meth
     """
 
     template = "superset/fab_overrides/list_role.html"
-    
+
     def __init__(self, **kwargs: Any) -> None:
         kwargs["appbuilder"] = current_app.appbuilder
         super().__init__(**kwargs)

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -94,6 +94,7 @@ class SupersetRoleListWidget(ListWidget):  # pylint: disable=too-few-public-meth
 
     template = "superset/fab_overrides/list_role.html"
 
+    
     def __init__(self, **kwargs: Any) -> None:
         kwargs["appbuilder"] = current_app.appbuilder
         super().__init__(**kwargs)


### PR DESCRIPTION
### SUMMARY

Per [here](https://github.com/apache/superset/search?q=metric_access) the `metric_access` permission is obsolete and not used anywhere. 

Note I assume that FAB should clean up after itself and thus no explicit migration is necessary.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
