### PR TITLE
fix: move emotion css babel preset from test only to general presets

### DIFF
--- a/superset-frontend/babel.config.js
+++ b/superset-frontend/babel.config.js
@@ -38,6 +38,7 @@ module.exports = {
       '@babel/preset-react',
       { development: process.env.BABEL_ENV === 'development' },
     ],
+    ['@emotion/babel-preset-css-prop'],
   ],
   plugins: [
     'lodash',
@@ -64,7 +65,6 @@ module.exports = {
             targets: { node: 'current' },
           },
         ],
-        ['@emotion/babel-preset-css-prop'],
       ],
       plugins: ['babel-plugin-dynamic-import-node'],
     },


### PR DESCRIPTION
When we tried to link superset-ui/core to main superset codebase, there was an error related to theme fields being undefined. After some investigation it turned out that the culprit was the `theme` used in `css` prop. `css` emotion prop is enabled by a babel preset `@emotion/babel-preset-css-prop`. 
For some reason we used the preset only in tests - this PR moves it to general presets.
Related PR: https://github.com/apache-superset/superset-ui/pull/1458

### TESTING INSTRUCTIONS
Using changes from this PR and https://github.com/apache-superset/superset-ui/pull/1458, try to `npm link` `superset-ui/core` to `superset`, verify that there are no errors related to theme being undefined

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
