### PR TITLE
fix: Remove title from the Cancel SVG

### DIFF
--- a/superset-frontend/src/assets/images/icons/cancel-x.svg
+++ b/superset-frontend/src/assets/images/icons/cancel-x.svg
@@ -18,7 +18,7 @@
 -->
 <svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 64 (93537) - https://sketch.com -->
-    <title>Icon / X-Small@1.5x</title>
+    <!-- <title>Icon / X-Small@1.5x</title> -->
     <desc>Created with Sketch.</desc>
     <g id="Icon-/-X-Small" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <polygon id="Shape" points="0 0 24 0 24 24 0 24"></polygon>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
There was a title on the cancel svg which was showing up as a tooltip. This comments it out in case we want to bring it back at some point. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: 

![Screen Shot 2021-10-18 at 3 47 44 PM](https://user-images.githubusercontent.com/48933336/137796989-d4aa911e-dfe2-41de-89f1-66e3398817ef.png)

After:


https://user-images.githubusercontent.com/48933336/137797017-e5852069-da99-498f-967d-b9255bb449c8.mov

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
