### PR TITLE
fix(filterset): failed to parse json_metadata json on creating new filterset

### DIFF
--- a/superset/dashboards/filter_sets/consts.py
+++ b/superset/dashboards/filter_sets/consts.py
@@ -26,5 +26,6 @@ DASHBOARD_ID_FIELD = "dashboard_id"
 OWNER_OBJECT_FIELD = "owner_object"
 DASHBOARD_FIELD = "dashboard"
 PARAMS_PROPERTY = "params"
+NATIVE_FILTERS_FIELD = "nativeFilters"
 
 FILTER_SET_API_PERMISSIONS_NAME = "FilterSets"

--- a/superset/dashboards/filter_sets/schemas.py
+++ b/superset/dashboards/filter_sets/schemas.py
@@ -16,7 +16,7 @@
 # under the License.
 from typing import Any, cast, Dict, Mapping
 
-from marshmallow import fields, post_load, Schema, ValidationError
+from marshmallow import fields, INCLUDE, post_load, Schema, ValidationError
 from marshmallow.validate import Length, OneOf
 
 from superset.dashboards.filter_sets.consts import (
@@ -34,7 +34,7 @@ class JsonMetadataSchema(Schema):
 
 
 class FilterSetSchema(Schema):
-    json_metadata_schema: JsonMetadataSchema = JsonMetadataSchema()
+    json_metadata_schema: JsonMetadataSchema = JsonMetadataSchema(unknown=INCLUDE)
 
     def _validate_json_meta_data(self, json_meta_data: str) -> None:
         try:
@@ -44,7 +44,6 @@ class FilterSetSchema(Schema):
 
 
 class FilterSetPostSchema(FilterSetSchema):
-    json_metadata_schema: JsonMetadataSchema = JsonMetadataSchema()
     # pylint: disable=W0613
     name = fields.String(required=True, allow_none=False, validate=Length(0, 500),)
     description = fields.String(

--- a/tests/integration_tests/dashboards/filter_sets/conftest.py
+++ b/tests/integration_tests/dashboards/filter_sets/conftest.py
@@ -26,6 +26,7 @@ from superset.dashboards.filter_sets.consts import (
     DESCRIPTION_FIELD,
     JSON_METADATA_FIELD,
     NAME_FIELD,
+    NATIVE_FILTERS_FIELD,
     OWNER_ID_FIELD,
     OWNER_TYPE_FIELD,
     USER_OWNER_TYPE,
@@ -258,7 +259,7 @@ def filterset_id(filtersets: Dict[str, List[FilterSet]]) -> int:
 
 @pytest.fixture
 def valid_json_metadata() -> Dict[str, Any]:
-    return {"nativeFilters": {}}
+    return {NATIVE_FILTERS_FIELD: {}}
 
 
 @pytest.fixture

--- a/tests/integration_tests/dashboards/filter_sets/create_api_tests.py
+++ b/tests/integration_tests/dashboards/filter_sets/create_api_tests.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import json
 from typing import Any, Dict, TYPE_CHECKING
 
 from superset.dashboards.filter_sets.consts import (
@@ -249,7 +250,7 @@ class TestCreateFilterSetsApi:
     ):
         # arrange
         login(client, "admin")
-        valid_filter_set_data_for_create[DESCRIPTION_FIELD] = {}
+        valid_filter_set_data_for_create[JSON_METADATA_FIELD] = {}
 
         # act
         response = call_create_filter_set(
@@ -259,6 +260,29 @@ class TestCreateFilterSetsApi:
         # assert
         assert response.status_code == 400
         assert_filterset_was_not_created(valid_filter_set_data_for_create)
+
+    def test_with_extra_json_metadata_fields__201(
+        self,
+        dashboard_id: int,
+        valid_filter_set_data_for_create: Dict[str, Any],
+        valid_json_metadata: Dict[Any, Any],
+        client: FlaskClient[Any],
+    ):
+        # arrange
+        login(client, "admin")
+        valid_json_metadata["extra"] = "value"
+        valid_filter_set_data_for_create[JSON_METADATA_FIELD] = json.dumps(
+            valid_json_metadata
+        )
+
+        # act
+        response = call_create_filter_set(
+            client, dashboard_id, valid_filter_set_data_for_create
+        )
+
+        # assert
+        assert response.status_code == 201
+        assert_filterset_was_created(valid_filter_set_data_for_create)
 
     def test_without_owner_type__400(
         self,


### PR DESCRIPTION
### SUMMARY
on creating new filterset with extra fields inside json_metadata, it failed due to parsing error

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
new test added

### ADDITIONAL INFORMATION
