### PR TITLE
fix: add fallback and validation for report and cron timezones

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -420,7 +420,7 @@ For example, the image referenced above actually lives in `superset-frontend/src
 
 #### OS Dependencies
 
-Make sure your machine meets the [OS dependencies](https://superset.apache.org/docs/installation/installing-superset-from-scratch#os-dependencies) before following these steps.  
+Make sure your machine meets the [OS dependencies](https://superset.apache.org/docs/installation/installing-superset-from-scratch#os-dependencies) before following these steps.
 You also need to install MySQL or [MariaDB](https://mariadb.com/downloads).
 
 Ensure that you are using Python version 3.7 or 3.8, then proceed with:
@@ -523,6 +523,7 @@ Frontend assets (TypeScript, JavaScript, CSS, and images) must be compiled in or
 ##### nvm and node
 
 First, be sure you are using the following versions of Node.js and npm:
+
 - `Node.js`: Version 16
 - `npm`: Version 7
 
@@ -765,13 +766,19 @@ Note that the test environment uses a temporary directory for defining the
 SQLite databases which will be cleared each time before the group of test
 commands are invoked.
 
-There is also a utility script included in the Superset codebase to run python tests. The [readme can be
+There is also a utility script included in the Superset codebase to run python integration tests. The [readme can be
 found here](https://github.com/apache/superset/tree/master/scripts/tests)
 
-To run all tests for example, run this script from the root directory:
+To run all integration tests for example, run this script from the root directory:
 
 ```bash
 scripts/tests/run.sh
+```
+
+You can run unit tests found in './tests/unit_tests' for example with pytest. It is a simple way to run an isolated test that doesn't need any database setup
+
+```bash
+pytest ./link_to_test.py
 ```
 
 ### Frontend Testing

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -21,6 +21,7 @@ from flask_babel import gettext as _
 from marshmallow import fields, Schema, validate, validates_schema
 from marshmallow.validate import Length, Range, ValidationError
 from marshmallow_enum import EnumField
+from pytz import all_timezones
 
 from superset.models.reports import (
     ReportCreationMethodType,
@@ -153,7 +154,11 @@ class ReportSchedulePostSchema(Schema):
         allow_none=False,
         required=True,
     )
-    timezone = fields.String(description=timezone_description, default="UTC")
+    timezone = fields.String(
+        description=timezone_description,
+        default="UTC",
+        validate=validate.OneOf(choices=tuple(all_timezones)),
+    )
     sql = fields.String(
         description=sql_description, example="SELECT value FROM time_series_table"
     )
@@ -233,7 +238,11 @@ class ReportSchedulePutSchema(Schema):
         validate=[validate_crontab, Length(1, 1000)],
         required=False,
     )
-    timezone = fields.String(description=timezone_description, default="UTC")
+    timezone = fields.String(
+        description=timezone_description,
+        default="UTC",
+        validate=validate.OneOf(choices=tuple(all_timezones)),
+    )
     sql = fields.String(
         description=sql_description,
         example="SELECT value FROM time_series_table",

--- a/superset/tasks/cron_util.py
+++ b/superset/tasks/cron_util.py
@@ -18,10 +18,13 @@
 from datetime import datetime, timedelta, timezone as dt_timezone
 from typing import Iterator
 
+import logging
 from croniter import croniter
 from pytz import timezone as pytz_timezone, UnknownTimeZoneError
 
 from superset import app
+
+logger = logging.getLogger(__name__)
 
 
 def cron_schedule_window(cron: str, timezone: str) -> Iterator[datetime]:
@@ -33,6 +36,8 @@ def cron_schedule_window(cron: str, timezone: str) -> Iterator[datetime]:
     except UnknownTimeZoneError:
         # fallback to default timezone
         tz = pytz_timezone("UTC")
+        logger.warning(
+            "Timezone %s was invalid. Falling back to 'UTC'", timezone)
     utc = pytz_timezone("UTC")
     # convert the current time to the user's local time for comparison
     time_now = time_now.astimezone(tz)

--- a/superset/tasks/cron_util.py
+++ b/superset/tasks/cron_util.py
@@ -18,8 +18,8 @@
 from datetime import datetime, timedelta, timezone as dt_timezone
 from typing import Iterator
 
-import pytz
 from croniter import croniter
+from pytz import timezone as pytz_timezone, UnknownTimeZoneError
 
 from superset import app
 
@@ -28,8 +28,12 @@ def cron_schedule_window(cron: str, timezone: str) -> Iterator[datetime]:
     window_size = app.config["ALERT_REPORTS_CRON_WINDOW_SIZE"]
     # create a time-aware datetime in utc
     time_now = datetime.now(tz=dt_timezone.utc)
-    tz = pytz.timezone(timezone)
-    utc = pytz.timezone("UTC")
+    try:
+        tz = pytz_timezone(timezone)
+    except UnknownTimeZoneError:
+        # fallback to default timezone
+        tz = pytz_timezone("UTC")
+    utc = pytz_timezone("UTC")
     # convert the current time to the user's local time for comparison
     time_now = time_now.astimezone(tz)
     start_at = time_now - timedelta(seconds=1)

--- a/superset/tasks/cron_util.py
+++ b/superset/tasks/cron_util.py
@@ -15,10 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import logging
 from datetime import datetime, timedelta, timezone as dt_timezone
 from typing import Iterator
 
-import logging
 from croniter import croniter
 from pytz import timezone as pytz_timezone, UnknownTimeZoneError
 
@@ -36,8 +36,7 @@ def cron_schedule_window(cron: str, timezone: str) -> Iterator[datetime]:
     except UnknownTimeZoneError:
         # fallback to default timezone
         tz = pytz_timezone("UTC")
-        logger.warning(
-            "Timezone %s was invalid. Falling back to 'UTC'", timezone)
+        logger.warning("Timezone %s was invalid. Falling back to 'UTC'", timezone)
     utc = pytz_timezone("UTC")
     # convert the current time to the user's local time for comparison
     time_now = time_now.astimezone(tz)

--- a/tests/unit_tests/tasks/test_cron_util.py
+++ b/tests/unit_tests/tasks/test_cron_util.py
@@ -67,6 +67,44 @@ def test_cron_schedule_window_los_angeles(
 @pytest.mark.parametrize(
     "current_dttm, cron, expected",
     [
+        ("2020-01-01T00:59:01Z", "0 1 * * *", []),
+        (
+            "2020-01-01T00:59:02Z",
+            "0 1 * * *",
+            [FakeDatetime(2020, 1, 1, 1, 0).strftime("%A, %d %B %Y, %H:%M:%S")],
+        ),
+        (
+            "2020-01-01T00:59:59Z",
+            "0 1 * * *",
+            [FakeDatetime(2020, 1, 1, 1, 0).strftime("%A, %d %B %Y, %H:%M:%S")],
+        ),
+        (
+            "2020-01-01T01:00:00Z",
+            "0 1 * * *",
+            [FakeDatetime(2020, 1, 1, 1, 0).strftime("%A, %d %B %Y, %H:%M:%S")],
+        ),
+        ("2020-01-01T01:00:01Z", "0 1 * * *", []),
+    ],
+)
+def test_cron_schedule_window_invalid_timezone(
+    app_context: AppContext, current_dttm: str, cron: str, expected: List[FakeDatetime]
+) -> None:
+    """
+    Reports scheduler: Test cron schedule window for "invalid timezone"
+    """
+
+    with freeze_time(current_dttm):
+        datetimes = cron_schedule_window(cron, "invalid timezone")
+        # it should default to UTC
+        assert (
+            list(cron.strftime("%A, %d %B %Y, %H:%M:%S") for cron in datetimes)
+            == expected
+        )
+
+
+@pytest.mark.parametrize(
+    "current_dttm, cron, expected",
+    [
         ("2020-01-01T05:59:01Z", "0 1 * * *", []),
         (
             "2020-01-01T05:59:02Z",


### PR DESCRIPTION
### SUMMARY
It was possible for short period of time to save an invalid timezone value (GMT Standard Time) in the reports schedule, which was causing errors and failures when running the cron job. With this change, I am catching any cron errors with regard to the timezone function and defaulting to UTC. I also added timezone validation when creating a report. 

### TESTING INSTRUCTIONS
unit and integration tests have been updated. To manually test, you should be able to create and run a report with a timezone. You should not be able to create a report with a bad timezone. 


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
