### PR TITLE
fix: Loading indicator of table and schema selectors

### DIFF
--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -194,9 +194,9 @@ export default function DatabaseSelector({
       const queryParams = rison.encode({ force: refresh > 0 });
       const endpoint = `/api/v1/database/${currentDb.value}/schemas/?q=${queryParams}`;
 
-      try {
-        // TODO: Would be nice to add pagination in a follow-up. Needs endpoint changes.
-        SupersetClient.get({ endpoint }).then(({ json }) => {
+      // TODO: Would be nice to add pagination in a follow-up. Needs endpoint changes.
+      SupersetClient.get({ endpoint })
+        .then(({ json }) => {
           const options = json.result
             .map((s: string) => ({
               value: s,
@@ -210,10 +210,12 @@ export default function DatabaseSelector({
             onSchemasLoad(options);
           }
           setSchemaOptions(options);
+          setLoadingSchemas(false);
+        })
+        .catch(e => {
+          setLoadingSchemas(false);
+          handleError(t('There was an error loading the schemas'));
         });
-      } finally {
-        setLoadingSchemas(false);
-      }
     }
   }, [currentDb, onSchemasLoad, refresh]);
 

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -189,8 +189,8 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
         setPreviousRefresh(refresh);
       }
 
-      try {
-        SupersetClient.get({ endpoint }).then(({ json }) => {
+      SupersetClient.get({ endpoint })
+        .then(({ json }) => {
           const options: TableOption[] = [];
           let currentTable;
           json.options.forEach((table: Table) => {
@@ -213,10 +213,12 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
             ),
           );
           setCurrentTable(currentTable);
+          setLoadingTables(false);
+        })
+        .catch(e => {
+          setLoadingTables(false);
+          handleError(t('There was an error loading the tables'));
         });
-      } finally {
-        setLoadingTables(false);
-      }
     }
     // We are using the refresh state to re-trigger the query
     // previousRefresh should be out of dependencies array


### PR DESCRIPTION
### SUMMARY
Fixes the loading indicatos in `TableSelector`.

@serenajiang 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/136609336-73a18dfc-68d9-4ee9-bb31-548035191b93.mov

https://user-images.githubusercontent.com/70410625/136609199-cd7e5f8f-66e3-4f53-a3b5-832df14c975c.mov

### TESTING INSTRUCTIONS
Check the videos for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
