### PR TITLE
fix: replace absolute difference with difference in compareOperator

### DIFF
--- a/superset/constants.py
+++ b/superset/constants.py
@@ -165,7 +165,7 @@ class PandasAxis(int, Enum):
 
 
 class PandasPostprocessingCompare(str, Enum):
-    ABS = "absolute"
+    DIFF = "difference"
     PCT = "percentage"
     RAT = "ratio"
 

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -498,13 +498,13 @@ def compare(  # pylint: disable=too-many-arguments
         )
     if compare_type not in tuple(PandasPostprocessingCompare):
         raise QueryObjectValidationError(
-            _("`compare_type` must be `absolute`, `percentage` or `ratio`")
+            _("`compare_type` must be `difference`, `percentage` or `ratio`")
         )
     if len(source_columns) == 0:
         return df
 
     for s_col, c_col in zip(source_columns, compare_columns):
-        if compare_type == PandasPostprocessingCompare.ABS:
+        if compare_type == PandasPostprocessingCompare.DIFF:
             diff_series = df[s_col] - df[c_col]
         elif compare_type == PandasPostprocessingCompare.PCT:
             diff_series = (

--- a/tests/integration_tests/pandas_postprocessing_tests.py
+++ b/tests/integration_tests/pandas_postprocessing_tests.py
@@ -478,18 +478,18 @@ class TestPostProcessing(SupersetTestCase):
         self.assertListEqual(series_to_list(post_df["z"]), [0.0, 2.0, 8.0, 6.0])
 
     def test_compare(self):
-        # `absolute` comparison
+        # `difference` comparison
         post_df = proc.compare(
             df=timeseries_df2,
             source_columns=["y"],
             compare_columns=["z"],
-            compare_type="absolute",
+            compare_type="difference",
         )
         self.assertListEqual(
-            post_df.columns.tolist(), ["label", "y", "z", "absolute__y__z",]
+            post_df.columns.tolist(), ["label", "y", "z", "difference__y__z",]
         )
         self.assertListEqual(
-            series_to_list(post_df["absolute__y__z"]), [0.0, -2.0, -8.0, -6.0],
+            series_to_list(post_df["difference__y__z"]), [0.0, -2.0, -8.0, -6.0],
         )
 
         # drop original columns
@@ -497,10 +497,10 @@ class TestPostProcessing(SupersetTestCase):
             df=timeseries_df2,
             source_columns=["y"],
             compare_columns=["z"],
-            compare_type="absolute",
+            compare_type="difference",
             drop_original_columns=True,
         )
-        self.assertListEqual(post_df.columns.tolist(), ["label", "absolute__y__z",])
+        self.assertListEqual(post_df.columns.tolist(), ["label", "difference__y__z",])
 
         # `percentage` comparison
         post_df = proc.compare(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, incorrect type of calculation in `time comparsion`, should replace `absolute difference` with `difference`

frontend codes at: https://github.com/apache-superset/superset-ui/pull/1383

closes: https://github.com/apache/superset/issues/16766

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:  https://github.com/apache/superset/issues/16766
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
