### PR TITLE
fix(Dashboard): Undefined error in default value in Native Filters

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DefaultValue.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DefaultValue.tsx
@@ -51,7 +51,7 @@ const DefaultValue: FC<DefaultValueProps> = ({
   const formFilter = (form.getFieldValue('filters') || {})[filterId];
   const queriesData = formFilter?.defaultValueQueriesData;
   const loading = hasDataset && queriesData === null;
-  const value = formFilter.defaultDataMask?.filterState.value;
+  const value = formFilter.defaultDataMask?.filterState?.value;
   const isMissingRequiredValue =
     hasDefaultValue && (value === null || value === undefined);
   return loading ? (


### PR DESCRIPTION
### SUMMARY
Fixes an undefined error generated by the DefaultValue component in the Native Filters.

### BEFORE

https://user-images.githubusercontent.com/60598000/145269355-892d7b23-e5ac-4a08-9780-ae2773e2d31a.mov

### AFTER

https://user-images.githubusercontent.com/60598000/145269421-03f1ab27-f777-4f1e-966a-79f0f4ea6b67.mp4

### NOTE
In the video, a new bug is shown. By typing the country name, the previous countries will be discarded. This requires a separate fix.

### TESTING INSTRUCTIONS
1. Open a Dashboard
2. Create a filter of type Value
3. Enter a default value
4. Observe the behavior 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
