### PR TITLE
fix(dashboard): Race condition when setting activeTabs with nested tabs

### DIFF
--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -370,8 +370,8 @@ export function setDirectPathToChild(path) {
 }
 
 export const SET_ACTIVE_TABS = 'SET_ACTIVE_TABS';
-export function setActiveTabs(tabIds) {
-  return { type: SET_ACTIVE_TABS, tabIds };
+export function setActiveTabs(tabId, prevTabId) {
+  return { type: SET_ACTIVE_TABS, tabId, prevTabId };
 }
 
 export const SET_FOCUSED_FILTER_FIELD = 'SET_FOCUSED_FILTER_FIELD';

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -133,15 +133,12 @@ export class Tabs extends React.PureComponent {
   }
 
   componentDidMount() {
-    this.props.setActiveTabs([...this.props.activeTabs, this.state.activeKey]);
+    this.props.setActiveTabs(this.state.activeKey);
   }
 
   componentDidUpdate(prevProps, prevState) {
     if (prevState.activeKey !== this.state.activeKey) {
-      this.props.setActiveTabs([
-        ...this.props.activeTabs.filter(tabId => tabId !== prevState.activeKey),
-        this.state.activeKey,
-      ]);
+      this.props.setActiveTabs(this.state.activeKey, prevState.activeKey);
     }
   }
 

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -47,7 +47,6 @@ const propTypes = {
   editMode: PropTypes.bool.isRequired,
   renderHoverMenu: PropTypes.bool,
   directPathToChild: PropTypes.arrayOf(PropTypes.string),
-  activeTabs: PropTypes.arrayOf(PropTypes.string),
 
   // actions (from DashboardComponent.jsx)
   logEvent: PropTypes.func.isRequired,
@@ -74,7 +73,6 @@ const defaultProps = {
   availableColumnCount: 0,
   columnWidth: 0,
   directPathToChild: [],
-  activeTabs: [],
   setActiveTabs() {},
   onResizeStart() {},
   onResize() {},
@@ -407,7 +405,6 @@ function mapStateToProps(state) {
   return {
     nativeFilters: state.nativeFilters,
     directPathToChild: state.dashboardState.directPathToChild,
-    activeTabs: state.dashboardState.activeTabs,
   };
 }
 export default connect(mapStateToProps)(Tabs);

--- a/superset-frontend/src/dashboard/reducers/dashboardState.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.js
@@ -150,9 +150,16 @@ export default function dashboardStateReducer(state = {}, action) {
       };
     },
     [SET_ACTIVE_TABS]() {
+      const prevActiveTabs = state.activeTabs ?? [];
+      const newActiveTabs = action.prevTabId
+        ? [
+            ...prevActiveTabs.filter(tabId => tabId !== action.prevTabId),
+            action.tabId,
+          ]
+        : [...prevActiveTabs, action.tabId];
       return {
         ...state,
-        activeTabs: action.tabIds,
+        activeTabs: newActiveTabs,
       };
     },
     [SET_FOCUSED_FILTER_FIELD]() {


### PR DESCRIPTION
### SUMMARY
Fixes #16972 
Active tabs were calculated in mount/update lifecycle events in Tabs components by taking current active tabs state and appending active tab key to it. That approach resulted in race condition when there are multiple Tabs components added to a dashboard - they were all operating on the same array and when 1 component finished its job, the rest were still operating on the now outdated array of active tabs. The result was overwriting the results calculated by other Tabs components.
In order to avoid that, I moved that logic into the Redux reducer, which is guaranteed to be synchronous. Now the Tabs only send current active key and previous active key as strings to Redux and the reducer handles calculating active tabs synchronously.
The described issue was the direct reason of the linked bug - the filters were out of scope, because `activeTabs` was not calculated correctly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see linked issue

After:
https://user-images.githubusercontent.com/15073128/136361545-77fa09ff-dffe-4832-b405-53af47d98727.mov

### TESTING INSTRUCTIONS
1. Create a dashboard with multiple separate Tabs components, including nested Tabs
2. Verify that `dashboardState.activeTabs` in Redux has correct value
3. Add some native filters with scopes set to different Tabs
4. Verify that in scope/out of scope feature works as expected

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes #16972 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @junlincc @graceguo-supercat 