### PR TITLE
fix: run npm install to fix a bad package version

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -87,7 +87,7 @@
         "query-string": "^6.13.7",
         "re-resizable": "^6.6.1",
         "react": "^16.13.1",
-        "react-ace": "^9.9.4",
+        "react-ace": "^9.4.4",
         "react-checkbox-tree": "^1.5.1",
         "react-color": "^2.13.8",
         "react-datetime": "^3.0.4",
@@ -15643,6 +15643,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ace-builds": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.4.13.tgz",
+      "integrity": "sha512-SOLzdaQkY6ecPKYRDDg+MY1WoGgXA34cIvYJNNoBMGGUswHmlauU2Hy0UL96vW0Fs/LgFbMUjD+6vqzWTldIYQ=="
+    },
     "node_modules/acorn": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
@@ -22157,6 +22162,11 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="
     },
     "node_modules/diff-sequences": {
       "version": "26.6.2",
@@ -35716,18 +35726,19 @@
       }
     },
     "node_modules/react-ace": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-5.10.0.tgz",
-      "integrity": "sha512-aEK/XZCowP8IXq91e2DYqOtGhabk1bbjt+fyeW0UBcIkzDzP/RX/MeJKeyW7wsZcwElACVwyy9nnwXBTqgky3A==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-9.5.0.tgz",
+      "integrity": "sha512-4l5FgwGh6K7A0yWVMQlPIXDItM4Q9zzXRqOae8KkCl6MkOob7sC1CzHxZdOGvV+QioKWbX2p5HcdOVUv6cAdSg==",
       "dependencies": {
-        "brace": "^0.11.0",
+        "ace-builds": "^1.4.13",
+        "diff-match-patch": "^1.0.5",
         "lodash.get": "^4.4.2",
-        "lodash.isequal": "^4.1.1",
-        "prop-types": "^15.5.8"
+        "lodash.isequal": "^4.5.0",
+        "prop-types": "^15.7.2"
       },
       "peerDependencies": {
-        "react": "^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0",
-        "react-dom": "^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0"
+        "react": "^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0",
+        "react-dom": "^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/react-base16-styling": {
@@ -56312,6 +56323,11 @@
         "negotiator": "0.6.1"
       }
     },
+    "ace-builds": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.4.13.tgz",
+      "integrity": "sha512-SOLzdaQkY6ecPKYRDDg+MY1WoGgXA34cIvYJNNoBMGGUswHmlauU2Hy0UL96vW0Fs/LgFbMUjD+6vqzWTldIYQ=="
+    },
     "acorn": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
@@ -61408,6 +61424,11 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
+    },
+    "diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="
     },
     "diff-sequences": {
       "version": "26.6.2",
@@ -72156,14 +72177,15 @@
       }
     },
     "react-ace": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-5.10.0.tgz",
-      "integrity": "sha512-aEK/XZCowP8IXq91e2DYqOtGhabk1bbjt+fyeW0UBcIkzDzP/RX/MeJKeyW7wsZcwElACVwyy9nnwXBTqgky3A==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-9.5.0.tgz",
+      "integrity": "sha512-4l5FgwGh6K7A0yWVMQlPIXDItM4Q9zzXRqOae8KkCl6MkOob7sC1CzHxZdOGvV+QioKWbX2p5HcdOVUv6cAdSg==",
       "requires": {
-        "brace": "^0.11.0",
+        "ace-builds": "^1.4.13",
+        "diff-match-patch": "^1.0.5",
         "lodash.get": "^4.4.2",
-        "lodash.isequal": "^4.1.1",
-        "prop-types": "^15.5.8"
+        "lodash.isequal": "^4.5.0",
+        "prop-types": "^15.7.2"
       }
     },
     "react-base16-styling": {


### PR DESCRIPTION
### SUMMARY
`npm ci` was breaking in some cases because there was a difference in the version of the required packages of react-ace in the package-lock.json file. 

### TESTING INSTRUCTIONS
Builds should work properly, and ace editors should still work

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
