### PR TITLE
fix(Dashboard): Make color scheme optional

### DIFF
--- a/superset-frontend/spec/javascripts/dashboard/components/PropertiesModal_spec.jsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/PropertiesModal_spec.jsx
@@ -148,6 +148,15 @@ describe('PropertiesModal', () => {
         expect(spy).toHaveBeenCalled();
       });
     });
+    describe('with an empty color scheme as an arg', () => {
+      const wrapper = setup();
+      const modalInstance = wrapper.find('PropertiesModal').instance();
+      it('will not raise an error', () => {
+        const spy = jest.spyOn(Modal, 'error');
+        modalInstance.onColorSchemeChange('');
+        expect(spy).not.toHaveBeenCalled();
+      });
+    });
   });
   describe('onOwnersChange', () => {
     it('should update the state with the value passed', () => {

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.jsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.jsx
@@ -147,7 +147,8 @@ class PropertiesModal extends React.PureComponent {
       ? JSON.parse(jsonMetadata)
       : {};
 
-    if (!colorScheme || !colorChoices.includes(colorScheme)) {
+    // only fire if the color_scheme is present and invalid
+    if (colorScheme && !colorChoices.includes(colorScheme)) {
       Modal.error({
         title: 'Error',
         content: t('A valid color scheme is required'),


### PR DESCRIPTION
### SUMMARY
It makes the color scheme optional when saving a Dashboard and adds a test case

### BEFORE
https://user-images.githubusercontent.com/60598000/140544068-058a395a-0dbe-4159-8802-b665171b9dd2.mp4

### AFTER
https://user-images.githubusercontent.com/60598000/140543812-b2e60a85-f475-4caa-9751-88bd7a3d29a0.mp4

### TESTING INSTRUCTIONS
1. Create a new Dashboard
2. Leave the color scheme empty
3. Make sure you can save

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
