### PR TITLE
feat: Add quarter unit to datetrunc

### DIFF
--- a/superset-frontend/src/explore/components/controls/DateFilterControl/components/DateFunctionTooltip.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/components/DateFunctionTooltip.tsx
@@ -62,7 +62,7 @@ dateadd(datetime("2020-03-01"), 2, day)`}</code>
       <h4>{t('Syntax')}</h4>
       <pre>
         <code>{`datetrunc([datetime], [dateunit])
-dateunit = (year | month | week)`}</code>
+dateunit = (year | quarter | month | week)`}</code>
       </pre>
       <h4>{t('Example')}</h4>
       <pre>

--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -21,6 +21,7 @@ from datetime import datetime, timedelta
 from time import struct_time
 from typing import Dict, List, Optional, Tuple
 
+import pandas as pd
 import parsedatetime
 from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
@@ -322,10 +323,12 @@ class EvalDateTruncFunc:  # pylint: disable=too-few-public-methods
             dttm = dttm.replace(
                 month=1, day=1, hour=0, minute=0, second=0, microsecond=0
             )
+        if unit == "quarter":
+            dttm = pd.Period(pd.Timestamp(dttm), freq="Q").to_timestamp()
         elif unit == "month":
             dttm = dttm.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
         elif unit == "week":
-            dttm = dttm - relativedelta(days=dttm.weekday())
+            dttm -= relativedelta(days=dttm.weekday())
             dttm = dttm.replace(hour=0, minute=0, second=0, microsecond=0)
         elif unit == "day":
             dttm = dttm.replace(hour=0, minute=0, second=0, microsecond=0)
@@ -443,7 +446,7 @@ def datetime_parser() -> ParseResults:  # pylint: disable=too-many-locals
         + Group(
             date_expr
             + comma
-            + (YEAR | MONTH | WEEK | DAY | HOUR | MINUTE | SECOND)
+            + (YEAR | QUARTER | MONTH | WEEK | DAY | HOUR | MINUTE | SECOND)
             + ppOptional(comma)
         )
         + rparen

--- a/tests/integration_tests/utils/date_parser_tests.py
+++ b/tests/integration_tests/utils/date_parser_tests.py
@@ -209,6 +209,10 @@ class TestDateParser(SupersetTestCase):
         expected = datetime(2016, 1, 1, 0, 0, 0)
         self.assertEqual(result, expected)
 
+        result = datetime_eval("datetrunc(datetime('now'), quarter)")
+        expected = datetime(2016, 10, 1, 0, 0, 0)
+        self.assertEqual(result, expected)
+
         result = datetime_eval("datetrunc(datetime('now'), month)")
         expected = datetime(2016, 11, 1, 0, 0, 0)
         self.assertEqual(result, expected)


### PR DESCRIPTION
### SUMMARY

It's somewhat typical to report for the current quarter (QTD) and currently the only way to do this is to define a broad time range and then add a custom SQL filter based on the current timestamp.

This request has been mentioned in a couple of Stack Overflow questions:

- [How to MTD, YTD in Apache Superset?](https://stackoverflow.com/questions/49862866/how-to-mtd-ytd-in-apache-superset)
- [how to set current quarter in Superset?](https://stackoverflow.com/questions/69043541/how-to-set-current-quarter-in-superset)

MTD, YTD, etc. are supported via the sweet date parse logic—kudos to whoever added this functionality—using the `datetrunc` functionality, thus I thought I should extend this to also include the `quarter` unit.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<img width="445" alt="Screen Shot 2021-11-11 at 8 19 15 PM" src="https://user-images.githubusercontent.com/4567245/141408829-b9b18d9a-cbc3-456b-85cb-dcab63af2d0a.png">

### TESTING INSTRUCTIONS

Added unit test.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
