### PR TITLE
chore: bumping react syntax highlighter and thusly prismjs

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -113,7 +113,7 @@
         "react-sortable-hoc": "^1.11.0",
         "react-split": "^2.0.9",
         "react-sticky": "^6.0.3",
-        "react-syntax-highlighter": "^15.4.4",
+        "react-syntax-highlighter": "^15.4.5",
         "react-table": "^7.6.3",
         "react-transition-group": "^2.5.3",
         "react-ultimate-pagination": "^1.2.0",
@@ -47623,19 +47623,24 @@
       }
     },
     "node_modules/react-syntax-highlighter": {
-      "version": "15.4.4",
-      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.4.4.tgz",
-      "integrity": "sha512-PsOFHNTzkb3OroXdoR897eKN5EZ6grht1iM+f1lJSq7/L0YVnkJaNVwC3wEUYPOAmeyl5xyer1DjL6MrumO6Zw==",
+      "version": "15.4.5",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.4.5.tgz",
+      "integrity": "sha512-RC90KQTxZ/b7+9iE6s9nmiFLFjWswUcfULi4GwVzdFVKVMQySkJWBuOmJFfjwjMVCo0IUUuJrWebNKyviKpwLQ==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "highlight.js": "^10.4.1",
         "lowlight": "^1.17.0",
-        "prismjs": "^1.22.0",
+        "prismjs": "^1.25.0",
         "refractor": "^3.2.0"
       },
       "peerDependencies": {
         "react": ">= 0.14.0"
       }
+    },
+    "node_modules/react-syntax-highlighter/node_modules/prismjs": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.25.0.tgz",
+      "integrity": "sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg=="
     },
     "node_modules/react-table": {
       "version": "7.6.3",
@@ -92272,15 +92277,22 @@
       }
     },
     "react-syntax-highlighter": {
-      "version": "15.4.4",
-      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.4.4.tgz",
-      "integrity": "sha512-PsOFHNTzkb3OroXdoR897eKN5EZ6grht1iM+f1lJSq7/L0YVnkJaNVwC3wEUYPOAmeyl5xyer1DjL6MrumO6Zw==",
+      "version": "15.4.5",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.4.5.tgz",
+      "integrity": "sha512-RC90KQTxZ/b7+9iE6s9nmiFLFjWswUcfULi4GwVzdFVKVMQySkJWBuOmJFfjwjMVCo0IUUuJrWebNKyviKpwLQ==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "highlight.js": "^10.4.1",
         "lowlight": "^1.17.0",
-        "prismjs": "^1.22.0",
+        "prismjs": "^1.25.0",
         "refractor": "^3.2.0"
+      },
+      "dependencies": {
+        "prismjs": {
+          "version": "1.25.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.25.0.tgz",
+          "integrity": "sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg=="
+        }
       }
     },
     "react-table": {

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -165,7 +165,7 @@
     "react-sortable-hoc": "^1.11.0",
     "react-split": "^2.0.9",
     "react-sticky": "^6.0.3",
-    "react-syntax-highlighter": "^15.4.4",
+    "react-syntax-highlighter": "^15.4.5",
     "react-table": "^7.6.3",
     "react-transition-group": "^2.5.3",
     "react-ultimate-pagination": "^1.2.0",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Finally managed to bump the prismjs dependency, which was at a vulnerable version due to `react-syntax-highlighter`. I managed to get [this](https://github.com/react-syntax-highlighter/react-syntax-highlighter/pull/430) PR through over on that repo, so I'm pulling in the resulting bump here.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
