### PR TITLE
fix: Unable to select None for Alert's log retention

### DIFF
--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.test.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { render, screen, waitFor } from 'spec/helpers/testing-library';
+import userEvent from '@testing-library/user-event';
+import AlertReportModal from 'src/views/CRUD/alert/AlertReportModal';
+
+test('allows change to None in log retention', async () => {
+  render(<AlertReportModal show />, { useRedux: true });
+  // open the log retention select
+  userEvent.click(screen.getByText('90 days'));
+  // change it to 30 days
+  userEvent.click(await screen.findByText('30 days'));
+  // open again
+  userEvent.click(screen.getAllByText('30 days')[0]);
+  // change it to None
+  userEvent.click(await screen.findByText('None'));
+  // get the selected item
+  const selectedItem = await waitFor(() =>
+    screen
+      .getAllByLabelText('Log retention')[0]
+      .querySelector('.ant-select-selection-item'),
+  );
+  // check if None is selected
+  expect(selectedItem).toHaveTextContent('None');
+});

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -1220,7 +1220,11 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                   ariaLabel={t('Log retention')}
                   placeholder={t('Log retention')}
                   onChange={onLogRetentionChange}
-                  value={currentAlert?.log_retention || DEFAULT_RETENTION}
+                  value={
+                    typeof currentAlert?.log_retention === 'number'
+                      ? currentAlert?.log_retention
+                      : DEFAULT_RETENTION
+                  }
                   options={RETENTION_OPTIONS}
                   sortComparator={propertyComparator('value')}
                 />


### PR DESCRIPTION
### SUMMARY
There was a bug when changing log retention to None in the alerts modal. This PR fixes this bug.
This PR also creates a new test for this case in a new test file using RTL. Previous tests are written with Enzyme.

@rusackas @junlincc 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/139282367-afe92f6a-cc75-4eea-b58f-b03818af51cf.mov

https://user-images.githubusercontent.com/70410625/139282528-a89d3b39-ac5a-455e-bb64-ad321a75f9d2.mov

### TESTING INSTRUCTIONS
Check the videos for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
