### PR TITLE
fix(Explore): Clear filter value when changing columns

### DIFF
--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
@@ -211,40 +211,11 @@ const AdhocFilterEditPopoverSimpleTabContent: React.FC<Props> = props => {
     onComparatorChange,
   } = useSimpleTabFilterProps(props);
   const [suggestions, setSuggestions] = useState<Record<string, any>>([]);
+  const [comparator, setComparator] = useState(props.adhocFilter.comparator);
   const [
     loadingComparatorSuggestions,
     setLoadingComparatorSuggestions,
   ] = useState(false);
-
-  useEffect(() => {
-    const refreshComparatorSuggestions = () => {
-      const { datasource } = props;
-      const col = props.adhocFilter.subject;
-      const having = props.adhocFilter.clause === CLAUSES.HAVING;
-
-      if (col && datasource && datasource.filter_select && !having) {
-        const controller = new AbortController();
-        const { signal } = controller;
-        if (loadingComparatorSuggestions) {
-          controller.abort();
-        }
-        setLoadingComparatorSuggestions(true);
-        SupersetClient.get({
-          signal,
-          endpoint: `/superset/filter/${datasource.type}/${datasource.id}/${col}/`,
-        })
-          .then(({ json }) => {
-            setSuggestions(json);
-            setLoadingComparatorSuggestions(false);
-          })
-          .catch(() => {
-            setSuggestions([]);
-            setLoadingComparatorSuggestions(false);
-          });
-      }
-    };
-    refreshComparatorSuggestions();
-  }, [props.adhocFilter.subject]);
 
   const onInputComparatorChange = (
     event: React.ChangeEvent<HTMLInputElement>,
@@ -257,7 +228,6 @@ const AdhocFilterEditPopoverSimpleTabContent: React.FC<Props> = props => {
   );
 
   const getOptionsRemaining = () => {
-    const { comparator } = props.adhocFilter;
     // if select is multi/value is array, we show the options not selected
     const valuesFromSuggestionsLength = Array.isArray(comparator)
       ? comparator.filter(v => suggestions.includes(v)).length
@@ -271,7 +241,7 @@ const AdhocFilterEditPopoverSimpleTabContent: React.FC<Props> = props => {
   };
 
   let columns = props.options;
-  const { subject, operator, comparator, operatorId } = props.adhocFilter;
+  const { subject, operator, operatorId } = props.adhocFilter;
 
   const subjectSelectProps = {
     ariaLabel: t('Select subject'),
@@ -344,6 +314,42 @@ const AdhocFilterEditPopoverSimpleTabContent: React.FC<Props> = props => {
       width: max-content;
     }
   `;
+
+  useEffect(() => {
+    const refreshComparatorSuggestions = () => {
+      const { datasource } = props;
+      const col = props.adhocFilter.subject;
+      const having = props.adhocFilter.clause === CLAUSES.HAVING;
+
+      if (col && datasource && datasource.filter_select && !having) {
+        const controller = new AbortController();
+        const { signal } = controller;
+        if (loadingComparatorSuggestions) {
+          controller.abort();
+        }
+        setLoadingComparatorSuggestions(true);
+        SupersetClient.get({
+          signal,
+          endpoint: `/superset/filter/${datasource.type}/${datasource.id}/${col}/`,
+        })
+          .then(({ json }) => {
+            setSuggestions(json);
+            setLoadingComparatorSuggestions(false);
+            setComparator(undefined);
+          })
+          .catch(() => {
+            setSuggestions([]);
+            setLoadingComparatorSuggestions(false);
+            setComparator(undefined);
+          });
+      }
+    };
+    refreshComparatorSuggestions();
+  }, [props.adhocFilter.subject]);
+
+  useEffect(() => {
+    setComparator(props.adhocFilter.comparator);
+  }, [props.adhocFilter.comparator]);
 
   return (
     <>

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
@@ -240,13 +240,18 @@ const AdhocFilterEditPopoverSimpleTabContent: React.FC<Props> = props => {
     return optionsRemaining ? placeholder : '';
   };
 
+  const handleSubjectChange = (subject: string) => {
+    setComparator(undefined);
+    onSubjectChange(subject);
+  };
+
   let columns = props.options;
   const { subject, operator, operatorId } = props.adhocFilter;
 
   const subjectSelectProps = {
     ariaLabel: t('Select subject'),
     value: subject ?? undefined,
-    onChange: onSubjectChange,
+    onChange: handleSubjectChange,
     notFoundContent: t(
       'No such column found. To filter on a metric, try the Custom SQL tab.',
     ),
@@ -335,12 +340,10 @@ const AdhocFilterEditPopoverSimpleTabContent: React.FC<Props> = props => {
           .then(({ json }) => {
             setSuggestions(json);
             setLoadingComparatorSuggestions(false);
-            setComparator(undefined);
           })
           .catch(() => {
             setSuggestions([]);
             setLoadingComparatorSuggestions(false);
-            setComparator(undefined);
           });
       }
     };


### PR DESCRIPTION
### SUMMARY
This PR fixes an issue for which the filter value wasn't resetting when the column was changed.

### BEFORE
See #16844

### AFTER

https://user-images.githubusercontent.com/60598000/135114360-f16989ce-7616-4b27-85c7-0484261afeee.mp4

### TESTING INSTRUCTIONS
1. Open a Chart in Explore
2. Set a filter
3. Change the column of the filter
4. Make sure the filter value resets

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #16844
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
