### PR TITLE
fix: Partial revert of 17236

### DIFF
--- a/superset-frontend/src/explore/controls.jsx
+++ b/superset-frontend/src/explore/controls.jsx
@@ -124,8 +124,8 @@ const groupByControl = {
   default: [],
   includeTime: false,
   description: t(
-    'One or many columns to group by. High cardinality groupings should include a sort by metric ' +
-      'and series limit to limit the number of fetched and rendered series.',
+    'One or many columns to group by. High cardinality groupings should include a series limit ' +
+      'to limit the number of fetched and rendered series.',
   ),
   optionRenderer: c => <StyledColumnOption column={c} showType />,
   valueKey: 'column_name',
@@ -361,10 +361,7 @@ export const controls = {
     validators: [legacyValidateInteger],
     default: 10000,
     choices: formatSelectOptions(ROW_LIMIT_OPTIONS),
-    description: t(
-      'Limits the number of rows that get displayed. Should be used in conjunction with a sort ' +
-        'by metric.',
-    ),
+    description: t('Limits the number of rows that get displayed.'),
   },
 
   limit: {
@@ -375,11 +372,10 @@ export const controls = {
     choices: formatSelectOptions(SERIES_LIMITS),
     clearable: true,
     description: t(
-      'Limits the number of series that get displayed. Should be used in conjunction with a sort ' +
-        'by metric. A joined subquery (or an extra phase where subqueries are not supported) is ' +
-        'applied to limit the number of series that get fetched and rendered. This feature is ' +
-        'useful when grouping by high cardinality column(s) though does increase the query ' +
-        'complexity and cost.',
+      'Limits the number of series that get displayed. A joined subquery (or an extra phase ' +
+        'where subqueries are not supported) is applied to limit the number of series that get ' +
+        'fetched and rendered. This feature is useful when grouping by high cardinality ' +
+        'column(s) though does increase the query complexity and cost.',
     ),
   },
 
@@ -389,8 +385,8 @@ export const controls = {
     default: null,
     clearable: true,
     description: t(
-      'Metric used to define the top series. Should be used in conjunction with the series or ' +
-        'row limit',
+      'Metric used to define how the top series are sorted if a series or row limit is present. ' +
+        'If undefined reverts to the first metric (where appropriate).',
     ),
     mapStateToProps: state => ({
       columns: state.datasource ? state.datasource.columns : [],

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1326,6 +1326,11 @@ def get_metric_names(metrics: Sequence[Metric]) -> List[str]:
     return [metric for metric in map(get_metric_name, metrics) if metric]
 
 
+def get_first_metric_name(metrics: Sequence[Metric]) -> Optional[str]:
+    metric_labels = get_metric_names(metrics)
+    return metric_labels[0] if metric_labels else None
+
+
 def ensure_path_exists(path: str) -> None:
     try:
         os.makedirs(path)

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1251,7 +1251,9 @@ class NVD3TimeSeriesViz(NVD3Viz):
 
     def query_obj(self) -> QueryObjectDict:
         query_obj = super().query_obj()
-        sort_by = self.form_data.get("timeseries_limit_metric")
+        sort_by = self.form_data.get(
+            "timeseries_limit_metric"
+        ) or utils.get_first_metric_name(query_obj.get("metrics") or [])
         is_asc = not self.form_data.get("order_desc")
         if sort_by:
             sort_by_label = utils.get_metric_name(sort_by)


### PR DESCRIPTION
### SUMMARY

This is a partial revert of https://github.com/apache/superset/pull/17236 as it seems other chart types: all ECharts, [Bar Chart](https://github.com/apache/superset/pull/15318), etc. already perform an implicit ordering if undefined, i.e., the ship has sailed on this one—previously I wasn't aware just how prevalent the behavior was and thus the fallback seems like the rule rather than the exception. I also added updated comments to reflect this behavior.

Personally I'm a tad upset/frustrated that this behavior differs by chart type (search for `sort_by` in [viz.py](https://github.com/apache/superset/blob/master/superset/viz.py)) as this simply adds confusion to the user and leads to a very inconsistent UX. When we introduce new behaviors we should:

1. Strive to make them consistent throughout.
2. Indicate said changes in `UPDATING.md` so institutions can inform/educate users of said changes. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
