### PR TITLE
fix: Owners selection in dataset edit UX

### DIFF
--- a/superset-frontend/spec/fixtures/mockDatasource.js
+++ b/superset-frontend/spec/fixtures/mockDatasource.js
@@ -168,6 +168,7 @@ export default {
     id,
     granularity_sqla: [['ds', 'ds']],
     name: 'birth_names',
+    owners: [{first_name: 'joe', last_name: 'man', id: 1}],
     database: {
       allow_multi_schema_metadata_fetch: null,
       name: 'main',

--- a/superset-frontend/spec/fixtures/mockDatasource.js
+++ b/superset-frontend/spec/fixtures/mockDatasource.js
@@ -168,7 +168,7 @@ export default {
     id,
     granularity_sqla: [['ds', 'ds']],
     name: 'birth_names',
-    owners: [{first_name: 'joe', last_name: 'man', id: 1}],
+    owners: [{ first_name: 'joe', last_name: 'man', id: 1 }],
     database: {
       allow_multi_schema_metadata_fetch: null,
       name: 'main',

--- a/superset-frontend/spec/javascripts/dashboard/components/FiltersBadge_spec.tsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/FiltersBadge_spec.tsx
@@ -139,7 +139,6 @@ describe('FiltersBadge', () => {
         wrapper.find('[data-test="incompatible-filter-count"]'),
       ).toHaveText('1');
       // to look at the shape of the wrapper use:
-      // console.log(wrapper.debug())
       expect(wrapper.find(Icons.AlertSolid)).toExist();
     });
   });

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -375,14 +375,10 @@ const defaultProps = {
 };
 
 function OwnersSelector({ datasource, onChange }) {
-  const selectedOwners = datasource.owners.map(owner => ({
-    value: owner.id,
-    label: `${owner.first_name} ${owner.last_name}`,
-  }));
   const loadOptions = useMemo(() => (search = '', page, pageSize) => {
     const query = rison.encode({ filter: search, page, page_size: pageSize });
     return SupersetClient.get({
-      endpoint: `/api/v1/chart/related/owners?q=${query}`,
+      endpoint: `/api/v1/dataset/related/owners?q=${query}`,
     }).then(response => ({
       data: response.json.result.map(item => ({
         value: item.value,
@@ -397,11 +393,9 @@ function OwnersSelector({ datasource, onChange }) {
       ariaLabel={t('Select owners')}
       mode="multiple"
       name="owners"
-      value={selectedOwners || []}
+      value={datasource.owners || []}
       options={loadOptions}
-      onChange={newOwners => {
-        onChange(newOwners);
-      }}
+      onChange={newOwners => onChange(newOwners)}
       header={<FormLabel>{t('Owners')}</FormLabel>}
       allowClear
     />
@@ -751,7 +745,12 @@ class DatasourceEditor extends React.PureComponent {
             }
           />
         )}
-        <OwnersSelector datasource={datasource} />
+        <OwnersSelector
+          datasource={datasource}
+          onChange={newOwners => {
+            this.onDatasourceChange({ ...datasource, owners: newOwners });
+          }}
+        />
       </Fieldset>
     );
   }

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -26,6 +26,8 @@ import Alert from 'src/components/Alert';
 import Badge from 'src/components/Badge';
 import shortid from 'shortid';
 import { styled, SupersetClient, t, supersetTheme } from '@superset-ui/core';
+import { Select } from 'src/components';
+import { FormLabel } from 'src/components/Form';
 import Button from 'src/components/Button';
 import Tabs from 'src/components/Tabs';
 import CertifiedIcon from 'src/components/CertifiedIcon';
@@ -40,7 +42,6 @@ import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 
 import CheckboxControl from 'src/explore/components/controls/CheckboxControl';
 import TextControl from 'src/explore/components/controls/TextControl';
-import { Select } from 'src/components';
 import TextAreaControl from 'src/explore/components/controls/TextAreaControl';
 import SelectAsyncControl from 'src/explore/components/controls/SelectAsyncControl';
 import SpatialControl from 'src/explore/components/controls/SpatialControl';
@@ -722,16 +723,23 @@ class DatasourceEditor extends React.PureComponent {
           label={t('Owners')}
           description={t('Owners of the dataset')}
           control={
-            <SelectAsyncControl
-              dataEndpoint="api/v1/dataset/related/owners"
-              multi
-              mutator={data =>
-                data.result.map(pk => ({
-                  value: pk.value,
-                  label: `${pk.text}`,
-                }))
-              }
-            />
+            <>
+              <Select
+                ariaLabel={t('Select owners')}
+                header={<FormLabel>{t('Owners')}</FormLabel>}
+                options={[{ label: 'foo', value: 'bar' }]}
+              />
+              <SelectAsyncControl
+                dataEndpoint="api/v1/dataset/related/owners"
+                multi
+                mutator={data =>
+                  data.result.map(pk => ({
+                    value: pk.value,
+                    label: `${pk.text}`,
+                  }))
+                }
+              />
+            </>
           }
           controlProps={{}}
         />

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -395,7 +395,7 @@ function OwnersSelector({ datasource, onChange }) {
       name="owners"
       value={datasource.owners || []}
       options={loadOptions}
-      onChange={newOwners => onChange(newOwners)}
+      onChange={onChange}
       header={<FormLabel>{t('Owners')}</FormLabel>}
       allowClear
     />

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -375,25 +375,28 @@ const defaultProps = {
 };
 
 function OwnersSelector({ datasource, onChange }) {
-  const loadOptions = useMemo(() => (search = '', page, pageSize) => {
-    const query = rison.encode({ filter: search, page, page_size: pageSize });
-    return SupersetClient.get({
-      endpoint: `/api/v1/dataset/related/owners?q=${query}`,
-    }).then(response => ({
-      data: response.json.result.map(item => ({
-        value: item.value,
-        label: item.text,
-      })),
-      totalCount: response.json.count,
-    }));
-  });
+  const loadOptions = useMemo(
+    () => (search = '', page, pageSize) => {
+      const query = rison.encode({ filter: search, page, page_size: pageSize });
+      return SupersetClient.get({
+        endpoint: `/api/v1/dataset/related/owners?q=${query}`,
+      }).then(response => ({
+        data: response.json.result.map(item => ({
+          value: item.value,
+          label: item.text,
+        })),
+        totalCount: response.json.count,
+      }));
+    },
+    [],
+  );
 
   return (
     <Select
       ariaLabel={t('Select owners')}
       mode="multiple"
       name="owners"
-      value={datasource.owners || []}
+      value={datasource.owners}
       options={loadOptions}
       onChange={onChange}
       header={<FormLabel>{t('Owners')}</FormLabel>}
@@ -408,6 +411,10 @@ class DatasourceEditor extends React.PureComponent {
     this.state = {
       datasource: {
         ...props.datasource,
+        owners: props.datasource.owners.map(owner => ({
+          value: owner.id,
+          label: `${owner.first_name} ${owner.last_name}`,
+        })),
         metrics: props.datasource.metrics?.map(metric => {
           const {
             certified_by: certifiedByMetric,

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import rison from 'rison';
-import React, { useMemo } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Row, Col } from 'src/common/components';
 import { Radio } from 'src/components/Radio';
@@ -375,7 +375,7 @@ const defaultProps = {
 };
 
 function OwnersSelector({ datasource, onChange }) {
-  const loadOptions = useMemo(() => (search = '', page, pageSize) => {
+  const loadOptions = () => (search = '', page, pageSize) => {
     const query = rison.encode({ filter: search, page, page_size: pageSize });
     return SupersetClient.get({
       endpoint: `/api/v1/dataset/related/owners?q=${query}`,
@@ -386,7 +386,7 @@ function OwnersSelector({ datasource, onChange }) {
       })),
       totalCount: response.json.count,
     }));
-  });
+  };
 
   return (
     <Select

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import rison from 'rison';
-import React, { useMemo } from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { Row, Col } from 'src/common/components';
 import { Radio } from 'src/components/Radio';
@@ -375,21 +375,18 @@ const defaultProps = {
 };
 
 function OwnersSelector({ datasource, onChange }) {
-  const loadOptions = useMemo(
-    () => (search = '', page, pageSize) => {
-      const query = rison.encode({ filter: search, page, page_size: pageSize });
-      return SupersetClient.get({
-        endpoint: `/api/v1/dataset/related/owners?q=${query}`,
-      }).then(response => ({
-        data: response.json.result.map(item => ({
-          value: item.value,
-          label: item.text,
-        })),
-        totalCount: response.json.count,
-      }));
-    },
-    [],
-  );
+  const loadOptions = useCallback((search = '', page, pageSize) => {
+    const query = rison.encode({ filter: search, page, page_size: pageSize });
+    return SupersetClient.get({
+      endpoint: `/api/v1/dataset/related/owners?q=${query}`,
+    }).then(response => ({
+      data: response.json.result.map(item => ({
+        value: item.value,
+        label: item.text,
+      })),
+      totalCount: response.json.count,
+    }));
+  }, []);
 
   return (
     <Select

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import rison from 'rison';
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Row, Col } from 'src/common/components';
 import { Radio } from 'src/components/Radio';
@@ -375,7 +375,7 @@ const defaultProps = {
 };
 
 function OwnersSelector({ datasource, onChange }) {
-  const loadOptions = () => (search = '', page, pageSize) => {
+  const loadOptions = useMemo(() => (search = '', page, pageSize) => {
     const query = rison.encode({ filter: search, page, page_size: pageSize });
     return SupersetClient.get({
       endpoint: `/api/v1/dataset/related/owners?q=${query}`,
@@ -386,7 +386,7 @@ function OwnersSelector({ datasource, onChange }) {
       })),
       totalCount: response.json.count,
     }));
-  };
+  });
 
   return (
     <Select

--- a/superset-frontend/src/datasource/DatasourceModal.tsx
+++ b/superset-frontend/src/datasource/DatasourceModal.tsx
@@ -99,7 +99,6 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
       currentDatasource.schema;
 
     setIsSaving(true);
-
     SupersetClient.post({
       endpoint: '/datasource/save/',
       postPayload: {
@@ -119,6 +118,9 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
             }),
           ),
           type: currentDatasource.type || currentDatasource.datasource_type,
+          owners: currentDatasource.owners.map(
+            (o: { label: string; value: number }) => o.value,
+          ),
         },
       },
     })

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
@@ -41,6 +41,7 @@ const createProps = () => ({
     name: 'channels',
     type: 'table',
     columns: [],
+    owners: [{ first_name: 'john', last_name: 'doe', id: 1, username: 'jd' }],
   },
   validationErrors: [],
   name: 'datasource',

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
@@ -165,7 +165,6 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
         endpoint: `/api/v1/dataset/${id}`,
       })
         .then(({ json = {} }) => {
-          const owners = json.result.owners.map((owner: any) => owner.id);
           const addCertificationFields = json.result.columns.map(
             (column: ColumnObject) => {
               const {
@@ -181,7 +180,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
           );
           // eslint-disable-next-line no-param-reassign
           json.result.columns = [...addCertificationFields];
-          setDatasetCurrentlyEditing({ ...json.result, owners });
+          setDatasetCurrentlyEditing(json.result);
         })
         .catch(() => {
           addDangerToast(

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
@@ -165,6 +165,10 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
         endpoint: `/api/v1/dataset/${id}`,
       })
         .then(({ json = {} }) => {
+          const owners = json.result.owners.map((owner: any) => ({
+            value: owner.id,
+            label: `${owner.first_name} ${owner.last_name}`,
+          }));
           const addCertificationFields = json.result.columns.map(
             (column: ColumnObject) => {
               const {
@@ -180,7 +184,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
           );
           // eslint-disable-next-line no-param-reassign
           json.result.columns = [...addCertificationFields];
-          setDatasetCurrentlyEditing(json.result);
+          setDatasetCurrentlyEditing({ ...json.result, owners });
         })
         .catch(() => {
           addDangerToast(

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
@@ -165,10 +165,6 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
         endpoint: `/api/v1/dataset/${id}`,
       })
         .then(({ json = {} }) => {
-          const owners = json.result.owners.map((owner: any) => ({
-            value: owner.id,
-            label: `${owner.first_name} ${owner.last_name}`,
-          }));
           const addCertificationFields = json.result.columns.map(
             (column: ColumnObject) => {
               const {
@@ -184,7 +180,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
           );
           // eslint-disable-next-line no-param-reassign
           json.result.columns = [...addCertificationFields];
-          setDatasetCurrentlyEditing({ ...json.result, owners });
+          setDatasetCurrentlyEditing(json.result);
         })
         .catch(() => {
           addDangerToast(

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -119,6 +119,18 @@ class BaseDatasource(
         return DatasourceKind.VIRTUAL if self.sql else DatasourceKind.PHYSICAL
 
     @property
+    def owners_data(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "first_name": o.first_name,
+                "last_name": o.last_name,
+                "username": o.username,
+                "id": o.id,
+            }
+            for o in self.owners
+        ]
+
+    @property
     def is_virtual(self) -> bool:
         return self.kind == DatasourceKind.VIRTUAL
 

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -265,11 +265,7 @@ class BaseDatasource(
             "metrics": [o.data for o in self.metrics],
             # TODO deprecate, move logic to JS
             "order_by_choices": order_by_choices,
-            # Passing the format needed to power owner selection in edit screen
-            "owners": [
-                {"label": f"{owner.first_name} {owner.last_name}", "value": owner.id}
-                for owner in self.owners
-            ],
+            "owners": [owner.id for owner in self.owners],
             "verbose_map": verbose_map,
             "select_star": self.select_star,
         }

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -265,7 +265,11 @@ class BaseDatasource(
             "metrics": [o.data for o in self.metrics],
             # TODO deprecate, move logic to JS
             "order_by_choices": order_by_choices,
-            "owners": [owner.id for owner in self.owners],
+            # Passing the format needed to power owner selection in edit screen
+            "owners": [
+                {"label": f"{owner.first_name} {owner.last_name}", "value": owner.id}
+                for owner in self.owners
+            ],
             "verbose_map": verbose_map,
             "select_star": self.select_star,
         }

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -856,12 +856,8 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         except (SupersetException, SQLAlchemyError):
             datasource_data = dummy_datasource_data
 
-        # passing the format needed to power owner selection in edit screen
         if datasource:
-            datasource_data["owners"] = [
-                {"label": f"{owner.first_name} {owner.last_name}", "value": owner.id}
-                for owner in datasource.owners
-            ]
+            datasource_data["owners"] = [owner.data for owner in datasource.owners]
 
         bootstrap_data = {
             "can_add": slice_add_perm,

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -857,7 +857,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             datasource_data = dummy_datasource_data
 
         if datasource:
-            datasource_data["owners"] = [owner.data for owner in datasource.owners]
+            datasource_data["owners"] = datasource.owners_data
 
         bootstrap_data = {
             "can_add": slice_add_perm,

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -856,6 +856,13 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         except (SupersetException, SQLAlchemyError):
             datasource_data = dummy_datasource_data
 
+        # passing the format needed to power owner selection in edit screen
+        if datasource:
+            datasource_data["owners"] = [
+                {"label": f"{owner.first_name} {owner.last_name}", "value": owner.id}
+                for owner in datasource.owners
+            ]
+
         bootstrap_data = {
             "can_add": slice_add_perm,
             "can_download": slice_download_perm,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The original dataset edit screen didn't populate owners and wasn't allowing users to properly query the db for potentially new owners.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
https://user-images.githubusercontent.com/27827808/136850207-f4658700-0058-4d60-a226-dbc9243915fc.mov

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Goto datasets
2. Click on edit dataset in one of list items
3. Goto settings
4. Change owners
5. Save
6. Make sure owners in list reflect owners you chose

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: closes #15530 closes #16883 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
