### PR TITLE
fix: Exclude SUPERSET_DEFAULT from the list of available color schemes

### DIFF
--- a/superset-frontend/src/explore/components/controls/ColorSchemeControl.jsx
+++ b/superset-frontend/src/explore/components/controls/ColorSchemeControl.jsx
@@ -110,23 +110,32 @@ export default class ColorSchemeControl extends React.PureComponent {
     // save parsed schemes for later
     this.schemes = isFunction(schemes) ? schemes() : schemes;
 
-    const options = (isFunction(choices) ? choices() : choices).map(
-      ([value]) => ({
-        value,
-        label: this.schemes?.[value]?.label || value,
-        customLabel: this.renderOption(value),
-      }),
+    const supersetDefaultSchemeId = this.schemes?.SUPERSET_DEFAULT?.id;
+    const allColorOptions = (isFunction(choices) ? choices() : choices).filter(
+      o => o[0] !== 'SUPERSET_DEFAULT',
     );
+    const options = allColorOptions.map(([value]) => ({
+      value,
+      label: this.schemes?.[value]?.label || value,
+      customLabel: this.renderOption(value),
+    }));
+
+    let currentScheme =
+      this.props.value ||
+      (this.props.default !== undefined ? this.props.default : undefined);
+
+    if (currentScheme === 'SUPERSET_DEFAULT') {
+      currentScheme = supersetDefaultSchemeId;
+    }
+
     const selectProps = {
       ariaLabel: t('Select color scheme'),
       allowClear: this.props.clearable,
-      defaultValue: this.props.default,
       name: `select-${this.props.name}`,
       onChange: this.onChange,
       options,
       placeholder: `Select (${options.length})`,
-      showSearch: true,
-      value: this.props.value,
+      value: currentScheme,
     };
     return (
       <Select header={<ControlHeader {...this.props} />} {...selectProps} />

--- a/superset-frontend/src/explore/components/controls/ColorSchemeControl.jsx
+++ b/superset-frontend/src/explore/components/controls/ColorSchemeControl.jsx
@@ -124,7 +124,7 @@ export default class ColorSchemeControl extends React.PureComponent {
       (this.props.default !== undefined ? this.props.default : undefined);
 
     if (currentScheme === 'SUPERSET_DEFAULT') {
-      currentScheme = supersetDefaultSchemeId;
+      currentScheme = this.schemes?.SUPERSET_DEFAULT?.id;
     }
 
     const selectProps = {

--- a/superset-frontend/src/explore/components/controls/ColorSchemeControl.jsx
+++ b/superset-frontend/src/explore/components/controls/ColorSchemeControl.jsx
@@ -110,7 +110,6 @@ export default class ColorSchemeControl extends React.PureComponent {
     // save parsed schemes for later
     this.schemes = isFunction(schemes) ? schemes() : schemes;
 
-    const supersetDefaultSchemeId = this.schemes?.SUPERSET_DEFAULT?.id;
     const allColorOptions = (isFunction(choices) ? choices() : choices).filter(
       o => o[0] !== 'SUPERSET_DEFAULT',
     );


### PR DESCRIPTION
### SUMMARY
The SUPERSET_DEFAULT theme should not be considered as an independent color scheme as it is just a reference to an existing color scheme that is already part of the list of schemes. This PR excludes the SUPERSET_DEFAULT from the options of color schemes while keeping retro-compatibility with those that use SUPERSET_DEFAULT as a scheme. 

### BEFORE

See issue #16962

### AFTER
https://user-images.githubusercontent.com/60598000/136429051-935feaa3-efce-477e-a742-bb1f915a5786.mp4

### TESTING INSTRUCTIONS
1. Open a Dashboard and edit the properties
2. View the color scheme options and make sure there are no duplicates
3. Select the D3Category10 option and make sure the right color scheme is represented in the advanced - json metadata

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #16962
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
