### PR TITLE
chore: migrate FormattedNumber component from jsx to tsx

### DIFF
--- a/superset-frontend/src/visualizations/TimeTable/FormattedNumber.tsx
+++ b/superset-frontend/src/visualizations/TimeTable/FormattedNumber.tsx
@@ -24,10 +24,7 @@ interface FormattedNumberProps {
   format?: string;
 }
 
-function FormattedNumber({
-  num = 0,
-  format = undefined,
-}: FormattedNumberProps) {
+function FormattedNumber({ num = 0, format }: FormattedNumberProps) {
   if (format) {
     return (
       <span title={num as string}>{formatNumber(format, num as number)}</span>

--- a/superset-frontend/src/visualizations/TimeTable/FormattedNumber.tsx
+++ b/superset-frontend/src/visualizations/TimeTable/FormattedNumber.tsx
@@ -26,7 +26,8 @@ interface FormattedNumberProps {
 
 function FormattedNumber({ num = 0, format }: FormattedNumberProps) {
   if (format) {
-    return <span title={`${num}`}>{formatNumber(format, num as number)}</span>;
+    // @ts-expect-error formatNumber can actually accept strings, even though it's not typed as such
+    return <span title={`${num}`}>{formatNumber(format, num)}</span>;
   }
   return <span>{num}</span>;
 }

--- a/superset-frontend/src/visualizations/TimeTable/FormattedNumber.tsx
+++ b/superset-frontend/src/visualizations/TimeTable/FormattedNumber.tsx
@@ -17,27 +17,23 @@
  * under the License.
  */
 import React from 'react';
-import PropTypes from 'prop-types';
 import { formatNumber } from '@superset-ui/core';
 
-const propTypes = {
-  num: PropTypes.number,
-  format: PropTypes.string,
-};
+interface FormattedNumberProps {
+  num?: string | number;
+  format?: string;
+}
 
-const defaultProps = {
-  num: 0,
-  format: undefined,
-};
-
-function FormattedNumber({ num, format }) {
+function FormattedNumber({
+  num = 0,
+  format = undefined,
+}: FormattedNumberProps) {
   if (format) {
-    return <span title={num}>{formatNumber(format, num)}</span>;
+    return (
+      <span title={num as string}>{formatNumber(format, num as number)}</span>
+    );
   }
   return <span>{num}</span>;
 }
-
-FormattedNumber.propTypes = propTypes;
-FormattedNumber.defaultProps = defaultProps;
 
 export default FormattedNumber;

--- a/superset-frontend/src/visualizations/TimeTable/FormattedNumber.tsx
+++ b/superset-frontend/src/visualizations/TimeTable/FormattedNumber.tsx
@@ -26,9 +26,7 @@ interface FormattedNumberProps {
 
 function FormattedNumber({ num = 0, format }: FormattedNumberProps) {
   if (format) {
-    return (
-      <span title={num as string}>{formatNumber(format, num as number)}</span>
-    );
+    return <span title={`${num}`}>{formatNumber(format, num as number)}</span>;
   }
   return <span>{num}</span>;
 }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

PR for migrating `FormattedNumberProps` functional react component from JSX to TSX

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] #10004
- [x] Enhancement (new features, refinement)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
