### PR TITLE
fix: [alert] should run alert query from report account

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -397,11 +397,12 @@ class Database(
         sql: str,
         schema: Optional[str] = None,
         mutator: Optional[Callable[[pd.DataFrame], None]] = None,
+        username: Optional[str] = None,
     ) -> pd.DataFrame:
         sqls = [str(s).strip(" ;") for s in sqlparse.parse(sql)]
 
-        engine = self.get_sqla_engine(schema=schema)
-        username = utils.get_username()
+        engine = self.get_sqla_engine(schema=schema, user_name=username)
+        username = utils.get_username() or username
 
         def needs_conversion(df_series: pd.Series) -> bool:
             return (

--- a/superset/reports/commands/alert.py
+++ b/superset/reports/commands/alert.py
@@ -23,9 +23,10 @@ from typing import Optional
 import numpy as np
 import pandas as pd
 from celery.exceptions import SoftTimeLimitExceeded
+from flask import g
 from flask_babel import lazy_gettext as _
 
-from superset import jinja_context
+from superset import app, jinja_context, security_manager
 from superset.commands.base import BaseCommand
 from superset.models.reports import ReportSchedule, ReportScheduleValidatorType
 from superset.reports.commands.exceptions import (
@@ -66,6 +67,9 @@ class AlertCommand(BaseCommand):
         :raises AlertQueryTimeout: The SQL query received a celery soft timeout
         :raises AlertValidatorConfigError: The validator query data is not valid
         """
+        g.user = security_manager.get_user_by_username(
+            app.config["THUMBNAIL_SELENIUM_USER"]
+        )
         self.validate()
 
         if self._is_validator_not_null:

--- a/tests/integration_tests/model_tests.py
+++ b/tests/integration_tests/model_tests.py
@@ -340,6 +340,18 @@ class TestDatabaseModel(SupersetTestCase):
             df = main_db.get_df("USE superset; SELECT ';';", None)
             self.assertEqual(df.iat[0, 0], ";")
 
+    @mock.patch("superset.models.core.Database.get_sqla_engine")
+    def test_username_param(self, mocked_get_sqla_engine):
+        main_db = get_example_database()
+        main_db.impersonate_user = True
+        test_username = "test_username_param"
+
+        if main_db.backend == "mysql":
+            main_db.get_df("USE superset; SELECT 1", username=test_username)
+            mocked_get_sqla_engine.assert_called_with(
+                schema=None, user_name="test_username_param",
+            )
+
     @mock.patch("superset.models.core.create_engine")
     def test_get_sqla_engine(self, mocked_create_engine):
         model = Database(


### PR DESCRIPTION
### SUMMARY
When user setup an alert with query and condition, we found that the query was run by `root` user. It will cause permission issue, since we give `THUMBNAIL_SELENIUM_USER` account extra data access, while `root` does not.

Note, after alert query, the screenshot was taken from `THUMBNAIL_SELENIUM_USER` config correctly.

Proposed solution: set correct username for the alert query.

### TESTING INSTRUCTIONS
CI

