### PR TITLE
fix: Change 500 error to 422 in Sql Lab

### DIFF
--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -233,4 +233,4 @@ class InvalidPayloadSchemaError(SupersetErrorException):
 
 
 class SupersetCancelQueryException(SupersetException):
-    pass
+    status = 422

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2347,6 +2347,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         )
 
     @has_access_api
+    @handle_api_exception
     @expose("/stop_query/", methods=["POST"])
     @event_logger.log_this
     @backoff.on_exception(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
The stop query function is currently only enabled for certain databases and not others. Currently we are sending a 500 Error when a user hits the stop query button. This PR changes that to a 422 while we enable the feature for all databases. 


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![Screen Shot 2021-10-29 at 5 03 33 PM](https://user-images.githubusercontent.com/48933336/139501421-cfc16eda-24f0-4b0e-abce-93f4aff9b715.png)
### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Run a query in Athena (or anything not postgres or mysql)
hit the stop query button
check network tab. 
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
