### PR TITLE
chore: Remove unreachable return statements

### DIFF
--- a/superset/utils/network.py
+++ b/superset/utils/network.py
@@ -30,7 +30,7 @@ def is_port_open(host: str, port: int) -> bool:
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.settimeout(PORT_TIMEOUT)
     try:
-        s.connect((host, int(port)))
+        s.connect((host, port))
         s.shutdown(socket.SHUT_RDWR)
         return True
     except socket.error:

--- a/superset/utils/network.py
+++ b/superset/utils/network.py
@@ -38,8 +38,6 @@ def is_port_open(host: str, port: int) -> bool:
     finally:
         s.close()
 
-    return False
-
 
 def is_hostname_valid(host: str) -> bool:
     """
@@ -50,8 +48,6 @@ def is_hostname_valid(host: str) -> bool:
         return True
     except socket.gaierror:
         return False
-
-    return False
 
 
 def is_host_up(host: str) -> bool:


### PR DESCRIPTION
Remove unreachable return statements in `superset/utils/network.py`.

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
