### PR TITLE
fix: Revert "fix(Dashboard): Only apply changes when editing properties"

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/edit_properties.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/edit_properties.test.ts
@@ -103,7 +103,7 @@ describe('Dashboard edit action', () => {
 
     // save edit changes
     cy.get('.ant-modal-footer')
-      .contains('Apply')
+      .contains('Save')
       .click()
       .then(() => {
         // assert that modal edit window has closed

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { render, screen, waitFor } from 'spec/helpers/testing-library';
+import { render, screen } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import { HeaderDropdownProps } from 'src/dashboard/components/Header/types';
@@ -197,13 +197,4 @@ test('should show the properties modal', async () => {
   await openDropdown();
   userEvent.click(screen.getByText('Edit dashboard properties'));
   expect(editModeOnProps.showPropertiesModal).toHaveBeenCalledTimes(1);
-});
-
-test('should display the Apply button when opening the modal', async () => {
-  render(setup(editModeOnProps));
-  await openDropdown();
-  userEvent.click(screen.getByText('Edit dashboard properties'));
-  waitFor(() => {
-    expect(screen.getByRole('button', { name: 'Apply' })).toBeInTheDocument();
-  });
 });

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -638,7 +638,6 @@ class Header extends React.PureComponent {
                   );
                 }
               }}
-              onlyApply
             />
           )}
 


### PR DESCRIPTION
Reverts apache/superset#17392

We found that the `onlyApply` tag was only partially working as the implementation was partial in both the frontend and the backend. I am working on the full implementation here https://github.com/apache/superset/pull/17570. However, we should revert the apache/superset#17392 PR in the meantime to avoid issues with the upcoming release.