### PR TITLE
fix: Dashboard access when DASHBOARD_RBAC is disabled

### DIFF
--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -39,6 +39,7 @@ from superset.dashboards.commands.bulk_delete import BulkDeleteDashboardCommand
 from superset.dashboards.commands.create import CreateDashboardCommand
 from superset.dashboards.commands.delete import DeleteDashboardCommand
 from superset.dashboards.commands.exceptions import (
+    DashboardAccessDeniedError,
     DashboardBulkDeleteFailedError,
     DashboardCreateFailedError,
     DashboardDeleteFailedError,
@@ -46,7 +47,6 @@ from superset.dashboards.commands.exceptions import (
     DashboardInvalidError,
     DashboardNotFoundError,
     DashboardUpdateFailedError,
-    DashboardAccessDeniedError,
 )
 from superset.dashboards.commands.export import ExportDashboardsCommand
 from superset.dashboards.commands.importers.dispatcher import ImportDashboardsCommand

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -46,6 +46,7 @@ from superset.dashboards.commands.exceptions import (
     DashboardInvalidError,
     DashboardNotFoundError,
     DashboardUpdateFailedError,
+    DashboardAccessDeniedError,
 )
 from superset.dashboards.commands.export import ExportDashboardsCommand
 from superset.dashboards.commands.importers.dispatcher import ImportDashboardsCommand
@@ -267,6 +268,8 @@ class DashboardRestApi(BaseSupersetModelRestApi):
               $ref: '#/components/responses/400'
             401:
               $ref: '#/components/responses/401'
+            403:
+              $ref: '#/components/responses/403'
             404:
               $ref: '#/components/responses/404'
         """
@@ -275,6 +278,8 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             dash = DashboardDAO.get_by_id_or_slug(id_or_slug)
             result = self.dashboard_get_response_schema.dump(dash)
             return self.response(200, result=result)
+        except DashboardAccessDeniedError:
+            return self.response_403()
         except DashboardNotFoundError:
             return self.response_404()
 
@@ -327,6 +332,8 @@ class DashboardRestApi(BaseSupersetModelRestApi):
               $ref: '#/components/responses/400'
             401:
               $ref: '#/components/responses/401'
+            403:
+              $ref: '#/components/responses/403'
             404:
               $ref: '#/components/responses/404'
         """
@@ -336,6 +343,8 @@ class DashboardRestApi(BaseSupersetModelRestApi):
                 self.dashboard_dataset_schema.dump(dataset) for dataset in datasets
             ]
             return self.response(200, result=result)
+        except DashboardAccessDeniedError:
+            return self.response_403()
         except DashboardNotFoundError:
             return self.response_404()
 
@@ -386,6 +395,8 @@ class DashboardRestApi(BaseSupersetModelRestApi):
               $ref: '#/components/responses/400'
             401:
               $ref: '#/components/responses/401'
+            403:
+              $ref: '#/components/responses/403'
             404:
               $ref: '#/components/responses/404'
         """
@@ -401,6 +412,8 @@ class DashboardRestApi(BaseSupersetModelRestApi):
                     form_data.pop("label_colors", None)
 
             return self.response(200, result=result)
+        except DashboardAccessDeniedError:
+            return self.response_403()
         except DashboardNotFoundError:
             return self.response_404()
 

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1174,19 +1174,22 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         from superset.views.base import get_user_roles, is_user_admin
         from superset.views.utils import is_owner
 
+        has_rbac_access = True
+
         if is_feature_enabled("DASHBOARD_RBAC"):
             has_rbac_access = any(
                 dashboard_role.id in [user_role.id for user_role in get_user_roles()]
                 for dashboard_role in dashboard.roles
             )
-            can_access = (
-                is_user_admin()
-                or is_owner(dashboard, g.user)
-                or (dashboard.published and has_rbac_access)
-            )
 
-            if not can_access:
-                raise DashboardAccessDeniedError()
+        can_access = (
+            is_user_admin()
+            or is_owner(dashboard, g.user)
+            or (dashboard.published and has_rbac_access)
+        )
+
+        if not can_access:
+            raise DashboardAccessDeniedError()
 
     @staticmethod
     def can_access_based_on_dashboard(datasource: "BaseDatasource") -> bool:

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1186,6 +1186,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             is_user_admin()
             or is_owner(dashboard, g.user)
             or (dashboard.published and has_rbac_access)
+            or (not dashboard.published and not dashboard.roles)
         )
 
         if not can_access:

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -395,7 +395,7 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
         self.login(username="gamma")
         uri = f"api/v1/dashboard/{dashboard.id}"
         rv = self.client.get(uri)
-        assert rv.status_code == 403
+        assert rv.status_code == 200
         # rollback changes
         db.session.delete(dashboard)
         db.session.commit()

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -395,7 +395,7 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
         self.login(username="gamma")
         uri = f"api/v1/dashboard/{dashboard.id}"
         rv = self.client.get(uri)
-        self.assertEqual(rv.status_code, 403)
+        assert rv.status_code == 403
         # rollback changes
         db.session.delete(dashboard)
         db.session.commit()

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -395,7 +395,7 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
         self.login(username="gamma")
         uri = f"api/v1/dashboard/{dashboard.id}"
         rv = self.client.get(uri)
-        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.status_code, 403)
         # rollback changes
         db.session.delete(dashboard)
         db.session.commit()

--- a/tests/integration_tests/dashboards/dao_tests.py
+++ b/tests/integration_tests/dashboards/dao_tests.py
@@ -85,6 +85,7 @@ class TestDashboardDAO(SupersetTestCase):
 
     @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
     def test_get_dashboard_changed_on(self):
+        self.login(username="admin")
         session = db.session()
         dashboard = session.query(Dashboard).filter_by(slug="world_health").first()
 


### PR DESCRIPTION
### SUMMARY
This PR fixes the security manager to also check for dashboard access when `DASHBOARD_RBAC` is disabled. Previously, if `DASHBOARD_RBAC` was disabled, this piece of code was skipped:

```
can_access = (
    is_user_admin()
    or is_owner(dashboard, g.user)
    or (dashboard.published and has_rbac_access)
)
```

I also changed some endpoints to emit a 403 when an access error occurs.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
