### PR TITLE
chore(sql_lab): Added Unit Test for stop query exception

### DIFF
--- a/tests/integration_tests/core_tests.py
+++ b/tests/integration_tests/core_tests.py
@@ -1549,28 +1549,26 @@ class TestCore(SupersetTestCase):
         self.assertIn("Error message", data)
 
     @mock.patch("superset.sql_lab.cancel_query")
-    def test_stop_query_no_cancel_query(self, mock_sql_lab_cancel_query):
+    @mock.patch("superset.views.core.db.session")
+    def test_stop_query_not_implemented(
+        self, mock_superset_db_session, mock_sql_lab_cancel_query
+    ):
         """
         Handles stop query when the DB engine spec does not
         have a cancel query method.
         """
         form_data = {"client_id": "foo"}
         query_mock = mock.Mock()
-        query_mock.sql = "SELECT *"
-        query_mock.database = 1
-        query_mock.schema = "superset"
         query_mock.client_id = "foo"
         query_mock.status = QueryStatus.RUNNING
         self.login(username="admin")
+        mock_superset_db_session.query().filter_by().one().return_value = query_mock
+        mock_sql_lab_cancel_query.return_value = False
+        rv = self.client.post(
+            "/superset/stop_query/", data={"form_data": json.dumps(form_data)},
+        )
 
-        with mock.patch("superset.views.core.db") as mock_superset_db:
-            mock_superset_db.session.query().filter_by().one().return_value = query_mock
-            mock_sql_lab_cancel_query.return_value = False
-            rv = self.client.post(
-                "/superset/stop_query/", data={"form_data": json.dumps(form_data)},
-            )
-
-        self.assertEqual(rv.status_code, 422)
+        assert rv.status_code == 422
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This PR adds a unit test for the changes made here: https://github.com/apache/superset/pull/17292

It checks to make sure that we are getting a 422 error when an engine does not support cancel_query in sql_lab.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
