### PR TITLE
fix(Dashboard): Save empty label_colors in json_metadata

### DIFF
--- a/superset/dashboards/dao.py
+++ b/superset/dashboards/dao.py
@@ -130,8 +130,7 @@ class DashboardDAO(BaseDAO):
     def validate_slug_uniqueness(slug: str) -> bool:
         if not slug:
             return True
-        dashboard_query = db.session.query(
-            Dashboard).filter(Dashboard.slug == slug)
+        dashboard_query = db.session.query(Dashboard).filter(Dashboard.slug == slug)
         return not db.session.query(dashboard_query.exists()).scalar()
 
     @staticmethod
@@ -188,8 +187,7 @@ class DashboardDAO(BaseDAO):
         ]
 
         session = db.session()
-        current_slices = session.query(Slice).filter(
-            Slice.id.in_(slice_ids)).all()
+        current_slices = session.query(Slice).filter(Slice.id.in_(slice_ids)).all()
 
         dashboard.slices = current_slices
 

--- a/superset/dashboards/dao.py
+++ b/superset/dashboards/dao.py
@@ -130,7 +130,8 @@ class DashboardDAO(BaseDAO):
     def validate_slug_uniqueness(slug: str) -> bool:
         if not slug:
             return True
-        dashboard_query = db.session.query(Dashboard).filter(Dashboard.slug == slug)
+        dashboard_query = db.session.query(
+            Dashboard).filter(Dashboard.slug == slug)
         return not db.session.query(dashboard_query.exists()).scalar()
 
     @staticmethod
@@ -187,7 +188,8 @@ class DashboardDAO(BaseDAO):
         ]
 
         session = db.session()
-        current_slices = session.query(Slice).filter(Slice.id.in_(slice_ids)).all()
+        current_slices = session.query(Slice).filter(
+            Slice.id.in_(slice_ids)).all()
 
         dashboard.slices = current_slices
 
@@ -241,10 +243,9 @@ class DashboardDAO(BaseDAO):
         }
         md["default_filters"] = json.dumps(applicable_filters)
         md["color_scheme"] = data.get("color_scheme")
+        md["label_colors"] = data.get("label_colors")
         if data.get("color_namespace"):
             md["color_namespace"] = data.get("color_namespace")
-        if data.get("label_colors"):
-            md["label_colors"] = data.get("label_colors")
         dashboard.json_metadata = json.dumps(md)
 
     @staticmethod


### PR DESCRIPTION
# SUMMARY
It was impossible to delete the entire `label_colors` object in `json_metadata` as the backend would not update it. This PR fixes that

### TESTING INSTRUCTIONS
1. Open a Dashboard with custom `label_colors` in `json_metadata` (Edit properties)
2. Delete the entire `label_colors` object 
3. Refresh the Dashboard
4. Make sure the `label_colors` are deleted

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
