### PR TITLE
feat: improve logic in is_select

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -146,6 +146,10 @@ class ParsedQuery:
         ):
             return False
 
+        # return false on `EXPLAIN`, `SET`, `SHOW`, etc.
+        if parsed[0][0].ttype == Keyword:
+            return False
+
         return any(
             token.ttype == DML and token.value == "SELECT" for token in parsed[0]
         )
@@ -165,7 +169,7 @@ class ParsedQuery:
         )
 
         # Explain statements will only be the first statement
-        return statements_without_comments.startswith("EXPLAIN")
+        return statements_without_comments.upper().startswith("EXPLAIN")
 
     def is_show(self) -> bool:
         # Remove comments

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -15,10 +15,17 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# pylint: disable=invalid-name
+
+import sqlparse
+
 from superset.sql_parse import ParsedQuery
 
 
-def test_cte_with_comments():
+def test_cte_with_comments_is_select():
+    """
+    Some CTES with comments are not correctly identified as SELECTS.
+    """
     sql = ParsedQuery(
         """WITH blah AS
   (SELECT * FROM core_dev.manager_team),
@@ -44,3 +51,43 @@ SELECT * FROM blah
 INNER JOIN blah2 ON blah2.team_id = blah.team_id"""
     )
     assert sql.is_select()
+
+
+def test_cte_is_select():
+    """
+    Some CTEs are not correctly identified as SELECTS.
+    """
+    # `AS(` gets parsed as a function
+    sql = ParsedQuery(
+        """WITH foo AS(
+SELECT
+  FLOOR(__time TO WEEK) AS "week",
+  name,
+  COUNT(DISTINCT user_id) AS "unique_users"
+FROM "druid"."my_table"
+GROUP BY 1,2
+)
+SELECT
+  f.week,
+  f.name,
+  f.unique_users
+FROM foo f"""
+    )
+    assert sql.is_select()
+
+
+def test_unknown_select():
+    """
+    Test that `is_select` works when sqlparse fails to identify the type.
+    """
+    sql = "WITH foo AS(SELECT 1) SELECT 1"
+    assert sqlparse.parse(sql)[0].get_type() == "UNKNOWN"
+    assert ParsedQuery(sql).is_select()
+
+    sql = "WITH foo AS(SELECT 1) INSERT INTO my_table (a) VALUES (1)"
+    assert sqlparse.parse(sql)[0].get_type() == "UNKNOWN"
+    assert not ParsedQuery(sql).is_select()
+
+    sql = "WITH foo AS(SELECT 1) DELETE FROM my_table"
+    assert sqlparse.parse(sql)[0].get_type() == "UNKNOWN"
+    assert not ParsedQuery(sql).is_select()


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

`sqlparse` fails to identify this query as a `SELECT`:

```sql
WITH foo AS(
SELECT
  FLOOR(__time TO WEEK) AS "week",
  name,
  COUNT(DISTINCT user_id) AS "unique_users"
FROM "druid"."my_table"
GROUP BY 1,2
)
SELECT
  f.week,
  f.name,
  f.unique_users
FROM foo f
```

This happens because `AS(` (no space) is identified as a function, and because of that the statement has type "UKNOWN".

I improved the logic in `is_select` so that when the token is "UNKNOWN" we check for DDL and DML, returning true only if there's no DDL and the only DML is a `SELECT`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

I added unit tests covering the bug and a few more.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
