### PR TITLE
feat(linting): restrict direct use of supersetTheme in favor of ThemeProvider

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -108,13 +108,19 @@ module.exports = {
         'no-prototype-builtins': 0,
         'no-restricted-properties': 0,
         'no-restricted-imports': [
-          'error',
+          'warn',
           {
             paths: [
               {
                 name: 'antd',
                 message:
                   'Please import Ant components from the index of common/components',
+              },
+              {
+                name: '@superset-ui/core',
+                importNames: ['supersetTheme'],
+                message:
+                  'Please use the theme directly from the ThemeProvider rather than importing supersetTheme.',
               },
             ],
           },

--- a/superset-frontend/spec/helpers/theming.ts
+++ b/superset-frontend/spec/helpers/theming.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { shallow as enzymeShallow, mount as enzymeMount } from 'enzyme';
+// eslint-disable-next-line no-restricted-imports
 import { supersetTheme } from '@superset-ui/core';
 import { ReactElement } from 'react';
 import { ProviderWrapper } from './ProviderWrapper';

--- a/superset-frontend/src/common/components/.eslintrc
+++ b/superset-frontend/src/common/components/.eslintrc
@@ -18,6 +18,17 @@
  */
 {
   "rules": {
-    "no-restricted-imports": 0
+    "no-restricted-imports": [
+      "warn",
+      {
+        "paths": [
+          {
+              "name": "@superset-ui/core",
+              "importNames": ["supersetTheme"],
+              "message": "Please use the theme directly from the ThemeProvider rather than importing supersetTheme."
+          }
+        ]
+      }
+    ]
   }
 }

--- a/superset-frontend/src/components/.eslintrc
+++ b/superset-frontend/src/components/.eslintrc
@@ -18,6 +18,19 @@
  */
 {
   "rules": {
-    "no-restricted-imports": 0
+    "no-restricted-imports": [
+      "warn",
+      {
+        "paths": [
+          {
+            "name": "@superset-ui/core",
+            "importNames": [
+              "supersetTheme"
+            ],
+            "message": "Please use the theme directly from the ThemeProvider rather than importing supersetTheme."
+          }
+        ]
+      }
+    ]
   }
 }

--- a/superset-frontend/src/preamble.ts
+++ b/superset-frontend/src/preamble.ts
@@ -19,6 +19,7 @@
 import { setConfig as setHotLoaderConfig } from 'react-hot-loader';
 import 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only';
 import moment from 'moment';
+// eslint-disable-next-line no-restricted-imports
 import { configure, supersetTheme } from '@superset-ui/core';
 import { merge } from 'lodash';
 import setupClient from './setup/setupClient';


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This PR adds linting to restrict use of the supersetTheme from direct import/use, instead preferring `useTheme` or `withTheme` or any other direct theme usage via the `ThemeProvider`.

In this PR, it's set to warn, so we can sweep up (or add lint override comments) for any offending instances, and then open up another PR to put it into an error state and lock things down.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
