### PR TITLE
feat(prophet): enable confidence intervals and y_hat without forecast

### DIFF
--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -542,7 +542,7 @@ class ChartDataProphetOptionsSchema(ChartDataPostProcessingOperationOptionsSchem
     )
     periods = fields.Integer(
         descrption="Time periods (in units of `time_grain`) to predict into the future",
-        min=1,
+        min=0,
         example=7,
         required=True,
     )

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -820,8 +820,8 @@ def prophet(  # pylint: disable=too-many-arguments
     freq = PROPHET_TIME_GRAIN_MAP[time_grain]
     # check type at runtime due to marhsmallow schema not being able to handle
     # union types
-    if not periods or periods < 0 or not isinstance(periods, int):
-        raise QueryObjectValidationError(_("Periods must be a positive integer value"))
+    if periods < 0 or not isinstance(periods, int):
+        raise QueryObjectValidationError(_("Periods must be a whole number"))
     if not confidence_interval or confidence_interval <= 0 or confidence_interval >= 1:
         raise QueryObjectValidationError(
             _("Confidence interval must be between 0 and 1 (exclusive)")

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -820,7 +820,7 @@ def prophet(  # pylint: disable=too-many-arguments
     freq = PROPHET_TIME_GRAIN_MAP[time_grain]
     # check type at runtime due to marhsmallow schema not being able to handle
     # union types
-    if periods < 0 or not isinstance(periods, int):
+    if not isinstance(periods, int) or periods < 0:
         raise QueryObjectValidationError(_("Periods must be a whole number"))
     if not confidence_interval or confidence_interval <= 0 or confidence_interval >= 1:
         raise QueryObjectValidationError(

--- a/tests/integration_tests/pandas_postprocessing_tests.py
+++ b/tests/integration_tests/pandas_postprocessing_tests.py
@@ -830,6 +830,28 @@ class TestPostProcessing(SupersetTestCase):
         assert df[DTTM_ALIAS].iloc[-1].to_pydatetime() == datetime(2022, 5, 31)
         assert len(df) == 9
 
+    def test_prophet_valid_zero_periods(self):
+        pytest.importorskip("prophet")
+
+        df = proc.prophet(
+            df=prophet_df, time_grain="P1M", periods=0, confidence_interval=0.9
+        )
+        columns = {column for column in df.columns}
+        assert columns == {
+            DTTM_ALIAS,
+            "a__yhat",
+            "a__yhat_upper",
+            "a__yhat_lower",
+            "a",
+            "b__yhat",
+            "b__yhat_upper",
+            "b__yhat_lower",
+            "b",
+        }
+        assert df[DTTM_ALIAS].iloc[0].to_pydatetime() == datetime(2018, 12, 31)
+        assert df[DTTM_ALIAS].iloc[-1].to_pydatetime() == datetime(2021, 12, 31)
+        assert len(df) == 4
+
     def test_prophet_import(self):
         prophet = find_spec("prophet")
         if prophet is None:
@@ -875,7 +897,7 @@ class TestPostProcessing(SupersetTestCase):
             proc.prophet,
             df=prophet_df,
             time_grain="P1M",
-            periods=0,
+            periods=-1,
             confidence_interval=0.8,
         )
 


### PR DESCRIPTION
### SUMMARY
Allows users to add confidence intervals and `y_hat` to charts with zero forecast period

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1407" alt="Screen Shot 2021-12-05 at 11 51 28 PM" src="https://user-images.githubusercontent.com/51683050/144830682-bd10ec81-5856-4fbc-87cc-1f9e03877866.png">
After:
![Screen Shot 2021-12-06 at 1 28 49 AM](https://user-images.githubusercontent.com/51683050/144830738-f4a83e77-a870-4697-a0c9-04143b0942c3.png)

### TESTING INSTRUCTIONS
Added tests to `tests/integration_tests/pandas_postprocessing_tests.py`

### ADDITIONAL INFORMATION
Addresses part of #17510 
- [x] Has associated issue: #17510 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @villebro @bkyryliuk