### PR TITLE
chore: use official isort in pre-commmit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,12 +15,8 @@
 # limitations under the License.
 #
 repos:
-  - repo: https://github.com/asottile/seed-isort-config
-    rev: v1.9.3
-    hooks:
-      - id: seed-isort-config
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.9.3
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/superset/config.py
+++ b/superset/config.py
@@ -53,6 +53,7 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from flask_appbuilder.security.sqla import models
+
     from superset.connectors.sqla.models import SqlaTable
     from superset.models.core import Database
 

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -112,8 +112,8 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         # the global Flask app
         #
         # pylint: disable=import-outside-toplevel,too-many-locals,too-many-statements
-        from superset.annotation_layers.api import AnnotationLayerRestApi
         from superset.annotation_layers.annotations.api import AnnotationRestApi
+        from superset.annotation_layers.api import AnnotationLayerRestApi
         from superset.async_events.api import AsyncEventsRestApi
         from superset.cachekeys.api import CacheRestApi
         from superset.charts.api import ChartRestApi
@@ -132,16 +132,16 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         )
         from superset.css_templates.api import CssTemplateRestApi
         from superset.dashboards.api import DashboardRestApi
+        from superset.dashboards.filter_sets.api import FilterSetRestApi
         from superset.databases.api import DatabaseRestApi
         from superset.datasets.api import DatasetRestApi
         from superset.datasets.columns.api import DatasetColumnsRestApi
         from superset.datasets.metrics.api import DatasetMetricRestApi
         from superset.queries.api import QueryRestApi
-        from superset.security.api import SecurityRestApi
         from superset.queries.saved_queries.api import SavedQueryRestApi
         from superset.reports.api import ReportScheduleRestApi
         from superset.reports.logs.api import ReportExecutionLogRestApi
-        from superset.dashboards.filter_sets.api import FilterSetRestApi
+        from superset.security.api import SecurityRestApi
         from superset.views.access_requests import AccessRequestsModelView
         from superset.views.alerts import (
             AlertLogModelView,

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -69,8 +69,8 @@ if TYPE_CHECKING:
     from superset.common.query_context import QueryContext
     from superset.connectors.base.models import BaseDatasource
     from superset.connectors.druid.models import DruidCluster
-    from superset.models.dashboard import Dashboard
     from superset.models.core import Database
+    from superset.models.dashboard import Dashboard
     from superset.models.sql_lab import Query
     from superset.sql_parse import Table
     from superset.viz import BaseViz
@@ -1169,10 +1169,10 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         :raises DashboardAccessDeniedError: If the user cannot access the resource
         """
         # pylint: disable=import-outside-toplevel
+        from superset import is_feature_enabled
         from superset.dashboards.commands.exceptions import DashboardAccessDeniedError
         from superset.views.base import get_user_roles, is_user_admin
         from superset.views.utils import is_owner
-        from superset import is_feature_enabled
 
         if is_feature_enabled("DASHBOARD_RBAC"):
             has_rbac_access = any(
@@ -1193,8 +1193,8 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         # pylint: disable=import-outside-toplevel
         from superset import db
         from superset.dashboards.filters import DashboardAccessFilter
-        from superset.models.slice import Slice
         from superset.models.dashboard import Dashboard
+        from superset.models.slice import Slice
 
         datasource_class = type(datasource)
         query = (

--- a/superset/sqllab/command.py
+++ b/superset/sqllab/command.py
@@ -37,10 +37,10 @@ from superset.sqllab.exceptions import (
 from superset.sqllab.limiting_factor import LimitingFactor
 
 if TYPE_CHECKING:
+    from superset.databases.dao import DatabaseDAO
+    from superset.queries.dao import QueryDAO
     from superset.sqllab.sql_json_executer import SqlJsonExecutor
     from superset.sqllab.sqllab_execution_context import SqlJsonExecutionContext
-    from superset.queries.dao import QueryDAO
-    from superset.databases.dao import DatabaseDAO
 
 logger = logging.getLogger(__name__)
 

--- a/superset/sqllab/execution_context_convertor.py
+++ b/superset/sqllab/execution_context_convertor.py
@@ -26,9 +26,9 @@ from superset.sqllab.command_status import SqlJsonExecutionStatus
 from superset.sqllab.utils import apply_display_max_row_configuration_if_require
 
 if TYPE_CHECKING:
-    from superset.sqllab.sqllab_execution_context import SqlJsonExecutionContext
-    from superset.sqllab.sql_json_executer import SqlResults
     from superset.models.sql_lab import Query
+    from superset.sqllab.sql_json_executer import SqlResults
+    from superset.sqllab.sqllab_execution_context import SqlJsonExecutionContext
 
 
 class ExecutionContextConvertorImpl(ExecutionContextConvertor):

--- a/superset/sqllab/query_render.py
+++ b/superset/sqllab/query_render.py
@@ -32,8 +32,8 @@ from superset.utils import core as utils
 MSG_OF_1006 = "Issue 1006 - One or more parameters specified in the query are missing."
 
 if TYPE_CHECKING:
-    from superset.sqllab.sqllab_execution_context import SqlJsonExecutionContext
     from superset.jinja_context import BaseTemplateProcessor
+    from superset.sqllab.sqllab_execution_context import SqlJsonExecutionContext
 
 PARAMETER_MISSING_ERR = (
     "Please check your template parameters for syntax errors and make sure "

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -16,6 +16,7 @@
 # under the License.
 """Utility functions used across Superset"""
 # pylint: disable=too-many-lines
+import _thread  # pylint: disable=C0411
 import collections
 import decimal
 import errno
@@ -85,7 +86,6 @@ from sqlalchemy.sql.type_api import Variant
 from sqlalchemy.types import TEXT, TypeDecorator, TypeEngine
 from typing_extensions import TypedDict, TypeGuard
 
-import _thread  # pylint: disable=C0411
 from superset.constants import (
     EXAMPLES_DB_UUID,
     EXTRA_FORM_DATA_APPEND_KEYS,

--- a/tests/integration_tests/dashboards/filter_sets/conftest.py
+++ b/tests/integration_tests/dashboards/filter_sets/conftest.py
@@ -49,17 +49,18 @@ from tests.integration_tests.test_app import app
 if TYPE_CHECKING:
     from flask.ctx import AppContext
     from flask.testing import FlaskClient
+    from flask_appbuilder.security.manager import BaseSecurityManager
     from flask_appbuilder.security.sqla.models import (
+        PermissionView,
         Role,
         User,
         ViewMenu,
-        PermissionView,
     )
-    from flask_appbuilder.security.manager import BaseSecurityManager
     from sqlalchemy.orm import Session
-    from superset.models.slice import Slice
+
     from superset.connectors.sqla.models import SqlaTable
     from superset.models.core import Database
+    from superset.models.slice import Slice
 
 
 security_manager: BaseSecurityManager = sm

--- a/tests/integration_tests/dashboards/filter_sets/delete_api_tests.py
+++ b/tests/integration_tests/dashboards/filter_sets/delete_api_tests.py
@@ -32,6 +32,7 @@ from tests.integration_tests.dashboards.filter_sets.utils import (
 
 if TYPE_CHECKING:
     from flask.testing import FlaskClient
+
     from superset.models.filter_set import FilterSet
 
 

--- a/tests/integration_tests/dashboards/filter_sets/get_api_tests.py
+++ b/tests/integration_tests/dashboards/filter_sets/get_api_tests.py
@@ -31,6 +31,7 @@ from tests.integration_tests.dashboards.filter_sets.utils import (
 
 if TYPE_CHECKING:
     from flask.testing import FlaskClient
+
     from superset.models.filter_set import FilterSet
 
 

--- a/tests/integration_tests/dashboards/filter_sets/update_api_tests.py
+++ b/tests/integration_tests/dashboards/filter_sets/update_api_tests.py
@@ -40,6 +40,7 @@ from tests.integration_tests.dashboards.filter_sets.utils import (
 
 if TYPE_CHECKING:
     from flask.testing import FlaskClient
+
     from superset.models.filter_set import FilterSet
 
 

--- a/tests/integration_tests/fixtures/birth_names_dashboard.py
+++ b/tests/integration_tests/fixtures/birth_names_dashboard.py
@@ -71,7 +71,7 @@ def _load_data():
             fetch_values_predicate="123 = 123",
         )
 
-        from superset.examples.birth_names import create_slices, create_dashboard
+        from superset.examples.birth_names import create_dashboard, create_slices
 
         slices, _ = create_slices(table, admin_owner=False)
         dash = create_dashboard(slices)

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -1610,8 +1610,9 @@ def test_grace_period_error_flap(
 )
 @patch("superset.reports.dao.ReportScheduleDAO.bulk_delete_logs")
 def test_prune_log_soft_time_out(bulk_delete_logs, create_report_email_dashboard):
-    from celery.exceptions import SoftTimeLimitExceeded
     from datetime import datetime, timedelta
+
+    from celery.exceptions import SoftTimeLimitExceeded
 
     bulk_delete_logs.side_effect = SoftTimeLimitExceeded()
     with pytest.raises(SoftTimeLimitExceeded) as excinfo:

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -58,6 +58,12 @@ VIRTUAL_TABLE_STRING_TYPES: Dict[str, Pattern[str]] = {
 }
 
 
+class FilterTestCase(NamedTuple):
+    operator: str
+    value: Union[float, int, List[Any], str]
+    expected: Union[str, List[str]]
+
+
 class TestDatabaseModel(SupersetTestCase):
     def test_is_time_druid_time_col(self):
         """Druid has a special __time column"""
@@ -223,11 +229,6 @@ class TestDatabaseModel(SupersetTestCase):
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_where_operators(self):
-        class FilterTestCase(NamedTuple):
-            operator: str
-            value: Union[float, int, List[Any], str]
-            expected: Union[str, List[str]]
-
         filters: Tuple[FilterTestCase, ...] = (
             FilterTestCase(FilterOperator.IS_NULL, "", "IS NULL"),
             FilterTestCase(FilterOperator.IS_NOT_NULL, "", "IS NOT NULL"),


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The [mirrors-isort ](https://github.com/pre-commit/mirrors-isort)is deprecated that 10 months ago. Use official `isort` repo instead of `isort mirror`




### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
