### PR TITLE
fix(Dashboard): Only apply changes when editing properties

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/edit_properties.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/edit_properties.test.ts
@@ -103,7 +103,7 @@ describe('Dashboard edit action', () => {
 
     // save edit changes
     cy.get('.ant-modal-footer')
-      .contains('Save')
+      .contains('Apply')
       .click()
       .then(() => {
         // assert that modal edit window has closed

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { render, screen } from 'spec/helpers/testing-library';
+import { render, screen, waitFor } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import { HeaderDropdownProps } from 'src/dashboard/components/Header/types';
@@ -197,4 +197,13 @@ test('should show the properties modal', async () => {
   await openDropdown();
   userEvent.click(screen.getByText('Edit dashboard properties'));
   expect(editModeOnProps.showPropertiesModal).toHaveBeenCalledTimes(1);
+});
+
+test('should only apply changes in the properties modal', async () => {
+  render(setup(editModeOnProps));
+  await openDropdown();
+  userEvent.click(screen.getByText('Edit dashboard properties'));
+  waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeInTheDocument();
+  });
 });

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
@@ -199,7 +199,7 @@ test('should show the properties modal', async () => {
   expect(editModeOnProps.showPropertiesModal).toHaveBeenCalledTimes(1);
 });
 
-test('should only apply changes in the properties modal', async () => {
+test('should display the Apply button when opening the modal', async () => {
   render(setup(editModeOnProps));
   await openDropdown();
   userEvent.click(screen.getByText('Edit dashboard properties'));

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -629,6 +629,7 @@ class Header extends React.PureComponent {
                   );
                 }
               }}
+              onlyApply
             />
           )}
 


### PR DESCRIPTION
### SUMMARY
This PR adds the `onlyApply` prop to the properties modal of the Dashboard, so that changes will only be applied but not saved. This is to avoid confusion with discarded changes that were actually saved.

### BEFORE

Fixes #17243

### AFTER

https://user-images.githubusercontent.com/60598000/141163753-93d37667-5205-45d4-a534-2a78b44c59bc.mp4

### TESTING INSTRUCTIONS
1. Open a Dashboard
2. Edit its properties and apply
3. Discard the changes
4. Make sure the changes were actually discarded

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #17243
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
