### PR TITLE
fix: reenabling terser plugin for webpack

### DIFF
--- a/docker/docker-frontend.sh
+++ b/docker/docker-frontend.sh
@@ -23,4 +23,4 @@ npm install -f --no-optional --global webpack webpack-cli
 npm install -f --no-optional
 
 echo "Running frontend"
-# npm run dev
+npm run dev

--- a/docker/docker-frontend.sh
+++ b/docker/docker-frontend.sh
@@ -23,4 +23,4 @@ npm install -f --no-optional --global webpack webpack-cli
 npm install -f --no-optional
 
 echo "Running frontend"
-npm run dev
+# npm run dev

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -274,7 +274,7 @@ const config = {
       },
     },
     usedExports: 'global',
-    minimizer: ['...', new CssMinimizerPlugin()],
+    minimizer: [new CssMinimizerPlugin(), '...'],
   },
   resolve: {
     modules: [APP_DIR, 'node_modules', ROOT_DIR],

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -274,7 +274,7 @@ const config = {
       },
     },
     usedExports: 'global',
-    minimizer: [new CssMinimizerPlugin()],
+    minimizer: [ '...', new CssMinimizerPlugin()],
   },
   resolve: {
     modules: [APP_DIR, 'node_modules', ROOT_DIR],

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -274,7 +274,7 @@ const config = {
       },
     },
     usedExports: 'global',
-    minimizer: [ '...', new CssMinimizerPlugin()],
+    minimizer: ['...', new CssMinimizerPlugin()],
   },
   resolve: {
     modules: [APP_DIR, 'node_modules', ROOT_DIR],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
In the Webpack 5 upgrade, we inadvertently lost the inclusion of the terser plugin due to the way the CssMinimizerPlugin was loaded. This PR uses webpack's `...` syntax to extend existing minimizers and ADD the CssMinimizerPlugin on top of the default terser plugin, rather than it being the ONLY minimizer.

This should shrink the JS bundle/chunk sizes by about 17MB in total.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Poke all over the place in an ephemeral build and make sure nothing randomly exploded, but I believe this is low risk.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
