### PR TITLE
fix: datatable crash when column is empty string [ID-59]

### DIFF
--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -135,7 +135,8 @@ export const useTableColumns = (
               key =>
                 ({
                   accessor: row => row[key],
-                  Header: key,
+                  // When the key is empty, have to give a string of length greater than 1
+                  Header: key || ' ',
                   Cell: ({ value }) => {
                     if (value === true) {
                       return BOOL_TRUE_DISPLAY;

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -135,7 +135,7 @@ export const useTableColumns = (
               key =>
                 ({
                   accessor: row => row[key],
-                  // When the key is empty, have to give a string of length greater than 1
+                  // When the key is empty, have to give a string of length greater than 0
                   Header: key || ' ',
                   Cell: ({ value }) => {
                     if (value === true) {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If a column contains an empty string(not a null value), then use the new time-series chart and open data pane will crash full page.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### after


https://user-images.githubusercontent.com/2016594/139668484-8bf57bcd-14f0-4cb1-9b1a-c1a0ce5d06fd.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
