### PR TITLE
refactor: JSON logic into `import_from_dict`

### DIFF
--- a/superset/charts/commands/importers/v1/utils.py
+++ b/superset/charts/commands/importers/v1/utils.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import json
 from typing import Any, Dict
 
 from flask import g
@@ -33,10 +32,9 @@ def import_chart(
             return existing
         config["id"] = existing.id
 
-    # TODO (betodealmeida): move this logic to import_from_dict
-    config["params"] = json.dumps(config["params"])
-
-    chart = Slice.import_from_dict(session, config, recursive=False)
+    chart = Slice.import_from_dict(
+        session, config, {"params": "params"}, recursive=False
+    )
     if chart.id is None:
         session.flush()
 

--- a/superset/dashboards/commands/importers/v1/utils.py
+++ b/superset/dashboards/commands/importers/v1/utils.py
@@ -142,17 +142,7 @@ def import_dashboard(
             return existing
         config["id"] = existing.id
 
-    # TODO (betodealmeida): move this logic to import_from_dict
-    config = config.copy()
-    for key, new_name in JSON_KEYS.items():
-        if config.get(key) is not None:
-            value = config.pop(key)
-            try:
-                config[new_name] = json.dumps(value)
-            except TypeError:
-                logger.info("Unable to encode `%s` field: %s", key, value)
-
-    dashboard = Dashboard.import_from_dict(session, config, recursive=False)
+    dashboard = Dashboard.import_from_dict(session, config, JSON_KEYS, recursive=False)
     if dashboard.id is None:
         session.flush()
 

--- a/superset/databases/commands/importers/v1/utils.py
+++ b/superset/databases/commands/importers/v1/utils.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import json
 from typing import Any, Dict
 
 from sqlalchemy.orm import Session
@@ -32,17 +31,9 @@ def import_database(
             return existing
         config["id"] = existing.id
 
-    # https://github.com/apache/superset/pull/16756 renamed ``csv`` to ``file``.
-    config["allow_file_upload"] = config.pop("allow_csv_upload")
-    if "schemas_allowed_for_csv_upload" in config["extra"]:
-        config["extra"]["schemas_allowed_for_file_upload"] = config["extra"].pop(
-            "schemas_allowed_for_csv_upload"
-        )
-
-    # TODO (betodealmeida): move this logic to import_from_dict
-    config["extra"] = json.dumps(config["extra"])
-
-    database = Database.import_from_dict(session, config, recursive=False)
+    database = Database.import_from_dict(
+        session, config, {"extra": "extra"}, recursive=False
+    )
     if database.id is None:
         session.flush()
 

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -151,6 +151,7 @@ class ImportExportMixin:
         cls,
         session: Session,
         dict_rep: Dict[Any, Any],
+        dict_keys: Dict[Any, Any] = {},
         parent: Optional[Any] = None,
         recursive: bool = True,
         sync: Optional[List[str]] = None,
@@ -165,6 +166,17 @@ class ImportExportMixin:
             | set(parent_refs.keys())
             | {"uuid"}
         )
+
+        if dict_keys:
+            dict_rep = dict_rep.copy()
+            for key, new_name in dict_keys.items():
+                if dict_rep.get(key) is not None:
+                    value = dict_rep.pop(key)
+                    try:
+                        dict_rep[new_name] = json.dumps(value)
+                    except TypeError:
+                        logger.info("Unable to encode `%s` field: %s", key, value)
+
         new_children = {c: dict_rep[c] for c in cls.export_children if c in dict_rep}
         unique_constrains = cls._unique_constrains()
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Refactors the helper method `import_from_dict` to convert dictionary values into JSON sting as per the TODO's given
https://github.com/apache/superset/blob/ac509611b6ca950bf373c065012414020dd224b7/superset/dashboards/commands/importers/v1/utils.py#L145-L155

https://github.com/apache/superset/blob/ac509611b6ca950bf373c065012414020dd224b7/superset/databases/commands/importers/v1/utils.py#L35-L38


https://github.com/apache/superset/blob/ac509611b6ca950bf373c065012414020dd224b7/superset/charts/commands/importers/v1/utils.py#L36-L39

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
