### PR TITLE
fix: ensure known dashboard id is used in save first

### DIFF
--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -90,7 +90,7 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
       const lastDashboard = sessionStorage.getItem(SK_DASHBOARD_ID);
       let recentDashboard = lastDashboard && parseInt(lastDashboard, 10);
 
-      if (!recentDashboard && this.props.dashboardId) {
+      if (this.props.dashboardId) {
         recentDashboard = this.props.dashboardId;
       }
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This pr fixes an issue where the user will get save selection for the wrong dashboard in save chart modal.

after

https://user-images.githubusercontent.com/17326228/136299723-ee12575a-71b1-47d4-9173-4b141eacc957.mov


### TESTING INSTRUCTIONS
Go to dashboard and change controls and hit run. Ensure that dashboard is the dashboard the chart is saving from

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ x] Has associated issue: Fixes https://github.com/apache/superset/issues/16964
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
