### PR TITLE
fix(presto): expand data with null item

### DIFF
--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -871,8 +871,9 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
                 for row in data:
                     values = row.get(name) or []
                     if isinstance(values, str):
-                        row[name] = values = cast(List[Any], destringify(values))
-                    for value, col in zip(values, expanded):
+                        values = cast(Optional[List[Any]], destringify(values))
+                        row[name] = values
+                    for value, col in zip(values or [], expanded):
                         row[col["name"]] = value
 
         data = [

--- a/tests/integration_tests/db_engine_specs/presto_tests.py
+++ b/tests/integration_tests/db_engine_specs/presto_tests.py
@@ -291,6 +291,66 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
         {"PRESTO_EXPAND_DATA": True},
         clear=True,
     )
+    def test_presto_expand_data_with_complex_row_columns_and_null_values(self):
+        cols = [
+            {
+                "name": "row_column",
+                "type": "ROW(NESTED_ROW ROW(NESTED_OBJ VARCHAR))",
+            }
+        ]
+        data = [
+            {"row_column": '[["a"]]'},
+            {"row_column": '[[null]]'},
+            {"row_column": '[null]'},
+            {"row_column": 'null'}
+        ]
+        actual_cols, actual_data, actual_expanded_cols = PrestoEngineSpec.expand_data(
+            cols, data
+        )
+        expected_cols = [
+            {
+                "name": "row_column",
+                "type": "ROW(NESTED_ROW ROW(NESTED_OBJ VARCHAR))",
+            },
+            {"name": "row_column.nested_row", "type": "ROW(NESTED_OBJ VARCHAR)"},
+            {"name": "row_column.nested_row.nested_obj", "type": "VARCHAR"},
+        ]
+        expected_data = [
+            {
+                "row_column": [["a"]],
+                "row_column.nested_row": ["a"],
+                "row_column.nested_row.nested_obj": "a",
+            },
+            {
+                "row_column": [[None]],
+                "row_column.nested_row": [None],
+                "row_column.nested_row.nested_obj": None,
+            },
+            {
+                "row_column": [None],
+                "row_column.nested_row": None,
+                "row_column.nested_row.nested_obj": "",
+            },
+            {
+                "row_column": None,
+                "row_column.nested_row": "",
+                "row_column.nested_row.nested_obj": "",
+            },
+        ]
+
+        expected_expanded_cols = [
+            {"name": "row_column.nested_row", "type": "ROW(NESTED_OBJ VARCHAR)"},
+            {"name": "row_column.nested_row.nested_obj", "type": "VARCHAR"},
+        ]
+        self.assertEqual(actual_cols, expected_cols)
+        self.assertEqual(actual_data, expected_data)
+        self.assertEqual(actual_expanded_cols, expected_expanded_cols)
+
+    @mock.patch.dict(
+        "superset.extensions.feature_flag_manager._feature_flags",
+        {"PRESTO_EXPAND_DATA": True},
+        clear=True,
+    )
     def test_presto_expand_data_with_complex_array_columns(self):
         cols = [
             {"name": "int_column", "type": "BIGINT"},

--- a/tests/integration_tests/db_engine_specs/presto_tests.py
+++ b/tests/integration_tests/db_engine_specs/presto_tests.py
@@ -293,25 +293,19 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
     )
     def test_presto_expand_data_with_complex_row_columns_and_null_values(self):
         cols = [
-            {
-                "name": "row_column",
-                "type": "ROW(NESTED_ROW ROW(NESTED_OBJ VARCHAR))",
-            }
+            {"name": "row_column", "type": "ROW(NESTED_ROW ROW(NESTED_OBJ VARCHAR))",}
         ]
         data = [
             {"row_column": '[["a"]]'},
-            {"row_column": '[[null]]'},
-            {"row_column": '[null]'},
-            {"row_column": 'null'}
+            {"row_column": "[[null]]"},
+            {"row_column": "[null]"},
+            {"row_column": "null"},
         ]
         actual_cols, actual_data, actual_expanded_cols = PrestoEngineSpec.expand_data(
             cols, data
         )
         expected_cols = [
-            {
-                "name": "row_column",
-                "type": "ROW(NESTED_ROW ROW(NESTED_OBJ VARCHAR))",
-            },
+            {"name": "row_column", "type": "ROW(NESTED_ROW ROW(NESTED_OBJ VARCHAR))",},
             {"name": "row_column.nested_row", "type": "ROW(NESTED_OBJ VARCHAR)"},
             {"name": "row_column.nested_row.nested_obj", "type": "VARCHAR"},
         ]


### PR DESCRIPTION
### SUMMARY
A simple fix for #17469

### TESTING INSTRUCTIONS
Run Presto engine tests:
```
tox -e py38 -- tests/integration_tests/db_engine_specs/presto_tests.py
```

### ADDITIONAL INFORMATION
- [x] Has associated issue: #17469
- [x] Required feature flags: `PRESTO_EXPAND_DATA`
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
