### PR TITLE
chore: no direct use of supersetTheme (or bad LESS vars) in SqlEditor

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -102,10 +102,9 @@ const LimitSelectStyled = styled.span`
 
 const StyledToolbar = styled.div`
   padding: ${({ theme }) => theme.gridUnit * 2}px;
-  background-color: @lightest;
   display: flex;
   justify-content: space-between;
-  border: 1px solid ${supersetTheme.colors.grayscale.light2};
+  border: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
   border-top: 0;
 
   form {

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -102,6 +102,7 @@ const LimitSelectStyled = styled.span`
 
 const StyledToolbar = styled.div`
   padding: ${({ theme }) => theme.gridUnit * 2}px;
+  background: ${({ theme }) => theme.colors.grayscale.light5};
   display: flex;
   justify-content: space-between;
   border: 1px solid ${({ theme }) => theme.colors.grayscale.light2};

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -24,7 +24,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
 import Split from 'react-split';
-import { t, styled, supersetTheme, withTheme } from '@superset-ui/core';
+import { t, styled, withTheme } from '@superset-ui/core';
 import debounce from 'lodash/debounce';
 import throttle from 'lodash/throttle';
 import StyledModal from 'src/components/Modal';


### PR DESCRIPTION

### SUMMARY
The SqlEditor had two small issues with some CSS that this PR corrects:
1) It was directly using the `supersetTheme` instead of pulling it in via the `ThemeProvider` as is preferred.
2) It randomly had a LESS var in there, which couldn't possibly be working... now it too uses the theme.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No difference.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
