### PR TITLE
fix(CRUD views): change empty rows layout in TableCollection to be consistent with its headers

### DIFF
--- a/superset-frontend/src/components/TableCollection/index.tsx
+++ b/superset-frontend/src/components/TableCollection/index.tsx
@@ -121,6 +121,12 @@ export const Table = styled.table`
       }
     }
 
+    .empty-loading-bar {
+      display: inline-block;
+      width: 100%;
+      height: 1.2em;
+    }
+
     &:after {
       position: absolute;
       transform: translateY(-50%);
@@ -257,7 +263,7 @@ export default React.memo(
       <tbody {...getTableBodyProps()}>
         {loading &&
           rows.length === 0 &&
-          [...new Array(25)].map((_, i) => (
+          [...new Array(12)].map((_, i) => (
             <tr key={i}>
               {columns.map((column, i2) => {
                 if (column.hidden) return null;
@@ -266,12 +272,13 @@ export default React.memo(
                     key={i2}
                     className={cx('table-cell', {
                       'table-cell-loader': loading,
-                      [column.size || '']: column.size,
                     })}
                   >
-                    <span className="loading-bar" role="progressbar">
-                      <span>LOADING</span>
-                    </span>
+                    <span
+                      className="loading-bar empty-loading-bar"
+                      role="progressbar"
+                      aria-label="loading"
+                    />
                   </td>
                 );
               })}

--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -230,7 +230,7 @@ function ChartList(props: ChartListProps) {
               Header: '',
               id: 'id',
               disableSortBy: true,
-              size: 'xs',
+              size: 'sm',
             },
           ]
         : []),


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The headers were not lining up with the loading layout for when the chart list was empty while they were loading, causing a noticeable jump in size. Very noticeable when pressing any of the sort buttons at the top of the charts table while the table is empty. As described in issue #15127 

### TL/DR:
Empty state table cells were being rendered with text that gave the loading bars different widths than what the headers have when rows are empty. 

The loading bar columns were hard set on `width` instead of `min-width` like the headers, causing slight differences.

Fixed by removing table cell text, removing logic setting hard width on empty columns, adding a class to make them inline-block, 100% width, and 1.2em height. Letting the loading bars stretch to be the size of the columns.

Other changes were changing the empty state rows to be 12 rows instead of 25 and changing Favorite column size from `'xs'` to `'sm'`

### DETAILED DESCRIPTION:
What was happening was the loading bars that get rendered when the rows are empty and the loading state is true, were having their width being hard set to the size that the columns are. This is what we want when the rows aren't empty but when they are empty having the table headers be set on `min-width` and the columns being set on `width`, was causing some issues.

Another problem is that the loading bar CSS effect covers up the text that is within the columns, which is very nice when you sort a table that has rows with data in it. But the temporary rows and columns that act as the loading bars were being created with the text LOADING in every table cell. This is why it was the loading bars were short and why the column that holds the Favorite star icon was expanding by the length of the word LOADING. 

The combination of the headers using `min-width`, the columns being set on `width`, and the text "LOADING" being in a `<span>`(inline) within the columns is what caused the jump in size and the look of the headers being pushed to the right of the screen when the empty/loading state appeared.

### THE FIX:
The fix I went with, is to remove the set width on the columns for the empty/loading table, letting the columns be the same size as their headers. Then create a new class for them that makes the `<span>` inside them inline-block instead of inline, sets width to 100% to fill the whole column, and adds a little height to better match text-filled size. Then remove the loading span, add an aria-label for the progressbar role tag because the text inside the span is no longer acting as the label.

After that, the columns and loading bars are the length of the headers and a jump in size no longer occurs.

### OTHER CHANGES:
I also changed the size of the Favorite Icon column to be `'sm'` (50px) instead of `'xs'` (25px) because the icons are always about 50px wide.

I changed the number of rows for the empty/loading table to better match with the size of the container around the 'No Data' graphic that gets displayed after loading is finished and there are no rows. 

### IN CONCLUSION:
I went with what I felt looked the best, made the most sense, and was the least intrusive to the code.

If the design and/or the implementation is not giving the desired effect or look, then please let me know so I can change it up.

### BEFORE:
![BeforeGif](https://user-images.githubusercontent.com/31329271/142944039-73a8afef-eeda-4968-be64-73f1d1a42c06.gif)

<img width="1438" alt="Screen Shot 2021-11-22 at 3 15 15 PM" src="https://user-images.githubusercontent.com/31329271/142943264-06da3188-d0e3-4860-b87b-4a1b1721b5be.png">

### AFTER:
![AfterGif](https://user-images.githubusercontent.com/31329271/142943891-165f548b-c4b9-4343-8fdc-63b998772728.gif)

<img width="1438" alt="Screen Shot 2021-11-22 at 3 11 25 PM" src="https://user-images.githubusercontent.com/31329271/142943447-30ac1715-e6bd-4f5c-96d4-b67d9d7370df.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Open Charts from the menu at top of the screen
- Change the Charts filters until you have an empty chart table
- Click away on those sorting headers
- Observe the loading bars in all their magnificence

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: #15127 
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
