### PR TITLE
fix(explore): remove unnecessary parameters from the explore url

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -230,7 +230,18 @@ export default class Chart extends React.Component {
     });
   };
 
-  getChartUrl = () => getExploreLongUrl(this.props.formData);
+  getChartUrl = () => {
+    const filters = this.props.formData?.extra_form_data?.filters;
+    // remove formData params that we don't need in the explore url
+    // this should be superseded by some sort of "exploration context" system
+    const formData = {
+      ...this.props.formData,
+      extra_form_data: { filters },
+      native_filters: undefined,
+      dataMask: undefined,
+    };
+    return getExploreLongUrl(formData, null, false);
+  };
 
   exportCSV(isFullCSV = false) {
     this.props.logEvent(LOG_ACTIONS_EXPORT_CSV_DASHBOARD_CHART, {

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -230,18 +230,7 @@ export default class Chart extends React.Component {
     });
   };
 
-  getChartUrl = () => {
-    const filters = this.props.formData?.extra_form_data?.filters;
-    // remove formData params that we don't need in the explore url
-    // this should be superseded by some sort of "exploration context" system
-    const formData = {
-      ...this.props.formData,
-      extra_form_data: { filters },
-      native_filters: undefined,
-      dataMask: undefined,
-    };
-    return getExploreLongUrl(formData, null, false);
-  };
+  getChartUrl = () => getExploreLongUrl(this.props.formData, null, false);
 
   exportCSV(isFullCSV = false) {
     this.props.logEvent(LOG_ACTIONS_EXPORT_CSV_DASHBOARD_CHART, {

--- a/superset-frontend/src/explore/exploreUtils/getExploreLongUrl.test.ts
+++ b/superset-frontend/src/explore/exploreUtils/getExploreLongUrl.test.ts
@@ -90,3 +90,26 @@ test('Get url when endpointType:results and allowOverflow:false', () => {
     '/superset/explore_json/?same=any-string&form_data=%7B%22datasource%22%3A%22datasource%22%2C%22viz_type%22%3A%22viz_type%22%7D',
   );
 });
+
+test('Get url from a dashboard', () => {
+  const formData = {
+    ...createParams().formData,
+    // these params should get filtered out
+    extra_form_data: {
+      filters: {
+        col: 'foo',
+        op: 'IN',
+        val: ['bar'],
+      },
+    },
+    dataMask: {
+      'NATIVE_FILTER-bqEoUsEPe': {
+        id: 'NATIVE_FILTER-bqEoUsEPe',
+        lots: 'of other stuff here too',
+      },
+    },
+  };
+  expect(getExploreLongUrl(formData, null, false)).toBe(
+    '/superset/explore/?form_data=%7B%22datasource%22%3A%22datasource%22%2C%22viz_type%22%3A%22viz_type%22%2C%22extra_form_data%22%3A%7B%22filters%22%3A%7B%22col%22%3A%22foo%22%2C%22op%22%3A%22IN%22%2C%22val%22%3A%5B%22bar%22%5D%7D%7D%7D',
+  );
+});

--- a/superset-frontend/src/explore/exploreUtils/index.js
+++ b/superset-frontend/src/explore/exploreUtils/index.js
@@ -18,6 +18,7 @@
  */
 
 import { useCallback, useEffect } from 'react';
+import { omit } from 'lodash';
 /* eslint camelcase: 0 */
 import URI from 'urijs';
 import {
@@ -103,13 +104,19 @@ export function getExploreLongUrl(
     return null;
   }
 
+  // remove formData params that we don't need in the explore url.
+  // These are present when generating explore urls from the dashboard page.
+  // This should be superseded by some sort of "exploration context" system
+  // where form data and other context is referenced by id.
+  const trimmedFormData = omit(formData, ['dataMask', 'url_params']);
+
   const uri = new URI('/');
   const directory = getURIDirectory(endpointType);
   const search = uri.search(true);
   Object.keys(extraSearch).forEach(key => {
     search[key] = extraSearch[key];
   });
-  search.form_data = safeStringify(formData);
+  search.form_data = safeStringify(trimmedFormData);
   if (endpointType === URL_PARAMS.standalone.name) {
     search.standalone = DashboardStandaloneMode.HIDE_NAV;
   }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The url was getting too long from including all this extra dashboard state that isn't used on the explore page. Now the extra state will be filtered out.

Truly solving the long explore url issue will require more substantial changes, but this will make it less likely for now.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes #17075 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
