### PR TITLE
fix(sqllab): Have table name tooltip only show when name is truncated

### DIFF
--- a/superset-frontend/src/SqlLab/components/TableElement/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement/index.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import Collapse from 'src/components/Collapse';
 import Card from 'src/components/Card';
 import ButtonGroup from 'src/components/ButtonGroup';
@@ -77,15 +77,7 @@ const Fade = styled.div`
 const TableElement = ({ table, actions, ...props }: TableElementProps) => {
   const [sortColumns, setSortColumns] = useState(false);
   const [hovered, setHovered] = useState(false);
-  const [tableNameOverflow, setTableNameOverflow] = useState(false);
   const tableNameRef = React.useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    const element = tableNameRef.current;
-    if (element && element.offsetWidth < element.scrollWidth) {
-      setTableNameOverflow(true);
-    }
-  }, []);
 
   const setHover = (hovered: boolean) => {
     debounce(() => setHovered(hovered), 100)();
@@ -222,42 +214,50 @@ const TableElement = ({ table, actions, ...props }: TableElementProps) => {
     );
   };
 
-  const renderHeader = () => (
-    <div
-      className="clearfix header-container"
-      onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => setHover(false)}
-    >
-      <Tooltip
-        id="copy-to-clipboard-tooltip"
-        style={{ cursor: 'pointer' }}
-        title={table.name}
-        trigger={tableNameOverflow ? ['hover'] : []}
-      >
-        <StyledSpan
-          data-test="collapse"
-          ref={tableNameRef}
-          className="table-name"
-        >
-          <strong>{table.name}</strong>
-        </StyledSpan>
-      </Tooltip>
+  const renderHeader = () => {
+    const element: HTMLInputElement | null = tableNameRef.current;
+    let trigger: string[] = [];
+    if (element && element.offsetWidth < element.scrollWidth) {
+      trigger = ['hover'];
+    }
 
-      <div className="pull-right header-right-side">
-        {table.isMetadataLoading || table.isExtraMetadataLoading ? (
-          <Loading position="inline" />
-        ) : (
-          <Fade
-            data-test="fade"
-            hovered={hovered}
-            onClick={e => e.stopPropagation()}
+    return (
+      <div
+        className="clearfix header-container"
+        onMouseEnter={() => setHover(true)}
+        onMouseLeave={() => setHover(false)}
+      >
+        <Tooltip
+          id="copy-to-clipboard-tooltip"
+          style={{ cursor: 'pointer' }}
+          title={table.name}
+          trigger={trigger}
+        >
+          <StyledSpan
+            data-test="collapse"
+            ref={tableNameRef}
+            className="table-name"
           >
-            {renderControls()}
-          </Fade>
-        )}
+            <strong>{table.name}</strong>
+          </StyledSpan>
+        </Tooltip>
+
+        <div className="pull-right header-right-side">
+          {table.isMetadataLoading || table.isExtraMetadataLoading ? (
+            <Loading position="inline" />
+          ) : (
+            <Fade
+              data-test="fade"
+              hovered={hovered}
+              onClick={e => e.stopPropagation()}
+            >
+              {renderControls()}
+            </Fade>
+          )}
+        </div>
       </div>
-    </div>
-  );
+    );
+  };
 
   const renderBody = () => {
     let cols;

--- a/superset-frontend/src/SqlLab/components/TableElement/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement/index.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Collapse from 'src/components/Collapse';
 import Card from 'src/components/Card';
 import ButtonGroup from 'src/components/ButtonGroup';
@@ -77,6 +77,15 @@ const Fade = styled.div`
 const TableElement = ({ table, actions, ...props }: TableElementProps) => {
   const [sortColumns, setSortColumns] = useState(false);
   const [hovered, setHovered] = useState(false);
+  const [tableNameOverflow, setTableNameOverflow] = useState(false);
+  const tableNameRef = React.useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const element = tableNameRef.current;
+    if (element && element.offsetWidth < element.scrollWidth) {
+      setTableNameOverflow(true);
+    }
+  }, []);
 
   const setHover = (hovered: boolean) => {
     debounce(() => setHovered(hovered), 100)();
@@ -221,12 +230,15 @@ const TableElement = ({ table, actions, ...props }: TableElementProps) => {
     >
       <Tooltip
         id="copy-to-clipboard-tooltip"
-        placement="topLeft"
         style={{ cursor: 'pointer' }}
         title={table.name}
-        trigger={['hover']}
+        trigger={tableNameOverflow ? ['hover'] : []}
       >
-        <StyledSpan data-test="collapse" className="table-name">
+        <StyledSpan
+          data-test="collapse"
+          ref={tableNameRef}
+          className="table-name"
+        >
           <strong>{table.name}</strong>
         </StyledSpan>
       </Tooltip>


### PR DESCRIPTION
### SUMMARY

**Short Summary:**

Removed the tooltip hover for tables that are not truncated

Changed tooltip popup to be centered over the table name

**Detailed Summary:**

This was done by adding a reference to the StyledSpan which is the element that had the styling to truncate when the table name text overflows.

Then when the component mounts, we check if the element is overflowing and if so remove the tooltip trigger that shows the tooltip pop up.

We did that by passing an empty array to the ToolTip trigger property instead of ['hover']. Doing this makes it so the tooltip never triggers and therefore never shows up.

I changed the tooltip to show up over the center of the name because it looked a little weird to have it placed on the left when the table name was so long. I might be the only one who feels that way, so please let me know if anybody disagrees and I will change it back.

### BEFORE 
![TableElementBefore](https://user-images.githubusercontent.com/31329271/141012989-744fcf96-36e4-4d5b-b0e1-1e0c706f2830.gif)

### AFTER
![TableElementAfter](https://user-images.githubusercontent.com/31329271/141013014-14692eef-1014-4aba-8211-33d075a9e4e9.gif)


### TESTING INSTRUCTIONS

Open Superset and select the SqlEditor option under SQL Lab at the top of the screen

On the left side of the screen select some schema and add some tables with the table schema dropdown

If you know where to find some tables with long enough names that it causes the name to truncate then open up some of those and then hover your mouse over the table names and observe.

If you are like me and you do not know where to find super long table names you can add a little bit of code at the file located here `superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.jsx`

Then we hop on down to line 213 and we can copy-paste this little map method in between `this.props.tables` and `.map`

`.map((table, i) => {
                  if (i % 2 == 0) return table;
                  return {
                    ...table,
                    name:
                      table.name +
                      'this_is_a_really_really_really_really_long_name',
                  };
                })
`

All this does is appends a really long string to the end of every other table name. You should remove this after visually testing.

Should go from this:
<img width="443" alt="Screen Shot 2021-11-09 at 4 11 54 PM" src="https://user-images.githubusercontent.com/31329271/141020643-df6553e1-f20b-42ed-939d-c18c9fba7159.png">


To This:
<img width="626" alt="Screen Shot 2021-11-09 at 4 14 23 PM" src="https://user-images.githubusercontent.com/31329271/141020586-7279d298-e302-4172-94bd-ab1ce85a34ee.png">


Then save and refresh the page and now every other table name should be really long.

Finally, you can observe the lack of tooltip on the short names and bear witness to the tooltip popup on the long ones.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
