### PR TITLE
fix: Allows PUT and DELETE only for owners of dashboard filter state

### DIFF
--- a/superset/dashboards/filter_state/commands/create.py
+++ b/superset/dashboards/filter_state/commands/create.py
@@ -16,6 +16,8 @@
 # under the License.
 from typing import Optional
 
+from flask_appbuilder.security.sqla.models import User
+
 from superset.dashboards.dao import DashboardDAO
 from superset.extensions import cache_manager
 from superset.key_value.commands.create import CreateKeyValueCommand
@@ -23,10 +25,12 @@ from superset.key_value.utils import cache_key
 
 
 class CreateFilterStateCommand(CreateKeyValueCommand):
-    def create(self, resource_id: int, key: str, value: str) -> Optional[bool]:
+    def create(
+        self, user: User, resource_id: int, key: str, value: str
+    ) -> Optional[bool]:
         dashboard = DashboardDAO.get_by_id_or_slug(str(resource_id))
         if dashboard:
             return cache_manager.filter_state_cache.set(
-                cache_key(resource_id, key), value
+                cache_key(resource_id, key), [user.get_user_id(), value]
             )
         return False

--- a/superset/dashboards/filter_state/commands/create.py
+++ b/superset/dashboards/filter_state/commands/create.py
@@ -19,6 +19,7 @@ from typing import Optional
 from flask_appbuilder.security.sqla.models import User
 
 from superset.dashboards.dao import DashboardDAO
+from superset.dashboards.filter_state.commands.entry import Entry
 from superset.extensions import cache_manager
 from superset.key_value.commands.create import CreateKeyValueCommand
 from superset.key_value.utils import cache_key
@@ -26,11 +27,12 @@ from superset.key_value.utils import cache_key
 
 class CreateFilterStateCommand(CreateKeyValueCommand):
     def create(
-        self, user: User, resource_id: int, key: str, value: str
+        self, actor: User, resource_id: int, key: str, value: str
     ) -> Optional[bool]:
         dashboard = DashboardDAO.get_by_id_or_slug(str(resource_id))
         if dashboard:
+            entry: Entry = {"owner": actor.get_user_id(), "value": value}
             return cache_manager.filter_state_cache.set(
-                cache_key(resource_id, key), [user.get_user_id(), value]
+                cache_key(resource_id, key), entry
             )
         return False

--- a/superset/dashboards/filter_state/commands/delete.py
+++ b/superset/dashboards/filter_state/commands/delete.py
@@ -19,6 +19,7 @@ from typing import Optional
 from flask_appbuilder.security.sqla.models import User
 
 from superset.dashboards.dao import DashboardDAO
+from superset.dashboards.filter_state.commands.entry import Entry
 from superset.extensions import cache_manager
 from superset.key_value.commands.delete import DeleteKeyValueCommand
 from superset.key_value.commands.exceptions import KeyValueAccessDeniedError
@@ -26,12 +27,14 @@ from superset.key_value.utils import cache_key
 
 
 class DeleteFilterStateCommand(DeleteKeyValueCommand):
-    def delete(self, user: User, resource_id: int, key: str) -> Optional[bool]:
+    def delete(self, actor: User, resource_id: int, key: str) -> Optional[bool]:
         dashboard = DashboardDAO.get_by_id_or_slug(str(resource_id))
         if dashboard:
-            entry = cache_manager.filter_state_cache.get(cache_key(resource_id, key))
+            entry: Entry = cache_manager.filter_state_cache.get(
+                cache_key(resource_id, key)
+            )
             if entry:
-                if entry[0] != user.get_user_id():
+                if entry["owner"] != actor.get_user_id():
                     raise KeyValueAccessDeniedError()
                 return cache_manager.filter_state_cache.delete(
                     cache_key(resource_id, key)

--- a/superset/dashboards/filter_state/commands/delete.py
+++ b/superset/dashboards/filter_state/commands/delete.py
@@ -16,15 +16,24 @@
 # under the License.
 from typing import Optional
 
+from flask_appbuilder.security.sqla.models import User
+
 from superset.dashboards.dao import DashboardDAO
 from superset.extensions import cache_manager
 from superset.key_value.commands.delete import DeleteKeyValueCommand
+from superset.key_value.commands.exceptions import KeyValueAccessDeniedError
 from superset.key_value.utils import cache_key
 
 
 class DeleteFilterStateCommand(DeleteKeyValueCommand):
-    def delete(self, resource_id: int, key: str) -> Optional[bool]:
+    def delete(self, user: User, resource_id: int, key: str) -> Optional[bool]:
         dashboard = DashboardDAO.get_by_id_or_slug(str(resource_id))
         if dashboard:
-            return cache_manager.filter_state_cache.delete(cache_key(resource_id, key))
+            entry = cache_manager.filter_state_cache.get(cache_key(resource_id, key))
+            if entry:
+                if entry[0] != user.get_user_id():
+                    raise KeyValueAccessDeniedError()
+                return cache_manager.filter_state_cache.delete(
+                    cache_key(resource_id, key)
+                )
         return False

--- a/superset/dashboards/filter_state/commands/entry.py
+++ b/superset/dashboards/filter_state/commands/entry.py
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import TypedDict
+
+
+class Entry(TypedDict):
+    owner: int
+    value: str

--- a/superset/dashboards/filter_state/commands/get.py
+++ b/superset/dashboards/filter_state/commands/get.py
@@ -26,8 +26,8 @@ class GetFilterStateCommand(GetKeyValueCommand):
     def get(self, resource_id: int, key: str, refreshTimeout: bool) -> Optional[str]:
         dashboard = DashboardDAO.get_by_id_or_slug(str(resource_id))
         if dashboard:
-            value = cache_manager.filter_state_cache.get(cache_key(resource_id, key))
+            entry = cache_manager.filter_state_cache.get(cache_key(resource_id, key))
             if refreshTimeout:
-                cache_manager.filter_state_cache.set(key, value)
-            return value
+                cache_manager.filter_state_cache.set(key, entry)
+            return entry[1]
         return None

--- a/superset/dashboards/filter_state/commands/get.py
+++ b/superset/dashboards/filter_state/commands/get.py
@@ -17,6 +17,7 @@
 from typing import Optional
 
 from superset.dashboards.dao import DashboardDAO
+from superset.dashboards.filter_state.commands.entry import Entry
 from superset.extensions import cache_manager
 from superset.key_value.commands.get import GetKeyValueCommand
 from superset.key_value.utils import cache_key
@@ -26,8 +27,10 @@ class GetFilterStateCommand(GetKeyValueCommand):
     def get(self, resource_id: int, key: str, refreshTimeout: bool) -> Optional[str]:
         dashboard = DashboardDAO.get_by_id_or_slug(str(resource_id))
         if dashboard:
-            entry = cache_manager.filter_state_cache.get(cache_key(resource_id, key))
+            entry: Entry = cache_manager.filter_state_cache.get(
+                cache_key(resource_id, key)
+            )
             if refreshTimeout:
                 cache_manager.filter_state_cache.set(key, entry)
-            return entry[1]
+            return entry["value"]
         return None

--- a/superset/dashboards/filter_state/commands/update.py
+++ b/superset/dashboards/filter_state/commands/update.py
@@ -39,8 +39,8 @@ class UpdateFilterStateCommand(UpdateKeyValueCommand):
                 user_id = actor.get_user_id()
                 if entry["owner"] != user_id:
                     raise KeyValueAccessDeniedError()
-                newEntry: Entry = {"owner": actor.get_user_id(), "value": value}
+                new_entry: Entry = {"owner": actor.get_user_id(), "value": value}
                 return cache_manager.filter_state_cache.set(
-                    cache_key(resource_id, key), newEntry
+                    cache_key(resource_id, key), new_entry
                 )
         return False

--- a/superset/key_value/api.py
+++ b/superset/key_value/api.py
@@ -29,6 +29,7 @@ from superset.dashboards.commands.exceptions import (
     DashboardNotFoundError,
 )
 from superset.exceptions import InvalidPayloadFormatError
+from superset.key_value.commands.exceptions import KeyValueAccessDeniedError
 from superset.key_value.schemas import KeyValuePostSchema, KeyValuePutSchema
 
 logger = logging.getLogger(__name__)
@@ -64,7 +65,7 @@ class KeyValueRestApi(BaseApi, ABC):
             return self.response(201, key=key)
         except ValidationError as error:
             return self.response_400(message=error.messages)
-        except DashboardAccessDeniedError:
+        except (DashboardAccessDeniedError, KeyValueAccessDeniedError):
             return self.response_403()
         except DashboardNotFoundError:
             return self.response_404()
@@ -80,7 +81,7 @@ class KeyValueRestApi(BaseApi, ABC):
             return self.response(200, message="Value updated successfully.")
         except ValidationError as error:
             return self.response_400(message=error.messages)
-        except DashboardAccessDeniedError:
+        except (DashboardAccessDeniedError, KeyValueAccessDeniedError):
             return self.response_403()
         except DashboardNotFoundError:
             return self.response_404()
@@ -91,7 +92,7 @@ class KeyValueRestApi(BaseApi, ABC):
             if not value:
                 return self.response_404()
             return self.response(200, value=value)
-        except DashboardAccessDeniedError:
+        except (DashboardAccessDeniedError, KeyValueAccessDeniedError):
             return self.response_403()
         except DashboardNotFoundError:
             return self.response_404()
@@ -102,7 +103,7 @@ class KeyValueRestApi(BaseApi, ABC):
             if not result:
                 return self.response_404()
             return self.response(200, message="Deleted successfully")
-        except DashboardAccessDeniedError:
+        except (DashboardAccessDeniedError, KeyValueAccessDeniedError):
             return self.response_403()
         except DashboardNotFoundError:
             return self.response_404()

--- a/superset/key_value/commands/create.py
+++ b/superset/key_value/commands/create.py
@@ -33,14 +33,14 @@ class CreateKeyValueCommand(BaseCommand, ABC):
     def __init__(
         self, user: User, resource_id: int, value: str,
     ):
-        self._actor = user
+        self._user = user
         self._resource_id = resource_id
         self._value = value
 
     def run(self) -> Model:
         try:
             key = token_urlsafe(48)
-            self.create(self._resource_id, key, self._value)
+            self.create(self._user, self._resource_id, key, self._value)
             return key
         except SQLAlchemyError as ex:
             logger.exception("Error running create command")
@@ -50,5 +50,7 @@ class CreateKeyValueCommand(BaseCommand, ABC):
         pass
 
     @abstractmethod
-    def create(self, resource_id: int, key: str, value: str) -> Optional[bool]:
+    def create(
+        self, user: User, resource_id: int, key: str, value: str
+    ) -> Optional[bool]:
         ...

--- a/superset/key_value/commands/create.py
+++ b/superset/key_value/commands/create.py
@@ -31,16 +31,16 @@ logger = logging.getLogger(__name__)
 
 class CreateKeyValueCommand(BaseCommand, ABC):
     def __init__(
-        self, user: User, resource_id: int, value: str,
+        self, actor: User, resource_id: int, value: str,
     ):
-        self._user = user
+        self._actor = actor
         self._resource_id = resource_id
         self._value = value
 
     def run(self) -> Model:
         try:
             key = token_urlsafe(48)
-            self.create(self._user, self._resource_id, key, self._value)
+            self.create(self._actor, self._resource_id, key, self._value)
             return key
         except SQLAlchemyError as ex:
             logger.exception("Error running create command")
@@ -51,6 +51,6 @@ class CreateKeyValueCommand(BaseCommand, ABC):
 
     @abstractmethod
     def create(
-        self, user: User, resource_id: int, key: str, value: str
+        self, actor: User, resource_id: int, key: str, value: str
     ) -> Optional[bool]:
         ...

--- a/superset/key_value/commands/delete.py
+++ b/superset/key_value/commands/delete.py
@@ -29,14 +29,14 @@ logger = logging.getLogger(__name__)
 
 
 class DeleteKeyValueCommand(BaseCommand, ABC):
-    def __init__(self, user: User, resource_id: int, key: str):
-        self._user = user
+    def __init__(self, actor: User, resource_id: int, key: str):
+        self._actor = actor
         self._resource_id = resource_id
         self._key = key
 
     def run(self) -> Model:
         try:
-            return self.delete(self._user, self._resource_id, self._key)
+            return self.delete(self._actor, self._resource_id, self._key)
         except SQLAlchemyError as ex:
             logger.exception("Error running delete command")
             raise KeyValueDeleteFailedError() from ex
@@ -45,5 +45,5 @@ class DeleteKeyValueCommand(BaseCommand, ABC):
         pass
 
     @abstractmethod
-    def delete(self, user: User, resource_id: int, key: str) -> Optional[bool]:
+    def delete(self, actor: User, resource_id: int, key: str) -> Optional[bool]:
         ...

--- a/superset/key_value/commands/delete.py
+++ b/superset/key_value/commands/delete.py
@@ -30,13 +30,13 @@ logger = logging.getLogger(__name__)
 
 class DeleteKeyValueCommand(BaseCommand, ABC):
     def __init__(self, user: User, resource_id: int, key: str):
-        self._actor = user
+        self._user = user
         self._resource_id = resource_id
         self._key = key
 
     def run(self) -> Model:
         try:
-            return self.delete(self._resource_id, self._key)
+            return self.delete(self._user, self._resource_id, self._key)
         except SQLAlchemyError as ex:
             logger.exception("Error running delete command")
             raise KeyValueDeleteFailedError() from ex
@@ -45,5 +45,5 @@ class DeleteKeyValueCommand(BaseCommand, ABC):
         pass
 
     @abstractmethod
-    def delete(self, resource_id: int, key: str) -> Optional[bool]:
+    def delete(self, user: User, resource_id: int, key: str) -> Optional[bool]:
         ...

--- a/superset/key_value/commands/exceptions.py
+++ b/superset/key_value/commands/exceptions.py
@@ -20,6 +20,7 @@ from superset.commands.exceptions import (
     CommandException,
     CreateFailedError,
     DeleteFailedError,
+    ForbiddenError,
     UpdateFailedError,
 )
 
@@ -38,3 +39,7 @@ class KeyValueDeleteFailedError(DeleteFailedError):
 
 class KeyValueUpdateFailedError(UpdateFailedError):
     message = _("An error occurred while updating the value.")
+
+
+class KeyValueAccessDeniedError(ForbiddenError):
+    message = _("You don't have permission to modify the value.")

--- a/superset/key_value/commands/get.py
+++ b/superset/key_value/commands/get.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 class GetKeyValueCommand(BaseCommand, ABC):
     def __init__(self, user: User, resource_id: int, key: str):
-        self._actor = user
+        self._user = user
         self._resource_id = resource_id
         self._key = key
 

--- a/superset/key_value/commands/get.py
+++ b/superset/key_value/commands/get.py
@@ -30,8 +30,8 @@ logger = logging.getLogger(__name__)
 
 
 class GetKeyValueCommand(BaseCommand, ABC):
-    def __init__(self, user: User, resource_id: int, key: str):
-        self._user = user
+    def __init__(self, actor: User, resource_id: int, key: str):
+        self._actor = actor
         self._resource_id = resource_id
         self._key = key
 

--- a/superset/key_value/commands/update.py
+++ b/superset/key_value/commands/update.py
@@ -32,14 +32,14 @@ class UpdateKeyValueCommand(BaseCommand, ABC):
     def __init__(
         self, user: User, resource_id: int, key: str, value: str,
     ):
-        self._actor = user
+        self._user = user
         self._resource_id = resource_id
         self._key = key
         self._value = value
 
     def run(self) -> Model:
         try:
-            return self.update(self._resource_id, self._key, self._value)
+            return self.update(self._user, self._resource_id, self._key, self._value)
         except SQLAlchemyError as ex:
             logger.exception("Error running update command")
             raise KeyValueUpdateFailedError() from ex
@@ -48,5 +48,7 @@ class UpdateKeyValueCommand(BaseCommand, ABC):
         pass
 
     @abstractmethod
-    def update(self, resource_id: int, key: str, value: str) -> Optional[bool]:
+    def update(
+        self, user: User, resource_id: int, key: str, value: str
+    ) -> Optional[bool]:
         ...

--- a/superset/key_value/commands/update.py
+++ b/superset/key_value/commands/update.py
@@ -30,16 +30,16 @@ logger = logging.getLogger(__name__)
 
 class UpdateKeyValueCommand(BaseCommand, ABC):
     def __init__(
-        self, user: User, resource_id: int, key: str, value: str,
+        self, actor: User, resource_id: int, key: str, value: str,
     ):
-        self._user = user
+        self._actor = actor
         self._resource_id = resource_id
         self._key = key
         self._value = value
 
     def run(self) -> Model:
         try:
-            return self.update(self._user, self._resource_id, self._key, self._value)
+            return self.update(self._actor, self._resource_id, self._key, self._value)
         except SQLAlchemyError as ex:
             logger.exception("Error running update command")
             raise KeyValueUpdateFailedError() from ex
@@ -49,6 +49,6 @@ class UpdateKeyValueCommand(BaseCommand, ABC):
 
     @abstractmethod
     def update(
-        self, user: User, resource_id: int, key: str, value: str
+        self, actor: User, resource_id: int, key: str, value: str
     ) -> Optional[bool]:
         ...

--- a/tests/integration_tests/dashboards/filter_state/api_tests.py
+++ b/tests/integration_tests/dashboards/filter_state/api_tests.py
@@ -23,6 +23,7 @@ from sqlalchemy.orm import Session
 
 from superset import app
 from superset.dashboards.commands.exceptions import DashboardAccessDeniedError
+from superset.dashboards.filter_state.commands.entry import Entry
 from superset.extensions import cache_manager
 from superset.key_value.utils import cache_key
 from superset.models.dashboard import Dashboard
@@ -63,9 +64,8 @@ def admin_id() -> int:
 def cache(dashboard_id, admin_id):
     app.config["FILTER_STATE_CACHE_CONFIG"] = {"CACHE_TYPE": "SimpleCache"}
     cache_manager.init_app(app)
-    cache_manager.filter_state_cache.set(
-        cache_key(dashboard_id, key), [admin_id, value]
-    )
+    entry: Entry = {"owner": admin_id, "value": value}
+    cache_manager.filter_state_cache.set(cache_key(dashboard_id, key), entry)
 
 
 def test_post(client, dashboard_id: int):

--- a/tests/integration_tests/dashboards/filter_state/api_tests.py
+++ b/tests/integration_tests/dashboards/filter_state/api_tests.py
@@ -15,11 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 import json
-from typing import Any
 from unittest.mock import patch
 
 import pytest
-from flask.testing import FlaskClient
+from flask_appbuilder.security.sqla.models import User
 from sqlalchemy.orm import Session
 
 from superset import app
@@ -27,131 +26,170 @@ from superset.dashboards.commands.exceptions import DashboardAccessDeniedError
 from superset.extensions import cache_manager
 from superset.key_value.utils import cache_key
 from superset.models.dashboard import Dashboard
+from tests.integration_tests.base_tests import login
 from tests.integration_tests.fixtures.world_bank_dashboard import (
     load_world_bank_dashboard_with_slices,
 )
 from tests.integration_tests.test_app import app
 
-dashboardId = 985374
 key = "test-key"
 value = "test"
 
 
-class FilterStateTests:
-    @pytest.fixture
-    def client(self):
-        with app.test_client() as client:
-            with app.app_context():
-                yield client
+@pytest.fixture
+def client():
+    with app.test_client() as client:
+        with app.app_context():
+            yield client
 
-    @pytest.fixture
-    def dashboard_id(self, load_world_bank_dashboard_with_slices) -> int:
-        with app.app_context() as ctx:
-            session: Session = ctx.app.appbuilder.get_session
-            dashboard = session.query(Dashboard).filter_by(slug="world_health").one()
-            return dashboard.id
 
-    @pytest.fixture
-    def cache(self, dashboard_id):
-        app.config["FILTER_STATE_CACHE_CONFIG"] = {"CACHE_TYPE": "SimpleCache"}
-        cache_manager.init_app(app)
-        cache_manager.filter_state_cache.set(cache_key(dashboard_id, key), value)
+@pytest.fixture
+def dashboard_id(load_world_bank_dashboard_with_slices) -> int:
+    with app.app_context() as ctx:
+        session: Session = ctx.app.appbuilder.get_session
+        dashboard = session.query(Dashboard).filter_by(slug="world_health").one()
+        return dashboard.id
 
-    def setUp(self):
-        self.login(username="admin")
 
-    def test_post(self, client, dashboard_id: int):
-        payload = {
-            "value": value,
-        }
-        resp = client.post(
-            f"api/v1/dashboard/{dashboard_id}/filter_state", json=payload
-        )
-        assert resp.status_code == 201
+@pytest.fixture
+def admin_id() -> int:
+    with app.app_context() as ctx:
+        session: Session = ctx.app.appbuilder.get_session
+        admin = session.query(User).filter_by(username="admin").one_or_none()
+        return admin.id
 
-    def test_post_bad_request(self, client, dashboard_id: int):
-        payload = {
-            "value": 1234,
-        }
-        resp = client.put(
-            f"api/v1/dashboard/{dashboard_id}/filter_state/{key}/", json=payload
-        )
-        assert resp.status_code == 400
 
-    @patch("superset.security.SupersetSecurityManager.raise_for_dashboard_access")
-    def test_post_access_denied(
-        self, client, mock_raise_for_dashboard_access, dashboard_id: int
-    ):
-        mock_raise_for_dashboard_access.side_effect = DashboardAccessDeniedError()
-        payload = {
-            "value": value,
-        }
-        resp = client.post(
-            f"api/v1/dashboard/{dashboard_id}/filter_state", json=payload
-        )
-        assert resp.status_code == 403
+@pytest.fixture(autouse=True)
+def cache(dashboard_id, admin_id):
+    app.config["FILTER_STATE_CACHE_CONFIG"] = {"CACHE_TYPE": "SimpleCache"}
+    cache_manager.init_app(app)
+    cache_manager.filter_state_cache.set(
+        cache_key(dashboard_id, key), [admin_id, value]
+    )
 
-    def test_put(self, client, dashboard_id: int):
-        payload = {
-            "value": "new value",
-        }
-        resp = client.put(
-            f"api/v1/dashboard/{dashboard_id}/filter_state/{key}/", json=payload
-        )
-        assert resp.status_code == 200
 
-    def test_put_bad_request(self, client, dashboard_id: int):
-        payload = {
-            "value": 1234,
-        }
-        resp = client.put(
-            f"api/v1/dashboard/{dashboard_id}/filter_state/{key}/", json=payload
-        )
-        assert resp.status_code == 400
+def test_post(client, dashboard_id: int):
+    login(client, "admin")
+    payload = {
+        "value": value,
+    }
+    resp = client.post(f"api/v1/dashboard/{dashboard_id}/filter_state", json=payload)
+    assert resp.status_code == 201
 
-    @patch("superset.security.SupersetSecurityManager.raise_for_dashboard_access")
-    def test_put_access_denied(
-        self, client, mock_raise_for_dashboard_access, dashboard_id: int
-    ):
-        mock_raise_for_dashboard_access.side_effect = DashboardAccessDeniedError()
-        payload = {
-            "value": "new value",
-        }
-        resp = client.put(
-            f"api/v1/dashboard/{dashboard_id}/filter_state/{key}/", json=payload
-        )
-        assert resp.status_code == 403
 
-    def test_get_key_not_found(self, client):
-        resp = client.get("unknown-key")
-        assert resp.status_code == 404
+def test_post_bad_request(client, dashboard_id: int):
+    login(client, "admin")
+    payload = {
+        "value": 1234,
+    }
+    resp = client.put(
+        f"api/v1/dashboard/{dashboard_id}/filter_state/{key}/", json=payload
+    )
+    assert resp.status_code == 400
 
-    def test_get_dashboard_not_found(self, client):
-        resp = client.get(f"api/v1/dashboard/{-1}/filter_state/{key}/")
-        assert resp.status_code == 404
 
-    def test_get(self, client, dashboard_id: int):
-        resp = client.get(f"api/v1/dashboard/{dashboard_id}/filter_state/{key}/")
-        assert resp.status_code == 200
-        data = json.loads(resp.data.decode("utf-8"))
-        assert value == data.get("value")
+@patch("superset.security.SupersetSecurityManager.raise_for_dashboard_access")
+def test_post_access_denied(mock_raise_for_dashboard_access, client, dashboard_id: int):
+    login(client, "admin")
+    mock_raise_for_dashboard_access.side_effect = DashboardAccessDeniedError()
+    payload = {
+        "value": value,
+    }
+    resp = client.post(f"api/v1/dashboard/{dashboard_id}/filter_state", json=payload)
+    assert resp.status_code == 403
 
-    @patch("superset.security.SupersetSecurityManager.raise_for_dashboard_access")
-    def test_get_access_denied(
-        self, client, mock_raise_for_dashboard_access, dashboard_id
-    ):
-        mock_raise_for_dashboard_access.side_effect = DashboardAccessDeniedError()
-        resp = client.get(f"api/v1/dashboard/{dashboard_id}/filter_state/{key}/")
-        assert resp.status_code == 403
 
-    def test_delete(self, client, dashboard_id: int):
-        resp = client.delete(f"api/v1/dashboard/{dashboard_id}/filter_state/{key}/")
-        assert resp.status_code == 200
+def test_put(client, dashboard_id: int):
+    login(client, "admin")
+    payload = {
+        "value": "new value",
+    }
+    resp = client.put(
+        f"api/v1/dashboard/{dashboard_id}/filter_state/{key}/", json=payload
+    )
+    assert resp.status_code == 200
 
-    @patch("superset.security.SupersetSecurityManager.raise_for_dashboard_access")
-    def test_delete_access_denied(
-        self, client, mock_raise_for_dashboard_access, dashboard_id: int
-    ):
-        mock_raise_for_dashboard_access.side_effect = DashboardAccessDeniedError()
-        resp = client.delete(f"api/v1/dashboard/{dashboard_id}/filter_state/{key}/")
-        assert resp.status_code == 403
+
+def test_put_bad_request(client, dashboard_id: int):
+    login(client, "admin")
+    payload = {
+        "value": 1234,
+    }
+    resp = client.put(
+        f"api/v1/dashboard/{dashboard_id}/filter_state/{key}/", json=payload
+    )
+    assert resp.status_code == 400
+
+
+@patch("superset.security.SupersetSecurityManager.raise_for_dashboard_access")
+def test_put_access_denied(mock_raise_for_dashboard_access, client, dashboard_id: int):
+    login(client, "admin")
+    mock_raise_for_dashboard_access.side_effect = DashboardAccessDeniedError()
+    payload = {
+        "value": "new value",
+    }
+    resp = client.put(
+        f"api/v1/dashboard/{dashboard_id}/filter_state/{key}/", json=payload
+    )
+    assert resp.status_code == 403
+
+
+def test_put_not_owner(client, dashboard_id: int):
+    login(client, "gamma")
+    payload = {
+        "value": "new value",
+    }
+    resp = client.put(
+        f"api/v1/dashboard/{dashboard_id}/filter_state/{key}/", json=payload
+    )
+    assert resp.status_code == 403
+
+
+def test_get_key_not_found(client):
+    login(client, "admin")
+    resp = client.get("unknown-key")
+    assert resp.status_code == 404
+
+
+def test_get_dashboard_not_found(client):
+    login(client, "admin")
+    resp = client.get(f"api/v1/dashboard/{-1}/filter_state/{key}/")
+    assert resp.status_code == 404
+
+
+def test_get(client, dashboard_id: int):
+    login(client, "admin")
+    resp = client.get(f"api/v1/dashboard/{dashboard_id}/filter_state/{key}/")
+    assert resp.status_code == 200
+    data = json.loads(resp.data.decode("utf-8"))
+    assert value == data.get("value")
+
+
+@patch("superset.security.SupersetSecurityManager.raise_for_dashboard_access")
+def test_get_access_denied(mock_raise_for_dashboard_access, client, dashboard_id):
+    login(client, "admin")
+    mock_raise_for_dashboard_access.side_effect = DashboardAccessDeniedError()
+    resp = client.get(f"api/v1/dashboard/{dashboard_id}/filter_state/{key}/")
+    assert resp.status_code == 403
+
+
+def test_delete(client, dashboard_id: int):
+    login(client, "admin")
+    resp = client.delete(f"api/v1/dashboard/{dashboard_id}/filter_state/{key}/")
+    assert resp.status_code == 200
+
+
+@patch("superset.security.SupersetSecurityManager.raise_for_dashboard_access")
+def test_delete_access_denied(
+    mock_raise_for_dashboard_access, client, dashboard_id: int
+):
+    login(client, "admin")
+    mock_raise_for_dashboard_access.side_effect = DashboardAccessDeniedError()
+    resp = client.delete(f"api/v1/dashboard/{dashboard_id}/filter_state/{key}/")
+    assert resp.status_code == 403
+
+
+def test_delete_not_owner(client, dashboard_id: int):
+    login(client, "gamma")
+    resp = client.delete(f"api/v1/dashboard/{dashboard_id}/filter_state/{key}/")
+    assert resp.status_code == 403


### PR DESCRIPTION
### SUMMARY
This PR changes the dashboard filters state endpoint to only allow `PUT` and `DELETE` for the owners of the dashboard filter state. If someone else tries to issue these operations, a `403` is returned. The main objective of this change is to prevent other users from overriding the owner's state.

Two more tests were added to include the new rules: `test_put_not_owner` and `test_delete_not_owner`

### TESTING INSTRUCTIONS
1 - Execute all tests
2 - All tests should pass

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
