### PR TITLE
fix: Table Selector Dropdown Out of Order After selecting a few items

### DIFF
--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -93,6 +93,7 @@ export interface SelectProps extends PickedSelectProps {
   pageSize?: number;
   invertSelection?: boolean;
   fetchOnlyOnSearch?: boolean;
+  keepOrder?: boolean;
   onError?: (error: string) => void;
 }
 
@@ -177,6 +178,7 @@ const Select = ({
   invertSelection = false,
   labelInValue = false,
   lazyLoading = true,
+  keepOrder = false, // keep order of options
   loading,
   mode = 'single',
   name,
@@ -246,7 +248,7 @@ const Select = ({
               : selectedValue === opt.value;
           }
 
-          if (found) {
+          if (found && !keepOrder) {
             topOptions.push(opt);
           } else {
             otherOptions.push(opt);

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -310,8 +310,9 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
         onChange={(table: TableOption) => internalTableChange(table)}
         options={tableOptions}
         placeholder={t('Select table or type table name')}
-        showSearch
         value={currentTable}
+        showSearch
+        keepOrder
       />
     );
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixing ordering with `TableSelect` component in sqllab. Now whenever a user chooses from the dropdown the the ordering will stay the same.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
https://user-images.githubusercontent.com/27827808/137183228-677301ec-ff00-430a-a8ed-04dd20a4b3d4.mov

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Goto sqllab
2. Go add tables
3. Make sure order stays the same

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
