### PR TITLE
fix(dataset): modal sql editor error

### DIFF
--- a/superset-frontend/src/CRUD/Field.test.tsx
+++ b/superset-frontend/src/CRUD/Field.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import { render, screen } from 'spec/helpers/testing-library';
+import { shallow } from 'enzyme';
+import TextAreaControl from 'src/explore/components/controls/TextAreaControl';
+import Field from './Field';
+
+describe('Field', () => {
+  const defaultProps = {
+    fieldKey: 'mock',
+    value: '',
+    label: 'mock',
+    description: 'description',
+    control: <TextAreaControl />,
+    onChange: jest.fn(),
+    compact: false,
+    inline: false,
+  };
+
+  it('should render', () => {
+    const { container } = render(<Field {...defaultProps} />);
+    expect(container).toBeInTheDocument();
+  });
+
+  it('should call onChange', () => {
+    const wrapper = shallow(<Field {...defaultProps} />);
+    const textArea = wrapper.find(TextAreaControl);
+    textArea.simulate('change', { target: { value: 'x' } });
+    expect(defaultProps.onChange).toHaveBeenCalled();
+  });
+
+  it('should render compact', () => {
+    render(<Field {...defaultProps} compact />);
+    expect(
+      screen.queryByText(defaultProps.description),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/superset-frontend/src/CRUD/Field.tsx
+++ b/superset-frontend/src/CRUD/Field.tsx
@@ -44,10 +44,10 @@ export default function Field<V>({
   fieldKey,
   value,
   label,
-  description,
+  description = null,
   control,
-  onChange,
-  compact,
+  onChange = () => {},
+  compact = false,
   inline,
 }: FieldProps<V>) {
   const onControlChange = useCallback(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This pr fixes the problem that when typing into the SQL editor, it always appends the old value to the end of the new value, causing it to grow exponentially. 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### before

https://user-images.githubusercontent.com/11830681/144241861-84d7857e-c65e-495f-9d90-d309efc3c085.mov


### after

https://user-images.githubusercontent.com/11830681/144241872-fabd832d-8b64-4ba8-8430-4ed63ec8d896.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
