### PR TITLE
chore(druid): No transform without time granularity for consistency

### DIFF
--- a/superset/db_engine_specs/druid.py
+++ b/superset/db_engine_specs/druid.py
@@ -40,7 +40,7 @@ class DruidEngineSpec(BaseEngineSpec):
     allows_subqueries = True
 
     _time_grain_expressions = {
-        None: "CAST({col} AS TIMESTAMP)",
+        None: "{col}",
         "PT1S": "TIME_FLOOR(CAST({col} AS TIMESTAMP), 'PT1S')",
         "PT5S": "TIME_FLOOR(CAST({col} AS TIMESTAMP), 'PT5S')",
         "PT30S": "TIME_FLOOR(CAST({col} AS TIMESTAMP), 'PT30S')",


### PR DESCRIPTION
### SUMMARY

Apologies @ktmud per the [Presto](https://github.com/apache/superset/blob/master/superset/db_engine_specs/presto.py#L154) spec, for simplicity, if no granularity is specified then no transformation should occur. See https://github.com/apache/superset/pull/17101 for details.

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
