### PR TITLE
fix(sqla): Adhere to series limit ordering for pre-query

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1384,7 +1384,7 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
                             self._get_series_orderby(
                                 series_limit_metric, metrics_by_name, columns_by_name,
                             ),
-                            False,
+                            not order_desc,
                         )
                     ]
 


### PR DESCRIPTION
### SUMMARY

This PR fixes an almost three year old regression defined in https://github.com/apache/superset/pull/6862 where if a sort-by metric was defined for a pre-query the ordering wasn't adhered to.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Tested locally. This logic is somewhat challenging to add unit tests for given the scale of the function. Ideally this should be modularized to improve the ability to write concise unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
