### PR TITLE
feat: add possibility to set ingress class name in Helm chart

### DIFF
--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
   - name: craig-rueda
     email: craig@craigrueda.com
     url: https://github.com/craig-rueda
-version: 0.3.11
+version: 0.3.12
 dependencies:
 - name: postgresql
   version: 10.2.0

--- a/helm/superset/templates/ingress.yaml
+++ b/helm/superset/templates/ingress.yaml
@@ -30,6 +30,9 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+{{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -165,6 +165,7 @@ service:
 
 ingress:
   enabled: false
+  # ingressClassName: nginx
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -167,7 +167,6 @@ ingress:
   enabled: false
   # ingressClassName: nginx
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     ## Extend timeout to allow long running queries.
     # nginx.ingress.kubernetes.io/proxy-connect-timeout: "300"


### PR DESCRIPTION
### SUMMARY
Adds the possibility to set ingress class name in Helm chart. See: #17085 

### ADDITIONAL INFORMATION
- [x] Has associated issue: #17085 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
