### PR TITLE
fix(sqllab): Query limit dropdown number breaks to separate lines

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -127,7 +127,7 @@ const StyledToolbar = styled.div`
   }
 
   .limitDropdown {
-    width: max-content;
+    white-space: nowrap;
   }
 `;
 

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -125,6 +125,10 @@ const StyledToolbar = styled.div`
       }
     }
   }
+
+  .limitDropdown {
+    width: max-content;
+  }
 `;
 
 const propTypes = {
@@ -646,7 +650,7 @@ class SqlEditor extends React.PureComponent {
               <Dropdown overlay={this.renderQueryLimit()} trigger="click">
                 <a onClick={e => e.preventDefault()}>
                   <span>LIMIT:</span>
-                  <span>
+                  <span className="limitDropdown">
                     {this.convertToNumWithSpaces(
                       this.props.queryEditor.queryLimit ||
                         this.props.defaultQueryLimit,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The query limit dropdown number in SQL Lab editor would break into separate lines when the screen was at smaller widths and the number is "1 000" or higher. This is corrected by giving the number result `white-space: nowrap`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### BEFORE
![limit-broken](https://user-images.githubusercontent.com/55605634/140986014-562bb1a2-3623-4057-982d-779a961d76e4.gif)

#### AFTER
![limit-fixed](https://user-images.githubusercontent.com/55605634/140986305-504d84d2-8244-4c85-8255-89da8ce64e3f.gif)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Go to the SQL Lab editor
- Set the query limit dropdown to "1 000" or higher
- Adjust the screen's width and observe that the number no longer breaks to separate lines

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
