### PR TITLE
fix: time comparison can't guarantee the accuracy

### DIFF
--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -203,7 +203,7 @@ class QueryContext:
             offset_df = self.left_join_df(
                 left_df=df, right_df=offset_metrics_df, join_keys=join_keys,
             )
-            offset_slice = offset_df[[m for m in metrics_mapping.values()]]
+            offset_slice = offset_df[metrics_mapping.values()]
 
             # set offset_slice to cache and stack.
             value = {

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -114,9 +114,9 @@ class QueryContext:
 
     @staticmethod
     def left_join_df(
-        left_df: pd.DataFrame, right_df: pd.DataFrame, on: List[str],
+        left_df: pd.DataFrame, right_df: pd.DataFrame, join_keys: List[str],
     ) -> pd.DataFrame:
-        df = left_df.set_index(on).join(right_df.set_index(on))
+        df = left_df.set_index(join_keys).join(right_df.set_index(join_keys))
         df.reset_index(inplace=True)
         return df
 
@@ -203,7 +203,7 @@ class QueryContext:
 
             # df left join `offset_metrics_df`
             offset_df = self.left_join_df(
-                left_df=df, right_df=offset_metrics_df, on=join_keys,
+                left_df=df, right_df=offset_metrics_df, join_keys=join_keys,
             )
             offset_slice = offset_df[
                 [m for m in metrics_and_dttm_mapping.values() if m != DTTM_ALIAS]

--- a/tests/integration_tests/query_context_tests.py
+++ b/tests/integration_tests/query_context_tests.py
@@ -20,6 +20,7 @@ import time
 from typing import Any, Dict
 
 import pytest
+from pandas import DateOffset
 
 from superset import db
 from superset.charts.schemas import ChartDataQueryContextSchema
@@ -546,11 +547,15 @@ class TestQueryContext(SupersetTestCase):
         self.login(username="admin")
         payload = get_query_context("birth_names")
         payload["queries"][0]["metrics"] = ["sum__num"]
+        # should process empty dateframe correctly
+        # duo to "name" is random generated, each time_offset slice will be empty
         payload["queries"][0]["groupby"] = ["name"]
         payload["queries"][0]["is_timeseries"] = True
         payload["queries"][0]["timeseries_limit"] = 5
         payload["queries"][0]["time_offsets"] = []
         payload["queries"][0]["time_range"] = "1990 : 1991"
+        payload["queries"][0]["granularity"] = "ds"
+        payload["queries"][0]["extras"]["time_grain_sqla"] = "P1Y"
         query_context = ChartDataQueryContextSchema().load(payload)
         query_object = query_context.queries[0]
         query_result = query_context.get_query_result(query_object)
@@ -588,3 +593,97 @@ class TestQueryContext(SupersetTestCase):
         self.assertIs(rv["df"], df)
         self.assertEqual(rv["queries"], [])
         self.assertEqual(rv["cache_keys"], [])
+
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+    def test_time_offsets_sql(self):
+        payload = get_query_context("birth_names")
+        payload["queries"][0]["metrics"] = ["sum__num"]
+        payload["queries"][0]["groupby"] = ["state"]
+        payload["queries"][0]["is_timeseries"] = True
+        payload["queries"][0]["timeseries_limit"] = 5
+        payload["queries"][0]["time_offsets"] = []
+        payload["queries"][0]["time_range"] = "1980 : 1991"
+        payload["queries"][0]["granularity"] = "ds"
+        payload["queries"][0]["extras"]["time_grain_sqla"] = "P1Y"
+        query_context = ChartDataQueryContextSchema().load(payload)
+        query_object = query_context.queries[0]
+        query_result = query_context.get_query_result(query_object)
+        # get main query dataframe
+        df = query_result.df
+
+        # set time_offsets to query_object
+        payload["queries"][0]["time_offsets"] = ["3 years ago", "3 years later"]
+        query_context = ChartDataQueryContextSchema().load(payload)
+        query_object = query_context.queries[0]
+        time_offsets_obj = query_context.processing_time_offsets(df, query_object)
+        query_from_1977_to_1988 = time_offsets_obj["queries"][0]
+        query_from_1983_to_1994 = time_offsets_obj["queries"][1]
+
+        # should generate expected date range in sql
+        assert "1977-01-01" in query_from_1977_to_1988
+        assert "1988-01-01" in query_from_1977_to_1988
+        assert "1983-01-01" in query_from_1983_to_1994
+        assert "1994-01-01" in query_from_1983_to_1994
+
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+    def test_time_offsets_accuracy(self):
+        payload = get_query_context("birth_names")
+        payload["queries"][0]["metrics"] = ["sum__num"]
+        payload["queries"][0]["groupby"] = ["state"]
+        payload["queries"][0]["is_timeseries"] = True
+        payload["queries"][0]["timeseries_limit"] = 5
+        payload["queries"][0]["time_offsets"] = []
+        payload["queries"][0]["time_range"] = "1980 : 1991"
+        payload["queries"][0]["granularity"] = "ds"
+        payload["queries"][0]["extras"]["time_grain_sqla"] = "P1Y"
+        query_context = ChartDataQueryContextSchema().load(payload)
+        query_object = query_context.queries[0]
+        query_result = query_context.get_query_result(query_object)
+        # get main query dataframe
+        df = query_result.df
+
+        # set time_offsets to query_object
+        payload["queries"][0]["time_offsets"] = ["3 years ago", "3 years later"]
+        query_context = ChartDataQueryContextSchema().load(payload)
+        query_object = query_context.queries[0]
+        time_offsets_obj = query_context.processing_time_offsets(df, query_object)
+        df_with_offsets = time_offsets_obj["df"]
+        df_with_offsets = df_with_offsets.set_index(["__timestamp", "state"])
+
+        # should get correct data when apply "3 years ago"
+        payload["queries"][0]["time_offsets"] = []
+        payload["queries"][0]["time_range"] = "1977 : 1988"
+        query_context = ChartDataQueryContextSchema().load(payload)
+        query_object = query_context.queries[0]
+        query_result = query_context.get_query_result(query_object)
+        # get df for "3 years ago"
+        df_3_years_ago = query_result.df
+        df_3_years_ago["__timestamp"] = df_3_years_ago["__timestamp"] + DateOffset(
+            years=3
+        )
+        df_3_years_ago = df_3_years_ago.set_index(["__timestamp", "state"])
+        for index, row in df_with_offsets.iterrows():
+            if index in df_3_years_ago.index:
+                assert (
+                    row["sum__num__3 years ago"]
+                    == df_3_years_ago.loc[index]["sum__num"]
+                )
+
+        # should get correct data when apply "3 years later"
+        payload["queries"][0]["time_offsets"] = []
+        payload["queries"][0]["time_range"] = "1983 : 1994"
+        query_context = ChartDataQueryContextSchema().load(payload)
+        query_object = query_context.queries[0]
+        query_result = query_context.get_query_result(query_object)
+        # get df for "3 years later"
+        df_3_years_later = query_result.df
+        df_3_years_later["__timestamp"] = df_3_years_later["__timestamp"] - DateOffset(
+            years=3
+        )
+        df_3_years_later = df_3_years_later.set_index(["__timestamp", "state"])
+        for index, row in df_with_offsets.iterrows():
+            if index in df_3_years_later.index:
+                assert (
+                    row["sum__num__3 years later"]
+                    == df_3_years_later.loc[index]["sum__num"]
+                )

--- a/tests/integration_tests/query_context_tests.py
+++ b/tests/integration_tests/query_context_tests.py
@@ -548,7 +548,7 @@ class TestQueryContext(SupersetTestCase):
         payload = get_query_context("birth_names")
         payload["queries"][0]["metrics"] = ["sum__num"]
         # should process empty dateframe correctly
-        # duo to "name" is random generated, each time_offset slice will be empty
+        # due to "name" is random generated, each time_offset slice will be empty
         payload["queries"][0]["groupby"] = ["name"]
         payload["queries"][0]["is_timeseries"] = True
         payload["queries"][0]["timeseries_limit"] = 5


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `time comparison` in AA can't guarantee accuracy when applied to multiple series line charts. 

Due to the errors of the original algorithm, only consider using the time column to `join`. Now the join algorithm is improved.



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### After

![Time comparison-after](https://user-images.githubusercontent.com/2016594/135451029-25564bd1-a1c5-4a37-b096-db623059f3e3.png)

#### Before
![Time comparison-before](https://user-images.githubusercontent.com/2016594/135258865-de5c4720-9d76-4bcf-9e5d-4cad9004b781.png)

https://user-images.githubusercontent.com/2016594/135259011-986c26a8-8189-40a7-a51a-fdbb51a86527.mov

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. select `birth_names` dataset
2. switch to time-series chart
3. set time grain to `year`
4. set time range to `1970 - 2000`
5. set metrics to `sum__num`
6. set group by to `state`
7. set series limit to `2` for convenience
8. set time shift to `3 years later`
9. set calculation type to `actual values`
10. use the `south panel` to observe the accuracy of the data

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
