### PR TITLE
fix(Dashboard): Missing dashboardId when refreshing Explore

### DIFF
--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -194,12 +194,19 @@ function ExploreViewContainer(props) {
 
   const addHistory = useCallback(
     ({ isReplace = false, title } = {}) => {
-      const payload = { ...props.form_data };
+      const formData = props.dashboardId
+        ? {
+            ...props.form_data,
+            dashboardId: props.dashboardId,
+          }
+        : props.form_data;
+      const payload = { ...formData };
       const longUrl = getExploreLongUrl(
-        props.form_data,
+        formData,
         props.standalone ? URL_PARAMS.standalone.name : null,
         false,
       );
+
       try {
         if (isReplace) {
           window.history.replaceState(payload, title, longUrl);


### PR DESCRIPTION
### SUMMARY
This PR fixes an issue for which the `dashboardId` was lost when refreshing Explore.

### BEFORE
Fixes #17244 

### AFTER

https://user-images.githubusercontent.com/60598000/140949428-9dde82ee-7ccc-4916-a60b-e2adf06b077f.mp4

### TESTING INSTRUCTIONS
1. Open a Chart in Explore from a Dashboard with custom label colors
2. Refresh Explore
3. Make sure the custom label colors are not lost

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #17244 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
