### PR TITLE
fix(druid): Fix regression with ISO 8601 format

### DIFF
--- a/superset/db_engine_specs/druid.py
+++ b/superset/db_engine_specs/druid.py
@@ -54,7 +54,7 @@ class DruidEngineSpec(BaseEngineSpec):
         "P1D": "TIME_FLOOR({col}, 'P1D')",
         "P1W": "TIME_FLOOR({col}, 'P1W')",
         "P1M": "TIME_FLOOR({col}, 'P1M')",
-        "P0.25Y": "TIME_FLOOR({col}, 'P0.25Y')",
+        "P0.25Y": "TIME_FLOOR({col}, 'P3M')",
         "P1Y": "TIME_FLOOR({col}, 'P1Y')",
         "P1W/1970-01-03T00:00:00Z": (
             "TIME_SHIFT(TIME_FLOOR(TIME_SHIFT({col}, 'P1D', 1), 'P1W'), 'P1D', 5)"


### PR DESCRIPTION
### SUMMARY

This PR fixes a regression I introduced in https://github.com/apache/superset/pull/17050 as it seems like the `P0.25Y` ISO8601 isn't supported, 

```
druid> SELECT TIME_FLOOR(TIME_PARSE('2020-10-12'), 'P0.25Y')
Unknown exception (java.lang.IllegalArgumentException): Invalid format: "P0.25Y"
```
yet per the Druid SQL documentation for `TIME_FLOOR`

> Rounds down a timestamp, returning it as a new timestamp. Period can be **any** ISO8601 period, like P3M (quarters) or PT12H (half-days).

it explicitly states **any** ISO8601 format is acceptable. This change uses `P3M` instead (which is the direction o https://github.com/apache/superset/pull/17078).

### TESTING INSTRUCTIONS

```
druid> SELECT TIME_FLOOR(TIME_PARSE('2020-10-12'), 'P3M')
2020-10-01T00:00:00.000Z
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
