### PR TITLE
chore: Test cases for annotations and annotation layers incorrect creation through API

### DIFF
--- a/tests/integration_tests/annotation_layers/api_tests.py
+++ b/tests/integration_tests/annotation_layers/api_tests.py
@@ -230,6 +230,8 @@ class TestAnnotationLayerApi(SupersetTestCase):
         uri = "api/v1/annotation_layer/"
         rv = self.client.post(uri, json=annotation_layer_data)
         assert rv.status_code == 400
+        data = json.loads(rv.data.decode("utf-8"))
+        assert data == {"message": {"name": ["Missing data for required field."]}}
 
     @pytest.mark.usefixtures("create_annotation_layers")
     def test_create_annotation_layer_uniqueness(self):
@@ -256,14 +258,15 @@ class TestAnnotationLayerApi(SupersetTestCase):
         )
 
         self.login(username="admin")
-        annotation_layer_data = {"name": "changed_name", "descr": "changed_description"}
+        annotation_layer_data = {"name": "changed_name"}
         uri = f"api/v1/annotation_layer/{annotation_layer.id}"
         rv = self.client.put(uri, json=annotation_layer_data)
         assert rv.status_code == 200
         updated_model = db.session.query(AnnotationLayer).get(annotation_layer.id)
         assert updated_model is not None
         assert updated_model.name == annotation_layer_data["name"]
-        assert updated_model.descr == annotation_layer_data["descr"]
+        # make sure the descr hasn't updated
+        assert updated_model.descr == annotation_layer.descr
 
     @pytest.mark.usefixtures("create_annotation_layers")
     def test_update_annotation_layer_uniqueness(self):
@@ -541,12 +544,19 @@ class TestAnnotationLayerApi(SupersetTestCase):
 
         self.login(username="admin")
         annotation_data = {
-            "short_descr": "new",
             "long_descr": "description",
         }
         uri = f"api/v1/annotation_layer/{layer.id}/annotation/"
         rv = self.client.post(uri, json=annotation_data)
+        data = json.loads(rv.data.decode("utf-8"))
         assert rv.status_code == 400
+        assert data == {
+            "message": {
+                "end_dttm": ["Missing data for required field."],
+                "short_descr": ["Missing data for required field."],
+                "start_dttm": ["Missing data for required field."],
+            }
+        }
 
     @pytest.mark.usefixtures("create_annotation_layers")
     def test_create_annotation_uniqueness(self):
@@ -585,17 +595,42 @@ class TestAnnotationLayerApi(SupersetTestCase):
         )
 
         self.login(username="admin")
-        annotation_layer_data = {
+        annotation_data = {
             "short_descr": "changed_name",
-            "long_descr": "changed_description",
         }
         uri = f"api/v1/annotation_layer/{layer.id}/annotation/{annotation.id}"
-        rv = self.client.put(uri, json=annotation_layer_data)
+        rv = self.client.put(uri, json=annotation_data)
         assert rv.status_code == 200
         updated_model: Annotation = db.session.query(Annotation).get(annotation.id)
         assert updated_model is not None
-        assert updated_model.short_descr == annotation_layer_data["short_descr"]
-        assert updated_model.long_descr == annotation_layer_data["long_descr"]
+        assert updated_model.short_descr == annotation_data["short_descr"]
+        # make sure long_descr hasn't updated
+        assert updated_model.long_descr == annotation.long_descr
+
+    @pytest.mark.usefixtures("create_annotation_layers")
+    def test_update_annotation_null_datetime(self):
+        """
+        Annotation Api: Test update annotation null datetime
+        """
+        layer = self.get_layer_with_annotation()
+        annotation = (
+            db.session.query(Annotation)
+            .filter(Annotation.short_descr == "short_descr2")
+            .one_or_none()
+        )
+
+        self.login(username="admin")
+        annotation_data = {"start_dttm": None, "end_dttm": None}
+        uri = f"api/v1/annotation_layer/{layer.id}/annotation/{annotation.id}"
+        rv = self.client.put(uri, json=annotation_data)
+        assert rv.status_code == 400
+        data = json.loads(rv.data.decode("utf-8"))
+        assert data == {
+            "message": {
+                "end_dttm": ["Field may not be null."],
+                "start_dttm": ["Field may not be null."],
+            }
+        }
 
     @pytest.mark.usefixtures("create_annotation_layers")
     def test_update_annotation_uniqueness(self):

--- a/tests/integration_tests/annotation_layers/api_tests.py
+++ b/tests/integration_tests/annotation_layers/api_tests.py
@@ -31,6 +31,8 @@ from tests.integration_tests.annotation_layers.fixtures import (
     create_annotation_layers,
     get_end_dttm,
     get_start_dttm,
+)
+from tests.unit_tests.annotation_layers.fixtures import (
     START_STR,
     END_STR,
 )
@@ -197,7 +199,6 @@ class TestAnnotationLayerApi(SupersetTestCase):
         assert data["count"] == 1
         assert data["result"][0] == expected_result
 
-    @pytest.mark.usefixtures("create_annotation_layers")
     def test_create_annotation_layer(self):
         """
         Annotation Api: Test create annotation layer
@@ -219,6 +220,16 @@ class TestAnnotationLayerApi(SupersetTestCase):
         # Rollback changes
         db.session.delete(created_model)
         db.session.commit()
+
+    def test_create_incorrect_annotation_layer(self):
+        """
+        Annotation Api: Test create incorrect annotation layer
+        """
+        self.login(username="admin")
+        annotation_layer_data = {}
+        uri = "api/v1/annotation_layer/"
+        rv = self.client.post(uri, json=annotation_layer_data)
+        assert rv.status_code == 400
 
     @pytest.mark.usefixtures("create_annotation_layers")
     def test_create_annotation_layer_uniqueness(self):
@@ -520,6 +531,22 @@ class TestAnnotationLayerApi(SupersetTestCase):
         # Rollback changes
         db.session.delete(created_model)
         db.session.commit()
+
+    @pytest.mark.usefixtures("create_annotation_layers")
+    def test_create_incorrect_annotation(self):
+        """
+        Annotation Api: Test create incorrect annotation
+        """
+        layer = self.get_layer_with_annotation()
+
+        self.login(username="admin")
+        annotation_data = {
+            "short_descr": "new",
+            "long_descr": "description",
+        }
+        uri = f"api/v1/annotation_layer/{layer.id}/annotation/"
+        rv = self.client.post(uri, json=annotation_data)
+        assert rv.status_code == 400
 
     @pytest.mark.usefixtures("create_annotation_layers")
     def test_create_annotation_uniqueness(self):

--- a/tests/integration_tests/annotation_layers/fixtures.py
+++ b/tests/integration_tests/annotation_layers/fixtures.py
@@ -16,7 +16,6 @@
 # under the License.
 # isort:skip_file
 import pytest
-import dateutil.parser
 from datetime import datetime
 from typing import Optional
 
@@ -29,10 +28,6 @@ from tests.integration_tests.test_app import app
 
 ANNOTATION_LAYERS_COUNT = 10
 ANNOTATIONS_COUNT = 5
-START_STR = "2019-01-02T03:04:05.678900"
-END_STR = "2020-01-02T03:04:05.678900"
-START_DTTM = dateutil.parser.parse(START_STR)
-END_DTTM = dateutil.parser.parse(END_STR)
 
 
 def get_start_dttm(annotation_id: int) -> datetime:

--- a/tests/unit_tests/annotation_layers/fixtures.py
+++ b/tests/unit_tests/annotation_layers/fixtures.py
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# isort:skip_file
+import dateutil.parser
+
+
+START_STR = "2019-01-02T03:04:05.678900"
+END_STR = "2020-01-02T03:04:05.678900"
+START_DTTM = dateutil.parser.parse(START_STR)
+END_DTTM = dateutil.parser.parse(END_STR)

--- a/tests/unit_tests/annotation_layers/schema_tests.py
+++ b/tests/unit_tests/annotation_layers/schema_tests.py
@@ -33,44 +33,44 @@ from tests.unit_tests.annotation_layers.fixtures import (
 )
 
 
-def test_annotation_layer_post_schema_with_name():
+def test_annotation_layer_post_schema_with_name() -> None:
     result = AnnotationLayerPostSchema().load({"name": "foo"})
     assert result["name"] == "foo"
     assert "descr" not in result
 
 
-def test_annotation_layer_post_schema_with_name_and_descr():
+def test_annotation_layer_post_schema_with_name_and_descr() -> None:
     result = AnnotationLayerPostSchema().load({"name": "foo", "descr": "bar"})
     assert result["name"] == "foo"
     assert result["descr"] == "bar"
 
 
-def test_annotation_layer_post_schema_with_null_name():
+def test_annotation_layer_post_schema_with_null_name() -> None:
     with pytest.raises(ValidationError):
         AnnotationLayerPostSchema().load({"name": None})
 
 
-def test_annotation_layer_post_schema_empty():
+def test_annotation_layer_post_schema_empty() -> None:
     with pytest.raises(ValidationError):
         AnnotationLayerPostSchema().load({})
 
 
-def test_annotation_layer_put_schema_empty():
+def test_annotation_layer_put_schema_empty() -> None:
     result = AnnotationLayerPutSchema().load({})
     assert result == {}
 
 
-def test_annotation_layer_put_schema_with_null_name():
+def test_annotation_layer_put_schema_with_null_name() -> None:
     with pytest.raises(ValidationError):
         AnnotationLayerPutSchema().load({"name": None})
 
 
-def test_annotation_layer_put_schema_with_null_descr():
+def test_annotation_layer_put_schema_with_null_descr() -> None:
     with pytest.raises(ValidationError):
         AnnotationLayerPutSchema().load({"descr": None})
 
 
-def test_annotation_post_schema_basic():
+def test_annotation_post_schema_basic() -> None:
     result = AnnotationPostSchema().load(
         {"short_descr": "foo", "start_dttm": START_STR, "end_dttm": END_STR}
     )
@@ -79,7 +79,7 @@ def test_annotation_post_schema_basic():
     assert result["end_dttm"] == END_DTTM
 
 
-def test_annotation_post_schema_full():
+def test_annotation_post_schema_full() -> None:
     result = AnnotationPostSchema().load(
         {
             "short_descr": "foo",
@@ -96,62 +96,62 @@ def test_annotation_post_schema_full():
     assert result["json_metadata"] == '{"abc": 123}'
 
 
-def test_annotation_post_schema_short_descr_null():
+def test_annotation_post_schema_short_descr_null() -> None:
     with pytest.raises(ValidationError):
         AnnotationPostSchema().load(
             {"short_descr": None, "start_dttm": START_STR, "end_dttm": END_STR}
         )
 
 
-def test_annotation_post_schema_start_dttm_null():
+def test_annotation_post_schema_start_dttm_null() -> None:
     with pytest.raises(ValidationError):
         result = AnnotationPostSchema().load(
             {"short_descr": "foo", "start_dttm": None, "end_dttm": END_STR}
         )
 
 
-def test_annotation_post_schema_end_dttm_null():
+def test_annotation_post_schema_end_dttm_null() -> None:
     with pytest.raises(ValidationError):
         AnnotationPostSchema().load(
             {"short_descr": "foo", "start_dttm": START_STR, "end_dttm": None}
         )
 
 
-def test_annotation_put_schema_empty():
+def test_annotation_put_schema_empty() -> None:
     result = AnnotationPutSchema().load({})
     assert result == {}
 
 
-def test_annotation_put_schema_short_descr_null():
+def test_annotation_put_schema_short_descr_null() -> None:
     with pytest.raises(ValidationError):
         AnnotationPutSchema().load({"short_descr": None})
 
 
-def test_annotation_put_schema_start_dttm_null():
+def test_annotation_put_schema_start_dttm_null() -> None:
     with pytest.raises(ValidationError):
         AnnotationPutSchema().load({"start_dttm": None})
 
 
-def test_annotation_put_schema_end_dttm_null():
+def test_annotation_put_schema_end_dttm_null() -> None:
     with pytest.raises(ValidationError):
         AnnotationPutSchema().load({"end_dttm": None})
 
 
-def test_annotation_put_schema_json_metadata():
+def test_annotation_put_schema_json_metadata() -> None:
     result = AnnotationPutSchema().load({"json_metadata": '{"abc": 123}'})
     assert result["json_metadata"] == '{"abc": 123}'
 
 
-def test_annotation_put_schema_json_metadata_null():
+def test_annotation_put_schema_json_metadata_null() -> None:
     result = AnnotationPutSchema().load({"json_metadata": None})
     assert result["json_metadata"] is None
 
 
-def test_annotation_put_schema_json_metadata_empty():
+def test_annotation_put_schema_json_metadata_empty() -> None:
     result = AnnotationPutSchema().load({"json_metadata": ""})
     assert result["json_metadata"] == ""
 
 
-def test_annotation_put_schema_json_metadata_invalid():
+def test_annotation_put_schema_json_metadata_invalid() -> None:
     with pytest.raises(ValidationError):
         AnnotationPutSchema().load({"json_metadata": "foo bar"})

--- a/tests/unit_tests/annotation_layers/schema_tests.py
+++ b/tests/unit_tests/annotation_layers/schema_tests.py
@@ -25,7 +25,7 @@ from superset.annotation_layers.schemas import (
     AnnotationLayerPostSchema,
     AnnotationLayerPutSchema,
 )
-from tests.integration_tests.annotation_layers.fixtures import (
+from tests.unit_tests.annotation_layers.fixtures import (
     END_DTTM,
     END_STR,
     START_DTTM,


### PR DESCRIPTION
### SUMMARY
This is a follow-up PR based on this request https://github.com/apache/superset/pull/17234#pullrequestreview-790312401.

It moves the integration tests that work best as unit tests and adds test cases to cover the creation of incorrect annotations and annotation layers through the API

Thanks @villebro for guiding me through this!

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
