### PR TITLE
fix(sqllab): SqlJsonExecutionContext.query null pointer

### DIFF
--- a/superset/sqllab/sqllab_execution_context.py
+++ b/superset/sqllab/sqllab_execution_context.py
@@ -180,7 +180,7 @@ class SqlJsonExecutionContext:  # pylint: disable=too-many-instance-attributes
 
     def get_query_details(self) -> str:
         try:
-            if self.query:
+            if hasattr(self, "query"):
                 if self.query.id:
                     return "query '{}' - '{}'".format(self.query.id, self.query.sql)
         except DetachedInstanceError:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Users saw this error when their sqllab queries failed due to access errors:
`'SqlJsonExecutionContext' object has no attribute 'query'`

The issue is that `_validate_access` is run before `set_query`, so the `execution_context` does not have a `query` attribute during `_validate_access`, which may throw an exception that uses query details to generate an error message. This was likely a regression caused by #16852.

I am not very satisfied with this fix - `SqlJsonExecutionContext` should probably always have a `query` attribute since it's a dataclass? But I'm not sure what the intended behavior is, so input is welcome.

@ofekisr @etr2460
