### PR TITLE
docs: fix numbering on getting started with kubernetes section

### DIFF
--- a/docs/src/pages/docs/installation/kubernetes.mdx
+++ b/docs/src/pages/docs/installation/kubernetes.mdx
@@ -24,14 +24,14 @@ helm repo add superset https://apache.github.io/superset
 "superset" has been added to your repositories
 ```
 
-1. View charts in repo
+2. View charts in repo
 ```sh
 helm search repo superset
 NAME                    CHART VERSION   APP VERSION     DESCRIPTION
 superset/superset       0.1.1           1.0             Apache Superset is a modern, enterprise-ready b...
 ```
 
-1. Configure your setting overrides
+3. Configure your setting overrides
 
 Just like any typical Helm chart, you'll need to craft a `values.yaml` file that would define/override any of the values exposed into the default [values.yaml](https://github.com/apache/superset/tree/master/helm/superset/values.yaml), or from any of the dependent charts it depends on:
 
@@ -40,7 +40,7 @@ Just like any typical Helm chart, you'll need to craft a `values.yaml` file that
 
 More info down below on some important overrides you might need.
 
-1. Install and run
+4. Install and run
 
 ```sh
 helm upgrade --install --values my-values.yaml superset superset/superset


### PR DESCRIPTION
Signed-off-by: jameskim0987 <kgh475926@gmail.com>

### SUMMARY
Currently, the numbering of the initial 4 steps on https://superset.apache.org/docs/installation/running-on-kubernetes are all numbered 1. This PR will fix the number from 1,1,1,1 to 1,2,3,4

### TESTING INSTRUCTIONS
Check manually

### ADDITIONAL INFORMATION
N/A