### PR TITLE
chore: move canAddReport to utils

### DIFF
--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -29,7 +29,6 @@ import {
   LOG_ACTIONS_FORCE_REFRESH_DASHBOARD,
   LOG_ACTIONS_TOGGLE_EDIT_DASHBOARD,
 } from 'src/logger/LogUtils';
-import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 import { canAddReports } from 'src/utils/permissionsUtils';
 
 import Icons from 'src/components/Icons';

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
@@ -34,7 +34,6 @@ import {
   toggleActive,
   deleteActiveReport,
 } from 'src/reports/actions/reports';
-import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 import { canAddReports } from 'src/utils/permissionsUtils';
 import HeaderReportActionsDropdown from 'src/components/ReportModal/HeaderReportActionsDropdown';
 import { chartPropShape } from 'src/dashboard/util/propShapes';

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
@@ -35,6 +35,7 @@ import {
   deleteActiveReport,
 } from 'src/reports/actions/reports';
 import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
+import { canAddReports } from 'src/utils/permissionsUtils';
 import HeaderReportActionsDropdown from 'src/components/ReportModal/HeaderReportActionsDropdown';
 import { chartPropShape } from 'src/dashboard/util/propShapes';
 import EditableTitle from 'src/components/EditableTitle';
@@ -125,9 +126,9 @@ export class ExploreChartHeader extends React.PureComponent {
   }
 
   componentDidMount() {
-    const { dashboardId } = this.props;
-    if (this.canAddReports()) {
-      const { user, chart } = this.props;
+    const { dashboardId, user } = this.props;
+    if (canAddReports(user)) {
+      const { chart } = this.props;
       // this is in the case that there is an anonymous user.
       this.props.fetchUISpecificReport(
         user.userId,
@@ -224,24 +225,6 @@ export class ExploreChartHeader extends React.PureComponent {
         </span>
       </>
     );
-  }
-
-  canAddReports() {
-    if (!isFeatureEnabled(FeatureFlag.ALERT_REPORTS)) {
-      return false;
-    }
-    const { user } = this.props;
-    if (!user?.userId) {
-      // this is in the case that there is an anonymous user.
-      return false;
-    }
-    const roles = Object.keys(user.roles || []);
-    const permissions = roles.map(key =>
-      user.roles[key].filter(
-        perms => perms[0] === 'menu_access' && perms[1] === 'Manage',
-      ),
-    );
-    return permissions[0].length > 0;
   }
 
   render() {
@@ -343,7 +326,7 @@ export class ExploreChartHeader extends React.PureComponent {
             isRunning={chartStatus === 'loading'}
             status={CHART_STATUS_MAP[chartStatus]}
           />
-          {this.canAddReports() && this.renderReportModal()}
+          {canAddReports(user) && this.renderReportModal()}
           <ReportModal
             show={this.state.showingReportModal}
             onHide={this.hideReportModal}

--- a/superset-frontend/src/utils/permissionsUtils.test.ts
+++ b/superset-frontend/src/utils/permissionsUtils.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as featureFlags from 'src/featureFlags';
+import { canAddReports } from './permissionsUtils';
+
+describe('permissions utils', () => {
+  let isFeatureEnabledMock: any;
+
+  beforeEach(async () => {
+    isFeatureEnabledMock = jest
+      .spyOn(featureFlags, 'isFeatureEnabled')
+      .mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    isFeatureEnabledMock.mockRestore();
+  });
+
+  it('can add reports', () => {
+    const user = {
+      roles: {
+        Admin: [['menu_access', 'Manage']],
+      },
+    };
+    expect(canAddReports(user as any)).toBe(true);
+  });
+
+  it('cannot add reports', () => {
+    const user = {
+      roles: {
+        Admin: [['some_permission', 'View']],
+      },
+    };
+    expect(canAddReports(user as any)).toBe(false);
+  });
+
+  it('cannot add reports - no roles', () => {
+    const user = {};
+    expect(canAddReports(user as any)).toBe(false);
+  });
+});

--- a/superset-frontend/src/utils/permissionsUtils.ts
+++ b/superset-frontend/src/utils/permissionsUtils.ts
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
+import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
+
+export function canAddReports(user: UserWithPermissionsAndRoles) {
+  if (!isFeatureEnabled(FeatureFlag.ALERT_REPORTS)) {
+    return false;
+  }
+  if (!user?.userId) {
+    // this is in the case that there is an anonymous user.
+    return false;
+  }
+  return Object.values(user.roles || {}).some(permissions =>
+    permissions.some(
+      permission =>
+        permission[0] === 'menu_access' && permission[1] === 'Manage',
+    ),
+  );
+}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Dashboard header and explore char header are currently using the exact same check `canAddReports` to verify user access. We moved the method to `utils` to keep it DRY. 
cc: @suddjian 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
