### PR TITLE
refactor(QueryObject): add QueryObjectFactory to meet SRP

### DIFF
--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -32,7 +32,7 @@ from superset.charts.dao import ChartDAO
 from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
 from superset.common.db_query_status import QueryStatus
 from superset.common.query_actions import get_query_results
-from superset.common.query_object import QueryObject
+from superset.common.query_object import QueryObject, QueryObjectFactory
 from superset.common.utils import QueryCacheManager
 from superset.connectors.base.models import BaseDatasource
 from superset.connectors.connector_registry import ConnectorRegistry
@@ -102,8 +102,10 @@ class QueryContext:
         )
         self.result_type = result_type or ChartDataResultType.FULL
         self.result_format = result_format or ChartDataResultFormat.JSON
+        query_object_factory = QueryObjectFactory()
         self.queries = [
-            QueryObject(self.result_type, **query_obj) for query_obj in queries
+            query_object_factory.create(self.result_type, **query_obj)
+            for query_obj in queries
         ]
         self.force = force
         self.custom_cache_timeout = custom_cache_timeout

--- a/tests/integration_tests/query_context_tests.py
+++ b/tests/integration_tests/query_context_tests.py
@@ -50,6 +50,7 @@ def get_sql_text(payload: Dict[str, Any]) -> str:
 
 
 class TestQueryContext(SupersetTestCase):
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_schema_deserialization(self):
         """
         Ensure that the deserialized QueryContext contains all required fields.


### PR DESCRIPTION
## **Background** 
When we have worked on #16991 we wanted to test the new functionalities in concrete and accurate unittest.
All chartData flows and its components are too couple to superset so it is impossible to create unittests. 
The flows are not testable and so many components do not meet the very important principle SRP and the code became so dirty 

So I've started to refactor it (#17344 ) but many changes were added and it was hard to review so I decided to split those changes into small PRs so will be easier to follow 

This is the eighth PR in a sequence of PRs to meet these
The next PR is #17479 

## PR description
Creating QueryObject is not only an assignment task, it contains some logic.
To meet the SRP, The creation task should be assigned to an external object.
After the PR the QueryObject constructor is decoupled from Superset so in the next PR, the module can be decoupled from Superset 

### Test plans 
There is no logic added so new tests are not required

## Previous PRs
1. #17399
2. #17400 
3. #17405 
4. #17407 
5. #17425 
6. #17461 
7. #17465 