### PR TITLE
fix(sqla): allow series limit without subquery support

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1292,8 +1292,8 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
         if row_offset:
             qry = qry.offset(row_offset)
 
-        if db_engine_spec.allows_subqueries and series_limit and groupby_series_columns:
-            if db_engine_spec.allows_joins:
+        if series_limit and groupby_series_columns:
+            if db_engine_spec.allows_joins and db_engine_spec.allows_subqueries:
                 # some sql dialects require for order by expressions
                 # to also be in the select clause -- others, e.g. vertica,
                 # require a unique inner alias


### PR DESCRIPTION
### SUMMARY
The recent PR #16660 broke series limiting for databases that don't support subqueries (Pinot and Solr). This moves the check for `allows_subqueries` down one level to the section where the subquery is constructed, thus allowing for a prequery to populate the series values to limit by if subqueries/joins aren't supported.

Note, however, that before #16660 we weren't checking for support for subqueries when constructing the limiting subquery. But since there are no db engine specs that allow joins but don't support subqueries, adding the check for subquery support shouldn't have any practical implications right now.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
