### PR TITLE
fix: escape bind-like strings in virtual table query

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -65,8 +65,8 @@ from sqlalchemy.orm import backref, Query, relationship, RelationshipProperty, S
 from sqlalchemy.orm.mapper import Mapper
 from sqlalchemy.schema import UniqueConstraint
 from sqlalchemy.sql import column, ColumnElement, literal_column, table, text
-from sqlalchemy.sql.elements import ColumnClause
-from sqlalchemy.sql.expression import Label, Select, TextAsFrom, TextClause
+from sqlalchemy.sql.elements import ColumnClause, TextClause
+from sqlalchemy.sql.expression import Label, Select, TextAsFrom
 from sqlalchemy.sql.selectable import Alias, TableClause
 
 from superset import app, db, is_feature_enabled, security_manager
@@ -809,6 +809,8 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
                     )
                 ) from ex
         sql = sqlparse.format(sql.strip("\t\r\n; "), strip_comments=True)
+        # we need to escape strings that SQLAlchemy interprets as bind parameters
+        sql = utils.escape_sqla_query_binds(sql)
         if not sql:
             raise QueryObjectValidationError(_("Virtual dataset query cannot be empty"))
         if len(sqlparse.split(sql)) > 1:


### PR DESCRIPTION
### SUMMARY
When executing a chart query with a virtual table that contains a literal value with a colon suffixed by text characters, SQLAlchemy interprets these as being bind parameters when wrapped in a `text` element and compiled. This PR ensures that these are escaped using the same pattern that SQLAlchemy uses to detect bind parameters (the regex is available as a private variable in `TextClause`). Relevant test cases are added (notice that the Postgres cast to `::TIMESTAMP` is not escaped, as SQLAlchemy doesn't consider it to be a bind parameter). To my knowledge there is no cleaner way to do this, and I also found several threads where the author of SQLAlchemy instructed people to solve this issue by mechanically escaping the colon in the statement, which is what this proposal in practice does.

Closes #17098

When executing the query `SELECT ':00 :abc' as abc, 123 as num` in SQL Lab, the query executes succesfully:
![image](https://user-images.githubusercontent.com/33317356/137272399-9c35408e-ce1f-4f68-83ff-23c8ee222b52.png)

### BEFORE
When used as a virtual table in a chart query, SQLAlchemy interprets there to be two bind parameters present, namely `00` and `abc`, resulting in the following error:
![image](https://user-images.githubusercontent.com/33317356/137271820-da952291-681f-49ed-b4a1-adeb8ee35cda.png)

### AFTER
After escaping the bind-like strings, the query renders as expected.
![image](https://user-images.githubusercontent.com/33317356/137271732-0cc27bfb-06ab-42f5-a698-2d468babc8ca.png)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
