### PR TITLE
fix: Dashboard export loading indicator

### DIFF
--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -722,9 +722,9 @@ class DashboardRestApi(BaseSupersetModelRestApi):
               $ref: '#/components/responses/500'
         """
         requested_ids = kwargs["rison"]
+        token = request.args.get("token")
 
         if is_feature_enabled("VERSIONED_EXPORT"):
-            token = request.args.get("token")
             timestamp = datetime.now().strftime("%Y%m%dT%H%M%S")
             root = f"dashboard_export_{timestamp}"
             filename = f"{root}.zip"
@@ -763,6 +763,8 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         resp.headers["Content-Disposition"] = generate_download_headers("json")[
             "Content-Disposition"
         ]
+        if token:
+            resp.set_cookie(token, "done", max_age=600)
         return resp
 
     @expose("/<pk>/thumbnail/<digest>/", methods=["GET"])


### PR DESCRIPTION
### SUMMARY
When exporting a dashboard, if the feature flag `VERSIONED_EXPORT` was set to false, the loading indicator would persist even after the download completes. This PR makes sure the export token used to control the status is set independently of the feature flag.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/144255465-cf507b0d-191a-4303-ab4d-542ede840c8d.mov

https://user-images.githubusercontent.com/70410625/144255525-b610d9f8-8531-47cb-99c6-bae5727ac72c.mov

### TESTING INSTRUCTIONS
Check the videos for instructions.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
