### PR TITLE
fix: replace absolute difference with difference in legacy charts

### DIFF
--- a/superset-frontend/src/explore/controlPanels/sections.tsx
+++ b/superset-frontend/src/explore/controlPanels/sections.tsx
@@ -233,13 +233,13 @@ export const NVD3TimeSeries: ControlPanelSectionConfig[] = [
             default: 'values',
             choices: [
               ['values', 'Actual values'],
-              ['absolute', 'Absolute difference'],
+              ['absolute', 'Difference'],
               ['percentage', 'Percentage change'],
               ['ratio', 'Ratio'],
             ],
             description: t(
               'How to display time shifts: as individual lines; as the ' +
-                'absolute difference between the main time series and each time shift; ' +
+                'difference between the main time series and each time shift; ' +
                 'as the percentage change; or as the ratio between series and time shifts.',
             ),
           },


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
replace `absolute difference` with `difference` in legacy charts

related issue: https://github.com/apache/superset/issues/16766


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### After:

![image](https://user-images.githubusercontent.com/2016594/135566938-a2299b32-e0a9-4fc4-a6e1-c78d850914f6.png)





### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
