### PR TITLE
feat: cleanup permissions when db updated/deleted

### DIFF
--- a/superset/databases/commands/exceptions.py
+++ b/superset/databases/commands/exceptions.py
@@ -139,6 +139,10 @@ class DatabaseImportError(ImportFailedError):
     message = _("Import database failed for an unknown reason")
 
 
+class DatabasePermissionCleanupError(CommandException):
+    message = _("Database permission cleanup failed for an unknown reason")
+
+
 class InvalidEngineError(SupersetErrorException):
     status = 422
 

--- a/superset/databases/commands/update.py
+++ b/superset/databases/commands/update.py
@@ -58,13 +58,13 @@ class UpdateDatabaseCommand(BaseCommand):
             except Exception as ex:
                 db.session.rollback()
                 raise DatabaseConnectionFailedError() from ex
-            
+
             try:
                 self._update_permissions(database, schemas, old_name)
             except Exception as ex:
                 db.session.rollback()
                 raise DatabasePermissionCleanupError() from ex
-            
+
             db.session.commit()
 
         except DAOUpdateFailedError as ex:

--- a/superset/databases/commands/update.py
+++ b/superset/databases/commands/update.py
@@ -48,7 +48,7 @@ class UpdateDatabaseCommand(BaseCommand):
     def run(self) -> Model:
         self.validate()
         try:
-            old_name = self._model.database_name
+            old_name = self._model.database_name  # type: ignore
             database = DatabaseDAO.update(self._model, self._properties, commit=False)
             database.set_sqlalchemy_uri(database.sqlalchemy_uri)
             # adding a new database we always want to force refresh schema list

--- a/superset/databases/commands/update.py
+++ b/superset/databases/commands/update.py
@@ -47,9 +47,12 @@ class UpdateDatabaseCommand(BaseCommand):
     def run(self) -> Model:
         self.validate()
         try:
+            old_name = self._model.database_name
             database = DatabaseDAO.update(self._model, self._properties, commit=False)
             database.set_sqlalchemy_uri(database.sqlalchemy_uri)
             security_manager.add_permission_view_menu("database_access", database.perm)
+            if old_name != database.database_name:
+                security_manager.cleanup_database_permissions(old_name)
             # adding a new database we always want to force refresh schema list
             # TODO Improve this simplistic implementation for catching DB conn fails
             try:

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -785,6 +785,9 @@ class Database(
         return sqla_url.get_dialect()()
 
 
+sqla.event.listen(Database, "after_insert", security_manager.set_perm)
+
+
 class Log(Model):  # pylint: disable=too-few-public-methods
 
     """ORM object used to log Superset actions to the database"""

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -785,10 +785,6 @@ class Database(
         return sqla_url.get_dialect()()
 
 
-sqla.event.listen(Database, "after_insert", security_manager.set_perm)
-sqla.event.listen(Database, "after_update", security_manager.set_perm)
-
-
 class Log(Model):  # pylint: disable=too-few-public-methods
 
     """ORM object used to log Superset actions to the database"""

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -957,7 +957,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             target.schema_perm = target.get_schema_perm()
 
         pvm_names = []
-        if target.__tablename__ == "clusters":
+        if target.__tablename__ in {"dbs", "clusters"}:
             pvm_names.append(("database_access", target.get_perm()))
         else:
             pvm_names.append(("datasource_access", target.get_perm()))

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -957,7 +957,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             target.schema_perm = target.get_schema_perm()
 
         pvm_names = []
-        if target.__tablename__ in {"dbs", "clusters"}:
+        if target.__tablename__ == "clusters":
             pvm_names.append(("database_access", target.get_perm()))
         else:
             pvm_names.append(("datasource_access", target.get_perm()))

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -77,6 +77,8 @@ from superset.utils.core import DatasourceName, RowLevelSecurityFilterType
 from superset.utils.urls import get_url_host
 
 if TYPE_CHECKING:
+    from flask_appbuilder.security.sqla.models import ViewMenu
+
     from superset.common.query_context import QueryContext
     from superset.connectors.base.models import BaseDatasource
     from superset.connectors.druid.models import DruidCluster

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -530,6 +530,10 @@ class TestDatabaseApi(SupersetTestCase):
         uri = f"api/v1/database/{test_database.id}"
         rv = self.client.put(uri, json=database_data)
         self.assertEqual(rv.status_code, 200)
+
+        old_perms = security_manager.get_view_menus_for_database("test-database")
+        self.assertEqual(len(old_perms), 0)
+
         # Cleanup
         model = db.session.query(Database).get(test_database.id)
         db.session.delete(model)
@@ -683,6 +687,9 @@ class TestDatabaseApi(SupersetTestCase):
         self.assertEqual(rv.status_code, 200)
         model = db.session.query(Database).get(database_id)
         self.assertEqual(model, None)
+
+        db_perms = security_manager.get_view_menus_for_database("test-database")
+        self.assertEqual(len(db_perms), 0)
 
     def test_delete_database_not_found(self):
         """

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -1033,7 +1033,9 @@ class TestSecurityManager(SupersetTestCase):
         dataset_access = security_manager.add_permission_view_menu(
             "datasource_access", f"[{database_name}].[tmp_dataset]"
         )
-        role = security_manager.add_role("tmp_role", [db_access, schema_access, dataset_access])
+        role = security_manager.add_role(
+            "tmp_role", [db_access, schema_access, dataset_access]
+        )
 
         view_menus = security_manager.get_view_menus_for_database(database_name)
         self.assertEqual(len(view_menus), 3)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Up until now, when deleting or renaming a database connection, permissions for the old connection name would persist.  Additionally, when renaming a database connection, permissions for access on that database's existing datasets would not be created with the new connection name.

This PR introduces a way to clean up unneeded permissions after a database is renamed or deleted, and also ensures that permissions for a database's associated datasets are kept up-to-date if the database connection is renamed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
* Create a database connection and associated datasets
* Rename the database connection
* See that permissions for the old name are gone and permissions for the new database name have been created

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
