### PR TITLE
feat: support disabling domain sharding with a query param

### DIFF
--- a/superset-frontend/src/utils/hostNamesConfig.js
+++ b/superset-frontend/src/utils/hostNamesConfig.js
@@ -28,12 +28,22 @@ function getDomainsConfig() {
     return [];
   }
 
+  const availableDomains = new Set([window.location.hostname]);
+
+  // don't do domain sharding if a certain query param is set
+  const disableDomainSharding =
+    new URLSearchParams(window.location.search).get('disableDomainSharding') ===
+    '1';
+  if (disableDomainSharding) {
+    return Array.from(availableDomains);
+  }
+
   const bootstrapData = JSON.parse(appContainer.getAttribute('data-bootstrap'));
   // this module is a little special, it may be loaded before index.jsx,
   // where window.featureFlags get initialized
   // eslint-disable-next-line camelcase
   initFeatureFlags(bootstrapData?.common?.feature_flags);
-  const availableDomains = new Set([window.location.hostname]);
+
   if (
     isFeatureEnabled(FeatureFlag.ALLOW_DASHBOARD_DOMAIN_SHARDING) &&
     bootstrapData &&


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This is helpful to enable some iframing of dashboard use cases. Depending on your domain sharding setup, it may not work across origins, so this is a convenient workaround

### TESTING INSTRUCTIONS
CI, manual verification

Note that no unit test was added because this function already is tightly integrated with the document and pulling data from it. This would require quite a large refactor to properly test the existing behavior, much less my newly added behavior

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @kgabryje @graceguo-supercat @michael-s-molina @ktmud 