### PR TITLE
fix(examples): incorrect covid row component id

### DIFF
--- a/superset/examples/configs/dashboards/COVID_Vaccine_Dashboard.yaml
+++ b/superset/examples/configs/dashboards/COVID_Vaccine_Dashboard.yaml
@@ -242,7 +242,7 @@ position:
       - CHART-dCUpAcPsji
       - CHART-fYo7IyvKZQ
       - CHART-j4hUvP5dDD
-    id: ROW-xSeNAspgw
+    id: ROW-dieUdkeUw
     meta:
       "0": ROOT_ID
       background: BACKGROUND_TRANSPARENT


### PR DESCRIPTION
### SUMMARY
The PR #16183 that updated some examples dashboard metadata contained a bug where a row component name was changed from `ROW-zhOlQLQnB` to `ROW-dieUdkeUw`, but its id was made equal to another row component (`ROW-xSeNAspgw` instead of its own name defined on line 240). This clashing id caused deleting rows/components on the dashboard to break.

### SCREENSHOT
![image](https://user-images.githubusercontent.com/33317356/135818666-226ca7b9-4277-4754-ac8a-a02cfcd9b539.png)

### TESTING INSTRUCTIONS

1. Run `superset load-examples`
2. Open the COVID dashobard
3. Go into edit mode
4. Delete all rows and and see the error above (after the fix all rows are properly deleted)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
