### PR TITLE
test: add native filter e2e test part3

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
@@ -195,6 +195,97 @@ describe('Nativefilters Sanity test', () => {
       .click();
     cy.get(nativeFilters.modal.container).should('not.exist');
   });
+  it("User can undo deleting a native filter", () => {
+    cy.get(nativeFilters.filterFromDashboardView.expand)
+      .should("be.visible")
+      .click();
+    cy.get(nativeFilters.createFilterButton).should("be.visible").click();
+    cy.get(nativeFilters.modal.container).should("be.visible");
+    cy.get(nativeFilters.modal.container)
+      .find(nativeFilters.filtersPanel.filterName)
+      .click()
+      .type("Country name");
+    cy.get(nativeFilters.modal.container)
+      .find(nativeFilters.filtersPanel.datasetName)
+      .click()
+      .type("World Bank's Data{enter}");
+
+    cy.get(".loading inline-centered css-101mkpk").should("not.exist");
+    // hack for unclickable country_name
+    cy.wait(5000);
+    cy.get(nativeFilters.filtersPanel.filterInfoInput)
+      .last()
+      .should("be.visible")
+      .click({ force: true });
+    cy.get(nativeFilters.filtersPanel.filterInfoInput).last().type("country_name");
+    cy.get(nativeFilters.filtersPanel.inputDropdown)
+      .should("be.visible", { timeout: 20000 })
+      .last()
+      .click();
+    cy.get(nativeFilters.modal.footer)
+      .contains("Save")
+      .should("be.visible")
+      .click();
+    cy.get(nativeFilters.filterFromDashboardView.filterName).should('be.visible').contains("Country name")
+    cy.get(nativeFilters.createFilterButton).should("be.visible").click();
+    cy.get(nativeFilters.modal.container).should("be.visible");
+    cy.get(nativeFilters.filtersList.removeIcon).first().click();  
+    cy.contains("Undo?").click();
+  });
+  it("Verify setting options and tooltips for value filter", () => {
+    cy.get(nativeFilters.filterFromDashboardView.expand)
+      .click({force: true});
+    cy.get(nativeFilters.createFilterButton).should("be.visible").click();
+    cy.get(nativeFilters.modal.container).should("be.visible");
+    cy.get(nativeFilters.filterConfigurationSections.collapseExpandButton)
+      .last()
+      .click();
+    [
+      "Filter has default value",
+      "Multiple select",
+      "Required",
+      "Filter is hierarchical",
+      "Default to first item",
+      "Inverse selection",
+      "Search all filter options",
+      "Pre-filter available values",
+      "Sort filter values",
+    ].forEach((el) => {
+      cy.contains(el);
+    });
+    cy.get(nativeFilters.filterConfigurationSections.checkedCheckbox).contains(
+      "Multiple select"
+    );
+    cy.get(nativeFilters.filterConfigurationSections.infoTooltip)
+      .eq(0)
+      .trigger("mouseover");
+    cy.contains("Allow selecting multiple values");
+
+    cy.get(nativeFilters.filterConfigurationSections.infoTooltip)
+      .eq(1)
+      .trigger("mouseover");
+    cy.contains("User must select a value before applying the filter");
+
+    cy.get(nativeFilters.filterConfigurationSections.infoTooltip)
+      .eq(2)
+      .trigger("mouseover");
+    cy.contains(
+      "Select first item by default (when using this option, default value can’t be set)"
+    );
+
+    cy.get(nativeFilters.filterConfigurationSections.infoTooltip)
+      .eq(3)
+      .trigger("mouseover");
+    cy.contains("Exclude selected values");
+
+    cy.get(nativeFilters.filterConfigurationSections.infoTooltip)
+      .eq(4)
+      .trigger("mouseover");
+    cy.contains(
+      "By default, each filter loads at most 1000 choices at the initial page load. Check this box if you have more than 1000 filter values and want to enable dynamically searching that loads filter values as users type (may add stress to your database)."
+    );
+  });
+ 
 });
 
 xdescribe('Nativefilters', () => {

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
@@ -195,97 +195,99 @@ describe('Nativefilters Sanity test', () => {
       .click();
     cy.get(nativeFilters.modal.container).should('not.exist');
   });
-  it("User can undo deleting a native filter", () => {
+  it('User can undo deleting a native filter', () => {
     cy.get(nativeFilters.filterFromDashboardView.expand)
-      .should("be.visible")
+      .should('be.visible')
       .click();
-    cy.get(nativeFilters.createFilterButton).should("be.visible").click();
-    cy.get(nativeFilters.modal.container).should("be.visible");
+    cy.get(nativeFilters.createFilterButton).should('be.visible').click();
+    cy.get(nativeFilters.modal.container).should('be.visible');
     cy.get(nativeFilters.modal.container)
       .find(nativeFilters.filtersPanel.filterName)
       .click()
-      .type("Country name");
+      .type('Country name');
     cy.get(nativeFilters.modal.container)
       .find(nativeFilters.filtersPanel.datasetName)
       .click()
       .type("World Bank's Data{enter}");
 
-    cy.get(".loading inline-centered css-101mkpk").should("not.exist");
+    cy.get('.loading inline-centered css-101mkpk').should('not.exist');
     // hack for unclickable country_name
     cy.wait(5000);
     cy.get(nativeFilters.filtersPanel.filterInfoInput)
       .last()
-      .should("be.visible")
+      .should('be.visible')
       .click({ force: true });
-    cy.get(nativeFilters.filtersPanel.filterInfoInput).last().type("country_name");
+    cy.get(nativeFilters.filtersPanel.filterInfoInput)
+      .last()
+      .type('country_name');
     cy.get(nativeFilters.filtersPanel.inputDropdown)
-      .should("be.visible", { timeout: 20000 })
+      .should('be.visible', { timeout: 20000 })
       .last()
       .click();
     cy.get(nativeFilters.modal.footer)
-      .contains("Save")
-      .should("be.visible")
+      .contains('Save')
+      .should('be.visible')
       .click();
-    cy.get(nativeFilters.filterFromDashboardView.filterName).should('be.visible').contains("Country name")
-    cy.get(nativeFilters.createFilterButton).should("be.visible").click();
-    cy.get(nativeFilters.modal.container).should("be.visible");
-    cy.get(nativeFilters.filtersList.removeIcon).first().click();  
-    cy.contains("Undo?").click();
+    cy.get(nativeFilters.filterFromDashboardView.filterName)
+      .should('be.visible')
+      .contains('Country name');
+    cy.get(nativeFilters.createFilterButton).should('be.visible').click();
+    cy.get(nativeFilters.modal.container).should('be.visible');
+    cy.get(nativeFilters.filtersList.removeIcon).first().click();
+    cy.contains('Undo?').click();
   });
-  it("Verify setting options and tooltips for value filter", () => {
-    cy.get(nativeFilters.filterFromDashboardView.expand)
-      .click({force: true});
-    cy.get(nativeFilters.createFilterButton).should("be.visible").click();
-    cy.get(nativeFilters.modal.container).should("be.visible");
+  it('Verify setting options and tooltips for value filter', () => {
+    cy.get(nativeFilters.filterFromDashboardView.expand).click({ force: true });
+    cy.get(nativeFilters.createFilterButton).should('be.visible').click();
+    cy.get(nativeFilters.modal.container).should('be.visible');
     cy.get(nativeFilters.filterConfigurationSections.collapseExpandButton)
       .last()
       .click();
     [
-      "Filter has default value",
-      "Multiple select",
-      "Required",
-      "Filter is hierarchical",
-      "Default to first item",
-      "Inverse selection",
-      "Search all filter options",
-      "Pre-filter available values",
-      "Sort filter values",
-    ].forEach((el) => {
+      'Filter has default value',
+      'Multiple select',
+      'Required',
+      'Filter is hierarchical',
+      'Default to first item',
+      'Inverse selection',
+      'Search all filter options',
+      'Pre-filter available values',
+      'Sort filter values',
+    ].forEach(el => {
       cy.contains(el);
     });
     cy.get(nativeFilters.filterConfigurationSections.checkedCheckbox).contains(
-      "Multiple select"
+      'Multiple select',
     );
     cy.get(nativeFilters.filterConfigurationSections.infoTooltip)
       .eq(0)
-      .trigger("mouseover");
-    cy.contains("Allow selecting multiple values");
+      .trigger('mouseover');
+    cy.contains('Allow selecting multiple values');
 
     cy.get(nativeFilters.filterConfigurationSections.infoTooltip)
       .eq(1)
-      .trigger("mouseover");
-    cy.contains("User must select a value before applying the filter");
+      .trigger('mouseover');
+    cy.contains('User must select a value before applying the filter');
 
     cy.get(nativeFilters.filterConfigurationSections.infoTooltip)
       .eq(2)
-      .trigger("mouseover");
+      .trigger('mouseover');
     cy.contains(
-      "Select first item by default (when using this option, default value can’t be set)"
+      'Select first item by default (when using this option, default value can’t be set)',
     );
 
     cy.get(nativeFilters.filterConfigurationSections.infoTooltip)
       .eq(3)
-      .trigger("mouseover");
-    cy.contains("Exclude selected values");
+      .trigger('mouseover');
+    cy.contains('Exclude selected values');
 
     cy.get(nativeFilters.filterConfigurationSections.infoTooltip)
       .eq(4)
-      .trigger("mouseover");
+      .trigger('mouseover');
     cy.contains(
-      "By default, each filter loads at most 1000 choices at the initial page load. Check this box if you have more than 1000 filter values and want to enable dynamically searching that loads filter values as users type (may add stress to your database)."
+      'By default, each filter loads at most 1000 choices at the initial page load. Check this box if you have more than 1000 filter values and want to enable dynamically searching that loads filter values as users type (may add stress to your database).',
     );
   });
- 
 });
 
 xdescribe('Nativefilters', () => {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
add 2 more e2e test for native filter
1, User can undo deleting a native filter
2, Verify setting options and tooltips for value filter

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
