### PR TITLE
feat(viz): export csv with verbose_name

### DIFF
--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -333,6 +333,10 @@ class QueryContextProcessor:
     def get_data(self, df: pd.DataFrame) -> Union[str, List[Dict[str, Any]]]:
         if self._query_context.result_format == ChartDataResultFormat.CSV:
             include_index = not isinstance(df.index, pd.RangeIndex)
+            columns = list(df.columns)
+            verbose_map = self._qc_datasource.data.get("verbose_map", {})
+            if verbose_map:
+                df.columns = [verbose_map.get(column, column) for column in columns]
             result = csv.df_to_escaped_csv(
                 df, index=include_index, **config["CSV_EXPORT"]
             )


### PR DESCRIPTION
The column names displayed on the report are inconsistent with the column names of the actual exported csv file, which can sometimes cause confusion. Therefore, I hope to add a feature to make the column names displayed on the report consistent with the column names of the exported csv file.

### SUMMARY
Use verbose_map to help the column names of csv export to be consistent with the front-end display.
Because of the revision of the Superset interface, this PR is changed. #10760

The previous PR was #17341 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE
![image](https://user-images.githubusercontent.com/23111194/144806996-02a52ad6-336d-40bf-84d7-a2ab3bcce561.png)
AFTER
![image](https://user-images.githubusercontent.com/23111194/144807030-2191dbb6-60cb-4550-a7ed-4da8d726b2a4.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
