### PR TITLE
feat: apply d3NumberFormat to table reports

### DIFF
--- a/superset/charts/post_processing.py
+++ b/superset/charts/post_processing.py
@@ -262,9 +262,28 @@ def pivot_table(df: pd.DataFrame, form_data: Dict[str, Any]) -> pd.DataFrame:
     )
 
 
+def table(df: pd.DataFrame, form_data: Dict[str, Any]) -> pd.DataFrame:
+    """
+    Table.
+    """
+    # apply `d3NumberFormat` to columns, if present
+    column_config = form_data.get("column_config", {})
+    for column, config in column_config.items():
+        if "d3NumberFormat" in config:
+            format_ = "{:" + config["d3NumberFormat"] + "}"
+            try:
+                df[column] = df[column].apply(format_.format)
+            except Exception:  # pylint: disable=broad-except
+                # if we can't format the column for any reason, send as is
+                pass
+
+    return df
+
+
 post_processors = {
     "pivot_table": pivot_table,
     "pivot_table_v2": pivot_table_v2,
+    "table": table,
 }
 
 

--- a/tests/unit_tests/charts/test_post_processing.py
+++ b/tests/unit_tests/charts/test_post_processing.py
@@ -17,7 +17,7 @@
 
 import pandas as pd
 
-from superset.charts.post_processing import pivot_df
+from superset.charts.post_processing import pivot_df, table
 
 
 def test_pivot_df_no_cols_no_rows_single_metric():
@@ -684,7 +684,6 @@ def test_pivot_df_complex():
         show_columns_total=True,
         apply_metrics_on_rows=True,
     )
-    print(pivoted.to_markdown())
     assert (
         pivoted.to_markdown()
         == """
@@ -727,5 +726,58 @@ def test_pivot_df_complex():
 | ('girl', 'Sophia')                         |            0.151002  |            0.178206  |            0.297745  |            0.3538    |
 | ('girl', 'Subtotal')                       |            0.719317  |            0.700516  |            0.783939  |            0.810432  |
 | ('Total (Sum as Fraction of Columns)', '') |            1         |            1         |            1         |            1         |
+    """.strip()
+    )
+
+
+def test_table():
+    """
+    Test that the table reports honor `d3NumberFormat`.
+    """
+    df = pd.DataFrame.from_dict({"count": {0: 80679663}})
+    form_data = {
+        "adhoc_filters": [
+            {
+                "clause": "WHERE",
+                "comparator": "NULL",
+                "expressionType": "SIMPLE",
+                "filterOptionName": "filter_ameaka2efjv_rfv1et5nwng",
+                "isExtra": False,
+                "isNew": False,
+                "operator": "!=",
+                "sqlExpression": None,
+                "subject": "lang_at_home",
+            }
+        ],
+        "all_columns": [],
+        "color_pn": True,
+        "column_config": {"count": {"d3NumberFormat": ",d"}},
+        "conditional_formatting": [],
+        "datasource": "8__table",
+        "extra_form_data": {},
+        "granularity_sqla": "time_start",
+        "groupby": ["lang_at_home"],
+        "metrics": ["count"],
+        "order_by_cols": [],
+        "order_desc": True,
+        "percent_metrics": [],
+        "query_mode": "aggregate",
+        "row_limit": "15",
+        "server_page_length": 10,
+        "show_cell_bars": True,
+        "table_timestamp_format": "smart_date",
+        "time_grain_sqla": "P1D",
+        "time_range": "No filter",
+        "time_range_endpoints": ["inclusive", "exclusive"],
+        "url_params": {},
+        "viz_type": "table",
+    }
+    formatted = table(df, form_data)
+    assert (
+        formatted.to_markdown()
+        == """
+|    | count      |
+|---:|:-----------|
+|  0 | 80,679,663 |
     """.strip()
     )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When sending the screenshot of a table in a report we should honor `d3NumberFormat` on columns.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

The chart:

<img width="1268" alt="Screen Shot 2021-11-03 at 9 59 11 AM" src="https://user-images.githubusercontent.com/1534870/140118026-648ea71f-07e6-43d6-9c19-91dc436a3776.png">

The report, before:

![Screenshot 2021-11-03 at 10-07-44  Report  ch27613 ch27613b - ralmeida gmail com - Gmail](https://user-images.githubusercontent.com/1534870/140129578-bfc99e51-8038-4fc0-8a6f-eb3de7b360d4.png)

The report, after:

![Screenshot 2021-11-03 at 10-08-17  Report  ch27613 ch27613b - ralmeida gmail com - Gmail](https://user-images.githubusercontent.com/1534870/140130127-bfaff429-5e35-494e-a5f5-55d72de11fa5.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Create a table chart, go to customize, and set a column's "d3 format" to `,d`.
2. Create a report.
3. Check that format matches (comma separated groups of thousands, in this case).

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
