### PR TITLE
fix(sqla): convert prequery results to native python types

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1813,3 +1813,35 @@ def escape_sqla_query_binds(sql: str) -> str:
             sql = sql.replace(bind, bind.replace(":", "\\:"))
             processed_binds.add(bind)
     return sql
+
+
+def normalize_prequery_result_type(
+    value: Union[str, int, float, bool, np.generic]
+) -> Union[str, int, float, bool]:
+    """
+    Convert a value that is potentially a numpy type into its equivalent Python type.
+
+    :param value: primitive datatype in either numpy or python format
+    :return: equivalent primitive python type
+    >>> normalize_prequery_result_type('abc')
+    'abc'
+    >>> normalize_prequery_result_type(True)
+    True
+    >>> normalize_prequery_result_type(123)
+    123
+    >>> normalize_prequery_result_type(np.int16(123))
+    123
+    >>> normalize_prequery_result_type(np.uint32(123))
+    123
+    >>> normalize_prequery_result_type(np.int64(123))
+    123
+    >>> normalize_prequery_result_type(123.456)
+    123.456
+    >>> normalize_prequery_result_type(np.float32(123.456))
+    123.45600128173828
+    >>> normalize_prequery_result_type(np.float64(123.456))
+    123.456
+    """
+    if isinstance(value, np.generic):
+        return value.item()
+    return value


### PR DESCRIPTION
### SUMMARY
When limiting a query with top n series on a db that doesn't support subqueries (e.g. Druid), numeric values are sometimes returned as `numpy` types. For instance, integer values are returned as `numpy.int64` instead of `int`. If the groupby column type is set to String type, despite the expression returning a numeric value, this causes the following SQLAlchemy compilation error:
![image](https://user-images.githubusercontent.com/33317356/138414120-e4bce69e-e827-4ab3-aab8-8a7c9fa64272.png)
![image](https://user-images.githubusercontent.com/33317356/138413412-af5a3717-6294-4428-b436-f8f558dd5a9d.png)

This is due to SQLAlchemy attempting to perform a string replacement operation on the numeric value to escape hyphens during query compilation. However, by ensuring that the value is first converted into its native Python equivalent (`np.inp64` to `int`), SQLAlchemy is able to ignore the incorrect target type (in this case `String`), and is able to successfully compile the query:
![image](https://user-images.githubusercontent.com/33317356/138414199-6d12a5c1-08f3-45d2-8654-a98fe4a9b912.png)

### TESTING INSTRUCTIONS
1. Use a database that doesn't support subqueries, e.g. Druid
2. Create a dataset with a calculated column that returns a numeric value but set it to "STRING" type
3. Create a chart with a limit on the series count
3. Notice how the query raises a 500 when fetching data

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
