### PR TITLE
chore: Adds the drag icon

### DIFF
--- a/superset-frontend/src/assets/images/icons/drag.svg
+++ b/superset-frontend/src/assets/images/icons/drag.svg
@@ -1,0 +1,22 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="24pt" height="24pt" viewBox="0 0 24 24" version="1.1">
+<path style=" stroke:none;fill-rule:evenodd;fill:rgb(0%,0%,0%);fill-opacity:1;" d="M 9.5 5.152344 C 9.5 6.34375 8.605469 7.308594 7.5 7.308594 C 6.394531 7.308594 5.5 6.34375 5.5 5.152344 C 5.5 3.964844 6.394531 3 7.5 3 C 8.605469 3 9.5 3.964844 9.5 5.152344 Z M 7.5 14.308594 C 8.605469 14.308594 9.5 13.34375 9.5 12.152344 C 9.5 10.964844 8.605469 10 7.5 10 C 6.394531 10 5.5 10.964844 5.5 12.152344 C 5.5 13.34375 6.394531 14.308594 7.5 14.308594 Z M 7.5 21.308594 C 8.605469 21.308594 9.5 20.34375 9.5 19.152344 C 9.5 17.964844 8.605469 17 7.5 17 C 6.394531 17 5.5 17.964844 5.5 19.152344 C 5.5 20.34375 6.394531 21.308594 7.5 21.308594 Z M 7.5 21.308594 "/>
+<path style=" stroke:none;fill-rule:evenodd;fill:rgb(0%,0%,0%);fill-opacity:1;" d="M 18.5 5.152344 C 18.5 6.34375 17.605469 7.308594 16.5 7.308594 C 15.394531 7.308594 14.5 6.34375 14.5 5.152344 C 14.5 3.964844 15.394531 3 16.5 3 C 17.605469 3 18.5 3.964844 18.5 5.152344 Z M 16.5 14.308594 C 17.605469 14.308594 18.5 13.34375 18.5 12.152344 C 18.5 10.964844 17.605469 10 16.5 10 C 15.394531 10 14.5 10.964844 14.5 12.152344 C 14.5 13.34375 15.394531 14.308594 16.5 14.308594 Z M 16.5 21.308594 C 17.605469 21.308594 18.5 20.34375 18.5 19.152344 C 18.5 17.964844 17.605469 17 16.5 17 C 15.394531 17 14.5 17.964844 14.5 19.152344 C 14.5 20.34375 15.394531 21.308594 16.5 21.308594 Z M 16.5 21.308594 "/>
+</svg>

--- a/superset-frontend/src/components/Icons/index.tsx
+++ b/superset-frontend/src/components/Icons/index.tsx
@@ -64,6 +64,7 @@ const IconFileNames = [
   'dataset_virtual_greyscale',
   'dataset_virtual',
   'download',
+  'drag',
   'edit_alt',
   'edit',
   'email',


### PR DESCRIPTION
### SUMMARY
Adds the drag icon.

@m-ajay @graceguo-supercat @junlincc 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1512" alt="Screen Shot 2021-09-30 at 10 01 57 AM" src="https://user-images.githubusercontent.com/70410625/135460010-8fbbf46f-3185-45d1-aca8-b47a4cf75384.png">

### TESTING INSTRUCTIONS
Check the new icon in the Storybook.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
