### PR TITLE
fix: revert default series sort-by metric

### DIFF
--- a/superset-frontend/src/explore/controls.jsx
+++ b/superset-frontend/src/explore/controls.jsx
@@ -92,7 +92,7 @@ export const D3_FORMAT_OPTIONS = [
 
 const ROW_LIMIT_OPTIONS = [10, 50, 100, 250, 500, 1000, 5000, 10000, 50000];
 
-const SERIES_LIMITS = [0, 5, 10, 25, 50, 100, 500];
+const SERIES_LIMITS = [5, 10, 25, 50, 100, 500];
 
 export const D3_FORMAT_DOCS =
   'D3 format syntax: https://github.com/d3/d3-format';
@@ -123,7 +123,10 @@ const groupByControl = {
   label: t('Group by'),
   default: [],
   includeTime: false,
-  description: t('One or many controls to group by'),
+  description: t(
+    'One or many columns to group by. High cardinality groupings should include a sort by metric ' +
+      'and series limit to limit the number of fetched and rendered series.',
+  ),
   optionRenderer: c => <StyledColumnOption column={c} showType />,
   valueKey: 'column_name',
   filterOption: ({ data: opt }, text) =>
@@ -358,6 +361,10 @@ export const controls = {
     validators: [legacyValidateInteger],
     default: 10000,
     choices: formatSelectOptions(ROW_LIMIT_OPTIONS),
+    description: t(
+      'Limits the number of rows that get displayed. Should be used in conjunction with a sort ' +
+        'by metric.',
+    ),
   },
 
   limit: {
@@ -366,11 +373,13 @@ export const controls = {
     label: t('Series limit'),
     validators: [legacyValidateInteger],
     choices: formatSelectOptions(SERIES_LIMITS),
+    clearable: true,
     description: t(
-      'Limits the number of time series that get displayed. A sub query ' +
-        '(or an extra phase where sub queries are not supported) is applied to limit ' +
-        'the number of time series that get fetched and displayed. This feature is useful ' +
-        'when grouping by high cardinality dimension(s).',
+      'Limits the number of series that get displayed. Should be used in conjunction with a sort ' +
+        'by metric. A joined subquery (or an extra phase where subqueries are not supported) is ' +
+        'applied to limit the number of series that get fetched and rendered. This feature is ' +
+        'useful when grouping by high cardinality column(s) though does increase the query ' +
+        'complexity and cost.',
     ),
   },
 
@@ -379,7 +388,10 @@ export const controls = {
     label: t('Sort by'),
     default: null,
     clearable: true,
-    description: t('Metric used to define the top series'),
+    description: t(
+      'Metric used to define the top series. Should be used in conjunction with the series or ' +
+        'row limit',
+    ),
     mapStateToProps: state => ({
       columns: state.datasource ? state.datasource.columns : [],
       savedMetrics: state.datasource ? state.datasource.metrics : [],

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1317,11 +1317,6 @@ def get_metric_names(metrics: Sequence[Metric]) -> List[str]:
     return [metric for metric in map(get_metric_name, metrics) if metric]
 
 
-def get_first_metric_name(metrics: Sequence[Metric]) -> Optional[str]:
-    metric_labels = get_metric_names(metrics)
-    return metric_labels[0] if metric_labels else None
-
-
 def ensure_path_exists(path: str) -> None:
     try:
         os.makedirs(path)

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1251,9 +1251,7 @@ class NVD3TimeSeriesViz(NVD3Viz):
 
     def query_obj(self) -> QueryObjectDict:
         query_obj = super().query_obj()
-        sort_by = self.form_data.get(
-            "timeseries_limit_metric"
-        ) or utils.get_first_metric_name(query_obj.get("metrics") or [])
+        sort_by = self.form_data.get("timeseries_limit_metric")
         is_asc = not self.form_data.get("order_desc")
         if sort_by:
             sort_by_label = utils.get_metric_name(sort_by)


### PR DESCRIPTION
### SUMMARY

This PR is one of a slew to the [apache/superset](https://github.com/apache/superset) and [apache-superset/superset-ui](https://github.com/apache-superset/superset-ui) repos to revert pseudo recent changes to the series restrictions for high cardinality groupings. For more context please refer to [this](https://apache-superset.slack.com/archives/G013HAE6Y0K/p1635192289021500) Slack thread in the #committers channel.

Specifically this PR reverts https://github.com/apache/superset/pull/15343 (and more), i.e., does not fallback to the first selected metric and requires the user to specify a sort-by metric for improved UX, i.e., it was not apparent to the user from the UI how the sorting was happening. Furthermore said change was actually a breaking change but was not protected with a feature flag.

Initially I added logic for an XOR check that required either neither or both the series sort-by and limit needed to be provided, but this would be a breaking change—in addition to thinking about how this should work with the table row limit—and thus I felt this would be better handled at a later stage.

Related PRs:

- https://github.com/apache-superset/superset-ui/pull/1430
- https://github.com/apache-superset/superset-ui/pull/1436

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
