### PR TITLE
chore: remove deprecated selects and deps

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -109,7 +109,6 @@
         "react-router-dom": "^5.1.2",
         "react-search-input": "^0.11.3",
         "react-select": "^3.1.0",
-        "react-select-async-paginate": "^0.4.1",
         "react-sortable-hoc": "^1.11.0",
         "react-split": "^2.0.9",
         "react-sticky": "^6.0.3",
@@ -8939,11 +8938,6 @@
       "peerDependencies": {
         "react": "*"
       }
-    },
-    "node_modules/@seznam/compose-react-refs": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@seznam/compose-react-refs/-/compose-react-refs-1.0.4.tgz",
-      "integrity": "sha512-TwrojUAFVSd+HPAdnul0o65X8mIam+dJOxcWI6LhHAUIpVRk2cJp2dyWXWl6sJvZTY9ODSJpOibt7JKSNUjVfQ=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.0",
@@ -47170,15 +47164,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.3.tgz",
       "integrity": "sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA=="
     },
-    "node_modules/react-is-mounted-hook": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/react-is-mounted-hook/-/react-is-mounted-hook-1.0.3.tgz",
-      "integrity": "sha512-YCCYcTVYMPfTi6WhWIwM9EYBcpHoivjjkE90O5ScsE9wXSbeXGZvLDMGt4mdSNcWshhc8JD0AzgBmsleCSdSFA==",
-      "peerDependencies": {
-        "react": "^16.8.6",
-        "react-dom": "^16.8.6"
-      }
-    },
     "node_modules/react-js-cron": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/react-js-cron/-/react-js-cron-1.2.0.tgz",
@@ -47576,21 +47561,6 @@
       "peerDependencies": {
         "react": "^16.8.0",
         "react-dom": "^16.8.0"
-      }
-    },
-    "node_modules/react-select-async-paginate": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/react-select-async-paginate/-/react-select-async-paginate-0.4.1.tgz",
-      "integrity": "sha512-zWeaN9C9PVQej4bz1+OvU6/ylHE6rHscDYcP+KiWdBedVQ5j2vXBjf/5RWLEvobvtUUHBOTbUF8+m2HDoeIcvQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.11.2",
-        "@seznam/compose-react-refs": "^1.0.4",
-        "react-is-mounted-hook": "^1.0.3",
-        "sleep-promise": "^8.0.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0",
-        "react-select": "^2.0.0 || ^3.0.0"
       }
     },
     "node_modules/react-select/node_modules/@emotion/cache": {
@@ -49979,11 +49949,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/sleep-promise": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/sleep-promise/-/sleep-promise-8.0.1.tgz",
-      "integrity": "sha1-jXlaJ+ojlT32tSuRCB5eImZZk8U="
     },
     "node_modules/slice-ansi": {
       "version": "4.0.0",
@@ -62277,11 +62242,6 @@
       "resolved": "https://registry.npmjs.org/@react-icons/all-files/-/all-files-4.1.0.tgz",
       "integrity": "sha512-hxBI2UOuVaI3O/BhQfhtb4kcGn9ft12RWAFVMUeNjqqhLsHvFtzIkFaptBJpFDANTKoDfdVoHTKZDlwKCACbMQ==",
       "requires": {}
-    },
-    "@seznam/compose-react-refs": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@seznam/compose-react-refs/-/compose-react-refs-1.0.4.tgz",
-      "integrity": "sha512-TwrojUAFVSd+HPAdnul0o65X8mIam+dJOxcWI6LhHAUIpVRk2cJp2dyWXWl6sJvZTY9ODSJpOibt7JKSNUjVfQ=="
     },
     "@sinonjs/commons": {
       "version": "1.8.0",
@@ -92049,12 +92009,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.3.tgz",
       "integrity": "sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA=="
     },
-    "react-is-mounted-hook": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/react-is-mounted-hook/-/react-is-mounted-hook-1.0.3.tgz",
-      "integrity": "sha512-YCCYcTVYMPfTi6WhWIwM9EYBcpHoivjjkE90O5ScsE9wXSbeXGZvLDMGt4mdSNcWshhc8JD0AzgBmsleCSdSFA==",
-      "requires": {}
-    },
     "react-js-cron": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/react-js-cron/-/react-js-cron-1.2.0.tgz",
@@ -92409,17 +92363,6 @@
             "prop-types": "^15.6.2"
           }
         }
-      }
-    },
-    "react-select-async-paginate": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/react-select-async-paginate/-/react-select-async-paginate-0.4.1.tgz",
-      "integrity": "sha512-zWeaN9C9PVQej4bz1+OvU6/ylHE6rHscDYcP+KiWdBedVQ5j2vXBjf/5RWLEvobvtUUHBOTbUF8+m2HDoeIcvQ==",
-      "requires": {
-        "@babel/runtime": "^7.11.2",
-        "@seznam/compose-react-refs": "^1.0.4",
-        "react-is-mounted-hook": "^1.0.3",
-        "sleep-promise": "^8.0.1"
       }
     },
     "react-sizeme": {
@@ -94288,11 +94231,6 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
       "dev": true
-    },
-    "sleep-promise": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/sleep-promise/-/sleep-promise-8.0.1.tgz",
-      "integrity": "sha1-jXlaJ+ojlT32tSuRCB5eImZZk8U="
     },
     "slice-ansi": {
       "version": "4.0.0",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -175,7 +175,6 @@
     "react-router-dom": "^5.1.2",
     "react-search-input": "^0.11.3",
     "react-select": "^3.1.0",
-    "react-select-async-paginate": "^0.4.1",
     "react-sortable-hoc": "^1.11.0",
     "react-split": "^2.0.9",
     "react-sticky": "^6.0.3",

--- a/superset-frontend/src/components/Select/DeprecatedSelect.tsx
+++ b/superset-frontend/src/components/Select/DeprecatedSelect.tsx
@@ -30,7 +30,6 @@ import BasicSelect, {
 import Async from 'react-select/async';
 import Creatable from 'react-select/creatable';
 import AsyncCreatable from 'react-select/async-creatable';
-import { withAsyncPaginate } from 'react-select-async-paginate';
 
 import { SelectComponents } from 'react-select/src/components';
 import {
@@ -45,7 +44,6 @@ import {
   WindowedSelectComponentType,
   WindowedSelectProps,
   WindowedSelect,
-  WindowedAsyncSelect,
   WindowedCreatableSelect,
   WindowedAsyncCreatableSelect,
 } from './WindowedSelect';
@@ -319,12 +317,6 @@ function styled<
 }
 
 export const Select = styled(WindowedSelect);
-export const AsyncSelect = styled(WindowedAsyncSelect);
 export const CreatableSelect = styled(WindowedCreatableSelect);
 export const AsyncCreatableSelect = styled(WindowedAsyncCreatableSelect);
-export const PaginatedSelect = withAsyncPaginate(
-  styled<OptionTypeBase, ComponentType<SelectProps<OptionTypeBase>>>(
-    BasicSelect,
-  ),
-);
 export default Select;

--- a/superset-frontend/src/components/Select/WindowedSelect/index.tsx
+++ b/superset-frontend/src/components/Select/WindowedSelect/index.tsx
@@ -17,7 +17,6 @@
  * under the License.
  */
 import Select from 'react-select';
-import Async from 'react-select/async';
 import Creatable from 'react-select/creatable';
 import AsyncCreatable from 'react-select/async-creatable';
 import windowed from './windowed';
@@ -25,7 +24,6 @@ import windowed from './windowed';
 export * from './windowed';
 
 export const WindowedSelect = windowed(Select);
-export const WindowedAsyncSelect = windowed(Async);
 export const WindowedCreatableSelect = windowed(Creatable);
 export const WindowedAsyncCreatableSelect = windowed(AsyncCreatable);
 export default WindowedSelect;


### PR DESCRIPTION
### SUMMARY
It appears we are no longer using the `AsyncSelect`, `PaginatedSelect` and `WindowedAsyncSelect` components, hence we can remove them and associated dependencies.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
