### PR TITLE
fix: use full resultType with csv download on chart in dashboard

### DIFF
--- a/superset-frontend/spec/javascripts/dashboard/components/gridComponents/Chart_spec.jsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/gridComponents/Chart_spec.jsx
@@ -116,7 +116,7 @@ describe('Chart', () => {
     expect(stubbedExportCSV.lastCall.args[0]).toEqual(
       expect.objectContaining({
         formData: expect.anything(),
-        resultType: 'results',
+        resultType: 'full',
         resultFormat: 'csv',
       }),
     );

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -252,7 +252,7 @@ export default class Chart extends React.Component {
       formData: isFullCSV
         ? { ...this.props.formData, row_limit: this.props.maxRows }
         : this.props.formData,
-      resultType: 'results',
+      resultType: 'full',
       resultFormat: 'csv',
     });
   }


### PR DESCRIPTION
### SUMMARY
Use the full resultType when downloading a csv so that it takes the same cache key as the chart itself. See https://github.com/apache/superset/pull/17194

This fixes a bug where if you refreshed cache and then downloaded a csv from a dashboard, the csv results would be different than the chart.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After: 

https://user-images.githubusercontent.com/5186919/141601024-8f2025b8-5833-4c8d-b5b7-692ad2ec9404.mov



### TESTING INSTRUCTIONS
We should also test to see that the full csv report download has a row limit.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
