### PR TITLE
fix(Explore): Undefined owners

### DIFF
--- a/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
@@ -409,8 +409,8 @@ class DatasourceEditor extends React.PureComponent {
       datasource: {
         ...props.datasource,
         owners: props.datasource.owners.map(owner => ({
-          value: owner.id,
-          label: `${owner.first_name} ${owner.last_name}`,
+          value: owner.value || owner.id,
+          label: owner.label || `${owner.first_name} ${owner.last_name}`,
         })),
         metrics: props.datasource.metrics?.map(metric => {
           const {

--- a/superset-frontend/src/components/Datasource/DatasourceModal.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal.tsx
@@ -126,7 +126,10 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
     })
       .then(({ json }) => {
         addSuccessToast(t('The dataset has been saved'));
-        onDatasourceSave(json);
+        onDatasourceSave({
+          ...json,
+          owners: currentDatasource.owners,
+        });
         onHide();
       })
       .catch(response => {

--- a/superset-frontend/src/components/Datasource/DatasourceModal.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal.tsx
@@ -119,7 +119,7 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
           ),
           type: currentDatasource.type || currentDatasource.datasource_type,
           owners: currentDatasource.owners.map(
-            (o: { label: string; value: number }) => o.value,
+            (o: Record<string, number>) => o.value || o.id,
           ),
         },
       },


### PR DESCRIPTION
### SUMMARY
This PR fixes the following issues:

- Undefined owners in the Datasource modal
- Impossible to save with the same owners

The problem arose from the fact that the data related to the owners is very inconsistent and comes in three forms:

- On load the data is of type `[{id: number; first_name: string; last_name: string;}]`
- On selection from the dropdown the data is of type `[{value: number; label: string;}]`
- On save the data is of type `number[]`

This PR checks for the different data types to make it work. However, a deeper refactor is required to make the data consistent in both the frontend and the backend

Follow-up of #17063

### BEFORE

https://user-images.githubusercontent.com/60598000/138094658-0cf94ad6-62d3-4ca8-bd3a-d4f0d8c4136e.mp4

### AFTER

https://user-images.githubusercontent.com/60598000/138094693-5cee5d69-5ea9-4880-85c9-50c8409d75d0.mp4

### TESTING INSTRUCTIONS
1. Open Explore
2. Click on "Edit dataset"
3. Select an owner and save
4. Re-open the modal and check the owners

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
