### PR TITLE
fix(legacy-plugin-chart-calendar): fix timestamp timezone in Calendar

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/src/Calendar.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/src/Calendar.js
@@ -19,26 +19,9 @@
 import PropTypes from 'prop-types';
 import { extent as d3Extent, range as d3Range } from 'd3-array';
 import { select as d3Select } from 'd3-selection';
-import {
-  getNumberFormatter,
-  getTimeFormatter,
-  getSequentialSchemeRegistry,
-} from '@superset-ui/core';
+import { getSequentialSchemeRegistry } from '@superset-ui/core';
 import CalHeatMap from './vendor/cal-heatmap';
 import './vendor/cal-heatmap.css';
-
-function convertUTC(dttm) {
-  return new Date(
-    dttm.getUTCFullYear(),
-    dttm.getUTCMonth(),
-    dttm.getUTCDate(),
-    dttm.getUTCHours(),
-    dttm.getUTCMinutes(),
-    dttm.getUTCSeconds(),
-  );
-}
-
-const convertUTCTS = uts => convertUTC(new Date(uts)).getTime();
 
 const propTypes = {
   data: PropTypes.shape({
@@ -65,8 +48,8 @@ const propTypes = {
   showMetricName: PropTypes.bool,
   showValues: PropTypes.bool,
   steps: PropTypes.number,
-  timeFormat: PropTypes.string,
-  valueFormat: PropTypes.string,
+  timeFormatter: PropTypes.func,
+  valueFormatter: PropTypes.string,
   verboseMap: PropTypes.object,
 };
 
@@ -84,13 +67,10 @@ function Calendar(element, props) {
     showValues,
     steps,
     subdomainGranularity,
-    timeFormat,
-    valueFormat,
+    timeFormatter,
+    valueFormatter,
     verboseMap,
   } = props;
-
-  const valueFormatter = getNumberFormatter(valueFormat);
-  const timeFormatter = getTimeFormatter(timeFormat);
 
   const container = d3Select(element)
     .classed('superset-legacy-chart-calendar', true)
@@ -102,17 +82,7 @@ function Calendar(element, props) {
     ? (date, value) => valueFormatter(value)
     : null;
 
-  // Trick to convert all timestamps to UTC
-  // TODO: Verify if this conversion is really necessary
-  // since all timestamps should always be in UTC.
-  const metricsData = {};
-  Object.keys(data.data).forEach(metric => {
-    metricsData[metric] = {};
-    Object.keys(data.data[metric]).forEach(ts => {
-      metricsData[metric][convertUTCTS(ts * 1000) / 1000] =
-        data.data[metric][ts];
-    });
-  });
+  const metricsData = data.data;
 
   Object.keys(metricsData).forEach(metric => {
     const calContainer = div.append('div');
@@ -131,7 +101,7 @@ function Calendar(element, props) {
 
     const cal = new CalHeatMap();
     cal.init({
-      start: convertUTCTS(data.start),
+      start: data.start,
       data: timestamps,
       itemSelector: calContainer.node(),
       legendVerticalPosition: 'top',

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/src/Calendar.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/src/Calendar.js
@@ -49,7 +49,7 @@ const propTypes = {
   showValues: PropTypes.bool,
   steps: PropTypes.number,
   timeFormatter: PropTypes.func,
-  valueFormatter: PropTypes.string,
+  valueFormatter: PropTypes.func,
   verboseMap: PropTypes.object,
 };
 

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/src/transformProps.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/src/transformProps.js
@@ -16,6 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
+import { getNumberFormatter } from '@superset-ui/core';
+import { getFormattedUTCTime } from './utils';
+
 export default function transformProps(chartProps) {
   const { height, formData, queriesData, datasource } = chartProps;
   const {
@@ -34,6 +38,8 @@ export default function transformProps(chartProps) {
   } = formData;
 
   const { verboseMap } = datasource;
+  const timeFormatter = ts => getFormattedUTCTime(ts, xAxisTimeFormat);
+  const valueFormatter = getNumberFormatter(yAxisFormat);
 
   return {
     height,
@@ -48,8 +54,8 @@ export default function transformProps(chartProps) {
     showValues,
     steps,
     subdomainGranularity,
-    timeFormat: xAxisTimeFormat,
-    valueFormat: yAxisFormat,
+    timeFormatter,
+    valueFormatter,
     verboseMap,
   };
 }

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/src/utils.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/src/utils.ts
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { getTimeFormatter } from '@superset-ui/core';
+
+// Assume that given timestamp is UTC
+export const getFormattedUTCTime = (
+  ts: number | string,
+  timeFormat?: string,
+) => {
+  const date = new Date(ts);
+  const offset = date.getTimezoneOffset() * 60 * 1000;
+  return getTimeFormatter(timeFormat)(date.getTime() - offset);
+};

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/test/getFormattedUTCTime.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/test/getFormattedUTCTime.ts
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { getFormattedUTCTime } from '../src/utils';
+
+describe('getFormattedUTCTime', () => {
+  it('formatted date string should equal to UTC date', () => {
+    const ts = 1420070400000; // 2015.01.01 00:00:00 UTC
+    const formattedTime = getFormattedUTCTime(ts, '%Y-%m-%d %H:%M:%S');
+    expect(formattedTime).toEqual('2015-01-01 00:00:00');
+  });
+});


### PR DESCRIPTION
### SUMMARY
Previously, the tooltips in Calendar Heatmap chart where displaying the date with user's local timezone applied. So for instance, if the query returned a date "2015-01-01 00:00:00", for a user in Poland the tooltip would be "2014-12-31 23:00:00" because of the timezone.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://user-images.githubusercontent.com/15073128/144892299-1e5e94ee-0ef4-4240-b6fa-1443c601ec29.png)

After:
![image](https://user-images.githubusercontent.com/15073128/144892124-0e5179f9-ce75-44de-aa77-3cb1610a79ad.png)

### TESTING INSTRUCTIONS
1. Create a Calendar Heatmap chart
2. Verify that the dates in the calendar are UTC

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @junlincc 

Internal: https://app.shortcut.com/preset/story/32292/fix-timezone-bug-on-cal-heatmap