### PR TITLE
fix: Order of Select items when unselecting

### DIFF
--- a/superset-frontend/src/addSlice/AddSliceContainer.tsx
+++ b/superset-frontend/src/addSlice/AddSliceContainer.tsx
@@ -256,15 +256,11 @@ export default class AddSliceContainer extends React.PureComponent<
         customLabel: ReactNode;
         label: string;
         value: string;
-      }[] = response.json.result
-        .map((item: Dataset) => ({
-          value: `${item.id}__${item.datasource_type}`,
-          customLabel: this.newLabel(item),
-          label: item.table_name,
-        }))
-        .sort((a: { label: string }, b: { label: string }) =>
-          a.label.localeCompare(b.label),
-        );
+      }[] = response.json.result.map((item: Dataset) => ({
+        value: `${item.id}__${item.datasource_type}`,
+        customLabel: this.newLabel(item),
+        label: item.table_name,
+      }));
       return {
         data: list,
         totalCount: response.json.count,

--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -201,22 +201,18 @@ export default function DatabaseSelector({
       // TODO: Would be nice to add pagination in a follow-up. Needs endpoint changes.
       SupersetClient.get({ endpoint })
         .then(({ json }) => {
-          const options = json.result
-            .map((s: string) => ({
-              value: s,
-              label: s,
-              title: s,
-            }))
-            .sort((a: { label: string }, b: { label: string }) =>
-              a.label.localeCompare(b.label),
-            );
+          const options = json.result.map((s: string) => ({
+            value: s,
+            label: s,
+            title: s,
+          }));
           if (onSchemasLoad) {
             onSchemasLoad(options);
           }
           setSchemaOptions(options);
           setLoadingSchemas(false);
         })
-        .catch(e => {
+        .catch(() => {
           setLoadingSchemas(false);
           handleError(t('There was an error loading the schemas'));
         });

--- a/superset-frontend/src/components/Select/Select.stories.tsx
+++ b/superset-frontend/src/components/Select/Select.stories.tsx
@@ -313,7 +313,7 @@ const USERS = [
   'Claire',
   'Benedetta',
   'Ilenia',
-];
+].sort();
 
 export const AsyncSelect = ({
   fetchOnlyOnSearch,
@@ -429,6 +429,7 @@ export const AsyncSelect = ({
 };
 
 AsyncSelect.args = {
+  allowClear: false,
   allowNewOptions: false,
   fetchOnlyOnSearch: false,
   pageSize: 10,

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -183,7 +183,7 @@ const defaultSortComparator = (a: AntdLabeledValue, b: AntdLabeledValue) => {
  * It creates a comparator to check for a specific property.
  * Can be used with string and number property values.
  * */
-const propertyComparator = (property: string) => (
+export const propertyComparator = (property: string) => (
   a: AntdLabeledValue,
   b: AntdLabeledValue,
 ) => {
@@ -683,7 +683,5 @@ const Select = ({
     </StyledContainer>
   );
 };
-
-Select.propertyComparator = propertyComparator;
 
 export default Select;

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -94,6 +94,7 @@ export interface SelectProps extends PickedSelectProps {
   invertSelection?: boolean;
   fetchOnlyOnSearch?: boolean;
   onError?: (error: string) => void;
+  sortComparator?: (a: AntdLabeledValue, b: AntdLabeledValue) => number;
 }
 
 const StyledContainer = styled.div`
@@ -168,6 +169,16 @@ const Error = ({ error }: { error: string }) => (
   </StyledError>
 );
 
+const defaultSortComparator = (a: AntdLabeledValue, b: AntdLabeledValue) => {
+  if (typeof a.label === 'string' && typeof b.label === 'string') {
+    return a.label.localeCompare(b.label);
+  }
+  if (typeof a.value === 'string' && typeof b.value === 'string') {
+    return a.value.localeCompare(b.value);
+  }
+  return (a.value as number) - (b.value as number);
+};
+
 const Select = ({
   allowNewOptions = false,
   ariaLabel,
@@ -189,6 +200,7 @@ const Select = ({
   pageSize = DEFAULT_PAGE_SIZE,
   placeholder = t('Select ...'),
   showSearch = true,
+  sortComparator = defaultSortComparator,
   value,
   ...props
 }: SelectProps) => {
@@ -277,14 +289,21 @@ const Select = ({
             }
           });
         }
-
-        const sortedOptions = [...topOptions, ...otherOptions];
+        const sortedOptions = [
+          ...topOptions.sort(sortComparator),
+          ...otherOptions.sort(sortComparator),
+        ];
+        if (!isEqual(sortedOptions, selectOptions)) {
+          setSelectOptions(sortedOptions);
+        }
+      } else {
+        const sortedOptions = [...selectOptions].sort(sortComparator);
         if (!isEqual(sortedOptions, selectOptions)) {
           setSelectOptions(sortedOptions);
         }
       }
     },
-    [isAsync, isSingleMode, labelInValue, selectOptions],
+    [isAsync, isSingleMode, labelInValue, selectOptions, sortComparator],
   );
 
   const handleOnSelect = (
@@ -342,28 +361,34 @@ const Select = ({
     [onError],
   );
 
-  const handleData = (data: OptionsType) => {
-    let mergedData: OptionsType = [];
-    if (data && Array.isArray(data) && data.length) {
-      const dataValues = new Set();
-      data.forEach(option =>
-        dataValues.add(String(option.value).toLocaleLowerCase()),
-      );
+  const handleData = useCallback(
+    (data: OptionsType) => {
+      let mergedData: OptionsType = [];
+      if (data && Array.isArray(data) && data.length) {
+        const dataValues = new Set();
+        data.forEach(option =>
+          dataValues.add(String(option.value).toLocaleLowerCase()),
+        );
 
-      // merges with existing and creates unique options
-      setSelectOptions(prevOptions => {
-        mergedData = [
-          ...prevOptions.filter(
-            previousOption =>
-              !dataValues.has(String(previousOption.value).toLocaleLowerCase()),
-          ),
-          ...data,
-        ];
-        return mergedData;
-      });
-    }
-    return mergedData;
-  };
+        // merges with existing and creates unique options
+        setSelectOptions(prevOptions => {
+          mergedData = [
+            ...prevOptions.filter(
+              previousOption =>
+                !dataValues.has(
+                  String(previousOption.value).toLocaleLowerCase(),
+                ),
+            ),
+            ...data,
+          ];
+          mergedData.sort(sortComparator);
+          return mergedData;
+        });
+      }
+      return mergedData;
+    },
+    [sortComparator],
+  );
 
   const handlePaginatedFetch = useMemo(
     () => (value: string, page: number, pageSize: number) => {
@@ -401,7 +426,7 @@ const Select = ({
           setIsTyping(false);
         });
     },
-    [allValuesLoaded, fetchOnlyOnSearch, internalOnError, options],
+    [allValuesLoaded, fetchOnlyOnSearch, handleData, internalOnError, options],
   );
 
   const handleOnSearch = useMemo(
@@ -474,8 +499,8 @@ const Select = ({
     }
 
     // multiple or tags mode keep the dropdown visible while selecting options
-    // this waits for the dropdown to be closed before sorting the top options
-    if (!isSingleMode && !isDropdownVisible) {
+    // this waits for the dropdown to be opened before sorting the top options
+    if (!isSingleMode && isDropdownVisible) {
       handleTopOptions(selectValue);
     }
   };

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -179,6 +179,20 @@ const defaultSortComparator = (a: AntdLabeledValue, b: AntdLabeledValue) => {
   return (a.value as number) - (b.value as number);
 };
 
+/**
+ * It creates a comparator to check for a specific property.
+ * Can be used with string and number property values.
+ * */
+const propertyComparator = (property: string) => (
+  a: AntdLabeledValue,
+  b: AntdLabeledValue,
+) => {
+  if (typeof a[property] === 'string' && typeof b[property] === 'string') {
+    return a[property].localeCompare(b[property]);
+  }
+  return (a[property] as number) - (b[property] as number);
+};
+
 const Select = ({
   allowNewOptions = false,
   ariaLabel,
@@ -669,5 +683,7 @@ const Select = ({
     </StyledContainer>
   );
 };
+
+Select.propertyComparator = propertyComparator;
 
 export default Select;

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -209,11 +209,7 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
           if (onTablesLoad) {
             onTablesLoad(json.options);
           }
-          setTableOptions(
-            options.sort((a: { text: string }, b: { text: string }) =>
-              a.text.localeCompare(b.text),
-            ),
-          );
+          setTableOptions(options);
           setCurrentTable(currentTable);
           setLoadingTables(false);
         })

--- a/superset-frontend/src/components/TimezoneSelector/index.tsx
+++ b/superset-frontend/src/components/TimezoneSelector/index.tsx
@@ -83,17 +83,13 @@ ALL_ZONES.forEach(zone => {
   }
 });
 
-const TIMEZONE_OPTIONS = TIMEZONES.sort(
-  // sort by offset
-  (a, b) =>
-    moment.tz(currentDate, a.name).utcOffset() -
-    moment.tz(currentDate, b.name).utcOffset(),
-).map(zone => ({
+const TIMEZONE_OPTIONS = TIMEZONES.map(zone => ({
   label: `GMT ${moment
     .tz(currentDate, zone.name)
     .format('Z')} (${getTimezoneName(zone.name)})`,
   value: zone.name,
   offsets: getOffsetKey(zone.name),
+  timezoneName: zone.name,
 }));
 
 const TimezoneSelector = ({ onTimezoneChange, timezone }: TimezoneProps) => {
@@ -126,6 +122,13 @@ const TimezoneSelector = ({ onTimezoneChange, timezone }: TimezoneProps) => {
       onChange={onTimezoneChange}
       value={timezone || DEFAULT_TIMEZONE.value}
       options={TIMEZONE_OPTIONS}
+      sortComparator={(
+        a: typeof TIMEZONE_OPTIONS[number],
+        b: typeof TIMEZONE_OPTIONS[number],
+      ) =>
+        moment.tz(currentDate, a.timezoneName).utcOffset() -
+        moment.tz(currentDate, b.timezoneName).utcOffset()
+      }
     />
   );
 };

--- a/superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx
+++ b/superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx
@@ -120,6 +120,9 @@ class RefreshIntervalModal extends React.PureComponent<
               options={options}
               value={refreshFrequency}
               onChange={this.handleFrequencyChange}
+              sortComparator={(a, b) =>
+                (a.value as number) - (b.value as number)
+              }
             />
             {showRefreshWarning && (
               <RefreshWarningContainer>

--- a/superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx
+++ b/superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx
@@ -25,6 +25,8 @@ import Button from 'src/components/Button';
 import ModalTrigger from 'src/components/ModalTrigger';
 import { FormLabel } from 'src/components/Form';
 
+const { propertyComparator } = Select;
+
 export const options = [
   [0, t("Don't refresh")],
   [10, t('10 seconds')],
@@ -120,9 +122,7 @@ class RefreshIntervalModal extends React.PureComponent<
               options={options}
               value={refreshFrequency}
               onChange={this.handleFrequencyChange}
-              sortComparator={(a, b) =>
-                (a.value as number) - (b.value as number)
-              }
+              sortComparator={propertyComparator('value')}
             />
             {showRefreshWarning && (
               <RefreshWarningContainer>

--- a/superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx
+++ b/superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx
@@ -17,15 +17,13 @@
  * under the License.
  */
 import React, { RefObject } from 'react';
-import { Select } from 'src/components';
+import Select, { propertyComparator } from 'src/components/Select/Select';
 import { t, styled } from '@superset-ui/core';
 import Alert from 'src/components/Alert';
 import Button from 'src/components/Button';
 
 import ModalTrigger from 'src/components/ModalTrigger';
 import { FormLabel } from 'src/components/Form';
-
-const { propertyComparator } = Select;
 
 export const options = [
   [0, t("Don't refresh")],

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.tsx
@@ -73,7 +73,6 @@ export function ColumnSelect({
       ensureIsArray(columns)
         .filter(filterValues)
         .map((col: Column) => col.column_name)
-        .sort((a: string, b: string) => a.localeCompare(b))
         .map((column: string) => ({ label: column, value: column })),
     [columns, filterValues],
   );

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DatasetSelect.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DatasetSelect.tsx
@@ -72,11 +72,7 @@ const DatasetSelect = ({ onChange, value }: DatasetSelectProps) => {
         const data: {
           label: string;
           value: string | number;
-        }[] = response.json.result
-          .map(datasetToSelectOption)
-          .sort((a: { label: string }, b: { label: string }) =>
-            a.label.localeCompare(b.label),
-          );
+        }[] = response.json.result.map(datasetToSelectOption);
         return {
           data,
           totalCount: response.json.count,

--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import { styled, t } from '@superset-ui/core';
 import { Form, FormItem, FormProps } from 'src/components/Form';
-import { Select } from 'src/components';
+import Select, { propertyComparator } from 'src/components/Select/Select';
 import { Col, InputNumber, Row } from 'src/common/components';
 import Button from 'src/components/Button';
 import {
@@ -27,8 +27,6 @@ import {
   ConditionalFormattingConfig,
   MULTIPLE_VALUE_COMPARATORS,
 } from './types';
-
-const { propertyComparator } = Select;
 
 const FullWidthInputNumber = styled(InputNumber)`
   width: 100%;

--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
@@ -28,6 +28,8 @@ import {
   MULTIPLE_VALUE_COMPARATORS,
 } from './types';
 
+const { propertyComparator } = Select;
+
 const FullWidthInputNumber = styled(InputNumber)`
   width: 100%;
 `;
@@ -129,10 +131,7 @@ const operatorField = (
     <Select
       ariaLabel={t('Operator')}
       options={operatorOptions}
-      sortComparator={(
-        a: typeof operatorOptions[number],
-        b: typeof operatorOptions[number],
-      ) => a.order - b.order}
+      sortComparator={propertyComparator('order')}
     />
   </FormItem>
 );

--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
@@ -44,17 +44,17 @@ const colorSchemeOptions = [
 ];
 
 const operatorOptions = [
-  { value: COMPARATOR.NONE, label: 'None' },
-  { value: COMPARATOR.GREATER_THAN, label: '>' },
-  { value: COMPARATOR.LESS_THAN, label: '<' },
-  { value: COMPARATOR.GREATER_OR_EQUAL, label: '≥' },
-  { value: COMPARATOR.LESS_OR_EQUAL, label: '≤' },
-  { value: COMPARATOR.EQUAL, label: '=' },
-  { value: COMPARATOR.NOT_EQUAL, label: '≠' },
-  { value: COMPARATOR.BETWEEN, label: '< x <' },
-  { value: COMPARATOR.BETWEEN_OR_EQUAL, label: '≤ x ≤' },
-  { value: COMPARATOR.BETWEEN_OR_LEFT_EQUAL, label: '≤ x <' },
-  { value: COMPARATOR.BETWEEN_OR_RIGHT_EQUAL, label: '< x ≤' },
+  { value: COMPARATOR.NONE, label: 'None', order: 0 },
+  { value: COMPARATOR.GREATER_THAN, label: '>', order: 1 },
+  { value: COMPARATOR.LESS_THAN, label: '<', order: 2 },
+  { value: COMPARATOR.GREATER_OR_EQUAL, label: '≥', order: 3 },
+  { value: COMPARATOR.LESS_OR_EQUAL, label: '≤', order: 4 },
+  { value: COMPARATOR.EQUAL, label: '=', order: 5 },
+  { value: COMPARATOR.NOT_EQUAL, label: '≠', order: 6 },
+  { value: COMPARATOR.BETWEEN, label: '< x <', order: 7 },
+  { value: COMPARATOR.BETWEEN_OR_EQUAL, label: '≤ x ≤', order: 8 },
+  { value: COMPARATOR.BETWEEN_OR_LEFT_EQUAL, label: '≤ x <', order: 9 },
+  { value: COMPARATOR.BETWEEN_OR_RIGHT_EQUAL, label: '< x ≤', order: 10 },
 ];
 
 const targetValueValidator = (
@@ -126,7 +126,14 @@ const operatorField = (
     rules={rulesRequired}
     initialValue={operatorOptions[0].value}
   >
-    <Select ariaLabel={t('Operator')} options={operatorOptions} />
+    <Select
+      ariaLabel={t('Operator')}
+      options={operatorOptions}
+      sortComparator={(
+        a: typeof operatorOptions[number],
+        b: typeof operatorOptions[number],
+      ) => a.order - b.order}
+    />
   </FormItem>
 );
 

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -40,7 +40,7 @@ import Label, { Type } from 'src/components/Label';
 import Popover from 'src/components/Popover';
 import { Divider } from 'src/common/components';
 import Icons from 'src/components/Icons';
-import { Select } from 'src/components';
+import Select, { propertyComparator } from 'src/components/Select/Select';
 import { Tooltip } from 'src/components/Tooltip';
 import { DEFAULT_TIME_RANGE } from 'src/explore/constants';
 import { useDebouncedEffect } from 'src/explore/exploreUtils';
@@ -54,8 +54,6 @@ import {
   CustomFrame,
   AdvancedFrame,
 } from './components';
-
-const { propertyComparator } = Select;
 
 const guessFrame = (timeRange: string): FrameType => {
   if (COMMON_RANGE_VALUES_SET.has(timeRange)) {

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -55,6 +55,8 @@ import {
   AdvancedFrame,
 } from './components';
 
+const { propertyComparator } = Select;
+
 const guessFrame = (timeRange: string): FrameType => {
   if (COMMON_RANGE_VALUES_SET.has(timeRange)) {
     return 'Common';
@@ -295,10 +297,7 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
         options={FRAME_OPTIONS}
         value={frame}
         onChange={onChangeFrame}
-        sortComparator={(
-          a: typeof FRAME_OPTIONS[number],
-          b: typeof FRAME_OPTIONS[number],
-        ) => a.order - b.order}
+        sortComparator={propertyComparator('order')}
       />
       {frame !== 'No filter' && <Divider />}
       {frame === 'Common' && (

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -295,6 +295,10 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
         options={FRAME_OPTIONS}
         value={frame}
         onChange={onChangeFrame}
+        sortComparator={(
+          a: typeof FRAME_OPTIONS[number],
+          b: typeof FRAME_OPTIONS[number],
+        ) => a.order - b.order}
       />
       {frame !== 'No filter' && <Divider />}
       {frame === 'Common' && (

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx
@@ -121,6 +121,10 @@ export function CustomFrame(props: FrameComponentProps) {
             options={SINCE_MODE_OPTIONS}
             value={sinceMode}
             onChange={(value: string) => onChange('sinceMode', value)}
+            sortComparator={(
+              a: typeof SINCE_MODE_OPTIONS[number],
+              b: typeof SINCE_MODE_OPTIONS[number],
+            ) => a.order - b.order}
           />
           {sinceMode === 'specific' && (
             <Row>
@@ -155,6 +159,10 @@ export function CustomFrame(props: FrameComponentProps) {
                   options={SINCE_GRAIN_OPTIONS}
                   value={sinceGrain}
                   onChange={(value: string) => onChange('sinceGrain', value)}
+                  sortComparator={(
+                    a: typeof SINCE_GRAIN_OPTIONS[number],
+                    b: typeof SINCE_GRAIN_OPTIONS[number],
+                  ) => a.order - b.order}
                 />
               </Col>
             </Row>
@@ -173,6 +181,10 @@ export function CustomFrame(props: FrameComponentProps) {
             options={UNTIL_MODE_OPTIONS}
             value={untilMode}
             onChange={(value: string) => onChange('untilMode', value)}
+            sortComparator={(
+              a: typeof UNTIL_MODE_OPTIONS[number],
+              b: typeof UNTIL_MODE_OPTIONS[number],
+            ) => a.order - b.order}
           />
           {untilMode === 'specific' && (
             <Row>
@@ -206,6 +218,10 @@ export function CustomFrame(props: FrameComponentProps) {
                   options={UNTIL_GRAIN_OPTIONS}
                   value={untilGrain}
                   onChange={(value: string) => onChange('untilGrain', value)}
+                  sortComparator={(
+                    a: typeof UNTIL_GRAIN_OPTIONS[number],
+                    b: typeof UNTIL_GRAIN_OPTIONS[number],
+                  ) => a.order - b.order}
                 />
               </Col>
             </Row>

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx
@@ -23,7 +23,7 @@ import { isInteger } from 'lodash';
 import { Col, InputNumber, Row } from 'src/common/components';
 import { DatePicker } from 'src/components/DatePicker';
 import { Radio } from 'src/components/Radio';
-import { Select } from 'src/components';
+import Select, { propertyComparator } from 'src/components/Select/Select';
 import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
 import {
   SINCE_GRAIN_OPTIONS,
@@ -41,7 +41,6 @@ import {
   FrameComponentProps,
 } from 'src/explore/components/controls/DateFilterControl/types';
 
-const { propertyComparator } = Select;
 const sortComparator = propertyComparator('order');
 
 export function CustomFrame(props: FrameComponentProps) {

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx
@@ -41,6 +41,9 @@ import {
   FrameComponentProps,
 } from 'src/explore/components/controls/DateFilterControl/types';
 
+const { propertyComparator } = Select;
+const sortComparator = propertyComparator('order');
+
 export function CustomFrame(props: FrameComponentProps) {
   const { customRange, matchedFlag } = customTimeRangeDecode(props.value);
   if (!matchedFlag) {
@@ -121,10 +124,7 @@ export function CustomFrame(props: FrameComponentProps) {
             options={SINCE_MODE_OPTIONS}
             value={sinceMode}
             onChange={(value: string) => onChange('sinceMode', value)}
-            sortComparator={(
-              a: typeof SINCE_MODE_OPTIONS[number],
-              b: typeof SINCE_MODE_OPTIONS[number],
-            ) => a.order - b.order}
+            sortComparator={sortComparator}
           />
           {sinceMode === 'specific' && (
             <Row>
@@ -159,10 +159,7 @@ export function CustomFrame(props: FrameComponentProps) {
                   options={SINCE_GRAIN_OPTIONS}
                   value={sinceGrain}
                   onChange={(value: string) => onChange('sinceGrain', value)}
-                  sortComparator={(
-                    a: typeof SINCE_GRAIN_OPTIONS[number],
-                    b: typeof SINCE_GRAIN_OPTIONS[number],
-                  ) => a.order - b.order}
+                  sortComparator={sortComparator}
                 />
               </Col>
             </Row>
@@ -181,10 +178,7 @@ export function CustomFrame(props: FrameComponentProps) {
             options={UNTIL_MODE_OPTIONS}
             value={untilMode}
             onChange={(value: string) => onChange('untilMode', value)}
-            sortComparator={(
-              a: typeof UNTIL_MODE_OPTIONS[number],
-              b: typeof UNTIL_MODE_OPTIONS[number],
-            ) => a.order - b.order}
+            sortComparator={sortComparator}
           />
           {untilMode === 'specific' && (
             <Row>
@@ -218,10 +212,7 @@ export function CustomFrame(props: FrameComponentProps) {
                   options={UNTIL_GRAIN_OPTIONS}
                   value={untilGrain}
                   onChange={(value: string) => onChange('untilGrain', value)}
-                  sortComparator={(
-                    a: typeof UNTIL_GRAIN_OPTIONS[number],
-                    b: typeof UNTIL_GRAIN_OPTIONS[number],
-                  ) => a.order - b.order}
+                  sortComparator={sortComparator}
                 />
               </Col>
             </Row>

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/types.ts
@@ -19,6 +19,7 @@
 export type SelectOptionType = {
   value: string;
   label: string;
+  order: number;
 };
 
 export type FrameType =

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts
@@ -28,28 +28,32 @@ import {
 } from 'src/explore/components/controls/DateFilterControl/types';
 
 export const FRAME_OPTIONS: SelectOptionType[] = [
-  { value: 'Common', label: t('Last') },
-  { value: 'Calendar', label: t('Previous') },
-  { value: 'Custom', label: t('Custom') },
-  { value: 'Advanced', label: t('Advanced') },
-  { value: 'No filter', label: t('No filter') },
+  { value: 'Common', label: t('Last'), order: 0 },
+  { value: 'Calendar', label: t('Previous'), order: 1 },
+  { value: 'Custom', label: t('Custom'), order: 2 },
+  { value: 'Advanced', label: t('Advanced'), order: 3 },
+  { value: 'No filter', label: t('No filter'), order: 4 },
 ];
 
 export const COMMON_RANGE_OPTIONS: SelectOptionType[] = [
-  { value: 'Last day', label: t('last day') },
-  { value: 'Last week', label: t('last week') },
-  { value: 'Last month', label: t('last month') },
-  { value: 'Last quarter', label: t('last quarter') },
-  { value: 'Last year', label: t('last year') },
+  { value: 'Last day', label: t('last day'), order: 0 },
+  { value: 'Last week', label: t('last week'), order: 1 },
+  { value: 'Last month', label: t('last month'), order: 2 },
+  { value: 'Last quarter', label: t('last quarter'), order: 3 },
+  { value: 'Last year', label: t('last year'), order: 4 },
 ];
 export const COMMON_RANGE_VALUES_SET = new Set(
   COMMON_RANGE_OPTIONS.map(({ value }) => value),
 );
 
 export const CALENDAR_RANGE_OPTIONS: SelectOptionType[] = [
-  { value: PreviousCalendarWeek, label: t('previous calendar week') },
-  { value: PreviousCalendarMonth, label: t('previous calendar month') },
-  { value: PreviousCalendarYear, label: t('previous calendar year') },
+  { value: PreviousCalendarWeek, label: t('previous calendar week'), order: 0 },
+  {
+    value: PreviousCalendarMonth,
+    label: t('previous calendar month'),
+    order: 1,
+  },
+  { value: PreviousCalendarYear, label: t('previous calendar year'), order: 2 },
 ];
 export const CALENDAR_RANGE_VALUES_SET = new Set(
   CALENDAR_RANGE_OPTIONS.map(({ value }) => value),
@@ -67,24 +71,26 @@ const GRAIN_OPTIONS = [
 ];
 
 export const SINCE_GRAIN_OPTIONS: SelectOptionType[] = GRAIN_OPTIONS.map(
-  item => ({
+  (item, index) => ({
     value: item.value,
     label: item.label(t('Before')),
+    order: index,
   }),
 );
 
 export const UNTIL_GRAIN_OPTIONS: SelectOptionType[] = GRAIN_OPTIONS.map(
-  item => ({
+  (item, index) => ({
     value: item.value,
     label: item.label(t('After')),
+    order: index,
   }),
 );
 
 export const SINCE_MODE_OPTIONS: SelectOptionType[] = [
-  { value: 'specific', label: t('Specific Date/Time') },
-  { value: 'relative', label: t('Relative Date/Time') },
-  { value: 'now', label: t('Now') },
-  { value: 'today', label: t('Midnight') },
+  { value: 'specific', label: t('Specific Date/Time'), order: 0 },
+  { value: 'relative', label: t('Relative Date/Time'), order: 1 },
+  { value: 'now', label: t('Now'), order: 2 },
+  { value: 'today', label: t('Midnight'), order: 3 },
 ];
 
 export const UNTIL_MODE_OPTIONS: SelectOptionType[] = SINCE_MODE_OPTIONS.slice();

--- a/superset-frontend/src/explore/components/controls/SelectAsyncControl/SelectAsyncControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/SelectAsyncControl/SelectAsyncControl.test.tsx
@@ -44,6 +44,7 @@ jest.mock('src/components/Select/Select', () => ({
       </button>
     </div>
   ),
+  propertyComparator: jest.fn(),
 }));
 
 fetchMock.get(datasetsOwnersEndpoint, {

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -57,6 +57,8 @@ import {
 import { AlertReportCronScheduler } from './components/AlertReportCronScheduler';
 import { NotificationMethod } from './components/NotificationMethod';
 
+const { propertyComparator } = Select;
+
 const TIMEOUT_MIN = 1;
 const TEXT_BASED_VISUALIZATION_TYPES = [
   'pivot_table',
@@ -1154,10 +1156,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                         currentAlert?.validator_config_json?.op || undefined
                       }
                       options={CONDITIONS}
-                      sortComparator={(
-                        a: typeof CONDITIONS[number],
-                        b: typeof CONDITIONS[number],
-                      ) => a.order - b.order}
+                      sortComparator={propertyComparator('order')}
                     />
                   </div>
                 </StyledInputContainer>
@@ -1225,9 +1224,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                   onChange={onLogRetentionChange}
                   value={currentAlert?.log_retention || DEFAULT_RETENTION}
                   options={RETENTION_OPTIONS}
-                  sortComparator={(a, b) =>
-                    (a.value as number) - (b.value as number)
-                  }
+                  sortComparator={propertyComparator('value')}
                 />
               </div>
             </StyledInputContainer>

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -85,30 +85,37 @@ const CONDITIONS = [
   {
     label: t('< (Smaller than)'),
     value: '<',
+    order: 0,
   },
   {
     label: t('> (Larger than)'),
     value: '>',
+    order: 1,
   },
   {
     label: t('<= (Smaller or equal)'),
     value: '<=',
+    order: 2,
   },
   {
     label: t('>= (Larger or equal)'),
     value: '>=',
+    order: 3,
   },
   {
     label: t('== (Is equal)'),
     value: '==',
+    order: 4,
   },
   {
     label: t('!= (Is not equal)'),
     value: '!=',
+    order: 5,
   },
   {
     label: t('Not null'),
     value: 'not null',
+    order: 6,
   },
 ];
 
@@ -1147,6 +1154,10 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                         currentAlert?.validator_config_json?.op || undefined
                       }
                       options={CONDITIONS}
+                      sortComparator={(
+                        a: typeof CONDITIONS[number],
+                        b: typeof CONDITIONS[number],
+                      ) => a.order - b.order}
                     />
                   </div>
                 </StyledInputContainer>
@@ -1214,6 +1225,9 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                   onChange={onLogRetentionChange}
                   value={currentAlert?.log_retention || DEFAULT_RETENTION}
                   options={RETENTION_OPTIONS}
+                  sortComparator={(a, b) =>
+                    (a.value as number) - (b.value as number)
+                  }
                 />
               </div>
             </StyledInputContainer>

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -38,7 +38,7 @@ import { Switch } from 'src/components/Switch';
 import Modal from 'src/components/Modal';
 import TimezoneSelector from 'src/components/TimezoneSelector';
 import { Radio } from 'src/components/Radio';
-import { Select } from 'src/components';
+import Select, { propertyComparator } from 'src/components/Select/Select';
 import { FeatureFlag, isFeatureEnabled } from 'src/featureFlags';
 import withToasts from 'src/components/MessageToasts/withToasts';
 import Owner from 'src/types/Owner';
@@ -56,8 +56,6 @@ import {
 } from 'src/views/CRUD/alert/types';
 import { AlertReportCronScheduler } from './components/AlertReportCronScheduler';
 import { NotificationMethod } from './components/NotificationMethod';
-
-const { propertyComparator } = Select;
 
 const TIMEOUT_MIN = 1;
 const TEXT_BASED_VISUALIZATION_TYPES = [


### PR DESCRIPTION
### SUMMARY
The objective of this PR is to fix an issue with the order of select options when unselecting. It also changes the default sorting algorithm of the `Select` component to alphabetical sorting while providing an alternative to the component's users to override this behavior. Alphabetical sorting is the most common sorting algorithm used by select components in Superset but we do have cases where the order is calculated by different criteria. Another objective of the solution is to enable server-side sorting.

To fill these objectives, this PR introduced an optional property to the `Select` called `sortCompator` that accepts a comparison function and is set to alphabetical comparison by default. This function accepts any object that adheres to the select options interface which allows custom properties to be used when comparing the options. This can be used by server-side sorting, where the response can include an `order` field or similar to be used in a custom sort comparator.

This comparator is also important to reorder the items after an unselect action because we don't know the original order of the elements, especially with server-side sorting.

This PR also:
- Includes test cases for the new property
- Removes previous sorting related code to avoid duplication
- Modifies previous sorting related code to use a custom comparator when necessary

@geido Can you include this information in the Select API docs?

@yousoph @rusackas @hughhhh @junlincc 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/138112216-83e12760-ac0f-4ef0-9e7b-2498474cb0c7.mov

https://user-images.githubusercontent.com/70410625/138112050-2be25716-b251-488c-858d-689d2ef80402.mov

### TESTING INSTRUCTIONS
Check the videos for instructions

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
