### PR TITLE
fix: Remove horizontal scroll navigation from SQL Lab

### DIFF
--- a/superset-frontend/src/SqlLab/components/App/index.jsx
+++ b/superset-frontend/src/SqlLab/components/App/index.jsx
@@ -50,6 +50,11 @@ class App extends React.PureComponent {
 
   componentDidMount() {
     window.addEventListener('hashchange', this.onHashChanged.bind(this));
+
+    // Horrible hack to disable side swipe navigation when in SQL Lab. Even though the
+    // docs say setting this style on any div will prevent it, turns out it only works
+    // when set on the body element.
+    document.body.style.overscrollBehaviorX = 'none';
   }
 
   componentDidUpdate() {
@@ -65,6 +70,9 @@ class App extends React.PureComponent {
 
   componentWillUnmount() {
     window.removeEventListener('hashchange', this.onHashChanged.bind(this));
+
+    // And now we need to reset the overscroll behavior back to the default.
+    document.body.style.overscrollBehaviorX = 'auto';
   }
 
   onHashChanged() {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
People commonly complain about accidentally navigating forwards or backwards in chrome when horizontally scrolling in SQL Lab. Most of our app doesn't have such a horizontal scrolling paradigm, but SQL Lab is the exception. So let's remove that horizontal scrolling navigation behavior in SQL Lab

### TESTING INSTRUCTIONS
Spin up a testenv and test. make sure you can't horizontal scroll to go forward and backwards in sql lab. But when you go back to a dashboard/explore see that you can

Before:

https://user-images.githubusercontent.com/7409244/140548224-aaad7f7e-2c10-4011-8df9-28b3444cf76d.mov

After:

https://user-images.githubusercontent.com/7409244/140548259-cab713f2-39fe-4bac-9194-262ced61f1f4.mov


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @graceguo-supercat @ktmud @rusackas @michael-s-molina 