### PR TITLE
fix: undefined error when anonymous user browses dashboards or charts

### DIFF
--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -163,7 +163,7 @@ function ChartList(props: ChartListProps) {
   const [preparingExport, setPreparingExport] = useState<boolean>(false);
 
   const { userId } = props.user;
-  const userKey = getFromLocalStorage(userId.toString(), null);
+  const userKey = getFromLocalStorage(userId?.toString(), null);
 
   const openChartImportModal = () => {
     showImportModal(true);

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
@@ -143,7 +143,7 @@ function DashboardList(props: DashboardListProps) {
   };
 
   const { userId } = props.user;
-  const userKey = getFromLocalStorage(userId.toString(), null);
+  const userKey = getFromLocalStorage(userId?.toString(), null);
 
   const canCreate = hasPerm('can_write');
   const canEdit = hasPerm('can_write');


### PR DESCRIPTION
### SUMMARY
Prevent 'undefined' error when viewing the dashboard (or charts) listview in an anonymous mode.

### TESTING INSTRUCTIONS
Reproduce the error as follows:
- Allow anonymous access by setting `PUBLIC_ROLE_LIKE = "Gamma"`
- Without logging in, click on dashboards or charts. This error displays: 
*Unexpected error: TypeError: Cannot read properties of undefined (reading 'toString')*

Cause: there's no null check on the userId variable.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
