### PR TITLE
fix(superset.cli): superset cli group doesn't support superset extension app 

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -14,6 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-#FLASK_APP="superset.app:create_app()"
-FLASK_APP="superset.ofek:create_for_ofek()"
+FLASK_APP="superset.app:create_app()"
 FLASK_ENV="development"

--- a/.flaskenv
+++ b/.flaskenv
@@ -14,5 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FLASK_APP="superset.app:create_app()"
+#FLASK_APP="superset.app:create_app()"
+FLASK_APP="superset.ofek:create_for_ofek()"
 FLASK_ENV="development"

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -34,10 +34,9 @@ assists people when migrating to a new version.
 ### Potential Downtime
 
 - [16756](https://github.com/apache/incubator-superset/pull/16756): a change which renames the `dbs.allow_csv_upload` column to `dbs.allow_file_upload` via a (potentially locking) DDL operation.
-- [17539](https://github.com/apache/superset/pull/17539): all Superset CLI commands 
-  (init, load_examples and etc) require FLASK_APP environment variable is set (by 
-  default is loaded from .
-  flaskenv)
+- [17539](https://github.com/apache/superset/pull/17539): all Superset CLI commands
+  (init, load_examples and etc) require setting the FLASK_APP environment variable
+  (which is set by default when .flaskenv is loaded)
 ### Deprecations
 
 ### Other

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -34,7 +34,10 @@ assists people when migrating to a new version.
 ### Potential Downtime
 
 - [16756](https://github.com/apache/incubator-superset/pull/16756): a change which renames the `dbs.allow_csv_upload` column to `dbs.allow_file_upload` via a (potentially locking) DDL operation.
-
+- [17539](https://github.com/apache/superset/pull/17539): all Superset CLI commands 
+  (init, load_examples and etc) require FLASK_APP environment variable is set (by 
+  default is loaded from .
+  flaskenv)
 ### Deprecations
 
 ### Other

--- a/superset/cli.py
+++ b/superset/cli.py
@@ -37,7 +37,6 @@ from flask_appbuilder import Model
 from flask_appbuilder.api import BaseApi
 
 from superset import app, appbuilder, config, security_manager
-from superset.app import create_app
 from superset.extensions import celery_app, db
 from superset.utils import core as utils
 from superset.utils.celery import session_scope
@@ -73,9 +72,7 @@ def normalize_token(token_name: str) -> str:
 
 
 @click.group(
-    cls=FlaskGroup,
-    create_app=create_app,
-    context_settings={"token_normalize_func": normalize_token},
+    cls=FlaskGroup, context_settings={"token_normalize_func": normalize_token},
 )
 @with_appcontext
 def superset() -> None:


### PR DESCRIPTION
### SUMMARY
When you run the Superset app, the app is loaded via Flask. Flask determines how to load the app by the FLASK_APP env variable. 
In case you would like to develop an app that extends Superset, you can extend the app creation by supplying alternative FLASK_APP value instead of FLASK_APP="superset.app:create_app()"

but the Superset Cli group ignores that value by passing a redundant argument to FlaskGroup. 

When the create_app argument is missed, it creates the application the same way the app is created on running Flask app

so when I set alternative value for Flask_app I can run superset init on the extended superset app
