### PR TITLE
fix: Workaround for Pandas Timestamp.isoformat issue

### DIFF
--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -324,7 +324,9 @@ class EvalDateTruncFunc:  # pylint: disable=too-few-public-methods
                 month=1, day=1, hour=0, minute=0, second=0, microsecond=0
             )
         if unit == "quarter":
-            dttm = pd.Period(pd.Timestamp(dttm), freq="Q").to_timestamp()
+            dttm = (
+                pd.Period(pd.Timestamp(dttm), freq="Q").to_timestamp().to_pydatetime()
+            )
         elif unit == "month":
             dttm = dttm.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
         elif unit == "week":


### PR DESCRIPTION
### SUMMARY

The Pandas timestamp differs from the `datetime.datetime` object and the [isoformat](https://pandas.pydata.org/docs/reference/api/pandas.Timestamp.isoformat.html) function doesn't include the `timespec` argument (the help description is wrong), i.e., it results in errors of the form,

```
TypeError: isoformat() got an unexpected keyword argument 'timespec
```

See https://github.com/pandas-dev/pandas/issues/26131 for more details. The fix is to convert the pandas.TImestamp` object into a `datetime.datetime` object which is consistent with the existing logic, even though 

```python
>>> isinstance(pd.Timestamp('2021-11-12'), datetime.datetime)
True
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI and tested manually, i.e., checked the return type.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
