### PR TITLE
ci: skip unnecessary test steps

### DIFF
--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -28,6 +28,7 @@ jobs:
         continue-on-error: true
         run: ./scripts/ci_check_no_file_changes.sh frontend
       - name: Setup Node.js
+        if: steps.check.outcome == 'failure'
         uses: actions/setup-node@v2
         with:
           node-version:  '16'

--- a/.github/workflows/superset-python-misc.yml
+++ b/.github/workflows/superset-python-misc.yml
@@ -29,6 +29,7 @@ jobs:
         continue-on-error: true
         run: ./scripts/ci_check_no_file_changes.sh python
       - name: Setup Python
+        if: steps.check.outcome == 'failure'
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
### SUMMARY
There are two instances where we install Node and Python even if we can skip these tests. This should marginally speed up CI by avoiding unnecessary installation steps.

### BEFORE

An example of Node being installed on a backend PR despite not needing to be installed (3 extra seconds):
![image](https://user-images.githubusercontent.com/33317356/136500513-6e06c5d3-b62f-4243-8393-c014798e5dfc.png)

Same for Python linting (no noticeable change in installation time, but still unnecessary):
![image](https://user-images.githubusercontent.com/33317356/136500837-ec7c88d8-b603-43d7-9e15-e2ea4b9affac.png)

<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
