### PR TITLE
fix: Database selector overflow

### DIFF
--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -41,6 +41,7 @@ const DatabaseSelectorWrapper = styled.div`
     }
 
     .select {
+      width: calc(100% - 30px - ${theme.gridUnit}px);
       flex: 1;
     }
 
@@ -55,6 +56,15 @@ const LabelStyle = styled.div`
   flex-direction: row;
   align-items: center;
   margin-left: ${({ theme }) => theme.gridUnit - 2}px;
+
+  .backend {
+    overflow: visible;
+  }
+
+  .name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 `;
 
 type DatabaseValue = {
@@ -97,8 +107,10 @@ const SelectLabel = ({
   databaseName: string;
 }) => (
   <LabelStyle>
-    <Label>{backend}</Label>
-    {databaseName}
+    <Label className="backend">{backend}</Label>
+    <span className="name" title={databaseName}>
+      {databaseName}
+    </span>
   </LabelStyle>
 );
 

--- a/superset-frontend/src/components/TimezoneSelector/TimezoneSelector.test.tsx
+++ b/superset-frontend/src/components/TimezoneSelector/TimezoneSelector.test.tsx
@@ -18,7 +18,7 @@
  */
 import React from 'react';
 import moment from 'moment-timezone';
-import { render, screen } from 'spec/helpers/testing-library';
+import { render, screen, wait, waitFor } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
 import TimezoneSelector from './index';
 
@@ -42,7 +42,7 @@ describe('TimezoneSelector', () => {
   });
   it('should properly select values from the offsetsToName map', async () => {
     jest.spyOn(moment.tz, 'guess').mockReturnValue('America/New_York');
-    render(
+    const { debug } = render(
       <TimezoneSelector
         onTimezoneChange={onTimezoneChange}
         timezone={timezone}
@@ -54,9 +54,7 @@ describe('TimezoneSelector', () => {
     });
     expect(select).toBeInTheDocument();
     userEvent.click(select);
-    const selection = await screen.findByTitle(
-      'GMT -06:00 (Mountain Daylight Time)',
-    );
+    const selection = await screen.findByTitle('GMT -06:00 (America/Belize)');
     expect(selection).toBeInTheDocument();
     userEvent.click(selection);
     expect(selection).toBeVisible();

--- a/superset-frontend/src/components/TimezoneSelector/TimezoneSelector.test.tsx
+++ b/superset-frontend/src/components/TimezoneSelector/TimezoneSelector.test.tsx
@@ -18,7 +18,7 @@
  */
 import React from 'react';
 import moment from 'moment-timezone';
-import { render, screen, wait, waitFor } from 'spec/helpers/testing-library';
+import { render, screen } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
 import TimezoneSelector from './index';
 
@@ -42,7 +42,7 @@ describe('TimezoneSelector', () => {
   });
   it('should properly select values from the offsetsToName map', async () => {
     jest.spyOn(moment.tz, 'guess').mockReturnValue('America/New_York');
-    const { debug } = render(
+    render(
       <TimezoneSelector
         onTimezoneChange={onTimezoneChange}
         timezone={timezone}


### PR DESCRIPTION
### SUMMARY
Fixes the database selector overflow.

@rusackas 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="867" alt="Screen Shot 2021-11-08 at 9 45 27 AM" src="https://user-images.githubusercontent.com/70410625/140744624-cfcd45ab-323a-4c45-a3b3-4f95efab9c9a.png">

<img width="860" alt="Screen Shot 2021-11-08 at 9 46 19 AM" src="https://user-images.githubusercontent.com/70410625/140744638-a29a163b-fc2b-4a6a-89ef-646a0dabeecc.png">

### TESTING INSTRUCTIONS
1 - Go to SQL Editor
2 - Select a database with a long name
3 - Check that the text is overflowed correctly

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
