### PR TITLE
fix(build): make npm linking work pt. 2

### DIFF
--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -292,7 +292,6 @@ const config = {
       react: path.resolve('./node_modules/react'),
     },
     extensions: ['.ts', '.tsx', '.js', '.jsx', '.yml'],
-    symlinks: true,
     fallback: {
       fs: false,
       vm: false,

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -289,9 +289,10 @@ const config = {
         APP_DIR,
         './node_modules/@superset-ui/chart-controls',
       ),
+      react: path.resolve('./node_modules/react'),
     },
     extensions: ['.ts', '.tsx', '.js', '.jsx', '.yml'],
-    symlinks: false,
+    symlinks: true,
     fallback: {
       fs: false,
       vm: false,
@@ -455,7 +456,6 @@ if (isDevMode) {
     },
     static: path.join(process.cwd(), '../static/assets'),
   };
-  config.watchOptions = { followSymlinks: true };
 
   // make sure to use @emotion/* modules in the root directory
   fs.readdirSync(path.resolve(APP_DIR, './node_modules/@emotion'), pkg => {


### PR DESCRIPTION
### SUMMARY

The recent upgrade to Webpack 5 in #16701 broke npm linking. While #16867 added watching for changed files, it still didn't update the browser with the new assets. This switches from using `watchOptions.followSymlinks` to the more conventional `config.symlinks` setting, and adds an alias for `react` to point to the one pulled in by the Superset application. This is necessary, as otherwise there will be two instances of React - one fro Superset, and one from `superset-ui`.

### TESTING INSTRUCTIONS
1. npm link a `superset-ui` package/plugin
2. make code changes to the package/plugin
3. watch the command line trigger the rebuild and the code changes reflected in the browser

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
