### PR TITLE
fix(dashboard): Return columns and verbose_map for groupby values of Pivot Table v2 [ID-7]

### DIFF
--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -282,7 +282,9 @@ class BaseDatasource(
             "select_star": self.select_star,
         }
 
-    def data_for_slices(self, slices: List[Slice]) -> Dict[str, Any]:
+    def data_for_slices(  # pylint: disable=too-many-locals
+        self, slices: List[Slice]
+    ) -> Dict[str, Any]:
         """
         The representation of the datasource containing only the required data
         to render the provided slices.
@@ -651,7 +653,6 @@ class BaseColumn(AuditMixinNullable, ImportExportMixin):
 
 
 class BaseMetric(AuditMixinNullable, ImportExportMixin):
-
     """Interface for Metrics"""
 
     __tablename__: Optional[str] = None  # {connector_name}_metric

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -320,13 +320,13 @@ class BaseDatasource(
             )
 
             # legacy charts don't have query_context charts
-            if slc.query_context:
-                query_context = slc.get_query_context()
+            query_context = slc.get_query_context()
+            if query_context:
                 column_names.update(
                     [
                         column
-                        for query in query_context.get("queries", [])
-                        for column in query.get("columns", [])
+                        for query in query_context.queries
+                        for column in query.columns
                     ]
                     or []
                 )

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -51,6 +51,8 @@ COLUMN_FORM_DATA_PARAMS = [
     "columns",
     "entity",
     "groupby",
+    "groupbyRows",
+    "groupbyColumns",
     "order_by_cols",
     "series",
 ]

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -51,8 +51,6 @@ COLUMN_FORM_DATA_PARAMS = [
     "columns",
     "entity",
     "groupby",
-    "groupbyRows",
-    "groupbyColumns",
     "order_by_cols",
     "series",
 ]
@@ -319,11 +317,23 @@ class BaseDatasource(
                 if "column" in filter_config
             )
 
-            column_names.update(
-                column
-                for column_param in COLUMN_FORM_DATA_PARAMS
-                for column in utils.get_iterable(form_data.get(column_param) or [])
-            )
+            # legacy charts don't have query_context charts
+            if slc.query_context:
+                query_context = slc.get_query_context()
+                column_names.update(
+                    [
+                        column
+                        for query in query_context.get("queries", [])
+                        for column in query.get("columns", [])
+                    ]
+                    or []
+                )
+            else:
+                column_names.update(
+                    column
+                    for column_param in COLUMN_FORM_DATA_PARAMS
+                    for column in utils.get_iterable(form_data.get(column_param) or [])
+                )
 
         filtered_metrics = [
             metric

--- a/superset/examples/birth_names.py
+++ b/superset/examples/birth_names.py
@@ -180,6 +180,13 @@ def create_slices(
         "markup_type": "markdown",
     }
 
+    default_query_context = {
+        "result_format": "json",
+        "result_type": "full",
+        "datasource": {"id": tbl.id, "type": "table",},
+        "queries": [{"columns": [], "metrics": [],},],
+    }
+
     admin = get_admin_user()
     if admin_owner:
         slice_props = dict(
@@ -370,7 +377,8 @@ def create_slices(
                 metrics=[metric],
             ),
             query_context=get_slice_json(
-                {"queries": [{"columns": ["name", "state"], "metrics": [metric],}]}
+                default_query_context,
+                queries=[{"columns": ["name", "state"], "metrics": [metric],}],
             ),
         ),
     ]

--- a/superset/examples/birth_names.py
+++ b/superset/examples/birth_names.py
@@ -358,6 +358,21 @@ def create_slices(
                 metrics=metrics,
             ),
         ),
+        Slice(
+            **slice_props,
+            slice_name="Pivot Table v2",
+            viz_type="pivot_table_v2",
+            params=get_slice_json(
+                defaults,
+                viz_type="pivot_table_v2",
+                groupbyRows=["name"],
+                groupbyColumns=["state"],
+                metrics=[metric],
+            ),
+            query_context=get_slice_json(
+                {"queries": [{"columns": ["name", "state"], "metrics": [metric],}]}
+            ),
+        ),
     ]
     misc_slices = [
         Slice(

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -249,6 +249,7 @@ class Slice(  # pylint: disable=too-many-public-methods
         return form_data
 
     def get_query_context(self) -> Optional["QueryContext"]:
+        # pylint: disable=import-outside-toplevel
         from superset.common.query_context import QueryContext
 
         if self.query_context:

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -247,6 +247,17 @@ class Slice(  # pylint: disable=too-many-public-methods
         update_time_range(form_data)
         return form_data
 
+    def get_query_context(self) -> Dict[str, Any]:
+        query_context: Dict[str, Any] = {}
+        if not self.query_context:
+            return query_context
+        try:
+            query_context = json.loads(self.query_context)
+        except json.decoder.JSONDecodeError as ex:
+            logger.error("Malformed json in slice's query context", exc_info=True)
+            logger.exception(ex)
+        return query_context
+
     def get_explore_url(
         self,
         base_url: str = "/superset/explore",

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -40,6 +40,7 @@ from superset.utils.urls import get_url_path
 from superset.viz import BaseViz, viz_types
 
 if TYPE_CHECKING:
+    from superset.common.query_context import QueryContext
     from superset.connectors.base.models import BaseDatasource
 
 metadata = Model.metadata  # pylint: disable=no-member
@@ -247,16 +248,16 @@ class Slice(  # pylint: disable=too-many-public-methods
         update_time_range(form_data)
         return form_data
 
-    def get_query_context(self) -> Dict[str, Any]:
-        query_context: Dict[str, Any] = {}
-        if not self.query_context:
-            return query_context
-        try:
-            query_context = json.loads(self.query_context)
-        except json.decoder.JSONDecodeError as ex:
-            logger.error("Malformed json in slice's query context", exc_info=True)
-            logger.exception(ex)
-        return query_context
+    def get_query_context(self) -> Optional["QueryContext"]:
+        from superset.common.query_context import QueryContext
+
+        if self.query_context:
+            try:
+                return QueryContext(**json.loads(self.query_context))
+            except json.decoder.JSONDecodeError as ex:
+                logger.error("Malformed json in slice's query context", exc_info=True)
+                logger.exception(ex)
+        return None
 
     def get_explore_url(
         self,

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -786,7 +786,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         rv = self.get_assert_metric(uri, "get_list")
         self.assertEqual(rv.status_code, 200)
         data = json.loads(rv.data.decode("utf-8"))
-        self.assertEqual(data["count"], 33)
+        self.assertEqual(data["count"], 34)
 
     def test_get_charts_changed_on(self):
         """

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -1036,7 +1036,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         """
         Chart API: Test get charts filter
         """
-        # Assuming we have 33 sample charts
+        # Assuming we have 34 sample charts
         self.login(username="admin")
         arguments = {"page_size": 10, "page": 0}
         uri = f"api/v1/chart/?q={prison.dumps(arguments)}"
@@ -1050,7 +1050,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         rv = self.get_assert_metric(uri, "get_list")
         self.assertEqual(rv.status_code, 200)
         data = json.loads(rv.data.decode("utf-8"))
-        self.assertEqual(len(data["result"]), 3)
+        self.assertEqual(len(data["result"]), 4)
 
     def test_get_charts_no_data_access(self):
         """

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -1099,7 +1099,7 @@ class TestDatabaseApi(SupersetTestCase):
         rv = self.get_assert_metric(uri, "related_objects")
         self.assertEqual(rv.status_code, 200)
         response = json.loads(rv.data.decode("utf-8"))
-        self.assertEqual(response["charts"]["count"], 33)
+        self.assertEqual(response["charts"]["count"], 34)
         self.assertEqual(response["dashboards"]["count"], 3)
 
     def test_get_database_related_objects_not_found(self):

--- a/tests/integration_tests/model_tests.py
+++ b/tests/integration_tests/model_tests.py
@@ -518,7 +518,7 @@ class TestSqlaTableModel(SupersetTestCase):
         self.assertTrue("Metric 'invalid' does not exist", context.exception)
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
-    def test_data_for_slices(self):
+    def test_data_for_slices_with_no_query_context(self):
         tbl = self.get_table(name="birth_names")
         slc = (
             metadata_db.session.query(Slice)
@@ -532,9 +532,35 @@ class TestSqlaTableModel(SupersetTestCase):
         assert len(data_for_slices["columns"]) == 1
         assert data_for_slices["metrics"][0]["metric_name"] == "sum__num"
         assert data_for_slices["columns"][0]["column_name"] == "gender"
-        assert set(data_for_slices["verbose_map"].keys()) == set(
-            ["__timestamp", "sum__num", "gender",]
+        assert set(data_for_slices["verbose_map"].keys()) == {
+            "__timestamp",
+            "sum__num",
+            "gender",
+        }
+
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+    def test_data_for_slices_with_query_context(self):
+        tbl = self.get_table(name="birth_names")
+        slc = (
+            metadata_db.session.query(Slice)
+            .filter_by(
+                datasource_id=tbl.id,
+                datasource_type=tbl.type,
+                slice_name="Pivot Table v2",
+            )
+            .first()
         )
+        data_for_slices = tbl.data_for_slices([slc])
+        assert len(data_for_slices["metrics"]) == 1
+        assert len(data_for_slices["columns"]) == 2
+        assert data_for_slices["metrics"][0]["metric_name"] == "sum__num"
+        assert data_for_slices["columns"][0]["column_name"] == "name"
+        assert set(data_for_slices["verbose_map"].keys()) == {
+            "__timestamp",
+            "sum__num",
+            "name",
+            "state",
+        }
 
 
 def test_literal_dttm_type_factory():


### PR DESCRIPTION
### SUMMARY
Columns used by Pivot Table v2 were not processed correctly by `/dashboard/{id}/datasets` endpoint, resulting in chart not displaying custom column labels when added to dashboard. This PR fixes the issue.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://user-images.githubusercontent.com/15073128/139445984-64578d17-6809-43ad-a54f-0d55f43e5cee.png)

After:
![image](https://user-images.githubusercontent.com/15073128/139445573-f4beddbb-1628-400a-a97a-2001a1a4fd42.png)


### TESTING INSTRUCTIONS
1. Create a pivot table v2 chart using columns with custom labels
2. Add the chart to dashboard
3. Verify that custom labels are used instead of column_names

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @junlincc 