### PR TITLE
fix(lint): remove redis xadd type ignore

### DIFF
--- a/superset/utils/async_query_manager.py
+++ b/superset/utils/async_query_manager.py
@@ -199,9 +199,5 @@ class AsyncQueryManager:
         logger.debug("********** logging event data to stream %s", scoped_stream_name)
         logger.debug(event_data)
 
-        self._redis.xadd(  # type: ignore
-            scoped_stream_name, event_data, "*", self._stream_limit
-        )
-        self._redis.xadd(  # type: ignore
-            full_stream_name, event_data, "*", self._stream_limit_firehose
-        )
+        self._redis.xadd(scoped_stream_name, event_data, "*", self._stream_limit)
+        self._redis.xadd(full_stream_name, event_data, "*", self._stream_limit_firehose)


### PR DESCRIPTION
### SUMMARY
Fix failing lint error on master, apparently due to redis stubs having been updated 6 hours ago: https://github.com/python/typeshed/pull/6368

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
