### PR TITLE
chore: removing use of supersetTheme in favor of ThemeProvider

### DIFF
--- a/superset-frontend/src/components/ErrorMessage/BasicErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/BasicErrorAlert.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { styled, supersetTheme } from '@superset-ui/core';
+import { styled, useTheme } from '@superset-ui/core';
 import Icons from 'src/components/Icons';
 import { ErrorLevel } from './types';
 
@@ -54,12 +54,14 @@ export default function BasicErrorAlert({
   level,
   title,
 }: BasicErrorAlertProps) {
+  const theme = useTheme();
+
   return (
     <StyledContainer level={level} role="alert">
       {level === 'error' ? (
-        <Icons.ErrorSolid iconColor={supersetTheme.colors[level].base} />
+        <Icons.ErrorSolid iconColor={theme.colors[level].base} />
       ) : (
-        <Icons.WarningSolid iconColor={supersetTheme.colors[level].base} />
+        <Icons.WarningSolid iconColor={theme.colors[level].base} />
       )}
       <StyledContent>
         <StyledTitle>{title}</StyledTitle>

--- a/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useState, ReactNode } from 'react';
-import { styled, supersetTheme, t } from '@superset-ui/core';
+import { styled, useTheme, t } from '@superset-ui/core';
 import { noOp } from 'src/utils/common';
 import Modal from 'src/components/Modal';
 import Button from 'src/components/Button';
@@ -97,6 +97,8 @@ export default function ErrorAlert({
   subtitle,
   title,
 }: ErrorAlertProps) {
+  const theme = useTheme();
+
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isBodyExpanded, setIsBodyExpanded] = useState(false);
 
@@ -109,12 +111,12 @@ export default function ErrorAlert({
           {level === 'error' ? (
             <Icons.ErrorSolid
               className="icon"
-              iconColor={supersetTheme.colors[level].base}
+              iconColor={theme.colors[level].base}
             />
           ) : (
             <Icons.WarningSolid
               className="icon"
-              iconColor={supersetTheme.colors[level].base}
+              iconColor={theme.colors[level].base}
             />
           )}
           <strong>{title}</strong>
@@ -172,12 +174,12 @@ export default function ErrorAlert({
               {level === 'error' ? (
                 <Icons.ErrorSolid
                   className="icon"
-                  iconColor={supersetTheme.colors[level].base}
+                  iconColor={theme.colors[level].base}
                 />
               ) : (
                 <Icons.WarningSolid
                   className="icon"
-                  iconColor={supersetTheme.colors[level].base}
+                  iconColor={theme.colors[level].base}
                 />
               )}
               <div className="title">{title}</div>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
For ErrorAlert and BasicErrorAlert this PR removes direct use of `supersetTheme` in favor of the `useTheme` hook and the `ThemeProvider` component.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
there should be no discernable change

### TESTING INSTRUCTIONS
Make sure errors look OK in the ephemeral environment.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
