### PR TITLE
fix: prevent caching error pages

### DIFF
--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -420,7 +420,7 @@ def show_http_exception(ex: HTTPException) -> FlaskResponse:
         and ex.code in {404, 500}
     ):
         path = resource_filename("superset", f"static/assets/{ex.code}.html")
-        return send_file(path), ex.code
+        return send_file(path, cache_timeout=0), ex.code
 
     return json_errors_response(
         errors=[
@@ -442,7 +442,7 @@ def show_command_errors(ex: CommandException) -> FlaskResponse:
     logger.warning(ex)
     if "text/html" in request.accept_mimetypes and not config["DEBUG"]:
         path = resource_filename("superset", "static/assets/500.html")
-        return send_file(path), 500
+        return send_file(path, cache_timeout=0), 500
 
     extra = ex.normalized_messages() if isinstance(ex, CommandInvalidError) else {}
     return json_errors_response(
@@ -464,7 +464,7 @@ def show_unexpected_exception(ex: Exception) -> FlaskResponse:
     logger.exception(ex)
     if "text/html" in request.accept_mimetypes and not config["DEBUG"]:
         path = resource_filename("superset", "static/assets/500.html")
-        return send_file(path), 500
+        return send_file(path, cache_timeout=0), 500
 
     return json_errors_response(
         errors=[


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
We were still caching 404s for static resources because `send_file` uses the default cache timeout of 1 year when returning any file. This should ensure that when we return a 404/500 error, we never cache the result.

### TESTING INSTRUCTIONS
CI and test env

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @betodealmeida @graceguo-supercat @john-bodley @rusackas 