### PR TITLE
fix(core): memory leak in memorized decorator

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -372,7 +372,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         cls,
         database: "Database",
         schema: Optional[str] = None,
-        source: Optional[str] = None,
+        source: Optional[utils.QuerySource] = None,
     ) -> Engine:
         user_name = utils.get_username()
         return database.get_sqla_engine(
@@ -1144,7 +1144,11 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
 
     @classmethod
     def estimate_query_cost(
-        cls, database: "Database", schema: str, sql: str, source: Optional[str] = None
+        cls,
+        database: "Database",
+        schema: str,
+        sql: str,
+        source: Optional[utils.QuerySource] = None,
     ) -> List[Dict[str, Any]]:
         """
         Estimate the cost of a multiple statement SQL query.

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -350,6 +350,29 @@ class Database(
         user_name: Optional[str] = None,
         source: Optional[utils.QuerySource] = None,
     ) -> Engine:
+        cache_key = (
+            f"{self.impersonate_user}"
+            f"{self.sqlalchemy_uri_decrypted}"
+            f"{json.dumps(self.get_extra())}"
+        )
+        return self._get_sqla_engine(
+            schema=schema,
+            nullpool=nullpool,
+            user_name=user_name,
+            source=source,
+            residual_cache_key=cache_key,
+        )
+
+    # pylint: disable=too-many-arguments,unused-argument
+    @memoized
+    def _get_sqla_engine(
+        self,
+        schema: Optional[str] = None,
+        nullpool: bool = True,
+        user_name: Optional[str] = None,
+        source: Optional[utils.QuerySource] = None,
+        residual_cache_key: Optional[str] = None,
+    ) -> Engine:
         extra = self.get_extra()
         sqlalchemy_url = make_url(self.sqlalchemy_uri_decrypted)
         self.db_engine_spec.adjust_database_uri(sqlalchemy_url, schema)

--- a/tests/unit_tests/memoized_tests.py
+++ b/tests/unit_tests/memoized_tests.py
@@ -14,26 +14,23 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import time
 
 from pytest import mark
 
-from superset.utils.memoized import memoized
+from superset.utils.memoized import _memoized, memoized
 
 
 @mark.unittest
 class TestMemoized:
     def test_memoized_on_functions(self):
-        watcher = {"val": 0}
-
         @memoized
         def test_function(a, b, c):
-            watcher["val"] += 1
-            return a * b * c
+            return {"key": a + b + c}
 
         result1 = test_function(1, 2, 3)
         result2 = test_function(1, 2, 3)
-        assert result1 == result2
-        assert watcher["val"] == 1
+        assert result1 is result2
 
     def test_memoized_on_methods(self):
         class test_class:
@@ -49,48 +46,35 @@ class TestMemoized:
         instance = test_class(5)
         result1 = instance.test_method(1, 2, 3)
         result2 = instance.test_method(1, 2, 3)
-        assert result1 == result2
+        assert result1 is result2
         assert instance.watcher == 1
         instance.num = 10
         assert result2 == instance.test_method(1, 2, 3)
 
-    def test_memoized_on_methods_with_watches(self):
-        class test_class:
-            def __init__(self, x, y):
-                self.x = x
-                self.y = y
-                self.watcher = 0
+    def test_memorized_size(self):
+        new_memoized = _memoized(maxsize=1)
 
-            @memoized(watch=("x", "y"))
-            def test_method(self, a, b, c):
-                self.watcher += 1
-                return a * b * c * self.x * self.y
+        @new_memoized
+        def test_add(a, b):
+            # return a reference type instead of primal type
+            return {"key": a + b}
 
-        instance = test_class(3, 12)
-        result1 = instance.test_method(1, 2, 3)
-        result2 = instance.test_method(1, 2, 3)
-        assert result1 == result2
-        assert instance.watcher == 1
-        result3 = instance.test_method(2, 3, 4)
-        assert instance.watcher == 2
-        result4 = instance.test_method(2, 3, 4)
-        assert instance.watcher == 2
-        assert result3 == result4
-        assert result3 != result1
-        instance.x = 1
-        result5 = instance.test_method(2, 3, 4)
-        assert instance.watcher == 3
-        assert result5 != result4
-        result6 = instance.test_method(2, 3, 4)
-        assert instance.watcher == 3
-        assert result6 == result5
-        instance.x = 10
-        instance.y = 10
-        result7 = instance.test_method(2, 3, 4)
-        assert instance.watcher == 4
-        assert result7 != result6
-        instance.x = 3
-        instance.y = 12
-        result8 = instance.test_method(1, 2, 3)
-        assert instance.watcher == 4
-        assert result1 == result8
+        result1 = test_add(1, 2)
+        # clear cache
+        test_add(2, 3)
+        result2 = test_add(1, 2)
+        assert result1 is not result2
+
+    def test_memorized_expire(self):
+        new_memoized = _memoized(seconds=1)
+
+        @new_memoized
+        def test_add(a, b):
+            # return a reference type instead of primal type
+            return {"key": a + b}
+
+        result1 = test_add(1, 2)
+        # clear cache
+        time.sleep(2)
+        result2 = test_add(1, 2)
+        assert result1 is not result2


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
closes: https://github.com/apache/superset/issues/15132
Currently, we use `@memorized` decorator to cache function results in memory. Obviously, the original decorator does not consider:
1. how to release memory in the application process
2. how to define cache size

In this PR:
1. I used a simple`functools.lru_cache` wrapper replaced with original `memorized`.
2. ~~I used `memoized_func` replaced with `memoized` when need to define a custom cache key.~~ pickle cannot serialize SQLAlchemy engine object, raise an error ```TypeError: can't pickle _thread._local objects```, so we we can't use memoized_func to cache this function
3. because `functools.lru_cache` can't support customized cache-key, add a minor proxy function to delegate `get_sqla_engine` function 


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/15132
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
