### PR TITLE
refactor: dashboard->explore url generation

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -22,7 +22,10 @@ import PropTypes from 'prop-types';
 import { styled } from '@superset-ui/core';
 import { isEqual } from 'lodash';
 
-import { exportChart, getExploreLongUrl } from 'src/explore/exploreUtils';
+import {
+  exportChart,
+  getExploreUrlFromDashboard,
+} from 'src/explore/exploreUtils';
 import ChartContainer from 'src/chart/ChartContainer';
 import {
   LOG_ACTIONS_CHANGE_DASHBOARD_FILTER,
@@ -230,7 +233,7 @@ export default class Chart extends React.Component {
     });
   };
 
-  getChartUrl = () => getExploreLongUrl(this.props.formData, null, false);
+  getChartUrl = () => getExploreUrlFromDashboard(this.props.formData);
 
   exportCSV(isFullCSV = false) {
     this.props.logEvent(LOG_ACTIONS_EXPORT_CSV_DASHBOARD_CHART, {

--- a/superset-frontend/src/explore/exploreUtils/getExploreLongUrl.test.ts
+++ b/superset-frontend/src/explore/exploreUtils/getExploreLongUrl.test.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { getExploreLongUrl } from '.';
+import { getExploreLongUrl, getExploreUrlFromDashboard } from '.';
 
 const createParams = () => ({
   formData: {
@@ -108,8 +108,12 @@ test('Get url from a dashboard', () => {
         lots: 'of other stuff here too',
       },
     },
+    url_params: {
+      native_filters: '(blah)',
+      standalone: true,
+    },
   };
-  expect(getExploreLongUrl(formData, null, false)).toBe(
+  expect(getExploreUrlFromDashboard(formData)).toBe(
     '/superset/explore/?form_data=%7B%22datasource%22%3A%22datasource%22%2C%22viz_type%22%3A%22viz_type%22%2C%22extra_form_data%22%3A%7B%22filters%22%3A%7B%22col%22%3A%22foo%22%2C%22op%22%3A%22IN%22%2C%22val%22%3A%5B%22bar%22%5D%7D%7D%7D',
   );
 });

--- a/superset-frontend/src/explore/exploreUtils/index.js
+++ b/superset-frontend/src/explore/exploreUtils/index.js
@@ -104,19 +104,13 @@ export function getExploreLongUrl(
     return null;
   }
 
-  // remove formData params that we don't need in the explore url.
-  // These are present when generating explore urls from the dashboard page.
-  // This should be superseded by some sort of "exploration context" system
-  // where form data and other context is referenced by id.
-  const trimmedFormData = omit(formData, ['dataMask', 'url_params']);
-
   const uri = new URI('/');
   const directory = getURIDirectory(endpointType);
   const search = uri.search(true);
   Object.keys(extraSearch).forEach(key => {
     search[key] = extraSearch[key];
   });
-  search.form_data = safeStringify(trimmedFormData);
+  search.form_data = safeStringify(formData);
   if (endpointType === URL_PARAMS.standalone.name) {
     search.standalone = DashboardStandaloneMode.HIDE_NAV;
   }
@@ -131,6 +125,15 @@ export function getExploreLongUrl(
     });
   }
   return url;
+}
+
+export function getExploreUrlFromDashboard(formData) {
+  // remove formData params that we don't need in the explore url.
+  // These are present when generating explore urls from the dashboard page.
+  // This should be superseded by some sort of "exploration context" system
+  // where form data and other context is referenced by id.
+  const trimmedFormData = omit(formData, ['dataMask', 'url_params']);
+  return getExploreLongUrl(trimmedFormData, null, false);
 }
 
 export function getChartDataUri({ path, qs, allowDomainSharding = false }) {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Just a small refactor that I didn't get a chance to push before #17123 was merged. This separates the dashboard-specific function from the function used by Explore. Extending rather than modifying to minimize the footprint of this change.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Go to a dashboard and Explore Chart on one of the charts.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
