### PR TITLE
chore(native_filter): feature on by default

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -369,7 +369,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     "DISPLAY_MARKDOWN_HTML": True,
     # When True, this escapes HTML (rather than rendering it) in Markdown components
     "ESCAPE_MARKDOWN_HTML": False,
-    "DASHBOARD_NATIVE_FILTERS": False,
+    "DASHBOARD_NATIVE_FILTERS": True,
     "DASHBOARD_CROSS_FILTERS": False,
     "DASHBOARD_NATIVE_FILTERS_SET": False,
     "DASHBOARD_FILTERS_EXPERIMENTAL": False,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR is making Dashboard Native_Filter on by default. User will be able to access to this feature without configuring going forward. This feature has been throughout tested and is ready for prime time. In fact, without this feature being visible, user may hit bugs when trying to use the legacy Filterbox along or with Native filter at the same time. This change will also drive users away from using Filterbox which has been causing errors.   

NOTE: We will remove this FF for good in about 1 month. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<img width="1184" alt="Screen Shot 2021-09-28 at 10 13 05 AM" src="https://user-images.githubusercontent.com/67837651/135134100-116e1c9b-73b8-4894-80fb-f7eacfe70184.png">
### TESTING INSTRUCTIONS
NA

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags: 
- [x ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
