### PR TITLE
fix(gsheets): bug fix for private sheets

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -551,6 +551,10 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       });
       // cast the new encrypted extra object into a string
       dbToUpdate.encrypted_extra = JSON.stringify(additionalEncryptedExtra);
+      // this needs to be added by default to gsheets
+      if (dbToUpdate.engine === 'gsheets') {
+        dbToUpdate.impersonate_user = true;
+      }
     }
 
     if (dbToUpdate?.parameters?.catalog) {

--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -153,9 +153,12 @@ class GSheetsEngineSpec(SqliteEngineSpec):
         cls, parameters: GSheetsParametersType,
     ) -> List[SupersetError]:
         errors: List[SupersetError] = []
-        encrypted_credentials = json.loads(
-            parameters.get("service_account_info") or "{}"
-        )
+        encrypted_credentials = parameters.get("service_account_info") or "{}"
+
+        # On create the encrypted credentials are a string,
+        # at all other times they are a dict
+        if isinstance(encrypted_credentials, str):
+            encrypted_credentials = json.loads(encrypted_credentials)
 
         table_catalog = parameters.get("catalog", {})
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

We weren't passing in impersonate_user as a payload in the front end so it was not allowing users to add private gsheets to datasets or to query them. 

This also has a fix for a small 500 error that was occurring when editing a private gsheet. It was occurring because encrypted_extra is sometimes a string and sometimes a dict. I'm just running a simple check to make sure. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Create a new private gsheet and add a service key. 
Go to sql lab
Query it

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
