### PR TITLE
fix(api): add missing fields to dataset schemas

### DIFF
--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -46,7 +46,7 @@ class DatasetColumnsPutSchema(Schema):
     verbose_name = fields.String(allow_none=True, Length=(1, 1024))
     description = fields.String(allow_none=True)
     expression = fields.String(allow_none=True)
-    extra = fields.Dict(allow_none=True)
+    extra = fields.String(allow_none=True)
     filterable = fields.Boolean()
     groupby = fields.Boolean()
     is_active = fields.Boolean()
@@ -54,17 +54,20 @@ class DatasetColumnsPutSchema(Schema):
     python_date_format = fields.String(
         allow_none=True, validate=[Length(1, 255), validate_python_date_format]
     )
-    uuid = fields.String(allow_none=True)
+    uuid = fields.UUID(allow_none=True)
 
 
 class DatasetMetricsPutSchema(Schema):
     id = fields.Integer()
     expression = fields.String(required=True)
     description = fields.String(allow_none=True)
+    extra = fields.String(allow_none=True)
     metric_name = fields.String(required=True, validate=Length(1, 255))
     metric_type = fields.String(allow_none=True, validate=Length(1, 32))
     d3format = fields.String(allow_none=True, validate=Length(1, 128))
+    verbose_name = fields.String(allow_none=True, Length=(1, 1024))
     warning_text = fields.String(allow_none=True)
+    uuid = fields.UUID(allow_none=True)
 
 
 class DatasetPostSchema(Schema):


### PR DESCRIPTION
### SUMMARY

The dataset metric PUT schema is missing a few key fields, namely `extra`, `verbose_name` and `uuid`. In addition, the fields `extra` and `uuid` on the column schema have incorrect types, causing schema validation errors. This PR fixes the errors and adds relevant tests that would fail on master. Closes #17390.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
