### PR TITLE
refactor(QueryContext): add QueryContextFactory to meet SRP

### DIFF
--- a/superset/common/query_context_factory.py
+++ b/superset/common/query_context_factory.py
@@ -1,0 +1,83 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+from superset import app, db
+from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
+from superset.common.query_context import QueryContext
+from superset.common.query_object_factory import QueryObjectFactory
+from superset.connectors.connector_registry import ConnectorRegistry
+from superset.utils.core import DatasourceDict
+
+if TYPE_CHECKING:
+    from superset.connectors.base.models import BaseDatasource
+
+config = app.config
+
+
+def create_query_object_factory() -> QueryObjectFactory:
+    return QueryObjectFactory(config, ConnectorRegistry(), db.session)
+
+
+class QueryContextFactory:  # pylint: disable=too-few-public-methods
+    _query_object_factory: QueryObjectFactory
+
+    def __init__(self) -> None:
+        self._query_object_factory = create_query_object_factory()
+
+    def create(
+        self,
+        *,
+        datasource: DatasourceDict,
+        queries: List[Dict[str, Any]],
+        result_type: Optional[ChartDataResultType] = None,
+        result_format: Optional[ChartDataResultFormat] = None,
+        force: bool = False,
+        custom_cache_timeout: Optional[int] = None
+    ) -> QueryContext:
+        datasource_model_instance = None
+        if datasource:
+            datasource_model_instance = self._convert_to_model(datasource)
+        result_type = result_type or ChartDataResultType.FULL
+        result_format = result_format or ChartDataResultFormat.JSON
+        queries_ = [
+            self._query_object_factory.create(result_type, **query_obj)
+            for query_obj in queries
+        ]
+        cache_values = {
+            "datasource": datasource,
+            "queries": queries,
+            "result_type": result_type,
+            "result_format": result_format,
+        }
+        return QueryContext(
+            datasource=datasource_model_instance,
+            queries=queries_,
+            result_type=result_type,
+            result_format=result_format,
+            force=force,
+            custom_cache_timeout=custom_cache_timeout,
+            cache_values=cache_values,
+        )
+
+    # pylint: disable=no-self-use
+    def _convert_to_model(self, datasource: DatasourceDict) -> BaseDatasource:
+        return ConnectorRegistry.get_datasource(
+            str(datasource["type"]), int(datasource["id"]), db.session
+        )

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
+
 import json
 import logging
 from typing import Any, Dict, Optional, Type, TYPE_CHECKING
@@ -41,6 +43,7 @@ from superset.viz import BaseViz, viz_types
 
 if TYPE_CHECKING:
     from superset.common.query_context import QueryContext
+    from superset.common.query_context_factory import QueryContextFactory
     from superset.connectors.base.models import BaseDatasource
 
 metadata = Model.metadata  # pylint: disable=no-member
@@ -58,6 +61,8 @@ class Slice(  # pylint: disable=too-many-public-methods
     Model, AuditMixinNullable, ImportExportMixin
 ):
     """A slice is essentially a report or a view on data"""
+
+    query_context_factory: Optional[QueryContextFactory] = None
 
     __tablename__ = "slices"
     id = Column(Integer, primary_key=True)
@@ -248,13 +253,12 @@ class Slice(  # pylint: disable=too-many-public-methods
         update_time_range(form_data)
         return form_data
 
-    def get_query_context(self) -> Optional["QueryContext"]:
-        # pylint: disable=import-outside-toplevel
-        from superset.common.query_context import QueryContext
-
+    def get_query_context(self) -> Optional[QueryContext]:
         if self.query_context:
             try:
-                return QueryContext(**json.loads(self.query_context))
+                return self.get_query_context_factory().create(
+                    **json.loads(self.query_context)
+                )
             except json.decoder.JSONDecodeError as ex:
                 logger.error("Malformed json in slice's query context", exc_info=True)
                 logger.exception(ex)
@@ -312,6 +316,14 @@ class Slice(  # pylint: disable=too-many-public-methods
     @property
     def url(self) -> str:
         return f"/superset/explore/?form_data=%7B%22slice_id%22%3A%20{self.id}%7D"
+
+    def get_query_context_factory(self) -> QueryContextFactory:
+        if self.query_context_factory is None:
+            # pylint: disable=import-outside-toplevel
+            from superset.common.query_context_factory import QueryContextFactory
+
+            self.query_context_factory = QueryContextFactory()
+        return self.query_context_factory
 
 
 def set_related_perm(_mapper: Mapper, _connection: Connection, target: Slice) -> None:


### PR DESCRIPTION
## **Background** 
When we have worked on #16991 we wanted to test the new functionalities in concrete and accurate unittest.
All chartData flows and its components are too couple to superset so it is impossible to create unittests. 
The flows are not testable and so many components do not meet the very important principle SRP and the code became so dirty 

So I've started to refactor it (#17344 ) but many changes were added and it was hard to review so I decided to split those changes into small PRs so will be easier to follow 

This is the tenth PR in a sequence of PRs to meet these
The next PR is #17496 

## PR description
Creating QueryContext is not only an assignment task, it contains some logic.
To meet the SRP, The creation task should be assigned to an external object.
After the PR the QueryContext constructor is decoupled from Superset so in the next PRs, the module can be decoupled from Superset 

### Test plans 
There is no logic added so new tests are not required

## Previous PRs
1. #17399
2. #17400 
3. #17405 
4. #17407 
5. #17425 
6. #17461 
7. #17465 
8. #17466 
9. #17479 