### PR TITLE
fix: sql lab crash caused by invalid template

### DIFF
--- a/superset-frontend/src/components/ErrorMessage/ParameterErrorMessage.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ParameterErrorMessage.tsx
@@ -56,7 +56,7 @@ function ParameterErrorMessage({
   source = 'sqllab',
   subtitle,
 }: ErrorMessageComponentProps<ParameterErrorExtra>) {
-  const { extra, level, message } = error;
+  const { extra = { issue_codes: [] }, level, message } = error;
 
   const triggerMessage = tn(
     'This was triggered by:',
@@ -99,9 +99,10 @@ function ParameterErrorMessage({
         )}
         {triggerMessage}
         <br />
-        {extra.issue_codes
-          .map<React.ReactNode>(issueCode => <IssueCode {...issueCode} />)
-          .reduce((prev, curr) => [prev, <br />, curr])}
+        {extra.issue_codes.length > 0 &&
+          extra.issue_codes
+            .map<React.ReactNode>(issueCode => <IssueCode {...issueCode} />)
+            .reduce((prev, curr) => [prev, <br />, curr])}
       </p>
     </>
   );


### PR DESCRIPTION
### SUMMARY
If user has invalid template in the query and run the query, SQL Lab will crash.
The error returned from backend seems not compatible with front-end error handle logic.
Front-end is expecting an `extra` object and has a list of `issue_codes` in extra object. but currently `error` contains single error message.

<img width="1135" alt="Screen_Shot_2021-10-15_at_2_07_24_PM" src="https://user-images.githubusercontent.com/27990562/137555557-8665c1f8-b435-489a-8938-f780708784f6.png">


This PR is only a short solution in the frontend **to handle JS error in the current format**, so that our sql lab users won't be blocked by simple syntax error. The root cause of the problem need further refactor work.

### BEFORE/AFTER SCREENSHOTS OR 
Before: SQL Lab page is blank

After:
<img width="713" alt="Screen Shot 2021-10-15 at 2 26 16 PM" src="https://user-images.githubusercontent.com/27990562/137555408-1b8764b5-c37c-4952-830f-351ccb1807a3.png">



### TESTING INSTRUCTIONS
CI and manual test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #17015
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


cc @etr2460 @ofekisr