### PR TITLE
chore(deps): bump cachelib from 0.1.1 to 0.4.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,7 +31,7 @@ bleach==3.3.1
     # via apache-superset
 brotli==1.0.9
     # via flask-compress
-cachelib==0.1.1
+cachelib==0.4.1
     # via apache-superset
 celery==4.4.7
     # via apache-superset

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     install_requires=[
         "backoff>=1.8.0",
         "bleach>=3.0.2, <4.0.0",
-        "cachelib>=0.1.1,<0.2",
+        "cachelib>=0.4.1,<0.5",
         "celery>=4.3.0, <5.0.0, !=4.4.1",
         "click<8",
         "colorama",


### PR DESCRIPTION
### SUMMARY
Upgrade `cachelib` to the latest version to pull in multiple bugfixes (see the [changelog](https://cachelib.readthedocs.io/en/stable/changes/) for details).

### TESTING INSTRUCTIONS
Ensure that the application works correctly with a cache (e.g. `cachelib.redis.RedisCache`)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
