### PR TITLE
fix: remove variables from styled component

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -73,16 +73,16 @@ const StyledDiv = styled.div`
   /* A row within a column has inset hover menu */
   .dragdroppable-column .dragdroppable-row .hover-menu--left {
     left: -12px;
-    background: @lightest;
-    border: 1px solid @gray-light;
+    background: ${({ theme }) => theme.colors.grayscale.light5};
+    border: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
   }
 
   /* A column within a column or tabs has inset hover menu */
   .dragdroppable-column .dragdroppable-column .hover-menu--top,
   .dashboard-component-tabs .dragdroppable-column .hover-menu--top {
     top: -12px;
-    background: @lightest;
-    border: 1px solid @gray-light;
+    background: ${({ theme }) => theme.colors.grayscale.light5};
+    border: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
   }
 
   /* move Tabs hover menu to top near actual Tabs */

--- a/superset-frontend/src/dashboard/components/menu/HoverMenu.tsx
+++ b/superset-frontend/src/dashboard/components/menu/HoverMenu.tsx
@@ -30,16 +30,16 @@ const HoverStyleOverrides = styled.div`
   .hover-menu {
     opacity: 0;
     position: absolute;
-    z-index: @z-index-above-dashboard-charts;
-    font-size: @font-size-m;
+    z-index: 10;
+    font-size: ${({ theme }) => theme.typography.sizes.m};
   }
 
   .hover-menu--left {
-    width: 24px;
+    width: ${({ theme }) => theme.gridUnit * 6}px;
     top: 50%;
     transform: translate(0, -50%);
-    left: -28px;
-    padding: 8px 0;
+    left: ${({ theme }) => theme.gridUnit * -7}px;
+    padding: ${({ theme }) => theme.gridUnit * 2}px 0;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -47,15 +47,15 @@ const HoverStyleOverrides = styled.div`
   }
 
   .hover-menu--left > :nth-child(n):not(:only-child):not(:last-child) {
-    margin-bottom: 12px;
+    margin-bottom: ${({ theme }) => theme.gridUnit * 3}px;
   }
 
   .hover-menu--top {
-    height: 24px;
-    top: -24px;
+    height: ${({ theme }) => theme.gridUnit * 6}px;
+    top: ${({ theme }) => theme.gridUnit * -6}px;
     left: 50%;
     transform: translate(-50%);
-    padding: 0 8px;
+    padding: 0 ${({ theme }) => theme.gridUnit * 2}px;
     display: flex;
     flex-direction: row;
     justify-content: center;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This pr remove less vars from styled component in the dashboard builder and hovermenu

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/17326228/138809636-97c0ef04-8070-4e0d-a087-8660d99b8b31.mov





### TESTING INSTRUCTIONS
Go to dashboard builder and check that styles are applied when user hovers over row within and column or row within tabs.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
