### PR TITLE
fix(dashboard): don't show report modal for anonymous user

### DIFF
--- a/superset-frontend/src/dashboard/components/Header/Header.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/Header.test.tsx
@@ -489,7 +489,7 @@ describe('Email Report Modal', () => {
     };
     render(setup(anonymousUserProps));
     expect(
-      screen.queryByRole('button', { name: 'Schedule email report' })
-    ).not.toBeInTheDocument()
+      screen.queryByRole('button', { name: 'Schedule email report' }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/superset-frontend/src/dashboard/components/Header/Header.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/Header.test.tsx
@@ -488,8 +488,8 @@ describe('Email Report Modal', () => {
       },
     };
     render(setup(anonymousUserProps));
-    expect(() =>
-      screen.getByRole('button', { name: 'Schedule email report' }),
-    ).toThrowError('Unable to find');
+    expect(
+      screen.queryByRole('button', { name: 'Schedule email report' })
+    ).not.toBeInTheDocument()
   });
 });

--- a/superset-frontend/src/dashboard/components/Header/Header.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/Header.test.tsx
@@ -465,4 +465,31 @@ describe('Email Report Modal', () => {
     // BLOCKER: I cannot get report to populate, as its data is handled through redux
     expect.anything();
   });
+
+  it('Should render report header', async () => {
+    const mockedProps = createProps();
+    render(setup(mockedProps));
+    expect(
+      screen.getByRole('button', { name: 'Schedule email report' }),
+    ).toBeInTheDocument();
+  });
+
+  it('Should not render report header even with menu access for anonymous user', async () => {
+    const mockedProps = createProps();
+    const anonymousUserProps = {
+      ...mockedProps,
+      user: {
+        roles: {
+          Public: [['menu_access', 'Manage']],
+        },
+        permissions: {
+          datasource_access: ['[examples].[birth_names](id:2)'],
+        },
+      },
+    };
+    render(setup(anonymousUserProps));
+    expect(() =>
+      screen.getByRole('button', { name: 'Schedule email report' }),
+    ).toThrowError('Unable to find');
+  });
 });

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -435,7 +435,7 @@ class Header extends React.PureComponent {
       return false;
     }
     const { user } = this.props;
-    if (!user) {
+    if (!user?.userId) {
       // this is in the case that there is an anonymous user.
       return false;
     }

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
@@ -227,7 +227,7 @@ export class ExploreChartHeader extends React.PureComponent {
       return false;
     }
     const { user } = this.props;
-    if (!user) {
+    if (!user?.userId) {
       // this is in the case that there is an anonymous user.
       return false;
     }

--- a/superset-frontend/src/visualizations/presets/MainPreset.js
+++ b/superset-frontend/src/visualizations/presets/MainPreset.js
@@ -70,6 +70,7 @@ import {
   EchartsTreemapChartPlugin,
   EchartsMixedTimeseriesChartPlugin,
   EchartsTreeChartPlugin,
+  EchartsSunburstChartPlugin
 } from '@superset-ui/plugin-chart-echarts';
 import {
   SelectFilterPlugin,
@@ -166,6 +167,7 @@ export default class MainPreset extends Preset {
         new TimeColumnFilterPlugin().configure({ key: 'filter_timecolumn' }),
         new TimeGrainFilterPlugin().configure({ key: 'filter_timegrain' }),
         new EchartsTreeChartPlugin().configure({ key: 'tree_chart' }),
+        new EchartsSunburstChartPlugin().configure({ key: 'sunburst_2' }),
         ...experimentalplugins,
       ],
     });

--- a/superset-frontend/src/visualizations/presets/MainPreset.js
+++ b/superset-frontend/src/visualizations/presets/MainPreset.js
@@ -70,7 +70,6 @@ import {
   EchartsTreemapChartPlugin,
   EchartsMixedTimeseriesChartPlugin,
   EchartsTreeChartPlugin,
-  EchartsSunburstChartPlugin
 } from '@superset-ui/plugin-chart-echarts';
 import {
   SelectFilterPlugin,
@@ -167,7 +166,6 @@ export default class MainPreset extends Preset {
         new TimeColumnFilterPlugin().configure({ key: 'filter_timecolumn' }),
         new TimeGrainFilterPlugin().configure({ key: 'filter_timegrain' }),
         new EchartsTreeChartPlugin().configure({ key: 'tree_chart' }),
-        new EchartsSunburstChartPlugin().configure({ key: 'sunburst_2' }),
         ...experimentalplugins,
       ],
     });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently dashboard and chart checks for anonymous user by just check `user` variable existance in store, but anonymous user can exists with that object and permissions allowed on public role without authenticating and user id.
So logic inside reports fails as it tries to encode payload with undefined user id,so check for anonymous user by explicitly checking for valid user id is present.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before, when visiting a public dashboard without authentication
![image](https://user-images.githubusercontent.com/12967587/137241568-d4f8aa09-f6da-4d5a-a202-a235a2b77dff.png)

After, it loads without report button
![image](https://user-images.githubusercontent.com/12967587/137241640-60f81cab-1ac2-48e1-84d5-33eb75f9b1b6.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Setup public dashboard and get public url
Setup public user with permissions to that dashboard
Log out and visit the dashboard

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/16718
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
