### PR TITLE
feat: Make Jinja template applied in timestamp columns

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -322,7 +322,9 @@ class TableColumn(Model, BaseColumn, CertificationMixin):
             sqla_col = column(self.column_name, type_=type_)
             return self.table.make_sqla_column_compatible(sqla_col, label)
         if self.expression:
-            col = literal_column(self.expression, type_=type_)
+            tp = self.table.get_template_processor()
+            expression = tp.process_template(self.expression)
+            col = literal_column(expression, type_=type_)
         else:
             col = column(self.column_name, type_=type_)
         time_expr = self.db_engine_spec.get_timestamp_expr(

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -303,8 +303,10 @@ class TableColumn(Model, BaseColumn, CertificationMixin):
         return and_(*l)
 
     def get_timestamp_expression(
-        self, time_grain: Optional[str], label: Optional[str] = None,
-        template_processor: Optional[BaseTemplateProcessor] = None
+        self,
+        time_grain: Optional[str],
+        label: Optional[str] = None,
+        template_processor: Optional[BaseTemplateProcessor] = None,
     ) -> Union[TimestampExpression, Label]:
         """
         Return a SQLAlchemy Core element representation of self to be used in a query.
@@ -1096,7 +1098,8 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
                     outer = table_col.get_timestamp_expression(
                         time_grain=time_grain,
                         label=selected,
-                        template_processor=template_processor)
+                        template_processor=template_processor,
+                    )
                 # if groupby field equals a selected column
                 elif table_col:
                     outer = table_col.get_sqla_col()
@@ -1130,8 +1133,8 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
 
             if is_timeseries:
                 timestamp = dttm_col.get_timestamp_expression(
-                    time_grain=time_grain,
-                    template_processor=template_processor)
+                    time_grain=time_grain, template_processor=template_processor
+                )
                 # always put timestamp as the first column
                 select_exprs.insert(0, timestamp)
                 groupby_all_columns[timestamp.name] = timestamp
@@ -1197,8 +1200,8 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
             if col_obj:
                 if filter_grain:
                     sqla_col = col_obj.get_timestamp_expression(
-                        time_grain=filter_grain,
-                        template_processor=template_processor)
+                        time_grain=filter_grain, template_processor=template_processor
+                    )
                 else:
                     sqla_col = col_obj.get_sqla_col()
                 col_spec = db_engine_spec.get_column_spec(col_obj.type)

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -303,7 +303,8 @@ class TableColumn(Model, BaseColumn, CertificationMixin):
         return and_(*l)
 
     def get_timestamp_expression(
-        self, time_grain: Optional[str], label: Optional[str] = None
+        self, time_grain: Optional[str], label: Optional[str] = None,
+        template_processor: Optional[BaseTemplateProcessor] = None
     ) -> Union[TimestampExpression, Label]:
         """
         Return a SQLAlchemy Core element representation of self to be used in a query.
@@ -322,8 +323,9 @@ class TableColumn(Model, BaseColumn, CertificationMixin):
             sqla_col = column(self.column_name, type_=type_)
             return self.table.make_sqla_column_compatible(sqla_col, label)
         if self.expression:
-            tp = self.table.get_template_processor()
-            expression = tp.process_template(self.expression)
+            expression = self.expression
+            if template_processor:
+                expression = template_processor.process_template(self.expression)
             col = literal_column(expression, type_=type_)
         else:
             col = column(self.column_name, type_=type_)
@@ -1091,7 +1093,10 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
                 # if groupby field/expr equals granularity field/expr
                 table_col = columns_by_name.get(selected)
                 if table_col and table_col.type_generic == GenericDataType.TEMPORAL:
-                    outer = table_col.get_timestamp_expression(time_grain, selected)
+                    outer = table_col.get_timestamp_expression(
+                        time_grain=time_grain,
+                        label=selected,
+                        template_processor=template_processor)
                 # if groupby field equals a selected column
                 elif table_col:
                     outer = table_col.get_sqla_col()
@@ -1124,7 +1129,9 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
             time_filters = []
 
             if is_timeseries:
-                timestamp = dttm_col.get_timestamp_expression(time_grain)
+                timestamp = dttm_col.get_timestamp_expression(
+                    time_grain=time_grain,
+                    template_processor=template_processor)
                 # always put timestamp as the first column
                 select_exprs.insert(0, timestamp)
                 groupby_all_columns[timestamp.name] = timestamp
@@ -1189,7 +1196,9 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
 
             if col_obj:
                 if filter_grain:
-                    sqla_col = col_obj.get_timestamp_expression(filter_grain)
+                    sqla_col = col_obj.get_timestamp_expression(
+                        time_grain=filter_grain,
+                        template_processor=template_processor)
                 else:
                     sqla_col = col_obj.get_sqla_col()
                 col_spec = db_engine_spec.get_column_spec(col_obj.type)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fix the timestamp expression in sqla model.py, adding jinja template processor to it. 

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
```
diff --git a/docker/pythonpath_dev/superset_config.py b/docker/pythonpath_dev/superset_config.py
index 6c58bec79..83ebedca1 100644
--- a/docker/pythonpath_dev/superset_config.py
+++ b/docker/pythonpath_dev/superset_config.py
@@ -99,6 +99,15 @@ WEBDRIVER_BASEURL_USER_FRIENDLY = WEBDRIVER_BASEURL

 SQLLAB_CTAS_NO_LIMIT = True

+# Local env test
+FEATURE_FLAGS = {
+    "ENABLE_TEMPLATE_PROCESSING": True
+}
+
+JINJA_CONTEXT_ADDONS = {
+    'jinja_tmpl': 'date'
+}
+
```

Apply the above changes, run `docker build -t apache/superset:latest-dev .` and then use `docker-compose` to start the superset app. Go to localhost:8088 in browser and login to superset.

Go to dataset, find **cleaned_sales_data** and go to calculated columns, add a new item like this:
<img width="880" alt="Screen Shot 2021-10-26 at 12 23 30 PM" src="https://user-images.githubusercontent.com/33602700/138947191-34c89399-012d-4543-89a4-f550ddfba964.png">

Then go to the chart **Proportion of Revenue by Product Line**, choose the jinja_date as time column and run. The chart should works fine without error. View the query and the order_{{ jinja_tmpl }} is already replaced by "order_date".

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #16984
- [x] Required feature flags: `"ENABLE_TEMPLATE_PROCESSING": True`
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
