### PR TITLE
fix: preventing sql lab None limit value

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -221,7 +221,7 @@ def execute_sql_statement(  # pylint: disable=too-many-arguments,too-many-locals
     ):
         if SQL_MAX_ROW and (not query.limit or query.limit > SQL_MAX_ROW):
             query.limit = SQL_MAX_ROW
-        if query.limit:
+        if query.limit and increased_limit:
             # We are fetching one more than the requested limit in order
             # to test whether there are more rows than the limit.
             # Later, the extra row will be dropped before sending

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -38,6 +38,7 @@ from superset.db_engine_specs import BaseEngineSpec
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import SupersetErrorException, SupersetErrorsException
 from superset.extensions import celery_app
+from superset.models.core import Database
 from superset.models.sql_lab import Query
 from superset.result_set import SupersetResultSet
 from superset.sql_parse import CtasMethod, ParsedQuery
@@ -221,12 +222,7 @@ def execute_sql_statement(  # pylint: disable=too-many-arguments,too-many-locals
     ):
         if SQL_MAX_ROW and (not query.limit or query.limit > SQL_MAX_ROW):
             query.limit = SQL_MAX_ROW
-        if query.limit and increased_limit:
-            # We are fetching one more than the requested limit in order
-            # to test whether there are more rows than the limit.
-            # Later, the extra row will be dropped before sending
-            # the results back to the user.
-            sql = database.apply_limit_to_sql(sql, increased_limit, force=True)
+        sql = apply_limit_if_exists(database, increased_limit, query, sql)
 
     # Hook to allow environment-specific mutation (usually comments) to the SQL
     sql = SQL_QUERY_MUTATOR(sql, user_name, security_manager, database)
@@ -289,6 +285,16 @@ def execute_sql_statement(  # pylint: disable=too-many-arguments,too-many-locals
     logger.debug("Query %d: Fetching cursor description", query.id)
     cursor_description = cursor.description
     return SupersetResultSet(data, cursor_description, db_engine_spec)
+
+
+def apply_limit_if_exists(database: Database, increased_limit: int, query: Query, sql: str) -> str:
+    if query.limit and increased_limit:
+        # We are fetching one more than the requested limit in order
+        # to test whether there are more rows than the limit.
+        # Later, the extra row will be dropped before sending
+        # the results back to the user.
+        sql = database.apply_limit_to_sql(sql, increased_limit, force=True)
+    return sql
 
 
 def _serialize_payload(

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -287,7 +287,9 @@ def execute_sql_statement(  # pylint: disable=too-many-arguments,too-many-locals
     return SupersetResultSet(data, cursor_description, db_engine_spec)
 
 
-def apply_limit_if_exists(database: Database, increased_limit: int, query: Query, sql: str) -> str:
+def apply_limit_if_exists(
+    database: Database, increased_limit: Optional[int], query: Query, sql: str
+) -> str:
     if query.limit and increased_limit:
         # We are fetching one more than the requested limit in order
         # to test whether there are more rows than the limit.

--- a/tests/integration_tests/sqllab_tests.py
+++ b/tests/integration_tests/sqllab_tests.py
@@ -1003,6 +1003,17 @@ class TestSqlLab(SupersetTestCase):
 
         assert final_sql == sql
 
+    def test_apply_limit_if_exists_when_increased_limit(self):
+        sql = """
+                   SET @value = 42;
+                   SELECT @value AS foo;
+               """
+        database = get_example_database()
+        mock_query = mock.MagicMock()
+        mock_query.limit = 300
+        final_sql = apply_limit_if_exists(database, 1000, mock_query, sql)
+        assert "LIMIT 1000" in final_sql
+
 
 @pytest.mark.parametrize("spec", [HiveEngineSpec, PrestoEngineSpec])
 def test_cancel_query_implicit(spec: BaseEngineSpec) -> None:

--- a/tests/integration_tests/sqllab_tests.py
+++ b/tests/integration_tests/sqllab_tests.py
@@ -43,7 +43,8 @@ from superset.sql_lab import (
     execute_sql_statements,
     execute_sql_statement,
     get_sql_results,
-    SqlLabException, apply_limit_if_exists,
+    SqlLabException,
+    apply_limit_if_exists,
 )
 from superset.sql_parse import CtasMethod
 from superset.utils.core import (
@@ -1001,7 +1002,6 @@ class TestSqlLab(SupersetTestCase):
         final_sql = apply_limit_if_exists(database, None, mock_query, sql)
 
         assert final_sql == sql
-
 
 
 @pytest.mark.parametrize("spec", [HiveEngineSpec, PrestoEngineSpec])

--- a/tests/integration_tests/sqllab_tests.py
+++ b/tests/integration_tests/sqllab_tests.py
@@ -43,7 +43,7 @@ from superset.sql_lab import (
     execute_sql_statements,
     execute_sql_statement,
     get_sql_results,
-    SqlLabException,
+    SqlLabException, apply_limit_if_exists,
 )
 from superset.sql_parse import CtasMethod
 from superset.utils.core import (
@@ -989,6 +989,19 @@ class TestSqlLab(SupersetTestCase):
                 }
             ]
         }
+
+    def test_apply_limit_if_exists_when_incremented_limit_is_none(self):
+        sql = """
+                   SET @value = 42;
+                   SELECT @value AS foo;
+               """
+        database = get_example_database()
+        mock_query = mock.MagicMock()
+        mock_query.limit = 300
+        final_sql = apply_limit_if_exists(database, None, mock_query, sql)
+
+        assert final_sql == sql
+
 
 
 @pytest.mark.parametrize("spec", [HiveEngineSpec, PrestoEngineSpec])


### PR DESCRIPTION

### SUMMARY
closes #17138
fix issue raised in #17138
preventing a None value in the increased_limit been past into the SQL limit expression building part

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
