### PR TITLE
fix: Dashboard header negative margin on save

### DIFF
--- a/superset-frontend/src/components/EditableTitle/index.tsx
+++ b/superset-frontend/src/components/EditableTitle/index.tsx
@@ -18,8 +18,9 @@
  */
 import React, { useEffect, useState, useRef } from 'react';
 import cx from 'classnames';
-import { t } from '@superset-ui/core';
+import { styled, t } from '@superset-ui/core';
 import { Tooltip } from 'src/components/Tooltip';
+import CertifiedIcon from '../CertifiedIcon';
 
 export interface EditableTitleProps {
   canEdit?: boolean;
@@ -34,7 +35,13 @@ export interface EditableTitleProps {
   title?: string;
   defaultTitle?: string;
   placeholder?: string;
+  certifiedBy?: string;
+  certificationDetails?: string;
 }
+
+const StyledCertifiedIcon = styled(CertifiedIcon)`
+  vertical-align: middle;
+`;
 
 export default function EditableTitle({
   canEdit = false,
@@ -48,6 +55,8 @@ export default function EditableTitle({
   title = '',
   defaultTitle = '',
   placeholder = '',
+  certifiedBy,
+  certificationDetails,
 }: EditableTitleProps) {
   const [isEditing, setIsEditing] = useState(editing);
   const [currentTitle, setCurrentTitle] = useState(title);
@@ -222,6 +231,14 @@ export default function EditableTitle({
       )}
       style={style}
     >
+      {certifiedBy && (
+        <>
+          <StyledCertifiedIcon
+            certifiedBy={certifiedBy}
+            details={certificationDetails}
+          />{' '}
+        </>
+      )}
       {titleComponent}
     </span>
   );

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -22,7 +22,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { styled, t } from '@superset-ui/core';
 import ButtonGroup from 'src/components/ButtonGroup';
-import CertifiedIcon from 'src/components/CertifiedIcon';
 
 import {
   LOG_ACTIONS_PERIODIC_RENDER_DASHBOARD,
@@ -499,19 +498,13 @@ class Header extends React.PureComponent {
         data-test-id={`${dashboardInfo.id}`}
       >
         <div className="dashboard-component-header header-large">
-          {dashboardInfo.certified_by && (
-            <>
-              <CertifiedIcon
-                certifiedBy={dashboardInfo.certified_by}
-                details={dashboardInfo.certification_details}
-              />{' '}
-            </>
-          )}
           <EditableTitle
             title={dashboardTitle}
             canEdit={userCanEdit && editMode}
             onSaveTitle={this.handleChangeText}
             showTooltip={false}
+            certifiedBy={dashboardInfo.certified_by}
+            certificationDetails={dashboardInfo.certification_details}
           />
           <PublishedStatus
             dashboardId={dashboardInfo.id}


### PR DESCRIPTION
### SUMMARY
Fixes an issue that was cutting the header with a negative margin

### BEFORE

![Screen Shot 2021-12-08 at 18 28 57](https://user-images.githubusercontent.com/60598000/145246231-00831f9e-6016-4685-ab3b-3d55f00aa69f.png)

### AFTER

https://user-images.githubusercontent.com/60598000/145245091-9df4dc10-1701-4442-b27a-07ddd227116c.mp4

### TESTING INSTRUCTIONS
1. Open a Dashboard
2. Set the certification details in the properties
3. Save and observe the header

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
