### PR TITLE
fix: rolling and cum operator on multiple series

### DIFF
--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -419,7 +419,8 @@ def rolling(  # pylint: disable=too-many-arguments
         ) from ex
 
     if is_pivot_df:
-        agg: Dict[str, Dict[str, Any]] = {col: {} for col in df.columns[:1].to_list()}
+        agg_in_pivot_df = df.columns.get_level_values(0).drop_duplicates().to_list()
+        agg: Dict[str, Dict[str, Any]] = {col: {} for col in agg_in_pivot_df}
         df_rolling.columns = [
             _flatten_column_after_pivot(col, agg) for col in df_rolling.columns
         ]
@@ -578,7 +579,8 @@ def cum(
         )
     if is_pivot_df:
         df_cum = getattr(df_cum, operation)()
-        agg: Dict[str, Dict[str, Any]] = {col: {} for col in df.columns[:1].to_list()}
+        agg_in_pivot_df = df.columns.get_level_values(0).drop_duplicates().to_list()
+        agg: Dict[str, Dict[str, Any]] = {col: {} for col in agg_in_pivot_df}
         df_cum.columns = [
             _flatten_column_after_pivot(col, agg) for col in df_cum.columns
         ]

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -349,8 +349,8 @@ def sort(df: DataFrame, columns: Dict[str, bool]) -> DataFrame:
 @validate_column_args("columns")
 def rolling(  # pylint: disable=too-many-arguments
     df: DataFrame,
-    columns: Dict[str, str],
     rolling_type: str,
+    columns: Optional[Dict[str, str]] = None,
     window: Optional[int] = None,
     rolling_type_options: Optional[Dict[str, Any]] = None,
     center: bool = False,
@@ -381,10 +381,10 @@ def rolling(  # pylint: disable=too-many-arguments
     :raises QueryObjectValidationError: If the request in incorrect
     """
     rolling_type_options = rolling_type_options or {}
+    columns = columns or {}
     if is_pivot_df:
         df_rolling = df
     else:
-        validate_column_args("columns")(rolling)
         df_rolling = df[columns.keys()]
     kwargs: Dict[str, Union[str, int]] = {}
     if window is None:
@@ -419,7 +419,7 @@ def rolling(  # pylint: disable=too-many-arguments
         ) from ex
 
     if is_pivot_df:
-        agg: Dict[str, Dict[str, Any]] = {col: {} for col in columns.values()}
+        agg: Dict[str, Dict[str, Any]] = {col: {} for col in df.columns[:1].to_list()}
         df_rolling.columns = [
             _flatten_column_after_pivot(col, agg) for col in df_rolling.columns
         ]
@@ -546,7 +546,10 @@ def compare(  # pylint: disable=too-many-arguments
 
 @validate_column_args("columns")
 def cum(
-    df: DataFrame, columns: Dict[str, str], operator: str, is_pivot_df: bool = False,
+    df: DataFrame,
+    operator: str,
+    columns: Optional[Dict[str, str]] = None,
+    is_pivot_df: bool = False,
 ) -> DataFrame:
     """
     Calculate cumulative sum/product/min/max for select columns.
@@ -561,10 +564,10 @@ def cum(
     :param is_pivot_df: Dataframe is pivoted or not
     :return: DataFrame with cumulated columns
     """
+    columns = columns or {}
     if is_pivot_df:
         df_cum = df
     else:
-        validate_column_args("columns")(rolling)
         df_cum = df[columns.keys()]
     operation = "cum" + operator
     if operation not in ALLOWLIST_CUMULATIVE_FUNCTIONS or not hasattr(
@@ -575,7 +578,7 @@ def cum(
         )
     if is_pivot_df:
         df_cum = getattr(df_cum, operation)()
-        agg: Dict[str, Dict[str, Any]] = {col: {} for col in columns.values()}
+        agg: Dict[str, Dict[str, Any]] = {col: {} for col in df.columns[:1].to_list()}
         df_cum.columns = [
             _flatten_column_after_pivot(col, agg) for col in df_cum.columns
         ]

--- a/tests/integration_tests/fixtures/dataframes.py
+++ b/tests/integration_tests/fixtures/dataframes.py
@@ -166,10 +166,18 @@ prophet_df = DataFrame(
     }
 )
 
-country_df = DataFrame(
+single_metric_df = DataFrame(
     {
         "dttm": to_datetime(["2019-01-01", "2019-01-01", "2019-01-02", "2019-01-02",]),
         "country": ["UK", "US", "UK", "US"],
-        "metric": [5, 6, 7, 8],
+        "sum_metric": [5, 6, 7, 8],
+    }
+)
+multiple_metrics_df = DataFrame(
+    {
+        "dttm": to_datetime(["2019-01-01", "2019-01-01", "2019-01-02", "2019-01-02",]),
+        "country": ["UK", "US", "UK", "US"],
+        "sum_metric": [5, 6, 7, 8],
+        "count_metric": [1, 2, 3, 4],
     }
 )

--- a/tests/integration_tests/fixtures/dataframes.py
+++ b/tests/integration_tests/fixtures/dataframes.py
@@ -165,3 +165,11 @@ prophet_df = DataFrame(
         "b": [4, 3, 4.1, 3.95],
     }
 )
+
+country_df = DataFrame(
+    {
+        "dttm": to_datetime(["2019-01-01", "2019-01-01", "2019-01-02", "2019-01-02",]),
+        "country": ["UK", "US", "UK", "US"],
+        "metric": [5, 6, 7, 8],
+    }
+)


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, `Rolling Window` calculation results are incorrect on multiple series. 

Frontend codes at: https://github.com/apache-superset/superset-ui/pull/1386

![image](https://user-images.githubusercontent.com/2016594/135754294-ea781d87-846d-430a-918b-23da0d75c012.png)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### After
![image](https://user-images.githubusercontent.com/2016594/135754492-2808fc56-88f4-4f26-9e41-3999537566c4.png)

#### Before
![image](https://user-images.githubusercontent.com/2016594/135754325-2307fc31-e5be-4b6c-a433-fffb423f2b3f.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. select `birth_names` dataset
2. switch to `time-series` chart
3. set time grain to `year`
4. set time range to `1970 - 2000`
5. set metrics to `sum__num`
6. set group by to `gender`
8. set rolling function to `sum`
9. set periods to `2`
10. set min periods to `2`
9. use the south panel to observe the accuracy of the data


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
