### PR TITLE
other(revert): "fix: the calculated columns explicit type convert into date"

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -338,8 +338,7 @@ class TableColumn(Model, BaseColumn, CertificationMixin):
         ],
     ) -> str:
         """Convert datetime object to a SQL expression string"""
-        dttm_type = self.type or ("DATETIME" if self.is_dttm else None)
-        sql = self.db_engine_spec.convert_dttm(dttm_type, dttm) if dttm_type else None
+        sql = self.db_engine_spec.convert_dttm(self.type, dttm) if self.type else None
 
         if sql:
             return sql


### PR DESCRIPTION
This PR reverts apache/superset#14813 as there should be no need for type inferencing—which could be incorrect—given that the type of the calculated column should be set in the same modal—exposed if one scrolls.

Note the widget also allows for user entered types, i.e, they're not restricted to only the pre-defined four options.

<img width="869" alt="Screen Shot 2021-10-03 at 7 38 42 PM" src="https://user-images.githubusercontent.com/4567245/135785454-d90e1423-d52d-47a5-857e-6483298bcd7b.png">
