### PR TITLE
test(sqllab): fix failed ctas tests due to missing schema

### DIFF
--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -490,6 +490,7 @@ class TestDatasetApi(SupersetTestCase):
             "message": {"table_name": ["Dataset energy_usage already exists"]}
         }
 
+    @pytest.mark.usefixtures("setup_ctas_schema")
     def test_create_dataset_same_name_different_schema(self):
         if backend() == "sqlite":
             # sqlite doesn't support schemas

--- a/tests/integration_tests/sqllab_tests.py
+++ b/tests/integration_tests/sqllab_tests.py
@@ -258,6 +258,7 @@ class TestSqlLab(SupersetTestCase):
         db.session.commit()
         self.assertLess(0, len(data["data"]))
 
+    @pytest.mark.usefixtures("setup_ctas_schema")
     def test_sql_json_schema_access(self):
         examples_db = get_example_database()
         db_backend = examples_db.backend


### PR DESCRIPTION
Added a new fixture that creates and remove the required schema 