### PR TITLE
fix: create-admin command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ superset:
                     --username admin \
                     --firstname Admin \
                     --lastname Strator \
-                    --email admin@apache.org \
+                    --email admin@superset.io \
                     --password admin
 
 	# Initialize the database

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,12 @@ superset:
 	pip install -e .
 
 	# Create an admin user in your metadata database
-	superset fab create-admin
+	superset fab create-admin \
+                    --username admin \
+                    --firstname Admin \
+                    --lastname Strator \
+                    --email admin@apache.org \
+                    --password admin
 
 	# Initialize the database
 	superset db upgrade
@@ -67,7 +72,7 @@ venv:
 	. venv/bin/activate
 
 activate:
-	source venv/bin/activate
+	. venv/bin/activate
 
 pre-commit:
 	# setup pre commit dependencies
@@ -98,3 +103,6 @@ build-cypress:
 open-cypress:
 	if ! [ $(port) ]; then cd superset-frontend/cypress-base; CYPRESS_BASE_URL=http://localhost:9000 npm run cypress open; fi
 	cd superset-frontend/cypress-base; CYPRESS_BASE_URL=http://localhost:$(port) npm run cypress open
+
+admin-user:
+	superset fab create-admin


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When a user runs `make install` the load-examples section would fail if the user didn't create an user with username `admin`. To fix this I've update the install command to create an admin user by default and added a `make admin-user` for users who need to create a specific Admin user

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
