### PR TITLE
fix(sql lab): NULL styling in grid cell

### DIFF
--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -426,7 +426,14 @@ export default class FilterableTable extends PureComponent<
   }) {
     const columnKey = this.props.orderedColumnKeys[columnIndex];
     const cellData = this.list[rowIndex][columnKey];
-    const content = this.getCellContent({ cellData, columnKey });
+    const content =
+      cellData === null ? (
+        <i className="text-muted">
+          {this.getCellContent({ cellData, columnKey })}
+        </i>
+      ) : (
+        this.getCellContent({ cellData, columnKey })
+      );
     const cellNode = (
       <div
         key={key}

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -426,14 +426,9 @@ export default class FilterableTable extends PureComponent<
   }) {
     const columnKey = this.props.orderedColumnKeys[columnIndex];
     const cellData = this.list[rowIndex][columnKey];
+    const cellText = this.getCellContent({ cellData, columnKey });
     const content =
-      cellData === null ? (
-        <i className="text-muted">
-          {this.getCellContent({ cellData, columnKey })}
-        </i>
-      ) : (
-        this.getCellContent({ cellData, columnKey })
-      );
+      cellData === null ? <i className="text-muted">{cellText}</i> : cellText;
     const cellNode = (
       <div
         key={key}

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -530,17 +530,12 @@ export default class FilterableTable extends PureComponent<
     cellData: CellDataType;
     columnKey: string;
   }) {
+    const cellNode = this.getCellContent({ cellData, columnKey });
     const content =
-      cellData === null ? (
-        <i className="text-muted">
-          {this.getCellContent({ cellData, columnKey })}
-        </i>
-      ) : (
-        this.getCellContent({ cellData, columnKey })
-      );
+      cellData === null ? <i className="text-muted">{cellNode}</i> : cellNode;
     const jsonObject = safeJsonObjectParse(cellData);
     if (jsonObject) {
-      return this.addJsonModal(content, jsonObject, cellData);
+      return this.addJsonModal(cellNode, jsonObject, cellData);
     }
     return content;
   }

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -28,13 +28,7 @@ import {
   SortIndicator,
   Table,
 } from 'react-virtualized';
-import {
-  getMultipleTextDimensions,
-  t,
-  styled,
-  SupersetTheme,
-  css,
-} from '@superset-ui/core';
+import { getMultipleTextDimensions, t, styled } from '@superset-ui/core';
 import { Tooltip } from 'src/components/Tooltip';
 import Button from '../Button';
 import CopyToClipboard from '../CopyToClipboard';

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -28,7 +28,13 @@ import {
   SortIndicator,
   Table,
 } from 'react-virtualized';
-import { getMultipleTextDimensions, t, styled } from '@superset-ui/core';
+import {
+  getMultipleTextDimensions,
+  t,
+  styled,
+  SupersetTheme,
+  css,
+} from '@superset-ui/core';
 import { Tooltip } from 'src/components/Tooltip';
 import Button from '../Button';
 import CopyToClipboard from '../CopyToClipboard';
@@ -426,14 +432,7 @@ export default class FilterableTable extends PureComponent<
   }) {
     const columnKey = this.props.orderedColumnKeys[columnIndex];
     const cellData = this.list[rowIndex][columnKey];
-    const content =
-      cellData === null ? (
-        <i className="text-muted">
-          {this.getCellContent({ cellData, columnKey })}
-        </i>
-      ) : (
-        this.getCellContent({ cellData, columnKey })
-      );
+    const content = this.getCellContent({ cellData, columnKey });
     const cellNode = (
       <div
         key={key}
@@ -530,12 +529,19 @@ export default class FilterableTable extends PureComponent<
     cellData: CellDataType;
     columnKey: string;
   }) {
-    const cellNode = this.getCellContent({ cellData, columnKey });
+    const content =
+      cellData === null ? (
+        <i className="text-muted">
+          {this.getCellContent({ cellData, columnKey })}
+        </i>
+      ) : (
+        this.getCellContent({ cellData, columnKey })
+      );
     const jsonObject = safeJsonObjectParse(cellData);
     if (jsonObject) {
-      return this.addJsonModal(cellNode, jsonObject, cellData);
+      return this.addJsonModal(content, jsonObject, cellData);
     }
-    return cellNode;
+    return content;
   }
 
   renderTable() {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`NULL` grid cells in SQL Lab's result set were no longer returning their muted styling (italicized and muted gray). This was fixed by applying the `NULL` styles through the `renderTableCell` function instead of `renderGridCell`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### BEFORE
<img width="824" alt="brokenNULL" src="https://user-images.githubusercontent.com/55605634/141013927-de94165d-89b5-4f6f-abf1-387a16a97110.png">

#### AFTER
- With  less than 50 columns (table)
<img width="824" alt="fixedNULL" src="https://user-images.githubusercontent.com/55605634/141013947-acdd30ae-58c2-457b-96e7-79944f98ef31.png">

- With 50+ columns (grid)
<img width="1175" alt="fixedNULLgrid" src="https://user-images.githubusercontent.com/55605634/141161472-25ef8c11-0725-4058-9db8-8a8a9f2ba830.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Go to the SQL Lab editor
- Make a query that returns a `NULL` value
- Observe the corrected styling

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
