### PR TITLE
feat: add a config to enable retina quality images in screenshots

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -209,7 +209,8 @@ SHOW_STACKTRACE = True
 # Use all X-Forwarded headers when ENABLE_PROXY_FIX is True.
 # When proxying to a different port, set "x_port" to 0 to avoid downstream issues.
 ENABLE_PROXY_FIX = False
-PROXY_FIX_CONFIG = {"x_for": 1, "x_proto": 1, "x_host": 1, "x_port": 1, "x_prefix": 1}
+PROXY_FIX_CONFIG = {"x_for": 1, "x_proto": 1,
+                    "x_host": 1, "x_port": 1, "x_prefix": 1}
 
 # ------------------------------
 # GLOBALS FOR APP Builder
@@ -410,12 +411,13 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     # This could cause the server to run out of memory or compute.
     "ALLOW_FULL_CSV_EXPORT": False,
     "UX_BETA": False,
+    "SCREENSHOTS_USE_RETINA_HIRES": False
 }
 
 # Feature flags may also be set via 'SUPERSET_FEATURE_' prefixed environment vars.
 DEFAULT_FEATURE_FLAGS.update(
     {
-        k[len("SUPERSET_FEATURE_") :]: parse_boolean_string(v)
+        k[len("SUPERSET_FEATURE_"):]: parse_boolean_string(v)
         for k, v in os.environ.items()
         if re.search(r"^SUPERSET_FEATURE_\w+", k)
     }
@@ -438,7 +440,8 @@ FEATURE_FLAGS: Dict[str, bool] = {}
 #     if hasattr(g, "user") and g.user.is_active:
 #         feature_flags_dict['some_feature'] = g.user and g.user.get_id() == 5
 #     return feature_flags_dict
-GET_FEATURE_FLAGS_FUNC: Optional[Callable[[Dict[str, bool]], Dict[str, bool]]] = None
+GET_FEATURE_FLAGS_FUNC: Optional[Callable[[
+    Dict[str, bool]], Dict[str, bool]]] = None
 # A function that receives a feature flag name and an optional default value.
 # Has a similar utility to GET_FEATURE_FLAGS_FUNC but it's useful to not force the
 # evaluation of all feature flags when just evaluating a single one.
@@ -848,6 +851,8 @@ CSV_TO_HIVE_UPLOAD_S3_BUCKET = None
 CSV_TO_HIVE_UPLOAD_DIRECTORY = "EXTERNAL_HIVE_TABLES/"
 # Function that creates upload directory dynamically based on the
 # database used, user and schema provided.
+
+
 def CSV_TO_HIVE_UPLOAD_DIRECTORY_FUNC(  # pylint: disable=invalid-name
     database: "Database",
     user: "models.User",  # pylint: disable=unused-argument
@@ -951,7 +956,10 @@ BLUEPRINTS: List[Blueprint] = []
 # Provide a callable that receives a tracking_url and returns another
 # URL. This is used to translate internal Hadoop job tracker URL
 # into a proxied one
-TRACKING_URL_TRANSFORMER = lambda x: x
+
+
+def TRACKING_URL_TRANSFORMER(x): return x
+
 
 # Interval between consecutive polls when using Hive Engine
 HIVE_POLL_INTERVAL = int(timedelta(seconds=5).total_seconds())
@@ -993,6 +1001,8 @@ DB_CONNECTION_MUTATOR = None
 #    def SQL_QUERY_MUTATOR(sql, user_name, security_manager, database):
 #        dttm = datetime.now().isoformat()
 #        return f"-- [SQL LAB] {username} {dttm}\n{sql}"
+
+
 def SQL_QUERY_MUTATOR(  # pylint: disable=invalid-name,unused-argument
     sql: str,
     user_name: Optional[str],
@@ -1026,7 +1036,8 @@ ALERT_REPORTS_WORKING_TIME_OUT_KILL = True
 ALERT_REPORTS_WORKING_TIME_OUT_LAG = int(timedelta(seconds=10).total_seconds())
 # if ALERT_REPORTS_WORKING_TIME_OUT_KILL is True, set a celery hard timeout
 # Equal to working timeout + ALERT_REPORTS_WORKING_SOFT_TIME_OUT_LAG
-ALERT_REPORTS_WORKING_SOFT_TIME_OUT_LAG = int(timedelta(seconds=1).total_seconds())
+ALERT_REPORTS_WORKING_SOFT_TIME_OUT_LAG = int(
+    timedelta(seconds=1).total_seconds())
 # If set to true no notification is sent, the worker will just log a message.
 # Useful for debugging
 ALERT_REPORTS_NOTIFICATION_DRY_RUN = False
@@ -1215,7 +1226,10 @@ OLD_API_CHECK_DATASET_OWNERSHIP = True
 # to allow mutating the object with this callback.
 # This can be used to set any properties of the object based on naming
 # conventions and such. You can find examples in the tests.
-SQLA_TABLE_MUTATOR = lambda table: table
+
+
+def SQLA_TABLE_MUTATOR(table): return table
+
 
 # Global async query config options.
 # Requires GLOBAL_ASYNC_QUERIES feature flag to be enabled.
@@ -1302,9 +1316,11 @@ if CONFIG_PATH_ENV_VAR in os.environ:
 elif importlib.util.find_spec("superset_config") and not is_test():
     try:
         import superset_config  # pylint: disable=import-error
-        from superset_config import *  # type: ignore # pylint: disable=import-error,wildcard-import,unused-wildcard-import
+        # type: ignore # pylint: disable=import-error,wildcard-import,unused-wildcard-import
+        from superset_config import *
 
-        print(f"Loaded your LOCAL configuration at [{superset_config.__file__}]")
+        print(
+            f"Loaded your LOCAL configuration at [{superset_config.__file__}]")
     except Exception:
         logger.exception("Found but failed to import local superset_config")
         raise

--- a/superset/config.py
+++ b/superset/config.py
@@ -209,8 +209,7 @@ SHOW_STACKTRACE = True
 # Use all X-Forwarded headers when ENABLE_PROXY_FIX is True.
 # When proxying to a different port, set "x_port" to 0 to avoid downstream issues.
 ENABLE_PROXY_FIX = False
-PROXY_FIX_CONFIG = {"x_for": 1, "x_proto": 1,
-                    "x_host": 1, "x_port": 1, "x_prefix": 1}
+PROXY_FIX_CONFIG = {"x_for": 1, "x_proto": 1, "x_host": 1, "x_port": 1, "x_prefix": 1}
 
 # ------------------------------
 # GLOBALS FOR APP Builder
@@ -411,13 +410,12 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     # This could cause the server to run out of memory or compute.
     "ALLOW_FULL_CSV_EXPORT": False,
     "UX_BETA": False,
-    "SCREENSHOTS_USE_RETINA_HIRES": False
 }
 
 # Feature flags may also be set via 'SUPERSET_FEATURE_' prefixed environment vars.
 DEFAULT_FEATURE_FLAGS.update(
     {
-        k[len("SUPERSET_FEATURE_"):]: parse_boolean_string(v)
+        k[len("SUPERSET_FEATURE_") :]: parse_boolean_string(v)
         for k, v in os.environ.items()
         if re.search(r"^SUPERSET_FEATURE_\w+", k)
     }
@@ -440,8 +438,7 @@ FEATURE_FLAGS: Dict[str, bool] = {}
 #     if hasattr(g, "user") and g.user.is_active:
 #         feature_flags_dict['some_feature'] = g.user and g.user.get_id() == 5
 #     return feature_flags_dict
-GET_FEATURE_FLAGS_FUNC: Optional[Callable[[
-    Dict[str, bool]], Dict[str, bool]]] = None
+GET_FEATURE_FLAGS_FUNC: Optional[Callable[[Dict[str, bool]], Dict[str, bool]]] = None
 # A function that receives a feature flag name and an optional default value.
 # Has a similar utility to GET_FEATURE_FLAGS_FUNC but it's useful to not force the
 # evaluation of all feature flags when just evaluating a single one.
@@ -956,9 +953,8 @@ BLUEPRINTS: List[Blueprint] = []
 # Provide a callable that receives a tracking_url and returns another
 # URL. This is used to translate internal Hadoop job tracker URL
 # into a proxied one
-
-
-def TRACKING_URL_TRANSFORMER(x): return x
+def TRACKING_URL_TRANSFORMER(x):  # pylint: disable=invalid-name
+    return x
 
 
 # Interval between consecutive polls when using Hive Engine
@@ -1001,8 +997,6 @@ DB_CONNECTION_MUTATOR = None
 #    def SQL_QUERY_MUTATOR(sql, user_name, security_manager, database):
 #        dttm = datetime.now().isoformat()
 #        return f"-- [SQL LAB] {username} {dttm}\n{sql}"
-
-
 def SQL_QUERY_MUTATOR(  # pylint: disable=invalid-name,unused-argument
     sql: str,
     user_name: Optional[str],
@@ -1036,8 +1030,7 @@ ALERT_REPORTS_WORKING_TIME_OUT_KILL = True
 ALERT_REPORTS_WORKING_TIME_OUT_LAG = int(timedelta(seconds=10).total_seconds())
 # if ALERT_REPORTS_WORKING_TIME_OUT_KILL is True, set a celery hard timeout
 # Equal to working timeout + ALERT_REPORTS_WORKING_SOFT_TIME_OUT_LAG
-ALERT_REPORTS_WORKING_SOFT_TIME_OUT_LAG = int(
-    timedelta(seconds=1).total_seconds())
+ALERT_REPORTS_WORKING_SOFT_TIME_OUT_LAG = int(timedelta(seconds=1).total_seconds())
 # If set to true no notification is sent, the worker will just log a message.
 # Useful for debugging
 ALERT_REPORTS_NOTIFICATION_DRY_RUN = False
@@ -1096,7 +1089,11 @@ EMAIL_REPORTS_USER = "admin"
 WEBDRIVER_TYPE = "firefox"
 
 # Window size - this will impact the rendering of the data
-WEBDRIVER_WINDOW = {"dashboard": (1600, 2000), "slice": (3000, 1200)}
+WEBDRIVER_WINDOW = {
+    "dashboard": (1600, 2000),
+    "slice": (3000, 1200),
+    "pixel_density": 1,
+}
 
 # An optional override to the default auth hook used to provide auth to the
 # offline webdriver
@@ -1226,9 +1223,8 @@ OLD_API_CHECK_DATASET_OWNERSHIP = True
 # to allow mutating the object with this callback.
 # This can be used to set any properties of the object based on naming
 # conventions and such. You can find examples in the tests.
-
-
-def SQLA_TABLE_MUTATOR(table): return table
+def SQLA_TABLE_MUTATOR(table):  # pylint: disable=invalid-name
+    return table
 
 
 # Global async query config options.
@@ -1316,11 +1312,11 @@ if CONFIG_PATH_ENV_VAR in os.environ:
 elif importlib.util.find_spec("superset_config") and not is_test():
     try:
         import superset_config  # pylint: disable=import-error
+
         # type: ignore # pylint: disable=import-error,wildcard-import,unused-wildcard-import
         from superset_config import *
 
-        print(
-            f"Loaded your LOCAL configuration at [{superset_config.__file__}]")
+        print(f"Loaded your LOCAL configuration at [{superset_config.__file__}]")
     except Exception:
         logger.exception("Found but failed to import local superset_config")
         raise

--- a/superset/config.py
+++ b/superset/config.py
@@ -848,8 +848,6 @@ CSV_TO_HIVE_UPLOAD_S3_BUCKET = None
 CSV_TO_HIVE_UPLOAD_DIRECTORY = "EXTERNAL_HIVE_TABLES/"
 # Function that creates upload directory dynamically based on the
 # database used, user and schema provided.
-
-
 def CSV_TO_HIVE_UPLOAD_DIRECTORY_FUNC(  # pylint: disable=invalid-name
     database: "Database",
     user: "models.User",  # pylint: disable=unused-argument
@@ -953,9 +951,7 @@ BLUEPRINTS: List[Blueprint] = []
 # Provide a callable that receives a tracking_url and returns another
 # URL. This is used to translate internal Hadoop job tracker URL
 # into a proxied one
-def TRACKING_URL_TRANSFORMER(x):  # pylint: disable=invalid-name
-    return x
-
+TRACKING_URL_TRANSFORMER = lambda x: x
 
 # Interval between consecutive polls when using Hive Engine
 HIVE_POLL_INTERVAL = int(timedelta(seconds=5).total_seconds())
@@ -1223,9 +1219,7 @@ OLD_API_CHECK_DATASET_OWNERSHIP = True
 # to allow mutating the object with this callback.
 # This can be used to set any properties of the object based on naming
 # conventions and such. You can find examples in the tests.
-def SQLA_TABLE_MUTATOR(table):  # pylint: disable=invalid-name
-    return table
-
+SQLA_TABLE_MUTATOR = lambda table: table
 
 # Global async query config options.
 # Requires GLOBAL_ASYNC_QUERIES feature flag to be enabled.
@@ -1312,9 +1306,7 @@ if CONFIG_PATH_ENV_VAR in os.environ:
 elif importlib.util.find_spec("superset_config") and not is_test():
     try:
         import superset_config  # pylint: disable=import-error
-
-        # type: ignore # pylint: disable=import-error,wildcard-import,unused-wildcard-import
-        from superset_config import *
+        from superset_config import *  # type: ignore # pylint: disable=import-error,wildcard-import,unused-wildcard-import
 
         print(f"Loaded your LOCAL configuration at [{superset_config.__file__}]")
     except Exception:

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -51,40 +51,28 @@ class DashboardStandaloneMode(Enum):
 
 
 class WebDriverProxy:
-    def __init__(
-        self,
-        driver_type: str,
-        window: Optional[WindowSize] = None,
-    ):
+    def __init__(self, driver_type: str, window: Optional[WindowSize] = None):
         self._driver_type = driver_type
         self._window: WindowSize = window or (800, 600)
         self._screenshot_locate_wait = current_app.config["SCREENSHOT_LOCATE_WAIT"]
         self._screenshot_load_wait = current_app.config["SCREENSHOT_LOAD_WAIT"]
 
     def create(self) -> WebDriver:
-        pixel_density = current_app.config["WEBDRIVER_WINDOW"].get(
-            "pixel_density", 1)
+        pixel_density = current_app.config["WEBDRIVER_WINDOW"].get("pixel_density", 1)
         if self._driver_type == "firefox":
             driver_class = firefox.webdriver.WebDriver
             options = firefox.options.Options()
             profile = FirefoxProfile()
-            profile.set_preference(
-                "layout.css.devPixelsPerPx",
-                str(pixel_density),
-            )
-            kwargs: Dict[Any, Any] = dict(
-                options=options, firefox_profile=profile)
+            profile.set_preference("layout.css.devPixelsPerPx", str(pixel_density))
+            kwargs: Dict[Any, Any] = dict(options=options, firefox_profile=profile)
         elif self._driver_type == "chrome":
             driver_class = chrome.webdriver.WebDriver
             options = chrome.options.Options()
-            options.add_argument(
-                f"--force-device-scale-factor={pixel_density}")
-            options.add_argument(
-                f"--window-size={self._window[0]},{self._window[1]}")
+            options.add_argument(f"--force-device-scale-factor={pixel_density}")
+            options.add_argument(f"--window-size={self._window[0]},{self._window[1]}")
             kwargs = dict(options=options)
         else:
-            raise Exception(
-                f"Webdriver name ({self._driver_type}) not supported")
+            raise Exception(f"Webdriver name ({self._driver_type}) not supported")
         # Prepare args for the webdriver init
 
         # Add additional configured options
@@ -117,10 +105,7 @@ class WebDriverProxy:
             pass
 
     def get_screenshot(
-        self,
-        url: str,
-        element_name: str,
-        user: "User",
+        self, url: str, element_name: str, user: "User"
     ) -> Optional[bytes]:
         params = {"standalone": DashboardStandaloneMode.REPORT.value}
         req = PreparedRequest()
@@ -153,14 +138,12 @@ class WebDriverProxy:
             selenium_animation_wait = current_app.config[
                 "SCREENSHOT_SELENIUM_ANIMATION_WAIT"
             ]
-            logger.debug("Wait %i seconds for chart animation",
-                         selenium_animation_wait)
+            logger.debug("Wait %i seconds for chart animation", selenium_animation_wait)
             sleep(selenium_animation_wait)
             logger.info("Taking a PNG screenshot of url %s", url)
             img = element.screenshot_as_png
         except TimeoutException:
-            logger.warning(
-                "Selenium timed out requesting url %s", url, exc_info=True)
+            logger.warning("Selenium timed out requesting url %s", url, exc_info=True)
             img = element.screenshot_as_png
         except StaleElementReferenceException:
             logger.error(
@@ -171,6 +154,5 @@ class WebDriverProxy:
         except WebDriverException as ex:
             logger.error(ex, exc_info=True)
         finally:
-            self.destroy(
-                driver, current_app.config["SCREENSHOT_SELENIUM_RETRIES"])
+            self.destroy(driver, current_app.config["SCREENSHOT_SELENIUM_RETRIES"])
         return img

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -17,8 +17,6 @@
 
 import logging
 from enum import Enum
-from superset.extensions import feature_flag_manager
-from superset import config
 from time import sleep
 from typing import Any, Dict, Optional, Tuple, TYPE_CHECKING
 
@@ -54,7 +52,9 @@ class DashboardStandaloneMode(Enum):
 
 class WebDriverProxy:
     def __init__(
-        self, driver_type: str, window: Optional[WindowSize] = None,
+        self,
+        driver_type: str,
+        window: Optional[WindowSize] = None,
     ):
         self._driver_type = driver_type
         self._window: WindowSize = window or (800, 600)
@@ -62,22 +62,26 @@ class WebDriverProxy:
         self._screenshot_load_wait = current_app.config["SCREENSHOT_LOAD_WAIT"]
 
     def create(self) -> WebDriver:
+        pixel_density = current_app.config["WEBDRIVER_WINDOW"].get(
+            "pixel_density", 1)
         if self._driver_type == "firefox":
             driver_class = firefox.webdriver.WebDriver
             options = firefox.options.Options()
             profile = FirefoxProfile()
-            if feature_flag_manager.is_feature_enabled("SCREENSHOTS_USE_RETINA_HIRES"):
-                profile.set_preference("layout.css.devPixelsPerPx", "2")
+            profile.set_preference(
+                "layout.css.devPixelsPerPx",
+                str(pixel_density),
+            )
             kwargs: Dict[Any, Any] = dict(
                 options=options, firefox_profile=profile)
         elif self._driver_type == "chrome":
             driver_class = chrome.webdriver.WebDriver
             options = chrome.options.Options()
-            if feature_flag_manager.is_feature_enabled("SCREENSHOTS_USE_RETINA_HIRES"):
-                options.add_argument("--force-device-scale-factor=2")
+            options.add_argument(
+                f"--force-device-scale-factor={pixel_density}")
             options.add_argument(
                 f"--window-size={self._window[0]},{self._window[1]}")
-            kwargs: Dict[Any, Any] = dict(options=options)
+            kwargs = dict(options=options)
         else:
             raise Exception(
                 f"Webdriver name ({self._driver_type}) not supported")
@@ -113,7 +117,10 @@ class WebDriverProxy:
             pass
 
     def get_screenshot(
-        self, url: str, element_name: str, user: "User",
+        self,
+        url: str,
+        element_name: str,
+        user: "User",
     ) -> Optional[bytes]:
         params = {"standalone": DashboardStandaloneMode.REPORT.value}
         req = PreparedRequest()


### PR DESCRIPTION
### SUMMARY
Adding support for configuring image quality for screenshots in both Chrome and Firefox. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
Update the config override with a pixel_density of 2. Create a report with an email and check the filesize for a 2x size. It should still be captured at the same width as declared in the config, but at a higher resolution. The email will also display the image at 1000px as per the html. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
