### PR TITLE
fix: Allow chart owners to edit title

### DIFF
--- a/superset-frontend/src/explore/components/ExploreChartHeader.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader.jsx
@@ -224,7 +224,13 @@ export class ExploreChartHeader extends React.PureComponent {
         <div className="title-panel">
           <EditableTitle
             title={this.getSliceName()}
-            canEdit={!this.props.slice || this.props.can_overwrite}
+            canEdit={
+              !this.props.slice ||
+              this.props.can_overwrite ||
+              (this.props.slice?.owners || []).includes(
+                this.props?.user?.userId,
+              )
+            }
             onSaveTitle={this.props.actions.updateChartTitle}
           />
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I added an additional condition to the logic that sets the `canEdit` prop of the `EditableTitle` component to explicitly allow owners of the chart to edit the title.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
There are no demonstrable changes - this new case uses the existing 'edit title' functionality.
### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- As a user viewing a saved chart that you own, confirm that a 'Click to edit' tooltip now appears when hovering over the char title.
- Confirm that you can click on the title field and edit the value.
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: Fixes [#16995](https://github.com/apache/superset/issues/16995)
- [ ] Required feature flags:
- [X] Changes UI: The previously existing 'Edit title' feature is now accessible in additional cases.
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
