### PR TITLE
refactor: Replaces areObjectsEqual with isEqualWith and adds default customizers

### DIFF
--- a/superset-frontend/src/dashboard/components/Dashboard.jsx
+++ b/superset-frontend/src/dashboard/components/Dashboard.jsx
@@ -22,6 +22,8 @@ import { isFeatureEnabled, t, FeatureFlag } from '@superset-ui/core';
 
 import { PluginContext } from 'src/components/DynamicPlugins';
 import Loading from 'src/components/Loading';
+import { isEqual, isEqualWith } from 'lodash';
+import { undefinedCustomizer } from 'src/utils/isEqualCustomizers';
 import getChartIdsFromLayout from '../util/getChartIdsFromLayout';
 import getLayoutComponentFromChartId from '../util/getLayoutComponentFromChartId';
 import DashboardBuilder from './DashboardBuilder/DashboardBuilder';
@@ -37,7 +39,6 @@ import {
   Logger,
 } from '../../logger/LogUtils';
 import OmniContainer from '../../components/OmniContainer';
-import { areObjectsEqual } from '../../reduxUtils';
 
 import '../stylesheets/index.less';
 import getLocationHash from '../util/getLocationHash';
@@ -176,12 +177,8 @@ class Dashboard extends React.PureComponent {
 
     if (
       !editMode &&
-      (!areObjectsEqual(appliedOwnDataCharts, ownDataCharts, {
-        ignoreUndefined: true,
-      }) ||
-        !areObjectsEqual(appliedFilters, activeFilters, {
-          ignoreUndefined: true,
-        }))
+      (!isEqualWith(appliedOwnDataCharts, ownDataCharts, undefinedCustomizer) ||
+        !isEqualWith(appliedFilters, activeFilters, undefinedCustomizer))
     ) {
       this.applyFilters();
     }
@@ -247,12 +244,10 @@ class Dashboard extends React.PureComponent {
         // if filterKey changes value,
         // update charts in its scope
         if (
-          !areObjectsEqual(
+          !isEqualWith(
             appliedFilters[filterKey].values,
             activeFilters[filterKey].values,
-            {
-              ignoreUndefined: true,
-            },
+            undefinedCustomizer,
           )
         ) {
           affectedChartIds.push(...activeFilters[filterKey].scope);
@@ -261,7 +256,7 @@ class Dashboard extends React.PureComponent {
         // if filterKey changes scope,
         // update all charts in its scope
         if (
-          !areObjectsEqual(
+          !isEqual(
             appliedFilters[filterKey].scope,
             activeFilters[filterKey].scope,
           )

--- a/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
@@ -26,7 +26,7 @@ import { NO_TIME_RANGE, TIME_FILTER_MAP } from 'src/explore/constants';
 import { getChartIdsInFilterScope } from 'src/dashboard/util/activeDashboardFilters';
 import { ChartConfiguration, Filters } from 'src/dashboard/reducers/types';
 import { DataMaskStateWithId, DataMaskType } from 'src/dataMask/types';
-import { areObjectsEqual } from 'src/reduxUtils';
+import { isEqual } from 'lodash';
 import { Layout } from '../../types';
 import { getTreeCheckedItems } from '../nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils';
 
@@ -180,10 +180,10 @@ export const selectIndicatorsForChart = (
   const cachedFilterData = cachedDashboardFilterDataForChart[chartId];
   if (
     cachedIndicatorsForChart[chartId] &&
-    areObjectsEqual(cachedFilterData?.appliedColumns, appliedColumns) &&
-    areObjectsEqual(cachedFilterData?.rejectedColumns, rejectedColumns) &&
-    areObjectsEqual(cachedFilterData?.matchingFilters, matchingFilters) &&
-    areObjectsEqual(cachedFilterData?.matchingDatasources, matchingDatasources)
+    isEqual(cachedFilterData?.appliedColumns, appliedColumns) &&
+    isEqual(cachedFilterData?.rejectedColumns, rejectedColumns) &&
+    isEqual(cachedFilterData?.matchingFilters, matchingFilters) &&
+    isEqual(cachedFilterData?.matchingDatasources, matchingDatasources)
   ) {
     return cachedIndicatorsForChart[chartId];
   }
@@ -228,8 +228,8 @@ export const selectNativeIndicatorsForChart = (
   const cachedFilterData = cachedNativeFilterDataForChart[chartId];
   if (
     cachedNativeIndicatorsForChart[chartId] &&
-    areObjectsEqual(cachedFilterData?.appliedColumns, appliedColumns) &&
-    areObjectsEqual(cachedFilterData?.rejectedColumns, rejectedColumns) &&
+    isEqual(cachedFilterData?.appliedColumns, appliedColumns) &&
+    isEqual(cachedFilterData?.rejectedColumns, rejectedColumns) &&
     cachedFilterData?.nativeFilters === nativeFilters &&
     cachedFilterData?.dashboardLayout === dashboardLayout &&
     cachedFilterData?.chartConfiguration === chartConfiguration &&

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -30,7 +30,6 @@ import {
   LOG_ACTIONS_EXPORT_CSV_DASHBOARD_CHART,
   LOG_ACTIONS_FORCE_REFRESH_CHART,
 } from 'src/logger/LogUtils';
-import { areObjectsEqual } from 'src/reduxUtils';
 
 import SliceHeader from '../SliceHeader';
 import MissingChart from '../MissingChart';
@@ -158,7 +157,7 @@ export default class Chart extends React.Component {
         const prop = SHOULD_UPDATE_ON_PROP_CHANGES[i];
         // use deep objects equality comparison to prevent
         // unneccessary updates when objects references change
-        if (!areObjectsEqual(nextProps[prop], this.props[prop])) {
+        if (!isEqual(nextProps[prop], this.props[prop])) {
           return true;
         }
       }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
@@ -30,6 +30,7 @@ import {
 } from '@superset-ui/core';
 import { useDispatch, useSelector } from 'react-redux';
 import { isEqual, isEqualWith } from 'lodash';
+import { ignorePropsCustomizer } from 'src/utils/isEqualCustomizers';
 import { getChartDataRequest } from 'src/chart/chartAction';
 import Loading from 'src/components/Loading';
 import BasicErrorAlert from 'src/components/ErrorMessage/BasicErrorAlert';
@@ -107,11 +108,7 @@ const FilterValue: React.FC<FilterProps> = ({
     const filterOwnState = filter.dataMask?.ownState || {};
     // TODO: We should try to improve our useEffect hooks to depend more on
     // granular information instead of big objects that require deep comparison.
-    const customizer = (
-      objValue: Partial<QueryFormData>,
-      othValue: Partial<QueryFormData>,
-      key: string,
-    ) => (key === 'url_params' ? true : undefined);
+    const customizer = ignorePropsCustomizer('url_params');
     if (
       !isRefreshing &&
       (!isEqualWith(formData, newFormData, customizer) ||

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/FiltersHeader.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/FiltersHeader.tsx
@@ -21,7 +21,8 @@ import { styled, t, useTheme } from '@superset-ui/core';
 import { Collapse, Typography, Tooltip } from 'src/common/components';
 import { DataMaskState } from 'src/dataMask/types';
 import Icons from 'src/components/Icons';
-import { areObjectsEqual } from 'src/reduxUtils';
+import { isEqualWith } from 'lodash';
+import { undefinedCustomizer } from 'src/utils/isEqualCustomizers';
 import { FilterSet } from 'src/dashboard/reducers/types';
 import { getFilterValueForDisplay } from './utils';
 import { useFilters } from '../state';
@@ -86,9 +87,11 @@ const FiltersHeader: FC<FiltersHeaderProps> = ({ dataMask, filterSet }) => {
   const getFilterRow = ({ id, name }: { id: string; name: string }) => {
     const changedFilter =
       filterSet &&
-      !areObjectsEqual(filters[id], filterSet?.nativeFilters?.[id], {
-        ignoreUndefined: true,
-      });
+      !isEqualWith(
+        filters[id],
+        filterSet?.nativeFilters?.[id],
+        undefinedCustomizer,
+      );
     const removedFilter = !Object.keys(filters).includes(id);
 
     return (

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/index.tsx
@@ -23,7 +23,8 @@ import { useDispatch } from 'react-redux';
 import { DataMaskState, DataMaskWithId } from 'src/dataMask/types';
 import { setFilterSetsConfiguration } from 'src/dashboard/actions/nativeFilters';
 import { Filters, FilterSet } from 'src/dashboard/reducers/types';
-import { areObjectsEqual } from 'src/reduxUtils';
+import { isEqualWith } from 'lodash';
+import { undefinedCustomizer } from 'src/utils/isEqualCustomizers';
 import { findExistingFilterSet, generateFiltersSetId } from './utils';
 import { Filter } from '../../types';
 import { useFilters, useNativeFiltersDataMask, useFilterSets } from '../state';
@@ -113,9 +114,11 @@ const FilterSets: React.FC<FilterSetsProps> = ({
     filterSet?: FilterSet,
   ) =>
     !filterValues.find(filter => filter?.id === id) ||
-    !areObjectsEqual(filters[id], filterSet?.nativeFilters?.[id], {
-      ignoreUndefined: true,
-    });
+    !isEqualWith(
+      filters[id],
+      filterSet?.nativeFilters?.[id],
+      undefinedCustomizer,
+    );
 
   const takeFilterSet = (id: string, target?: HTMLElement) => {
     const ignoreSelectorHeader = 'ant-collapse-header';

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/utils/index.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/utils/index.ts
@@ -19,7 +19,7 @@
 
 import shortid from 'shortid';
 import { t } from '@superset-ui/core';
-import { areObjectsEqual } from 'src/reduxUtils';
+import { isEqual } from 'lodash';
 import { DataMaskState } from 'src/dataMask/types';
 import { FilterSet } from 'src/dashboard/reducers/types';
 
@@ -55,13 +55,13 @@ export const findExistingFilterSet = ({
   filterSetFilterValues.find(({ dataMask: dataMaskFromFilterSet = {} }) => {
     const dataMaskSelectedEntries = Object.entries(dataMaskSelected);
     return dataMaskSelectedEntries.every(([id, filterFromSelectedFilters]) => {
-      const isEqual = areObjectsEqual(
+      const isEqualState = isEqual(
         filterFromSelectedFilters.filterState,
         dataMaskFromFilterSet?.[id]?.filterState,
       );
       const hasSamePropsNumber =
         dataMaskSelectedEntries.length ===
         Object.keys(dataMaskFromFilterSet ?? {}).length;
-      return isEqual && hasSamePropsNumber;
+      return isEqualState && hasSamePropsNumber;
     });
   });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
@@ -18,7 +18,8 @@
  */
 
 import { DataMaskStateWithId } from 'src/dataMask/types';
-import { areObjectsEqual } from 'src/reduxUtils';
+import { isEqualWith } from 'lodash';
+import { undefinedCustomizer } from 'src/utils/isEqualCustomizers';
 import { FilterState } from '@superset-ui/core';
 import { Filter } from '../types';
 
@@ -70,10 +71,10 @@ export const checkIsApplyDisabled = (
   const dataAppliedValues = Object.values(dataMaskApplied);
 
   return (
-    areObjectsEqual(
+    isEqualWith(
       getOnlyExtraFormData(dataMaskSelected),
       getOnlyExtraFormData(dataMaskApplied),
-      { ignoreUndefined: true },
+      undefinedCustomizer,
     ) ||
     dataSelectedValues.length !== dataAppliedValues.length ||
     filters.some(filter =>

--- a/superset-frontend/src/dashboard/util/charts/getFormDataWithExtraFilters.ts
+++ b/superset-frontend/src/dashboard/util/charts/getFormDataWithExtraFilters.ts
@@ -24,7 +24,8 @@ import {
 import { ChartQueryPayload, Charts, LayoutItem } from 'src/dashboard/types';
 import { getExtraFormData } from 'src/dashboard/components/nativeFilters/utils';
 import { DataMaskStateWithId } from 'src/dataMask/types';
-import { areObjectsEqual } from 'src/reduxUtils';
+import { isEqualWith } from 'lodash';
+import { undefinedCustomizer } from 'src/utils/isEqualCustomizers';
 import getEffectiveExtraFilters from './getEffectiveExtraFilters';
 import { ChartConfiguration, NativeFiltersState } from '../../reducers/types';
 import { getAllActiveFilters } from '../activeAllDashboardFilters';
@@ -70,19 +71,23 @@ export default function getFormDataWithExtraFilters({
   const cachedFormData = cachedFormdataByChart[sliceId];
   if (
     cachedFiltersByChart[sliceId] === filters &&
-    areObjectsEqual(cachedFormData?.color_scheme, colorScheme, {
-      ignoreUndefined: true,
-    }) &&
-    areObjectsEqual(cachedFormData?.color_namespace, colorNamespace, {
-      ignoreUndefined: true,
-    }) &&
-    areObjectsEqual(cachedFormData?.label_colors, labelColors, {
-      ignoreUndefined: true,
-    }) &&
+    isEqualWith(
+      cachedFormData?.color_scheme,
+      colorScheme,
+      undefinedCustomizer,
+    ) &&
+    isEqualWith(
+      cachedFormData?.color_namespace,
+      colorNamespace,
+      undefinedCustomizer,
+    ) &&
+    isEqualWith(
+      cachedFormData?.label_colors,
+      labelColors,
+      undefinedCustomizer,
+    ) &&
     !!cachedFormData &&
-    areObjectsEqual(cachedFormData?.dataMask, dataMask, {
-      ignoreUndefined: true,
-    })
+    isEqualWith(cachedFormData?.dataMask, dataMask, undefinedCustomizer)
   ) {
     return cachedFormData;
   }

--- a/superset-frontend/src/dashboard/util/charts/getOwnDataCharts.ts
+++ b/superset-frontend/src/dashboard/util/charts/getOwnDataCharts.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { JsonObject } from '@superset-ui/core';
-import { areObjectsEqual } from '../../../reduxUtils';
+import { isEqual } from 'lodash';
 
 export const arrayDiff = (a: string[], b: string[]) => [
   ...a.filter(x => !b.includes(x)),
@@ -35,9 +35,7 @@ export const getAffectedOwnDataCharts = (
   );
   const checkForUpdateIds = new Set<string>([...chartIds, ...appliedChartIds]);
   checkForUpdateIds.forEach(chartId => {
-    if (
-      !areObjectsEqual(ownDataCharts[chartId], appliedOwnDataCharts[chartId])
-    ) {
+    if (!isEqual(ownDataCharts[chartId], appliedOwnDataCharts[chartId])) {
       affectedIds.push(chartId);
     }
   });

--- a/superset-frontend/src/dataMask/reducer.ts
+++ b/superset-frontend/src/dataMask/reducer.ts
@@ -26,6 +26,8 @@ import { HYDRATE_DASHBOARD } from 'src/dashboard/actions/hydrate';
 import { isFeatureEnabled } from 'src/featureFlags';
 import { getUrlParam } from 'src/utils/urlUtils';
 import { URL_PARAMS } from 'src/constants';
+import { isEqualWith } from 'lodash';
+import { undefinedCustomizer } from 'src/utils/isEqualCustomizers';
 import { DataMaskStateWithId, DataMaskWithId } from './types';
 import {
   AnyDataMaskAction,
@@ -37,7 +39,6 @@ import {
   Filter,
   FilterConfiguration,
 } from '../dashboard/components/nativeFilters/types';
-import { areObjectsEqual } from '../reduxUtils';
 import { Filters } from '../dashboard/reducers/types';
 
 export function getInitialDataMask(
@@ -78,10 +79,10 @@ function fillNativeFilters(
     };
     if (
       currentFilters &&
-      !areObjectsEqual(
+      !isEqualWith(
         filter.defaultDataMask,
         currentFilters[filter.id]?.defaultDataMask,
-        { ignoreUndefined: true },
+        undefinedCustomizer,
       )
     ) {
       mergedDataMask[filter.id] = {

--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -22,7 +22,7 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { styled, t, css, useTheme } from '@superset-ui/core';
-import { debounce } from 'lodash';
+import { isEqual, debounce } from 'lodash';
 import { Resizable } from 're-resizable';
 
 import { usePluginContext } from 'src/components/DynamicPlugins';
@@ -46,7 +46,6 @@ import SaveModal from './SaveModal';
 import QueryAndSaveBtns from './QueryAndSaveBtns';
 import DataSourcePanel from './DatasourcePanel';
 import { getExploreLongUrl } from '../exploreUtils';
-import { areObjectsEqual } from '../../reduxUtils';
 import { getFormDataFromControls } from '../controlUtils';
 import * as exploreActions from '../actions/exploreActions';
 import * as saveModalActions from '../actions/saveModalActions';
@@ -329,10 +328,7 @@ function ExploreViewContainer(props) {
       const changedControlKeys = Object.keys(props.controls).filter(
         key =>
           typeof previousControls[key] !== 'undefined' &&
-          !areObjectsEqual(
-            props.controls[key].value,
-            previousControls[key].value,
-          ),
+          !isEqual(props.controls[key].value, previousControls[key].value),
       );
 
       // this should also be handled by the actions that are actually changing the controls
@@ -350,10 +346,7 @@ function ExploreViewContainer(props) {
       const changedControlKeys = Object.keys(props.controls).filter(
         key =>
           typeof lastQueriedControls[key] !== 'undefined' &&
-          !areObjectsEqual(
-            props.controls[key].value,
-            lastQueriedControls[key].value,
-          ),
+          !isEqual(props.controls[key].value, lastQueriedControls[key].value),
       );
 
       return changedControlKeys.some(

--- a/superset-frontend/src/reduxUtils.ts
+++ b/superset-frontend/src/reduxUtils.ts
@@ -19,7 +19,6 @@
 import shortid from 'shortid';
 import { compose } from 'redux';
 import persistState, { StorageAdapter } from 'redux-localstorage';
-import { isEqual, omitBy, isUndefined } from 'lodash';
 
 export function addToObject(
   state: Record<string, any>,
@@ -167,18 +166,4 @@ export function areArraysShallowEqual(arr1: unknown[], arr2: unknown[]) {
     }
   }
   return true;
-}
-
-export function areObjectsEqual(
-  obj1: any,
-  obj2: any,
-  opts = { ignoreUndefined: false },
-) {
-  let comp1 = obj1;
-  let comp2 = obj2;
-  if (opts.ignoreUndefined) {
-    comp1 = omitBy(obj1, isUndefined);
-    comp2 = omitBy(obj2, isUndefined);
-  }
-  return isEqual(comp1, comp2);
 }

--- a/superset-frontend/src/utils/isEqualCustomizers.test.ts
+++ b/superset-frontend/src/utils/isEqualCustomizers.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { isEqualWith } from 'lodash';
+import {
+  undefinedCustomizer,
+  ignorePropsCustomizer,
+  compoundCustomizer,
+} from './isEqualCustomizers';
+
+test('ignores undefined with truthty result', () => {
+  expect(
+    isEqualWith({ a: 1, b: undefined }, { a: 1, b: 2 }, undefinedCustomizer),
+  ).toBe(true);
+});
+
+test('ignores undefined with falsy result', () => {
+  expect(
+    isEqualWith({ a: 1, b: undefined }, { a: 2, b: 2 }, undefinedCustomizer),
+  ).toBe(false);
+});
+
+test('ignores props with truthty result', () => {
+  const customizer = ignorePropsCustomizer('b', 'c');
+  expect(
+    isEqualWith({ a: 1, b: 1, c: 1 }, { a: 1, b: 2, c: 2 }, customizer),
+  ).toBe(true);
+});
+
+test('ignores props with falsy result', () => {
+  const customizer = ignorePropsCustomizer('b', 'c');
+  expect(
+    isEqualWith({ a: 1, b: 1, c: 1 }, { a: 2, b: 2, c: 2 }, customizer),
+  ).toBe(false);
+});
+
+test('ignores undefined and props with truthty result', () => {
+  const propsCustomizer = ignorePropsCustomizer('b');
+  const customizer = compoundCustomizer(undefinedCustomizer, propsCustomizer);
+  expect(
+    isEqualWith({ a: 1, b: 1, c: 1 }, { a: 1, b: 2, c: undefined }, customizer),
+  ).toBe(true);
+});
+
+test('ignores undefined and props with falsy result', () => {
+  const propsCustomizer = ignorePropsCustomizer('b');
+  const customizer = compoundCustomizer(undefinedCustomizer, propsCustomizer);
+  expect(
+    isEqualWith({ a: 1, b: 1, c: 1 }, { a: 2, b: 2, c: undefined }, customizer),
+  ).toBe(false);
+});

--- a/superset-frontend/src/utils/isEqualCustomizers.ts
+++ b/superset-frontend/src/utils/isEqualCustomizers.ts
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { IsEqualCustomizer } from 'lodash';
+
+const undefinedCustomizer: IsEqualCustomizer = (value: any, other: any) =>
+  value === undefined || other === undefined ? true : undefined;
+
+const ignorePropsCustomizer = (...props: string[]): IsEqualCustomizer => (
+  value: any,
+  other: any,
+  key: string,
+) => (key && props.includes(key) ? true : undefined);
+
+const compoundCustomizer = (...customizers: IsEqualCustomizer[]) => (
+  value: any,
+  other: any,
+  key: string,
+) =>
+  customizers
+    .map(customizer =>
+      customizer(value, other, key, undefined, undefined, undefined),
+    )
+    .reduce((previousValue, currentValue) =>
+      previousValue || currentValue ? true : undefined,
+    );
+
+export { undefinedCustomizer, ignorePropsCustomizer, compoundCustomizer };


### PR DESCRIPTION
### SUMMARY
Replaces `src/reduxUtils/areObjectsEqual` occurrences with Lodash `isEqualWith` and adds default customizers. The removed `areObjectsEqual` function was using `omitBy` to remove `undefined` values before passing the object to Lodash `isEqual`. A more efficient way is to pass a customizer to `isEqualWith` ignoring the `undefined` values during the comparison. Apart from the efficiency gain, this PR also aims to provide a utility with default customizers to be used throughout the application and that can be enhanced in the future with more custom functions.

Follow-up of https://github.com/apache/superset/pull/16994

@rusackas @junlincc 

### TESTING INSTRUCTIONS
1 - Execute all tests
2 - All tests should pass

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
