### PR TITLE
chore(druid): Explicitly cast col to TIMESTAMP

### DIFF
--- a/superset/db_engine_specs/druid.py
+++ b/superset/db_engine_specs/druid.py
@@ -40,27 +40,27 @@ class DruidEngineSpec(BaseEngineSpec):
     allows_subqueries = True
 
     _time_grain_expressions = {
-        None: "{col}",
-        "PT1S": "TIME_FLOOR({col}, 'PT1S')",
-        "PT5S": "TIME_FLOOR({col}, 'PT5S')",
-        "PT30S": "TIME_FLOOR({col}, 'PT30S')",
-        "PT1M": "TIME_FLOOR({col}, 'PT1M')",
-        "PT5M": "TIME_FLOOR({col}, 'PT5M')",
-        "PT10M": "TIME_FLOOR({col}, 'PT10M')",
-        "PT15M": "TIME_FLOOR({col}, 'PT15M')",
-        "PT30M": "TIME_FLOOR({col}, 'PT30M')",
-        "PT1H": "TIME_FLOOR({col}, 'PT1H')",
-        "PT6H": "TIME_FLOOR({col}, 'PT6H')",
-        "P1D": "TIME_FLOOR({col}, 'P1D')",
-        "P1W": "TIME_FLOOR({col}, 'P1W')",
-        "P1M": "TIME_FLOOR({col}, 'P1M')",
-        "P3M": "TIME_FLOOR({col}, 'P3M')",
-        "P1Y": "TIME_FLOOR({col}, 'P1Y')",
+        None: "CAST({col} AS TIMESTAMP)",
+        "PT1S": "TIME_FLOOR(CAST({col} AS TIMESTAMP), 'PT1S')",
+        "PT5S": "TIME_FLOOR(CAST({col} AS TIMESTAMP), 'PT5S')",
+        "PT30S": "TIME_FLOOR(CAST({col} AS TIMESTAMP), 'PT30S')",
+        "PT1M": "TIME_FLOOR(CAST({col} AS TIMESTAMP), 'PT1M')",
+        "PT5M": "TIME_FLOOR(CAST({col} AS TIMESTAMP), 'PT5M')",
+        "PT10M": "TIME_FLOOR(CAST({col} AS TIMESTAMP), 'PT10M')",
+        "PT15M": "TIME_FLOOR(CAST({col} AS TIMESTAMP), 'PT15M')",
+        "PT30M": "TIME_FLOOR(CAST({col} AS TIMESTAMP), 'PT30M')",
+        "PT1H": "TIME_FLOOR(CAST({col} AS TIMESTAMP), 'PT1H')",
+        "PT6H": "TIME_FLOOR(CAST({col} AS TIMESTAMP), 'PT6H')",
+        "P1D": "TIME_FLOOR(CAST({col} AS TIMESTAMP), 'P1D')",
+        "P1W": "TIME_FLOOR(CAST({col} AS TIMESTAMP), 'P1W')",
+        "P1M": "TIME_FLOOR(CAST({col} AS TIMESTAMP), 'P1M')",
+        "P3M": "TIME_FLOOR(CAST({col} AS TIMESTAMP), 'P3M')",
+        "P1Y": "TIME_FLOOR(CAST({col} AS TIMESTAMP), 'P1Y')",
         "P1W/1970-01-03T00:00:00Z": (
-            "TIME_SHIFT(TIME_FLOOR(TIME_SHIFT({col}, 'P1D', 1), 'P1W'), 'P1D', 5)"
+            "TIME_SHIFT(TIME_FLOOR(TIME_SHIFT(CAST({col} AS TIMESTAMP), 'P1D', 1), 'P1W'), 'P1D', 5)"  # pylint: disable=line-too-long
         ),
         "1969-12-28T00:00:00Z/P1W": (
-            "TIME_SHIFT(TIME_FLOOR(TIME_SHIFT({col}, 'P1D', 1), 'P1W'), 'P1D', -1)"
+            "TIME_SHIFT(TIME_FLOOR(TIME_SHIFT(CAST({col} AS TIMESTAMP), 'P1D', 1), 'P1W'), 'P1D', -1)"  # pylint: disable=line-too-long
         ),
     }
 

--- a/tests/integration_tests/db_engine_specs/druid_tests.py
+++ b/tests/integration_tests/db_engine_specs/druid_tests.py
@@ -50,10 +50,10 @@ class TestDruidDbEngineSpec(TestDbEngineSpec):
         col = "__time"
         sqla_col = column(col)
         test_cases = {
-            "PT1S": f"TIME_FLOOR({col}, 'PT1S')",
-            "PT5M": f"TIME_FLOOR({col}, 'PT5M')",
-            "P1W/1970-01-03T00:00:00Z": f"TIME_SHIFT(TIME_FLOOR(TIME_SHIFT({col}, 'P1D', 1), 'P1W'), 'P1D', 5)",
-            "1969-12-28T00:00:00Z/P1W": f"TIME_SHIFT(TIME_FLOOR(TIME_SHIFT({col}, 'P1D', 1), 'P1W'), 'P1D', -1)",
+            "PT1S": f"TIME_FLOOR(CAST({col} AS TIMESTAMP), 'PT1S')",
+            "PT5M": f"TIME_FLOOR(CAST({col} AS TIMESTAMP), 'PT5M')",
+            "P1W/1970-01-03T00:00:00Z": f"TIME_SHIFT(TIME_FLOOR(TIME_SHIFT(CAST({col} AS TIMESTAMP), 'P1D', 1), 'P1W'), 'P1D', 5)",
+            "1969-12-28T00:00:00Z/P1W": f"TIME_SHIFT(TIME_FLOOR(TIME_SHIFT(CAST({col} AS TIMESTAMP), 'P1D', 1), 'P1W'), 'P1D', -1)",
         }
         for grain, expected in test_cases.items():
             actual = DruidEngineSpec.get_timestamp_expr(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This speaks somewhat to [SIP-15A](https://github.com/apache/superset/issues/7656) and the proof-of-concept defined in https://github.com/apache/superset/pull/7682, but in theory any column in Druid (and not just `__time` which is of type `TIMESTAMP`) could be used as the temporal column and thus should first be converted to a `TIMESTAMP`. 

This PR replicates the Presto logic which leveraging `CAST(x AS TIMESTAMP)` which works when `x` is a `DATE`, `TIMESTAMP` or `STRING` (these adhere to the ISO 8601 format per the column "DATETIME FORMAT"), i.e., 

```
druid> SELECT CAST(TIMESTAMP '2021-01-01 00:00:00' AS TIMESTAMP)
2021-01-01T00:00:00.000Z

druid> SELECT CAST(DATE '2021-01-01' AS TIMESTAMP)
2021-01-01T00:00:00.000Z

druid> SELECT CAST('2021-01' AS TIMESTAMP)
2021-01-01T00:00:00.000Z
```

Long term it would be good to implement something similar to the proof-of-concept to bring clarity to the various transforms and type conversions which are needed for both the left- and right-hand-side of a comparator.

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
