### PR TITLE
fix(Mixed Timeseries Chart): Custom Metric Label 

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/types/QueryFormData.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/QueryFormData.ts
@@ -34,6 +34,7 @@ import { TimeRange, TimeRangeEndpoints } from './Time';
 import { TimeGranularity } from '../../time-format';
 import { JsonObject } from '../../connection';
 import { AdhocColumn, PhysicalColumn } from './Column';
+import { Datasource } from '..';
 
 /**
  * Metric definition/reference in query object.
@@ -146,7 +147,7 @@ export type ExtraFormData = ExtraFormDataAppend & ExtraFormDataOverride;
 
 export interface BaseFormData extends TimeRange, FormDataResidual {
   /** datasource identifier ${id}_${type} */
-  datasource: string;
+  datasource: Datasource;
   /**
    * visualization type
    * - necessary if you use the plugin and want to use

--- a/superset-frontend/packages/superset-ui-core/src/query/types/QueryFormData.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/QueryFormData.ts
@@ -34,7 +34,6 @@ import { TimeRange, TimeRangeEndpoints } from './Time';
 import { TimeGranularity } from '../../time-format';
 import { JsonObject } from '../../connection';
 import { AdhocColumn, PhysicalColumn } from './Column';
-import { Datasource } from '..';
 
 /**
  * Metric definition/reference in query object.
@@ -147,7 +146,7 @@ export type ExtraFormData = ExtraFormDataAppend & ExtraFormDataOverride;
 
 export interface BaseFormData extends TimeRange, FormDataResidual {
   /** datasource identifier ${id}_${type} */
-  datasource: Datasource;
+  datasource: string;
   /**
    * visualization type
    * - necessary if you use the plugin and want to use

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -65,10 +65,16 @@ import { TIMESERIES_CONSTANTS } from '../constants';
 export default function transformProps(
   chartProps: EchartsMixedTimeseriesFormData,
 ): EchartsMixedTimeseriesChartTransformedProps {
-  const { width, height, formData, queriesData, hooks, filterState,datasource  } =
-    chartProps;
+  const {
+    width,
+    height,
+    formData,
+    queriesData,
+    hooks,
+    filterState,
+    datasource,
+  } = chartProps;
   const { verboseMap = {} } = datasource;
-
   const { annotation_data: annotationData_ } = queriesData[0];
   const annotationData = annotationData_ || {};
   const data1: TimeseriesDataRecord[] = queriesData[0].data || [];

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -74,9 +74,9 @@ export default function transformProps(
     filterState,
     datasource,
   } = chartProps;
-  const { verboseMap = {} } = datasource;
   const { annotation_data: annotationData_ } = queriesData[0];
   const annotationData = annotationData_ || {};
+  const extractedDataSource = datasource || {};
   const data1: TimeseriesDataRecord[] = queriesData[0].data || [];
   const data2: TimeseriesDataRecord[] = queriesData[1].data || [];
 
@@ -129,11 +129,11 @@ export default function transformProps(
   }: EchartsMixedTimeseriesFormData = { ...DEFAULT_FORM_DATA, ...formData };
 
   const colorScale = CategoricalColorNamespace.getScale(colorScheme as string);
-  const rebasedDataA = rebaseTimeseriesDatum(data1, verboseMap);
+  const rebasedDataA = rebaseTimeseriesDatum(data1, extractedDataSource);
   const rawSeriesA = extractTimeseriesSeries(rebasedDataA, {
     fillNeighborValue: stack ? 0 : undefined,
   });
-  const rebasedDataB = rebaseTimeseriesDatum(data2, verboseMap);
+  const rebasedDataB = rebaseTimeseriesDatum(data2, extractedDataSource);
   const rawSeriesB = extractTimeseriesSeries(rebasedDataB, {
     fillNeighborValue: stackB ? 0 : undefined,
   });

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -65,8 +65,10 @@ import { TIMESERIES_CONSTANTS } from '../constants';
 export default function transformProps(
   chartProps: EchartsMixedTimeseriesFormData,
 ): EchartsMixedTimeseriesChartTransformedProps {
-  const { width, height, formData, queriesData, hooks, filterState } =
+  const { width, height, formData, queriesData, hooks, filterState,datasource  } =
     chartProps;
+  const { verboseMap = {} } = datasource;
+
   const { annotation_data: annotationData_ } = queriesData[0];
   const annotationData = annotationData_ || {};
   const data1: TimeseriesDataRecord[] = queriesData[0].data || [];
@@ -121,10 +123,12 @@ export default function transformProps(
   }: EchartsMixedTimeseriesFormData = { ...DEFAULT_FORM_DATA, ...formData };
 
   const colorScale = CategoricalColorNamespace.getScale(colorScheme as string);
-  const rawSeriesA = extractTimeseriesSeries(rebaseTimeseriesDatum(data1), {
+  const rebasedDataA = rebaseTimeseriesDatum(data1, verboseMap);
+  const rawSeriesA = extractTimeseriesSeries(rebasedDataA, {
     fillNeighborValue: stack ? 0 : undefined,
   });
-  const rawSeriesB = extractTimeseriesSeries(rebaseTimeseriesDatum(data2), {
+  const rebasedDataB = rebaseTimeseriesDatum(data2, verboseMap);
+  const rawSeriesB = extractTimeseriesSeries(rebasedDataB, {
     fillNeighborValue: stackB ? 0 : undefined,
   });
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -33,6 +33,7 @@ import {
   DEFAULT_FORM_DATA,
   EchartsMixedTimeseriesFormData,
   EchartsMixedTimeseriesChartTransformedProps,
+  EchartsMixedTimeseriesProps,
 } from './types';
 import { ForecastSeriesEnum } from '../types';
 import { parseYAxisBound } from '../utils/controls';
@@ -63,7 +64,7 @@ import {
 import { TIMESERIES_CONSTANTS } from '../constants';
 
 export default function transformProps(
-  chartProps: EchartsMixedTimeseriesFormData,
+  chartProps: EchartsMixedTimeseriesProps,
 ): EchartsMixedTimeseriesChartTransformedProps {
   const {
     width,
@@ -76,9 +77,9 @@ export default function transformProps(
   } = chartProps;
   const { annotation_data: annotationData_ } = queriesData[0];
   const annotationData = annotationData_ || {};
-  const extractedDataSource = datasource || {};
-  const data1: TimeseriesDataRecord[] = queriesData[0].data || [];
-  const data2: TimeseriesDataRecord[] = queriesData[1].data || [];
+  const { verboseMap = {} } = datasource;
+  const data1 = (queriesData[0].data || []) as TimeseriesDataRecord[];
+  const data2 = (queriesData[1].data || []) as TimeseriesDataRecord[];
 
   const {
     area,
@@ -129,11 +130,11 @@ export default function transformProps(
   }: EchartsMixedTimeseriesFormData = { ...DEFAULT_FORM_DATA, ...formData };
 
   const colorScale = CategoricalColorNamespace.getScale(colorScheme as string);
-  const rebasedDataA = rebaseTimeseriesDatum(data1, extractedDataSource);
+  const rebasedDataA = rebaseTimeseriesDatum(data1, verboseMap);
   const rawSeriesA = extractTimeseriesSeries(rebasedDataA, {
     fillNeighborValue: stack ? 0 : undefined,
   });
-  const rebasedDataB = rebaseTimeseriesDatum(data2, extractedDataSource);
+  const rebasedDataB = rebaseTimeseriesDatum(data2, verboseMap);
   const rawSeriesB = extractTimeseriesSeries(rebasedDataB, {
     fillNeighborValue: stackB ? 0 : undefined,
   });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Bug Fix
This PR fixes the problem in which custom metric name is shown in legend instead of custom metric label inside Mixed Time series charts. Reference: Issue #17586

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![before](https://user-images.githubusercontent.com/42173629/144707163-fbe53b87-3afd-4d4a-9555-cd80443b6940.PNG)
![after](https://user-images.githubusercontent.com/42173629/144707167-fa7616d5-29fb-4b30-89f9-9120048419ea.PNG)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [x] Fixes #17586
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
