### PR TITLE
fix(Dashboard): Handle undefined tab when collapsing tabs

### DIFF
--- a/superset-frontend/src/dashboard/util/getLeafComponentIdFromPath.js
+++ b/superset-frontend/src/dashboard/util/getLeafComponentIdFromPath.js
@@ -24,7 +24,7 @@ export default function getLeafComponentIdFromPath(directPathToChild = []) {
 
     while (currentPath.length) {
       const componentId = currentPath.pop();
-      const componentType = componentId.split('-')[0];
+      const componentType = componentId && componentId.split('-')[0];
 
       if (!IN_COMPONENT_ELEMENT_TYPES.includes(componentType)) {
         return componentId;


### PR DESCRIPTION
### SUMMARY
It handles collapsing tabs when there is no tab left.

### BEFORE

Fixes https://github.com/apache/superset/issues/17180

### AFTER

https://user-images.githubusercontent.com/60598000/138283921-ad069eb5-930e-4339-bbf3-61c399908445.mp4

### TESTING INSTRUCTIONS
1. Edit a Dashboard
2. Add a tab component
3. Delete all tabs and collapse

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/17180
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
