### PR TITLE
fix: error alerts js crash

### DIFF
--- a/superset-frontend/src/components/ErrorMessage/BasicErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/BasicErrorAlert.tsx
@@ -58,7 +58,7 @@ export default function BasicErrorAlert({
 
   return (
     <StyledContainer level={level} role="alert">
-      {level === 'error' ? (
+      {!level || level === 'error' ? (
         <Icons.ErrorSolid iconColor={theme.colors[level].base} />
       ) : (
         <Icons.WarningSolid iconColor={theme.colors[level].base} />

--- a/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
@@ -108,7 +108,7 @@ export default function ErrorAlert({
     <ErrorAlertDiv level={level} role="alert">
       <div className="top-row">
         <LeftSideContent>
-          {level === 'error' ? (
+          {!level || level === 'error' ? (
             <Icons.ErrorSolid
               className="icon"
               iconColor={theme.colors[level].base}
@@ -171,7 +171,7 @@ export default function ErrorAlert({
           onHide={() => setIsModalOpen(false)}
           title={
             <div className="header">
-              {level === 'error' ? (
+              {!level || level === 'error' ? (
                 <Icons.ErrorSolid
                   className="icon"
                   iconColor={theme.colors[level].base}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When template params are malformed in sql lab, we return an error from the backend that doesn't include an error level. This caused the frontend to crash

I think this was likely caused by https://github.com/apache/superset/pull/16917 or https://github.com/apache/superset/pull/16852, but i don't have enough context on the backend right now to resolve it there. I figure we should also harden the frontend to handle this case, so i added the check there. @ofekisr, could you follow up your PR and ensure that all errors you pass from the backend contain an ErrorLevel? We have helper functions to construct those errors, so it shouldn't be too difficult

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
CI, write a query with a malformed jinja template param and see the error properly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @rusackas @pkdotson @graceguo-supercat @michael-s-molina 