### PR TITLE
fix: allow null comparator in adhocfilter

### DIFF
--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/AdhocFilter.test.js
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/AdhocFilter.test.js
@@ -188,7 +188,7 @@ describe('AdhocFilter', () => {
       clause: CLAUSES.WHERE,
     });
     // eslint-disable-next-line no-unused-expressions
-    expect(adhocFilter8.isValid()).toBe(false);
+    expect(adhocFilter8.isValid()).toBe(true);
 
     const adhocFilter9 = new AdhocFilter({
       expressionType: EXPRESSION_TYPES.SIMPLE,

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/index.js
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/index.js
@@ -33,6 +33,20 @@ export const CLAUSES = {
   WHERE: 'WHERE',
 };
 
+// eslint-disable-next-line camelcase
+const NON_VAlID_NULL_OPRS = {
+  '>': '>',
+  '<': '<',
+  '>=': '>=',
+  '<=': '<=',
+};
+
+const VALID_COMPARATORS = {
+  string: 'string',
+  number: 'number',
+  object: 'object',
+};
+
 const OPERATORS_TO_SQL = {
   '==': '=',
   '!=': '<>',
@@ -153,12 +167,13 @@ export default class AdhocFilter {
     const truthCheckOperators = [Operators.IS_TRUE, Operators.IS_FALSE].map(
       op => OPERATOR_ENUM_TO_OPERATOR_TYPE[op].operation,
     );
+    const validComparator = VALID_COMPARATORS[typeof this.comparator];
     if (this.expressionType === EXPRESSION_TYPES.SIMPLE) {
       if (nullCheckOperators.indexOf(this.operator) >= 0) {
         return !!(this.operator && this.subject);
       }
       if (truthCheckOperators.indexOf(this.operator) >= 0) {
-        return !!(this.subject && this.comparator !== null);
+        return !!(this.subject && validComparator);
       }
       if (this.operator && this.subject && this.clause) {
         if (Array.isArray(this.comparator)) {
@@ -166,8 +181,11 @@ export default class AdhocFilter {
             // A non-empty array of values ('IN' or 'NOT IN' clauses)
             return true;
           }
-        } else if (this.comparator === null) {
-          // A value has been selected or typed
+        } else if (validComparator) {
+          // A valid value has been selected
+          if (this.comparator === null && NON_VAlID_NULL_OPRS[this.operator]) {
+            return false;
+          }
           return true;
         }
       }

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/index.js
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/index.js
@@ -166,7 +166,7 @@ export default class AdhocFilter {
             // A non-empty array of values ('IN' or 'NOT IN' clauses)
             return true;
           }
-        } else if (this.comparator !== null) {
+        } else if (this.comparator === null) {
           // A value has been selected or typed
           return true;
         }

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/AdhocFilterEditPopover.test.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/AdhocFilterEditPopover.test.jsx
@@ -122,7 +122,7 @@ describe('AdhocFilterEditPopover', () => {
 
   it('prevents saving if the filter is invalid', () => {
     const { wrapper } = setup();
-    expect(wrapper.find(Button).find({ disabled: true })).not.toExist();
+    expect(wrapper.find(Button).find({ disabled: true })).toExist();
     wrapper
       .instance()
       .onAdhocFilterChange(simpleAdhocFilter.duplicateWith({ operator: null }));

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/AdhocFilterEditPopover.test.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/AdhocFilterEditPopover.test.jsx
@@ -122,7 +122,7 @@ describe('AdhocFilterEditPopover', () => {
 
   it('prevents saving if the filter is invalid', () => {
     const { wrapper } = setup();
-    expect(wrapper.find(Button).find({ disabled: true })).toExist();
+    expect(wrapper.find(Button).find({ disabled: true })).not.toExist();
     wrapper
       .instance()
       .onAdhocFilterChange(simpleAdhocFilter.duplicateWith({ operator: null }));


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This pr fixes an issue where in the adhocfilter control null value is not allowed causing the user not able to save. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
after

https://user-images.githubusercontent.com/17326228/135650934-b404b80d-1a69-4375-8946-ab2071df9820.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x ] Has associated issue: Fixes https://github.com/apache/superset/issues/16803
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
