### PR TITLE
fix(sqllab): Bugfix for tracking url transformation

### DIFF
--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -363,7 +363,7 @@ class HiveEngineSpec(PrestoEngineSpec):
                             str(query_id),
                             tracking_url,
                         )
-                        tracking_url = current_app.config["TRACKING_URL_TRANSFORMER"]
+                        tracking_url = current_app.config["TRACKING_URL_TRANSFORMER"](tracking_url)
                         logger.info(
                             "Query %s: Transformation applied: %s",
                             str(query_id),

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -363,7 +363,8 @@ class HiveEngineSpec(PrestoEngineSpec):
                             str(query_id),
                             tracking_url,
                         )
-                        tracking_url = current_app.config["TRACKING_URL_TRANSFORMER"](tracking_url)
+                        transformer = current_app.config["TRACKING_URL_TRANSFORMER"]
+                        tracking_url = transformer(tracking_url)
                         logger.info(
                             "Query %s: Transformation applied: %s",
                             str(query_id),


### PR DESCRIPTION
### SUMMARY

This is a bugfix for #17262, review this issue for more information.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:
![image](https://user-images.githubusercontent.com/5211253/139176705-28aa4db9-f235-4835-9280-7326fb3737e0.png)

After:
![image](https://user-images.githubusercontent.com/5211253/139176917-734d3db2-43c2-4893-b725-f6d20dbc0086.png)

### TESTING INSTRUCTIONS

1. Create sample data table in Hive:
```
CREATE TABLE some_table(
    a INT,
    b STRING
);
INSERT INTO some_table(a, b) VALUES (1, '1'), (2, '2'), (3, '3'), (4, '4');
```
2. Execute query `SELECT a, COUNT(1) AS count FROM some_table GROUP BY a;`, it should not report error and return results

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #17262
- [ ] Required feature flags: no
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
