### PR TITLE
fix(Explore): Handle undefined operatorId

### DIFF
--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
@@ -140,7 +140,7 @@ export const useSimpleTabFilterProps = (props: Props) => {
         subject,
         clause,
         operator:
-          operator && isOperatorRelevant(operatorId, subject)
+          operator && operatorId && isOperatorRelevant(operatorId, subject)
             ? OPERATOR_ENUM_TO_OPERATOR_TYPE[operatorId].operation
             : null,
         expressionType: EXPRESSION_TYPES.SIMPLE,


### PR DESCRIPTION
### SUMMARY
Checks whether `operatorId` is undefined in an `AdhocFilter` as a quick fix for a bug that wouldn't allow the user the change the column of a filter. However, more investigation is required in order to understand why the `operatorId` was `undefined` in the first place for this filter in the "First time developer?" chart specifically.

### BEFORE
https://user-images.githubusercontent.com/81597121/135327094-6c5b3b46-9853-4f70-97fa-73b745d1778b.mov

### AFTER
https://user-images.githubusercontent.com/60598000/135480563-092405ce-41c7-4e7e-bedb-41508057989b.mp4

### TESTING INSTRUCTIONS
1. Open the sample chat "First time developer?"
2. Edit the existing filter and change the column
3. Make sure the column can be changed 

_Originally reported here https://github.com/apache/superset/pull/16871#issuecomment-930433964_

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
