### PR TITLE
fix(dashboard): recursive parent on dashboard components

### DIFF
--- a/superset-frontend/spec/javascripts/dashboard/util/newEntitiesFromDrop_spec.js
+++ b/superset-frontend/spec/javascripts/dashboard/util/newEntitiesFromDrop_spec.js
@@ -97,6 +97,8 @@ describe('newEntitiesFromDrop', () => {
     const newRow = result[newRowId];
     expect(newRow.type).toBe(ROW_TYPE);
     expect(newRow.parents).toEqual(['a']);
-    expect(result[newChartId].type).toBe(CHART_TYPE);
+    const newChart = result[newChartId];
+    expect(newChart.type).toBe(CHART_TYPE);
+    expect(newChart.parents).toEqual(['a', newRowId]);
   });
 });

--- a/superset-frontend/spec/javascripts/dashboard/util/newEntitiesFromDrop_spec.js
+++ b/superset-frontend/spec/javascripts/dashboard/util/newEntitiesFromDrop_spec.js
@@ -94,7 +94,9 @@ describe('newEntitiesFromDrop', () => {
 
     expect(result.a.children).toHaveLength(1);
     expect(Object.keys(result)).toHaveLength(3);
-    expect(result[newRowId].type).toBe(ROW_TYPE);
+    const newRow = result[newRowId];
+    expect(newRow.type).toBe(ROW_TYPE);
+    expect(newRow.parents).toEqual(['a']);
     expect(result[newChartId].type).toBe(CHART_TYPE);
   });
 });

--- a/superset-frontend/src/dashboard/util/newEntitiesFromDrop.js
+++ b/superset-frontend/src/dashboard/util/newEntitiesFromDrop.js
@@ -52,7 +52,6 @@ export default function newEntitiesFromDrop({ dropResult, layout }) {
     rowWrapper.parents = (dropEntity.parents || []).concat(dropEntity.id);
     newEntities[rowWrapper.id] = rowWrapper;
     newDropChild = rowWrapper;
-    newDropChild.parents = rowWrapper.parents.concat(rowWrapper.id);
   } else if (dragType === TABS_TYPE) {
     // create a new tab component
     const tabChild = newComponentFactory(TAB_TYPE);

--- a/superset-frontend/src/dashboard/util/newEntitiesFromDrop.js
+++ b/superset-frontend/src/dashboard/util/newEntitiesFromDrop.js
@@ -51,6 +51,7 @@ export default function newEntitiesFromDrop({ dropResult, layout }) {
     rowWrapper.children = [newDropChild.id];
     rowWrapper.parents = (dropEntity.parents || []).concat(dropEntity.id);
     newEntities[rowWrapper.id] = rowWrapper;
+    newDropChild.parents = rowWrapper.parents.concat(rowWrapper.id);
     newDropChild = rowWrapper;
   } else if (dragType === TABS_TYPE) {
     // create a new tab component


### PR DESCRIPTION
### SUMMARY
When a component is dropped directly under a tab in the dashboard editor and the cross filter feature flag is enabled, the following error sometimes appears:
![image](https://user-images.githubusercontent.com/33317356/135617512-b7a2de56-8a50-469d-a9c0-39e2093d3fcf.png)

This is caused by the dashboard creating a wrapper component that marks itself as its parent, causing an infinite loop when traversing all children in the cross filter indicator. The reason for this was a logical error in the code, where the wrapper id was supposed to be added to the wrapped component, but ended up being added to the wrapper itself. Tests are added to check for this going forward.

### DETAILS

When dropping a a component on the dashboard that requires wrapping (in this case dropping a markdown component directly on a tab, but could also be a chart, or column object: https://github.com/apache/superset/blob/87baac7650bdb6a8f8f82cf4992567a2c5c73cba/superset-frontend/src/dashboard/util/shouldWrapChildInRow.js#L27-L39), the component is wrapped in a wrapper component (in this case a ROW component). However, the wrapper adds itself as it's own parent, while it should add itself to the wrapped component:
![image](https://user-images.githubusercontent.com/33317356/135616201-42a7bb12-087b-4043-9e83-782e8ae7bf60.png)

Interestingly enough, after saving the dashboard, the layout metadata is fixed:
- the wrapped component correctly references the wrapper as its closest parent
- the wrapper no longer references itself

See the screenshot below for the post-save state:
![image](https://user-images.githubusercontent.com/33317356/135616416-0b099491-14d1-4e33-8fa7-1efd2249b441.png)

With the changes in this PR, the parents are correct after creation, i.e. won't change after saving.

This bug exposed several problems in the associated code, causing unnecessary performance problems. However, these should be fixed in follow-up PRs.

### TESTING INSTRUCTIONS
Local testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #16436
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
