### PR TITLE
docs: mention that username should be admin to load examples in superset docs

### DIFF
--- a/docs/src/pages/docs/installation/installing_scratch.mdx
+++ b/docs/src/pages/docs/installation/installing_scratch.mdx
@@ -129,7 +129,7 @@ superset db upgrade
 Finish installing by running through the following commands:
 
 ```
-# Create an admin user (you will be prompted to set a username, first and last name before setting a password)
+# Create an admin user in your metadata database (use `admin` as username to be able to load the examples)
 $ export FLASK_APP=superset
 superset fab create-admin
 


### PR DESCRIPTION
### SUMMARY
Mention that username should be admin to load examples in superset docs

This info is correctly presented in the Contributing Guide for local development. But in the superset docs that gets published into https://superset.apache.org/docs/installation/installing-superset-from-scratch does not have this information and it is confusing for first time users.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
NA

### TESTING INSTRUCTIONS
NA

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
