### PR TITLE
fix(sqllab): Hover tooltip flashes in SQL Lab

### DIFF
--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -359,7 +359,7 @@ export default class FilterableTable extends PureComponent<
         ? 'header-style-disabled'
         : 'header-style';
     return (
-      <Tooltip id="header-tooltip" title={label}>
+      <Tooltip id="header-tooltip" title={label} placement="topLeft">
         <div className={className}>
           {label}
           {sortBy === dataKey && (
@@ -385,7 +385,7 @@ export default class FilterableTable extends PureComponent<
         ? 'header-style-disabled'
         : 'header-style';
     return (
-      <Tooltip key={key} id="header-tooltip" title={label}>
+      <Tooltip key={key} id="header-tooltip" title={label} placement="topLeft">
         <div
           style={{
             ...style,
@@ -396,7 +396,7 @@ export default class FilterableTable extends PureComponent<
           }}
           className={`${className} grid-cell grid-header-cell`}
         >
-          <div css={{ width: 'max-content' }}>{label}</div>
+          <div>{label}</div>
         </div>
       </Tooltip>
     );

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -359,7 +359,12 @@ export default class FilterableTable extends PureComponent<
         ? 'header-style-disabled'
         : 'header-style';
     return (
-      <Tooltip id="header-tooltip" title={label} placement="topLeft">
+      <Tooltip
+        id="header-tooltip"
+        title={label}
+        placement="topLeft"
+        css={{ display: 'block' }}
+      >
         <div className={className}>
           {label}
           {sortBy === dataKey && (
@@ -385,7 +390,13 @@ export default class FilterableTable extends PureComponent<
         ? 'header-style-disabled'
         : 'header-style';
     return (
-      <Tooltip key={key} id="header-tooltip" title={label} placement="topLeft">
+      <Tooltip
+        key={key}
+        id="header-tooltip"
+        title={label}
+        placement="topLeft"
+        css={{ display: 'block' }}
+      >
         <div
           style={{
             ...style,

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -396,7 +396,7 @@ export default class FilterableTable extends PureComponent<
           }}
           className={`${className} grid-cell grid-header-cell`}
         >
-          <div>{label}</div>
+          <div css={{ width: 'max-content' }}>{label}</div>
         </div>
       </Tooltip>
     );

--- a/superset-frontend/src/components/Tooltip/index.tsx
+++ b/superset-frontend/src/components/Tooltip/index.tsx
@@ -30,7 +30,7 @@ export const Tooltip = (props: TooltipProps) => {
       <Global
         styles={css`
           .ant-tooltip-open {
-            display: block;
+            display: inline-block;
             &::after {
               content: '';
               display: block;

--- a/superset-frontend/src/components/Tooltip/index.tsx
+++ b/superset-frontend/src/components/Tooltip/index.tsx
@@ -30,7 +30,7 @@ export const Tooltip = (props: TooltipProps) => {
       <Global
         styles={css`
           .ant-tooltip-open {
-            display: inline-block;
+            display: block;
             &::after {
               content: '';
               display: block;


### PR DESCRIPTION
### SUMMARY
In FilterableTable, changing each Tooltip implementation's display to `block` and the placement to "topLeft" fixed this.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE
![before](https://user-images.githubusercontent.com/55605634/136883010-5da3b0d7-9a1d-40f2-8d09-753a136b6e1d.gif)

#### AFTER
![tooltipAfter](https://user-images.githubusercontent.com/55605634/137155764-4438715f-f12f-4d1b-b7bc-954a28df4133.gif)

### TESTING INSTRUCTIONS
Hover over the column header of any SQL Lab result query and observe that the tooltip no longer flashes.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/16824
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
