### PR TITLE
refactor(ChartDataCommand): remove create queryContext command's responsibly 

### DIFF
--- a/superset/charts/data/commands.py
+++ b/superset/charts/data/commands.py
@@ -18,13 +18,11 @@ import logging
 from typing import Any, Dict, Optional
 
 from flask import Request
-from marshmallow import ValidationError
 
 from superset.charts.commands.exceptions import (
     ChartDataCacheLoadError,
     ChartDataQueryFailedError,
 )
-from superset.charts.schemas import ChartDataQueryContextSchema
 from superset.commands.base import BaseCommand
 from superset.common.query_context import QueryContext
 from superset.exceptions import CacheLoadError
@@ -36,6 +34,9 @@ logger = logging.getLogger(__name__)
 
 class ChartDataCommand(BaseCommand):
     _query_context: QueryContext
+
+    def __init__(self, query_context: QueryContext):
+        self._query_context = query_context
 
     def run(self, **kwargs: Any) -> Dict[str, Any]:
         # caching is handled in query_context.get_df_payload
@@ -62,15 +63,6 @@ class ChartDataCommand(BaseCommand):
             return_value.update(cache_key=payload["cache_key"])
 
         return return_value
-
-    def set_query_context(self, form_data: Dict[str, Any]) -> QueryContext:
-        try:
-            self._query_context = ChartDataQueryContextSchema().load(form_data)
-        except KeyError as ex:
-            raise ValidationError("Request is incorrect") from ex
-        except ValidationError as error:
-            raise error
-        return self._query_context
 
     def validate(self) -> None:
         self._query_context.raise_for_access()

--- a/superset/tasks/async_queries.py
+++ b/superset/tasks/async_queries.py
@@ -14,14 +14,17 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import copy
 import logging
-from typing import Any, cast, Dict, Optional
+from typing import Any, cast, Dict, Optional, TYPE_CHECKING
 
 from celery.exceptions import SoftTimeLimitExceeded
 from flask import current_app, g
+from marshmallow import ValidationError
 
+from superset.charts.schemas import ChartDataQueryContextSchema
 from superset.exceptions import SupersetVizException
 from superset.extensions import (
     async_query_manager,
@@ -31,6 +34,9 @@ from superset.extensions import (
 )
 from superset.utils.cache import generate_cache_key, set_and_log_cache
 from superset.views.utils import get_datasource_info, get_viz
+
+if TYPE_CHECKING:
+    from superset.common.query_context import QueryContext
 
 logger = logging.getLogger(__name__)
 query_timeout = current_app.config[
@@ -50,6 +56,15 @@ def set_form_data(form_data: Dict[str, Any]) -> None:
     g.form_data = form_data
 
 
+def _create_query_context_from_form(form_data: Dict[str, Any]) -> QueryContext:
+    try:
+        return ChartDataQueryContextSchema().load(form_data)
+    except KeyError as ex:
+        raise ValidationError("Request is incorrect") from ex
+    except ValidationError as error:
+        raise error
+
+
 @celery_app.task(name="load_chart_data_into_cache", soft_time_limit=query_timeout)
 def load_chart_data_into_cache(
     job_metadata: Dict[str, Any], form_data: Dict[str, Any],
@@ -60,8 +75,8 @@ def load_chart_data_into_cache(
     try:
         ensure_user_is_set(job_metadata.get("user_id"))
         set_form_data(form_data)
-        command = ChartDataCommand()
-        command.set_query_context(form_data)
+        query_context = _create_query_context_from_form(form_data)
+        command = ChartDataCommand(query_context)
         result = command.run(cache=True)
         cache_key = result["cache_key"]
         result_url = f"/api/v1/chart/data/{cache_key}"


### PR DESCRIPTION
## **Background** 
When we have worked on #16991 we wanted to test the new functionalities in concrete and accurate unittest.
All chartData flows and its components are too couple to superset so it is impossible to create unittests. 
The flows are not testable and so many components do not meet the very important principle SRP and the code became so dirty 

So I've started to refactor it (#17344 ) but many changes were added and it was hard to review so I decided to split those changes into small PRs so will be easier to follow 

This is the sixth PR in a sequence of PRs to meet these
The next PR is #17465 

## PR description
move create queryContext command's responsibility to the command clients (ChartDataRestApi and load_chart_data_into_cache celery task) to achieve meeting the SRP 

Note - moving it to the view layer is an anti-pattern but remember, the refactor is combination of many PRs, so it'll be changed in one of the next PRs
Note 2 - the more optimal design is to encapsulate it under an ad-hoc object or keep refactoring the CommandaData into three separated commands 

### Test plans 
There are no logic changes, only calling ordering so new tests are not required

## Previous PRs
1. #17399
2. #17400 
3. #17405 
4. #17407 
5. #17425 