### PR TITLE
fix: Disable lazy loading for the Database selector

### DIFF
--- a/superset-frontend/src/components/DatabaseSelector/DatabaseSelector.test.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/DatabaseSelector.test.tsx
@@ -180,7 +180,7 @@ test('Refresh should work', async () => {
   userEvent.click(select);
 
   await waitFor(() => {
-    expect(SupersetClientGet).toBeCalledTimes(1);
+    expect(SupersetClientGet).toBeCalledTimes(2);
     expect(props.getDbList).toBeCalledTimes(0);
     expect(props.getTableList).toBeCalledTimes(0);
     expect(props.handleError).toBeCalledTimes(0);
@@ -193,8 +193,8 @@ test('Refresh should work', async () => {
   userEvent.click(screen.getByRole('button', { name: 'refresh' }));
 
   await waitFor(() => {
-    expect(SupersetClientGet).toBeCalledTimes(2);
-    expect(props.getDbList).toBeCalledTimes(0);
+    expect(SupersetClientGet).toBeCalledTimes(3);
+    expect(props.getDbList).toBeCalledTimes(1);
     expect(props.getTableList).toBeCalledTimes(0);
     expect(props.handleError).toBeCalledTimes(0);
     expect(props.onDbChange).toBeCalledTimes(0);

--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -253,6 +253,7 @@ export default function DatabaseSelector({
         ariaLabel={t('Select database or type database name')}
         data-test="select-database"
         header={<FormLabel>{t('Database')}</FormLabel>}
+        lazyLoading={false}
         onChange={changeDataBase}
         value={currentDb}
         placeholder={t('Select database or type database name')}


### PR DESCRIPTION
### SUMMARY
Disables the lazy loading for the Database selector. Currently, the SQL Editor depends on some information that is only present when querying the databases like `allows_virtual_table_explore`. Since this information is not present anywhere, we need to force the query of the database selector when first loading the page.

@jinghua-qa

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/135336639-e14746c3-b00b-4b30-baad-c13eb97cdebc.mov

https://user-images.githubusercontent.com/70410625/135336765-1572b8be-a013-4c70-82a4-f8ff4fd27196.mov

### TESTING INSTRUCTIONS
Check the videos for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
