### PR TITLE
fix(Dashboard): Position of the tools of the Tabs component in Edit Dashboard

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -77,6 +77,10 @@ const StyledDiv = styled.div`
     border: 1px solid @gray-light;
   }
 
+  .dashboard-component-tabs {
+    position: relative;
+  }
+
   /* A column within a column or tabs has inset hover menu */
   .dragdroppable-column .dragdroppable-column .hover-menu--top,
   .dashboard-component-tabs .dragdroppable-column .hover-menu--top {
@@ -86,7 +90,7 @@ const StyledDiv = styled.div`
   }
 
   /* move Tabs hover menu to top near actual Tabs */
-  .dashboard-component-tabs > .hover-menu--left {
+  .dashboard-component-tabs > .hover-menu-container > .hover-menu--left {
     top: 0;
     transform: unset;
     background: transparent;


### PR DESCRIPTION
### SUMMARY
This PR fixes the positions of the tools of the tabs when editing a Dashboard.

### BEFORE
Fixes #17156

### AFTER

https://user-images.githubusercontent.com/60598000/138765610-57e44639-5ee4-467f-b651-f98c51e18d33.mp4

### TESTING INSTRUCTIONS
1. Edit a Dashboard
2. Hover a Tabs component
3. Observe the position of the floating left tools

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #17156
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
