### PR TITLE
feat(metrics): Provide override for disabling ad-hoc metrics

### DIFF
--- a/superset-frontend/src/explore/components/ExploreContentPopover.tsx
+++ b/superset-frontend/src/explore/components/ExploreContentPopover.tsx
@@ -29,10 +29,4 @@ export const ExplorePopoverContent = styled.div`
   .filter-sql-editor {
     border: ${({ theme }) => theme.colors.grayscale.light2} solid thin;
   }
-  .custom-sql-disabled-message {
-    color: ${({ theme }) => theme.colors.grayscale.light1};
-    font-size: ${({ theme }) => theme.typography.sizes.xs}px;
-    text-align: center;
-    margin-top: ${({ theme }) => theme.gridUnit * 15}px;
-  }
 `;

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -284,7 +284,7 @@ export const DndMetricSelect = (props: any) => {
         columns={props.columns}
         savedMetrics={props.savedMetrics}
         savedMetricsOptions={getSavedMetricOptionsForMetric(index)}
-        datasourceType={props.datasourceType}
+        datasource={props.datasource}
         onMoveLabel={moveLabel}
         onDropLabel={handleDropLabel}
         type={`${DndItemType.AdhocMetricOption}_${props.name}_${props.label}`}
@@ -299,7 +299,7 @@ export const DndMetricSelect = (props: any) => {
       onMetricEdit,
       onRemoveMetric,
       props.columns,
-      props.datasourceType,
+      props.datasource,
       props.label,
       props.name,
       props.savedMetrics,
@@ -396,7 +396,7 @@ export const DndMetricSelect = (props: any) => {
         columns={props.columns}
         savedMetricsOptions={newSavedMetricOptions}
         savedMetric={EMPTY_OBJECT as savedMetricType}
-        datasourceType={props.datasourceType}
+        datasource={props.datasource}
         isControlledComponent
         visible={newMetricPopoverVisible}
         togglePopover={togglePopover}

--- a/superset-frontend/src/explore/components/controls/FixedOrMetricControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/FixedOrMetricControl/index.jsx
@@ -178,6 +178,7 @@ export default class FixedOrMetricControl extends React.Component {
                   }}
                   onChange={this.setMetric}
                   value={this.state.metricValue}
+                  datasource={this.props.datasource}
                 />
               </PopoverSection>
             </div>

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.tsx
@@ -41,7 +41,10 @@ const createProps = () => ({
     },
   ],
   adhocMetric: new AdhocMetric({ isNew: true }),
-  datasourceType: 'table',
+  datasource: {
+    extra: '{}',
+    type: 'table',
+  },
   columns: [
     {
       id: 1342,
@@ -62,18 +65,61 @@ test('Should render', () => {
 test('Should render correct elements', () => {
   const props = createProps();
   render(<AdhocMetricEditPopover {...props} />);
-
   expect(screen.getByRole('tablist')).toBeVisible();
-
-  expect(screen.getByRole('tab', { name: 'Custom SQL' })).toBeVisible();
-  expect(screen.getByRole('tab', { name: 'Simple' })).toBeVisible();
-  expect(screen.getByRole('tab', { name: 'Saved' })).toBeVisible();
-
-  expect(screen.getByRole('tabpanel', { name: 'Saved' })).toBeVisible();
-
   expect(screen.getByRole('button', { name: 'Resize' })).toBeVisible();
   expect(screen.getByRole('button', { name: 'Save' })).toBeVisible();
   expect(screen.getByRole('button', { name: 'Close' })).toBeVisible();
+});
+
+test('Should render correct elements for SQL', () => {
+  const props = createProps();
+  render(<AdhocMetricEditPopover {...props} />);
+  expect(screen.getByRole('tab', { name: 'Custom SQL' })).toBeVisible();
+  expect(screen.getByRole('tab', { name: 'Simple' })).toBeVisible();
+  expect(screen.getByRole('tab', { name: 'Saved' })).toBeVisible();
+  expect(screen.getByRole('tabpanel', { name: 'Saved' })).toBeVisible();
+});
+
+test('Should render correct elements for native Druid', () => {
+  const props = { ...createProps(), datasource: { type: 'druid' } };
+  render(<AdhocMetricEditPopover {...props} />);
+  expect(screen.getByRole('tab', { name: 'Custom SQL' })).toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
+  expect(screen.getByRole('tab', { name: 'Simple' })).toBeEnabled();
+  expect(screen.getByRole('tab', { name: 'Saved' })).toBeEnabled();
+  expect(screen.getByRole('tabpanel', { name: 'Saved' })).toBeVisible();
+});
+
+test('Should render correct elements for allow ad-hoc metrics', () => {
+  const props = {
+    ...createProps(),
+    datasource: { extra: '{"disallow_adhoc_metrics": false}' },
+  };
+  render(<AdhocMetricEditPopover {...props} />);
+  expect(screen.getByRole('tab', { name: 'Custom SQL' })).toBeEnabled();
+  expect(screen.getByRole('tab', { name: 'Simple' })).toBeEnabled();
+  expect(screen.getByRole('tab', { name: 'Saved' })).toBeEnabled();
+  expect(screen.getByRole('tabpanel', { name: 'Saved' })).toBeVisible();
+});
+
+test('Should render correct elements for disallow ad-hoc metrics', () => {
+  const props = {
+    ...createProps(),
+    datasource: { extra: '{"disallow_adhoc_metrics": true}' },
+  };
+  render(<AdhocMetricEditPopover {...props} />);
+  expect(screen.getByRole('tab', { name: 'Custom SQL' })).toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
+  expect(screen.getByRole('tab', { name: 'Simple' })).toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
+  expect(screen.getByRole('tab', { name: 'Saved' })).toBeEnabled();
+  expect(screen.getByRole('tabpanel', { name: 'Saved' })).toBeVisible();
 });
 
 test('Clicking on "Close" should call onClose', () => {

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
@@ -22,6 +22,7 @@ import PropTypes from 'prop-types';
 import Tabs from 'src/components/Tabs';
 import Button from 'src/components/Button';
 import { Select } from 'src/components';
+import { Tooltip } from 'src/components/Tooltip';
 import { t, styled } from '@superset-ui/core';
 
 import { Form, FormItem } from 'src/components/Form';
@@ -50,7 +51,7 @@ const propTypes = {
   columns: PropTypes.arrayOf(columnType),
   savedMetricsOptions: PropTypes.arrayOf(savedMetricType),
   savedMetric: savedMetricType,
-  datasourceType: PropTypes.string,
+  datasource: PropTypes.object,
 };
 
 const defaultProps = {
@@ -277,7 +278,7 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
       onChange,
       onClose,
       onResize,
-      datasourceType,
+      datasource,
       ...popoverProps
     } = this.props;
     const { adhocMetric, savedMetric } = this.state;
@@ -322,7 +323,10 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
       autoFocus: true,
     };
 
-    if (this.props.datasourceType === 'druid' && aggregateSelectProps.options) {
+    if (
+      this.props.datasource?.type === 'druid' &&
+      aggregateSelectProps.options
+    ) {
       aggregateSelectProps.options = aggregateSelectProps.options.filter(
         aggregate => aggregate !== 'AVG',
       );
@@ -336,6 +340,13 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
         typeof propsSavedMetric?.metric_name === 'undefined'
       ) &&
         savedMetric?.metric_name !== propsSavedMetric?.metric_name);
+
+    let extra = {};
+    if (datasource?.extra) {
+      try {
+        extra = JSON.parse(datasource.extra);
+      } catch {} // eslint-disable-line no-empty
+    }
 
     return (
       <Form
@@ -370,7 +381,23 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
               />
             </FormItem>
           </Tabs.TabPane>
-          <Tabs.TabPane key={EXPRESSION_TYPES.SIMPLE} tab={t('Simple')}>
+          <Tabs.TabPane
+            key={EXPRESSION_TYPES.SIMPLE}
+            tab={
+              extra.disallow_adhoc_metrics ? (
+                <Tooltip
+                  title={t(
+                    'Simple ad-hoc metrics are not enabled for this dataset',
+                  )}
+                >
+                  {t('Simple')}
+                </Tooltip>
+              ) : (
+                t('Simple')
+              )
+            }
+            disabled={extra.disallow_adhoc_metrics}
+          >
             <FormItem label={t('column')}>
               <Select
                 options={columns.map(column => ({
@@ -395,32 +422,47 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
           </Tabs.TabPane>
           <Tabs.TabPane
             key={EXPRESSION_TYPES.SQL}
-            tab={t('Custom SQL')}
+            tab={
+              extra.disallow_adhoc_metrics ||
+              this.props.datasource?.type === 'druid' ? (
+                <Tooltip
+                  title={
+                    this.props.datasource?.type === 'druid'
+                      ? t(
+                          'Custom SQL ad-hoc metrics are not available for the native Druid connector',
+                        )
+                      : t(
+                          'Custom SQL ad-hoc metrics are not enabled for this dataset',
+                        )
+                  }
+                >
+                  {t('Custom SQL')}
+                </Tooltip>
+              ) : (
+                t('Custom SQL')
+              )
+            }
             data-test="adhoc-metric-edit-tab#custom"
+            disabled={
+              extra.disallow_adhoc_metrics ||
+              this.props.datasource?.type === 'druid'
+            }
           >
-            {this.props.datasourceType !== 'druid' ? (
-              <SQLEditor
-                data-test="sql-editor"
-                showLoadingForImport
-                ref={this.handleAceEditorRef}
-                keywords={keywords}
-                height={`${this.state.height - 80}px`}
-                onChange={this.onSqlExpressionChange}
-                width="100%"
-                showGutter={false}
-                value={
-                  adhocMetric.sqlExpression || adhocMetric.translateToSql()
-                }
-                editorProps={{ $blockScrolling: true }}
-                enableLiveAutocompletion
-                className="filter-sql-editor"
-                wrapEnabled
-              />
-            ) : (
-              <div className="custom-sql-disabled-message">
-                Custom SQL Metrics are not available on druid datasources
-              </div>
-            )}
+            <SQLEditor
+              data-test="sql-editor"
+              showLoadingForImport
+              ref={this.handleAceEditorRef}
+              keywords={keywords}
+              height={`${this.state.height - 80}px`}
+              onChange={this.onSqlExpressionChange}
+              width="100%"
+              showGutter={false}
+              value={adhocMetric.sqlExpression || adhocMetric.translateToSql()}
+              editorProps={{ $blockScrolling: true }}
+              enableLiveAutocompletion
+              className="filter-sql-editor"
+              wrapEnabled
+            />
           </Tabs.TabPane>
         </Tabs>
         <div>

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricOption.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricOption.jsx
@@ -32,7 +32,7 @@ const propTypes = {
   columns: PropTypes.arrayOf(columnType),
   savedMetricsOptions: PropTypes.arrayOf(savedMetricType),
   savedMetric: savedMetricType,
-  datasourceType: PropTypes.string,
+  datasource: PropTypes.object,
   onMoveLabel: PropTypes.func,
   onDropLabel: PropTypes.func,
   index: PropTypes.number,
@@ -58,7 +58,7 @@ class AdhocMetricOption extends React.PureComponent {
       columns,
       savedMetricsOptions,
       savedMetric,
-      datasourceType,
+      datasource,
       onMoveLabel,
       onDropLabel,
       index,
@@ -73,7 +73,7 @@ class AdhocMetricOption extends React.PureComponent {
         columns={columns}
         savedMetricsOptions={savedMetricsOptions}
         savedMetric={savedMetric}
-        datasourceType={datasourceType}
+        datasource={datasource}
       >
         <OptionControlLabel
           savedMetric={savedMetric}

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { ReactNode } from 'react';
-import { Metric } from '@superset-ui/core';
+import { Datasource, Metric } from '@superset-ui/core';
 import Popover from 'src/components/Popover';
 import AdhocMetricEditPopoverTitle from 'src/explore/components/controls/MetricControl/AdhocMetricEditPopoverTitle';
 import { ExplorePopoverContent } from 'src/explore/components/ExploreContentPopover';
@@ -33,7 +33,7 @@ export type AdhocMetricPopoverTriggerProps = {
   columns: { column_name: string; type: string }[];
   savedMetricsOptions: savedMetricType[];
   savedMetric: savedMetricType;
-  datasourceType: string;
+  datasource?: Datasource;
   children: ReactNode;
   isControlledComponent?: boolean;
   visible?: boolean;
@@ -170,7 +170,7 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
       savedMetric,
       columns,
       savedMetricsOptions,
-      datasourceType,
+      datasource,
       isControlledComponent,
     } = this.props;
     const { verbose_name, metric_name } = savedMetric;
@@ -204,7 +204,7 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
           columns={columns}
           savedMetricsOptions={savedMetricsOptions}
           savedMetric={savedMetric}
-          datasourceType={datasourceType}
+          datasource={datasource}
           onResize={this.onPopoverResize}
           onClose={closePopover}
           onChange={this.onChange}

--- a/superset-frontend/src/explore/components/controls/MetricControl/MetricDefinitionValue.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/MetricDefinitionValue.jsx
@@ -34,7 +34,7 @@ const propTypes = {
   savedMetrics: PropTypes.arrayOf(savedMetricType),
   savedMetricsOptions: PropTypes.arrayOf(savedMetricType),
   multi: PropTypes.bool,
-  datasourceType: PropTypes.string,
+  datasource: PropTypes.object,
 };
 
 export default function MetricDefinitionValue({
@@ -44,7 +44,7 @@ export default function MetricDefinitionValue({
   columns,
   savedMetrics,
   savedMetricsOptions,
-  datasourceType,
+  datasource,
   onMoveLabel,
   onDropLabel,
   index,
@@ -70,7 +70,7 @@ export default function MetricDefinitionValue({
       onRemoveMetric,
       columns,
       savedMetricsOptions,
-      datasourceType,
+      datasource,
       adhocMetric,
       onMoveLabel,
       onDropLabel,

--- a/superset-frontend/src/explore/components/controls/MetricControl/MetricsControl.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/MetricsControl.jsx
@@ -48,7 +48,7 @@ const propTypes = {
   isLoading: PropTypes.bool,
   multi: PropTypes.bool,
   clearable: PropTypes.bool,
-  datasourceType: PropTypes.string,
+  datasource: PropTypes.object,
 };
 
 const defaultProps = {
@@ -122,7 +122,6 @@ const MetricsControl = ({
   columns,
   savedMetrics,
   datasource,
-  datasourceType,
   ...props
 }) => {
   const [value, setValue] = useState(coerceAdhocMetrics(propsValue));
@@ -232,9 +231,8 @@ const MetricsControl = ({
           onMetricEdit={onNewMetric}
           columns={columns}
           savedMetricsOptions={savedMetricOptions}
-          datasource={datasource}
           savedMetric={emptySavedMetric}
-          datasourceType={datasourceType}
+          datasource={datasource}
         >
           {trigger}
         </AdhocMetricPopoverTrigger>
@@ -243,7 +241,6 @@ const MetricsControl = ({
     [
       columns,
       datasource,
-      datasourceType,
       isAddNewMetricDisabled,
       newAdhocMetric,
       onNewMetric,
@@ -295,7 +292,6 @@ const MetricsControl = ({
           value,
           value?.[index],
         )}
-        datasourceType={datasourceType}
         onMoveLabel={moveLabel}
         onDropLabel={onDropLabel}
         multi={multi}
@@ -304,7 +300,6 @@ const MetricsControl = ({
     [
       columns,
       datasource,
-      datasourceType,
       moveLabel,
       multi,
       onDropLabel,

--- a/superset-frontend/src/explore/controls.jsx
+++ b/superset-frontend/src/explore/controls.jsx
@@ -153,7 +153,7 @@ const metrics = {
     return {
       columns: datasource ? datasource.columns : [],
       savedMetrics: datasource ? datasource.metrics : [],
-      datasourceType: datasource && datasource.type,
+      datasource,
     };
   },
   description: t('One or many metrics to display'),
@@ -383,7 +383,7 @@ export const controls = {
     mapStateToProps: state => ({
       columns: state.datasource ? state.datasource.columns : [],
       savedMetrics: state.datasource ? state.datasource.metrics : [],
-      datasourceType: state.datasource && state.datasource.type,
+      datasource: state.datasource,
     }),
   },
 


### PR DESCRIPTION
### SUMMARY

There could be some instances where ad-hoc metrics for specific datasets should be disabled, i.e., the dataset owner specifically does not want users to create ad-hoc non-sanctioned metrics. This PR adds—at the dataset level—a custom override for disabling ad-hoc metrics, i.e., removing the `SIMPLE` and `CUSTOM SQL` tabs. The default behavior preserves the existing workflow.

Note if this override is enabled, any existing ad-hoc metric will persist and be deemed editable even though the tab is officially marked as disabled. 

For consistency, for the native Druid connector I also disabled the `CUSTOM SQL` tab (which housed a message as to why this was invalid—this proposed way seems cleaner as well) and added the same treatment for ad-hoc filters.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Disallowed

<img width="343" alt="Screen Shot 2021-11-05 at 11 33 31 AM" src="https://user-images.githubusercontent.com/4567245/140561813-428ff696-bc47-41e8-b9ea-61ff291d2e94.png">

<img width="357" alt="Screen Shot 2021-11-05 at 11 33 39 AM" src="https://user-images.githubusercontent.com/4567245/140561816-eacb58ad-b1c2-44b2-b80b-fa37bcb4a18a.png">

<img width="363" alt="Screen Shot 2021-11-05 at 11 41 45 AM" src="https://user-images.githubusercontent.com/4567245/140562758-29ff4a7d-975f-4b81-bdfb-6d94fba9cf66.png">

#### Disallowed (pre-existing)

Interestingly the tab is disabled but the canvas remains operational.

<img width="317" alt="Screen Shot 2021-10-28 at 2 58 27 PM" src="https://user-images.githubusercontent.com/4567245/139342093-cd2ec511-abde-4b26-add2-356d4b234b34.png">

#### Allowed (default)

<img width="316" alt="Screen Shot 2021-10-22 at 11 30 10 AM" src="https://user-images.githubusercontent.com/4567245/138507430-4d751d93-fe83-4a7e-8bc7-fd28715cd245.png">

### TESTING INSTRUCTIONS

Added unit tests and manually tested for a number of visualization types and ad-hoc metric components: metric, metrics, percentage metric, sort-by metric, etc.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
