### PR TITLE
fix(sqllab): Floating numbers not sorting correctly in result column

### DIFF
--- a/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
@@ -22,6 +22,8 @@ import { styledMount as mount } from 'spec/helpers/theming';
 import FilterableTable, {
   MAX_COLUMNS_FOR_TABLE,
 } from 'src/components/FilterableTable/FilterableTable';
+import { render, screen } from 'spec/helpers/testing-library';
+import userEvent from '@testing-library/user-event';
 
 describe('FilterableTable', () => {
   const mockedProps = {
@@ -82,5 +84,191 @@ describe('FilterableTable', () => {
     };
     wrapper = mount(<FilterableTable {...props} />);
     expect(wrapper.find('.ReactVirtualized__Table__row')).toExist();
+  });
+});
+
+describe('FilterableTable sorting - RTL', () => {
+  it('sorts strings correctly', () => {
+    const stringProps = {
+      orderedColumnKeys: ['a'],
+      data: [{ a: 'Bravo' }, { a: 'Alpha' }, { a: 'Charlie' }],
+      height: 500,
+    };
+    render(<FilterableTable {...stringProps} />);
+
+    const stringColumn = screen.getByRole('columnheader', { name: 'a' });
+    const gridCells = screen.getAllByRole('gridcell');
+
+    // Original order
+    expect(gridCells[0]).toHaveTextContent('Bravo');
+    expect(gridCells[1]).toHaveTextContent('Alpha');
+    expect(gridCells[2]).toHaveTextContent('Charlie');
+
+    // First click to sort ascending
+    userEvent.click(stringColumn);
+    expect(gridCells[0]).toHaveTextContent('Alpha');
+    expect(gridCells[1]).toHaveTextContent('Bravo');
+    expect(gridCells[2]).toHaveTextContent('Charlie');
+
+    // Second click to sort descending
+    userEvent.click(stringColumn);
+    expect(gridCells[0]).toHaveTextContent('Charlie');
+    expect(gridCells[1]).toHaveTextContent('Bravo');
+    expect(gridCells[2]).toHaveTextContent('Alpha');
+
+    // Third click to sort ascending again
+    userEvent.click(stringColumn);
+    expect(gridCells[0]).toHaveTextContent('Alpha');
+    expect(gridCells[1]).toHaveTextContent('Bravo');
+    expect(gridCells[2]).toHaveTextContent('Charlie');
+  });
+
+  it('sorts integers correctly', () => {
+    const integerProps = {
+      orderedColumnKeys: ['b'],
+      data: [{ b: 10 }, { b: 0 }, { b: 100 }],
+      height: 500,
+    };
+    render(<FilterableTable {...integerProps} />);
+
+    const integerColumn = screen.getByRole('columnheader', { name: 'b' });
+    const gridCells = screen.getAllByRole('gridcell');
+
+    // Original order
+    expect(gridCells[0]).toHaveTextContent('10');
+    expect(gridCells[1]).toHaveTextContent('0');
+    expect(gridCells[2]).toHaveTextContent('100');
+
+    // First click to sort ascending
+    userEvent.click(integerColumn);
+    expect(gridCells[0]).toHaveTextContent('0');
+    expect(gridCells[1]).toHaveTextContent('10');
+    expect(gridCells[2]).toHaveTextContent('100');
+
+    // Second click to sort descending
+    userEvent.click(integerColumn);
+    expect(gridCells[0]).toHaveTextContent('100');
+    expect(gridCells[1]).toHaveTextContent('10');
+    expect(gridCells[2]).toHaveTextContent('0');
+
+    // Third click to sort ascending again
+    userEvent.click(integerColumn);
+    expect(gridCells[0]).toHaveTextContent('0');
+    expect(gridCells[1]).toHaveTextContent('10');
+    expect(gridCells[2]).toHaveTextContent('100');
+  });
+
+  it('sorts floating numbers correctly', () => {
+    const floatProps = {
+      orderedColumnKeys: ['c'],
+      data: [{ c: 45.67 }, { c: 1.23 }, { c: 89.0000001 }],
+      height: 500,
+    };
+    render(<FilterableTable {...floatProps} />);
+
+    const floatColumn = screen.getByRole('columnheader', { name: 'c' });
+    const gridCells = screen.getAllByRole('gridcell');
+
+    // Original order
+    expect(gridCells[0]).toHaveTextContent('45.67');
+    expect(gridCells[1]).toHaveTextContent('1.23');
+    expect(gridCells[2]).toHaveTextContent('89.0000001');
+
+    // First click to sort ascending
+    userEvent.click(floatColumn);
+    expect(gridCells[0]).toHaveTextContent('1.23');
+    expect(gridCells[1]).toHaveTextContent('45.67');
+    expect(gridCells[2]).toHaveTextContent('89.0000001');
+
+    // Second click to sort descending
+    userEvent.click(floatColumn);
+    expect(gridCells[0]).toHaveTextContent('89.0000001');
+    expect(gridCells[1]).toHaveTextContent('45.67');
+    expect(gridCells[2]).toHaveTextContent('1.23');
+
+    // Third click to sort ascending again
+    userEvent.click(floatColumn);
+    expect(gridCells[0]).toHaveTextContent('1.23');
+    expect(gridCells[1]).toHaveTextContent('45.67');
+    expect(gridCells[2]).toHaveTextContent('89.0000001');
+  });
+
+  it('sorts rows properly when floating numbers have mixed types', () => {
+    const mixedFloatProps = {
+      orderedColumnKeys: ['d'],
+      data: [
+        { d: 48710.92 },
+        { d: 145776.56 },
+        { d: 72212.86 },
+        { d: '144729.96000000002' },
+        { d: '26260.210000000003' },
+        { d: '152718.97999999998' },
+        { d: 28550.59 },
+        { d: '24078.610000000004' },
+        { d: '98089.08000000002' },
+        { d: '3439718.0300000007' },
+        { d: '4528047.219999993' },
+      ],
+      height: 500,
+    };
+    render(<FilterableTable {...mixedFloatProps} />);
+
+    const mixedFloatColumn = screen.getByRole('columnheader', { name: 'd' });
+    const gridCells = screen.getAllByRole('gridcell');
+
+    // Original order
+    expect(gridCells[0]).toHaveTextContent('48710.92');
+    expect(gridCells[1]).toHaveTextContent('145776.56');
+    expect(gridCells[2]).toHaveTextContent('72212.86');
+    expect(gridCells[3]).toHaveTextContent('144729.96000000002');
+    expect(gridCells[4]).toHaveTextContent('26260.210000000003');
+    expect(gridCells[5]).toHaveTextContent('152718.97999999998');
+    expect(gridCells[6]).toHaveTextContent('28550.59');
+    expect(gridCells[7]).toHaveTextContent('24078.610000000004');
+    expect(gridCells[8]).toHaveTextContent('98089.08000000002');
+    expect(gridCells[9]).toHaveTextContent('3439718.0300000007');
+    expect(gridCells[10]).toHaveTextContent('4528047.219999993');
+
+    // First click to sort ascending
+    userEvent.click(mixedFloatColumn);
+    expect(gridCells[0]).toHaveTextContent('24078.610000000004');
+    expect(gridCells[1]).toHaveTextContent('26260.210000000003');
+    expect(gridCells[2]).toHaveTextContent('28550.59');
+    expect(gridCells[3]).toHaveTextContent('48710.92');
+    expect(gridCells[4]).toHaveTextContent('72212.86');
+    expect(gridCells[5]).toHaveTextContent('98089.08000000002');
+    expect(gridCells[6]).toHaveTextContent('144729.96000000002');
+    expect(gridCells[7]).toHaveTextContent('145776.56');
+    expect(gridCells[8]).toHaveTextContent('152718.97999999998');
+    expect(gridCells[9]).toHaveTextContent('3439718.0300000007');
+    expect(gridCells[10]).toHaveTextContent('4528047.219999993');
+
+    // Second click to sort descending
+    userEvent.click(mixedFloatColumn);
+    expect(gridCells[0]).toHaveTextContent('4528047.219999993');
+    expect(gridCells[1]).toHaveTextContent('3439718.0300000007');
+    expect(gridCells[2]).toHaveTextContent('152718.97999999998');
+    expect(gridCells[3]).toHaveTextContent('145776.56');
+    expect(gridCells[4]).toHaveTextContent('144729.96000000002');
+    expect(gridCells[5]).toHaveTextContent('98089.08000000002');
+    expect(gridCells[6]).toHaveTextContent('72212.86');
+    expect(gridCells[7]).toHaveTextContent('48710.92');
+    expect(gridCells[8]).toHaveTextContent('28550.59');
+    expect(gridCells[9]).toHaveTextContent('26260.210000000003');
+    expect(gridCells[10]).toHaveTextContent('24078.610000000004');
+
+    // Third click to sort ascending again
+    userEvent.click(mixedFloatColumn);
+    expect(gridCells[0]).toHaveTextContent('24078.610000000004');
+    expect(gridCells[1]).toHaveTextContent('26260.210000000003');
+    expect(gridCells[2]).toHaveTextContent('28550.59');
+    expect(gridCells[3]).toHaveTextContent('48710.92');
+    expect(gridCells[4]).toHaveTextContent('72212.86');
+    expect(gridCells[5]).toHaveTextContent('98089.08000000002');
+    expect(gridCells[6]).toHaveTextContent('144729.96000000002');
+    expect(gridCells[7]).toHaveTextContent('145776.56');
+    expect(gridCells[8]).toHaveTextContent('152718.97999999998');
+    expect(gridCells[9]).toHaveTextContent('3439718.0300000007');
+    expect(gridCells[10]).toHaveTextContent('4528047.219999993');
   });
 });

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -323,28 +323,23 @@ export default class FilterableTable extends PureComponent<
 
   sortResults(sortBy: string, descending: boolean) {
     return (a: Datum, b: Datum) => {
-      const aValue = a[sortBy];
-      const bValue = b[sortBy];
-
       // Parse any floating numbers so they'll sort correctly
-      const parseFloatingNums = (value: any) =>
-        value.isNan ? value : parseFloat(value);
+      const parseFloatingNums = (value: any) => {
+        const floatValue = parseFloat(value);
+        return Number.isNaN(floatValue) ? value : parseFloat(value);
+      };
 
-      if (aValue === bValue) {
-        // equal items sort equally
-        return 0;
-      }
-      if (aValue === null) {
-        // nulls sort after anything else
-        return 1;
-      }
-      if (bValue === null) {
-        return -1;
-      }
+      const aValue = parseFloatingNums(a[sortBy]);
+      const bValue = parseFloatingNums(b[sortBy]);
+
+      String(aValue).localeCompare(String(bValue), undefined, {
+        numeric: true,
+      });
+
       if (descending) {
-        return parseFloatingNums(aValue) < parseFloatingNums(bValue) ? 1 : -1;
+        return aValue < bValue ? 1 : -1;
       }
-      return parseFloatingNums(aValue) < parseFloatingNums(bValue) ? -1 : 1;
+      return aValue < bValue ? -1 : 1;
     };
   }
 

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -325,6 +325,11 @@ export default class FilterableTable extends PureComponent<
     return (a: Datum, b: Datum) => {
       const aValue = a[sortBy];
       const bValue = b[sortBy];
+
+      // Parse any floating numbers so they'll sort correctly
+      const parseFloatingNums = (value: any) =>
+        value.isNan ? value : parseFloat(value);
+
       if (aValue === bValue) {
         // equal items sort equally
         return 0;
@@ -337,9 +342,9 @@ export default class FilterableTable extends PureComponent<
         return -1;
       }
       if (descending) {
-        return aValue < bValue ? 1 : -1;
+        return parseFloatingNums(aValue) < parseFloatingNums(bValue) ? 1 : -1;
       }
-      return aValue < bValue ? -1 : 1;
+      return parseFloatingNums(aValue) < parseFloatingNums(bValue) ? -1 : 1;
     };
   }
 

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -332,10 +332,6 @@ export default class FilterableTable extends PureComponent<
       const aValue = this.parseFloatingNums(a[sortBy]);
       const bValue = this.parseFloatingNums(b[sortBy]);
 
-      String(aValue).localeCompare(String(bValue), undefined, {
-        numeric: true,
-      });
-
       // nulls sort after anything else
       if (aValue === null) {
         return 1;

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -321,16 +321,16 @@ export default class FilterableTable extends PureComponent<
     );
   }
 
+  // Parse any floating numbers so they'll sort correctly
+  parseFloatingNums = (value: any) => {
+    const floatValue = parseFloat(value);
+    return Number.isNaN(floatValue) ? value : parseFloat(value);
+  };
+
   sortResults(sortBy: string, descending: boolean) {
     return (a: Datum, b: Datum) => {
-      // Parse any floating numbers so they'll sort correctly
-      const parseFloatingNums = (value: any) => {
-        const floatValue = parseFloat(value);
-        return Number.isNaN(floatValue) ? value : parseFloat(value);
-      };
-
-      const aValue = parseFloatingNums(a[sortBy]);
-      const bValue = parseFloatingNums(b[sortBy]);
+      const aValue = this.parseFloatingNums(a[sortBy]);
+      const bValue = this.parseFloatingNums(b[sortBy]);
 
       String(aValue).localeCompare(String(bValue), undefined, {
         numeric: true,

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -336,6 +336,14 @@ export default class FilterableTable extends PureComponent<
         numeric: true,
       });
 
+      // nulls sort after anything else
+      if (aValue === null) {
+        return 1;
+      }
+      if (bValue === null) {
+        return -1;
+      }
+
       if (descending) {
         return aValue < bValue ? 1 : -1;
       }

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -324,7 +324,7 @@ export default class FilterableTable extends PureComponent<
   // Parse any floating numbers so they'll sort correctly
   parseFloatingNums = (value: any) => {
     const floatValue = parseFloat(value);
-    return Number.isNaN(floatValue) ? value : parseFloat(value);
+    return Number.isNaN(floatValue) ? value : floatValue;
   };
 
   sortResults(sortBy: string, descending: boolean) {

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -332,6 +332,11 @@ export default class FilterableTable extends PureComponent<
       const aValue = this.parseFloatingNums(a[sortBy]);
       const bValue = this.parseFloatingNums(b[sortBy]);
 
+      // equal items sort equally
+      if (aValue === bValue) {
+        return 0;
+      }
+
       // nulls sort after anything else
       if (aValue === null) {
         return 1;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Floating numbers were not sorting correctly in the result column. This was fixed by creating a `parseFloatingNums` function to parse any numbers in the result set.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### BEFORE
<img width="167" alt="floatSortBefore" src="https://user-images.githubusercontent.com/55605634/143881005-4b5d7f2b-1de1-444f-a1ca-c9eac23370b6.png">

#### AFTER
<img width="167" alt="floatSortAfter" src="https://user-images.githubusercontent.com/55605634/143881069-d0e9994b-da96-4539-882f-fef9bba166f0.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Go to SQL Lab
- Enter the following query using the superset example database:
```
SELECT status, year, sum(sales)
FROM main.cleaned_sales_data
GROUP BY status, year
```
- Click the sales column to sort
- Observe that floating numbers are now sorting correctly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/16971
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
