### PR TITLE
fix(build): enable hot reloading of linked packages

### DIFF
--- a/superset-frontend/src/setup/setupColors.ts
+++ b/superset-frontend/src/setup/setupColors.ts
@@ -52,6 +52,7 @@ export default function setupColors(
   extraSequentialColorSchemes: SequentialScheme[] = [],
 ) {
   registerColorSchemes(
+    // @ts-ignore
     getCategoricalSchemeRegistry(),
     [
       ...superset,
@@ -66,6 +67,7 @@ export default function setupColors(
     'supersetColors',
   );
   registerColorSchemes(
+    // @ts-ignore
     getSequentialSchemeRegistry(),
     [...sequentialCommon, ...sequentialD3, ...extraSequentialColorSchemes],
     'superset_seq_1',

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -455,6 +455,7 @@ if (isDevMode) {
     },
     static: path.join(process.cwd(), '../static/assets'),
   };
+  config.watchOptions = { followSymlinks: true };
 
   // make sure to use @emotion/* modules in the root directory
   fs.readdirSync(path.resolve(APP_DIR, './node_modules/@emotion'), pkg => {


### PR DESCRIPTION
### SUMMARY
The recent upgrade of Webpack to version 5 (#16701) broke hot reloading of linked packages. This fixes hot reloading by enabling the `config.watchOptions.followSymlinks` flag (https://webpack.js.org/configuration/watch/#watchoptionsfollowsymlinks) . Enabling `config.resolve.symlinks` doesn't work, as it breaks a bunch of dependencies.  We also ignore a few type errors that are raised when linking `superset-ui/core`. It is unclear why this error is raised when npm linking, but appears to be happening due to fairly complex polymorphism in the registry classes.

### TESTING INSTRUCTIONS
1. `npm ci`
2. Link `core` and `chart-controls` and a chart plugin, e.g. `npm link ../../superset-ui/packages/superset-ui-core ../../superset-ui/packages/superset-ui-chart-controls ../../superset-ui/plugins/plugin-chart-echarts`
3. `npm run dev-server`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
