### PR TITLE
fix: FilterableTable result div width

### DIFF
--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -435,7 +435,7 @@ export default class FilterableTable extends PureComponent<
         }}
         className={`grid-cell ${this.rowClassName({ index: rowIndex })}`}
       >
-        <div>{content}</div>
+        <div style={{ width: 'inherit' }}>{content}</div>
       </div>
     );
 

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -435,7 +435,7 @@ export default class FilterableTable extends PureComponent<
         }}
         className={`grid-cell ${this.rowClassName({ index: rowIndex })}`}
       >
-        <div style={{ width: 'inherit' }}>{content}</div>
+        <div css={{ width: 'inherit' }}>{content}</div>
       </div>
     );
 


### PR DESCRIPTION
### SUMMARY
When a table exceeded 50 columns, some of the results would appear to be cut off. The results now show properly by setting the width of the div wrapping the result to `inherit`.

- Note: This also seems to work the same with `max-content` but `inherit` seemed safer.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE
<img width="243" alt="before" src="https://user-images.githubusercontent.com/55605634/135544860-e06cb481-b15f-4617-a0bf-fa4735431f2d.png">

#### AFTER
<img width="243" alt="after" src="https://user-images.githubusercontent.com/55605634/135544866-598f8d7a-b025-4122-9240-f164b37106c7.png">

### TESTING INSTRUCTIONS
Find/create a table that exceeds 50 columns and contains timestamps. Observe that the results are no longer cut off and display correctly.
- If you use the longer superset examples (`superset load-examples -b`), you can repro this in SQL Lab's SQL editor with this query: `SELECT * FROM wide_table`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/15554
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
