### PR TITLE
fix(explore): Metrics disappearing after removing metric from dataset

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
@@ -19,14 +19,47 @@
 import React from 'react';
 import { render, screen } from 'spec/helpers/testing-library';
 import { DndMetricSelect } from 'src/explore/components/controls/DndColumnSelectControl/DndMetricSelect';
+import { AGGREGATES } from 'src/explore/constants';
+import { EXPRESSION_TYPES } from '../MetricControl/AdhocMetric';
 
 const defaultProps = {
   savedMetrics: [
     {
-      metric_name: 'Metric A',
-      expression: 'Expression A',
+      metric_name: 'metric_a',
+      expression: 'expression_a',
+    },
+    {
+      metric_name: 'metric_b',
+      expression: 'expression_b',
+      verbose_name: 'Metric B',
     },
   ],
+  columns: [
+    {
+      column_name: 'column_a',
+    },
+    {
+      column_name: 'column_b',
+      verbose_name: 'Column B',
+    },
+  ],
+};
+
+const adhocMetricA = {
+  expressionType: EXPRESSION_TYPES.SIMPLE,
+  column: {
+    column_name: 'column_a',
+  },
+  aggregate: AGGREGATES.SUM,
+  optionName: 'abc',
+};
+const adhocMetricB = {
+  expressionType: EXPRESSION_TYPES.SIMPLE,
+  column: {
+    column_name: 'column_b',
+  },
+  aggregate: AGGREGATES.SUM,
+  optionName: 'def',
 };
 
 test('renders with default props', () => {
@@ -37,4 +70,106 @@ test('renders with default props', () => {
 test('renders with default props and multi = true', () => {
   render(<DndMetricSelect {...defaultProps} multi />, { useDnd: true });
   expect(screen.getByText('Drop columns or metrics here')).toBeInTheDocument();
+});
+
+test('render selected metrics correctly', () => {
+  const metricValues = ['metric_a', 'metric_b', adhocMetricB];
+  render(<DndMetricSelect {...defaultProps} value={metricValues} multi />, {
+    useDnd: true,
+  });
+  expect(screen.getByText('metric_a')).toBeVisible();
+  expect(screen.getByText('Metric B')).toBeVisible();
+  expect(screen.getByText('SUM(column_b)')).toBeVisible();
+});
+
+test('remove selected custom metric when metric gets removed from dataset', () => {
+  let metricValues = ['metric_a', 'metric_b', adhocMetricA, adhocMetricB];
+  const onChange = (val: any[]) => {
+    metricValues = val;
+  };
+
+  const { rerender } = render(
+    <DndMetricSelect
+      {...defaultProps}
+      value={metricValues}
+      onChange={onChange}
+      multi
+    />,
+    {
+      useDnd: true,
+    },
+  );
+
+  const newPropsWithRemovedMetric = {
+    ...defaultProps,
+    savedMetrics: [
+      {
+        metric_name: 'metric_a',
+        expression: 'expression_a',
+      },
+    ],
+  };
+  rerender(
+    <DndMetricSelect
+      {...newPropsWithRemovedMetric}
+      value={metricValues}
+      onChange={onChange}
+      multi
+    />,
+  );
+  expect(screen.getByText('metric_a')).toBeVisible();
+  expect(screen.queryByText('Metric B')).not.toBeInTheDocument();
+  expect(screen.getByText('SUM(column_a)')).toBeVisible();
+  expect(screen.getByText('SUM(column_b)')).toBeVisible();
+});
+
+test('remove selected adhoc metric when column gets removed from dataset', async () => {
+  let metricValues = ['metric_a', 'metric_b', adhocMetricA, adhocMetricB];
+  const onChange = (val: any[]) => {
+    metricValues = val;
+  };
+
+  const { rerender } = render(
+    <DndMetricSelect
+      {...defaultProps}
+      value={metricValues}
+      onChange={onChange}
+      multi
+    />,
+    {
+      useDnd: true,
+    },
+  );
+
+  const newPropsWithRemovedColumn = {
+    ...defaultProps,
+    columns: [
+      {
+        column_name: 'column_a',
+      },
+    ],
+  };
+
+  // rerender twice - first to update columns, second to update value
+  rerender(
+    <DndMetricSelect
+      {...newPropsWithRemovedColumn}
+      value={metricValues}
+      onChange={onChange}
+      multi
+    />,
+  );
+  rerender(
+    <DndMetricSelect
+      {...newPropsWithRemovedColumn}
+      value={metricValues}
+      onChange={onChange}
+      multi
+    />,
+  );
+
+  expect(screen.getByText('metric_a')).toBeVisible();
+  expect(screen.getByText('Metric B')).toBeVisible();
+  expect(screen.getByText('SUM(column_a)')).toBeVisible();
+  expect(screen.queryByText('SUM(column_b)')).not.toBeInTheDocument();
 });

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
@@ -43,6 +43,7 @@ const defaultProps = {
       verbose_name: 'Column B',
     },
   ],
+  onChange: () => {},
 };
 
 const adhocMetricA = {

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
@@ -48,17 +48,13 @@ const defaultProps = {
 
 const adhocMetricA = {
   expressionType: EXPRESSION_TYPES.SIMPLE,
-  column: {
-    column_name: 'column_a',
-  },
+  column: defaultProps.columns[0],
   aggregate: AGGREGATES.SUM,
   optionName: 'abc',
 };
 const adhocMetricB = {
   expressionType: EXPRESSION_TYPES.SIMPLE,
-  column: {
-    column_name: 'column_b',
-  },
+  column: defaultProps.columns[1],
   aggregate: AGGREGATES.SUM,
   optionName: 'def',
 };
@@ -80,7 +76,7 @@ test('render selected metrics correctly', () => {
   });
   expect(screen.getByText('metric_a')).toBeVisible();
   expect(screen.getByText('Metric B')).toBeVisible();
-  expect(screen.getByText('SUM(column_b)')).toBeVisible();
+  expect(screen.getByText('SUM(Column B)')).toBeVisible();
 });
 
 test('remove selected custom metric when metric gets removed from dataset', () => {
@@ -121,7 +117,7 @@ test('remove selected custom metric when metric gets removed from dataset', () =
   expect(screen.getByText('metric_a')).toBeVisible();
   expect(screen.queryByText('Metric B')).not.toBeInTheDocument();
   expect(screen.getByText('SUM(column_a)')).toBeVisible();
-  expect(screen.getByText('SUM(column_b)')).toBeVisible();
+  expect(screen.getByText('SUM(Column B)')).toBeVisible();
 });
 
 test('remove selected adhoc metric when column gets removed from dataset', async () => {
@@ -172,5 +168,61 @@ test('remove selected adhoc metric when column gets removed from dataset', async
   expect(screen.getByText('metric_a')).toBeVisible();
   expect(screen.getByText('Metric B')).toBeVisible();
   expect(screen.getByText('SUM(column_a)')).toBeVisible();
-  expect(screen.queryByText('SUM(column_b)')).not.toBeInTheDocument();
+  expect(screen.queryByText('SUM(Column B)')).not.toBeInTheDocument();
+});
+
+test('update adhoc metric name when column label in dataset changes', () => {
+  let metricValues = ['metric_a', 'metric_b', adhocMetricA, adhocMetricB];
+  const onChange = (val: any[]) => {
+    metricValues = val;
+  };
+
+  const { rerender } = render(
+    <DndMetricSelect
+      {...defaultProps}
+      value={metricValues}
+      onChange={onChange}
+      multi
+    />,
+    {
+      useDnd: true,
+    },
+  );
+
+  const newPropsWithUpdatedColNames = {
+    ...defaultProps,
+    columns: [
+      {
+        column_name: 'column_a',
+        verbose_name: 'new col A name',
+      },
+      {
+        column_name: 'column_b',
+        verbose_name: 'new col B name',
+      },
+    ],
+  };
+
+  // rerender twice - first to update columns, second to update value
+  rerender(
+    <DndMetricSelect
+      {...newPropsWithUpdatedColNames}
+      value={metricValues}
+      onChange={onChange}
+      multi
+    />,
+  );
+  rerender(
+    <DndMetricSelect
+      {...newPropsWithUpdatedColNames}
+      value={metricValues}
+      onChange={onChange}
+      multi
+    />,
+  );
+
+  expect(screen.getByText('metric_a')).toBeVisible();
+  expect(screen.getByText('Metric B')).toBeVisible();
+  expect(screen.getByText('SUM(new col A name)')).toBeVisible();
+  expect(screen.getByText('SUM(new col B name)')).toBeVisible();
 });

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -19,7 +19,6 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  DatasourceType,
   ensureIsArray,
   FeatureFlag,
   GenericDataType,
@@ -42,7 +41,6 @@ import { DndItemType } from 'src/explore/components/DndItemType';
 import DndSelectLabel from 'src/explore/components/controls/DndColumnSelectControl/DndSelectLabel';
 import { savedMetricType } from 'src/explore/components/controls/MetricControl/types';
 import { AGGREGATES } from 'src/explore/constants';
-import { DndControlProps } from './types';
 
 const EMPTY_OBJECT = {};
 const DND_ACCEPTED_TYPES = [DndItemType.Column, DndItemType.Metric];
@@ -82,6 +80,7 @@ const getOptionsForSavedMetrics = (
 
 type ValueType = Metric | AdhocMetric | QueryFormMetric;
 
+// TODO: use typeguards to distinguish saved metrics from adhoc metrics
 const getMetricsMatchingCurrentDataset = (
   value: ValueType | ValueType[] | null | undefined,
   columns: ColumnMeta[],
@@ -100,12 +99,6 @@ const getMetricsMatchingCurrentDataset = (
         (metric as AdhocMetric).column?.column_name === column.column_name,
     );
   });
-
-export type DndMetricSelectProps = DndControlProps<ValueType> & {
-  savedMetrics: savedMetricType[];
-  columns: ColumnMeta[];
-  datasourceType?: DatasourceType;
-};
 
 export const DndMetricSelect = (props: any) => {
   const { onChange, multi, columns, savedMetrics } = props;
@@ -154,7 +147,7 @@ export const DndMetricSelect = (props: any) => {
     ) {
       // Remove selected custom metrics that do not exist in the dataset anymore
       // Remove selected adhoc metrics that use columns which do not exist in the dataset anymore
-      onChange(
+      handleChange(
         getMetricsMatchingCurrentDataset(props.value, columns, savedMetrics),
       );
     }
@@ -164,7 +157,7 @@ export const DndMetricSelect = (props: any) => {
     prevSavedMetrics,
     savedMetrics,
     props.value,
-    onChange,
+    handleChange,
   ]);
 
   const canDrop = useCallback(

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -88,16 +88,17 @@ const getMetricsMatchingCurrentDataset = (
   prevColumns: ColumnMeta[],
   prevSavedMetrics: (savedMetricType | Metric)[],
 ) => {
-  const areMetricsEqual = isEqual(prevSavedMetrics, savedMetrics);
-  const areColsEqual = isEqual(prevColumns, columns);
+  const areSavedMetricsEqual =
+    !prevSavedMetrics || isEqual(prevSavedMetrics, savedMetrics);
+  const areColsEqual = !prevColumns || isEqual(prevColumns, columns);
 
-  if (areColsEqual && areMetricsEqual) {
+  if (areColsEqual && areSavedMetricsEqual) {
     return values;
   }
   return values.reduce((acc: ValueType[], metric) => {
     if (
       (typeof metric === 'string' || (metric as Metric).metric_name) &&
-      (areMetricsEqual ||
+      (areSavedMetricsEqual ||
         savedMetrics?.some(
           savedMetric =>
             savedMetric.metric_name === metric ||
@@ -166,6 +167,10 @@ export const DndMetricSelect = (props: any) => {
   useEffect(() => {
     // Remove selected custom metrics that do not exist in the dataset anymore
     // Remove selected adhoc metrics that use columns which do not exist in the dataset anymore
+    // Sync adhoc metrics with dataset columns when they are modified by the user
+    if (!props.value) {
+      return;
+    }
     const propsValues = ensureIsArray(props.value);
     const matchingMetrics = getMetricsMatchingCurrentDataset(
       propsValues,
@@ -178,7 +183,7 @@ export const DndMetricSelect = (props: any) => {
     if (!isEqual(propsValues, matchingMetrics)) {
       handleChange(matchingMetrics);
     }
-  }, [prevColumns, columns, prevSavedMetrics, savedMetrics, handleChange]);
+  }, [columns, savedMetrics, handleChange]);
 
   const canDrop = useCallback(
     (item: DatasourcePanelDndItem) => {

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -178,14 +178,7 @@ export const DndMetricSelect = (props: any) => {
     if (!isEqual(propsValues, matchingMetrics)) {
       handleChange(matchingMetrics);
     }
-  }, [
-    prevColumns,
-    columns,
-    prevSavedMetrics,
-    savedMetrics,
-    props.value,
-    handleChange,
-  ]);
+  }, [prevColumns, columns, prevSavedMetrics, savedMetrics, handleChange]);
 
   const canDrop = useCallback(
     (item: DatasourcePanelDndItem) => {
@@ -275,7 +268,6 @@ export const DndMetricSelect = (props: any) => {
     [multi, onChange, value],
   );
 
-  console.log('value', value);
   const valueRenderer = useCallback(
     (option: ValueType, index: number) => (
       <MetricDefinitionValue

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetric.js
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetric.js
@@ -86,17 +86,20 @@ export default class AdhocMetric {
   }
 
   getDefaultLabel() {
-    const label = this.translateToSql();
+    const label = this.translateToSql(true);
     return label.length < 43 ? label : `${label.substring(0, 40)}...`;
   }
 
-  translateToSql() {
+  translateToSql(useVerboseName = false) {
     if (this.expressionType === EXPRESSION_TYPES.SIMPLE) {
       const aggregate = this.aggregate || '';
       // eslint-disable-next-line camelcase
-      const column = this.column?.column_name
-        ? `(${this.column.column_name})`
-        : '';
+      const column =
+        useVerboseName && this.column?.verbose_name
+          ? `(${this.column.verbose_name})`
+          : this.column?.column_name
+          ? `(${this.column.column_name})`
+          : '';
       return aggregate + column;
     }
     if (this.expressionType === EXPRESSION_TYPES.SQL) {

--- a/superset-frontend/src/explore/components/controls/MetricControl/MetricsControl.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/MetricsControl.jsx
@@ -110,7 +110,8 @@ const getMetricsMatchingCurrentDataset = (value, columns, savedMetrics) =>
       );
     }
     return columns?.some(
-      column => metric.column?.column_name === column.column_name,
+      column =>
+        !metric.column || metric.column.column_name === column.column_name,
     );
   });
 
@@ -251,25 +252,23 @@ const MetricsControl = ({
   );
 
   useEffect(() => {
-    // Remove all metrics if selected value no longer a valid column
-    // in the dataset. Must use `nextProps` here because Redux reducers may
-    // have already updated the value for this control.
+    // Remove selected custom metrics that do not exist in the dataset anymore
+    // Remove selected adhoc metrics that use columns which do not exist in the dataset anymore
     if (
-      !isEqual(prevColumns, columns) ||
-      !isEqual(prevSavedMetrics, savedMetrics)
+      propsValue &&
+      (!isEqual(prevColumns, columns) ||
+        !isEqual(prevSavedMetrics, savedMetrics))
     ) {
-      handleChange(
-        getMetricsMatchingCurrentDataset(propsValue, columns, savedMetrics),
+      const matchingMetrics = getMetricsMatchingCurrentDataset(
+        propsValue,
+        columns,
+        savedMetrics,
       );
+      if (!isEqual(matchingMetrics, propsValue)) {
+        handleChange(matchingMetrics);
+      }
     }
-  }, [
-    columns,
-    handleChange,
-    prevColumns,
-    prevSavedMetrics,
-    propsValue,
-    savedMetrics,
-  ]);
+  }, [columns, handleChange, savedMetrics]);
 
   useEffect(() => {
     setValue(coerceAdhocMetrics(propsValue));


### PR DESCRIPTION
### SUMMARY
Before, when a custom metric that was currently selected got removed from dataset, all selected metrics where cleared and user had to rebuild their chart.
This PR fixes that behaviour by removing from metrics picker only those custom metrics that were removed from dataset. Also, if user removes a column from dataset, the adhoc metrics that use that column will also be removed.
Also, it fixes another bug that's been around for long time - now adhoc metric labels display column's verbose name as a default label rather than it's name from database.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see linked issue
After:

https://user-images.githubusercontent.com/15073128/138493397-8a6a218a-60b3-4ef0-b1e7-996264b349eb.mov

### TESTING INSTRUCTIONS
Follow the reproduction steps from linked issue, make sure that only the metric that got removed from dataset is removed from metrics picker.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes #16719, fixes #16384
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @graceguo-supercat @rusackas @junlincc 