### PR TITLE
fix: Verify when null value should be undefined in Select

### DIFF
--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -520,8 +520,13 @@ const Select = ({
   }, [options]);
 
   useEffect(() => {
-    setSelectValue(value);
-  }, [value]);
+    let selectValue = value;
+    // special case where null is intended to be undefined
+    if (value === null && !selectOptions.find(o => o.value === null)) {
+      selectValue = undefined;
+    }
+    setSelectValue(selectValue);
+  }, [value, selectOptions]);
 
   useEffect(() => {
     if (selectValue) {

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -524,13 +524,8 @@ const Select = ({
   }, [options]);
 
   useEffect(() => {
-    let selectValue = value;
-    // special case where null is intended to be undefined
-    if (value === null && !selectOptions.find(o => o.value === null)) {
-      selectValue = undefined;
-    }
-    setSelectValue(selectValue);
-  }, [value, selectOptions]);
+    setSelectValue(value);
+  }, [value]);
 
   useEffect(() => {
     if (selectValue) {

--- a/superset-frontend/src/explore/components/controls/SelectAsyncControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/SelectAsyncControl/index.tsx
@@ -71,6 +71,17 @@ const SelectAsyncControl = ({
     onChange(onChangeVal);
   };
 
+  const getValue = () => {
+    const currentValue =
+      value || (props.default !== undefined ? props.default : undefined);
+
+    // safety check - the value is intended to be undefined but null was used
+    if (currentValue === null && !options.find(o => o.value === null)) {
+      return undefined;
+    }
+    return currentValue;
+  };
+
   useEffect(() => {
     const onError = (response: Response) =>
       getClientErrorObject(response).then(e => {
@@ -93,7 +104,7 @@ const SelectAsyncControl = ({
     <Select
       allowClear={allowClear}
       ariaLabel={ariaLabel || t('Select ...')}
-      value={value || (props.default !== undefined ? props.default : undefined)}
+      value={getValue()}
       header={<ControlHeader {...props} />}
       mode={multi ? 'multiple' : 'single'}
       onChange={handleOnChange}

--- a/superset-frontend/src/explore/components/controls/SelectControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.jsx
@@ -205,6 +205,21 @@ export default class SelectControl extends React.PureComponent {
       danger,
     };
 
+    const getValue = () => {
+      const currentValue =
+        value ||
+        (this.props.default !== undefined ? this.props.default : undefined);
+
+      // safety check - the value is intended to be undefined but null was used
+      if (
+        currentValue === null &&
+        !this.state.options.find(o => o.value === null)
+      ) {
+        return undefined;
+      }
+      return currentValue;
+    };
+
     const selectProps = {
       allowNewOptions: freeForm,
       autoFocus,
@@ -225,9 +240,7 @@ export default class SelectControl extends React.PureComponent {
       optionRenderer,
       options: this.state.options,
       placeholder,
-      value:
-        value ||
-        (this.props.default !== undefined ? this.props.default : undefined),
+      value: getValue(),
     };
 
     return (


### PR DESCRIPTION
### SUMMARY
This PR fixes an edge case with the Select component. With dynamic controls there might be the case where a default value is being passed as `null` when it was intended to be `undefined`. This change makes sure that a `null` value that is not available in the options is considered as`undefined` instead.

### BEFORE
![Screen Shot 2021-10-07 at 17 35 15](https://user-images.githubusercontent.com/60598000/136406429-fc33a0d2-afd0-48bf-838d-0168d1c83ce9.png)

### AFTER
![Screen Shot 2021-10-07 at 17 33 45](https://user-images.githubusercontent.com/60598000/136406179-3ee489de-0cdd-4c01-9ece-38ccdd60df43.png)

### TESTING INSTRUCTIONS
1. Create a Histogram chart
2. Observe the Columns control

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
