### PR TITLE
refactor(ChartDataCommand): into two separate commands

### DIFF
--- a/superset/charts/data/commands.py
+++ b/superset/charts/data/commands.py
@@ -35,10 +35,7 @@ logger = logging.getLogger(__name__)
 
 
 class ChartDataCommand(BaseCommand):
-    def __init__(self) -> None:
-        self._form_data: Dict[str, Any]
-        self._query_context: QueryContext
-        self._async_channel_id: str
+    _query_context: QueryContext
 
     def run(self, **kwargs: Any) -> Dict[str, Any]:
         # caching is handled in query_context.get_df_payload
@@ -66,26 +63,27 @@ class ChartDataCommand(BaseCommand):
 
         return return_value
 
-    def run_async(self, user_id: Optional[str]) -> Dict[str, Any]:
-        job_metadata = async_query_manager.init_job(self._async_channel_id, user_id)
-        load_chart_data_into_cache.delay(job_metadata, self._form_data)
-
-        return job_metadata
-
     def set_query_context(self, form_data: Dict[str, Any]) -> QueryContext:
-        self._form_data = form_data
         try:
-            self._query_context = ChartDataQueryContextSchema().load(self._form_data)
+            self._query_context = ChartDataQueryContextSchema().load(form_data)
         except KeyError as ex:
             raise ValidationError("Request is incorrect") from ex
         except ValidationError as error:
             raise error
-
         return self._query_context
 
     def validate(self) -> None:
         self._query_context.raise_for_access()
 
-    def validate_async_request(self, request: Request) -> None:
+
+class CreateAsyncChartDataJobCommand:
+    _async_channel_id: str
+
+    def validate(self, request: Request) -> None:
         jwt_data = async_query_manager.parse_jwt_from_request(request)
         self._async_channel_id = jwt_data["channel"]
+
+    def run(self, form_data: Dict[str, Any], user_id: Optional[str]) -> Dict[str, Any]:
+        job_metadata = async_query_manager.init_job(self._async_channel_id, user_id)
+        load_chart_data_into_cache.delay(job_metadata, form_data)
+        return job_metadata

--- a/superset/tasks/async_queries.py
+++ b/superset/tasks/async_queries.py
@@ -55,7 +55,7 @@ def load_chart_data_into_cache(
     job_metadata: Dict[str, Any], form_data: Dict[str, Any],
 ) -> None:
     # pylint: disable=import-outside-toplevel
-    from superset.charts.commands.data import ChartDataCommand
+    from superset.charts.data.commands import ChartDataCommand
 
     try:
         ensure_user_is_set(job_metadata.get("user_id"))

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -37,7 +37,7 @@ from tests.integration_tests.test_app import app
 
 import pytest
 
-from superset.charts.commands.data import ChartDataCommand
+from superset.charts.data.commands import ChartDataCommand
 from superset.connectors.sqla.models import TableColumn, SqlaTable
 from superset.errors import SupersetErrorType
 from superset.extensions import async_query_manager, db

--- a/tests/integration_tests/tasks/async_queries_tests.py
+++ b/tests/integration_tests/tasks/async_queries_tests.py
@@ -22,10 +22,8 @@ import pytest
 from celery.exceptions import SoftTimeLimitExceeded
 from flask import g
 
-from superset import db
-from superset.charts.commands.data import ChartDataCommand
 from superset.charts.commands.exceptions import ChartDataQueryFailedError
-from superset.connectors.sqla.models import SqlaTable
+from superset.charts.data.commands import ChartDataCommand
 from superset.exceptions import SupersetException
 from superset.extensions import async_query_manager, security_manager
 from superset.tasks import async_queries


### PR DESCRIPTION
## **Background** 
When we have worked on #16991 we wanted to test the new functionalities in concrete and accurate unittest.
All chartData flows and its components are too couple to superset so it is impossible to create unittests. 
The flows are not testable and so many components do not meet the very important principle SRP and the code became so dirty 

So I've started to refactor it (#17344 ) but many changes were added and it was hard to review so I decided to split those changes into small PRs so will be easier to follow 

This is the fifth PR in a sequence of PRs to meet these
The next PR is #17461 


## PR description
1. Moves the commands module to be under charts.data package 
2. Retrieving data and creating retrieve data job are two different responsibilities, so they should be in separate commands so the PR split it. 

Note - The pr consists of the #17407 commit until it will be merged then I'll recreate the branch from master

### Test plans 
There are no logic changes so new tests are not required

## Previous PRs
1. #17399
2. #17400 
3. #17405 
4. #17407 
