### PR TITLE
fix: import should accept old keys

### DIFF
--- a/superset/databases/commands/export.py
+++ b/superset/databases/commands/export.py
@@ -39,11 +39,11 @@ def parse_extra(extra_payload: str) -> Dict[str, Any]:
         logger.info("Unable to decode `extra` field: %s", extra_payload)
         return {}
 
-    # Fix for DBs saved with an invalid ``schemas_allowed_for_file_upload``
-    schemas_allowed_for_file_upload = extra.get("schemas_allowed_for_file_upload")
-    if isinstance(schemas_allowed_for_file_upload, str):
-        extra["schemas_allowed_for_file_upload"] = json.loads(
-            schemas_allowed_for_file_upload
+    # Fix for DBs saved with an invalid ``schemas_allowed_for_csv_upload``
+    schemas_allowed_for_csv_upload = extra.get("schemas_allowed_for_csv_upload")
+    if isinstance(schemas_allowed_for_csv_upload, str):
+        extra["schemas_allowed_for_csv_upload"] = json.loads(
+            schemas_allowed_for_csv_upload
         )
 
     return extra
@@ -65,10 +65,25 @@ class ExportDatabasesCommand(ExportModelsCommand):
             include_defaults=True,
             export_uuids=True,
         )
+
+        # https://github.com/apache/superset/pull/16756 renamed ``allow_csv_upload``
+        # to ``allow_file_upload`, but we can't change the V1 schema
+        replacements = {"allow_file_upload": "allow_csv_upload"}
+        # this preserves key order, which is important
+        payload = {replacements.get(key, key): value for key, value in payload.items()}
+
         # TODO (betodealmeida): move this logic to export_to_dict once this
         # becomes the default export endpoint
         if payload.get("extra"):
-            payload["extra"] = parse_extra(payload["extra"])
+            extra = payload["extra"] = parse_extra(payload["extra"])
+
+            # ``schemas_allowed_for_csv_upload`` was also renamed to
+            # ``schemas_allowed_for_file_upload``, we need to change to preserve the
+            # V1 schema
+            if "schemas_allowed_for_file_upload" in extra:
+                extra["schemas_allowed_for_csv_upload"] = extra.pop(
+                    "schemas_allowed_for_file_upload"
+                )
 
         payload["version"] = EXPORT_VERSION
 

--- a/superset/databases/commands/importers/v1/utils.py
+++ b/superset/databases/commands/importers/v1/utils.py
@@ -32,6 +32,13 @@ def import_database(
             return existing
         config["id"] = existing.id
 
+    # https://github.com/apache/superset/pull/16756 renamed ``csv`` to ``file``.
+    config["allow_file_upload"] = config.pop("allow_csv_upload")
+    if "schemas_allowed_for_csv_upload" in config["extra"]:
+        config["extra"]["schemas_allowed_for_file_upload"] = config["extra"].pop(
+            "schemas_allowed_for_csv_upload"
+        )
+
     # TODO (betodealmeida): move this logic to import_from_dict
     config["extra"] = json.dumps(config["extra"])
 

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -587,6 +587,7 @@ class ImportV1DatabaseExtraSchema(Schema):
 
 
 class ImportV1DatabaseSchema(Schema):
+    # pylint: disable=no-self-use, unused-argument
     @pre_load
     def fix_allow_file_upload(
         self, data: Dict[str, Any], **kwargs: Any

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -558,23 +558,23 @@ class ImportV1DatabaseExtraSchema(Schema):
         self, data: Dict[str, Any], **kwargs: Any
     ) -> Dict[str, Any]:
         """
-        Fixes for ``schemas_allowed_for_file_upload``.
+        Fixes for ``schemas_allowed_for_csv_upload``.
         """
-        # Fix for https://github.com/apache/superset/pull/16756.
-        # The PR changed the V1 schema. We need to support old fields for backwards
-        # compatibility.
-        if "schemas_allowed_for_csv_upload" in data:
-            data["schemas_allowed_for_file_upload"] = data.pop(
-                "schemas_allowed_for_csv_upload"
+        # Fix for https://github.com/apache/superset/pull/16756, which temporarily
+        # changed the V1 schema. We need to support exports made after that PR and
+        # before this PR.
+        if "schemas_allowed_for_file_upload" in data:
+            data["schemas_allowed_for_csv_upload"] = data.pop(
+                "schemas_allowed_for_file_upload"
             )
 
-        # Fix ``schemas_allowed_for_file_upload`` being a string.
+        # Fix ``schemas_allowed_for_csv_upload`` being a string.
         # Due to a bug in the database modal, some databases might have been
-        # saved and exported with a string for ``schemas_allowed_for_file_upload``.
-        schemas_allowed_for_file_upload = data.get("schemas_allowed_for_file_upload")
-        if isinstance(schemas_allowed_for_file_upload, str):
-            data["schemas_allowed_for_file_upload"] = json.loads(
-                schemas_allowed_for_file_upload
+        # saved and exported with a string for ``schemas_allowed_for_csv_upload``.
+        schemas_allowed_for_csv_upload = data.get("schemas_allowed_for_csv_upload")
+        if isinstance(schemas_allowed_for_csv_upload, str):
+            data["schemas_allowed_for_csv_upload"] = json.loads(
+                schemas_allowed_for_csv_upload
             )
 
         return data
@@ -582,24 +582,24 @@ class ImportV1DatabaseExtraSchema(Schema):
     metadata_params = fields.Dict(keys=fields.Str(), values=fields.Raw())
     engine_params = fields.Dict(keys=fields.Str(), values=fields.Raw())
     metadata_cache_timeout = fields.Dict(keys=fields.Str(), values=fields.Integer())
-    schemas_allowed_for_file_upload = fields.List(fields.String())
+    schemas_allowed_for_csv_upload = fields.List(fields.String())
     cost_estimate_enabled = fields.Boolean()
 
 
 class ImportV1DatabaseSchema(Schema):
     # pylint: disable=no-self-use, unused-argument
     @pre_load
-    def fix_allow_file_upload(
+    def fix_allow_csv_upload(
         self, data: Dict[str, Any], **kwargs: Any
     ) -> Dict[str, Any]:
         """
-        Fixes for ``allow_file_upload`` and ``schemas_allowed_for_file_upload``.
+        Fix for ``allow_csv_upload`` .
         """
-        # Fix for https://github.com/apache/superset/pull/16756.
-        # The PR changed the V1 schema. We need to support old fields for backwards
-        # compatibility.
-        if "allow_csv_upload" in data:
-            data["allow_file_upload"] = data.pop("allow_csv_upload")
+        # Fix for https://github.com/apache/superset/pull/16756, which temporarily
+        # changed the V1 schema. We need to support exports made after that PR and
+        # before this PR.
+        if "allow_file_upload" in data:
+            data["allow_csv_upload"] = data.pop("allow_file_upload")
 
         return data
 
@@ -611,7 +611,7 @@ class ImportV1DatabaseSchema(Schema):
     allow_run_async = fields.Boolean()
     allow_ctas = fields.Boolean()
     allow_cvas = fields.Boolean()
-    allow_file_upload = fields.Boolean()
+    allow_csv_upload = fields.Boolean()
     extra = fields.Nested(ImportV1DatabaseExtraSchema)
     uuid = fields.UUID(required=True)
     version = fields.String(required=True)

--- a/tests/integration_tests/databases/commands_tests.py
+++ b/tests/integration_tests/databases/commands_tests.py
@@ -107,7 +107,7 @@ class TestExportDatabasesCommand(SupersetTestCase):
         metadata = yaml.safe_load(contents["databases/examples.yaml"])
         assert metadata == (
             {
-                "allow_file_upload": True,
+                "allow_csv_upload": True,
                 "allow_ctas": True,
                 "allow_cvas": True,
                 "allow_run_async": False,
@@ -305,7 +305,7 @@ class TestExportDatabasesCommand(SupersetTestCase):
             "allow_run_async",
             "allow_ctas",
             "allow_cvas",
-            "allow_file_upload",
+            "allow_csv_upload",
             "extra",
             "uuid",
             "version",
@@ -338,17 +338,21 @@ class TestImportDatabasesCommand(SupersetTestCase):
         db.session.delete(database)
         db.session.commit()
 
-    def test_import_v1_database_old_csv_fields(self):
+    def test_import_v1_database_broken_csv_fields(self):
         """
-        Test that a database can be imported with the old csv fields.
+        Test that a database can be imported with broken schema.
+
+        https://github.com/apache/superset/pull/16756 renamed some fields, changing
+        the V1 schema. This test ensures that we can import databases that were
+        exported with the broken schema.
         """
-        old_config = database_config.copy()
-        old_config["allow_csv_upload"] = old_config.pop("allow_file_upload")
-        old_config["extra"] = {"schemas_allowed_for_csv_upload": ["upload"]}
+        broken_config = database_config.copy()
+        broken_config["allow_file_upload"] = broken_config.pop("allow_csv_upload")
+        broken_config["extra"] = {"schemas_allowed_for_file_upload": ["upload"]}
 
         contents = {
             "metadata.yaml": yaml.safe_dump(database_metadata_config),
-            "databases/imported_database.yaml": yaml.safe_dump(old_config),
+            "databases/imported_database.yaml": yaml.safe_dump(broken_config),
         }
         command = ImportDatabasesCommand(contents)
         command.run()
@@ -390,7 +394,7 @@ class TestImportDatabasesCommand(SupersetTestCase):
 
         # update allow_file_upload to False
         new_config = database_config.copy()
-        new_config["allow_file_upload"] = False
+        new_config["allow_csv_upload"] = False
         contents = {
             "databases/imported_database.yaml": yaml.safe_dump(new_config),
             "metadata.yaml": yaml.safe_dump(database_metadata_config),

--- a/tests/integration_tests/fixtures/importexport.py
+++ b/tests/integration_tests/fixtures/importexport.py
@@ -347,7 +347,7 @@ saved_queries_metadata_config: Dict[str, Any] = {
     "timestamp": "2021-03-30T20:37:54.791187+00:00",
 }
 database_config: Dict[str, Any] = {
-    "allow_file_upload": True,
+    "allow_csv_upload": True,
     "allow_ctas": True,
     "allow_cvas": True,
     "allow_run_async": False,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

https://github.com/apache/superset/pull/16756/ renamed a few fields on a versioned schema, breaking import/export, since old exports are no longer valid.

I reverted the schema to the original V1, and fixed export to produce the original schema. I also fixed the import to support the new keys, since exports might've been made with the incorrect schema.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Added unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
