### PR TITLE
feat: support superset celery app to be extendable

### DIFF
--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -38,10 +38,10 @@ fi
 
 if [[ "${1}" == "worker" ]]; then
   echo "Starting Celery worker..."
-  celery --app=superset.tasks.celery_app:app worker -Ofair -l INFO
+  celery --app=${SUPERSET_CELERY_APP:-superset.tasks.celery_app:app} worker -Ofair -l INFO
 elif [[ "${1}" == "beat" ]]; then
   echo "Starting Celery beat..."
-  celery --app=superset.tasks.celery_app:app beat --pidfile /tmp/celerybeat.pid -l INFO -s "${SUPERSET_HOME}"/celerybeat-schedule
+  celery --app=${SUPERSET_CELERY_APP:-superset.tasks.celery_app:app} beat --pidfile /tmp/celerybeat.pid -l INFO -s "${SUPERSET_HOME}"/celerybeat-schedule
 elif [[ "${1}" == "app" ]]; then
   echo "Starting web app..."
   flask run -p 8088 --with-threads --reload --debugger --host=0.0.0.0

--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
   - name: craig-rueda
     email: craig@craigrueda.com
     url: https://github.com/craig-rueda
-version: 0.5.0
+version: 0.6.0
 dependencies:
 - name: postgresql
   version: 10.2.0

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -234,11 +234,14 @@ supersetNode:
 
 ##
 ## Superset worker configuration
+
+supersetCeleryApp: ${SUPERSET_CELERY_APP:-superset.tasks.celery_app:app}
+
 supersetWorker:
   command:
     - "/bin/sh"
     - "-c"
-    - ". {{ .Values.configMountPath }}/superset_bootstrap.sh; celery --app=superset.tasks.celery_app:app worker"
+    - ". {{ .Values.configMountPath }}/superset_bootstrap.sh; celery --app={{ .Values.supersetCeleryApp }} worker"
   forceReload: false # If true, forces deployment to reload on each upgrade
   initContainers:
     - name: wait-for-postgres
@@ -261,7 +264,7 @@ supersetCeleryBeat:
   command:
     - "/bin/sh"
     - "-c"
-    - ". {{ .Values.configMountPath }}/superset_bootstrap.sh; celery --app=superset.tasks.celery_app:app beat --pidfile /tmp/celerybeat.pid --schedule /tmp/celerybeat-schedule"
+    - ". {{ .Values.configMountPath }}/superset_bootstrap.sh; celery --app={{ .Values.supersetCeleryApp }} beat --pidfile /tmp/celerybeat.pid --schedule /tmp/celerybeat-schedule"
   forceReload: false # If true, forces deployment to reload on each upgrade
   initContainers:
     - name: wait-for-postgres


### PR DESCRIPTION
### SUMMARY
In general, superset can be extended by supplying alternative FLASK_APP environment variable, or by defining APP_INITIALIZER in config. 

in case there is a need to extend the functionality of celery tasks, currently is hard 

this PR try to solve it by replacing the hard coded superset celery app into environment variable 

### TESTING INSTRUCTIONS
I ran the charts in the local environment using Helm chart v3 and Minikube 

helm: v3.7.1
minikube: v1.22.0
kubectl 
  - client: v1.21.2
  - server: v1.20.0

 by 
``` helm upgrade superset superset --install --debug -f superset/values.yaml ```

The generated manifest 
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: superset-worker
  labels:
    app: superset-worker
    chart: superset-0.3.12
    release: superset
    heritage: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app: superset-worker
      release: superset
  template:
    metadata:
      annotations:
        checksum/superset_config.py: 9facd455e9be6a40e3c9af7f0fcb7a2cf2c97f7f764b349cbeb9be0d9f217665
        checksum/connections: a91716d6d1088e870fbe02159dc0b066dd011885aa08a22fbe60ea1cd4720f82
        checksum/extraConfigs: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
        checksum/extraSecrets: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
        checksum/extraSecretEnv: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
        checksum/configOverrides: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
        
      labels:
        app: superset-worker
        release: superset
    spec:
      securityContext:
        runAsUser: 0
      initContainers:
      - command:
        - /bin/sh
        - -c
        - until nc -zv $DB_HOST $DB_PORT -w1; do echo 'waiting for db'; sleep 1; done
        envFrom:
        - secretRef:
            name: 'superset-env'
        image: busybox:latest
        imagePullPolicy: IfNotPresent
        name: wait-for-postgres
      containers:
        - name: superset
          image: "apache/superset:latest"
          imagePullPolicy: IfNotPresent
          command: ["/bin/sh","-c",". /app/pythonpath/superset_bootstrap.sh; celery --app=${SUPERSET_CELERY_APP:-superset.tasks.celery_app:app} worker"]
          env:
            - name: "SUPERSET_PORT"
              value: "8088"
          envFrom:
            - secretRef:
                name: "superset-env"
          volumeMounts:
            - name: superset-config
              mountPath: "/app/pythonpath"
              readOnly: true
          resources:
            {}
      volumes:
        - name: superset-config
          secret:
            secretName: superset-config
---
```

then I fetched the pod 
``` kubectl get pods   ```
```                                                                                                                                                                
NAME                              READY   STATUS      RESTARTS   AGE
superset-58d7dd68c4-kdnnb         1/1     Running     0          2d18h
superset-init-db-w5nfs            0/1     Completed   0          40m
superset-postgresql-0             1/1     Running     0          2d18h
superset-redis-master-0           1/1     Running     0          2d18h
superset-worker-c8b4466fd-f5829   1/1     Running     0          40m
```

fetched the logs:

``` kubectl logs superset-worker-c8b4466fd-f5829       ```
```                                                                                                     
             1.99      10:49    05.12.21  
Collecting psycopg2==2.8.5
  Downloading psycopg2-2.8.5.tar.gz (380 kB)
Collecting redis==3.2.1
  Downloading redis-3.2.1-py2.py3-none-any.whl (65 kB)
Building wheels for collected packages: psycopg2
  Building wheel for psycopg2 (setup.py): started
  Building wheel for psycopg2 (setup.py): finished with status 'done'
  Created wheel for psycopg2: filename=psycopg2-2.8.5-cp38-cp38-linux_x86_64.whl size=449133 sha256=9c77e60385c89e0e7d5a9d4f2e15971a77d0b129c9c0178e532788887df1b4e0
  Stored in directory: /root/.cache/pip/wheels/35/64/21/9c9e2c1bb9cd6bca3c1b97b955615e37fd309f8e8b0b9fdf1a
Successfully built psycopg2
Installing collected packages: redis, psycopg2
  Attempting uninstall: redis
    Found existing installation: redis 3.5.3
    Uninstalling redis-3.5.3:
      Successfully uninstalled redis-3.5.3
Successfully installed psycopg2-2.8.5 redis-3.2.1
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
WARNING: You are using pip version 21.2.4; however, version 21.3.1 is available.
You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
logging was configured successfully
2021-12-05 08:09:54,487:INFO:superset.utils.logging_configurator:logging was configured successfully
2021-12-05 08:09:54,492:INFO:root:Configured event logger of type <class 'superset.utils.log.DBEventLogger'>
```

and finally checked what is running in the pod 
```kubectl exec superset-worker-c8b4466fd-f5829 -- ps -ef```
``` 0.07      10:52    05.12.21  
Defaulted container "superset" out of: superset, wait-for-postgres (init)
UID          PID    PPID  C STIME TTY          TIME CMD
root           1       0  0 08:09 ?        00:00:00 /bin/sh -c . /app/pythonpath/superset_bootstrap.sh; celery --app=${SUPERSET_CELERY_APP:-superset.tasks.celery_app:app} worker
root         136       1  0 08:09 ?        00:00:10 /usr/local/bin/python /usr/bin/celery --app=superset.tasks.celery_app:app worker
root         142     136  0 08:09 ?        00:00:00 /usr/local/bin/python /usr/bin/celery --app=superset.tasks.celery_app:app worker
root         143     136  0 08:09 ?        00:00:00 /usr/local/bin/python /usr/bin/celery --app=superset.tasks.celery_app:app worker
root         144     136  0 08:09 ?        00:00:00 /usr/local/bin/python /usr/bin/celery --app=superset.tasks.celery_app:app worker
root         145     136  0 08:09 ?        00:00:00 /usr/local/bin/python /usr/bin/celery --app=superset.tasks.celery_app:app worker
root         155       0  0 08:53 ?        00:00:00 ps -ef
```














