### PR TITLE
chore(de-translations): Add missing German translations

### DIFF
--- a/superset/translations/de/LC_MESSAGES/messages.json
+++ b/superset/translations/de/LC_MESSAGES/messages.json
@@ -75,6 +75,9 @@
       "%s-%s of %s": ["%s-%s von %s"],
       "(Removed)": ["(Entfernt)"],
       "(deleted)": ["(gelöscht)"],
+      "(no description, click to see stack trace)": [
+        "(keine Beschreibung, klicken Sie hier, um Fehlermeldung zu sehen)"
+      ],
       "(optional) default value for the filter, when using the multiple option, you can use a semicolon-delimited list of options.": [
         "(Optionaler) Standardwert für den Filter, wenn Sie die Option ‚multiple‘ verwenden, können Sie eine durch Semikolons getrennte Liste von Optionen verwenden."
       ],
@@ -98,6 +101,8 @@
       "12 hours": ["12 Stunden"],
       "15 minute": ["15 Minuten"],
       "24 hours": ["24 Stunden"],
+      "2D": ["2D"],
+      "3 letter code of the country": ["3-Buchstaben-Code des Landes"],
       "30 days": ["30 Tage"],
       "30 minute": ["30 Minuten"],
       "30 minutes": ["30 Minuten"],
@@ -119,6 +124,7 @@
       "== (Is equal)": ["== (Ist gleich)"],
       "> (Larger than)": ["> (Größer als)"],
       ">= (Larger or equal)": [">= (Größer oder gleich)"],
+      "A Big Number": ["Eine Große Zahl"],
       "A SQL statement that defines whether the alert should get triggered or not. The query is expected to return either NULL or a number value.": [
         "Eine SQL-Anweisung, die definiert, ob ein Alarm ausgelöst werden soll oder nicht. Es wird erwartet, dass die Abfrage entweder NULL oder einen Zahlenwert zurückgibt."
       ],
@@ -138,8 +144,14 @@
       "A list of users who can alter the chart. Searchable by name or username.": [
         "Eine Liste der Benutzer*innen, die das Diagramm ändern können. Durchsuchbar nach Name oder Benutzer*innenname."
       ],
+      "A map of the world, that can indicate values in different countries.": [
+        "Eine Weltkarte, die Werte in verschiedenen Ländern anzeigen kann."
+      ],
       "A metric to use for color": [
         "Eine Metrik, die für die Farbe verwendet werden soll"
+      ],
+      "A polar coordinate chart where the circle is broken into wedges of equal angle, and the value represented by any wedge is illustrated by its area, rather than its radius or sweep angle.": [
+        "Ein Polarkoordinatendiagramm, in dem der Kreis in Sektoren mit gleichem Winkel unterteilt ist und der Wert, der durch einen Sektor dargestellt wird, durch seine Fläche und nicht durch seinen Radius oder Sweep-Winkel veranschaulicht wird."
       ],
       "A readable URL for your dashboard": [
         "Eine sprechende URL für Ihr Dashboard"
@@ -152,6 +164,9 @@
       ],
       "A set of parameters that become available in the query using Jinja templating syntax": [
         "Ein Satz von Parametern, die in der Abfrage mithilfe der Jinja-Vorlagensyntax verfügbar werden"
+      ],
+      "A time series chart that visualizes how a related metric from multiple groups vary over time. Each group is visualized using a different color.": [
+        "Ein Zeitreihendiagramm, das visualisiert, wie sich eine verwandte Metrik aus mehreren Gruppen im Laufe der Zeit ändert. Jede Gruppe wird mit einer anderen Farbe visualisiert."
       ],
       "A timeout occurred while executing the query.": [
         "Beim Ausführen der Abfrage ist ein Timeout aufgetreten."
@@ -175,12 +190,16 @@
       "About": ["Über"],
       "Access": ["Zugang"],
       "Access requests": ["Zugriffsanforderungen"],
+      "Access to user activity data is restricted": [
+        "Der Zugriff auf Benutzeraktivitätsdaten ist eingeschränkt"
+      ],
       "Access was requested": ["Zugang wurde beantragt"],
       "Action": ["Aktion"],
       "Action Log": ["Aktionsprotokoll"],
       "Actions": ["Aktion"],
       "Active": ["Aktiv"],
       "Actual time range": ["Tatsächlicher Zeitbereich"],
+      "Adaptative formating": ["Adaptative Formatierung"],
       "Add": ["Hinzufügen"],
       "Add Alert": ["Alarm hinzufügen"],
       "Add Annotation": ["Anmerkungen hinzufügen"],
@@ -227,12 +246,23 @@
       "Additional text to add before or after the value, e.g. unit": [
         "Zusätzlicher Text, der vor oder nach dem Wert hinzugefügt werden kann, z. B. Einheit"
       ],
+      "Additive": ["Additiv"],
       "Advanced": ["Erweitert"],
       "Advanced Analytics": ["Erweiterte Analysen"],
       "Advanced analytics": ["Erweiterte Analysen"],
       "Advanced-Analytics": ["Erweiterte Analysen"],
+      "Aesthetic": ["Ästhetisch"],
+      "After": ["Nach"],
+      "Aggregate": ["Aggregieren"],
       "Aggregate Mean": ["Aggregater Mittelwert"],
       "Aggregate Sum": ["Aggregierte Summe"],
+      "Aggregate function applied to the list of points in each cluster to produce the cluster label.": [
+        "Aggregatfunktion, die auf die Liste der Punkte in jedem Cluster angewendet wird, um die Clusterbezeichnung zu erstellen."
+      ],
+      "Aggregate function to apply when pivoting and computing the total rows and columns": [
+        "Aggregatfunktion, die beim Pivotieren und Berechnen der Summe der Zeilen und Spalten angewendet werden soll"
+      ],
+      "Aggregation function": ["Aggregationsfunktion"],
       "Alert Triggered, In Grace Period": ["Alarm ausgelöst, in Kulanzzeit"],
       "Alert condition": ["Alarmierungsbedingung"],
       "Alert condition schedule": ["Alarmierung-Zeitplan"],
@@ -275,7 +305,9 @@
       "All": ["Alle"],
       "All Text": ["Gesamter Texte"],
       "All charts": ["Alle Diagramme"],
+      "All filters": ["Alle Filter"],
       "All filters (%(filterCount)d)": ["Alle Filter (%(filterCount)d)"],
+      "All panels": ["Alle Bereiche"],
       "All panels with this column will be affected by this filter": [
         "Alle Bereiche mit dieser Spalte sind von diesem Filter betroffen"
       ],
@@ -310,6 +342,7 @@
       ],
       "Allow multiple selections": ["Mehrfachauswahl möglich"],
       "Allow node selections": ["Knotenauswahl zulassen"],
+      "Allow selecting multiple values": ["Auswählen mehrerer Werte zulassen"],
       "Allow this database to be explored": [
         "Abfragen dieser Datenbank in SQL Lab zulassen"
       ],
@@ -320,6 +353,9 @@
         "Benutzer*innen das Ausführen von Nicht-SELECT-Anweisungen (UPDATE, DELETE, CREATE, ...) in SQL Lab erlauben"
       ],
       "Alphabetical": ["Alphabetisch"],
+      "Also known as a box and whisker plot, this visualization compares the distributions of a related metric across multiple groups. The box in the middle emphasizes the mean, median, and inner 2 quartiles. The whiskers around each box visualize the min, max, range, and outer 2 quartiles.": [
+        "Diese Visualisierung, die auch als Box-Whisker-Plot bezeichnet wird, vergleicht die Verteilungen einer Metrik über mehrere Gruppen hinweg. Der Kasten in der Mitte stellt den Mittelwert, den Median und die inneren 2 Quartile dar. Die sogenannten „Whisker“ um jede Box visualisieren die Min-, Max-, Range- und äußeren 2 Quartile."
+      ],
       "Altered": ["Geändert"],
       "An enclosed time range (both start and end) must be specified when using a Time Comparison.": [
         "Bei Verwendung eines Zeitvergleichs muss ein geschlossener Zeitbereich (sowohl Anfang als auch Ende) angegeben werden."
@@ -334,6 +370,39 @@
       ],
       "An error occurred when refreshing queries": [
         "Beim Aktualisieren von Abfragen ist ein Fehler aufgetreten"
+      ],
+      "An error occurred while accessing the value.": [
+        "Beim Zugriff auf den Wert ist ein Fehler aufgetreten."
+      ],
+      "An error occurred while collapsing the table schema. Please contact your administrator.": [
+        "Beim Reduzieren des Tabellenschemas ist ein Fehler aufgetreten. Wenden Sie sich an Ihre*n Administrator*in."
+      ],
+      "An error occurred while creating %ss: %s": [
+        "Beim Erstellen von %s ist ein Fehler aufgetreten: %s"
+      ],
+      "An error occurred while creating the data source": [
+        "Beim Erstellen der Datenquelle ist ein Fehler aufgetreten"
+      ],
+      "An error occurred while creating the value.": [
+        "Beim Erstellen des Werts ist ein Fehler aufgetreten."
+      ],
+      "An error occurred while deleting the value.": [
+        "Beim Löschen des Werts ist ein Fehler aufgetreten."
+      ],
+      "An error occurred while editing this report.": [
+        "Beim Bearbeiten des Reports ist ein Fehler aufgetreten."
+      ],
+      "An error occurred while editing this report: %s": [
+        "Beim Bearbeiten dieses Reports ist ein Fehler aufgetreten: %s"
+      ],
+      "An error occurred while expanding the table schema. Please contact your administrator.": [
+        "Beim Erweitern des Tabellenschemas ist ein Fehler aufgetreten. Wenden Sie sich an Ihre*n Administrator*in."
+      ],
+      "An error occurred while fetching %s info: %s": [
+        "Beim Abrufen von %s ist ein Fehler aufgetreten: %s"
+      ],
+      "An error occurred while fetching %ss: %s": [
+        "Beim Abrufen von %s ist ein Fehler aufgetreten: %s"
       ],
       "An error occurred while fetching available CSS templates": [
         "Beim Abrufen verfügbarer CSS-Vorlagen ist ein Fehler aufgetreten"
@@ -352,6 +421,9 @@
       ],
       "An error occurred while fetching dashboard owner values: %s": [
         "Beim Abrufen von Dashboardbesitzer*innen-Werten ist ein Fehler aufgetreten: %s"
+      ],
+      "An error occurred while fetching dashboards": [
+        "Beim Abrufen von Dashboards ist ein Fehler aufgetreten"
       ],
       "An error occurred while fetching dashboards: %s": [
         "Beim Abrufen von Dashboards ist ein Fehler aufgetreten: %s"
@@ -377,14 +449,77 @@
       "An error occurred while fetching datasets: %s": [
         "Beim Abrufen von Datensätzen ist ein Fehler aufgetreten: %s"
       ],
+      "An error occurred while fetching function names.": [
+        "Fehler bei Abruf von Funktionsnamen."
+      ],
       "An error occurred while fetching schema values: %s": [
         "Beim Abrufen von Schemawerten ist ein Fehler aufgetreten: %s"
+      ],
+      "An error occurred while fetching tab state": [
+        "Beim Abrufen des Registerkartenstatus ist ein Fehler aufgetreten"
+      ],
+      "An error occurred while fetching table metadata": [
+        "Beim Abrufen von Tabellen-Metadaten ist ein Fehler aufgetreten"
+      ],
+      "An error occurred while fetching table metadata. Please contact your administrator.": [
+        "Beim Abrufen von Tabellen-Metadaten ist ein Fehler aufgetreten. Wenden Sie sich an Ihre*n Administrator*in."
       ],
       "An error occurred while fetching user values: %s": [
         "Beim Abrufen von Schemawerten ist ein Fehler aufgetreten: %s"
       ],
+      "An error occurred while hiding the left bar. Please contact your administrator.": [
+        "Beim Ausblenden der linken Leiste ist ein Fehler aufgetreten. Wenden Sie sich an Ihre*n Administrator*in."
+      ],
+      "An error occurred while importing %s: %s": [
+        "Beim Importieren von %s ist ein Fehler aufgetreten: %s"
+      ],
+      "An error occurred while loading the SQL": [
+        "Beim Laden des SQL ist ein Fehler aufgetreten"
+      ],
       "An error occurred while pruning logs ": [
         "Beim Kürzen von Protokollen ist ein Fehler aufgetreten "
+      ],
+      "An error occurred while removing query. Please contact your administrator.": [
+        "Beim Entfernen der Abfrage ist ein Fehler aufgetreten. Wenden Sie sich an Ihre*n Administrator*in."
+      ],
+      "An error occurred while removing tab. Please contact your administrator.": [
+        "Beim Entfernen der Registerkarte ist ein Fehler aufgetreten. Wenden Sie sich an Ihre*n Administrator*in."
+      ],
+      "An error occurred while removing the table schema. Please contact your administrator.": [
+        "Beim Entfernen des Tabellenschemas ist ein Fehler aufgetreten. Wenden Sie sich an Ihre*n Administrator*in."
+      ],
+      "An error occurred while rendering the visualization: %s": [
+        "Bei der Darstellung dieser Visualisierung ist ein Fehler aufgetreten: %s"
+      ],
+      "An error occurred while setting the active tab. Please contact your administrator.": [
+        "Beim Festlegen der aktiven Registerkarte ist ein Fehler aufgetreten. Wenden Sie sich an Ihre*n Administrator*in."
+      ],
+      "An error occurred while setting the tab autorun. Please contact your administrator.": [
+        "Beim Festlegen der Registerkarte Autorun ist ein Fehler aufgetreten. Wenden Sie sich an Ihre*n Administrator*in."
+      ],
+      "An error occurred while setting the tab database ID. Please contact your administrator.": [
+        "Beim Festlegen der Registerkartendatenbank-ID ist ein Fehler aufgetreten. Wenden Sie sich an Ihre*n Administrator*in."
+      ],
+      "An error occurred while setting the tab schema. Please contact your administrator.": [
+        "Beim Festlegen des Registerkartenschemas ist ein Fehler aufgetreten. Wenden Sie sich an Ihre*n Administrator*in."
+      ],
+      "An error occurred while setting the tab template parameters. Please contact your administrator.": [
+        "Beim Festlegen der Vorlagen-Parameter ist ein Fehler aufgetreten. Wenden Sie sich an Ihre*n Administrator*in."
+      ],
+      "An error occurred while setting the tab title. Please contact your administrator.": [
+        "Beim Festlegen des Registerkartentitels ist ein Fehler aufgetreten. Wenden Sie sich an Ihre*n Administrator*in."
+      ],
+      "An error occurred while starring this chart": [
+        "Beim Favorisieren des Diagramms ist ein Fehler aufgetreten."
+      ],
+      "An error occurred while storing the latest query id in the backend. Please contact your administrator if this problem persists.": [
+        "Beim Speichern der letzten Abfrage-ID im Backend ist ein Fehler aufgetreten. Wenden Sie sich an Ihre*n Administrator*in, wenn dieses Problem weiterhin besteht."
+      ],
+      "An error occurred while storing your query in the backend. To avoid losing your changes, please save your query using the \"Save Query\" button.": [
+        "Beim Speichern der Abfrage im Backend ist ein Fehler aufgetreten. Um zu vermeiden, dass Ihre Änderungen verloren gehen, speichern Sie Ihre Abfrage bitte über die Schaltfläche \"Abfrage speichern\"."
+      ],
+      "An error occurred while updating the value.": [
+        "Beim Aktualisieren des Werts ist ein Fehler aufgetreten."
       ],
       "An unknown error occurred. Please contact your Superset administrator": [
         "Ein unbekannter Fehler ist aufgetreten. Wenden Sie sich an Ihre*n Superset-Administrator*in"
@@ -481,9 +616,13 @@
         "Das angewendete rollierende Fenster hat keine Daten zurückgegeben. Bitte stellen Sie sicher, dass die Quellabfrage die im rollierenden Fenster definierten Mindestzeiträume erfüllt."
       ],
       "Apply": ["Übernehmen"],
+      "Apply conditional color formatting to metrics": [
+        "Bedingten Farbformatierung auf Metriken anwenden"
+      ],
       "Apply conditional color formatting to numeric columns": [
         "Bedingte Farbformatierung auf numerische Spalten anwenden"
       ],
+      "Apply metrics on": ["Metriken anwenden auf"],
       "Apply to all panels": ["Auf alle Bereiche anwenden"],
       "Apply to specific panels": ["Anwenden auf bestimmte Bereiche"],
       "April": ["April"],
@@ -533,11 +672,17 @@
       "Autocomplete query predicate": [
         "Abfrageprädikat für die automatische Vervollständigung"
       ],
+      "Available sorting modes:": ["Verfügbare Sortiermodi:"],
       "Axis": ["Achse"],
+      "Axis ascending": ["Achse aufsteigend"],
+      "Axis descending": ["Achse absteigend"],
       "Back": ["Zurück"],
       "Backend": ["Backend"],
       "Bad spatial key": ["Fehlerhafter räumlicher Schlüssel"],
+      "Bar": ["Balken"],
+      "Bar Chart": ["Balkendiagramm"],
       "Bar Values": ["Balkenwerte"],
+      "Base layer map style": ["Hintergrundkarten-Stil"],
       "Based on a metric": ["Auf Metrik basierend"],
       "Based on granularity, number of time periods to compare against": [
         "Basierend auf der Granularität, Anzahl der Zeiträume, mit denen verglichen werden soll"
@@ -545,9 +690,13 @@
       "Basic": ["Basic"],
       "Basic information": ["Basisangaben"],
       "Batch editing %d filters:": ["Stapelbearbeitung %d Filter:"],
+      "Battery level over time": ["Akkustand im Laufe der Zeit"],
       "Be careful.": ["Seien Sie vorsichtig."],
+      "Before": ["Vor"],
       "Big Number": ["Große Zahl"],
+      "Big Number Font Size": ["Große Zahl Schriftgröße"],
       "Big Number with Trendline": ["Große Zahl mit Trendlinie"],
+      "Bottom": ["Unten"],
       "Bottom Margin": ["Unterer Abstand"],
       "Bottom margin, in pixels, allowing for more room for axis labels": [
         "Unterer Rand in Pixeln, ermöglicht mehr Platz für Achsenbeschriftungen"
@@ -556,18 +705,31 @@
       "Bounds for the Y-axis. When left empty, the bounds are dynamically defined based on the min/max of the data. Note that this feature will only expand the axis range. It won't narrow the data's extent.": [
         "Grenzen für die Y-Achse. Wenn sie leer gelassen werden, werden die Grenzen basierend auf Min/Max der Daten dynamisch definiert. Beachten Sie, dass diese Funktion nur den Achsenbereich erweitert. Es wird den Umfang der Daten nicht einschränken."
       ],
+      "Box Plot": ["Boxplot"],
+      "Breakdowns": ["Aufschlüsselungen"],
       "Broker Endpoint": ["Broker-Endpunkt"],
       "Broker Host": ["Broker-Host"],
       "Broker Password": ["Broker-Passwort"],
       "Broker Port": ["Broker-Port"],
       "Broker Username": ["Broker-Benutzer*innenname"],
       "Bubble Chart": ["Blasen-Diagramm"],
+      "Bubble Color": ["Blasenfarbe"],
       "Bubble Size": ["Blasengröße"],
       "Bubble size": ["Blasengröße"],
       "Bulk select": ["Massenauswahl"],
       "Bullet Chart": ["Bullet-Diagramm"],
+      "Business": ["Geschäftlich"],
       "By default, each filter loads at most 1000 choices at the initial page load. Check this box if you have more than 1000 filter values and want to enable dynamically searching that loads filter values as users type (may add stress to your database).": [
         "Standardmäßig lädt jeder Filter beim ersten Laden der Seite höchstens 1000 Auswahlmöglichkeiten. Aktivieren Sie dieses Kontrollkästchen, wenn Sie über mehr als 1000 Filterwerte verfügen und die dynamische Suche aktivieren möchten, die Filterwerte während der Benutzereingabe lädt (was die Datenbank belasten kann)."
+      ],
+      "By key: use column names as sorting key": [
+        "Nach Schlüssel: Spaltennamen als Sortierschlüssel verwenden"
+      ],
+      "By key: use row names as sorting key": [
+        "Nach Schlüssel: Zeilennamen als Sortierschlüssel verwenden"
+      ],
+      "By value: use metric values as sorting key": [
+        "Nach Wert: Metrikwerte als Sortierschlüssel verwenden"
       ],
       "CANCEL": ["ABBRECHEN"],
       "CREATE TABLE AS": ["CREATE TABLE AS"],
@@ -617,6 +779,9 @@
       "Calculated columns": ["Berechnete Spalten"],
       "Calculation type": ["Berechnungstyp"],
       "Calendar Heatmap": ["Kalender Heatmap"],
+      "Can not move top level tab into nested tabs": [
+        "Registerkarte der obersten Ebene kann nicht in verschachtelte Registerkarten verschoben werden"
+      ],
       "Can't find DruidCluster with cluster_name = '%(name)s'": [
         "DruidCluster mit cluster_name = '%(name)s' nicht gefunden"
       ],
@@ -630,6 +795,9 @@
       "Cancel query on window unload event": [
         "Abfrage abbrechen bei ‚Window unload‘-Ereignis"
       ],
+      "Cannot create cyclic hierarchy": [
+        "Zyklische Hierarchie kann nicht erstellt werden"
+      ],
       "Cannot delete a database that has datasets attached": [
         "Eine Datenbank mit verknüpften Datensätzen kann nicht gelöscht werden"
       ],
@@ -640,8 +808,15 @@
       "Cannot parse time string [%(human_readable)s]": [
         "Zeitzeichenfolge [%(human_readable)s] kann nicht analysiert werden"
       ],
+      "Categorical": ["Kategorisch"],
+      "Categories to group by on the x-axis.": [
+        "Kategorien, nach denen auf der x-Achse gruppiert werden soll."
+      ],
       "Category": ["Kategorie"],
       "Category of target nodes": ["Kategorie der Zielknoten"],
+      "Cell Padding": ["Zellen Abstand"],
+      "Cell Radius": ["Zellenradius"],
+      "Cell Size": ["Zellengröße"],
       "Cell bars": ["Zellenbalken"],
       "Cell content": ["Zellinhalt"],
       "Center": ["Zentriert"],
@@ -652,6 +827,8 @@
       "Certified by": ["Zertifiziert durch"],
       "Certified by %s": ["Zertifiziert von %s"],
       "Change dataset": ["Datensatz wechseln"],
+      "Change order of columns.": ["Reihenfolge der Spalten ändern."],
+      "Change order of rows.": ["Reihenfolge der Zeilen ändern."],
       "Changed By": ["Bearbeitet von"],
       "Changed On": ["Bearbeitet am"],
       "Changed on": ["Bearbeitet am"],
@@ -682,6 +859,8 @@
       "Character to interpret as decimal point.": [
         "Zeichen, das als Dezimalstelle zu interpretieren ist."
       ],
+      "Charge": ["Laden"],
+      "Charge in the force layout": ["In kraftbasierte Anordnung laden"],
       "Chart": ["Diagramm"],
       "Chart %(id)s not found": ["Diagramm %(id)s nicht gefunden"],
       "Chart Cache Timeout": ["Diagramm Cache-Timeout"],
@@ -693,10 +872,13 @@
       "Chart [{}] has been overwritten": ["Diagramm [{}] wurde überschrieben"],
       "Chart [{}] has been saved": ["Diagramm [{}] wurde gespeichert"],
       "Chart [{}] was added to dashboard [{}]": [
-        "Diagramm [{}] wurde dem Dashboard hinzugefügt [{}]"
+        "Diagramm [{}] wurde dem Dashboard [{}] hinzugefügt"
       ],
       "Chart cache timeout": ["Diagramm-Cache Timeout"],
       "Chart changes": ["Diagrammänderungen"],
+      "Chart component that lets you add a custom filter UI in your dashboard. When added to dashboard, a filter box lets users specify specific values or ranges to filter charts by. The charts that each filter box is applied to can be fine tuned as well in the dashboard view.\n\n    Note that this plugin is being replaced with the new Filters feature that lives in the dashboard view itself. It's easier to use and has more capabilities!": [
+        "Diagrammkomponente, mit der Sie Ihrem Dashboard eine benutzerdefinierte Filter-Oberfläche hinzufügen können. Ist sie dem Dashboard zugefügt, können Benutzer*innen in einem Filterfeld bestimmte Werte oder Bereiche angeben, nach denen Diagramme gefiltert werden sollen. Die Diagramme, auf die jedes Filterfeld angewendet wird, können auch in der Dashboardansicht optimiert werden.\n\nBeachten Sie, dass dieses Plugin durch die neue Filterfunktion ersetzt wird, die sich in der Dashboard-Ansicht selbst befindet. Sie ist einfacher zu bedienen und hat mehr Funktionen!"
+      ],
       "Chart could not be created.": ["Diagramm konnte nicht erstellt werden."],
       "Chart could not be deleted.": ["Diagramm konnte nicht gelöscht werden."],
       "Chart could not be updated.": [
@@ -760,22 +942,42 @@
       ],
       "Choose a database...": ["Wählen Sie eine Datenbank..."],
       "Choose a dataset": ["Datensatz auswählen"],
+      "Choose a metric for left axis": [
+        "Wählen Sie eine Metrik für die linke Achse"
+      ],
       "Choose a metric for right axis": [
         "Wählen Sie eine Metrik für die rechte Achse"
       ],
+      "Choose a number format": ["Wählen Sie ein Zahlenformat"],
+      "Choose a source": ["Wählen Sie eine Quelle"],
+      "Choose a source and a target": ["Wählen Sie eine Quelle und ein Ziel"],
+      "Choose a target": ["Wählen Sie ein Ziel"],
       "Choose chart type": ["Diagrammtyp auswählen"],
+      "Choose one or more charts for left axis": [
+        "Wählen Sie ein oder mehrere Diagramme die rechte Achse"
+      ],
+      "Choose one or more charts for right axis": [
+        "Wählen Sie ein oder mehrerer Diagramme für die rechte Achse"
+      ],
       "Choose the annotation layer type": [
         "Auswählen des Anmerkungsebenen-Typs"
       ],
       "Choose the source of your annotations": [
         "Wählen Sie die Quelle Ihrer Anmerkungen aus"
       ],
+      "Chord Diagram": ["Sehnendiagramm"],
       "Chosen non-numeric column": ["Ausgewählte nicht numerische Spalte"],
       "Circle": ["Kreis"],
       "Circle -> Arrow": ["Kreis -> Pfeil"],
       "Circle -> Circle": ["Kreis -> Kreis"],
       "Circle radar shape": ["Kreisradarform"],
       "Circular": ["Kreisförmig"],
+      "Classic chart that visualizes how metrics change over time.": [
+        "Klassisches Diagramm, das visualisiert, wie sich Metriken im Laufe der Zeit ändern."
+      ],
+      "Classic row-by-column spreadsheet like view of a dataset. Use tables to showcase a view into the underlying data or to show aggregated metrics.": [
+        "Klassische Zeilen-für-Spalten-Tabellenansicht eines Datensatzes. Verwenden Sie Tabellen, um eine Ansicht der zugrunde liegenden Daten oder aggregierter Metriken anzuzeigen."
+      ],
       "Clause": ["Ausdruck"],
       "Clear": ["Zurücksetzen"],
       "Clear all": ["Alles löschen"],
@@ -811,20 +1013,32 @@
       "Close tab": ["Registerkarte schließen"],
       "Cluster": ["Cluster"],
       "Cluster Name": ["Cluster Name"],
+      "Cluster label aggregator": ["Cluster-Beschriftung-Aggregator"],
+      "Clustering Radius": ["Clustering-Radius"],
+      "Code": ["Code"],
       "Collapse all": ["Alle einklappen"],
       "Collapse table preview": ["Tabellenvorschau komprimieren"],
       "Color": ["Farbe"],
       "Color +/-": ["Farbe +/-"],
       "Color Metric": ["Farbmetrik"],
       "Color Scheme": ["Farbschema"],
+      "Color Steps": ["Farbschritte"],
       "Color metric": ["Metrik auswählen"],
       "Color scheme": ["Farbschema"],
+      "Color will be rendered based on a ratio of the cell against the sum of across this criteria": [
+        "Die Farbe wird basierend auf dem Verhältnis der Zelle zur Gesamtsumme dieses Kriteriums dargestellt."
+      ],
       "Colors": ["Farben"],
       "Column": ["Spalte"],
       "Column \"%(column)s\" is not numeric or does not exists in the query results.": [
         "Die Spalte \"%(column)s\" ist nicht numerisch oder existiert nicht in den Abfrageergebnissen."
       ],
       "Column Label(s)": ["Spaltenbezeichnung(en)"],
+      "Column containing ISO 3166-2 codes of region/province/department in your table.": [
+        "Spalte mit ISO 3166-2-Codes der Region/Provinz/Kreis in Ihrer Tabelle."
+      ],
+      "Column containing latitude data": ["Spalte mit Breitengraddaten"],
+      "Column containing longitude data": ["Spalte mit Längengraddaten"],
       "Column is required": ["Spalte ist erforderlich"],
       "Column label for index column(s). If None is given and Dataframe Index is True, Index Names are used.": [
         "Spaltenbezeichnung für Indexspalte(n). Wenn None angegeben ist und Dataframe Index den Wert True hat, werden Indexnamen verwendet."
@@ -849,8 +1063,20 @@
       "Columns missing in datasource: %(invalid_columns)s": [
         "Fehlende Spalten in Datenquelle: %(invalid_columns)s"
       ],
+      "Columns subtotal position": ["Zwischensummenposition der Spalten"],
+      "Columns to calculate distribution across. Defaults to temporal column if left empty.": [
+        "Spalten zum Berechnen der Verteilung. Falls leer, wird standardmäßig wird die temporale Spalte verwendet."
+      ],
       "Columns to display": ["Anzuzeigende Spalten"],
       "Columns to group by": ["Spalten, nach denen gruppiert wird"],
+      "Columns to group by on the columns": [
+        "Spalten, nach denen in den Spalten gruppiert werden soll"
+      ],
+      "Columns to group by on the rows": [
+        "Spalten, nach denen in den Zeilen gruppiert werden soll"
+      ],
+      "Combine Metrics": ["Metriken kombinieren"],
+      "Combine metrics": ["Metriken kombinieren"],
       "Comma-separated color picks for the intervals, e.g. 1,2,4. Integers denote colors from the chosen color scheme and are 1-indexed. Length must be matching that of interval bounds.": [
         "Kommagetrennte Farbwerte für die Intervalle, z.B. 1,2,4. Ganzzahlen bezeichnen Farben aus dem gewählten Farbschema und sind 1-indiziert. Die Anzahl muss mit der der Intervallgrenzen übereinstimmen."
       ],
@@ -858,6 +1084,22 @@
         "Durch Kommas getrennte Intervallgrenzen, z.B. 2,4,5 für die Intervalle 0-2, 2-4 und 4-5. Die letzte Zahl sollte mit dem für MAX angegebenen Wert übereinstimmen."
       ],
       "Comparator option": ["Komparator-Option"],
+      "Compare multiple time series charts (as sparklines) and related metrics quickly.": [
+        "Vergleichen Sie schnell mehrere Zeitreihendiagramme (als Sparklines) und verwandte Metriken."
+      ],
+      "Compare the same summarized metric across multiple groups.": [
+        "Vergleichen Sie dieselbe zusammengefasste Metrik über mehrere Gruppen hinweg."
+      ],
+      "Compares how a metric changes over time between different groups. Each group is mapped to a row and change over time is visualized bar lengths and color.": [
+        "Vergleicht, wie sich eine Metrik im Laufe der Zeit zwischen verschiedenen Gruppen ändert. Jede Gruppe wird einer Zeile zugeordnet und die Änderung im Laufe der Zeit werden als Balkenlängen und -farben visualisiert."
+      ],
+      "Compares metrics from different categories using bars. Bar lengths are used to indicate the magnitude of each value and color is used to differentiate groups.": [
+        "Vergleicht Metriken aus verschiedenen Kategorien mithilfe von Balken. Balkenlängen werden verwendet, um die Größe jedes Werts anzugeben, und Farbe wird verwendet, um Gruppen zu unterscheiden."
+      ],
+      "Compares the lengths of time different activities take in a shared timeline view.": [
+        "Vergleicht die Zeitspanne, die verschiedene Aktivitäten in einer freigegebenen Zeitachsenansicht benötigen."
+      ],
+      "Comparison": ["Vergleich"],
       "Comparison Period Lag": ["Verzögerung des Vergleichszeitraums"],
       "Comparison suffix": ["Vergleichssuffix"],
       "Components": ["Komponenten"],
@@ -904,10 +1146,13 @@
       "Connection failed, please check your connection settings": [
         "Verbindung fehlgeschlagen, bitte überprüfen Sie Ihre Verbindungseinstellungen"
       ],
+      "Connection looks good!": ["Verbindung möglich!"],
+      "Continuous": ["Kontinuierlich"],
       "Contribution": ["Beitrag"],
       "Contribution Mode": ["Beitragsmodus"],
       "Control labeled ": ["Feld "],
       "Controls labeled ": ["Steuerelemente beschriftet "],
+      "Coordinates": ["Koordinaten"],
       "Copied to clipboard!": ["In Zwischenablage kopiert!"],
       "Copy": ["Kopieren"],
       "Copy SELECT statement to the clipboard": [
@@ -926,6 +1171,7 @@
       "Copy dashboard URL": ["Dashboard-URL kopieren"],
       "Copy link": ["Link kopieren"],
       "Copy message": ["Meldung kopieren"],
+      "Copy of %s": ["Kopie von %s"],
       "Copy partition query to clipboard": [
         "Partitionsabfrage in Zwischenablage kopieren"
       ],
@@ -941,9 +1187,13 @@
       ],
       "Copy to Clipboard": ["In Zwischenablage kopieren"],
       "Copy to clipboard": ["In die Zwischenablage kopieren"],
+      "Correlation": ["Korrelation"],
       "Cost estimate": ["Kostenschätzung"],
       "Could not determine datasource type": [
         "Datenquellentyp konnte nicht ermittelt werden"
+      ],
+      "Could not fetch all saved charts": [
+        "Nicht alle gespeicherten Diagramme konnten abgerufen werden"
       ],
       "Could not find viz object": [
         "Visualisierungsobjekt konnte nicht gefunden werden"
@@ -958,6 +1208,10 @@
         "Datenbanktreiber konnte nicht geladen werden: {}"
       ],
       "Could not verify the host": ["Der Host konnte nicht überprüft werden"],
+      "Country": ["Land"],
+      "Country Color Scheme": ["Länderfarbschema"],
+      "Country Column": ["Länderspalte"],
+      "Country Field Type": ["Feldtyp \"Land\""],
       "Country Map": ["Länderkarte"],
       "Create": ["Erstellen"],
       "Create a new chart": ["Neues Diagramm erstellen"],
@@ -976,6 +1230,8 @@
       "Crontab": ["Crontab"],
       "Cross Filter Scoping": ["Kreuzfilter-Festlegung"],
       "Cross-filter scoping": ["Kreuzfilter-Bereichsdefinition"],
+      "Cumulative": ["Kumuliert"],
+      "Custom": ["Angepasst"],
       "Custom Plugin": ["Benutzerdefiniertes Plugin"],
       "Custom Plugins": ["Benutzerdefinierte Plugins"],
       "Custom SQL": ["Benutzerdefinierte SQL"],
@@ -988,6 +1244,7 @@
       "Custom SQL ad-hoc metrics are not enabled for this dataset": [
         "Benutzerdefinierte SQL-Ad-hoc-Metriken sind für diesen Datasatz nicht aktiviert"
       ],
+      "Custom time filter plugin": ["Benutzerdefiniertes Zeitfilter-Plugin"],
       "Customize": ["Anpassen"],
       "Customize Metrics": ["Anpassen von Metriken"],
       "Customize columns": ["Spalten anpassen"],
@@ -1002,10 +1259,14 @@
       "D3 time format for datetime columns": [
         "D3-Zeitformat für datetime-Spalten"
       ],
+      "D3 time format syntax: https://github.com/d3/d3-time-format": [
+        "D3-Zeitformatsyntax: https://github.com/d3/d3-time-format"
+      ],
       "DEC": ["DEZ"],
       "DELETE": ["LÖSCHEN"],
       "DESCRIPTION ERROR": ["BESCHREIBUNG FEHLER"],
       "DML": ["DML"],
+      "Dark mode": ["Dunkelmodus"],
       "Dashboard": ["Dashboard"],
       "Dashboard Emails": ["Dashboard-E-Mails"],
       "Dashboard [{}] just got created and chart [{}] was added to it": [
@@ -1033,6 +1294,7 @@
       "Dashboards do not exist": ["Dashboards existieren nicht"],
       "Data": ["Daten"],
       "Data Source": ["Datenquelle"],
+      "Data Table": ["Datentabelle"],
       "Data Zoom": ["Datenzoom"],
       "Data could not be deserialized from the results backend. The storage format might have changed, rendering the old data stake. You need to re-run the original query.": [
         "Daten konnten nicht aus dem Ergebnis-Backend deserialisiert werden. Das Speicherformat hat sich möglicherweise geändert, wodurch die alten Daten ungültig wurden. Sie müssen die ursprüngliche Abfrage erneut ausführen."
@@ -1140,6 +1402,7 @@
       ],
       "Datetime format": ["Datum Zeit Format"],
       "Day": ["Tag"],
+      "Days %s": ["Tage %s"],
       "Db engine did not return all queried columns": [
         "Db-Modul hat nicht alle abgefragten Spalten zurückgegeben"
       ],
@@ -1161,12 +1424,27 @@
         "Standard-URL, auf die beim Zugriff von der Datensatz-Listenseite aus zugegriffen werden soll"
       ],
       "Default Value": ["Standardwert"],
+      "Default latitude": ["Standard Breitengrad"],
+      "Default longitude": ["Standard-Längengrad"],
       "Default minimal column width in pixels, actual width may still be larger than this if other columns don't need much space": [
         "Standardmäßig minimale Spaltenbreite in Pixel, tatsächliche Breite kann immer noch größer sein, wenn andere Spalten nicht viel Platz benötigen"
       ],
+      "Default to first item": ["Erstes Element als Standard verwenden"],
       "Default value is required": ["Standardwert ist erforderlich"],
+      "Default value must be set when \"Filter has default value\" is checked": [
+        "Standardwert muss festgelegt werden, wenn \"Filter hat Standardwert\" aktiviert ist"
+      ],
+      "Default value must be set when \"Required\" is checked": [
+        "Der Standardwert muss festgelegt werden, wenn \"Erforderlich\" aktiviert ist"
+      ],
+      "Default value set automatically when \"Default to first item\" is checked": [
+        "Standardwert wird automatisch festgelegt, wenn „Erstes Element als Standard“ aktiviert ist"
+      ],
       "Defines a rolling window function to apply, works along with the [Periods] text box": [
         "Definiert eine Funktion ‚Rollierendes Fenster‘, die angewendet werden soll. Arbeitet zusammen mit dem Textfeld [Punkte]"
+      ],
+      "Defines how each series is broken down": [
+        "Definiert, wie jede Reihe aufgeschlüsselt wird"
       ],
       "Defines the grouping of entities. Each series is shown as a specific color on the chart and has a legend toggle": [
         "Definiert die Gruppierung von Entitäten. Jede Serie wird als bestimmte Farbe im Diagramm angezeigt und verfügt über einen Legenden-Umschalter"
@@ -1242,13 +1520,22 @@
       "Deliver As Group": ["Als Gruppe liefern"],
       "Delivery Type": ["Zustellart"],
       "Delivery method": ["Übermittlungsmethode"],
+      "Demographics": ["Demographische Daten"],
+      "Density": ["Dichte"],
+      "Deprecated": ["Veraltet"],
       "Description": ["Beschreibung"],
       "Description (this can be seen in the list)": [
         "Beschreibung (diese ist in der Liste zu sehen)"
       ],
       "Description Columns": ["Beschreibungsspalten"],
+      "Description text that shows up below your Big Number": [
+        "Beschreibungstext, der unter Ihrer Großen Zahl angezeigt wird"
+      ],
       "Deselect all": ["Alle abwählen"],
       "Details of the certification": ["Details zur Zertifizierung"],
+      "Determines how whiskers and outliers are calculated.": [
+        "Bestimmt, wie „Whisker“ und Ausreißer berechnet werden."
+      ],
       "Determines whether or not this dashboard is visible in the list of all dashboards": [
         "Bestimmt, ob dieses Dashboard in der Liste aller Dashboards sichtbar ist"
       ],
@@ -1256,14 +1543,28 @@
       "Did you mean:": ["Meintest du:"],
       "Difference": ["Differenz"],
       "Directed Force Layout": ["Kraftbasierte Anordnung"],
+      "Directional": ["Direktional"],
       "Disabled": ["Deaktiviert"],
       "Discard changes": ["Änderungen verwerfen"],
+      "Discrete": ["Diskret"],
       "Display Name": ["Anzeigename"],
+      "Display column level total": ["Summe auf Spaltenebene anzeigen"],
       "Display configuration": ["Anzeige-Konfiguration"],
+      "Display metrics side by side within each column, as opposed to each column being displayed side by side for each metric.": [
+        "Zeigen Sie Metriken innerhalb jeder Spalte nebeneinander an, im Gegensatz zur Darstellung einer Spalte je Metrik."
+      ],
+      "Display row level total": ["Summe auf Zeilenebene anzeigen"],
+      "Display total row/column": ["Gesamtsumme Zeile/Spalte anzeigen"],
+      "Displays connections between entities in a graph structure. Useful for mapping relationships and showing which nodes are important in a network. Graph charts can be configured to be force-directed or circulate. If your data has a geospatial component, try the deck.gl Arc chart.": [
+        "Zeigt Verbindungen zwischen Elementen in einer Graphstruktur an. Nützlich, um Beziehungen abzubilden und zu zeigen, welche Knoten in einem Netzwerk wichtig sind. Graphen-Diagramme können so konfiguriert werden, dass sie kraftgesteuert sind oder zirkulieren. Wenn Ihre Daten über eine Geodatenkomponente verfügen, versuchen Sie es mit dem deck.gl Arc-Diagramm."
+      ],
+      "Distribute across": ["Verteilen über"],
+      "Distribution": ["Verteilung"],
       "Distribution - Bar Chart": ["Verteilung - Balkendiagramm"],
       "Divider": ["Trenner"],
       "Do you want a donut or a pie?": ["Donut oder Torten-Diagramm?"],
       "Documentation": ["Dokumentation"],
+      "Domain": ["Wertebereich"],
       "Don't refresh": ["Nicht aktualisieren"],
       "Donut": ["Donut"],
       "Download as image": ["Herunterladen als Bild"],
@@ -1303,6 +1604,7 @@
       "Druid supports basic authentication. See [auth](http://druid.io/docs/latest/design/auth.html) and druid-basic-security extension": [
         "Druid unterstützt die Standardauthentifizierung. Siehe [auth](http://druid.io/docs/latest/design/auth.html) und druid-basic-security extension"
       ],
+      "Dual Line Chart": ["Doppelliniendiagramm"],
       "Duplicate column name(s): %(columns)s": [
         "Doppelte Spaltenname(n): %(columns)s"
       ],
@@ -1335,9 +1637,14 @@
       "Duration (in seconds) of the metadata caching timeout for tables of this database. If left unset, the cache never expires. ": [
         "Dauer (in Sekunden) der Caching-Zeitdauer für Diagramme dieser Datenbank. Ein Timeout von 0 gibt an, dass der Cache nie abläuft. Beachten Sie, dass standardmäßig der globale Timeout verwendet wird, wenn keiner definiert ist. "
       ],
+      "Duration in ms (1.40008 => 1ms 400µs 80ns)": [
+        "Dauer in ms (1,40008 => 1ms 400μs 80ns)"
+      ],
+      "Duration in ms (66000 => 1m 6s)": ["Dauer in ms (66000 => 1m 6s)"],
       "Duration: %s": ["Laufzeit: %s"],
       "ECharts": ["ECharts"],
       "END (EXCLUSIVE)": ["ENDE (EXKLUSIV)"],
+      "ERROR: %s": ["FEHLER: %s"],
       "Edge length": ["Kantenlänge"],
       "Edge length between nodes": ["Kantenlänge zwischen Knoten"],
       "Edge symbols": ["Kantensymbole"],
@@ -1410,6 +1717,7 @@
       "Emit dashboard cross filters.": ["Geben Sie Dashboard-Querfilter aus."],
       "Emitted values": ["Ausgegebene Werte"],
       "Emphasis": ["Hervorhebung"],
+      "Employment and education": ["Beschäftigung und Bildung"],
       "Empty circle": ["Leerer Kreis"],
       "Empty collection": ["Leere Sammlung"],
       "Empty query?": ["Leere Abfrage?"],
@@ -1477,6 +1785,7 @@
         "Fehler beim Laden von Diagrammdatenquellen. Filter funktionieren möglicherweise nicht ordnungsgemäß."
       ],
       "Error message": ["Fehlermeldung"],
+      "Error while fetching charts": ["Fehler beim Abrufen von Diagrammen"],
       "Error while fetching data: %s": ["Fehler beim Abrufen von Daten: %s"],
       "Error while rendering virtual dataset query: %(msg)s": [
         "Fehler bei Anzeige der virtuellen Datensatzabfrage: %(msg)s"
@@ -1488,14 +1797,17 @@
       "Estimate the cost before running a query": [
         "Schätzen der Kosten vor dem Ausführen einer Abfrage"
       ],
+      "Event Flow": ["Ereignisablauf"],
       "Event Names": ["Ereignisnamen"],
       "Event definition": ["Ereignisdefinition"],
       "Event flow": ["Ereignisablauf"],
       "Event time column": ["Spalte \"Ereigniszeit\""],
       "Every": ["Jeden"],
+      "Evolution": ["Entwicklung"],
+      "Exact": ["Genau"],
       "Example": ["Beispiel"],
       "Example %(tableName)s will appear here": [
-        "Beispiel %(tableName)s wird hier angezeigt"
+        "Beispiel-%(tableName)s werden hier angezeigt"
       ],
       "Examples": ["Beispiele"],
       "Excel File": ["Excel-Datei"],
@@ -1503,6 +1815,7 @@
         "Excel-Datei \"%(excel_filename)s\" in Tabelle \"%(table_name)s\" in Datenbank \"%(db_name)s\" hochgeladen"
       ],
       "Excel to Database configuration": ["Excel-zu-Datenbank-Konfiguration"],
+      "Exclude selected values": ["Auswahlwerte ausschließen"],
       "Executed SQL": ["Ausgeführtes SQL"],
       "Executed query": ["Ausgeführte Abfrage"],
       "Execution ID": ["Ausführungs-ID"],
@@ -1511,6 +1824,7 @@
       "Expand all": ["Alle aufklappen"],
       "Expand table preview": ["Tabellenvorschau erweitern"],
       "Expand tool bar": ["Werkzeugleiste erweitern"],
+      "Experimental": ["Experimentell"],
       "Explore": ["Erkunden"],
       "Explore - %(table)s": ["Erkunden - %(table)s"],
       "Explore in Superset": ["In Superset erkunden"],
@@ -1555,6 +1869,8 @@
       "Factor": ["Faktor"],
       "Fail": ["Fehlschlagen"],
       "Failed": ["Fehlgeschlagen"],
+      "Failed at retrieving results": ["Fehler beim Abrufen der Ergebnisse"],
+      "Failed at stopping query. %s": ["Fehler beim Beenden der Abfrage. %s"],
       "Failed to start remote query on a worker.": [
         "Remoteabfrage für einen Worker konnte nicht gestartet werden."
       ],
@@ -1583,6 +1899,7 @@
       "Filter": ["Filter"],
       "Filter List": ["Filterliste"],
       "Filter Type": ["Filtertyp"],
+      "Filter box": ["Filterkomponente"],
       "Filter by database": ["Filtern nach Datenbank"],
       "Filter by status": ["Nach Status filtern"],
       "Filter by user": ["Filtern nach Benutzer*in"],
@@ -1635,9 +1952,16 @@
       "Fixed": ["Fixiert"],
       "Fixed Color": ["Fixierte Farbe"],
       "Fixed color": ["Fixierte Farbe"],
+      "Flow": ["Fluss"],
       "Font size": ["Schriftgröße"],
       "Font size for axis labels, detail value and other text elements": [
         "Schriftgröße für Achsenbeschriftungen, Detailwerte und andere Textelemente"
+      ],
+      "Font size for the biggest value in the list": [
+        "Schriftgröße für den größten Wert in der Liste"
+      ],
+      "Font size for the smallest value in the list": [
+        "Schriftgröße für den kleinsten Wert in der Liste"
       ],
       "For Presto and Postgres, shows a button to compute cost before running a query.": [
         "Für Presto und Postgres wird ein Buttons angezeigt, um Kosten vor dem Ausführen einer Abfrage zu schätzen."
@@ -1652,24 +1976,31 @@
       "Force refresh": ["Aktualisierung erzwingen"],
       "Force refresh schema list": ["Aktualisierung der Schemaliste erzwingen"],
       "Force refresh table list": ["Aktualisierung erzwingen"],
+      "Force-directed Graph": ["Kraftgesteuerter Graph"],
       "Forecast periods": ["Prognosezeiträume"],
+      "Formattable": ["Formattabelle"],
       "Formatted CSV attached in email": [
         "Formatierte CSV-Datei in E-Mail angehängt"
       ],
+      "Found invalid orderby options": ["Ungültige Order-By-Optionen gefunden"],
       "Fraction digits": ["Nachkommastellen"],
+      "Frequency": ["Häufigkeit"],
       "Friction": ["Reibung"],
       "Friction between nodes": ["Reibung zwischen Knoten"],
       "Friday": ["Freitag"],
       "From date cannot be larger than to date": [
         "‚Von Datum' kann nicht größer als ‚Bis-Datum' sein"
       ],
+      "Funnel Chart": ["Trichterdiagramm"],
       "Further customize how to display each column": [
         "Weitere Anpassungen der Anzeige der Spaltenanzeige"
       ],
       "Further customize how to display each metric": [
         "Passen Sie weiter an, wie die einzelnen Metriken angezeigt werden sollen"
       ],
+      "Gauge Chart": ["Tachometerdiagramm"],
       "General": ["Allgemein"],
+      "Geo": ["Räumlich"],
       "Geohash": ["Geo Hashing"],
       "Get the last date by the date unit.": [
         "Das letzte Datum anhand der Datumseinheit anfordern."
@@ -1679,9 +2010,11 @@
       ],
       "Google Sheet Name and URL": ["Google Tabellen-Name und URL"],
       "Grace period": ["Kulanzzeit"],
+      "Graph Chart": ["Graphen-Diagramm"],
       "Graph layout": ["Graph-Layout"],
       "Gravity": ["Anziehungskraft"],
       "Group By": ["Gruppieren nach"],
+      "Group By filter plugin": ["Gruppieren nach Filter-Plugin"],
       "Group By' and 'Columns' can't overlap": [
         "„Gruppieren nach\" und \"Spalten\" dürfen sich nicht überlappen"
       ],
@@ -1690,19 +2023,26 @@
       ],
       "Group by": ["Gruppieren nach"],
       "Groupable": ["Gruppierbar"],
+      "Hard value bounds applied for color coding. Is only relevant and applied when the normalization is applied against the whole heatmap.": [
+        "Harte Wertgrenzen für die Farbcodierung. Ist nur relevant und wird angewendet, wenn die Normalisierung auf die gesamte Heatmap angewendet wird."
+      ],
       "Header": ["Header"],
       "Header Row": ["Kopfzeile"],
       "Heatmap": ["Heatmap"],
+      "Heatmap Options": ["Heatmap-Optionen"],
       "Height": ["Höhe"],
       "Hide layer": ["Ebene verstecken"],
       "Hide tool bar": ["Werkzeugleiste ausblenden"],
+      "Hierarchy": ["Hierarchie"],
       "Histogram": ["Histogramm"],
       "Home": ["Startseite"],
+      "Horizon Chart": ["Horizont-Diagramm"],
       "Horizon Charts": ["Horizontdiagramme"],
       "Horizontal alignment": ["Horizontale Ausrichtung"],
       "Host": ["Host"],
       "Hostname or IP address": ["Hostname oder IP-Adresse"],
       "Hour": ["Stunde"],
+      "Hours %s": ["Stunden %s"],
       "Hours offset": ["Stunden-Versatz"],
       "How do you want to enter service account credentials?": [
         "Wie möchten Sie die Anmeldeinformationen für das Dienstkonto eingeben?"
@@ -1716,6 +2056,8 @@
       "How to display time shifts: as individual lines; as the difference between the main time series and each time shift; as the percentage change; or as the ratio between series and time shifts.": [
         "So zeigen Sie Zeitverschiebungen an: als einzelne Linien; als absolute Differenz zwischen der Hauptzeitreihe und jeder Zeitverschiebung; als prozentuale Veränderung; oder wenn sich das Verhältnis zwischen Reihe und Zeit verschiebt."
       ],
+      "Huge": ["Riesig"],
+      "ISO 3166-2 Codes": ["ISO-3166-2-Codes"],
       "ISO 8601": ["ISO 8601"],
       "Id": ["ID"],
       "Id of root node of the tree.": ["ID des Stammknotens der Struktur."],
@@ -1743,6 +2085,9 @@
       ],
       "Ignore time": ["Zeit ignorieren"],
       "Image (PNG) embedded in email": ["Bild (PNG) in E-Mail eingebettet"],
+      "Image download failed, please refresh and try again.": [
+        "Bilddownload fehlgeschlagen, bitte aktualisieren und erneut versuchen."
+      ],
       "Impersonate logged in user (Presto, Trino, Drill, Hive, and GSheets)": [
         "Identität von angemeldeter Benutzer*in annehmen (Presto, Trino, Drill & Hive)"
       ],
@@ -1777,6 +2122,8 @@
       "Important! Select this if the table is not already sorted by entity id, else there is no guarantee that all events for each entity are returned.": [
         "Wichtig! Wählen Sie diese Option, wenn die Tabelle nicht bereits nach Entitäts-ID sortiert ist, da sonst nicht garantiert ist, dass alle Ereignisse für jede Entität zurückgegeben werden."
       ],
+      "Include Series": ["Serien einschließen"],
+      "Include series name as an axis": ["Seriennamen als Achse einschließen"],
       "Include time": ["Zeit einschließen"],
       "Incompatible Filters (%d)": ["Inkompatible Filter (%d)"],
       "Incorrect Fields": ["Falsche Felder"],
@@ -1792,6 +2139,7 @@
       "Instructions to add a dataset are available in the Superset tutorial.": [
         "Anleitungen zum Hinzufügen eines Datensatz finden Sie im Superset-Tutorial."
       ],
+      "Intensity": ["Intensität"],
       "Interval End column": ["Spalte \"Intervallende\""],
       "Interval bounds": ["Intervallgrenzen"],
       "Interval colors": ["Intervallfarben"],
@@ -1841,12 +2189,19 @@
       "Invalid spatial point encountered: %s": [
         "Ungültiger räumlicher Punkt: %s"
       ],
+      "Inverse selection": ["Auswahl umkehren"],
       "Is Hidden": ["Ist versteckt"],
       "Is certified": ["Zertifiziert"],
       "Is dimension": ["Ist Dimension"],
       "Is favorite": ["Favoriten"],
       "Is filterable": ["Ist filterbar"],
       "Is temporal": ["Ist zeitlich"],
+      "Issue 1000 - The dataset is too large to query.": [
+        "Problem 1000 - Die Datenquelle ist zu groß, um sie abzufragen."
+      ],
+      "Issue 1001 - The database is under an unusual load.": [
+        "Problem 1001 - Die Datenbank ist ungewöhnlich belastet."
+      ],
       "It seems you don't have access to any database": [
         "Es scheint, dass Sie keinen Zugriff auf eine Datenbank haben"
       ],
@@ -1871,6 +2226,7 @@
       ],
       "July": ["Juli"],
       "June": ["Juni"],
+      "KPI": ["KPI"],
       "Keep editing": ["Weiter bearbeiten"],
       "Keys for table": ["Schlüssel für Tabelle"],
       "Label": ["Label"],
@@ -1879,7 +2235,13 @@
       "Label for your query": ["Bezeichnung für Ihre Anfrage"],
       "Label position": ["Beschriftungsposition"],
       "Label threshold": ["Beschriftungsschwellenwert"],
+      "Labelling": ["Beschriftung"],
       "Labels": ["Beschriftungen"],
+      "Labels for the marker lines": ["Beschriftungen für die Markerlinien"],
+      "Labels for the markers": ["Beschriftungen für die Marker"],
+      "Labels for the ranges": ["Beschriftungen für Bereiche"],
+      "Large": ["Groß"],
+      "Last": ["Letzte"],
       "Last Changed": ["Zuletzt geändert"],
       "Last Modified": ["Zuletzt geändert"],
       "Last Updated %s": ["Letzte Aktualisierung %s"],
@@ -1887,6 +2249,10 @@
       "Last modified": ["Zuletzt geändert"],
       "Last modified by %s": ["Zuletzt geändert durch %s"],
       "Last run": ["Letzte Ausführung"],
+      "Latitude": ["Breitengrad"],
+      "Latitude of default viewport": [
+        "Breitengrad des Standardansichtsfensters"
+      ],
       "Layer": ["Ebene"],
       "Layer configuration": ["Ebenen-Konfiguration"],
       "Layout": ["Layout"],
@@ -1897,22 +2263,33 @@
       ],
       "Least recently modified": ["Zuletzt geändert"],
       "Left": ["Links"],
+      "Left Axis Format": ["Format der linken Achse"],
+      "Left Axis Metric": ["Metrik linke Achse"],
+      "Left Axis chart(s)": ["Diagramm(e) der linken Achse"],
       "Left Margin": ["Linker Abstand"],
       "Left margin, in pixels, allowing for more room for axis labels": [
         "Linker Rand in Pixeln, um mehr Platz für Achsenbeschriftungen zu schaffen"
       ],
       "Left to Right": ["Links nach rechts"],
       "Left value": ["Linker Wert"],
+      "Legacy": ["Veraltet"],
       "Legend": ["Legende"],
       "Legend type": ["Legendentyp"],
+      "Lift percent precision": ["Prozentuale Präzision erhöhen"],
+      "Light mode": ["Heller Modus"],
       "Limit reached": ["Limit erreicht"],
       "Limit selector values": ["Auswahlwerte einschränken"],
+      "Limiting rows may result in incomplete data and misleading charts. Consider filtering or grouping source/target names instead.": [
+        "Das Einschränken von Zeilen kann zu unvollständigen Daten und irreführenden Diagrammen führen. Erwägen Sie stattdessen, Quell-/Zielnamen zu filtern oder zu gruppieren."
+      ],
       "Limits the number of rows that get displayed.": [
         "Begrenzt die Anzahl der Zeilen, die angezeigt werden."
       ],
       "Limits the number of series that get displayed. A joined subquery (or an extra phase where subqueries are not supported) is applied to limit the number of series that get fetched and rendered. This feature is useful when grouping by high cardinality column(s) though does increase the query complexity and cost.": [
         "Begrenzt die Anzahl der Zeitreihen, die angezeigt werden. Eine Unterabfrage (oder eine zusätzliche Phase, falls Unterabfragen nicht unterstützt werden) wird angewendet, um die Anzahl der Zeitreihen zu begrenzen, die abgerufen und angezeigt werden. Diese Funktion ist nützlich, wenn Sie nach Dimension(en) mit hoher Kardinalität gruppieren, erhöht jedoch die Abfragekomplexität und -kosten."
       ],
+      "Line": ["Linie"],
+      "Line Chart": ["Liniendiagramm"],
       "Line Style": ["Linien Stil"],
       "Line interpolation as defined by d3.js": [
         "Linieninterpolation gemäß d3.js"
@@ -1921,9 +2298,20 @@
       "Linear Color Scheme": ["Farbverlaufschema"],
       "Linear color scheme": ["Farbverlaufschema"],
       "Link Copied!": ["Link kopiert!"],
+      "Link Length": ["Kantenlänge"],
+      "Link length in the force layout": [
+        "Kantenlänge in kraftbasierter Anordnung"
+      ],
       "List Observations": ["Beobachtungen auflisten"],
       "List Saved Query": ["Gespeicherte Abfragen auflisten"],
+      "List of values to mark with lines": [
+        "Liste der Werte, die mit Linien markiert werden sollen"
+      ],
+      "List of values to mark with triangles": [
+        "Liste der Werte, die mit Dreiecken markiert werden sollen"
+      ],
       "Live CSS editor": ["Live CSS Editor"],
+      "Live render": ["Live-Darstellung"],
       "Load a CSS template": ["CSS Vorlage laden"],
       "Loaded data cached": ["Geladene Daten zwischengespeichert"],
       "Loaded from cache": ["Aus Zwischenspeicher geladen"],
@@ -1941,7 +2329,11 @@
       "Login": ["Anmelden"],
       "Logout": ["Abmelden"],
       "Logs": ["Protokolle"],
+      "Longitude": ["Längengrad"],
       "Longitude & Latitude columns": ["Längen- und Breitengradspalten"],
+      "Longitude of default viewport": [
+        "Längengrad des Standardansichtfensters"
+      ],
       "MAR": ["MÄR"],
       "MAY": ["MAI"],
       "MON": ["MO"],
@@ -1958,15 +2350,26 @@
       ],
       "Mandatory": ["Notwendig"],
       "Mangle Duplicate Columns": ["Doppelte Spalten zusammenführen"],
+      "Map": ["Karte"],
+      "Map Style": ["Karten Stil"],
+      "MapBox": ["MapBox"],
       "Mapbox": ["Mapbox"],
       "March": ["März"],
       "Margin": ["Rand"],
       "Marker": ["Marker"],
       "Marker Size": ["Markergröße"],
+      "Marker labels": ["Markierungsbeschriftungen"],
+      "Marker line labels": ["Markierungslinienbeschriftungen"],
+      "Marker lines": ["Markierungslinien"],
       "Marker size": ["Markergröße"],
+      "Markers": ["Marker"],
+      "Markup type": ["Markup-Typ"],
       "Max": ["Max"],
+      "Max Bubble Size": ["Maximale Blasengröße"],
       "Max Events": ["Maximale Anzahl von Ereignissen"],
       "Maximize chart": ["Diagramm maximieren"],
+      "Maximum": ["Maximum"],
+      "Maximum Font Size": ["Maximale Schriftgrösse"],
       "Maximum value on the gauge axis": [
         "Maximalwert auf der Messgerät-Skala"
       ],
@@ -1980,6 +2383,7 @@
       "Median node size, the largest node will be 4 times larger than the smallest": [
         "Mittlere Knotengröße, der größte Knoten ist 4-mal größer als der kleinste"
       ],
+      "Medium": ["Mittel"],
       "Message Content": ["Inhalt der Nachricht"],
       "Message content": ["Nachrichteninhalt"],
       "Metadata": ["Metadaten"],
@@ -1994,6 +2398,7 @@
       "Metric '%(metric)s' does not exist": [
         "Metrik '%(metric)s' existiert nicht"
       ],
+      "Metric ascending": ["Metrik aufsteigend"],
       "Metric assigned to the [X] axis": [
         "Metrik, die der [X]-Achse zugewiesen ist"
       ],
@@ -2003,13 +2408,24 @@
       "Metric change in value from `since` to `until`": [
         "Metrische Wertänderung von 'seit' zu 'bis'"
       ],
+      "Metric descending": ["Metrik absteigend"],
       "Metric factor change from `since` to `until`": [
         "Änderung des metrischen Faktors von \"seit\" zu \"bis\""
       ],
+      "Metric for Color": ["Metrik für Farbe"],
       "Metric for node values": ["Metrik für Knotenwerte"],
       "Metric name [%s] is duplicated": ["Metrikname [%s] wird dupliziert"],
       "Metric percent change in value from `since` to `until`": [
         "Metrische prozentuale Wertänderung von \"seit\" zu \"bis\""
+      ],
+      "Metric that defines the color of the country": [
+        "Metrik, die die Farbe des Landes definiert"
+      ],
+      "Metric that defines the size of the bubble": [
+        "Metrik, die die Größe der Blase definiert"
+      ],
+      "Metric to display bottom title": [
+        "Metrik zur Anzeige des unteren Titels"
       ],
       "Metric to sort the results by": [
         "Metrik zum Sortieren der Ergebnisse nach"
@@ -2027,12 +2443,15 @@
       "Metrics for which percentage of total are to be displayed. Calculated from only data within the row limit.": [
         "Metriken, für die ein Prozentsatz der Gesamtsumme angezeigt werden soll. Berechnet nur aus Daten innerhalb des Zeilenlimits."
       ],
+      "Midnight": ["Mitternacht"],
       "Min": ["Min"],
       "Min Periods": ["Mindestzeiträume"],
       "Min Width": ["Min. Breite"],
       "Min periods": ["Mindestzeiträume"],
       "Mine": ["Meine"],
       "Minimize chart": ["Diagramm minimieren"],
+      "Minimum": ["Minimum"],
+      "Minimum Font Size": ["Minimale Schriftgröße"],
       "Minimum leaf node event count": [
         "Minimale Anzahl der Blattknotenereignisse"
       ],
@@ -2047,26 +2466,35 @@
       ],
       "Minor Split Line": ["Kleine geteilte Linie"],
       "Minute": ["Minute"],
+      "Minutes %s": ["Minuten %s"],
       "Missing Required Fields": ["Fehlende Pflichtfelder"],
       "Missing dataset": ["Fehlender Datensatz"],
+      "Mixed Time-Series": ["Gemischte Zeitreihen"],
       "Modified": ["Geändert"],
       "Modified %s": ["Geändert %s"],
       "Modified by": ["Geändert durch"],
       "Modified columns: %s": ["Geänderte Spalten: %s"],
       "Monday": ["Montag"],
       "Month": ["Monat"],
+      "Months %s": ["Monate %s"],
       "More dataset related options": ["Weitere Optionen zum Datensatz"],
       "Move only": ["Nur verschieben"],
       "Moves the given set of dates by a specified interval.": [
         "Verschiebt den angegebenen Satz von Datumsangaben um ein angegebenes Intervall."
       ],
+      "Multi-Dimensions": ["Multi-Dimensionen"],
+      "Multi-Layers": ["Mehr-Ebenen"],
+      "Multi-Levels": ["Mehrstufige"],
+      "Multi-Variables": ["Multi-Variablen"],
       "Multiple": ["Mehrfach"],
+      "Multiple Line Charts": ["Mehr-Liniendiagramme"],
       "Multiple file extensions are not allowed for columnar uploads. Please make sure all files are of the same extension.": [
         "Unterschiedliche Dateierweiterungen sind für spaltenförmige Uploads nicht zulässig. Bitte stellen Sie sicher, dass alle Dateien die gleiche Erweiterung haben."
       ],
       "Multiple formats accepted, look the geopy.points Python library for more details": [
         "Mehrere Formate akzeptiert, recherchieren Sie in der geopy.points Python-Bibliothek nach weiteren Details"
       ],
+      "Multiple select": ["Mehrfachauswahl"],
       "Multiple selections allowed, otherwise filter is limited to a single value": [
         "Mehrfachauswahl zulässig, andernfalls ist der Filter auf einen einzelnen Wert beschränkt"
       ],
@@ -2107,6 +2535,7 @@
       ],
       "Name of the target nodes": ["Name der Zielknoten"],
       "Name your database": ["Benennen der Datenbank"],
+      "Network error.": ["Netzwerk-Fehler."],
       "New": ["Neu"],
       "New Email Report": ["Neuer E-Mail-Bericht"],
       "New chart": ["Neues Diagramm"],
@@ -2116,6 +2545,7 @@
       "New tab (Ctrl + q)": ["Neue Registerkarte (Strg + q)"],
       "New tab (Ctrl + t)": ["Neue Registerkarte (Strg + t)"],
       "Next": ["Weiter"],
+      "Nightingale Rose Chart": ["Nightingale Rose Diagramm"],
       "No": ["Nein"],
       "No %(tableName)s yet": ["Noch keine %(tableName)s"],
       "No %s yet": ["Noch keine %s"],
@@ -2142,6 +2572,7 @@
       ],
       "No filter": ["Kein Filter"],
       "No filter is selected.": ["Kein Filter ausgewählt."],
+      "No of Bins": ["Anzahl der Bis"],
       "No query history yet...": ["Noch kein Abfrageverlauf..."],
       "No records found": ["Keine Datensätze gefunden"],
       "No results found": ["Keine Ergebnisse gefunden"],
@@ -2161,6 +2592,9 @@
       "None": ["Keine"],
       "None -> Arrow": ["Keine -> Pfeil"],
       "None -> None": ["Keine -> Keine"],
+      "Normal": ["Normal"],
+      "Normalize Across": ["Normalisieren über"],
+      "Normalized": ["Normalisiert"],
       "Not Time Series": ["Keine Zeitreihen"],
       "Not null": ["Nicht NULL"],
       "Not triggered": ["Nicht ausgelöst"],
@@ -2168,11 +2602,19 @@
       "Nothing triggered": ["Nichts ausgelöst"],
       "Notification method": ["Benachrichtigungsmethode"],
       "November": ["November"],
+      "Now": ["Jetzt"],
       "Null or Empty": ["Null oder Leer"],
       "Null values": ["NULL Werte"],
+      "Number Format": ["Zahlenformat"],
       "Number format": ["Nummern Format"],
       "Number of decimal digits to round numbers to": [
         "Anzahl der Dezimalstellen, auf die gerundet wird"
+      ],
+      "Number of decimal places with which to display lift values": [
+        "Anzahl der Dezimalstellen, mit denen Hubwerte angezeigt werden sollen"
+      ],
+      "Number of decimal places with which to display p-values": [
+        "Anzahl der Dezimalstellen, mit denen p-Werte angezeigt werden sollen"
       ],
       "Number of rows of file to read.": [
         "Anzahl der aus Datei zu lesenden Zeilen."
@@ -2182,6 +2624,12 @@
       ],
       "Number of split segments on the axis": [
         "Anzahl der geteilten Segmente auf der Achse"
+      ],
+      "Number of steps to take between ticks when displaying the X scale": [
+        "Anzahl der Schritte, die zwischen den Strichen bei der Anzeige der X-Skala ausgeführt werden müssen"
+      ],
+      "Number of steps to take between ticks when displaying the Y scale": [
+        "Anzahl der Schritte, die zwischen den Strichen bei der Anzeige der Y-Skala ausgeführt werden müssen"
       ],
       "Numerical range": ["Numerischer Bereich"],
       "OCT": ["OKT"],
@@ -2202,6 +2650,9 @@
       ],
       "One or many columns to pivot as columns": [
         "Eine oder mehrere Spalten, die als Spalten pivotiert werden sollen"
+      ],
+      "One or many controls to group by. If grouping, latitude and longitude columns must be present.": [
+        "Ein oder mehrere Steuerelemente, nach denen gruppiert werden soll. Bei der Gruppierung müssen Breiten- und Längengradspalten vorhanden sein."
       ],
       "One or many controls to pivot as columns": [
         "Ein oder mehrere Steuerelemente, um zu Spalten zu pivotieren"
@@ -2265,6 +2716,9 @@
       "Opacity of Area Chart. Also applies to confidence band.": [
         "Deckkraft des Flächendiagramms. Gilt auch für das Vertrauensband."
       ],
+      "Opacity of all clusters, points, and labels. Between 0 and 1.": [
+        "Deckkraft aller Cluster, Punkte und Beschriftungen. Zwischen 0 und 1."
+      ],
       "Opacity of area chart.": ["Deckkraft des Flächendiagramms."],
       "Open Datasource tab": ["Datenquellen-Reiter öffnen"],
       "Open in SQL Lab": ["In SQL Lab öffnen"],
@@ -2299,6 +2753,8 @@
       ],
       "Ordering": ["Sortierung"],
       "Orientation of tree": ["Ausrichtung des Baumes"],
+      "Origin": ["Herkunft"],
+      "Original": ["Original"],
       "Original table column order": [
         "Ursprüngliche Tabellenspaltenreihenfolge"
       ],
@@ -2327,6 +2783,7 @@
         "Besitzende ist eine Liste von Benutzer*innen, die das Dashboard ändern können. Durchsuchbar nach Name oder Benutzer*innenname."
       ],
       "Page length": ["Seitenlänge"],
+      "Paired t-test Table": ["Gepaarte t-Test-Tabelle"],
       "Pandas resample method": ["Pandas Resample-Methode"],
       "Pandas resample rule": ["Pandas Resample-Regel"],
       "Parallel Coordinates": ["Parallele Koordinaten"],
@@ -2337,6 +2794,8 @@
       "Parent filter": ["Übergeordneter Filter"],
       "Parent filter is required": ["Übergeordneter Filter ist erforderlich"],
       "Parse Dates": ["Datumsangaben auswerten"],
+      "Part of a Whole": ["Teil eines Ganzen"],
+      "Partition Chart": ["Partitionsdiagramm"],
       "Partition Diagram": ["Partitionsdiagramm"],
       "Partition Limit": ["Partitionslimit"],
       "Partition Threshold": ["Partitionsschwellenwert"],
@@ -2347,12 +2806,14 @@
       "Paste the shareable Google Sheet URL here": [
         "Fügen Sie die gemeinsam nutzbare Google Tabellen-URL hier ein"
       ],
+      "Pattern": ["Muster"],
       "Percent Change": ["Prozentuale Veränderung"],
       "Percentage metrics": ["Prozentuale Metriken"],
       "Percentage threshold": ["Prozentualer Schwellenwert"],
+      "Percentages": ["Prozentwerte"],
       "Periods": ["Zeiträume"],
-      "Periods must be a positive integer value": [
-        "Perioden müssen ein positiver ganzzahliger Wert sein"
+      "Periods must be a whole number": [
+        "Perioden müssen eine ganze Zahl sein"
       ],
       "Person or group that has certified this chart.": [
         "Person oder Gruppe, die dieses Diagramm zertifiziert hat."
@@ -2402,15 +2863,24 @@
       "Pick one or more columns that should be shown in the annotation. If you don't select a column all of them will be shown.": [
         "Wählen Sie eine oder mehrere Spalten aus, die in der Anmerkung angezeigt werden sollen. Wenn Sie keine Spalte auswählen, werden alle angezeigt."
       ],
+      "Pick your favorite markup language": [
+        "Wählen Sie Ihre bevorzugte Markup-Sprache"
+      ],
+      "Pie Chart": ["Kreisdiagramm"],
       "Pie shape": ["Kreisform"],
       "Pin": ["Pin"],
+      "Pivot Options": ["Pivot-Optionen"],
       "Pivot Table": ["Pivot-Tabelle"],
+      "Pivot Table v2": ["Pivot-Tabelle v2"],
       "Pivot operation must include at least one aggregate": [
         "Pivot-Operation muss mindestens ein Aggregat enthalten"
       ],
       "Pivot operation requires at least one index": [
         "Pivot-Operation erfordert mindestens einen Index"
       ],
+      "Pivoted": ["Pilotiert"],
+      "Pixel height of each series": ["Pixelhöhe jeder Serie"],
+      "Please apply filter changes": ["Bitte wenden Sie Filteränderungen an"],
       "Please check your query and confirm that all template parameters are surround by double braces, for example, \"{{ ds }}\". Then, try running your query again.": [
         "Bitte überprüfen Sie Ihre Anfrage und vergewissern Sie sich, dass alle Vorlagenparameter von doppelten Klammern umgeben sind, z. B. \"{{ ds }}\". Versuchen Sie dann erneut, die Abfrage auszuführen."
       ],
@@ -2463,12 +2933,22 @@
       "Please verify that port is open to connect.": [
         "Stellen Sie sicher, dass der Port für die Verbindung geöffnet ist."
       ],
+      "Plots the individual metrics for each row in the data vertically and links them together as a line. This chart is useful for comparing multiple metrics across all of the samples or rows in the data.": [
+        "Stellt die einzelnen Metriken für jede Zeile in den Daten vertikal dar und verknüpft sie als Linie miteinander. Dieses Diagramm ist nützlich, um mehrere Metriken in allen Stichproben oder Zeilen in den Daten zu vergleichen."
+      ],
       "Plugins": ["Plugins"],
+      "Point Radius": ["Punktradius"],
+      "Point Radius Unit": ["Punktradius-Einheit"],
+      "Points": ["Punkte"],
+      "Points and clusters will update as the viewport is being changed": [
+        "Punkte und Cluster werden aktualisiert, wenn das Ansichtsfenster geändert wird"
+      ],
       "Pop Tab Link": ["Tab-Link"],
       "Popular": ["Beliebt"],
       "Populate \"Default value\" to enable this control": [
         "Geben Sie den \"Standardwert\" an, um dieses Steuerelement zu aktivieren"
       ],
+      "Population age data": ["Daten zum Bevölkerungsalter"],
       "Port %(port)s on hostname \"%(hostname)s\" refused the connection.": [
         "Port %(port)s auf Hostname \"%(hostname)s\" verweigerte die Verbindung."
       ],
@@ -2477,8 +2957,14 @@
       "Position of child node label on tree": [
         "Position der Beschriftung des untergeordneten Knotens in der Struktur"
       ],
+      "Position of column level subtotal": [
+        "Position der Zwischensumme auf Spaltenebene"
+      ],
       "Position of intermidiate node label on tree": [
         "Position der Zwischenknoten-Beschriftung im Baum"
+      ],
+      "Position of row level subtotal": [
+        "Position der Zwischensumme auf Zeilenebene"
       ],
       "Powered by Apache Superset": ["Powered Apache Superset"],
       "Pre-filter": ["Vorfilter"],
@@ -2487,16 +2973,24 @@
       "Predicate applied when fetching distinct value to populate the filter control component. Supports jinja template syntax. Applies only when `Enable Filter Select` is on.": [
         "Prädikat, das beim Abrufen eines eindeutigen Werts angewendet wird, um die Filtersteuerelementkomponente aufzufüllen. Unterstützt jinja-Vorlagensyntax. Gilt nur, wenn \"Filterauswahl aktivieren\" aktiviert ist."
       ],
+      "Predictive": ["Prädikativ"],
       "Predictive Analytics": ["Prädiktive Analysen"],
+      "Prefix metric name with slice name": [
+        "Metrikname den Slice-Namen voranstellen"
+      ],
       "Preview": ["Vorschau"],
       "Preview: `%s`": ["Vorschau: `%s"],
       "Previous": ["Zurück"],
       "Primary": ["Primär"],
+      "Primary Metric": ["Primäre Metrik"],
       "Primary or secondary y-axis": ["Primäre oder sekundäre y-Achse"],
       "Primary y-axis format": ["Primäres y-Achsenformat"],
       "Profile": ["Profil"],
       "Profile picture provided by Gravatar": ["Profilbild von Gravatar"],
       "Progress": ["Fortschritt"],
+      "Progressive": ["Progressiv"],
+      "Propagate": ["Propagieren"],
+      "Proportional": ["Proportional"],
       "Public and privately shared sheets": [
         "Öffentliche und privat freigegebene Blätter"
       ],
@@ -2506,10 +3000,15 @@
       "Put the labels outside of the pie?": [
         "Sollen die Beschriftungen außerhalb der Torte dargestellt werden?"
       ],
+      "Put the labels outside the pie?": [
+        "Beschriftungen außerhalb des Kuchens anordnen?"
+      ],
+      "Put your code here": ["Geben Sie Ihren Code hier ein"],
       "Python Functions": ["Python-Funktionen"],
       "Python datetime string pattern": ["Python Datetime-Zeichenfolge"],
       "Python functions": ["Python-Funktionen"],
       "Quarter": ["Quartal"],
+      "Quarters %s": ["Quartale %s"],
       "Query": ["Abfrage"],
       "Query %s: %s": ["Abfrage %s: %s"],
       "Query A": ["Abfrage A"],
@@ -2525,15 +3024,28 @@
       "Query preview": ["Abfragen-Voransicht"],
       "Query search string": ["Abfragen suchen"],
       "Query was stopped": ["Abfrage wurde angehalten"],
+      "Query was stopped.": ["Die Abfrage wurde gestoppt."],
       "RANGE TYPE": ["BEREICHSTYP"],
       "REPORT NAME ERROR": ["BERICHTNAMEN FEHLER"],
+      "RGB Color": ["RGB-Farbe"],
       "Radar": ["Radar"],
+      "Radar Chart": ["Radar-Diagramm"],
       "Radar render type, whether to display 'circle' shape.": [
         "Radar-Darstellungsart, ob die Kreisform angezeigt werden soll."
       ],
       "Radial": ["Radial"],
       "Ran %s": ["Ausgeführt %s"],
+      "Range": ["Bereich"],
       "Range filter": ["Bereichsfilter"],
+      "Range filter plugin using AntD": ["Bereichsfilter-Plugin mit AntD"],
+      "Range labels": ["Bereichsbeschriftungen"],
+      "Ranges": ["Bereiche"],
+      "Ranges to highlight with shading": [
+        "Bereiche, die mit Schattierung hervorgehoben werden sollen"
+      ],
+      "Ranking": ["Rangliste"],
+      "Ratio": ["Verhältnis"],
+      "Raw records": ["Rohdatensätze"],
       "Ready to review filters in this dashboard?": [
         "Bereit, die Filter In diesem Dashboard zu prüfen?"
       ],
@@ -2587,6 +3099,11 @@
       "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter. Base filters apply filters to all queries except the roles defined in the filter, and can be used to define what users can see if no RLS filters within a filter group apply to them.": [
         "Reguläre Filter fügen Abfragen WHERE-Ausrücke hinzu, falls ein*e Benutzer*in einer im Filter referenzierten Rolle angehört. Basisfilter wenden Filter auf alle Abfragen mit Ausnahme der im Filter definierten Rollen an. Über sie lässt sich definieren, was Benutzer*innen sehen können, wenn auf sie keine RLS-Filter angewendet werden."
       ],
+      "Relational": ["Relational"],
+      "Relationships between community channels": [
+        "Beziehungen zwischen Community-Kanälen"
+      ],
+      "Relative Date/Time": ["Relatives Datum/Uhrzeit"],
       "Relative period": ["Relativer Zeitraum"],
       "Relative quantity": ["Relative Menge"],
       "Remind me in 24 hours": ["In 24 Stunden erinnern"],
@@ -2597,7 +3114,9 @@
       "Remove table preview": ["Tabellenvorschau entfernen"],
       "Removed columns: %s": ["Entfernte Spalten: %s"],
       "Rename tab": ["Registerkarte umbenennen"],
+      "Rendering": ["Darstellen"],
       "Replace": ["Ersetzen"],
+      "Report": ["Melden"],
       "Report Schedule could not be created.": [
         "Report-Ausführungsplan konnte nicht erstellt werden."
       ],
@@ -2677,6 +3196,7 @@
       "Right": ["Rechts"],
       "Right Axis Format": ["Format der rechten Achse"],
       "Right Axis Metric": ["Metrik der rechten Achse"],
+      "Right Axis chart(s)": ["Diagramm(e) der rechten Achse"],
       "Right axis metric": ["Metrik der rechten Achse"],
       "Right to Left": ["Rechts nach links"],
       "Right value": ["Rechter Wert"],
@@ -2699,6 +3219,9 @@
       "Root certificate": ["Root-Zertifikat"],
       "Root node id": ["Wurzelknoten-ID"],
       "Rotate x axis label": ["X-Achsenbeschriftung drehen"],
+      "Rotation to apply to words in the cloud": [
+        "Rotation, die auf Wörter in der Cloud angewendet werden soll"
+      ],
       "Round cap": ["Runde Kappe"],
       "Row": ["Zeile"],
       "Row Level Security": ["Sicherheit auf Zeilenebene"],
@@ -2711,6 +3234,7 @@
       "Rows per page, 0 means no pagination": [
         "Zeilen pro Seite, 0 bedeutet keine Paginierung"
       ],
+      "Rows subtotal position": ["Zeilen Zwischensummenposition"],
       "Rows to Read": ["Zu lesende Zeilen"],
       "Rule": ["Regel"],
       "Run": ["Ausführen"],
@@ -2746,6 +3270,8 @@
       "START (INCLUSIVE)": ["START (INKLUSIVE)"],
       "SUN": ["SO"],
       "Sankey": ["Sankey"],
+      "Sankey Diagram": ["Sankey-Diagramm"],
+      "Sankey Diagram with Loops": ["Sankey-Diagramm mit Schleifen"],
       "Saturday": ["Samstag"],
       "Save": ["Speichern"],
       "Save & Explore": ["Speichern & Erkunden"],
@@ -2778,6 +3304,8 @@
       "Scale and Move": ["Skalieren und Verschieben"],
       "Scale only": ["Nur Skalieren"],
       "Scan New Datasources": ["Neue Datenquellen suchen"],
+      "Scatter": ["Streudiagramm"],
+      "Scatter Plot": ["Streudiagramm"],
       "Schedule": ["Zeitplan"],
       "Schedule Email Reports for Charts": [
         "Planen von E-Mail-Berichten für Diagramme"
@@ -2814,8 +3342,10 @@
       "Search...": ["Suche..."],
       "Second": ["Sekunde"],
       "Secondary": ["Sekundär"],
+      "Secondary Metric": ["Sekundäre Metrik"],
       "Secondary y-axis format": ["Sekundäres y-Achsenformat"],
       "Secondary y-axis title": ["Titel der sekundären y-Achse"],
+      "Seconds %s": ["Sekunden %s"],
       "Secure Extra": ["Sicherheit Extra"],
       "Secure extra": ["Sicherheit extra"],
       "Security": ["Sicherheit"],
@@ -2844,6 +3374,7 @@
       "Select any columns for metadata inspection": [
         "Auswählen beliebiger Spalten für die Metadatenüberprüfung"
       ],
+      "Select charts": ["Diagramme auswählen"],
       "Select color scheme": ["Farbschema auswählen"],
       "Select column": ["Spalte auswählen"],
       "Select database or type database name": [
@@ -2853,6 +3384,10 @@
         "Für ausgewählte Datenbanken müssen zusätzliche Felder auf der Registerkarte Erweitert ausgefüllt werden, um die Datenbank erfolgreich zu verbinden. Erfahren Sie, welche Anforderungen Ihre Datenbanken haben "
       ],
       "Select filter": ["Filter auswählen"],
+      "Select filter plugin using AntD": ["Filter-Plugin mit AntD auswählen"],
+      "Select first item by default (when using this option, default value can’t be set)": [
+        "Standardmäßig das erste Element auswählen (bei Verwendung dieser Option kann der Standardwert nicht festgelegt werden)"
+      ],
       "Select operator": ["Operator auswählen"],
       "Select or type a value": ["Wert eingeben oder auswählen"],
       "Select owners": ["Besitzende auswählen"],
@@ -2867,11 +3402,22 @@
       "Select table or type table name": [
         "Tabelle auswählen oder Tabellennamen eingeben"
       ],
+      "Select the number of bins for the histogram": [
+        "Wählen Sie die Anzahl der Klassen für das Histogramm aus"
+      ],
+      "Select the numeric columns to draw the histogram": [
+        "Auswählen der numerischen Spalten zum Zeichnen des Histogramms"
+      ],
       "Send as CSV": ["Als CSV senden"],
       "Send as PNG": ["Als PNG senden"],
       "Send as text": ["Als Text senden"],
+      "Send range filter events to other charts": [
+        "Bereichsfilter-Ereignisse an andere Diagramme senden"
+      ],
       "September": ["September"],
+      "Sequential": ["Fortlaufend"],
       "Series": ["Serien"],
+      "Series Height": ["Serienhöhe"],
       "Series Style": ["Serienstil"],
       "Series chart type (line, bar etc)": [
         "Seriendiagrammtyp (Linie, Balken usw.)"
@@ -2888,6 +3434,7 @@
       "Share": ["Teilen"],
       "Share chart by email": ["Diagramm per Email teilen"],
       "Share dashboard by email": ["Dashboard per Email teilen"],
+      "Shared query": ["Geteilte Abfrage"],
       "Sheet Name": ["Blattname"],
       "Short description must be unique for this layer": [
         "Kurzbeschreibung muss für diese Ebene eindeutig sein"
@@ -2903,6 +3450,7 @@
       ],
       "Show Annotation": ["Anmerkungen anzeigen"],
       "Show Annotation Layer": ["Anmerkungsebene anzeigen"],
+      "Show Bubbles": ["Blasen anzeigen"],
       "Show CREATE VIEW statement": ["CREATE VIEW-Anweisung anzeigen"],
       "Show CSS Template": ["CSS Vorlagen anzeigen"],
       "Show Chart": ["Diagramm anzeigen"],
@@ -2922,6 +3470,7 @@
       "Show Log": ["Protokoll anzeigen"],
       "Show Markers": ["Markierungen anzeigen"],
       "Show Metric": ["Metrik anzeigen"],
+      "Show Metric Names": ["Metriknamen anzeigen"],
       "Show Observation": ["Beobachtung anzeigen"],
       "Show Range Filter": ["Bereichsfilter anzeigen"],
       "Show Row level security filter": [
@@ -2942,18 +3491,25 @@
       "Show all...": ["Zeige alle …"],
       "Show axis line ticks": ["Anzeigen von Achsenlinien-Ticks"],
       "Show cell bars": ["Zellenbalken anzeigen"],
+      "Show columns total": ["Spaltensumme anzeigen"],
       "Show data points as circle markers on the lines": [
         "Datenpunkte als Kreismarkierungen auf den Linien darstellen"
       ],
+      "Show hierarchical relationships of data, with with the value represented by area, showing proportion and contribution to the whole.": [
+        "Hierarchische Beziehungen von Daten anzeigen, wobei der Wert durch die Fläche dargestellt wird, die Anteil und Beitrag zum Ganzen darstellt."
+      ],
       "Show info tooltip": ["Info-Tooltip anzeigen"],
+      "Show label": ["Beschriftung anzeigen"],
       "Show labels when the node has children.": [
         "Zeigen Sie Beschriftungen an, wenn der Knoten untergeordnete Elemente hat."
       ],
       "Show legend": ["Legende anzeigen"],
       "Show less columns": ["Weniger Spalten anzeigen"],
       "Show less...": ["Weniger..."],
+      "Show percentage": ["Prozentsatz anzeigen"],
       "Show pointer": ["Zeiger anzeigen"],
       "Show progress": ["Fortschritt anzeigen"],
+      "Show rows total": ["Zeilensumme anzeigen"],
       "Show series values on the chart": ["Reihenwerten im Diagramm anzeigen"],
       "Show split lines": ["Geteilte Linien anzeigen"],
       "Show the value on top of the bar": [
@@ -2965,19 +3521,43 @@
         "Zeigen Sie die Gesamtaggregationen ausgewählter Metriken an. Beachten Sie, dass das Zeilenlimit nicht für das Ergebnis gilt."
       ],
       "Show totals": ["Gesamtwerte anzeigen"],
+      "Showcases a single metric front-and-center. Big number is best used to call attention to a KPI or the one thing you want your audience to focus on.": [
+        "Zeigt eine einzelne Metrik im Vordergrund. ‚Große Zahl‘ wird am besten verwendet, um die Aufmerksamkeit auf einen KPI oder die eine Information zu lenken, auf die sich Ihr Publikum konzentrieren soll."
+      ],
+      "Showcases a single number accompanied by a simple line chart, to call attention to an important metric along with its change over time or other dimension.": [
+        "Zeigt eine einzelne Zahl zusammen mit einem einfachen Liniendiagramm, um die Aufmerksamkeit auf eine wichtige Metrik zusammen mit ihrer Veränderung im Laufe der Zeit oder einer anderen Dimension zu lenken."
+      ],
+      "Showcases how a metric changes as the funnel progresses. This classic chart is useful for visualizing drop-off between stages in a pipeline or lifecycle.": [
+        "Zeigt, wie sich eine Metrik im Laufe des Trichters ändert. Dieses klassische Diagramm ist nützlich, um den Abfall zwischen Phasen in einer Pipeline oder einem Lebenszyklus zu visualisieren."
+      ],
+      "Showcases the flow or link between categories using thickness of chords. The value and corresponding thickness can be different for each side.": [
+        "Zeigt den Fluss oder die Verknüpfung zwischen Kategorien anhand der Dicke der Sehnen. Der Wert und die entsprechende Dicke können für jede Seite unterschiedlich sein."
+      ],
+      "Showcases the progress of a single metric against a given target. The higher the fill, the closer the metric is to the target.": [
+        "Zeigt den Fortschritt einer einzelnen Metrik gegenüber einem bestimmten Ziel. Je höher die Füllung, desto näher ist die Metrik am Ziel."
+      ],
       "Showing %s of %s": ["Sie sehen %s von %s"],
       "Shows a list of all series available at that point in time": [
         "Zeigt eine Liste aller zu diesem Zeitpunkt verfügbaren Serien an."
       ],
+      "Shows the composition of a dataset by segmenting a given rectangle as smaller rectangles with areas proportional to their value or contribution to the whole. Those rectangles may also, in turn, be further segmented hierarchically.": [
+        "Zeigt die Zusammensetzung eines Datensatzes an, indem ein bestimmtes Rechteck als kleinere Rechtecke mit Bereichen segmentiert wird, die proportional zu ihrem Wert oder Beitrag zum Ganzen sind. Diese Rechtecke können wiederum auch hierarchisch weiter segmentiert werden."
+      ],
+      "Significance Level": ["Signifikanzniveau"],
       "Simple": ["Einfach"],
       "Simple ad-hoc metrics are not enabled for this dataset": [
         "Einfache Ad-hoc-Metriken sind für diesen Datensatz nicht aktiviert"
       ],
       "Single": ["Einzeln"],
+      "Single Metric": ["Einzelne Metrik"],
+      "Single Value": ["Einzelner Wert"],
+      "Single value": ["Einzelner Wert"],
+      "Single value type": ["Einzelwerttyp"],
       "Size of edge symbols": ["Größe der Kantensymbole"],
       "Size of marker. Also applies to forecast observations.": [
         "Größe des Markers. Gilt auch für Prognosebeobachtungen."
       ],
+      "Sizes of vehicles": ["Fahrzeuggrößen"],
       "Skip Blank Lines": ["Leerzeilen überspringen"],
       "Skip Initial Space": ["Führende Leerzeichen überspringen"],
       "Skip Rows": ["Zeilen überspringen"],
@@ -2989,10 +3569,14 @@
       ],
       "Slack Channel": ["Slack-Kanal"],
       "Slug": ["Kopfzeile"],
+      "Small": ["Klein"],
       "Small number format": ["Kleines Zahlenformat"],
       "Some roles do not exist": ["Einige Rollen sind nicht vorhanden"],
       "Sorry there was an error fetching database information: %s": [
         "Beim Abrufen von Datenbankinformationen ist leider ein Fehler aufgetreten: %s"
+      ],
+      "Sorry there was an error fetching saved charts: ": [
+        "Beim Abrufen gespeicherter Diagramme ist leider ein Fehler aufgetreten: "
       ],
       "Sorry, An error occurred": ["Leider ist ein Fehler aufgetreten"],
       "Sorry, something went wrong. Try again later.": [
@@ -3001,6 +3585,9 @@
       "Sorry, there appears to be no data": [
         "Leider scheint es keine Daten zu geben"
       ],
+      "Sorry, there was an error saving this dashboard: %s": [
+        "Leider ist beim Speichern dieses Dashboards ein Fehler aufgetreten: %s"
+      ],
       "Sorry, your browser does not support copying.": [
         "Entschuldigung. Ihr Browser unterstützt leider kein Kopieren."
       ],
@@ -3008,21 +3595,29 @@
         "Ihr Browser unterstützt leider kein Kopieren. Verwenden Sie Strg / Cmd + C!"
       ],
       "Sort": ["Sortieren"],
+      "Sort Bars": ["Balken sortieren"],
       "Sort Descending": ["Absteigend sortieren"],
       "Sort Metric": ["Sortiermetrik"],
+      "Sort X Axis": ["X-Achse sortieren"],
+      "Sort Y Axis": ["Y-Achse sortieren"],
       "Sort ascending": ["Aufsteigend sortieren"],
+      "Sort bars by x labels.": ["Sortieren Sie Balken nach x-Beschriftungen."],
       "Sort by": ["Sortieren nach"],
       "Sort by %s": ["Sortieren nach %s"],
       "Sort by metric": ["Nach Metrik sortieren"],
       "Sort columns alphabetically": ["Spalten alphabetisch sortieren"],
+      "Sort columns by": ["Spalten sortieren nach"],
       "Sort descending": ["Absteigend sortieren"],
       "Sort filter values": ["Filterwerte sortieren"],
       "Sort metric": ["Metrik anzeigen"],
+      "Sort rows by": ["Zeilen sortieren nach"],
       "Sort type": ["Art der Sortierung"],
       "Source": ["Quelle"],
+      "Source / Target": ["Quelle / Ziel"],
       "Source SQL": ["Quell-SQL"],
       "Source category": ["Quellkategorie"],
       "Spatial": ["Raumbezug"],
+      "Specific Date/Time": ["Spezifisches Datum/Uhrzeit"],
       "Specify a schema (if database flavor supports this).": [
         "Geben Sie ein Schema an (wenn die Datenbankvariante dies unterstützt)."
       ],
@@ -3035,7 +3630,10 @@
       "Split number": ["Zahl aufteilen"],
       "Stack series": ["Stack-Serie"],
       "Stack series on top of each other": ["Reihen übereinander stapeln"],
+      "Stacked": ["Gestapelt"],
       "Stacked Bars": ["Gestapelte Balken"],
+      "Stacked Style": ["Gestapelter Stil"],
+      "Stacked style": ["Gestapelter Stil"],
       "Standard time series": ["Standard-Zeitreihen"],
       "Start": ["Start"],
       "Start Review": ["Starte Prüfung"],
@@ -3049,6 +3647,7 @@
         "Beginnen Sie die y-Achse bei Null. Deaktivieren Sie das Kontrollkästchen, um die y-Achse beim Minimalwert in den Daten beginnen zu lassen."
       ],
       "State": ["Zustand"],
+      "Statistical": ["Statistisch"],
       "Status": ["Status"],
       "Step type": ["Schritttyp"],
       "Stop": ["Stopp"],
@@ -3060,13 +3659,18 @@
       "Strength to pull the graph toward center": [
         "Stärke, mit der Graph in Richtung Mitte gezogen wird"
       ],
+      "Stretched style": ["Gestreckter Stil"],
       "Strings used for sheet names (default is the first sheet).": [
         "Zeichenfolgen, die für Blattnamen verwendet werden (Standard ist das erste Blatt)."
       ],
+      "Structural": ["Strukturell"],
       "Style": ["Stil"],
       "Style the ends of the progress bar with a round cap": [
         "Enden des Fortschrittsbalkens mit einer runden Kappe versehen"
       ],
+      "Subdomain": ["Subdomain"],
+      "Subheader": ["Untertitel"],
+      "Subheader Font Size": ["Schriftgröße Untertitel"],
       "Success": ["Erfolg"],
       "Suffix to apply after the percentage display": [
         "Suffix, das hinter der Prozentanzeige angezeigt werden soll"
@@ -3075,6 +3679,7 @@
         "Summe der Werte über einen bestimmten Zeitraum"
       ],
       "Sunburst": ["Sunburst"],
+      "Sunburst Chart": ["Sunburst Diagramm"],
       "Sunday": ["Sonntag"],
       "Superset Chart": ["Superset Diagramm"],
       "Superset chart": ["Superset Diagramm"],
@@ -3086,6 +3691,12 @@
         "Superset hat einen unerwarteten Fehler festgestellt."
       ],
       "Supported databases": ["Unterstützte Datenbanken"],
+      "Survey Responses": ["Umfrage-Antworten"],
+      "Swap Groups and Columns": ["Gruppen und Spalten tauschen"],
+      "Swap rows and columns": ["Zeilen und Spalten vertauschen"],
+      "Swiss army knife for visualizing time series data. Choose between  step, line, scatter, and bar charts. This viz type has many customization options as well.": [
+        "Schweizer Taschenmesser zur Visualisierung von Zeitreihendaten. Wählen Sie zwischen Schritt-, Linien-, Punkt- und Balkendiagrammen. Dieser Visualisierungstyp verfügt auch über viele Anpassungsoptionen."
+      ],
       "Symbol": ["Symbol"],
       "Symbol of two ends of edge line": [
         "Symbol für zwei Enden der Kantenlinie"
@@ -3097,6 +3708,7 @@
       "THU": ["DO"],
       "TUE": ["DI"],
       "Tab name": ["Tabellenname"],
+      "Tab title": ["Registerkartentitel"],
       "Table": ["Tabelle"],
       "Table %(table)s wasn't found in the database %(db)s": [
         "Tabelle %(table)s wurde in der Datenbank nicht gefunden %(db)s"
@@ -3112,14 +3724,27 @@
       ],
       "Table cache timeout": ["Tabellen-Cache Timeout"],
       "Table name undefined": ["Tabellenname nicht definiert"],
+      "Table that visualizes paired t-tests, which are used to understand statistical differences between groups.": [
+        "Tabelle, die gepaarte t-Tests visualisiert, die verwendet werden, um statistische Unterschiede zwischen Gruppen zu verstehen."
+      ],
       "Tables": ["Tabellen"],
       "Tabs": ["Reiter"],
+      "Tabular": ["Tabellarisch"],
       "Tags": ["Schlagwörter"],
+      "Take your data points, and group them into \"bins\" to see where the densest areas of information lie": [
+        "Gruppieren Sie Ihre Datenpunkte in Klassen, um zu sehen, wo die dichtesten Informationsbereiche liegen"
+      ],
       "Target": ["Ziel"],
+      "Target aspect ratio for treemap tiles.": [
+        "Ziel-Seitenverhältnis für Treemap-Kacheln."
+      ],
       "Target category": ["Zielkategorie"],
       "Target value": ["Zielwert"],
       "Template Name": ["Vorlagenname"],
       "Template parameters": ["Vorlagen-Parameter"],
+      "Templated link, it's possible to include {{ metric }} or other values coming from the controls.": [
+        "Vorlagen-Link. Es ist möglich, {{ metric }} oder andere Werte aus den Steuerelementen einzuschließen."
+      ],
       "Temporal expression not supported for type: %(col_type)s": [
         "Temporaler Ausdruck wird für type: %(col_type)s nicht unterstützt"
       ],
@@ -3128,6 +3753,7 @@
       ],
       "Test Connection": ["Verbindungstest"],
       "Test connection": ["Verbindungstest"],
+      "Text": ["Text"],
       "Text align": ["Textausrichtung"],
       "Text embedded in email": ["In E-Mail eingebetteter Text"],
       "The CSS for individual dashboards can be altered here, or in the dashboard view where changes are immediately visible": [
@@ -3153,6 +3779,12 @@
         "Die Kategorie der Quellknoten, die zum Zuweisen von Farben verwendet werden. Wenn ein Knoten mehr als einer Kategorie zugeordnet ist, wird nur die erste verwendet."
       ],
       "The chart does not exist": ["Das Diagramm ist nicht vorhanden"],
+      "The classic. Great for showing how much of a company each investor gets, what demographics follow your blog, or what portion of the budget goes to the military industrial complex.\n\n        Pie charts can be difficult to interpret precisely. If clarity of relative proportion is important, consider using a bar or other chart type instead.": [
+        "Der Klassiker. Großartig, um zu zeigen, wie viel von einem Unternehmen jeder Investor bekommt, welche Demografie Ihrem Blog folgt oder welcher Teil des Budgets in den militärisch-industriellen Komplex fließt.\n\nKreisdiagramme können schwierig zu interpretieren sein. Wenn die Klarheit des relativen Anteils wichtig ist, sollten Sie stattdessen die Verwendung eines Balkens oder eines anderen Diagrammtyps in Betracht ziehen."
+      ],
+      "The color for points and clusters in RGB": [
+        "Die Farbe für Punkte und Cluster in RGB"
+      ],
       "The color scheme for rendering chart": [
         "Das zur Diagrammanzeige verwendete Farbschema"
       ],
@@ -3161,6 +3793,9 @@
       ],
       "The column was deleted or renamed in the database.": [
         "Die Spalte wurde in der Datenbank gelöscht oder umbenannt."
+      ],
+      "The country code standard that Superset should expect to find in the [country] column": [
+        "Der Ländercodestandard, den Superset in der Spalte [Land] erwarten sollte"
       ],
       "The dashboard has been saved": [
         "Dashboard wurde erfolgreich gespeichert"
@@ -3201,11 +3836,17 @@
       "The dataset linked to this chart may have been deleted.": [
         "Der mit diesem Diagramm verknüpfte Datensatz wurde möglicherweise gelöscht."
       ],
+      "The datasource couldn't be loaded": [
+        "Datenquelle konnte nicht geladen werden"
+      ],
       "The datasource is too large to query.": [
         "Die Datenquelle ist zu groß, um sie abzufragen."
       ],
       "The description can be displayed as widget headers in the dashboard view. Supports markdown.": [
         "Die Beschreibung kann als Widget-Titel in der Dashboard-Ansicht angezeigt werden. Unterstützt Markdown."
+      ],
+      "The distance between cells, in pixels": [
+        "Der Abstand zwischen Zellen in Pixel"
       ],
       "The duration of time in seconds before the cache is invalidated": [
         "Die Zeitdauer in Sekunden, bevor der Cache ungültig wird"
@@ -3269,6 +3910,7 @@
       "The minimum number of rolling periods required to show a value. For instance if you do a cumulative sum on 7 days you may want your \"Min Period\" to be 7, so that all data points shown are the total of 7 periods. This will hide the \"ramp up\" taking place over the first 7 periods": [
         "Die Mindestanzahl von rollierender Perioden, die erforderlich sind, um einen Wert anzuzeigen. Wenn Sie beispielsweise eine kumulative Summe an 7 Tagen durchführen, möchten Sie möglicherweise, dass Ihr \"Mindestzeitraum\" 7 beträgt, so dass alle angezeigten Datenpunkte die Summe von 7 Perioden sind. Dies wird den \"Hochlauf\" verbergen, der in den ersten 7 Perioden stattfindet"
       ],
+      "The number color \"steps\"": ["Die Anzahl Farbabstufungen"],
       "The number of hours, negative or positive, to shift the time column. This can be used to move UTC time to local time.": [
         "Die Anzahl der Stunden, negativ oder positiv, um die Zeitspalte zu verschieben. Dies kann verwendet werden, um die UTC-Zeit auf die Ortszeit zu verschieben."
       ],
@@ -3312,6 +3954,9 @@
       "The passwords for the databases below are needed in order to import them together with the dashboards. Please note that the \"Secure Extra\" and \"Certificate\" sections of the database configuration are not present in export files, and should be added manually after the import if they are needed.": [
         "Die Passwörter für die unten aufgeführten Datenbanken werden benötigt, um sie zusammen mit den Dashboards zu importieren. Bitte beachten Sie, dass die Abschnitte \"Secure Extra\" und \"Certificate\" der Datenbankkonfiguration in Exportdateien nicht vorhanden sind und bei Bedarf nach dem Import manuell hinzugefügt werden sollten."
       ],
+      "The passwords for the databases below are needed in order to import them together with the datasets. Please note that the \"Secure Extra\" and \"Certificate\" sections of the database configuration are not present in export files, and should be added manually after the import if they are needed.": [
+        "Die Passwörter für die folgenden Datenbanken werden benötigt, um sie zusammen mit den Diagrammen zu importieren. Bitte beachten Sie, dass die Abschnitte \"Secure Extra\" und \"Certificate\" der Datenbankkonfiguration in Exportdateien nicht vorhanden sind und bei Bedarf nach dem Import manuell hinzugefügt werden sollten."
+      ],
       "The passwords for the databases below are needed in order to import them together with the saved queries. Please note that the \"Secure Extra\" and \"Certificate\" sections of the database configuration are not present in export files, and should be added manually after the import if they are needed.": [
         "Die Passwörter für die unten aufgeführten Datenbanken werden benötigt, um sie zusammen mit den gespeicherten Abfragen zu importieren. Bitte beachten Sie, dass die Abschnitte \"Secure Extra\" und \"Certificate\" der Datenbankkonfiguration in Exportdateien nicht vorhanden sind und bei Bedarf nach dem Import manuell hinzugefügt werden sollten."
       ],
@@ -3321,6 +3966,10 @@
       "The pattern of timestamp format. For strings use ": [
         "Das Muster des Zeitstempelformats. Für Zeichenfolgen verwenden Sie eine "
       ],
+      "The periodicity over which to pivot time. Users can provide\n            \"Pandas\" offset alias.\n            Click on the info bubble for more details on accepted \"freq\" expressions.": [
+        "Die Periodizität, über die die Zeit pilotiert werden soll. Benutzer können\n            ein“ Pandas\" Offset-Alias angeben.\n            Klicken Sie auf die Infoblase, um weitere Informationen zu akzeptierten \"freq\"-Ausdrücken zu erhalten."
+      ],
+      "The pixel radius": ["Der Pixelradius"],
       "The pointer to a physical table (or view). Keep in mind that the chart is associated to this Superset logical table, and this logical table points the physical table referenced here.": [
         "Der Zeiger auf eine physische Tabelle (oder Ansicht). Beachten Sie, dass das Diagramm dieser logischen Superset-Tabelle zugeordnet ist welche auf die hier angegebene physische Tabelle verweist."
       ],
@@ -3329,6 +3978,9 @@
         "Der Port muss eine ganze Zahl kleiner oder gleich 65535 sein."
       ],
       "The port number is invalid.": ["Die Port-Nummer ist ungültig."],
+      "The primary metric is used to define the arc segment sizes": [
+        "Die primäre Metrik wird verwendet, um die Bogensegmentgrößen zu definieren"
+      ],
       "The provided `rows` argument is not a valid integer.": [
         "Das angegebene Argument 'rows' ist keine gültige ganze Zahl."
       ],
@@ -3341,6 +3993,9 @@
       "The query contains one or more malformed template parameters.": [
         "Die Abfrage enthält einen oder mehrere fehlerhafte Vorlagenparameter."
       ],
+      "The query couldn't be loaded": [
+        "Die Abfrage konnte nicht geladen werden"
+      ],
       "The query has a syntax error.": [
         "Die Abfrage weist einen Syntaxfehler auf."
       ],
@@ -3350,6 +4005,13 @@
       "The query was killed after %(sqllab_timeout)s seconds. It might be too complex, or the database might be under heavy load.": [
         "Die Abfrage wurde nach %(sqllab_timeout)s Sekunden abgebrochen. Sie war eventuell zu komplex, oder die Datenbank ist aktuell stark belastet."
       ],
+      "The radius (in pixels) the algorithm uses to define a cluster. Choose 0 to turn off clustering, but beware that a large number of points (>1000) will cause lag.": [
+        "Der Radius (in Pixel), den der Algorithmus zum Definieren eines Clusters verwendet. Wählen Sie 0, um das Clustering zu deaktivieren, aber beachten Sie, dass eine große Anzahl von Punkten (>1000) zu Verzögerungen führt."
+      ],
+      "The radius of individual points (ones that are not in a cluster). Either a numerical column or `Auto`, which scales the point based on the largest cluster": [
+        "Der Radius einzelner Punkte (die sich nicht in einem Cluster befinden). Entweder eine numerische Spalte oder \"Auto\", die den Punkt basierend auf dem größten Cluster skaliert"
+      ],
+      "The report has been created": ["Der Report wurde erstellt"],
       "The results backend no longer has the data from the query.": [
         "Das Ergebnis-Backend verfügt nicht mehr über die Daten aus der Abfrage."
       ],
@@ -3367,6 +4029,9 @@
       ],
       "The schema was deleted or renamed in the database.": [
         "Das Schema wurde in der Datenbank gelöscht oder umbenannt."
+      ],
+      "The size of the square cell, in pixels": [
+        "Die Größe der quadratischen Zelle in Pixel"
       ],
       "The submitted payload has the incorrect format.": [
         "Die übermittelte Nutzlast hat das falsche Format."
@@ -3398,8 +4063,17 @@
       "The time range for the visualization. All relative times, e.g. \"Last month\", \"Last 7 days\", \"now\", etc. are evaluated on the server using the server's local time (sans timezone). All tooltips and placeholder times are expressed in UTC (sans timezone). The timestamps are then evaluated by the database using the engine's local timezone. Note one can explicitly set the timezone per the ISO 8601 format if specifying either the start and/or end time.": [
         "Der Zeitraum für die Visualisierung. Alle relativen Zeiten, z.B. \"Letzter Monat\", \"Letzte 7 Tage\", \"jetzt\" usw., werden auf dem Server anhand der Ortszeit des Servers (ohne Zeitzone) ausgewertet. Alle QuickInfos und Platzhalterzeiten werden in UTC (ohne Zeitzone) ausgedrückt. Die Zeitstempel werden dann von der Datenbank anhand der lokalen Zeitzone des Moduls ausgewertet. Beachten Sie, dass man die Zeitzone explizit nach dem ISO 8601-Format festlegen kann, wenn entweder die Start- und/oder Endzeit angegeben wird."
       ],
+      "The time unit for each block. Should be a smaller unit than domain_granularity. Should be larger or equal to Time Grain": [
+        "Die Zeiteinheit für jeden Block. Sollte eine kleinere Einheit als domain_granularity sein. Sollte größer oder gleich Zeitgranularität sein"
+      ],
+      "The time unit used for the grouping of blocks": [
+        "Die Zeiteinheit, die für die Gruppierung von Blöcken verwendet wird"
+      ],
       "The type of visualization to display": [
         "Der anzuzeigende Visualisierungstyp"
+      ],
+      "The unit of measure for the specified point radius": [
+        "Die Maßeinheit für den angegebenen Punktradius"
       ],
       "The user seems to have been deleted": [
         "Der/die Benutzer*in scheint gelöscht worden zu sein"
@@ -3429,6 +4103,12 @@
       "There is no chart definition associated with this component, could it have been deleted?": [
         "Es gibt keine Diagrammdefinition, die dieser Komponente zugeordnet ist. Könnte sie gelöscht worden sein?"
       ],
+      "There is not enough space for this component. Try decreasing its width, or increasing the destination width.": [
+        "Für diese Komponente ist nicht genügend Platz vorhanden. Versuchen Sie, die Breite zu verringern oder die Zielbreite zu erhöhen."
+      ],
+      "There was an error fetching the favorite status: %s": [
+        "Beim Abrufen des Favoritenstatus ist ein Problem aufgetreten: %s"
+      ],
       "There was an error fetching your recent activity:": [
         "Beim Abrufen der letzten Aktivität ist ein Fehler aufgetreten:"
       ],
@@ -3437,6 +4117,9 @@
       ],
       "There was an error loading the tables": [
         "Beim Laden der Tabellen ist ein Fehler aufgetreten"
+      ],
+      "There was an error saving the favorite status: %s": [
+        "Beim Speichern des Favoritenstatus ist ein Fehler aufgetreten: %s"
       ],
       "There was an error with your request": [
         "Bei Ihrer Anfrage ist ein Fehler aufgetreten"
@@ -3470,6 +4153,15 @@
       ],
       "There was an issue deleting: %s": [
         "Beim Löschen ist ein Problem aufgetreten: %s"
+      ],
+      "There was an issue favoriting this dashboard.": [
+        "Es gab ein Problem dabei, dieses Dashboard zu den Favoriten hinzuzufügen."
+      ],
+      "There was an issue fetching reports attached to this dashboard.": [
+        "Es gab ein Problem beim Abrufen von Reports, die an dieses Dashboard angehängt waren."
+      ],
+      "There was an issue fetching the favorite status of this dashboard.": [
+        "Beim Abrufen des Favoritenstatus dieses Dashboards ist ein Problem aufgetreten."
       ],
       "There was an issue fetching your recent activity: %s": [
         "Beim Abrufen Ihrer letzten Aktivität ist ein Problem aufgetreten: %s"
@@ -3519,6 +4211,12 @@
       "This can be either an IP address (e.g. 127.0.0.1) or a domain name (e.g. mydatabase.com).": [
         "Dies kann entweder eine IP-Adresse (z.B. 127.0.0.1) oder ein Domainname (z.B. mydatabase.com) sein."
       ],
+      "This chart has been moved to a different filter scope.": [
+        "Dieses Diagramm wurde in einen anderen Filterbereich verschoben."
+      ],
+      "This chart might be incompatible with the filter (datasets don't match)": [
+        "Dieses Diagramm ist möglicherweise nicht mit dem Filter kompatibel (Datensätze stimmen nicht überein)"
+      ],
       "This color scheme is being overriden by custom label colors.\n              Check the JSON metadata in the Advanced settings": [
         "Dieses Farbschema wird durch benutzerdefinierte Beschriftungsfarben überschrieben.\n              Überprüfen Sie die JSON-Metadaten in den erweiterten Einstellungen"
       ],
@@ -3534,14 +4232,24 @@
       "This dashboard is not published, it will not show up in the list of dashboards. Click here to publish this dashboard.": [
         "Dieses Dashboard ist nicht veröffentlicht, es wird nicht in der Liste der Dashboards angezeigt. Klicken Sie hier, um dieses Dashboard zu veröffentlichen."
       ],
+      "This dashboard is now hidden": ["Dieses Dashboard ist nun verborgen"],
+      "This dashboard is now published": [
+        "Dieses Dashboard ist jetzt veröffentlicht"
+      ],
       "This dashboard is published. Click to make it a draft.": [
         "Dieses Dashboard ist veröffentlicht. Klicken Sie hier, um es in den Entwurfstatus zu setzen."
       ],
       "This dashboard was changed recently. Please reload dashboard to get latest version.": [
         "Dieses Dashboard wurde kürzlich geändert. Bitte laden Sie das Dashboard neu, um die neueste Version zu erhalten."
       ],
+      "This dashboard was saved successfully.": [
+        "Dieses Dashboard wurde erfolgreich gespeichert."
+      ],
       "This defines the element to be plotted on the chart": [
         "Definiert das Element, das im Diagramm dargestellt werden soll"
+      ],
+      "This defines the level of the hierarchy": [
+        "Dies definiert die Ebene der Hierarchie"
       ],
       "This feature is deprecated and will be removed on 2.0. Take a look at the replacement feature <a href='https://superset.apache.org/docs/installation/alerts-reports'>Alerts & Reports documentation</a>": [
         "Diese Funktion ist veraltet und wird in 2.0 entfernt. Werfen Sie einen Blick auf die Dokumentation zur Ersatzfunktion <a href='https://superset.apache.org/docs/installation/alerts-reports'>Alerts & Reports</a>"
@@ -3587,10 +4295,18 @@
         "Dieser Visualisierungstyp wird nicht unterstützt."
       ],
       "This was triggered by:": ["Ausgelöst durch:"],
+      "Threshold alpha level for determining significance": [
+        "Schwellenwert für Alpha-Level zur Bestimmung der Signifikanz"
+      ],
       "Thursday": ["Donnerstag"],
       "Time": ["Zeit"],
+      "Time Column": ["Zeitspalte"],
       "Time Comparison": ["Zeitvergleich"],
+      "Time Format": ["Zeitformat"],
+      "Time Grain": ["Zeitgranularität"],
+      "Time Granularity": ["Zeitgranularität"],
       "Time Offset": ["Zeitversatz"],
+      "Time Range": ["Zeitraum"],
       "Time Series": ["Zeitreihen"],
       "Time Series - Bar Chart": ["Zeitreihen - Balkendiagramm"],
       "Time Series - Dual Axis Line Chart": [
@@ -3614,6 +4330,7 @@
       "Time column \"%(col)s\" does not exist in dataset": [
         "Zeitspalte \"%(col)s\" ist im Datensatz nicht vorhanden"
       ],
+      "Time column filter plugin": ["Zeitspalten-Filter-Plugin"],
       "Time comparison": ["Zeitvergleich"],
       "Time delta is ambiguous. Please specify [%(human_readable)s ago] or [%(human_readable)s later].": [
         "Zeitinterval ist unklar. Bitte geben Sie [%(human_readable)s ago] oder [%(human_readable)s later] an."
@@ -3624,7 +4341,9 @@
       "Time filter": ["Zeitfilter"],
       "Time format": ["Zeitformat"],
       "Time grain": ["Zeitgranularität"],
+      "Time grain filter plugin": ["Zeitgranularität-Plugin"],
       "Time grain missing": ["Zeiteinteilung fehlt"],
+      "Time granularity": ["Zeitgranularität"],
       "Time in seconds": ["Zeit in Sekunden"],
       "Time range": ["Zeitbereich"],
       "Time range endpoints": ["Endpunkte des Zeitbereichs"],
@@ -3635,13 +4354,44 @@
       "Time string is ambiguous. Please specify [%(human_readable)s ago] or [%(human_readable)s later].": [
         "Die Zeitzeichenfolge ist mehrdeutig. Bitte geben Sie [%(human_readable)s ago] oder [%(human_readable)s later] an."
       ],
+      "Time-series Area Chart": ["Zeitreihen-Flächendiagramm"],
+      "Time-series Area chart are similar to line chart in that they represent variables with the same scale, but area charts stack the metrics on top of each other. An area chart in Superset can be stream, stack, or expand.": [
+        "Zeitreihen-Flächendiagramme ähneln Liniendiagrammen insofern, als sie Variablen mit der gleichen Skala darstellen, aber Flächendiagramme stapeln die Metriken übereinander. Ein Flächendiagramm in Superset kann streamen, stapeln oder erweitern."
+      ],
+      "Time-series Bar Chart": ["Zeitreihen - Balkendiagramm"],
+      "Time-series Bar Chart v2": ["Zeitreihen-Balkendiagramm v2"],
+      "Time-series Bar Charts are used to show the changes in a metric over time as a series of bars.": [
+        "Zeitreihen-Balkendiagramme werden verwendet, um die Änderungen in einer Metrik im Laufe der Zeit als eine Reihe von Balken anzuzeigen."
+      ],
+      "Time-series Chart": ["Zeitreihendiagramm"],
+      "Time-series Line Chart": ["Zeitreihen - Liniendiagramm"],
+      "Time-series Percent Change": ["Zeitreihen - Prozentuale Veränderung"],
+      "Time-series Period Pivot": ["Zeitreihen - Perioden-Pivot"],
+      "Time-series Scatter Plot": ["Zeitreihen-Streudiagramm"],
+      "Time-series Scatter Plot has time on the horizontal axis in linear units, and the points are connected in order. It shows a statistical relationship between two variables.": [
+        "Das Zeitreihen-Streudiagramm stellt die Zeit auf der horizontalen Achse in linearen Einheiten dar, und die Punkte sind in der richtigen Reihenfolge verbunden. Es zeigt eine statistische Beziehung zwischen zwei Variablen."
+      ],
+      "Time-series Smooth Line": ["Zeitreihe Glatte Linie"],
+      "Time-series Smooth-line is a variation of line chart. Without angles and hard edges, Smooth-line looks more smarter and more professional.": [
+        "Zeitreihe Glatte Linie ist eine Variation des Liniendiagramms. Ohne Winkel und harte Kanten sieht Smooth-line raffinierter und professioneller aus."
+      ],
+      "Time-series Stepped Line": ["Zeitreihen-Stufenlinie"],
+      "Time-series Stepped-line graph (also called step chart) is a variation of line chart but with the line forming a series of steps between data points. A step chart can be useful when you want to show the changes that occur at irregular intervals.": [
+        "Zeitreihen-Stufenliniendiagramm (auch Schrittdiagramm genannt) ist eine Variation des Liniendiagramms, wobei die Linie jedoch eine Reihe von Schritten zwischen Datenpunkten bildet. Ein Schrittdiagramm kann nützlich sein, wenn Sie die Änderungen anzeigen möchten, die in unregelmäßigen Abständen auftreten."
+      ],
+      "Time-series Table": ["Zeitreihentabelle"],
+      "Time-series line chart is used to visualize repeated measurements taken over regular time intervals. Line chart is a type of chart which displays information as a series of data points connected by straight line segments. It is a basic type of chart common in many fields.": [
+        "Das Zeitreihen-Liniendiagramm wird verwendet, um wiederholte Messungen in regelmäßigen Zeitintervallen zu visualisieren. Liniendiagramm ist ein Diagrammtyp, der Informationen als eine Reihe von Datenpunkten anzeigt, die durch gerade Liniensegmente verbunden sind. Es ist ein grundlegender Diagrammtyp, der in vielen Bereichen üblich ist."
+      ],
       "Timeout error": ["Zeitüberschreitung"],
+      "Timestamp Format": ["Zeitstempelformat"],
       "Timestamp format": ["Zeitstempelformat"],
       "Timezone": ["Zeitzone"],
       "Timezone offset (in hours) for this datasource": [
         "Zeitzonen-Offset (in Stunden) für diese Datenquelle"
       ],
       "Timezone selector": ["Zeitzonen-Auswahl"],
+      "Tiny": ["Sehr klein"],
       "Title": ["Titel"],
       "Title Column": ["Titelspalte"],
       "Title is required": ["Titel ist erforderlich"],
@@ -3653,15 +4403,24 @@
         "So erhalten Sie eine sprechende URL für Ihr Dashboard"
       ],
       "Toggle chart description": ["Diagramm-Beschreibung umschalten"],
+      "Tools": ["Werkzeuge"],
       "Tooltip": ["Tooltip"],
       "Tooltip sort by metric": ["Tooltip nach Metrik sortieren"],
       "Tooltip time format": ["Tooltip-Zeitformat"],
+      "Top": ["Oben"],
       "Top to Bottom": ["Oben nach unten"],
       "Totals": ["Summen"],
       "Track job": ["Auftrag verfolgen"],
+      "Transformable": ["Transportierbar"],
+      "Transparent": ["Transparent"],
+      "Transpose Pivot": ["Pivot transponieren"],
+      "Transpose pivot": ["Pivot transponieren"],
+      "Tree Chart": ["Baumdiagramm"],
       "Tree layout": ["Baum-Layout"],
       "Tree orientation": ["Baumausrichtung"],
       "Treemap": ["Treemap"],
+      "Treemap v2": ["Treemap v2"],
+      "Trend": ["Trend"],
       "Triangle": ["Dreieck"],
       "Trigger Alert If...": ["Alarm auslösen falls..."],
       "Truncate Y Axis": ["Y-Achse abschneiden"],
@@ -3682,10 +4441,15 @@
       "Type is required": ["Typ ist erforderlich"],
       "Type of Google Sheets allowed": ["Art der zulässigen Google Tabellen"],
       "Type or Select [%s]": ["Geben Sie ein oder wählen Sie [%s] aus."],
+      "UI Configuration": ["UI Konfiguration"],
+      "URL": ["URL"],
       "URL Parameters": ["URL-Parameter"],
       "URL could not be identified": ["URL konnte nicht identifiziert werden"],
       "URL parameters": ["URL-Parameter"],
       "URL slug": ["URL Titelform"],
+      "Unable to add a new tab to the backend. Please contact your administrator.": [
+        "Dem Backend kann keine neue Registerkarte hinzugefügt werden. Wenden Sie sich an Ihre*n Administrator*in."
+      ],
       "Unable to connect to catalog named \"%(catalog_name)s\".": [
         "Es konnte keine Verbindung zum Katalog mit dem Namen \"%(catalog_name)s\" hergestellt werden."
       ],
@@ -3694,6 +4458,15 @@
       ],
       "Unable to find such a holiday: [%(holiday)s]": [
         "Kann einen solchen Feiertag nicht finden: [%(holiday)s]"
+      ],
+      "Unable to migrate query editor state to backend. Superset will retry later. Please contact your administrator if this problem persists.": [
+        "Der Status des Abfrage-Editors kann nicht zum Backend übertragen werden. Superset wird es später erneut versuchen. Wenden Sie sich an Ihre*n Administrator*in, wenn dieses Problem weiterhin besteht."
+      ],
+      "Unable to migrate query state to backend. Superset will retry later. Please contact your administrator if this problem persists.": [
+        "Der Abfragestatus kann nicht zum Backend übertragen werden. Superset wird es später erneut versuchen. Wenden Sie sich an Ihre*n Administrator*in, wenn dieses Problem weiterhin besteht."
+      ],
+      "Unable to migrate table schema state to backend. Superset will retry later. Please contact your administrator if this problem persists.": [
+        "Der Tabellenschemastatus kann nicht zum Backend übertragen werden. Superset wird es später erneut versuchen. Wenden Sie sich an Ihre*n Administrator*in, wenn dieses Problem weiterhin besteht."
       ],
       "Unable to refresh metadata for the following table(s): %(tables)s": [
         "Metadaten für die folgende(n) Tabelle(n) können nicht aktualisiert werden: %(tables)s"
@@ -3716,6 +4489,7 @@
       "Unexpected error occurred, please check your logs for details": [
         "Unerwarteter Fehler aufgetreten, bitte überprüfen Sie Ihre Protokolle auf Details"
       ],
+      "Unexpected error: ": ["Unerwarteter Fehler:"],
       "Unknown": ["Unbekannt"],
       "Unknown MySQL server host \"%(hostname)s\".": [
         "Unbekannter MySQL-Server-Host \"%(hostname)s\"."
@@ -3725,6 +4499,8 @@
       "Unknown column used in orderby: %(col)s": [
         "Unbekannte Spalte in ORDER BY verwendet: %(col)s"
       ],
+      "Unknown error": ["Unbekannter Fehler"],
+      "Unknown value": ["Unbekannter Wert"],
       "Unsafe return type for function %(func)s: %(value_type)s": [
         "Unsicherer Rückgabetyp für %(func)s: %(value_type)s"
       ],
@@ -3753,6 +4529,9 @@
       "Untitled Query %s": ["Unbenannte Abfrage %s"],
       "Untitled query": ["Unbenannte Abfrage"],
       "Update": ["Aktualisieren"],
+      "Updating chart was stopped": [
+        "Aktualisierung des Diagramms wurde abgebrochen"
+      ],
       "Upload": ["Hochladen"],
       "Upload Credentials": ["Anmeldeinformationen hochladen"],
       "Upload Excel": ["Excel hochladen"],
@@ -3765,6 +4544,9 @@
         "Verwenden Sie Pandas, um das datetime-Format automatisch zu interpretieren."
       ],
       "Use a log scale": ["Verwenden einer Logarithmischen Skala"],
+      "Use a log scale for the X-axis": [
+        "Logarithmische Skala für die X-Achse verwenden"
+      ],
       "Use a log scale for the Y-axis": [
         "Logarithmische Skala für die Y-Achse verwenden"
       ],
@@ -3774,6 +4556,10 @@
       "Use legacy datasource editor": [
         "Verwenden des Legacy-Datenquellen-Editors"
       ],
+      "Use metrics as a top level group for columns or for rows": [
+        "Verwenden von Metriken als Gruppe der obersten Ebene für Spalten oder Zeilen"
+      ],
+      "Use only a single value.": ["Verwenden Sie nur einen einzigen Wert."],
       "Use the Advanced Analytics options below": [
         "Verwenden Sie die untenstehenden fortgeschrittenen Analytik-Optionen"
       ],
@@ -3789,23 +4575,47 @@
       "Used internally to identify the plugin. Should be set to the package name from the pluginʼs package.json": [
         "Wird intern verwendet, um das Plugin zu identifizieren. Sollte auf den Paketnamen aus der paket.json des Plugins gesetzt werden"
       ],
+      "Used to summarize a set of data by grouping together multiple statistics along two axes. Examples: Sales numbers by region and month, tasks by status and assignee, active users by age and location.\n\n  This chart is being deprecated and we recommend checking out Pivot Table V2 instead!": [
+        "Wird verwendet, um einen Datensatz zusammenzufassen, indem mehrere Statistiken entlang zweier Achsen gruppiert werden. Beispiele: Verkaufszahlen nach Region und Monat, Aufgaben nach Status und Beauftragtem, aktive Nutzer nach Alter und Standort.\n\nDieses Diagramm ist überholt, und wir empfehlen stattdessen, Pivot Table V2 auszuprobieren!"
+      ],
+      "Used to summarize a set of data by grouping together multiple statistics along two axes. Examples: Sales numbers by region and month, tasks by status and assignee, active users by age and location. Not the most visually stunning visualization, but highly informative and versatile.": [
+        "Wird verwendet, um einen Datensatz zusammenzufassen, indem mehrere Statistiken entlang zweier Achsen gruppiert werden. Beispiele: Verkaufszahlen nach Region und Monat, Aufgaben nach Status und Beauftragtem, aktive Nutzer nach Alter und Standort. Nicht die visuell beeindruckendste Visualisierung, aber sehr informativ und vielseitig."
+      ],
       "User": ["Nutzer*in"],
       "User Roles": ["Nutzer*innen-Rollen"],
       "User doesn't have the proper permissions.": [
         "Benutzer*in verfügt nicht über die richtigen Berechtigungen."
       ],
+      "User must select a value before applying the filter": [
+        "Benutzer*in muss einen Wert für diesen Filter auswählen"
+      ],
       "User must select a value for this filter": [
+        "Benutzer*in muss einen Wert für diesen Filter auswählen"
+      ],
+      "User must select a value for this filter.": [
         "Benutzer*in muss einen Wert für diesen Filter auswählen"
       ],
       "User query": ["Benutzer*innen-Abfrage"],
       "Username": ["Benutzer*innenname"],
+      "Uses a gauge to showcase progress of a metric towards a target. The position of the dial represents the progress and the terminal value in the gauge represents the target value.": [
+        "Verwendet ein Tachometer, um den Fortschritt einer Metrik in Richtung eines Ziels anzuzeigen. Die Position des Zifferblatts stellt den Fortschritt und der Endwert im Tachometer den Zielwert dar."
+      ],
+      "Uses circles to visualize the flow of data through different stages of a system. Hover over individual paths in the visualization to understand the stages a value took. Useful for multi-stage, multi-group visualizing funnels and pipelines.": [
+        "Verwendet Kreise, um den Datenfluss durch verschiedene Phasen eines Systems zu visualisieren. Bewegen Sie den Mauszeiger über einzelne Pfade in der Visualisierung, um die Phasen zu verstehen, die ein Wert durchlaufen hat. Nützlich für die Visualisierung von Trichtern und Pipelines in mehreren Gruppen."
+      ],
       "Value": ["Wert"],
+      "Value Domain": ["Wertebereich"],
+      "Value Format": ["Wertformat"],
+      "Value bounds": ["Wertgrenzen"],
       "Value format": ["Wertformat"],
       "Value is required": ["Wert ist erforderlich"],
       "Value must be greater than 0": ["Der Wert muss größer als 0 sein"],
+      "Vehicle Types": ["Fahrzeugtypen"],
       "Verbose Name": ["Ausführlicher Name"],
       "Version": ["Version"],
       "Version number": ["Versionsnummer"],
+      "Vertical": ["Vertikal"],
+      "Video game consoles": ["Videospielkonsolen"],
       "View All »": ["Alle ansehen »"],
       "View chart in Explore": ["Diagramm in Explorer anzeigen"],
       "View in SQL Lab": ["In SQL Lab anzeigen"],
@@ -3815,6 +4625,7 @@
       "View samples": ["Beispiele anzeigen"],
       "Viewed": ["Angesehen"],
       "Viewed %s": ["%s angesehen"],
+      "Viewport": ["Ansichtsfenster"],
       "Virtual (SQL)": ["Virtuell (SQL)"],
       "Virtual dataset": ["Virtueller Datensatz"],
       "Virtual dataset query cannot be empty": [
@@ -3826,9 +4637,49 @@
       "Virtual dataset query must be read-only": [
         "Virtuelle Datensatzabfrage muss schreibgeschützt sein"
       ],
+      "Visual Tweaks": ["Visuelle Optimierungen"],
       "Visualization": ["Visualisierung"],
       "Visualization Type": ["Visualisierungstyp"],
       "Visualization type": ["Visualisierungstyp"],
+      "Visualize a parallel set of metrics across multiple groups. Each group is visualized using its own line of points and each metric is represented as an edge in the chart.": [
+        "Visualisieren Sie einen parallelen Satz von Metriken über mehrere Gruppen hinweg. Jede Gruppe wird mit einer eigenen Punktlinie visualisiert und jede Metrik wird als Kante im Diagramm dargestellt."
+      ],
+      "Visualize a related metric across pairs of groups. Heatmaps excel at showcasing the correlation or strength between two groups. Color is used to emphasize the strength of the link between each pair of groups.": [
+        "Visualisieren Sie eine verwandte Metrik über Gruppenpaare hinweg. Heatmaps zeichnen sich dadurch aus, dass sie die Korrelation oder Stärke zwischen zwei Gruppen darstellen. Farbe wird verwendet, um die Stärke der Verbindung zwischen jedem Gruppenpaar zu betonen."
+      ],
+      "Visualize how a metric changes over time using bars. Add a group by column to visualize group level metrics and how they change over time.": [
+        "Visualisieren Sie mithilfe von Balken, wie sich eine Metrik im Laufe der Zeit ändert. Fügen Sie eine Gruppe nach Spalte hinzu, um Metriken auf Gruppenebene und deren Änderung im Laufe der Zeit zu visualisieren."
+      ],
+      "Visualize multiple levels of hierarchy using a familiar tree-like structure.": [
+        "Visualisieren Sie mehrere Hierarchieebenen mit einer vertrauten baumartigen Struktur."
+      ],
+      "Visualize two different time series using the same x-axis time range. Note that each time series can be visualized differently (e.g. 1 using bars and 1 using a line).": [
+        "Visualisieren Sie zwei verschiedene Zeitreihen mit demselben x-Achsen-Zeitbereich. Beachten Sie, dass jede Zeitreihe unterschiedlich visualisiert werden kann (z. B. 1 mit Balken und 1 mit einer Linie)."
+      ],
+      "Visualize two different time series using the same x-axis time range. This chart is being deprecated and we recommend using the Mixed Timeseries Chart instead!": [
+        "Visualisieren Sie zwei verschiedene Zeitreihen mit demselben x-Achsen-Zeitbereich. Dieses Diagramm ist überholt und wir empfehlen stattdessen, das Gemischte Zeitreihen-Diagramm zu verwenden!"
+      ],
+      "Visualizes 2 metrics as line plots using the same x-axis. This chart is useful for comparing metrics across the same time range.": [
+        "Visualisiert 2 Metriken als Liniendiagramme mit derselben x-Achse. Dieses Diagramm ist nützlich, um Metriken über den gleichen Zeitraum zu vergleichen."
+      ],
+      "Visualizes a metric across three dimensions of data in a single chart (X axis, Y axis, and bubble size). Bubbles from the same group can be showcased using bubble color.": [
+        "Visualisiert eine Metrik über drei Datendimensionen in einem einzelnen Diagramm (X-Achse, Y-Achse und Blasengröße). Blasen aus derselben Gruppe können mit Blasenfarbe präsentiert werden."
+      ],
+      "Visualizes how a metric has changed over a time using a color scale and a calendar view. Gray values are used to indicate missing values and the linear color scheme is used to encode the magnitude of each day's value.": [
+        "Visualisiert, wie sich eine Metrik im Laufe der Zeit mithilfe einer Farbskala und einer Kalenderansicht verändert hat. Grauwerte werden verwendet, um fehlende Werte anzuzeigen, und das lineare Farbschema wird verwendet, um den Betrag jedes Tageswerts zu kodieren."
+      ],
+      "Visualizes how a single metric varies across a country's principal subdivisions (states, provinces, etc) on a chloropleth map. Each subdivision's value is elevated when you hover over the corresponding geographic boundary.": [
+        "Visualisiert, wie sich eine einzelne Metrik zwischen den wichtigsten Unterteilungen eines Landes (Bundesstaaten, Provinzen usw.) auf einer Chlorplethenkarte unterscheidet. Der Wert jeder Unterteilung wird erhöht, wenn Sie den Mauszeiger über die entsprechende geografische Grenze bewegen."
+      ],
+      "Visualizes many different time-series objects in a single chart. This chart is being deprecated and we recommend using the Time-series Chart instead.": [
+        "Visualisiert viele verschiedene Zeitreihenobjekte in einem einzigen Diagramm. Dieses Diagramm ist überholt, und wir empfehlen, stattdessen das Zeitreihendiagramm zu verwenden."
+      ],
+      "Visualizes the flow of different group's values through different stages of a system. New stages in the pipeline are visualized as nodes or layers. The thickness of the bars or edges represent the metric being visualized.": [
+        "Visualisiert den Fluss der Werte verschiedener Gruppen durch verschiedene Phasen eines Systems. Neue Stufen in der Pipeline werden als Knoten oder Layer visualisiert. Die Dicke der Balken oder Kanten stellt die Metrik dar, die visualisiert wird."
+      ],
+      "Visualizes the words in a column that appear the most often. Bigger font corresponds to higher frequency.": [
+        "Visualisiert die Wörter in einer Spalte, die am häufigsten vorkommen. Größere Schrift entspricht einer höheren Frequenz."
+      ],
       "Viz is missing a datasource": ["Visualisierung fehlt eine Datenquelle"],
       "Viz type": ["Visualisierungstyp"],
       "WED": ["MI"],
@@ -3853,18 +4704,23 @@
       "We recommend your summarize your data further before following that flow. ": [
         "Wir empfehlen Ihnen, Ihre Daten weiter zusammenzufassen, bevor Sie fortfahren. "
       ],
+      "We were unable to active or deactivate this report.": [
+        "Wir konnten diesen Bericht nicht aktivieren oder deaktivieren."
+      ],
       "We were unable to connect to your database named \"%(database)s\". Please verify your database name and try again.": [
         "Wir konnten keine Verbindung zu Ihrer Datenbank mit dem Namen \"%(database)s\" herstellen. Überprüfen Sie Ihren Datenbanknamen und versuchen Sie es erneut."
       ],
       "We were unable to connect to your database. Please confirm that your service account has the Viewer and Job User roles on the project.": [
         "Wir konnten keine Verbindung zu Ihrer Datenbank herstellen. Vergewissern Sie sich, dass Ihr Dienstkonto über die Rollen „Viewer“ und „Job User“ im Projekt verfügt."
       ],
+      "Web": ["Web"],
       "Wednesday": ["Mittwoch"],
       "Week": ["Woche"],
       "Week ending Saturday": ["Woche endet am Samstag"],
       "Week starting Monday": ["Woche beginnt am Montag"],
       "Week starting Sunday": ["Woche beginnt am Sonntag"],
       "Week_ending Sunday": ["Woche endet am Sonntag"],
+      "Weeks %s": ["Wochen %s"],
       "We’re having trouble loading these results. Queries are set to timeout after %s second.": [
         "Wir haben Probleme beim Laden dieser Ergebnisse. Abfragen überschreiten nach %s Sekunden die Ausführungszeit (Timeout)."
       ],
@@ -3877,11 +4733,17 @@
       "When `Calculation type` is set to \"Percentage change\", the Y Axis Format is forced to `.1%`": [
         "Wenn 'Berechnungstyp' auf \"Prozentuale Änderung\" gesetzt ist, wird das Y-Achsenformat '.1%' erzwungen"
       ],
+      "When a secondary metric is provided, a linear color scale is used.": [
+        "Wenn eine sekundäre Metrik bereitgestellt wird, wird eine lineare Farbskala verwendet."
+      ],
       "When allowing CREATE TABLE AS option in SQL Lab, this option forces the table to be created in this schema": [
         "Wenn Sie die Option CREATE TABLE AS in SQL Lab zulassen, erzwingt diese Option, dass die Tabelle in diesem Schema erstellt wird"
       ],
       "When enabled, users are able to visualize SQL Lab results in Explore.": [
         "Wenn diese Option aktiviert ist, können Benutzer*innen SQL Lab-Ergebnisse in Explore visualisieren."
+      ],
+      "When only a primary metric is provided, a categorical color scale is used.": [
+        "Wenn nur eine primäre Metrik bereitgestellt wird, wird eine kategoriale Farbpalette verwendet."
       ],
       "When specifying SQL, the datasource acts as a view. Superset will use this statement as a subquery while grouping and filtering on the generated parent queries.": [
         "Beim Angeben von SQL fungiert die Datenquelle als Ansicht. Superset verwendet diese Anweisung als Unterabfrage beim Gruppieren und Filtern der generierten übergeordneten Abfragen."
@@ -3907,8 +4769,14 @@
       "Whether to align positive and negative values in cell bar chart at 0": [
         "Ob positive und negative Werte im Zellbalkendiagramm bei 0 ausgerichtet werden sollen"
       ],
+      "Whether to always show the annotation label": [
+        "Ob die Anmerkungs-Beschriftung immer angezeigt werden soll"
+      ],
       "Whether to animate the progress and the value or just display them": [
         "Ob der Fortschritt und der Wert animiert oder nur angezeigt werden sollen"
+      ],
+      "Whether to apply a normal distribution based on rank on the color scale": [
+        "Ob eine Normalverteilung basierend auf dem Rang auf der Farbskala angewendet werden soll"
       ],
       "Whether to colorize numeric values by if they are positive or negative": [
         "Ob numerische Werte eingefärbt werden sollen, wenn sie positiv oder negativ sind"
@@ -3919,11 +4787,23 @@
       "Whether to display a legend for the chart": [
         "Ob eine Legende für das Diagramm angezeigt werden soll"
       ],
+      "Whether to display bubbles on top of countries": [
+        "Ob Blasen über Ländern angezeigt werden sollen"
+      ],
+      "Whether to display the interactive data table": [
+        "Ob die interaktive Datentabelle angezeigt werden soll"
+      ],
       "Whether to display the labels.": [
         "Ob die Beschriftungen angezeigt werden sollen."
       ],
+      "Whether to display the labels. Note that the label only displays when the the 5% threshold.": [
+        "Ob die Beschriftungen angezeigt werden sollen. Beachten Sie, dass die Beschriftung nur angezeigt wird, wenn der Schwellenwert von 5 % erreicht ist."
+      ],
       "Whether to display the legend (toggles)": [
         "Ob die Legende angezeigt werden soll (Wechselschalter)"
+      ],
+      "Whether to display the metric name as a title": [
+        "Ob der Metrikname als Titel angezeigt werden soll"
       ],
       "Whether to display the min and max values of the X-axis": [
         "Ob die Min- und Max-Werte der X-Achse angezeigt werden sollen"
@@ -3949,17 +4829,29 @@
       "Whether to enable node dragging in force layout mode.": [
         "Ob das Ziehen von Knoten im Kräfte-basierten Layoutmodus aktiviert werden soll."
       ],
+      "Whether to format the timestamp": [
+        "Ob der Zeitstempel formatiert werden soll"
+      ],
       "Whether to include a client-side search box": [
         "Ob ein clientseitiges Suchfeld eingeschlossen werden soll"
       ],
       "Whether to include a time filter": [
         "Ob ein Zeitfilter eingebunden werden soll"
       ],
+      "Whether to include the percentage in the tooltip": [
+        "Ob der Prozentsatz in Tooltip aufgenommen werden soll"
+      ],
       "Whether to include the time granularity as defined in the time section": [
         "Ob die im Zeitabschnitt definierte Zeitgranularität einbezogen werden soll"
       ],
+      "Whether to make the histogram cumulative": [
+        "Ob das Histogramm kumulativ dargestellt werden soll"
+      ],
       "Whether to make this column available as a [Time Granularity] option, column has to be DATETIME or DATETIME-like": [
         "Unabhängig davon, ob diese Spalte als [Zeitgranularität]-Option verfügbar gemacht werden soll, muss die Spalte DATETIME oder DATETIME-ähnlich sein"
+      ],
+      "Whether to normalize the histogram": [
+        "Ob das Histogramm normalisiert werden soll"
       ],
       "Whether to populate autocomplete filters options": [
         "Ob Optionen für Auto-Vervollständigen-Filter vorgefühlt werden sollen"
@@ -3992,14 +4884,22 @@
       "Whether to sort tooltip by the selected metric in descending order.": [
         "Ob der Tooltip nach der ausgewählten Metrik in absteigender Reihenfolge sortiert werden soll."
       ],
+      "Which country to plot the map for?": [
+        "Für welches Land soll die Karte geplottet werden?"
+      ],
       "Which relatives to highlight on hover": [
         "Welche Verwandten beim Überfahren mit der Maus hervorgehoben werden sollen"
       ],
+      "Whisker/outlier options": ["Whisker/Ausreißer-Optionen"],
+      "White": ["Weiß"],
       "Width": ["Breite"],
       "Width of the confidence interval. Should be between 0 and 1": [
         "Breite des Konfidenzintervalls. Sollte zwischen 0 und 1 liegen"
       ],
       "Window must be > 0": ["Fenster muss > 0 sein"],
+      "With a subheader": ["Mit einem Untertitel"],
+      "Word Cloud": ["Wortwolke"],
+      "Word Rotation": ["Wort-Rotation"],
       "Working": ["In Bearbeitung"],
       "Working timeout": ["Zeitüberschreitung"],
       "World Map": ["Weltkarte"],
@@ -4012,20 +4912,28 @@
       "X Axis Format": ["X-Achsen-Format"],
       "X Axis Label": ["X Achsenbeschriftung"],
       "X Axis Title": ["Titel der X-Achse"],
+      "X Log Scale": ["X-Log-Skala"],
       "X Tick Layout": ["X Tick Layout"],
       "X bounds": ["X-Grenzen"],
+      "XScale Interval": ["X-Skalen-Intervall"],
       "Y 2 bounds": ["Y 2 Grenzen"],
       "Y AXIS TITLE MARGIN": ["Y-ACHSE TITEL RAND"],
       "Y AXIS TITLE POSITION": ["Y-ACHSE TITEL POSITION"],
       "Y Axis": ["Y-Achse"],
+      "Y Axis 1": ["Y-Achse 1"],
+      "Y Axis 2": ["Y-Achse 2"],
       "Y Axis 2 Bounds": ["Grenzen der Y-Achse 2"],
       "Y Axis Bounds": ["Grenzen der Y-Achse"],
       "Y Axis Format": ["Y-Achsenformat"],
       "Y Axis Label": ["Y Achsenbeschriftung"],
+      "Y Axis Left": ["Y-Achse links"],
+      "Y Axis Right": ["Y-Achse rechts"],
       "Y Axis Title": ["Titel der Y-Achse"],
       "Y Log Scale": ["Y-Log-Skala"],
       "Y bounds": ["Y-Grenzen"],
+      "YScale Interval": ["Y-Skalen-Intervall"],
       "Year": ["Jahr"],
+      "Years %s": ["Jahre %s"],
       "Yes": ["Ja"],
       "Yes, cancel": ["Ja, abbrechen"],
       "You are importing one or more charts that already exist. Overwriting might cause you to lose some of your work. Are you sure you want to overwrite?": [
@@ -4035,6 +4943,9 @@
         "Sie importieren ein oder mehrere Dashboards, die bereits vorhanden sind. Das Überschreiben kann dazu führen, dass Sie einen Teil Ihrer Arbeit verlieren. Sind Sie sicher, dass Sie diese überschreiben möchten?"
       ],
       "You are importing one or more databases that already exist. Overwriting might cause you to lose some of your work. Are you sure you want to overwrite?": [
+        "Sie importieren eine oder mehrere Datenbanken, die bereits vorhanden sind. Das Überschreiben kann dazu führen, dass Sie einen Teil Ihrer Arbeit verlieren. Sind Sie sicher, dass Sie diese überschreiben möchten?"
+      ],
+      "You are importing one or more datasets that already exist. Overwriting might cause you to lose some of your work. Are you sure you want to overwrite?": [
         "Sie importieren eine oder mehrere Datenbanken, die bereits vorhanden sind. Das Überschreiben kann dazu führen, dass Sie einen Teil Ihrer Arbeit verlieren. Sind Sie sicher, dass Sie diese überschreiben möchten?"
       ],
       "You are importing one or more saved queries that already exist. Overwriting might cause you to lose some of your work. Are you sure you want to overwrite?": [
@@ -4055,6 +4966,9 @@
       "You cannot specify a namespace both in the name of the table: \"%(excel_table.table)s\" and in the schema field: \"%(excel_table.schema)s\". Please remove one": [
         "Sie können keinen Namespace sowohl im Namen der Tabelle: \"%(excel_table.table)s\" als auch im Schemafeld: \"%(excel_table.schema)s\" angeben. Bitte entfernen Sie eine"
       ],
+      "You cannot use 45° tick layout along with the time range filter": [
+        "Sie können das 45°-Strich-Layout nicht zusammen mit dem Zeitbereichsfilter verwenden"
+      ],
       "You cannot use [Columns] in combination with [Group By]/[Metrics]/[Percentage Metrics]. Please choose one or the other.": [
         "Sie können [Spalten] nicht in Kombination mit [Gruppieren nach]/[Metriken]/[Prozentmetriken] verwenden. Bitte wählen Sie das eine oder das andere."
       ],
@@ -4067,10 +4981,16 @@
       "You do not have permissions to access the datasource(s): %(name)s.": [
         "Sie haben keine Berechtigungen für den Zugriff auf die Datenquelle(n): %(name)s."
       ],
+      "You do not have permissions to edit this dashboard.": [
+        "Sie haben keine Berechtigungen zum Bearbeiten dieses Dashboards."
+      ],
       "You don't have access to this dashboard.": [
         "Sie haben keinen Zugriff auf dieses Dashboard."
       ],
       "You don't have any favorites yet!": ["Sie haben noch keine Favoriten!"],
+      "You don't have permission to modify the value.": [
+        "Sie sind nicht berechtigt, den Wert zu ändern."
+      ],
       "You don't have the rights to ": ["Sie haben nicht die Rechte "],
       "You don't have the rights to alter this title.": [
         "Sie haben nicht das Recht, diesen Titel zu ändern."
@@ -4089,6 +5009,25 @@
       "Your dashboard is too large. Please reduce its size before saving it.": [
         "Ihr Dashboard ist zu groß. Bitte reduzieren Sie die Größe, bevor Sie es speichern."
       ],
+      "Your query could not be saved": [
+        "Ihre Abfrage konnte nicht gespeichert werden"
+      ],
+      "Your query could not be scheduled": [
+        "Ihre Abfrage konnte nicht eingeplant werden"
+      ],
+      "Your query could not be updated": [
+        "Ihre Abfrage konnte nicht aktualisiert werden."
+      ],
+      "Your query has been scheduled. To see details of your query, navigate to Saved queries": [
+        "Ihre Abfrage wurde geplant. Um Details zu Ihrer Abfrage anzuzeigen, navigieren Sie zu Gespeicherte Abfragen"
+      ],
+      "Your query was saved": ["Ihre Abfrage wurde gespeichert"],
+      "Your query was updated": ["Ihre Abfrage wurde angehalten"],
+      "Your report could not be deleted": [
+        "Ihr Report konnte nicht gelöscht werden"
+      ],
+      "Zoom": ["Zoom"],
+      "Zoom level of the map": ["Zoomstufe der Karte"],
       "[Alert] %(label)s": ["[Alarm] %(label)s"],
       "[From]-": ["[Von]-"],
       "[Longitude] and [Latitude] columns must be present in [Group By]": [
@@ -4104,6 +5043,9 @@
       "[To]-": ["[Bis]-"],
       "[Untitled]": ["[Unbenannt]"],
       "[dashboard name]": ["[Dashboard-Name]"],
+      "[optional] this secondary metric is used to define the color as a ratio against the primary metric. When omitted, the color is categorical and based on labels": [
+        "[optional] Diese sekundäre Metrik wird verwendet, um die Farbe als Verhältnis zur primären Metrik zu definieren. Wenn keine angegeben, werden diskrete Farben verwendet, die auf den Beschriftungen basieren"
+      ],
       "`compare_columns` must have the same length as `source_columns`.": [
         "„compare_columns“ muss die gleiche Länge wie „source_columns“ haben."
       ],
@@ -4112,6 +5054,9 @@
       ],
       "`confidence_interval` must be between 0 and 1 (exclusive)": [
         "\"confidence_interval\" muss zwischen 0 und 1 liegen (exklusiv)"
+      ],
+      "`count` is COUNT(*) if a group by is used. Numerical columns will be aggregated with the aggregator. Non-numerical columns will be used to label points. Leave empty to get a count of points in each cluster.": [
+        "'count' ist COUNT(*), wenn ein ‚GROUP BY’ verwendet wird. Numerische Spalten werden mit der Aggregatfunktion aggregiert. Nicht numerische Spalten werden verwendet, um Punkte zu beschriften. Falls leer, wird die Anzahl der Punkte in jedem Cluster zurückgegeben."
       ],
       "`operation` property of post processing object undefined": [
         "'operation'-Eigenschaft des Nachbearbeitungsobjekts undefiniert"
@@ -4148,6 +5093,7 @@
       "bolt": ["Riegel"],
       "bottom": ["Unten"],
       "cached": ["gecached"],
+      "cannot be empty": ["darf nicht leer sein"],
       "cannot be used as a column name. The column name/alias \"__timestamp\"\n          is reserved for the main temporal expression, and column aliases ending with\n          double underscores followed by a numeric value (e.g. \"my_col__1\") are reserved\n          for deduplicating duplicate column names. Please use aliases to rename the\n          invalid column names.": [
         "kann nicht als Spaltenname verwendet werden. Der Spaltenname/Alias \"__timestamp\"\n          ist für den temporalen Hauptausdruck reserviert, und Spaltenaliase, die mit\n          doppelten Unterstrichen, gefolgt von einem numerischen Wert, enden (z. B. \"my_col__1“), sind\n          zum Deduplizieren doppelter Spaltennamen reserviert. Bitte verwenden Sie Aliase, um die\n          ungültigen Spaltennamen umzubenennen.\n."
       ],
@@ -4207,10 +5153,23 @@
       "here": ["hier"],
       "hour": ["Stunde"],
       "id:": ["id:"],
+      "image-rendering CSS attribute of the canvas object that defines how the browser scales up the image": [
+        "CSS-Attribut zum Rendern von Bildern des Canvas-Objekts, das definiert, wie der Browser das Bild hochskaliert"
+      ],
       "in": ["in"],
       "in modal": [" "],
+      "is expected to be a number": ["wird als Zahl erwartet"],
+      "is expected to be an integer": ["wird als Ganzzahl erwartet"],
       "joined": ["Verknüpft"],
       "json isn't valid": ["JSON ist ungültig"],
+      "key a-z": ["Schlüssel a-z"],
+      "key z-a": ["Schlüssel z-a"],
+      "label": ["Beschriftung"],
+      "last day": ["Gestern"],
+      "last month": ["letzter Monat"],
+      "last quarter": ["letztes Quartal"],
+      "last week": ["letzte Woche"],
+      "last year": ["letztes Jahr"],
       "latest partition:": ["neueste Partition:"],
       "left": ["Links"],
       "log": ["Protokoll"],
@@ -4221,16 +5180,22 @@
       "minute(s)": ["Minute(n)"],
       "month": ["Monat"],
       "must have a value": ["Muss einen Wert haben"],
+      "nvd3": ["nvd3"],
       "on": ["an"],
       "orderby column must be populated": [
         "ORDER BY-Spalte muss angegeben werden"
       ],
+      "p-value precision": ["p-Wert-Präzision"],
+      "page_size.all": ["page_size.all"],
       "page_size.entries": ["page_size.entries"],
       "page_size.show": ["page_size.show"],
       "percentile (exclusive)": ["Perzentil (exklusiv)"],
       "percentiles must be a list or tuple with two numeric values, of which the first is lower than the second value": [
         "Perzentile müssen eine Liste oder ein Tupel mit zwei numerischen Werten sein, von denen der erste niedriger als der zweite Wert ist"
       ],
+      "previous calendar month": ["vorheriger Kalendermonat"],
+      "previous calendar week": ["vorherige Kalenderwoche"],
+      "previous calendar year": ["vorheriges Kalenderjahr"],
       "published": ["veröffentlicht"],
       "queries": ["Abfragen"],
       "query": ["Abfrage"],
@@ -4244,11 +5209,16 @@
       "rows retrieved": ["abgerufene Zeilen"],
       "saved queries": ["gespeicherte Abfragen"],
       "search.num_records": ["search.num_records"],
+      "series: Treat each series independently; overall: All series use the same scale; change: Show changes compared to the first data point in each series": [
+        "Serie: Behandeln Sie jede Serie unabhängig voneinander; insgesamt: Alle Serien verwenden den gleichen Maßstab; Änderung: Änderungen im Vergleich zum ersten Datenpunkt in jeder Datenreihe anzeigen"
+      ],
       "textarea": ["Textfeld"],
       "top": ["Oben"],
       "upper percentile must be greater than 0 and less than 100. Must be higher than lower percentile.": [
         "Das obere Perzentil muss größer als 0 und kleiner als 100 sein. Muss größer als das untere Perzentil sein."
       ],
+      "value ascending": ["Wert aufsteigend"],
+      "value descending": ["Wert absteigend"],
       "virtual": ["virtuell"],
       "was created": ["wurde erstellt"],
       "week": ["Woche"],

--- a/superset/translations/de/LC_MESSAGES/messages.po
+++ b/superset/translations/de/LC_MESSAGES/messages.po
@@ -18,8 +18,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-12-08 12:22+0800\n"
-"PO-Revision-Date: 2021-11-29 20:28+0100\n"
+"POT-Creation-Date: 2021-12-08 22:44+0100\n"
+"PO-Revision-Date: 2021-12-08 22:46+0100\n"
 "Last-Translator: Holger Bruch <holger.bruch@wattbewerb.de>\n"
 "Language: de\n"
 "Language-Team: de <LL@li.org>\n"
@@ -225,12 +225,12 @@ msgstr ""
 "%(user)s wurde die Rolle %(role)s gewährt, die den Zugriff auf "
 "%(datasource)s erlaubt"
 
-#: superset/views/core.py:2773
+#: superset/views/core.py:2790
 #, python-format
 msgid "%(user)s's profile"
 msgstr "Profil von %(user)s"
 
-#: superset/views/core.py:2442
+#: superset/views/core.py:2459
 #, python-format
 msgid ""
 "%(validator)s was unable to check your query.\n"
@@ -241,7 +241,7 @@ msgstr ""
 "Bitte überprüfen Sie Ihre Anfrage.\n"
 "Ausnahme: %(ex)s"
 
-#: superset-frontend/src/explore/components/ExploreChartHeader/index.jsx:170
+#: superset-frontend/src/explore/components/ExploreChartHeader/index.jsx:176
 #, python-format
 msgid "%s - untitled"
 msgstr "%s - unbenannt"
@@ -334,7 +334,7 @@ msgstr "(gelöscht)"
 
 #: superset-frontend/src/utils/getClientErrorObject.ts:56
 msgid "(no description, click to see stack trace)"
-msgstr ""
+msgstr "(keine Beschreibung, klicken Sie hier, um Fehlermeldung zu sehen)"
 
 #: superset-frontend/src/explore/components/controls/FilterBoxItemControl/index.jsx:168
 msgid ""
@@ -428,12 +428,11 @@ msgstr "24 Stunden"
 #: superset-frontend/plugins/legacy-plugin-chart-country-map/src/index.js:32
 #: superset-frontend/plugins/legacy-plugin-chart-world-map/src/index.js:35
 msgid "2D"
-msgstr ""
+msgstr "2D"
 
 #: superset-frontend/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:116
-#, fuzzy
 msgid "3 letter code of the country"
-msgstr "jeden Tag des Monats"
+msgstr "3-Buchstaben-Code des Landes"
 
 #: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:128
 msgid "30 days"
@@ -513,9 +512,8 @@ msgid ">= (Larger or equal)"
 msgstr ">= (Größer oder gleich)"
 
 #: superset-frontend/plugins/legacy-preset-chart-big-number/src/BigNumberTotal/index.ts:35
-#, fuzzy
 msgid "A Big Number"
-msgstr "Große Zahl"
+msgstr "Eine Große Zahl"
 
 #: superset/views/alerts.py:195
 msgid ""
@@ -562,7 +560,7 @@ msgstr ""
 
 #: superset-frontend/plugins/legacy-plugin-chart-world-map/src/index.js:29
 msgid "A map of the world, that can indicate values in different countries."
-msgstr ""
+msgstr "Eine Weltkarte, die Werte in verschiedenen Ländern anzeigen kann."
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:161
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:209
@@ -576,6 +574,10 @@ msgid ""
 "angle, and the value represented by any wedge is illustrated by its area,"
 " rather than its radius or sweep angle."
 msgstr ""
+"Ein Polarkoordinatendiagramm, in dem der Kreis in Sektoren mit gleichem "
+"Winkel unterteilt ist und der Wert, der durch einen Sektor dargestellt "
+"wird, durch seine Fläche und nicht durch seinen Radius oder Sweep-Winkel "
+"veranschaulicht wird."
 
 #: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:523
 msgid "A readable URL for your dashboard"
@@ -606,6 +608,9 @@ msgid ""
 "A time series chart that visualizes how a related metric from multiple "
 "groups vary over time. Each group is visualized using a different color."
 msgstr ""
+"Ein Zeitreihendiagramm, das visualisiert, wie sich eine verwandte Metrik "
+"aus mehreren Gruppen im Laufe der Zeit ändert. Jede Gruppe wird mit einer"
+" anderen Farbe visualisiert."
 
 #: superset/reports/commands/exceptions.py:198
 msgid "A timeout occurred while executing the query."
@@ -658,6 +663,10 @@ msgstr "Zugang"
 msgid "Access requests"
 msgstr "Zugriffsanforderungen"
 
+#: superset-frontend/src/components/TableLoader/index.tsx:91
+msgid "Access to user activity data is restricted"
+msgstr "Der Zugriff auf Benutzeraktivitätsdaten ist eingeschränkt"
+
 #: superset/views/core.py:300
 msgid "Access was requested"
 msgstr "Zugang wurde beantragt"
@@ -694,9 +703,8 @@ msgstr "Tatsächlicher Zeitbereich"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:28
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:49
-#, fuzzy
 msgid "Adaptative formating"
-msgstr "Datumsformat"
+msgstr "Adaptative Formatierung"
 
 #: superset-frontend/src/components/ReportModal/index.tsx:267
 #: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTitlePane.tsx:133
@@ -880,9 +888,8 @@ msgstr ""
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js:40
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/index.ts:55
 #: superset-frontend/plugins/plugin-chart-table/src/index.ts:43
-#, fuzzy
 msgid "Additive"
-msgstr "Element hinzufügen"
+msgstr "Additiv"
 
 #: superset-frontend/src/components/Datasource/DatasourceEditor.jsx:765
 #: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:580
@@ -939,17 +946,15 @@ msgstr "Erweiterte Analysen"
 #: superset-frontend/plugins/plugin-chart-echarts/src/Treemap/index.ts:58
 #: superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/index.ts:41
 msgid "Aesthetic"
-msgstr ""
+msgstr "Ästhetisch"
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:84
-#, fuzzy
 msgid "After"
-msgstr "Datum"
+msgstr "Nach"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/constants.ts:45
-#, fuzzy
 msgid "Aggregate"
-msgstr "Aggregat"
+msgstr "Aggregieren"
 
 #: superset-frontend/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:91
 msgid "Aggregate Mean"
@@ -964,6 +969,8 @@ msgid ""
 "Aggregate function applied to the list of points in each cluster to "
 "produce the cluster label."
 msgstr ""
+"Aggregatfunktion, die auf die Liste der Punkte in jedem Cluster "
+"angewendet wird, um die Clusterbezeichnung zu erstellen."
 
 #: superset-frontend/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.ts:74
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:137
@@ -971,12 +978,13 @@ msgid ""
 "Aggregate function to apply when pivoting and computing the total rows "
 "and columns"
 msgstr ""
+"Aggregatfunktion, die beim Pivotieren und Berechnen der Summe der Zeilen "
+"und Spalten angewendet werden soll"
 
 #: superset-frontend/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.ts:63
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:114
-#, fuzzy
 msgid "Aggregation function"
-msgstr "Python-Funktionen"
+msgstr "Aggregationsfunktion"
 
 #: superset-frontend/src/views/CRUD/alert/components/AlertStatusIcon.tsx:92
 msgid "Alert Triggered, In Grace Period"
@@ -1093,9 +1101,8 @@ msgid "All charts"
 msgstr "Alle Diagramme"
 
 #: superset-frontend/src/dashboard/util/getFilterFieldNodesTree.js:44
-#, fuzzy
 msgid "All filters"
-msgstr "Datumsfilter"
+msgstr "Alle Filter"
 
 #: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx:326
 #, python-format
@@ -1103,9 +1110,8 @@ msgid "All filters (%(filterCount)d)"
 msgstr "Alle Filter (%(filterCount)d)"
 
 #: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/state.ts:49
-#, fuzzy
 msgid "All panels"
-msgstr "Auf alle Bereiche anwenden"
+msgstr "Alle Bereiche"
 
 #: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.tsx:132
 msgid "All panels with this column will be affected by this filter"
@@ -1190,7 +1196,7 @@ msgstr "Knotenauswahl zulassen"
 #: superset-frontend/src/filters/components/GroupBy/controlPanel.ts:64
 #: superset-frontend/src/filters/components/Select/controlPanel.ts:82
 msgid "Allow selecting multiple values"
-msgstr ""
+msgstr "Auswählen mehrerer Werte zulassen"
 
 #: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:192
 msgid "Allow this database to be explored"
@@ -1220,6 +1226,11 @@ msgid ""
 "middle emphasizes the mean, median, and inner 2 quartiles. The whiskers "
 "around each box visualize the min, max, range, and outer 2 quartiles."
 msgstr ""
+"Diese Visualisierung, die auch als Box-Whisker-Plot bezeichnet wird, "
+"vergleicht die Verteilungen einer Metrik über mehrere Gruppen hinweg. Der"
+" Kasten in der Mitte stellt den Mittelwert, den Median und die inneren 2 "
+"Quartile dar. Die sogenannten „Whisker“ um jede Box visualisieren die "
+"Min-, Max-, Range- und äußeren 2 Quartile."
 
 #: superset-frontend/src/components/AlteredSliceTag/index.jsx:182
 msgid "Altered"
@@ -1251,7 +1262,7 @@ msgid "An error has occurred"
 msgstr "Ein Fehler ist aufgetreten"
 
 #: superset-frontend/src/SqlLab/components/ExploreCtasResultsButton/index.jsx:80
-#: superset-frontend/src/components/TableLoader/index.tsx:48
+#: superset-frontend/src/components/TableLoader/index.tsx:55
 #: superset-frontend/src/utils/getClientErrorObject.ts:135
 msgid "An error occurred"
 msgstr "Ein Fehler ist aufgetreten"
@@ -1265,70 +1276,63 @@ msgid "An error occurred when refreshing queries"
 msgstr "Beim Aktualisieren von Abfragen ist ein Fehler aufgetreten"
 
 #: superset/key_value/commands/exceptions.py:33
-#, fuzzy, python-format
 msgid "An error occurred while accessing the value."
-msgstr "Beim Abrufen von Schemawerten ist ein Fehler aufgetreten: %s"
+msgstr "Beim Zugriff auf den Wert ist ein Fehler aufgetreten."
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:1165
-#, fuzzy
 msgid ""
 "An error occurred while collapsing the table schema. Please contact your "
 "administrator."
 msgstr ""
-"Ein unbekannter Fehler ist aufgetreten. Wenden Sie sich an Ihre*n "
-"Superset-Administrator*in"
+"Beim Reduzieren des Tabellenschemas ist ein Fehler aufgetreten. Wenden "
+"Sie sich an Ihre*n Administrator*in."
 
 #: superset-frontend/src/views/CRUD/hooks.ts:301
-#, fuzzy, python-format
+#, python-format
 msgid "An error occurred while creating %ss: %s"
-msgstr "Beim Abrufen von Datensätzen ist ein Fehler aufgetreten: %s"
+msgstr "Beim Erstellen von %s ist ein Fehler aufgetreten: %s"
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:1313
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:1335
-#, fuzzy, python-format
 msgid "An error occurred while creating the data source"
-msgstr "Beim Abrufen von Datensätzen ist ein Fehler aufgetreten: %s"
+msgstr "Beim Erstellen der Datenquelle ist ein Fehler aufgetreten"
 
 #: superset/key_value/commands/exceptions.py:29
-#, fuzzy, python-format
 msgid "An error occurred while creating the value."
-msgstr "Beim Abrufen von Schemawerten ist ein Fehler aufgetreten: %s"
+msgstr "Beim Erstellen des Werts ist ein Fehler aufgetreten."
 
 #: superset/key_value/commands/exceptions.py:37
-#, fuzzy, python-format
 msgid "An error occurred while deleting the value."
-msgstr "Beim Abrufen von Schemawerten ist ein Fehler aufgetreten: %s"
+msgstr "Beim Löschen des Werts ist ein Fehler aufgetreten."
 
 #: superset-frontend/src/reports/actions/reports.js:138
-#, fuzzy, python-format
 msgid "An error occurred while editing this report."
-msgstr "Beim Abrufen von Datensätzen ist ein Fehler aufgetreten: %s"
+msgstr "Beim Bearbeiten des Reports ist ein Fehler aufgetreten."
 
 #: superset-frontend/src/reports/actions/reports.js:120
-#, fuzzy, python-format
+#, python-format
 msgid "An error occurred while editing this report: %s"
-msgstr "Beim Abrufen von Datensätzen ist ein Fehler aufgetreten: %s"
+msgstr "Beim Bearbeiten dieses Reports ist ein Fehler aufgetreten: %s"
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:1141
-#, fuzzy
 msgid ""
 "An error occurred while expanding the table schema. Please contact your "
 "administrator."
 msgstr ""
-"Ein unbekannter Fehler ist aufgetreten. Wenden Sie sich an Ihre*n "
-"Superset-Administrator*in"
+"Beim Erweitern des Tabellenschemas ist ein Fehler aufgetreten. Wenden Sie"
+" sich an Ihre*n Administrator*in."
 
 #: superset-frontend/src/views/CRUD/hooks.ts:103
-#, fuzzy, python-format
+#, python-format
 msgid "An error occurred while fetching %s info: %s"
-msgstr "Beim Abrufen von Dashboards ist ein Fehler aufgetreten: %s"
+msgstr "Beim Abrufen von %s ist ein Fehler aufgetreten: %s"
 
 #: superset-frontend/src/views/CRUD/hooks.ts:171
 #: superset-frontend/src/views/CRUD/hooks.ts:258
 #: superset-frontend/src/views/CRUD/hooks.ts:344
-#, fuzzy, python-format
+#, python-format
 msgid "An error occurred while fetching %ss: %s"
-msgstr "Beim Abrufen von Datensätzen ist ein Fehler aufgetreten: %s"
+msgstr "Beim Abrufen von %s ist ein Fehler aufgetreten: %s"
 
 #: superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx:132
 msgid "An error occurred while fetching available CSS templates"
@@ -1368,9 +1372,8 @@ msgstr ""
 "aufgetreten: %s"
 
 #: superset-frontend/src/components/OmniContainer/getDashboards.ts:48
-#, fuzzy, python-format
 msgid "An error occurred while fetching dashboards"
-msgstr "Beim Abrufen von Dashboards ist ein Fehler aufgetreten: %s"
+msgstr "Beim Abrufen von Dashboards ist ein Fehler aufgetreten"
 
 #: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:200
 #: superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx:127
@@ -1419,9 +1422,8 @@ msgid "An error occurred while fetching datasets: %s"
 msgstr "Beim Abrufen von Datensätzen ist ein Fehler aufgetreten: %s"
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:1356
-#, fuzzy, python-format
 msgid "An error occurred while fetching function names."
-msgstr "Beim Abrufen von Schemawerten ist ein Fehler aufgetreten: %s"
+msgstr "Fehler bei Abruf von Funktionsnamen."
 
 #: superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx:460
 #: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:358
@@ -1431,24 +1433,21 @@ msgid "An error occurred while fetching schema values: %s"
 msgstr "Beim Abrufen von Schemawerten ist ein Fehler aufgetreten: %s"
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:662
-#, fuzzy
 msgid "An error occurred while fetching tab state"
-msgstr "Fehler beim Abrufen von Daten des Datensatzes"
+msgstr "Beim Abrufen des Registerkartenstatus ist ein Fehler aufgetreten"
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:1027
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:1052
-#, fuzzy, python-format
 msgid "An error occurred while fetching table metadata"
-msgstr "Beim Abrufen von Datensätzen ist ein Fehler aufgetreten: %s"
+msgstr "Beim Abrufen von Tabellen-Metadaten ist ein Fehler aufgetreten"
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:1093
-#, fuzzy
 msgid ""
 "An error occurred while fetching table metadata. Please contact your "
 "administrator."
 msgstr ""
-"Ein unbekannter Fehler ist aufgetreten. Wenden Sie sich an Ihre*n "
-"Superset-Administrator*in"
+"Beim Abrufen von Tabellen-Metadaten ist ein Fehler aufgetreten. Wenden "
+"Sie sich an Ihre*n Administrator*in."
 
 #: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:375
 #, python-format
@@ -1456,116 +1455,104 @@ msgid "An error occurred while fetching user values: %s"
 msgstr "Beim Abrufen von Schemawerten ist ein Fehler aufgetreten: %s"
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:698
-#, fuzzy
 msgid ""
 "An error occurred while hiding the left bar. Please contact your "
 "administrator."
 msgstr ""
-"Ein unbekannter Fehler ist aufgetreten. Wenden Sie sich an Ihre*n "
-"Superset-Administrator*in"
+"Beim Ausblenden der linken Leiste ist ein Fehler aufgetreten. Wenden Sie "
+"sich an Ihre*n Administrator*in."
 
 #: superset-frontend/src/views/CRUD/hooks.ts:438
 #: superset-frontend/src/views/CRUD/hooks.ts:451
-#, fuzzy, python-format
+#, python-format
 msgid "An error occurred while importing %s: %s"
-msgstr "Beim Kürzen von Protokollen ist ein Fehler aufgetreten "
+msgstr "Beim Importieren von %s ist ein Fehler aufgetreten: %s"
 
 #: superset-frontend/src/chart/chartAction.js:569
-#, fuzzy
 msgid "An error occurred while loading the SQL"
-msgstr "Beim Kürzen von Protokollen ist ein Fehler aufgetreten "
+msgstr "Beim Laden des SQL ist ein Fehler aufgetreten"
 
 #: superset/reports/commands/exceptions.py:242
 msgid "An error occurred while pruning logs "
 msgstr "Beim Kürzen von Protokollen ist ein Fehler aufgetreten "
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:744
-#, fuzzy
 msgid "An error occurred while removing query. Please contact your administrator."
 msgstr ""
-"Ein unbekannter Fehler ist aufgetreten. Wenden Sie sich an Ihre*n "
-"Superset-Administrator*in"
+"Beim Entfernen der Abfrage ist ein Fehler aufgetreten. Wenden Sie sich an"
+" Ihre*n Administrator*in."
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:720
-#, fuzzy
 msgid "An error occurred while removing tab. Please contact your administrator."
 msgstr ""
-"Ein unbekannter Fehler ist aufgetreten. Wenden Sie sich an Ihre*n "
-"Superset-Administrator*in"
+"Beim Entfernen der Registerkarte ist ein Fehler aufgetreten. Wenden Sie "
+"sich an Ihre*n Administrator*in."
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:1188
-#, fuzzy
 msgid ""
 "An error occurred while removing the table schema. Please contact your "
 "administrator."
 msgstr ""
-"Ein unbekannter Fehler ist aufgetreten. Wenden Sie sich an Ihre*n "
-"Superset-Administrator*in"
+"Beim Entfernen des Tabellenschemas ist ein Fehler aufgetreten. Wenden Sie"
+" sich an Ihre*n Administrator*in."
 
 #: superset-frontend/src/chart/chartReducer.ts:94
-#, fuzzy, python-format
+#, python-format
 msgid "An error occurred while rendering the visualization: %s"
-msgstr "Beim Abrufen von Schemawerten ist ein Fehler aufgetreten: %s"
+msgstr "Bei der Darstellung dieser Visualisierung ist ein Fehler aufgetreten: %s"
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:575
-#, fuzzy
 msgid ""
 "An error occurred while setting the active tab. Please contact your "
 "administrator."
 msgstr ""
-"Ein unbekannter Fehler ist aufgetreten. Wenden Sie sich an Ihre*n "
-"Superset-Administrator*in"
+"Beim Festlegen der aktiven Registerkarte ist ein Fehler aufgetreten. "
+"Wenden Sie sich an Ihre*n Administrator*in."
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:825
-#, fuzzy
 msgid ""
 "An error occurred while setting the tab autorun. Please contact your "
 "administrator."
 msgstr ""
-"Ein unbekannter Fehler ist aufgetreten. Wenden Sie sich an Ihre*n "
-"Superset-Administrator*in"
+"Beim Festlegen der Registerkarte Autorun ist ein Fehler aufgetreten. "
+"Wenden Sie sich an Ihre*n Administrator*in."
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:767
-#, fuzzy
 msgid ""
 "An error occurred while setting the tab database ID. Please contact your "
 "administrator."
 msgstr ""
-"Ein unbekannter Fehler ist aufgetreten. Wenden Sie sich an Ihre*n "
-"Superset-Administrator*in"
+"Beim Festlegen der Registerkartendatenbank-ID ist ein Fehler aufgetreten."
+" Wenden Sie sich an Ihre*n Administrator*in."
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:792
-#, fuzzy
 msgid ""
 "An error occurred while setting the tab schema. Please contact your "
 "administrator."
 msgstr ""
-"Ein unbekannter Fehler ist aufgetreten. Wenden Sie sich an Ihre*n "
-"Superset-Administrator*in"
+"Beim Festlegen des Registerkartenschemas ist ein Fehler aufgetreten. "
+"Wenden Sie sich an Ihre*n Administrator*in."
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:967
-#, fuzzy
 msgid ""
 "An error occurred while setting the tab template parameters. Please "
 "contact your administrator."
 msgstr ""
-"Ein unbekannter Fehler ist aufgetreten. Wenden Sie sich an Ihre*n "
-"Superset-Administrator*in"
+"Beim Festlegen der Vorlagen-Parameter ist ein Fehler aufgetreten. Wenden "
+"Sie sich an Ihre*n Administrator*in."
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:850
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:941
-#, fuzzy
 msgid ""
 "An error occurred while setting the tab title. Please contact your "
 "administrator."
 msgstr ""
-"Ein unbekannter Fehler ist aufgetreten. Wenden Sie sich an Ihre*n "
-"Superset-Administrator*in"
+"Beim Festlegen des Registerkartentitels ist ein Fehler aufgetreten. "
+"Wenden Sie sich an Ihre*n Administrator*in."
 
 #: superset-frontend/src/explore/actions/exploreActions.ts:95
-#, fuzzy
 msgid "An error occurred while starring this chart"
-msgstr "Beim Kürzen von Protokollen ist ein Fehler aufgetreten "
+msgstr "Beim Favorisieren des Diagramms ist ein Fehler aufgetreten."
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:232
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:258
@@ -1573,6 +1560,9 @@ msgid ""
 "An error occurred while storing the latest query id in the backend. "
 "Please contact your administrator if this problem persists."
 msgstr ""
+"Beim Speichern der letzten Abfrage-ID im Backend ist ein Fehler "
+"aufgetreten. Wenden Sie sich an Ihre*n Administrator*in, wenn dieses "
+"Problem weiterhin besteht."
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:908
 msgid ""
@@ -1580,11 +1570,13 @@ msgid ""
 "losing your changes, please save your query using the \"Save Query\" "
 "button."
 msgstr ""
+"Beim Speichern der Abfrage im Backend ist ein Fehler aufgetreten. Um zu "
+"vermeiden, dass Ihre Änderungen verloren gehen, speichern Sie Ihre "
+"Abfrage bitte über die Schaltfläche \"Abfrage speichern\"."
 
 #: superset/key_value/commands/exceptions.py:41
-#, fuzzy, python-format
 msgid "An error occurred while updating the value."
-msgstr "Beim Abrufen von Schemawerten ist ein Fehler aufgetreten: %s"
+msgstr "Beim Aktualisieren des Werts ist ein Fehler aufgetreten."
 
 #: superset/views/core.py:711
 msgid "An unknown error occurred. Please contact your Superset administrator"
@@ -1832,18 +1824,16 @@ msgid "Apply"
 msgstr "Übernehmen"
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:321
-#, fuzzy
 msgid "Apply conditional color formatting to metrics"
-msgstr "Bedingte Farbformatierung auf numerische Spalten anwenden"
+msgstr "Bedingten Farbformatierung auf Metriken anwenden"
 
 #: superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx:474
 msgid "Apply conditional color formatting to numeric columns"
 msgstr "Bedingte Farbformatierung auf numerische Spalten anwenden"
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:79
-#, fuzzy
 msgid "Apply metrics on"
-msgstr "Meine Metrik"
+msgstr "Metriken anwenden auf"
 
 #: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.tsx:123
 msgid "Apply to all panels"
@@ -1968,21 +1958,19 @@ msgstr "Abfrageprädikat für die automatische Vervollständigung"
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:242
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:270
 msgid "Available sorting modes:"
-msgstr ""
+msgstr "Verfügbare Sortiermodi:"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:200
 msgid "Axis"
 msgstr "Achse"
 
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:36
-#, fuzzy
 msgid "Axis ascending"
-msgstr "Aufsteigend sortieren"
+msgstr "Achse aufsteigend"
 
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:37
-#, fuzzy
 msgid "Axis descending"
-msgstr "Absteigend sortieren"
+msgstr "Achse absteigend"
 
 #: superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx:770
 #: superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx:786
@@ -2000,12 +1988,11 @@ msgstr "Fehlerhafter räumlicher Schlüssel"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/index.ts:85
 msgid "Bar"
-msgstr ""
+msgstr "Balken"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js:38
-#, fuzzy
 msgid "Bar Chart"
-msgstr "Diagramm speichern"
+msgstr "Balkendiagramm"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:294
 msgid "Bar Values"
@@ -2013,7 +2000,7 @@ msgstr "Balkenwerte"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:227
 msgid "Base layer map style"
-msgstr ""
+msgstr "Hintergrundkarten-Stil"
 
 #: superset-frontend/src/explore/components/controls/FixedOrMetricControl/index.jsx:165
 msgid "Based on a metric"
@@ -2046,16 +2033,15 @@ msgstr "Stapelbearbeitung %d Filter:"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Line/index.js:36
 msgid "Battery level over time"
-msgstr ""
+msgstr "Akkustand im Laufe der Zeit"
 
 #: superset-frontend/src/components/Datasource/DatasourceEditor.jsx:1175
 msgid "Be careful."
 msgstr "Seien Sie vorsichtig."
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:76
-#, fuzzy
 msgid "Before"
-msgstr "Aktualisieren"
+msgstr "Vor"
 
 #: superset-frontend/plugins/legacy-preset-chart-big-number/src/BigNumberTotal/index.ts:38
 #: superset/viz.py:1254
@@ -2064,7 +2050,7 @@ msgstr "Große Zahl"
 
 #: superset-frontend/plugins/legacy-preset-chart-big-number/src/sharedControls.ts:28
 msgid "Big Number Font Size"
-msgstr ""
+msgstr "Große Zahl Schriftgröße"
 
 #: superset-frontend/plugins/legacy-preset-chart-big-number/src/BigNumber/index.ts:34
 #: superset/viz.py:1220
@@ -2072,7 +2058,6 @@ msgid "Big Number with Trendline"
 msgstr "Große Zahl mit Trendlinie"
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:290
-#, fuzzy
 msgid "Bottom"
 msgstr "Unten"
 
@@ -2112,14 +2097,12 @@ msgstr ""
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/BoxPlot/index.js:26
 #: superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/index.ts:54
 #: superset-frontend/plugins/preset-chart-xy/src/BoxPlot/createMetadata.ts:27
-#, fuzzy
 msgid "Box Plot"
-msgstr "Riegel"
+msgstr "Boxplot"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts:133
-#, fuzzy
 msgid "Breakdowns"
-msgstr "Erstellt am"
+msgstr "Aufschlüsselungen"
 
 #: superset/connectors/druid/views.py:237
 msgid "Broker Endpoint"
@@ -2147,9 +2130,8 @@ msgid "Bubble Chart"
 msgstr "Blasen-Diagramm"
 
 #: superset-frontend/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:127
-#, fuzzy
 msgid "Bubble Color"
-msgstr "Fixierte Farbe"
+msgstr "Blasenfarbe"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:141
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:420
@@ -2187,7 +2169,7 @@ msgstr "Bullet-Diagramm"
 #: superset-frontend/plugins/plugin-chart-echarts/src/Radar/index.ts:55
 #: superset-frontend/plugins/plugin-chart-table/src/index.ts:44
 msgid "Business"
-msgstr ""
+msgstr "Geschäftlich"
 
 #: superset-frontend/src/explore/components/controls/FilterBoxItemControl/index.jsx:233
 #: superset-frontend/src/filters/components/Select/controlPanel.ts:139
@@ -2205,16 +2187,16 @@ msgstr ""
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:272
 msgid "By key: use column names as sorting key"
-msgstr ""
+msgstr "Nach Schlüssel: Spaltennamen als Sortierschlüssel verwenden"
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:244
 msgid "By key: use row names as sorting key"
-msgstr ""
+msgstr "Nach Schlüssel: Zeilennamen als Sortierschlüssel verwenden"
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:245
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:273
 msgid "By value: use metric values as sorting key"
-msgstr ""
+msgstr "Nach Wert: Metrikwerte als Sortierschlüssel verwenden"
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx:334
 msgid "CANCEL"
@@ -2317,11 +2299,11 @@ msgstr ""
 "dass Ihre Anfrage nur eine SELECT-Anweisung hat. Versuchen Sie dann "
 "erneut, die Abfrage auszuführen."
 
-#: superset/errors.py:123
+#: superset/errors.py:124
 msgid "CVAS (create view as select) query has more than one statement."
 msgstr "CVAS-Abfrage (Create View as Select) hat mehr als eine Anweisung."
 
-#: superset/errors.py:124
+#: superset/errors.py:125
 msgid "CVAS (create view as select) query is not a SELECT statement."
 msgstr "CVAS-Abfrage (Create View as Select) ist keine SELECT-Anweisung."
 
@@ -2383,13 +2365,15 @@ msgstr "Kalender Heatmap"
 #: superset-frontend/src/dashboard/actions/dashboardLayout.js:211
 msgid "Can not move top level tab into nested tabs"
 msgstr ""
+"Registerkarte der obersten Ebene kann nicht in verschachtelte "
+"Registerkarten verschoben werden"
 
-#: superset/views/core.py:2010
+#: superset/views/core.py:2027
 #, python-format
 msgid "Can't find DruidCluster with cluster_name = '%(name)s'"
 msgstr "DruidCluster mit cluster_name = '%(name)s' nicht gefunden"
 
-#: superset/views/core.py:1998
+#: superset/views/core.py:2015
 #, python-format
 msgid "Can't find User '%(name)s', please ask your admin to create one."
 msgstr ""
@@ -2424,7 +2408,7 @@ msgstr "Abfrage abbrechen bei ‚Window unload‘-Ereignis"
 
 #: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/utils.ts:83
 msgid "Cannot create cyclic hierarchy"
-msgstr ""
+msgstr "Zyklische Hierarchie kann nicht erstellt werden"
 
 #: superset/databases/commands/exceptions.py:109
 msgid "Cannot delete a database that has datasets attached"
@@ -2458,13 +2442,12 @@ msgstr "Zeitzeichenfolge [%(human_readable)s] kann nicht analysiert werden"
 #: superset-frontend/plugins/plugin-chart-echarts/src/Tree/index.ts:41
 #: superset-frontend/plugins/plugin-chart-echarts/src/Treemap/index.ts:59
 #: superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/index.ts:42
-#, fuzzy
 msgid "Categorical"
-msgstr "Kategorie"
+msgstr "Kategorisch"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts:129
 msgid "Categories to group by on the x-axis."
-msgstr ""
+msgstr "Kategorien, nach denen auf der x-Achse gruppiert werden soll."
 
 #: superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx:602
 msgid "Category"
@@ -2476,17 +2459,15 @@ msgstr "Kategorie der Zielknoten"
 
 #: superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:103
 msgid "Cell Padding"
-msgstr ""
+msgstr "Zellen Abstand"
 
 #: superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:117
-#, fuzzy
 msgid "Cell Radius"
-msgstr "Aussenradius"
+msgstr "Zellenradius"
 
 #: superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:91
-#, fuzzy
 msgid "Cell Size"
-msgstr "Knotengröße"
+msgstr "Zellengröße"
 
 #: superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx:413
 msgid "Cell bars"
@@ -2547,11 +2528,11 @@ msgstr "Datensatz wechseln"
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:269
 msgid "Change order of columns."
-msgstr ""
+msgstr "Reihenfolge der Spalten ändern."
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:241
 msgid "Change order of rows."
-msgstr ""
+msgstr "Reihenfolge der Zeilen ändern."
 
 #: superset/connectors/druid/views.py:354 superset/connectors/sqla/views.py:489
 msgid "Changed By"
@@ -2619,13 +2600,12 @@ msgid "Character to interpret as decimal point."
 msgstr "Zeichen, das als Dezimalstelle zu interpretieren ist."
 
 #: superset-frontend/plugins/legacy-plugin-chart-force-directed/src/controlPanel.ts:81
-#, fuzzy
 msgid "Charge"
-msgstr "Diagramm"
+msgstr "Laden"
 
 #: superset-frontend/plugins/legacy-plugin-chart-force-directed/src/controlPanel.ts:95
 msgid "Charge in the force layout"
-msgstr ""
+msgstr "In kraftbasierte Anordnung laden"
 
 #: superset-frontend/src/components/Menu/MenuRight.tsx:39
 #: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:387
@@ -2640,7 +2620,7 @@ msgstr ""
 msgid "Chart"
 msgstr "Diagramm"
 
-#: superset/views/core.py:1748
+#: superset/views/core.py:1765
 #, python-format
 msgid "Chart %(id)s not found"
 msgstr "Diagramm %(id)s nicht gefunden"
@@ -2741,6 +2721,16 @@ msgid ""
 "that lives in the dashboard view itself. It's easier to use and has more "
 "capabilities!"
 msgstr ""
+"Diagrammkomponente, mit der Sie Ihrem Dashboard eine benutzerdefinierte "
+"Filter-Oberfläche hinzufügen können. Ist sie dem Dashboard zugefügt, "
+"können Benutzer*innen in einem Filterfeld bestimmte Werte oder Bereiche "
+"angeben, nach denen Diagramme gefiltert werden sollen. Die Diagramme, auf"
+" die jedes Filterfeld angewendet wird, können auch in der "
+"Dashboardansicht optimiert werden.\n"
+"\n"
+"Beachten Sie, dass dieses Plugin durch die neue Filterfunktion ersetzt "
+"wird, die sich in der Dashboard-Ansicht selbst befindet. Sie ist "
+"einfacher zu bedienen und hat mehr Funktionen!"
 
 #: superset/charts/commands/exceptions.py:115
 msgid "Chart could not be created."
@@ -2889,9 +2879,8 @@ msgid "Choose a dataset"
 msgstr "Datensatz auswählen"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/DualLine/controlPanel.ts:69
-#, fuzzy
 msgid "Choose a metric for left axis"
-msgstr "Wählen Sie eine Metrik für die rechte Achse"
+msgstr "Wählen Sie eine Metrik für die linke Achse"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:120
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:185
@@ -2900,40 +2889,34 @@ msgid "Choose a metric for right axis"
 msgstr "Wählen Sie eine Metrik für die rechte Achse"
 
 #: superset-frontend/plugins/legacy-plugin-chart-chord/src/controlPanel.ts:57
-#, fuzzy
 msgid "Choose a number format"
-msgstr "Kleines Zahlenformat"
+msgstr "Wählen Sie ein Zahlenformat"
 
 #: superset-frontend/plugins/legacy-plugin-chart-chord/src/controlPanel.ts:63
-#, fuzzy
 msgid "Choose a source"
-msgstr "Datensatz auswählen"
+msgstr "Wählen Sie eine Quelle"
 
 #: superset-frontend/plugins/legacy-plugin-chart-force-directed/src/controlPanel.ts:105
 #: superset-frontend/plugins/legacy-plugin-chart-sankey-loop/src/controlPanel.ts:44
 #: superset-frontend/plugins/legacy-plugin-chart-sankey/src/controlPanel.ts:34
-#, fuzzy
 msgid "Choose a source and a target"
-msgstr "Datensatz auswählen"
+msgstr "Wählen Sie eine Quelle und ein Ziel"
 
 #: superset-frontend/plugins/legacy-plugin-chart-chord/src/controlPanel.ts:69
-#, fuzzy
 msgid "Choose a target"
-msgstr "Datensatz auswählen"
+msgstr "Wählen Sie ein Ziel"
 
 #: superset-frontend/src/addSlice/AddSliceContainer.tsx:308
 msgid "Choose chart type"
 msgstr "Diagrammtyp auswählen"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:100
-#, fuzzy
 msgid "Choose one or more charts for left axis"
-msgstr "Wählen Sie eine Metrik für die rechte Achse"
+msgstr "Wählen Sie ein oder mehrere Diagramme die rechte Achse"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:135
-#, fuzzy
 msgid "Choose one or more charts for right axis"
-msgstr "Wählen Sie eine Metrik für die rechte Achse"
+msgstr "Wählen Sie ein oder mehrerer Diagramme für die rechte Achse"
 
 #: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:745
 msgid "Choose the annotation layer type"
@@ -2945,7 +2928,7 @@ msgstr "Wählen Sie die Quelle Ihrer Anmerkungen aus"
 
 #: superset-frontend/plugins/legacy-plugin-chart-chord/src/index.js:34
 msgid "Chord Diagram"
-msgstr ""
+msgstr "Sehnendiagramm"
 
 #: superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx:281
 msgid "Chosen non-numeric column"
@@ -2978,12 +2961,17 @@ msgstr "Kreisförmig"
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Line/index.js:32
 msgid "Classic chart that visualizes how metrics change over time."
 msgstr ""
+"Klassisches Diagramm, das visualisiert, wie sich Metriken im Laufe der "
+"Zeit ändern."
 
 #: superset-frontend/plugins/plugin-chart-table/src/index.ts:37
 msgid ""
 "Classic row-by-column spreadsheet like view of a dataset. Use tables to "
 "showcase a view into the underlying data or to show aggregated metrics."
 msgstr ""
+"Klassische Zeilen-für-Spalten-Tabellenansicht eines Datensatzes. "
+"Verwenden Sie Tabellen, um eine Ansicht der zugrunde liegenden Daten oder"
+" aggregierter Metriken anzuzeigen."
 
 #: superset/connectors/sqla/views.py:369
 msgid "Clause"
@@ -3079,18 +3067,16 @@ msgstr "Cluster Name"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:171
 msgid "Cluster label aggregator"
-msgstr ""
+msgstr "Cluster-Beschriftung-Aggregator"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:74
-#, fuzzy
 msgid "Clustering Radius"
-msgstr "Aussenradius"
+msgstr "Clustering-Radius"
 
 #: superset-frontend/src/explore/controlPanels/Separator.js:25
 #: superset-frontend/src/explore/controlPanels/Separator.js:46
-#, fuzzy
 msgid "Code"
-msgstr "Sekunde"
+msgstr "Code"
 
 #: superset-frontend/src/dashboard/components/filterscope/treeIcons.jsx:39
 msgid "Collapse all"
@@ -3120,9 +3106,8 @@ msgid "Color Scheme"
 msgstr "Farbschema"
 
 #: superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:129
-#, fuzzy
 msgid "Color Steps"
-msgstr "Farbschema"
+msgstr "Farbschritte"
 
 #: superset-frontend/src/explore/controls.jsx:235
 msgid "Color metric"
@@ -3141,6 +3126,8 @@ msgid ""
 "Color will be rendered based on a ratio of the cell against the sum of "
 "across this criteria"
 msgstr ""
+"Die Farbe wird basierend auf dem Verhältnis der Zelle zur Gesamtsumme "
+"dieses Kriteriums dargestellt."
 
 #: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:374
 msgid "Colors"
@@ -3176,15 +3163,15 @@ msgstr "Spaltenbezeichnung(en)"
 msgid ""
 "Column containing ISO 3166-2 codes of region/province/department in your "
 "table."
-msgstr ""
+msgstr "Spalte mit ISO 3166-2-Codes der Region/Provinz/Kreis in Ihrer Tabelle."
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:64
 msgid "Column containing latitude data"
-msgstr ""
+msgstr "Spalte mit Breitengraddaten"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:54
 msgid "Column containing longitude data"
-msgstr ""
+msgstr "Spalte mit Längengraddaten"
 
 #: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/getControlItemsMap.tsx:115
 msgid "Column is required"
@@ -3265,13 +3252,15 @@ msgstr "Fehlende Spalten in Datenquelle: %(invalid_columns)s"
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:302
 msgid "Columns subtotal position"
-msgstr ""
+msgstr "Zwischensummenposition der Spalten"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts:134
 msgid ""
 "Columns to calculate distribution across. Defaults to temporal column if "
 "left empty."
 msgstr ""
+"Spalten zum Berechnen der Verteilung. Falls leer, wird standardmäßig wird"
+" die temporale Spalte verwendet."
 
 #: superset-frontend/plugins/legacy-plugin-chart-event-flow/src/controlPanel.tsx:44
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:45
@@ -3286,24 +3275,20 @@ msgid "Columns to group by"
 msgstr "Spalten, nach denen gruppiert wird"
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:60
-#, fuzzy
 msgid "Columns to group by on the columns"
-msgstr "Spalten, nach denen gruppiert wird"
+msgstr "Spalten, nach denen in den Spalten gruppiert werden soll"
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:50
-#, fuzzy
 msgid "Columns to group by on the rows"
-msgstr "Spalten, nach denen gruppiert wird"
+msgstr "Spalten, nach denen in den Zeilen gruppiert werden soll"
 
 #: superset-frontend/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.ts:96
-#, fuzzy
 msgid "Combine Metrics"
-msgstr "Anpassen von Metriken"
+msgstr "Metriken kombinieren"
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:185
-#, fuzzy
 msgid "Combine metrics"
-msgstr "Anpassen von Metriken"
+msgstr "Metriken kombinieren"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:301
 msgid ""
@@ -3333,10 +3318,14 @@ msgid ""
 "Compare multiple time series charts (as sparklines) and related metrics "
 "quickly."
 msgstr ""
+"Vergleichen Sie schnell mehrere Zeitreihendiagramme (als Sparklines) und "
+"verwandte Metriken."
 
 #: superset-frontend/plugins/legacy-plugin-chart-partition/src/index.js:26
 msgid "Compare the same summarized metric across multiple groups."
 msgstr ""
+"Vergleichen Sie dieselbe zusammengefasste Metrik über mehrere Gruppen "
+"hinweg."
 
 #: superset-frontend/plugins/legacy-plugin-chart-horizon/src/index.js:28
 msgid ""
@@ -3344,6 +3333,9 @@ msgid ""
 "group is mapped to a row and change over time is visualized bar lengths "
 "and color."
 msgstr ""
+"Vergleicht, wie sich eine Metrik im Laufe der Zeit zwischen verschiedenen"
+" Gruppen ändert. Jede Gruppe wird einer Zeile zugeordnet und die Änderung"
+" im Laufe der Zeit werden als Balkenlängen und -farben visualisiert."
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js:30
 msgid ""
@@ -3351,12 +3343,17 @@ msgid ""
 "used to indicate the magnitude of each value and color is used to "
 "differentiate groups."
 msgstr ""
+"Vergleicht Metriken aus verschiedenen Kategorien mithilfe von Balken. "
+"Balkenlängen werden verwendet, um die Größe jedes Werts anzugeben, und "
+"Farbe wird verwendet, um Gruppen zu unterscheiden."
 
 #: superset-frontend/plugins/legacy-plugin-chart-event-flow/src/index.ts:26
 msgid ""
 "Compares the lengths of time different activities take in a shared "
 "timeline view."
 msgstr ""
+"Vergleicht die Zeitspanne, die verschiedene Aktivitäten in einer "
+"freigegebenen Zeitachsenansicht benötigen."
 
 #: superset-frontend/plugins/legacy-plugin-chart-calendar/src/index.js:33
 #: superset-frontend/plugins/legacy-plugin-chart-country-map/src/index.js:33
@@ -3375,9 +3372,8 @@ msgstr ""
 #: superset-frontend/plugins/plugin-chart-echarts/src/Treemap/index.ts:60
 #: superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/index.ts:43
 #: superset-frontend/src/visualizations/TimeTable/TimeTableChartPlugin.ts:31
-#, fuzzy
 msgid "Comparison"
-msgstr "Zeitvergleich"
+msgstr "Vergleich"
 
 #: superset-frontend/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx:48
 msgid "Comparison Period Lag"
@@ -3495,11 +3491,11 @@ msgstr ""
 
 #: superset-frontend/src/views/CRUD/hooks.ts:625
 msgid "Connection looks good!"
-msgstr ""
+msgstr "Verbindung möglich!"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Area/index.js:46
 msgid "Continuous"
-msgstr ""
+msgstr "Kontinuierlich"
 
 #: superset-frontend/plugins/legacy-plugin-chart-horizon/src/controlPanel.ts:51
 #: superset-frontend/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts:54
@@ -3529,9 +3525,8 @@ msgstr "Steuerelemente beschriftet "
 
 #: superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/src/index.js:31
 #: superset-frontend/plugins/plugin-chart-echarts/src/Radar/index.ts:57
-#, fuzzy
 msgid "Coordinates"
-msgstr "Parallele Koordinaten"
+msgstr "Koordinaten"
 
 #: superset-frontend/src/components/CopyToClipboard/index.jsx:75
 #: superset-frontend/src/dashboard/components/menu/ShareMenuItems/index.tsx:53
@@ -3581,7 +3576,7 @@ msgstr "Meldung kopieren"
 #: superset-frontend/src/SqlLab/reducers/sqlLab.js:74
 #, python-format
 msgid "Copy of %s"
-msgstr ""
+msgstr "Kopie von %s"
 
 #: superset-frontend/src/SqlLab/components/TableElement/index.tsx:103
 msgid "Copy partition query to clipboard"
@@ -3621,9 +3616,8 @@ msgstr "In die Zwischenablage kopieren"
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/index.js:28
 #: superset-frontend/plugins/legacy-plugin-chart-paired-t-test/src/index.js:25
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bubble/index.js:25
-#, fuzzy
 msgid "Correlation"
-msgstr "Dauer"
+msgstr "Korrelation"
 
 #: superset-frontend/src/SqlLab/components/EstimateQueryCostButton/index.tsx:95
 msgid "Cost estimate"
@@ -3636,7 +3630,7 @@ msgstr "Datenquellentyp konnte nicht ermittelt werden"
 #: superset-frontend/src/dashboard/actions/sliceEntities.js:116
 #: superset-frontend/src/dashboard/reducers/sliceEntities.js:65
 msgid "Could not fetch all saved charts"
-msgstr ""
+msgstr "Nicht alle gespeicherten Diagramme konnten abgerufen werden"
 
 #: superset/views/utils.py:563
 msgid "Could not find viz object"
@@ -3660,23 +3654,20 @@ msgid "Could not verify the host"
 msgstr "Der Host konnte nicht überprüft werden"
 
 #: superset-frontend/plugins/legacy-plugin-chart-country-map/src/controlPanel.ts:40
-#, fuzzy
 msgid "Country"
-msgstr "Anzahl"
+msgstr "Land"
 
 #: superset-frontend/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:130
-#, fuzzy
 msgid "Country Color Scheme"
-msgstr "Farbschema auswählen"
+msgstr "Länderfarbschema"
 
 #: superset-frontend/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:115
-#, fuzzy
 msgid "Country Column"
-msgstr "Meine Spalte"
+msgstr "Länderspalte"
 
 #: superset-frontend/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:39
 msgid "Country Field Type"
-msgstr ""
+msgstr "Feldtyp \"Land\""
 
 #: superset-frontend/plugins/legacy-plugin-chart-country-map/src/index.js:30
 #: superset/viz.py:2007
@@ -3758,14 +3749,12 @@ msgid "Cross-filter scoping"
 msgstr "Kreuzfilter-Bereichsdefinition"
 
 #: superset-frontend/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts:153
-#, fuzzy
 msgid "Cumulative"
-msgstr "kumulativ"
+msgstr "Kumuliert"
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:33
-#, fuzzy
 msgid "Custom"
-msgstr "Anpassen"
+msgstr "Angepasst"
 
 #: superset/views/dynamic_plugins.py:59
 msgid "Custom Plugin"
@@ -3803,7 +3792,7 @@ msgstr ""
 
 #: superset-frontend/src/filters/components/Time/index.ts:28
 msgid "Custom time filter plugin"
-msgstr ""
+msgstr "Benutzerdefiniertes Zeitfilter-Plugin"
 
 #: superset-frontend/src/explore/components/ControlPanelsContainer.tsx:417
 msgid "Customize"
@@ -3847,9 +3836,8 @@ msgid "D3 time format for datetime columns"
 msgstr "D3-Zeitformat für datetime-Spalten"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:44
-#, fuzzy
 msgid "D3 time format syntax: https://github.com/d3/d3-time-format"
-msgstr "D3-Formatsyntax: https://github.com/d3/d3-format"
+msgstr "D3-Zeitformatsyntax: https://github.com/d3/d3-time-format"
 
 #: superset-frontend/src/components/CronPicker/CronPicker.tsx:102
 msgid "DEC"
@@ -3868,9 +3856,8 @@ msgid "DML"
 msgstr "DML"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/index.js:31
-#, fuzzy
 msgid "Dark mode"
-msgstr "Abfragemodus"
+msgstr "Dunkelmodus"
 
 #: superset-frontend/src/components/Menu/MenuRight.tsx:46
 #: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1296
@@ -3956,9 +3943,8 @@ msgid "Data Source"
 msgstr "Datenquelle"
 
 #: superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/src/controlPanel.ts:57
-#, fuzzy
 msgid "Data Table"
-msgstr "Tabelle bearbeiten"
+msgstr "Datentabelle"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:290
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx:181
@@ -3970,7 +3956,7 @@ msgstr "Tabelle bearbeiten"
 msgid "Data Zoom"
 msgstr "Datenzoom"
 
-#: superset/views/core.py:2313
+#: superset/views/core.py:2330
 msgid ""
 "Data could not be deserialized from the results backend. The storage "
 "format might have changed, rendering the old data stake. You need to re-"
@@ -3980,7 +3966,7 @@ msgstr ""
 "Speicherformat hat sich möglicherweise geändert, wodurch die alten Daten "
 "ungültig wurden. Sie müssen die ursprüngliche Abfrage erneut ausführen."
 
-#: superset/views/core.py:2266
+#: superset/views/core.py:2283
 msgid ""
 "Data could not be retrieved from the results backend. You need to re-run "
 "the original query."
@@ -4079,7 +4065,7 @@ msgstr "Datenbank konnte nicht gelöscht werden."
 msgid "Database could not be updated."
 msgstr "Datenbank konnte nicht aktualisiert werden."
 
-#: superset/errors.py:117
+#: superset/errors.py:118
 msgid "Database does not allow data manipulation."
 msgstr "Die Datenbank lässt keine Datenbearbeitung zu."
 
@@ -4282,9 +4268,9 @@ msgid "Day"
 msgstr "Tag"
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:66
-#, fuzzy, python-format
+#, python-format
 msgid "Days %s"
-msgstr "Ausgeführt %s"
+msgstr "Tage %s"
 
 #: superset/connectors/sqla/models.py:1593
 msgid "Db engine did not return all queried columns"
@@ -4357,14 +4343,12 @@ msgid "Default Value"
 msgstr "Standardwert"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:290
-#, fuzzy
 msgid "Default latitude"
-msgstr "Standardwert"
+msgstr "Standard Breitengrad"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:276
-#, fuzzy
 msgid "Default longitude"
-msgstr "Standardwert"
+msgstr "Standard-Längengrad"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:91
 msgid ""
@@ -4376,7 +4360,7 @@ msgstr ""
 
 #: superset-frontend/src/filters/components/Select/controlPanel.ts:105
 msgid "Default to first item"
-msgstr ""
+msgstr "Erstes Element als Standard verwenden"
 
 #: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:936
 #: superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx:222
@@ -4386,14 +4370,20 @@ msgstr "Standardwert ist erforderlich"
 #: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/state.ts:95
 msgid "Default value must be set when \"Filter has default value\" is checked"
 msgstr ""
+"Standardwert muss festgelegt werden, wenn \"Filter hat Standardwert\" "
+"aktiviert ist"
 
 #: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/state.ts:93
 msgid "Default value must be set when \"Required\" is checked"
 msgstr ""
+"Der Standardwert muss festgelegt werden, wenn \"Erforderlich\" aktiviert "
+"ist"
 
 #: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/state.ts:89
 msgid "Default value set automatically when \"Default to first item\" is checked"
 msgstr ""
+"Standardwert wird automatisch festgelegt, wenn „Erstes Element als "
+"Standard“ aktiviert ist"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/sections/advancedAnalytics.tsx:44
 #: superset-frontend/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:266
@@ -4410,7 +4400,7 @@ msgstr ""
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts:134
 msgid "Defines how each series is broken down"
-msgstr ""
+msgstr "Definiert, wie jede Reihe aufgeschlüsselt wird"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:64
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:388
@@ -4640,21 +4630,19 @@ msgstr "Übermittlungsmethode"
 
 #: superset-frontend/plugins/legacy-plugin-chart-sankey/src/index.js:33
 msgid "Demographics"
-msgstr ""
+msgstr "Demographische Daten"
 
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/index.js:43
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/index.js:38
 #: superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/index.ts:45
-#, fuzzy
 msgid "Density"
-msgstr "Element"
+msgstr "Dichte"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Area/index.js:55
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Line/index.js:45
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/LineMulti/index.js:38
-#, fuzzy
 msgid "Deprecated"
-msgstr "Erstellt"
+msgstr "Veraltet"
 
 #: superset-frontend/plugins/legacy-preset-chart-big-number/src/BigNumber/index.ts:42
 #: superset-frontend/plugins/legacy-preset-chart-big-number/src/BigNumberTotal/index.ts:47
@@ -4693,7 +4681,7 @@ msgstr "Beschreibungsspalten"
 
 #: superset-frontend/plugins/legacy-preset-chart-big-number/src/BigNumberTotal/controlPanel.ts:48
 msgid "Description text that shows up below your Big Number"
-msgstr ""
+msgstr "Beschreibungstext, der unter Ihrer Großen Zahl angezeigt wird"
 
 #: superset-frontend/src/components/ListView/ListView.tsx:348
 msgid "Deselect all"
@@ -4707,7 +4695,7 @@ msgstr "Details zur Zertifizierung"
 #: superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts:53
 #: superset-frontend/plugins/preset-chart-xy/src/BoxPlot/controlPanel.ts:47
 msgid "Determines how whiskers and outliers are calculated."
-msgstr ""
+msgstr "Bestimmt, wie „Whisker“ und Ausreißer berechnet werden."
 
 #: superset/views/dashboard/mixin.py:71
 msgid ""
@@ -4734,9 +4722,8 @@ msgstr "Kraftbasierte Anordnung"
 #: superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/src/index.js:31
 #: superset-frontend/plugins/legacy-plugin-chart-sankey/src/index.js:39
 #: superset-frontend/plugins/plugin-chart-echarts/src/Graph/index.ts:42
-#, fuzzy
 msgid "Directional"
-msgstr "Beschreibung"
+msgstr "Direktional"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:165
 #: superset-frontend/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:185
@@ -4749,9 +4736,8 @@ msgid "Discard changes"
 msgstr "Änderungen verwerfen"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js:43
-#, fuzzy
 msgid "Discrete"
-msgstr "wurde erstellt"
+msgstr "Diskret"
 
 #: superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm/CommonParameters.tsx:149
 #: superset-frontend/src/views/CRUD/data/database/DatabaseModal/SqlAlchemyForm.tsx:42
@@ -4760,7 +4746,7 @@ msgstr "Anzeigename"
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:164
 msgid "Display column level total"
-msgstr ""
+msgstr "Summe auf Spaltenebene anzeigen"
 
 #: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:615
 msgid "Display configuration"
@@ -4772,14 +4758,16 @@ msgid ""
 "Display metrics side by side within each column, as opposed to each "
 "column being displayed side by side for each metric."
 msgstr ""
+"Zeigen Sie Metriken innerhalb jeder Spalte nebeneinander an, im Gegensatz"
+" zur Darstellung einer Spalte je Metrik."
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:152
 msgid "Display row level total"
-msgstr ""
+msgstr "Summe auf Zeilenebene anzeigen"
 
 #: superset-frontend/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.ts:89
 msgid "Display total row/column"
-msgstr ""
+msgstr "Gesamtsumme Zeile/Spalte anzeigen"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Graph/index.ts:34
 msgid ""
@@ -4788,19 +4776,23 @@ msgid ""
 " Graph charts can be configured to be force-directed or circulate. If "
 "your data has a geospatial component, try the deck.gl Arc chart."
 msgstr ""
+"Zeigt Verbindungen zwischen Elementen in einer Graphstruktur an. "
+"Nützlich, um Beziehungen abzubilden und zu zeigen, welche Knoten in einem"
+" Netzwerk wichtig sind. Graphen-Diagramme können so konfiguriert werden, "
+"dass sie kraftgesteuert sind oder zirkulieren. Wenn Ihre Daten über eine "
+"Geodatenkomponente verfügen, versuchen Sie es mit dem deck.gl Arc-"
+"Diagramm."
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts:132
-#, fuzzy
 msgid "Distribute across"
-msgstr "Kosten schätzen"
+msgstr "Verteilen über"
 
 #: superset-frontend/plugins/legacy-plugin-chart-histogram/src/index.js:28
 #: superset-frontend/plugins/legacy-plugin-chart-horizon/src/index.js:26
 #: superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/index.ts:48
 #: superset-frontend/plugins/preset-chart-xy/src/BoxPlot/createMetadata.ts:25
-#, fuzzy
 msgid "Distribution"
-msgstr "Beitrag"
+msgstr "Verteilung"
 
 #: superset/viz.py:1769
 msgid "Distribution - Bar Chart"
@@ -4821,7 +4813,7 @@ msgstr "Dokumentation"
 
 #: superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:40
 msgid "Domain"
-msgstr ""
+msgstr "Wertebereich"
 
 #: superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx:29
 msgid "Don't refresh"
@@ -4937,9 +4929,8 @@ msgstr ""
 "security extension"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/DualLine/index.js:30
-#, fuzzy
 msgid "Dual Line Chart"
-msgstr "Bullet-Diagramm"
+msgstr "Doppelliniendiagramm"
 
 #: superset/views/datasource/views.py:119
 #, python-format
@@ -5049,11 +5040,11 @@ msgstr ""
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:41
 msgid "Duration in ms (1.40008 => 1ms 400µs 80ns)"
-msgstr ""
+msgstr "Dauer in ms (1,40008 => 1ms 400μs 80ns)"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:40
 msgid "Duration in ms (66000 => 1m 6s)"
-msgstr ""
+msgstr "Dauer in ms (66000 => 1m 6s)"
 
 #: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:205
 #, python-format
@@ -5088,7 +5079,7 @@ msgstr "ENDE (EXKLUSIV)"
 #: superset-frontend/src/views/CRUD/hooks.ts:628
 #, python-format
 msgid "ERROR: %s"
-msgstr ""
+msgstr "FEHLER: %s"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:241
 msgid "Edge length"
@@ -5226,8 +5217,8 @@ msgstr "Anmerkungsebene bearbeiten"
 msgid "Edit annotation layer properties"
 msgstr "Eigenschaften der Anmerkungsebene bearbeiten"
 
-#: superset-frontend/src/explore/components/ExploreChartHeader/index.jsx:305
-#: superset-frontend/src/explore/components/ExploreChartHeader/index.jsx:308
+#: superset-frontend/src/explore/components/ExploreChartHeader/index.jsx:311
+#: superset-frontend/src/explore/components/ExploreChartHeader/index.jsx:314
 msgid "Edit chart properties"
 msgstr "Diagrammeigenschaften bearbeiten"
 
@@ -5288,7 +5279,7 @@ msgstr "Bearbeiten von einem Filter:"
 msgid "Editing filter set:"
 msgstr "Filterguppe bearbeiten:"
 
-#: superset/errors.py:110
+#: superset/errors.py:111
 msgid "Either the database is spelled incorrectly or does not exist."
 msgstr "Entweder ist die Datenbank falsch geschrieben oder existiert nicht."
 
@@ -5314,7 +5305,7 @@ msgstr ""
 msgid "Either the username or password is incorrect."
 msgstr "Entweder der Benutzername oder das Kennwort ist falsch."
 
-#: superset/errors.py:109
+#: superset/errors.py:110
 msgid "Either the username or the password is wrong."
 msgstr "Entweder der Benutzer*innenname oder das Kennwort ist falsch."
 
@@ -5348,7 +5339,7 @@ msgstr "Hervorhebung"
 
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/index.js:36
 msgid "Employment and education"
-msgstr ""
+msgstr "Beschäftigung und Bildung"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:214
 msgid "Empty circle"
@@ -5535,9 +5526,8 @@ msgstr "Fehlermeldung"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:104
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:139
-#, fuzzy, python-format
 msgid "Error while fetching charts"
-msgstr "Fehler beim Abrufen von Daten: %s"
+msgstr "Fehler beim Abrufen von Diagrammen"
 
 #: superset-frontend/src/explore/components/controls/SelectAsyncControl/index.tsx:89
 #, python-format
@@ -5562,7 +5552,6 @@ msgid "Estimate the cost before running a query"
 msgstr "Schätzen der Kosten vor dem Ausführen einer Abfrage"
 
 #: superset-frontend/plugins/legacy-plugin-chart-event-flow/src/index.ts:29
-#, fuzzy
 msgid "Event Flow"
 msgstr "Ereignisablauf"
 
@@ -5602,12 +5591,11 @@ msgstr "Jeden"
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/index.ts:48
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/index.ts:57
 msgid "Evolution"
-msgstr ""
+msgstr "Entwicklung"
 
 #: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:1263
-#, fuzzy
 msgid "Exact"
-msgstr "Weiter"
+msgstr "Genau"
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/components/DateFunctionTooltip.tsx:34
 #: superset-frontend/src/explore/components/controls/DateFilterControl/components/DateFunctionTooltip.tsx:49
@@ -5620,7 +5608,7 @@ msgstr "Beispiel"
 #: superset-frontend/src/views/CRUD/welcome/EmptyState.tsx:92
 #, python-format
 msgid "Example %(tableName)s will appear here"
-msgstr "Beispiel %(tableName)s wird hier angezeigt"
+msgstr "Beispiel-%(tableName)s werden hier angezeigt"
 
 #: superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx:759
 #: superset-frontend/src/views/CRUD/welcome/ChartTable.tsx:180
@@ -5646,9 +5634,8 @@ msgid "Excel to Database configuration"
 msgstr "Excel-zu-Datenbank-Konfiguration"
 
 #: superset-frontend/src/filters/components/Select/controlPanel.ts:126
-#, fuzzy
 msgid "Exclude selected values"
-msgstr "Auswahlwerte einschränken"
+msgstr "Auswahlwerte ausschließen"
 
 #: superset-frontend/src/SqlLab/components/HighlightedSql/index.tsx:82
 msgid "Executed SQL"
@@ -5690,7 +5677,7 @@ msgstr "Werkzeugleiste erweitern"
 #: superset-frontend/src/filters/components/TimeColumn/index.ts:31
 #: superset-frontend/src/filters/components/TimeGrain/index.ts:31
 msgid "Experimental"
-msgstr ""
+msgstr "Experimentell"
 
 #: superset-frontend/src/SqlLab/components/ExploreCtasResultsButton/index.jsx:98
 #: superset-frontend/src/SqlLab/components/ExploreResultsButton/index.jsx:168
@@ -5849,16 +5836,15 @@ msgstr "Fehlgeschlagen"
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:194
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:305
-#, fuzzy
 msgid "Failed at retrieving results"
-msgstr "Ergebnisse filtern"
+msgstr "Fehler beim Abrufen der Ergebnisse"
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:409
 #, python-format
 msgid "Failed at stopping query. %s"
-msgstr ""
+msgstr "Fehler beim Beenden der Abfrage. %s"
 
-#: superset/errors.py:137 superset/sqllab/sql_json_executer.py:194
+#: superset/errors.py:138 superset/sqllab/sql_json_executer.py:194
 msgid "Failed to start remote query on a worker."
 msgstr "Remoteabfrage für einen Worker konnte nicht gestartet werden."
 
@@ -5940,9 +5926,8 @@ msgid "Filter Type"
 msgstr "Filtertyp"
 
 #: superset-frontend/src/visualizations/FilterBox/FilterBoxChartPlugin.js:26
-#, fuzzy
 msgid "Filter box"
-msgstr "Kein Filter"
+msgstr "Filterkomponente"
 
 #: superset-frontend/src/SqlLab/components/QuerySearch/index.tsx:204
 msgid "Filter by database"
@@ -6108,9 +6093,8 @@ msgstr "Fixierte Farbe"
 #: superset-frontend/plugins/legacy-plugin-chart-event-flow/src/index.ts:24
 #: superset-frontend/plugins/legacy-plugin-chart-sankey/src/index.js:27
 #: superset-frontend/plugins/plugin-chart-echarts/src/Graph/index.ts:32
-#, fuzzy
 msgid "Flow"
-msgstr "Gelb"
+msgstr "Fluss"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:133
 msgid "Font size"
@@ -6122,11 +6106,11 @@ msgstr "Schriftgröße für Achsenbeschriftungen, Detailwerte und andere Textele
 
 #: superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.ts:71
 msgid "Font size for the biggest value in the list"
-msgstr ""
+msgstr "Schriftgröße für den größten Wert in der Liste"
 
 #: superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.ts:60
 msgid "Font size for the smallest value in the list"
-msgstr ""
+msgstr "Schriftgröße für den kleinsten Wert in der Liste"
 
 #: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:179
 msgid ""
@@ -6173,7 +6157,7 @@ msgstr "Aktualisierung erzwingen"
 
 #: superset-frontend/plugins/legacy-plugin-chart-force-directed/src/index.js:27
 msgid "Force-directed Graph"
-msgstr ""
+msgstr "Kraftgesteuerter Graph"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/sections/forecastInterval.tsx:56
 msgid "Forecast periods"
@@ -6182,9 +6166,8 @@ msgstr "Prognosezeiträume"
 #: superset-frontend/plugins/legacy-preset-chart-big-number/src/BigNumber/index.ts:37
 #: superset-frontend/plugins/legacy-preset-chart-big-number/src/BigNumberTotal/index.ts:42
 #: superset-frontend/plugins/plugin-chart-table/src/index.ts:45
-#, fuzzy
 msgid "Formattable"
-msgstr "Schlüssel für Tabelle"
+msgstr "Formattabelle"
 
 #: superset-frontend/src/components/ReportModal/index.tsx:296
 msgid "Formatted CSV attached in email"
@@ -6192,16 +6175,15 @@ msgstr "Formatierte CSV-Datei in E-Mail angehängt"
 
 #: superset-frontend/packages/superset-ui-core/src/query/extractQueryFields.ts:130
 msgid "Found invalid orderby options"
-msgstr ""
+msgstr "Ungültige Order-By-Optionen gefunden"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:80
 msgid "Fraction digits"
 msgstr "Nachkommastellen"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/TimePivot/controlPanel.ts:53
-#, fuzzy
 msgid "Frequency"
-msgstr "Aktualisierungsfrequenz"
+msgstr "Häufigkeit"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:304
 msgid "Friction"
@@ -6220,9 +6202,8 @@ msgid "From date cannot be larger than to date"
 msgstr "‚Von Datum' kann nicht größer als ‚Bis-Datum' sein"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Funnel/index.ts:52
-#, fuzzy
 msgid "Funnel Chart"
-msgstr "Neues Diagramm"
+msgstr "Trichterdiagramm"
 
 #: superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx:454
 msgid "Further customize how to display each column"
@@ -6233,9 +6214,8 @@ msgid "Further customize how to display each metric"
 msgstr "Passen Sie weiter an, wie die einzelnen Metriken angezeigt werden sollen"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Gauge/index.ts:42
-#, fuzzy
 msgid "Gauge Chart"
-msgstr "Diagramm speichern"
+msgstr "Tachometerdiagramm"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:78
 msgid "General"
@@ -6243,7 +6223,7 @@ msgstr "Allgemein"
 
 #: superset-frontend/plugins/legacy-plugin-chart-country-map/src/index.js:34
 msgid "Geo"
-msgstr ""
+msgstr "Räumlich"
 
 #: superset-frontend/src/explore/components/controls/SpatialControl.jsx:203
 msgid "Geohash"
@@ -6266,9 +6246,8 @@ msgid "Grace period"
 msgstr "Kulanzzeit"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Graph/index.ts:37
-#, fuzzy
 msgid "Graph Chart"
-msgstr "Flächendiagramm"
+msgstr "Graphen-Diagramm"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:108
 msgid "Graph layout"
@@ -6285,7 +6264,7 @@ msgstr "Gruppieren nach"
 
 #: superset-frontend/src/filters/components/GroupBy/index.ts:29
 msgid "Group By filter plugin"
-msgstr ""
+msgstr "Gruppieren nach Filter-Plugin"
 
 #: superset/viz.py:895
 msgid "Group By' and 'Columns' can't overlap"
@@ -6312,6 +6291,9 @@ msgid ""
 "Hard value bounds applied for color coding. Is only relevant and applied "
 "when the normalization is applied against the whole heatmap."
 msgstr ""
+"Harte Wertgrenzen für die Farbcodierung. Ist nur relevant und wird "
+"angewendet, wenn die Normalisierung auf die gesamte Heatmap angewendet "
+"wird."
 
 #: superset-frontend/src/dashboard/components/gridComponents/new/NewHeader.jsx:31
 msgid "Header"
@@ -6327,9 +6309,8 @@ msgid "Heatmap"
 msgstr "Heatmap"
 
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:104
-#, fuzzy
 msgid "Heatmap Options"
-msgstr "Diagramm-Optionen"
+msgstr "Heatmap-Optionen"
 
 #: superset-frontend/src/explore/components/EmbedCodeButton.jsx:116
 msgid "Height"
@@ -6344,9 +6325,8 @@ msgid "Hide tool bar"
 msgstr "Werkzeugleiste ausblenden"
 
 #: superset-frontend/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts:81
-#, fuzzy
 msgid "Hierarchy"
-msgstr "Suche"
+msgstr "Hierarchie"
 
 #: superset-frontend/plugins/legacy-plugin-chart-histogram/src/index.js:37
 #: superset/viz.py:1711
@@ -6358,9 +6338,8 @@ msgid "Home"
 msgstr "Startseite"
 
 #: superset-frontend/plugins/legacy-plugin-chart-horizon/src/index.js:32
-#, fuzzy
 msgid "Horizon Chart"
-msgstr "Horizontdiagramme"
+msgstr "Horizont-Diagramm"
 
 #: superset/viz.py:2273
 msgid "Horizon Charts"
@@ -6383,9 +6362,9 @@ msgid "Hour"
 msgstr "Stunde"
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:65
-#, fuzzy, python-format
+#, python-format
 msgid "Hours %s"
-msgstr "Stunde"
+msgstr "Stunden %s"
 
 #: superset-frontend/src/components/Datasource/DatasourceEditor.jsx:779
 msgid "Hours offset"
@@ -6421,11 +6400,11 @@ msgstr ""
 #: superset-frontend/plugins/legacy-preset-chart-big-number/src/sharedControls.ts:51
 #: superset-frontend/plugins/legacy-preset-chart-big-number/src/sharedControls.ts:85
 msgid "Huge"
-msgstr ""
+msgstr "Riesig"
 
 #: superset-frontend/plugins/legacy-plugin-chart-country-map/src/controlPanel.ts:78
 msgid "ISO 3166-2 Codes"
-msgstr ""
+msgstr "ISO-3166-2-Codes"
 
 #: superset-frontend/src/components/Datasource/DatasourceEditor.jsx:237
 msgid "ISO 8601"
@@ -6519,7 +6498,7 @@ msgstr "Bild (PNG) in E-Mail eingebettet"
 
 #: superset-frontend/src/utils/downloadAsImage.ts:63
 msgid "Image download failed, please refresh and try again."
-msgstr ""
+msgstr "Bilddownload fehlgeschlagen, bitte aktualisieren und erneut versuchen."
 
 #: superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx:395
 msgid "Impersonate logged in user (Presto, Trino, Drill, Hive, and GSheets)"
@@ -6605,13 +6584,12 @@ msgstr ""
 "Ereignisse für jede Entität zurückgegeben werden."
 
 #: superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/src/controlPanel.ts:67
-#, fuzzy
 msgid "Include Series"
-msgstr "Zeit einschließen"
+msgstr "Serien einschließen"
 
 #: superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/src/controlPanel.ts:70
 msgid "Include series name as an axis"
-msgstr ""
+msgstr "Seriennamen als Achse einschließen"
 
 #: superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx:325
 msgid "Include time"
@@ -6671,9 +6649,8 @@ msgstr ""
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/index.js:41
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/index.js:36
 #: superset-frontend/plugins/legacy-plugin-chart-world-map/src/index.js:38
-#, fuzzy
 msgid "Intensity"
-msgstr "Element"
+msgstr "Intensität"
 
 #: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:495
 msgid "Interval End column"
@@ -6809,9 +6786,8 @@ msgid "Invalid spatial point encountered: %s"
 msgstr "Ungültiger räumlicher Punkt: %s"
 
 #: superset-frontend/src/filters/components/Select/controlPanel.ts:124
-#, fuzzy
 msgid "Inverse selection"
-msgstr "Auswahl ausführen"
+msgstr "Auswahl umkehren"
 
 #: superset/connectors/druid/views.py:347
 msgid "Is Hidden"
@@ -6839,14 +6815,12 @@ msgid "Is temporal"
 msgstr "Ist zeitlich"
 
 #: superset-frontend/src/utils/getClientErrorObject.ts:112
-#, fuzzy
 msgid "Issue 1000 - The dataset is too large to query."
-msgstr "Die Datenquelle ist zu groß, um sie abzufragen."
+msgstr "Problem 1000 - Die Datenquelle ist zu groß, um sie abzufragen."
 
 #: superset-frontend/src/utils/getClientErrorObject.ts:118
-#, fuzzy
 msgid "Issue 1001 - The database is under an unusual load."
-msgstr "Die Datenbank ist ungewöhnlich belastet."
+msgstr "Problem 1001 - Die Datenbank ist ungewöhnlich belastet."
 
 #: superset-frontend/src/SqlLab/components/QuerySearch/index.tsx:180
 #: superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.jsx:125
@@ -6933,7 +6907,7 @@ msgstr "Juni"
 #: superset-frontend/plugins/plugin-chart-echarts/src/Funnel/index.ts:47
 #: superset-frontend/plugins/plugin-chart-echarts/src/Gauge/index.ts:37
 msgid "KPI"
-msgstr ""
+msgstr "KPI"
 
 #: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/Footer/CancelConfirmationAlert.tsx:56
 msgid "Keep editing"
@@ -6979,9 +6953,8 @@ msgid "Label threshold"
 msgstr "Beschriftungsschwellenwert"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:144
-#, fuzzy
 msgid "Labelling"
-msgstr "Beschriftungslinie"
+msgstr "Beschriftung"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Funnel/controlPanel.tsx:79
 #: superset-frontend/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:93
@@ -6991,29 +6964,26 @@ msgid "Labels"
 msgstr "Beschriftungen"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:90
-#, fuzzy
 msgid "Labels for the marker lines"
-msgstr "Name der Zielknoten"
+msgstr "Beschriftungen für die Markerlinien"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:70
 msgid "Labels for the markers"
-msgstr ""
+msgstr "Beschriftungen für die Marker"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:50
 msgid "Labels for the ranges"
-msgstr ""
+msgstr "Beschriftungen für Bereiche"
 
 #: superset-frontend/plugins/legacy-preset-chart-big-number/src/sharedControls.ts:47
 #: superset-frontend/plugins/legacy-preset-chart-big-number/src/sharedControls.ts:81
 #: superset-frontend/src/dashboard/util/headerStyleOptions.ts:35
-#, fuzzy
 msgid "Large"
-msgstr "Ziel"
+msgstr "Groß"
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:31
-#, fuzzy
 msgid "Last"
-msgstr "bei"
+msgstr "Letzte"
 
 #: superset/connectors/sqla/views.py:492 superset/views/database/mixins.py:193
 msgid "Last Changed"
@@ -7051,11 +7021,11 @@ msgstr "Letzte Ausführung"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:63
 msgid "Latitude"
-msgstr ""
+msgstr "Breitengrad"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:294
 msgid "Latitude of default viewport"
-msgstr ""
+msgstr "Breitengrad des Standardansichtsfensters"
 
 #: superset/views/annotations.py:76
 msgid "Layer"
@@ -7099,18 +7069,16 @@ msgstr "Links"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/DualLine/controlPanel.ts:72
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:166
-#, fuzzy
 msgid "Left Axis Format"
-msgstr "Y-Achsenformat"
+msgstr "Format der linken Achse"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/DualLine/controlPanel.ts:68
-#, fuzzy
 msgid "Left Axis Metric"
-msgstr "Metrik der rechten Achse"
+msgstr "Metrik linke Achse"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:97
 msgid "Left Axis chart(s)"
-msgstr ""
+msgstr "Diagramm(e) der linken Achse"
 
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:187
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:77
@@ -7157,7 +7125,7 @@ msgstr "Linker Wert"
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/TimePivot/index.js:29
 #: superset-frontend/src/visualizations/TimeTable/TimeTableChartPlugin.ts:32
 msgid "Legacy"
-msgstr ""
+msgstr "Veraltet"
 
 #: superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:154
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:275
@@ -7174,12 +7142,11 @@ msgstr "Legendentyp"
 
 #: superset-frontend/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts:98
 msgid "Lift percent precision"
-msgstr ""
+msgstr "Prozentuale Präzision erhöhen"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/index.js:30
-#, fuzzy
 msgid "Light mode"
-msgstr "Rechts nach links"
+msgstr "Heller Modus"
 
 #: superset-frontend/src/explore/components/RowCountLabel.jsx:45
 msgid "Limit reached"
@@ -7194,6 +7161,9 @@ msgid ""
 "Limiting rows may result in incomplete data and misleading charts. "
 "Consider filtering or grouping source/target names instead."
 msgstr ""
+"Das Einschränken von Zeilen kann zu unvollständigen Daten und "
+"irreführenden Diagrammen führen. Erwägen Sie stattdessen, "
+"Quell-/Zielnamen zu filtern oder zu gruppieren."
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:335
 #: superset-frontend/src/explore/controls.jsx:364
@@ -7225,15 +7195,13 @@ msgstr ""
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/index.ts:76
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/SmoothLine/index.ts:76
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/index.ts:73
-#, fuzzy
 msgid "Line"
-msgstr "Meine"
+msgstr "Linie"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Line/index.js:38
 #: superset-frontend/plugins/preset-chart-xy/src/Line/createMetadata.ts:26
-#, fuzzy
 msgid "Line Chart"
-msgstr "Diagramm minimieren"
+msgstr "Liniendiagramm"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:113
 msgid "Line Style"
@@ -7261,13 +7229,12 @@ msgid "Link Copied!"
 msgstr "Link kopiert!"
 
 #: superset-frontend/plugins/legacy-plugin-chart-force-directed/src/controlPanel.ts:58
-#, fuzzy
 msgid "Link Length"
-msgstr "Seitenlänge"
+msgstr "Kantenlänge"
 
 #: superset-frontend/plugins/legacy-plugin-chart-force-directed/src/controlPanel.ts:70
 msgid "Link length in the force layout"
-msgstr ""
+msgstr "Kantenlänge in kraftbasierter Anordnung"
 
 #: superset/views/alerts.py:75
 msgid "List Observations"
@@ -7279,11 +7246,11 @@ msgstr "Gespeicherte Abfragen auflisten"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:81
 msgid "List of values to mark with lines"
-msgstr ""
+msgstr "Liste der Werte, die mit Linien markiert werden sollen"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:61
 msgid "List of values to mark with triangles"
-msgstr ""
+msgstr "Liste der Werte, die mit Dreiecken markiert werden sollen"
 
 #: superset-frontend/src/dashboard/components/CssEditor/index.jsx:108
 msgid "Live CSS editor"
@@ -7291,7 +7258,7 @@ msgstr "Live CSS Editor"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:199
 msgid "Live render"
-msgstr ""
+msgstr "Live-Darstellung"
 
 #: superset-frontend/src/dashboard/components/CssEditor/index.jsx:93
 msgid "Load a CSS template"
@@ -7367,7 +7334,7 @@ msgstr "Protokolle"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:53
 msgid "Longitude"
-msgstr ""
+msgstr "Längengrad"
 
 #: superset-frontend/src/explore/components/controls/SpatialControl.jsx:168
 msgid "Longitude & Latitude columns"
@@ -7375,7 +7342,7 @@ msgstr "Längen- und Breitengradspalten"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:280
 msgid "Longitude of default viewport"
-msgstr ""
+msgstr "Längengrad des Standardansichtfensters"
 
 #: superset-frontend/src/components/CronPicker/CronPicker.tsx:93
 msgid "MAR"
@@ -7393,7 +7360,7 @@ msgstr "MO"
 msgid "Main Datetime Column"
 msgstr "Haupt-Datums/Zeit-Spalte"
 
-#: superset/views/core.py:1738
+#: superset/views/core.py:1755
 msgid ""
 "Malformed request. slice_id or table_name and db_name arguments are "
 "expected"
@@ -7432,18 +7399,16 @@ msgstr "Doppelte Spalten zusammenführen"
 #: superset-frontend/plugins/legacy-plugin-chart-country-map/src/index.js:25
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/index.js:26
 #: superset-frontend/plugins/legacy-plugin-chart-world-map/src/index.js:27
-#, fuzzy
 msgid "Map"
-msgstr "Treemap"
+msgstr "Karte"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:212
 msgid "Map Style"
-msgstr ""
+msgstr "Karten Stil"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/index.js:33
-#, fuzzy
 msgid "MapBox"
-msgstr "Mapbox"
+msgstr "MapBox"
 
 #: superset/viz.py:2285
 msgid "Mapbox"
@@ -7477,32 +7442,28 @@ msgid "Marker Size"
 msgstr "Markergröße"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:68
-#, fuzzy, python-format
 msgid "Marker labels"
-msgstr "[Alarm] %(label)s"
+msgstr "Markierungsbeschriftungen"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:88
 msgid "Marker line labels"
-msgstr ""
+msgstr "Markierungslinienbeschriftungen"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:79
-#, fuzzy
 msgid "Marker lines"
-msgstr "Markergröße"
+msgstr "Markierungslinien"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:225
 msgid "Marker size"
 msgstr "Markergröße"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:59
-#, fuzzy
 msgid "Markers"
 msgstr "Marker"
 
 #: superset-frontend/src/explore/controlPanels/Separator.js:32
-#, fuzzy
 msgid "Markup type"
-msgstr "Diagrammtyp"
+msgstr "Markup-Typ"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:100
 #: superset-frontend/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx:48
@@ -7512,9 +7473,8 @@ msgstr "Max"
 
 #: superset-frontend/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:94
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bubble/controlPanel.ts:59
-#, fuzzy
 msgid "Max Bubble Size"
-msgstr "Blasengröße"
+msgstr "Maximale Blasengröße"
 
 #: superset-frontend/plugins/legacy-plugin-chart-event-flow/src/controlPanel.tsx:129
 msgid "Max Events"
@@ -7526,12 +7486,11 @@ msgstr "Diagramm maximieren"
 
 #: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:1266
 msgid "Maximum"
-msgstr ""
+msgstr "Maximum"
 
 #: superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.ts:68
-#, fuzzy
 msgid "Maximum Font Size"
-msgstr "Schriftgröße"
+msgstr "Maximale Schriftgrösse"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:101
 msgid "Maximum value on the gauge axis"
@@ -7559,7 +7518,7 @@ msgstr "Mittlere Knotengröße, der größte Knoten ist 4-mal größer als der k
 
 #: superset-frontend/src/dashboard/util/headerStyleOptions.ts:30
 msgid "Medium"
-msgstr ""
+msgstr "Mittel"
 
 #: superset-frontend/src/components/ReportModal/index.tsx:275
 msgid "Message Content"
@@ -7618,9 +7577,8 @@ msgid "Metric '%(metric)s' does not exist"
 msgstr "Metrik '%(metric)s' existiert nicht"
 
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:38
-#, fuzzy
 msgid "Metric ascending"
-msgstr "Aufsteigend sortieren"
+msgstr "Metrik aufsteigend"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:148
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:407
@@ -7639,18 +7597,16 @@ msgid "Metric change in value from `since` to `until`"
 msgstr "Metrische Wertänderung von 'seit' zu 'bis'"
 
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:39
-#, fuzzy
 msgid "Metric descending"
-msgstr "Absteigend sortieren"
+msgstr "Metrik absteigend"
 
 #: superset-frontend/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:117
 msgid "Metric factor change from `since` to `until`"
 msgstr "Änderung des metrischen Faktors von \"seit\" zu \"bis\""
 
 #: superset-frontend/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:119
-#, fuzzy
 msgid "Metric for Color"
-msgstr "Eine Metrik, die für die Farbe verwendet werden soll"
+msgstr "Metrik für Farbe"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:98
 msgid "Metric for node values"
@@ -7667,16 +7623,15 @@ msgstr "Metrische prozentuale Wertänderung von \"seit\" zu \"bis\""
 
 #: superset-frontend/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:120
 msgid "Metric that defines the color of the country"
-msgstr ""
+msgstr "Metrik, die die Farbe des Landes definiert"
 
 #: superset-frontend/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:124
 msgid "Metric that defines the size of the bubble"
-msgstr ""
+msgstr "Metrik, die die Größe der Blase definiert"
 
 #: superset-frontend/plugins/legacy-plugin-chart-country-map/src/controlPanel.ts:85
-#, fuzzy
 msgid "Metric to display bottom title"
-msgstr "Ob der Zeitstempel angezeigt werden soll"
+msgstr "Metrik zur Anzeige des unteren Titels"
 
 #: superset-frontend/src/explore/components/controls/FilterBoxItemControl/index.jsx:185
 msgid "Metric to sort the results by"
@@ -7722,9 +7677,8 @@ msgstr ""
 "Berechnet nur aus Daten innerhalb des Zeilenlimits."
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:93
-#, fuzzy
 msgid "Midnight"
-msgstr "Rechts"
+msgstr "Mitternacht"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:88
 #: superset-frontend/src/explore/components/controls/BoundsControl.jsx:112
@@ -7758,14 +7712,12 @@ msgid "Minimize chart"
 msgstr "Diagramm minimieren"
 
 #: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:1260
-#, fuzzy
 msgid "Minimum"
-msgstr "Minute"
+msgstr "Minimum"
 
 #: superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.ts:57
-#, fuzzy
 msgid "Minimum Font Size"
-msgstr "Schriftgröße"
+msgstr "Minimale Schriftgröße"
 
 #: superset-frontend/plugins/legacy-plugin-chart-event-flow/src/controlPanel.tsx:78
 msgid "Minimum leaf node event count"
@@ -7798,9 +7750,9 @@ msgid "Minute"
 msgstr "Minute"
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:64
-#, fuzzy, python-format
+#, python-format
 msgid "Minutes %s"
-msgstr "Minute"
+msgstr "Minuten %s"
 
 #: superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx:93
 msgid "Missing Required Fields"
@@ -7812,9 +7764,8 @@ msgid "Missing dataset"
 msgstr "Fehlender Datensatz"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/index.ts:67
-#, fuzzy
 msgid "Mixed Time-Series"
-msgstr "Standard-Zeitreihen"
+msgstr "Gemischte Zeitreihen"
 
 #: superset-frontend/src/dashboard/components/AddSliceCard.jsx:128
 #: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:312
@@ -7854,9 +7805,9 @@ msgid "Month"
 msgstr "Monat"
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:68
-#, fuzzy, python-format
+#, python-format
 msgid "Months %s"
-msgstr "Monat"
+msgstr "Monate %s"
 
 #: superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx:238
 msgid "More dataset related options"
@@ -7875,24 +7826,21 @@ msgstr ""
 
 #: superset-frontend/plugins/legacy-plugin-chart-world-map/src/index.js:40
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bubble/index.js:32
-#, fuzzy
 msgid "Multi-Dimensions"
-msgstr "Ist Dimension"
+msgstr "Multi-Dimensionen"
 
 #: superset-frontend/plugins/legacy-plugin-chart-rose/src/index.js:34
 #: superset-frontend/plugins/legacy-plugin-chart-world-map/src/index.js:41
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/LineMulti/index.js:37
-#, fuzzy
 msgid "Multi-Layers"
-msgstr "Mehrfach"
+msgstr "Mehr-Ebenen"
 
 #: superset-frontend/plugins/legacy-plugin-chart-sunburst/src/index.js:33
 #: superset-frontend/plugins/legacy-plugin-chart-treemap/src/index.js:44
 #: superset-frontend/plugins/plugin-chart-echarts/src/Tree/index.ts:43
 #: superset-frontend/plugins/plugin-chart-echarts/src/Treemap/index.ts:62
-#, fuzzy
 msgid "Multi-Levels"
-msgstr "kumulativ"
+msgstr "Mehrstufige"
 
 #: superset-frontend/plugins/legacy-plugin-chart-world-map/src/index.js:42
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/LineMulti/index.js:32
@@ -7901,16 +7849,15 @@ msgstr "kumulativ"
 #: superset-frontend/plugins/plugin-chart-echarts/src/Radar/index.ts:58
 #: superset-frontend/src/visualizations/TimeTable/TimeTableChartPlugin.ts:30
 msgid "Multi-Variables"
-msgstr ""
+msgstr "Multi-Variablen"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:187
 msgid "Multiple"
 msgstr "Mehrfach"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/LineMulti/index.js:30
-#, fuzzy
 msgid "Multiple Line Charts"
-msgstr "Zeitreihen - Diagramme mit mehreren Linien"
+msgstr "Mehr-Liniendiagramme"
 
 #: superset/views/database/views.py:439
 msgid ""
@@ -7931,9 +7878,8 @@ msgstr ""
 
 #: superset-frontend/src/filters/components/GroupBy/controlPanel.ts:59
 #: superset-frontend/src/filters/components/Select/controlPanel.ts:77
-#, fuzzy
 msgid "Multiple select"
-msgstr "Mehrfachauswahl möglich"
+msgstr "Mehrfachauswahl"
 
 #: superset-frontend/src/explore/components/controls/FilterBoxItemControl/index.jsx:218
 msgid "Multiple selections allowed, otherwise filter is limited to a single value"
@@ -8043,9 +7989,8 @@ msgstr "Benennen der Datenbank"
 
 #: superset-frontend/src/chart/chartReducer.ts:106
 #: superset-frontend/src/chart/chartReducer.ts:170
-#, fuzzy
 msgid "Network error."
-msgstr "Parameter-Fehler"
+msgstr "Netzwerk-Fehler."
 
 #: superset/templates/appbuilder/navbar_right.html:35
 msgid "New"
@@ -8086,9 +8031,8 @@ msgid "Next"
 msgstr "Weiter"
 
 #: superset-frontend/plugins/legacy-plugin-chart-rose/src/index.js:29
-#, fuzzy
 msgid "Nightingale Rose Chart"
-msgstr "Zeitreihe - Nightingale Rose Chart"
+msgstr "Nightingale Rose Diagramm"
 
 #: superset-frontend/src/views/CRUD/chart/ChartList.tsx:444
 #: superset-frontend/src/views/CRUD/chart/ChartList.tsx:538
@@ -8184,7 +8128,7 @@ msgstr "Kein Filter ausgewählt."
 
 #: superset-frontend/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts:86
 msgid "No of Bins"
-msgstr ""
+msgstr "Anzahl der Bis"
 
 #: superset-frontend/src/SqlLab/components/QueryHistory/index.tsx:49
 msgid "No query history yet..."
@@ -8256,18 +8200,17 @@ msgstr "Keine -> Keine"
 
 #: superset-frontend/plugins/legacy-preset-chart-big-number/src/sharedControls.ts:43
 #: superset-frontend/plugins/legacy-preset-chart-big-number/src/sharedControls.ts:77
-#, fuzzy
 msgid "Normal"
-msgstr "Allgemein"
+msgstr "Normal"
 
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:165
 msgid "Normalize Across"
-msgstr ""
+msgstr "Normalisieren über"
 
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:315
 #: superset-frontend/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts:141
 msgid "Normalized"
-msgstr ""
+msgstr "Normalisiert"
 
 #: superset-frontend/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:81
 msgid "Not Time Series"
@@ -8300,9 +8243,8 @@ msgid "November"
 msgstr "November"
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:92
-#, fuzzy
 msgid "Now"
-msgstr "Zeile"
+msgstr "Jetzt"
 
 #: superset/datasets/filters.py:26
 msgid "Null or Empty"
@@ -8313,9 +8255,8 @@ msgid "Null values"
 msgstr "NULL Werte"
 
 #: superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:191
-#, fuzzy
 msgid "Number Format"
-msgstr "Nummern Format"
+msgstr "Zahlenformat"
 
 #: superset-frontend/plugins/legacy-plugin-chart-chord/src/controlPanel.ts:56
 #: superset-frontend/plugins/legacy-plugin-chart-country-map/src/controlPanel.ts:64
@@ -8341,11 +8282,11 @@ msgstr "Anzahl der Dezimalstellen, auf die gerundet wird"
 
 #: superset-frontend/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts:100
 msgid "Number of decimal places with which to display lift values"
-msgstr ""
+msgstr "Anzahl der Dezimalstellen, mit denen Hubwerte angezeigt werden sollen"
 
 #: superset-frontend/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts:87
 msgid "Number of decimal places with which to display p-values"
-msgstr ""
+msgstr "Anzahl der Dezimalstellen, mit denen p-Werte angezeigt werden sollen"
 
 #: superset/views/database/forms.py:194 superset/views/database/forms.py:335
 msgid "Number of rows of file to read."
@@ -8362,10 +8303,14 @@ msgstr "Anzahl der geteilten Segmente auf der Achse"
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:119
 msgid "Number of steps to take between ticks when displaying the X scale"
 msgstr ""
+"Anzahl der Schritte, die zwischen den Strichen bei der Anzeige der "
+"X-Skala ausgeführt werden müssen"
 
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:135
 msgid "Number of steps to take between ticks when displaying the Y scale"
 msgstr ""
+"Anzahl der Schritte, die zwischen den Strichen bei der Anzeige der "
+"Y-Skala ausgeführt werden müssen"
 
 #: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:295
 msgid "Numerical range"
@@ -8441,6 +8386,8 @@ msgid ""
 "One or many controls to group by. If grouping, latitude and longitude "
 "columns must be present."
 msgstr ""
+"Ein oder mehrere Steuerelemente, nach denen gruppiert werden soll. Bei "
+"der Gruppierung müssen Breiten- und Längengradspalten vorhanden sein."
 
 #: superset-frontend/src/explore/controls.jsx:246
 msgid "One or many controls to pivot as columns"
@@ -8476,21 +8423,21 @@ msgstr "Eine oder mehrere Metriken werden dupliziert"
 msgid "One or more metrics do not exist"
 msgstr "Eine oder mehrere Metriken sind nicht vorhanden"
 
-#: superset/errors.py:113
+#: superset/errors.py:114
 msgid "One or more parameters needed to configure a database are missing."
 msgstr "Ein oder mehrere in der Abfrage angegebene Parameter fehlen."
 
-#: superset/errors.py:127
+#: superset/errors.py:128
 msgid "One or more parameters specified in the query are malformatted."
 msgstr ""
 "Ein oder mehrere in der Abfrage angegebene Parameter haben das falsche "
 "Format."
 
-#: superset/errors.py:101
+#: superset/errors.py:102
 msgid "One or more parameters specified in the query are missing."
 msgstr "Ein oder mehrere in der Abfrage angegebene Parameter fehlen."
 
-#: superset/views/core.py:2075
+#: superset/views/core.py:2092
 msgid ""
 "One or more required fields are missing in the request. Please try again,"
 " and if the problem persists conctact your administrator."
@@ -8551,7 +8498,7 @@ msgstr "Deckkraft des Flächendiagramms. Gilt auch für das Vertrauensband."
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:239
 msgid "Opacity of all clusters, points, and labels. Between 0 and 1."
-msgstr ""
+msgstr "Deckkraft aller Cluster, Punkte und Beschriftungen. Zwischen 0 und 1."
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:202
 msgid "Opacity of area chart."
@@ -8665,14 +8612,12 @@ msgstr "Ausrichtung des Baumes"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/constants.ts:27
 #: superset-frontend/src/explore/constants.ts:116
-#, fuzzy
 msgid "Origin"
-msgstr "Anmelden"
+msgstr "Herkunft"
 
 #: superset-frontend/src/explore/components/ExportToCSVDropdown/index.tsx:74
-#, fuzzy
 msgid "Original"
-msgstr "Ursprünglicher Wert"
+msgstr "Original"
 
 #: superset-frontend/src/SqlLab/components/TableElement/index.tsx:183
 msgid "Original table column order"
@@ -8784,7 +8729,7 @@ msgstr "Seitenlänge"
 
 #: superset-frontend/plugins/legacy-plugin-chart-paired-t-test/src/index.js:29
 msgid "Paired t-test Table"
-msgstr ""
+msgstr "Gepaarte t-Test-Tabelle"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/sections/advancedAnalytics.tsx:177
 #: superset-frontend/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:388
@@ -8844,10 +8789,9 @@ msgstr "Datumsangaben auswerten"
 #: superset-frontend/plugins/plugin-chart-echarts/src/Tree/index.ts:33
 #: superset-frontend/plugins/plugin-chart-echarts/src/Treemap/index.ts:50
 msgid "Part of a Whole"
-msgstr ""
+msgstr "Teil eines Ganzen"
 
 #: superset-frontend/plugins/legacy-plugin-chart-partition/src/index.js:27
-#, fuzzy
 msgid "Partition Chart"
 msgstr "Partitionsdiagramm"
 
@@ -8884,9 +8828,8 @@ msgstr "Fügen Sie die gemeinsam nutzbare Google Tabellen-URL hier ein"
 #: superset-frontend/plugins/legacy-plugin-chart-histogram/src/index.js:38
 #: superset-frontend/plugins/legacy-plugin-chart-rose/src/index.js:35
 #: superset-frontend/plugins/plugin-chart-table/src/index.ts:46
-#, fuzzy
 msgid "Pattern"
-msgstr "Aktualisieren"
+msgstr "Muster"
 
 #: superset-frontend/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:108
 msgid "Percent Change"
@@ -8911,9 +8854,8 @@ msgstr "Prozentualer Schwellenwert"
 #: superset-frontend/plugins/plugin-chart-echarts/src/Pie/index.ts:69
 #: superset-frontend/plugins/plugin-chart-echarts/src/Treemap/index.ts:63
 #: superset-frontend/src/visualizations/TimeTable/TimeTableChartPlugin.ts:33
-#, fuzzy
 msgid "Percentages"
-msgstr "Prozentuale Veränderung"
+msgstr "Prozentwerte"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/sections/advancedAnalytics.tsx:56
 #: superset-frontend/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:278
@@ -8925,8 +8867,8 @@ msgid "Periods"
 msgstr "Zeiträume"
 
 #: superset/utils/pandas_postprocessing.py:824
-msgid "Periods must be a positive integer value"
-msgstr "Perioden müssen ein positiver ganzzahliger Wert sein"
+msgid "Periods must be a whole number"
+msgstr "Perioden müssen eine ganze Zahl sein"
 
 #: superset-frontend/src/explore/components/PropertiesModal/index.tsx:258
 msgid "Person or group that has certified this chart."
@@ -9021,13 +8963,12 @@ msgstr ""
 
 #: superset-frontend/src/explore/controlPanels/Separator.js:37
 msgid "Pick your favorite markup language"
-msgstr ""
+msgstr "Wählen Sie Ihre bevorzugte Markup-Sprache"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Pie/index.js:27
 #: superset-frontend/plugins/plugin-chart-echarts/src/Pie/index.ts:63
-#, fuzzy
 msgid "Pie Chart"
-msgstr "Neues Diagramm"
+msgstr "Kreisdiagramm"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:187
 msgid "Pie shape"
@@ -9038,9 +8979,8 @@ msgid "Pin"
 msgstr "Pin"
 
 #: superset-frontend/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.ts:56
-#, fuzzy
 msgid "Pivot Options"
-msgstr "Diagramm-Optionen"
+msgstr "Pivot-Optionen"
 
 #: superset-frontend/plugins/legacy-plugin-chart-pivot-table/src/index.js:30
 #: superset/viz.py:862
@@ -9048,9 +8988,8 @@ msgid "Pivot Table"
 msgstr "Pivot-Tabelle"
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/index.ts:54
-#, fuzzy
 msgid "Pivot Table v2"
-msgstr "Pivot-Tabelle"
+msgstr "Pivot-Tabelle v2"
 
 #: superset/utils/pandas_postprocessing.py:260
 msgid "Pivot operation must include at least one aggregate"
@@ -9061,17 +9000,16 @@ msgid "Pivot operation requires at least one index"
 msgstr "Pivot-Operation erfordert mindestens einen Index"
 
 #: superset-frontend/src/explore/components/ExportToCSVDropdown/index.tsx:80
-#, fuzzy
 msgid "Pivoted"
-msgstr "Bearbeitet"
+msgstr "Pilotiert"
 
 #: superset-frontend/plugins/legacy-plugin-chart-horizon/src/controlPanel.ts:83
 msgid "Pixel height of each series"
-msgstr ""
+msgstr "Pixelhöhe jeder Serie"
 
 #: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/utils/index.ts:28
 msgid "Please apply filter changes"
-msgstr ""
+msgstr "Bitte wenden Sie Filteränderungen an"
 
 #: superset/sqllab/query_render.py:116
 msgid ""
@@ -9199,6 +9137,10 @@ msgid ""
 "links them together as a line. This chart is useful for comparing "
 "multiple metrics across all of the samples or rows in the data."
 msgstr ""
+"Stellt die einzelnen Metriken für jede Zeile in den Daten vertikal dar "
+"und verknüpft sie als Linie miteinander. Dieses Diagramm ist nützlich, um"
+" mehrere Metriken in allen Stichproben oder Zeilen in den Daten zu "
+"vergleichen."
 
 #: superset/initialization/__init__.py:254
 msgid "Plugins"
@@ -9206,20 +9148,21 @@ msgstr "Plugins"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:108
 msgid "Point Radius"
-msgstr ""
+msgstr "Punktradius"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:132
 msgid "Point Radius Unit"
-msgstr ""
+msgstr "Punktradius-Einheit"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:101
-#, fuzzy
 msgid "Points"
-msgstr "Komponenten"
+msgstr "Punkte"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:201
 msgid "Points and clusters will update as the viewport is being changed"
 msgstr ""
+"Punkte und Cluster werden aktualisiert, wenn das Ansichtsfenster geändert"
+" wird"
 
 #: superset/views/sql_lab.py:74
 msgid "Pop Tab Link"
@@ -9246,7 +9189,7 @@ msgstr "Geben Sie den \"Standardwert\" an, um dieses Steuerelement zu aktivieren
 
 #: superset-frontend/plugins/legacy-plugin-chart-histogram/src/index.js:33
 msgid "Population age data"
-msgstr ""
+msgstr "Daten zum Bevölkerungsalter"
 
 #: superset/db_engine_specs/mssql.py:87
 #: superset/db_engine_specs/postgres.py:132
@@ -9269,9 +9212,8 @@ msgid "Position of child node label on tree"
 msgstr "Position der Beschriftung des untergeordneten Knotens in der Struktur"
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:310
-#, fuzzy
 msgid "Position of column level subtotal"
-msgstr "Position der Beschriftung des untergeordneten Knotens in der Struktur"
+msgstr "Position der Zwischensumme auf Spaltenebene"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:163
 msgid "Position of intermidiate node label on tree"
@@ -9279,7 +9221,7 @@ msgstr "Position der Zwischenknoten-Beschriftung im Baum"
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:293
 msgid "Position of row level subtotal"
-msgstr ""
+msgstr "Position der Zwischensumme auf Zeilenebene"
 
 #: superset-frontend/src/components/Menu/MenuRight.tsx:180
 msgid "Powered by Apache Superset"
@@ -9318,9 +9260,8 @@ msgstr ""
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/SmoothLine/index.ts:72
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/index.ts:63
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/index.ts:74
-#, fuzzy
 msgid "Predictive"
-msgstr "Aktiv"
+msgstr "Prädikativ"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/sections/forecastInterval.tsx:36
 msgid "Predictive Analytics"
@@ -9328,7 +9269,7 @@ msgstr "Prädiktive Analysen"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:64
 msgid "Prefix metric name with slice name"
-msgstr ""
+msgstr "Metrikname den Slice-Namen voranstellen"
 
 #: superset-frontend/src/dashboard/components/menu/MarkdownModeDropdown.tsx:39
 msgid "Preview"
@@ -9350,9 +9291,8 @@ msgid "Primary"
 msgstr "Primär"
 
 #: superset-frontend/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts:56
-#, fuzzy
 msgid "Primary Metric"
-msgstr "Meine Metrik"
+msgstr "Primäre Metrik"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:248
 msgid "Primary or secondary y-axis"
@@ -9377,13 +9317,12 @@ msgstr "Fortschritt"
 
 #: superset-frontend/plugins/legacy-plugin-chart-event-flow/src/index.ts:30
 #: superset-frontend/plugins/plugin-chart-echarts/src/Funnel/index.ts:56
-#, fuzzy
 msgid "Progressive"
-msgstr "Fortschritt"
+msgstr "Progressiv"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Line/controlPanel.ts:55
 msgid "Propagate"
-msgstr ""
+msgstr "Propagieren"
 
 #: superset-frontend/plugins/legacy-plugin-chart-chord/src/index.js:39
 #: superset-frontend/plugins/legacy-plugin-chart-partition/src/index.js:28
@@ -9395,7 +9334,7 @@ msgstr ""
 #: superset-frontend/plugins/plugin-chart-echarts/src/Pie/index.ts:71
 #: superset-frontend/plugins/plugin-chart-echarts/src/Treemap/index.ts:64
 msgid "Proportional"
-msgstr ""
+msgstr "Proportional"
 
 #: superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm/EncryptedField.tsx:86
 msgid "Public and privately shared sheets"
@@ -9422,13 +9361,12 @@ msgid "Put the labels outside of the pie?"
 msgstr "Sollen die Beschriftungen außerhalb der Torte dargestellt werden?"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Pie/controlPanel.ts:112
-#, fuzzy
 msgid "Put the labels outside the pie?"
-msgstr "Sollen die Beschriftungen außerhalb der Torte dargestellt werden?"
+msgstr "Beschriftungen außerhalb des Kuchens anordnen?"
 
 #: superset-frontend/src/explore/controlPanels/Separator.js:47
 msgid "Put your code here"
-msgstr ""
+msgstr "Geben Sie Ihren Code hier ein"
 
 #: superset-frontend/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:351
 #: superset-frontend/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:234
@@ -9449,9 +9387,9 @@ msgid "Quarter"
 msgstr "Quartal"
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:69
-#, fuzzy, python-format
+#, python-format
 msgid "Quarters %s"
-msgstr "Quartal"
+msgstr "Quartale %s"
 
 #: superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:32
 #: superset-frontend/plugins/legacy-plugin-chart-chord/src/controlPanel.ts:26
@@ -9539,7 +9477,7 @@ msgstr "Abfragenverlauf"
 msgid "Query in a new tab"
 msgstr "Abfrage auf einer neuen Registerkarte"
 
-#: superset/errors.py:125
+#: superset/errors.py:126
 msgid "Query is too complex and takes too long to run."
 msgstr "Die Abfrage ist zu komplex und dauert zu lange."
 
@@ -9566,9 +9504,8 @@ msgid "Query was stopped"
 msgstr "Abfrage wurde angehalten"
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:407
-#, fuzzy
 msgid "Query was stopped."
-msgstr "Abfrage wurde angehalten"
+msgstr "Die Abfrage wurde gestoppt."
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx:292
 #: superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx:294
@@ -9580,18 +9517,16 @@ msgid "REPORT NAME ERROR"
 msgstr "BERICHTNAMEN FEHLER"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:251
-#, fuzzy
 msgid "RGB Color"
-msgstr "Fixierte Farbe"
+msgstr "RGB-Farbe"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx:161
 msgid "Radar"
 msgstr "Radar"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Radar/index.ts:53
-#, fuzzy
 msgid "Radar Chart"
-msgstr "Flächendiagramm"
+msgstr "Radar-Diagramm"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx:201
 msgid "Radar render type, whether to display 'circle' shape."
@@ -9609,9 +9544,8 @@ msgstr "Ausgeführt %s"
 #: superset-frontend/plugins/legacy-plugin-chart-country-map/src/index.js:35
 #: superset-frontend/plugins/legacy-plugin-chart-histogram/src/index.js:38
 #: superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/index.ts:55
-#, fuzzy
 msgid "Range"
-msgstr "Dreieck"
+msgstr "Bereich"
 
 #: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:295
 #: superset-frontend/src/filters/components/Range/index.ts:28
@@ -9620,39 +9554,35 @@ msgstr "Bereichsfilter"
 
 #: superset-frontend/src/filters/components/Range/index.ts:29
 msgid "Range filter plugin using AntD"
-msgstr ""
+msgstr "Bereichsfilter-Plugin mit AntD"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:48
-#, fuzzy
 msgid "Range labels"
-msgstr "Dreieck"
+msgstr "Bereichsbeschriftungen"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:39
-#, fuzzy
 msgid "Ranges"
-msgstr "Dreieck"
+msgstr "Bereiche"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts:41
 msgid "Ranges to highlight with shading"
-msgstr ""
+msgstr "Bereiche, die mit Schattierung hervorgehoben werden sollen"
 
 #: superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/src/index.js:25
 #: superset-frontend/plugins/legacy-plugin-chart-rose/src/index.js:25
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js:28
 #: superset-frontend/plugins/plugin-chart-echarts/src/Radar/index.ts:48
 #: superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/index.ts:33
-#, fuzzy
 msgid "Ranking"
-msgstr "In Bearbeitung"
+msgstr "Rangliste"
 
 #: superset-frontend/plugins/legacy-plugin-chart-treemap/src/controlPanel.ts:63
-#, fuzzy
 msgid "Ratio"
-msgstr "Dauer"
+msgstr "Verhältnis"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/constants.ts:46
 msgid "Raw records"
-msgstr ""
+msgstr "Rohdatensätze"
 
 #: superset-frontend/src/dashboard/components/FilterBoxMigrationModal.tsx:64
 msgid "Ready to review filters in this dashboard?"
@@ -9814,19 +9744,17 @@ msgstr ""
 #: superset-frontend/plugins/legacy-plugin-chart-sankey/src/index.js:43
 #: superset-frontend/plugins/plugin-chart-echarts/src/Graph/index.ts:44
 #: superset-frontend/plugins/plugin-chart-echarts/src/Tree/index.ts:44
-#, fuzzy
 msgid "Relational"
-msgstr "Dauer"
+msgstr "Relational"
 
 #: superset-frontend/plugins/legacy-plugin-chart-chord/src/index.js:32
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/index.js:35
 msgid "Relationships between community channels"
-msgstr ""
+msgstr "Beziehungen zwischen Community-Kanälen"
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:91
-#, fuzzy
 msgid "Relative Date/Time"
-msgstr "Relative Menge"
+msgstr "Relatives Datum/Uhrzeit"
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx:157
 #: superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx:210
@@ -9872,9 +9800,8 @@ msgid "Rename tab"
 msgstr "Registerkarte umbenennen"
 
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:146
-#, fuzzy
 msgid "Rendering"
-msgstr "Sortierung"
+msgstr "Darstellen"
 
 #: superset/views/database/forms.py:146 superset/views/database/forms.py:299
 #: superset/views/database/forms.py:427
@@ -9891,9 +9818,8 @@ msgstr "Ersetzen"
 #: superset-frontend/plugins/plugin-chart-echarts/src/Radar/index.ts:59
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/index.ts:55
 #: superset-frontend/plugins/plugin-chart-table/src/index.ts:48
-#, fuzzy
 msgid "Report"
-msgstr "Report"
+msgstr "Melden"
 
 #: superset/reports/commands/exceptions.py:118
 msgid "Report Schedule could not be created."
@@ -10047,11 +9973,11 @@ msgstr "Filter wiederherstellen"
 msgid "Results"
 msgstr "Ergebnisse"
 
-#: superset/sql_lab.py:375 superset/views/core.py:2251
+#: superset/sql_lab.py:375 superset/views/core.py:2268
 msgid "Results backend is not configured."
 msgstr "Das Ergebnis-Backend ist nicht konfiguriert."
 
-#: superset/errors.py:116
+#: superset/errors.py:117
 msgid "Results backend needed for asynchronous queries is not configured."
 msgstr ""
 "Das Ergebnis-Backend, das für asynchrone Abfragen benötigt wird, ist "
@@ -10090,9 +10016,8 @@ msgid "Right Axis Metric"
 msgstr "Metrik der rechten Achse"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:132
-#, fuzzy
 msgid "Right Axis chart(s)"
-msgstr "Alle Diagramm durchsuchen"
+msgstr "Diagramm(e) der rechten Achse"
 
 #: superset-frontend/src/explore/controls.jsx:215
 msgid "Right axis metric"
@@ -10195,7 +10120,7 @@ msgstr "X-Achsenbeschriftung drehen"
 
 #: superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.ts:89
 msgid "Rotation to apply to words in the cloud"
-msgstr ""
+msgstr "Rotation, die auf Wörter in der Cloud angewendet werden soll"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:271
 msgid "Round cap"
@@ -10239,9 +10164,8 @@ msgid "Rows per page, 0 means no pagination"
 msgstr "Zeilen pro Seite, 0 bedeutet keine Paginierung"
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:285
-#, fuzzy
 msgid "Rows subtotal position"
-msgstr "Position der Knotenbeschriftung"
+msgstr "Zeilen Zwischensummenposition"
 
 #: superset/views/database/forms.py:193 superset/views/database/forms.py:334
 msgid "Rows to Read"
@@ -10389,11 +10313,11 @@ msgstr "Sankey"
 
 #: superset-frontend/plugins/legacy-plugin-chart-sankey/src/index.js:36
 msgid "Sankey Diagram"
-msgstr ""
+msgstr "Sankey-Diagramm"
 
 #: superset-frontend/plugins/legacy-plugin-chart-sankey-loop/src/index.js:27
 msgid "Sankey Diagram with Loops"
-msgstr ""
+msgstr "Sankey-Diagramm mit Schleifen"
 
 #: superset-frontend/src/components/CronPicker/CronPicker.tsx:62
 msgid "Saturday"
@@ -10535,12 +10459,11 @@ msgstr "Neue Datenquellen suchen"
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bubble/index.js:36
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/index.ts:77
 msgid "Scatter"
-msgstr ""
+msgstr "Streudiagramm"
 
 #: superset-frontend/plugins/preset-chart-xy/src/ScatterPlot/createMetadata.ts:26
-#, fuzzy
 msgid "Scatter Plot"
-msgstr "Deck.gl - Streudiagramm"
+msgstr "Streudiagramm"
 
 #: superset-frontend/src/SqlLab/components/ScheduleQueryButton/index.tsx:221
 #: superset-frontend/src/components/ReportModal/index.tsx:357
@@ -10557,7 +10480,7 @@ msgid "Schedule Email Reports for Dashboards"
 msgstr "Planen von E-Mail-Berichten für Dashboards"
 
 #: superset-frontend/src/dashboard/components/Header/index.jsx:423
-#: superset-frontend/src/explore/components/ExploreChartHeader/index.jsx:218
+#: superset-frontend/src/explore/components/ExploreChartHeader/index.jsx:224
 msgid "Schedule email report"
 msgstr "Planen von E-Mail-Reports"
 
@@ -10674,9 +10597,8 @@ msgid "Secondary"
 msgstr "Sekundär"
 
 #: superset-frontend/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts:62
-#, fuzzy
 msgid "Secondary Metric"
-msgstr "Auf Metrik basierend"
+msgstr "Sekundäre Metrik"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx:392
 msgid "Secondary y-axis format"
@@ -10687,9 +10609,9 @@ msgid "Secondary y-axis title"
 msgstr "Titel der sekundären y-Achse"
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:63
-#, fuzzy, python-format
+#, python-format
 msgid "Seconds %s"
-msgstr "30 Sekunden"
+msgstr "Sekunden %s"
 
 #: superset/views/database/mixins.py:197
 msgid "Secure Extra"
@@ -10787,9 +10709,8 @@ msgstr "Auswählen beliebiger Spalten für die Metadatenüberprüfung"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:103
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:138
-#, fuzzy
 msgid "Select charts"
-msgstr "Alle Diagramme"
+msgstr "Diagramme auswählen"
 
 #: superset-frontend/src/explore/components/controls/ColorSchemeControl/index.jsx:188
 msgid "Select color scheme"
@@ -10823,13 +10744,15 @@ msgstr "Filter auswählen"
 
 #: superset-frontend/src/filters/components/Select/index.ts:29
 msgid "Select filter plugin using AntD"
-msgstr ""
+msgstr "Filter-Plugin mit AntD auswählen"
 
 #: superset-frontend/src/filters/components/Select/controlPanel.ts:111
 msgid ""
 "Select first item by default (when using this option, default value can’t"
 " be set)"
 msgstr ""
+"Standardmäßig das erste Element auswählen (bei Verwendung dieser Option "
+"kann der Standardwert nicht festgelegt werden)"
 
 #: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx:303
 msgid "Select operator"
@@ -10875,12 +10798,12 @@ msgstr "Tabelle auswählen oder Tabellennamen eingeben"
 
 #: superset-frontend/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts:98
 msgid "Select the number of bins for the histogram"
-msgstr ""
+msgstr "Wählen Sie die Anzahl der Klassen für das Histogramm aus"
 
 #: superset-frontend/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts:38
 #: superset-frontend/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts:48
 msgid "Select the numeric columns to draw the histogram"
-msgstr ""
+msgstr "Auswählen der numerischen Spalten zum Zeichnen des Histogramms"
 
 #: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1340
 msgid "Send as CSV"
@@ -10896,7 +10819,7 @@ msgstr "Als Text senden"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Line/controlPanel.ts:58
 msgid "Send range filter events to other charts"
-msgstr ""
+msgstr "Bereichsfilter-Ereignisse an andere Diagramme senden"
 
 #: superset-frontend/src/components/CronPicker/CronPicker.tsx:74
 msgid "September"
@@ -10905,7 +10828,7 @@ msgstr "September"
 #: superset-frontend/plugins/plugin-chart-echarts/src/Funnel/index.ts:58
 #: superset-frontend/plugins/plugin-chart-table/src/index.ts:49
 msgid "Sequential"
-msgstr ""
+msgstr "Fortlaufend"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:61
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:385
@@ -10916,9 +10839,8 @@ msgid "Series"
 msgstr "Serien"
 
 #: superset-frontend/plugins/legacy-plugin-chart-horizon/src/controlPanel.ts:71
-#, fuzzy
 msgid "Series Height"
-msgstr "Serienbegrenzung"
+msgstr "Serienhöhe"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx:112
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx:113
@@ -10984,9 +10906,8 @@ msgid "Share dashboard by email"
 msgstr "Dashboard per Email teilen"
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:1221
-#, fuzzy
 msgid "Shared query"
-msgstr "Benutzer*innen-Abfrage"
+msgstr "Geteilte Abfrage"
 
 #: superset/views/database/forms.py:272
 msgid "Sheet Name"
@@ -11029,9 +10950,8 @@ msgid "Show Annotation Layer"
 msgstr "Anmerkungsebene anzeigen"
 
 #: superset-frontend/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:80
-#, fuzzy
 msgid "Show Bubbles"
-msgstr "Tabelle anzeigen"
+msgstr "Blasen anzeigen"
 
 #: superset-frontend/src/SqlLab/components/TableElement/index.tsx:204
 msgid "Show CREATE VIEW statement"
@@ -11106,9 +11026,8 @@ msgid "Show Metric"
 msgstr "Metrik anzeigen"
 
 #: superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:178
-#, fuzzy
 msgid "Show Metric Names"
-msgstr "Metrik anzeigen"
+msgstr "Metriknamen anzeigen"
 
 #: superset/views/alerts.py:76
 msgid "Show Observation"
@@ -11178,9 +11097,8 @@ msgid "Show cell bars"
 msgstr "Zellenbalken anzeigen"
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:161
-#, fuzzy
 msgid "Show columns total"
-msgstr "Alle Spalten anzeigen"
+msgstr "Spaltensumme anzeigen"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:67
 msgid "Show data points as circle markers on the lines"
@@ -11191,13 +11109,14 @@ msgid ""
 "Show hierarchical relationships of data, with with the value represented "
 "by area, showing proportion and contribution to the whole."
 msgstr ""
+"Hierarchische Beziehungen von Daten anzeigen, wobei der Wert durch die "
+"Fläche dargestellt wird, die Anteil und Beitrag zum Ganzen darstellt."
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/components/InfoTooltipWithTrigger.tsx:50
 msgid "Show info tooltip"
 msgstr "Info-Tooltip anzeigen"
 
 #: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:736
-#, fuzzy
 msgid "Show label"
 msgstr "Beschriftung anzeigen"
 
@@ -11218,9 +11137,8 @@ msgid "Show less..."
 msgstr "Weniger..."
 
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:287
-#, fuzzy
 msgid "Show percentage"
-msgstr "Prozentuale Veränderung"
+msgstr "Prozentsatz anzeigen"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:179
 msgid "Show pointer"
@@ -11231,9 +11149,8 @@ msgid "Show progress"
 msgstr "Fortschritt anzeigen"
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:149
-#, fuzzy
 msgid "Show rows total"
-msgstr "Gesamtwerte anzeigen"
+msgstr "Zeilensumme anzeigen"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx:109
 msgid "Show series values on the chart"
@@ -11274,6 +11191,9 @@ msgid ""
 "call attention to a KPI or the one thing you want your audience to focus "
 "on."
 msgstr ""
+"Zeigt eine einzelne Metrik im Vordergrund. ‚Große Zahl‘ wird am besten "
+"verwendet, um die Aufmerksamkeit auf einen KPI oder die eine Information "
+"zu lenken, auf die sich Ihr Publikum konzentrieren soll."
 
 #: superset-frontend/plugins/legacy-preset-chart-big-number/src/BigNumber/index.ts:30
 msgid ""
@@ -11281,6 +11201,9 @@ msgid ""
 "attention to an important metric along with its change over time or other"
 " dimension."
 msgstr ""
+"Zeigt eine einzelne Zahl zusammen mit einem einfachen Liniendiagramm, um "
+"die Aufmerksamkeit auf eine wichtige Metrik zusammen mit ihrer "
+"Veränderung im Laufe der Zeit oder einer anderen Dimension zu lenken."
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Funnel/index.ts:49
 msgid ""
@@ -11288,18 +11211,26 @@ msgid ""
 "chart is useful for visualizing drop-off between stages in a pipeline or "
 "lifecycle."
 msgstr ""
+"Zeigt, wie sich eine Metrik im Laufe des Trichters ändert. Dieses "
+"klassische Diagramm ist nützlich, um den Abfall zwischen Phasen in einer "
+"Pipeline oder einem Lebenszyklus zu visualisieren."
 
 #: superset-frontend/plugins/legacy-plugin-chart-chord/src/index.js:28
 msgid ""
 "Showcases the flow or link between categories using thickness of chords. "
 "The value and corresponding thickness can be different for each side."
 msgstr ""
+"Zeigt den Fluss oder die Verknüpfung zwischen Kategorien anhand der Dicke"
+" der Sehnen. Der Wert und die entsprechende Dicke können für jede Seite "
+"unterschiedlich sein."
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bullet/index.js:27
 msgid ""
 "Showcases the progress of a single metric against a given target. The "
 "higher the fill, the closer the metric is to the target."
 msgstr ""
+"Zeigt den Fortschritt einer einzelnen Metrik gegenüber einem bestimmten "
+"Ziel. Je höher die Füllung, desto näher ist die Metrik am Ziel."
 
 #: superset-frontend/src/explore/components/DatasourcePanel/index.tsx:305
 #: superset-frontend/src/explore/components/DatasourcePanel/index.tsx:338
@@ -11318,10 +11249,14 @@ msgid ""
 " to the whole. Those rectangles may also, in turn, be further segmented "
 "hierarchically."
 msgstr ""
+"Zeigt die Zusammensetzung eines Datensatzes an, indem ein bestimmtes "
+"Rechteck als kleinere Rechtecke mit Bereichen segmentiert wird, die "
+"proportional zu ihrem Wert oder Beitrag zum Ganzen sind. Diese Rechtecke "
+"können wiederum auch hierarchisch weiter segmentiert werden."
 
 #: superset-frontend/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts:72
 msgid "Significance Level"
-msgstr ""
+msgstr "Signifikanzniveau"
 
 #: superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx:262
 #: superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.jsx:201
@@ -11340,23 +11275,20 @@ msgstr "Einzeln"
 
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/index.js:45
 #: superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/index.ts:46
-#, fuzzy
 msgid "Single Metric"
-msgstr "Prozentuale Metriken"
+msgstr "Einzelne Metrik"
 
 #: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:1234
-#, fuzzy
 msgid "Single Value"
-msgstr "Rechter Wert"
+msgstr "Einzelner Wert"
 
 #: superset-frontend/src/filters/components/Range/controlPanel.ts:65
-#, fuzzy
 msgid "Single value"
-msgstr "Rechter Wert"
+msgstr "Einzelner Wert"
 
 #: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:1251
 msgid "Single value type"
-msgstr ""
+msgstr "Einzelwerttyp"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:261
 msgid "Size of edge symbols"
@@ -11374,7 +11306,7 @@ msgstr "Größe des Markers. Gilt auch für Prognosebeobachtungen."
 
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/index.js:34
 msgid "Sizes of vehicles"
-msgstr ""
+msgstr "Fahrzeuggrößen"
 
 #: superset/views/database/forms.py:199
 msgid "Skip Blank Lines"
@@ -11408,7 +11340,7 @@ msgstr "Kopfzeile"
 #: superset-frontend/plugins/legacy-preset-chart-big-number/src/sharedControls.ts:73
 #: superset-frontend/src/dashboard/util/headerStyleOptions.ts:25
 msgid "Small"
-msgstr ""
+msgstr "Klein"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:153
 msgid "Small number format"
@@ -11426,11 +11358,8 @@ msgstr ""
 "aufgetreten: %s"
 
 #: superset-frontend/src/dashboard/actions/sliceEntities.js:121
-#, fuzzy, python-format
 msgid "Sorry there was an error fetching saved charts: "
-msgstr ""
-"Beim Abrufen von Datenbankinformationen ist leider ein Fehler "
-"aufgetreten: %s"
+msgstr "Beim Abrufen gespeicherter Diagramme ist leider ein Fehler aufgetreten: "
 
 #: superset-frontend/src/explore/components/DataTablesPane/index.tsx:273
 #: superset-frontend/src/explore/components/controls/ViewQueryModal.tsx:84
@@ -11447,11 +11376,9 @@ msgid "Sorry, there appears to be no data"
 msgstr "Leider scheint es keine Daten zu geben"
 
 #: superset-frontend/src/dashboard/actions/dashboardState.js:238
-#, fuzzy, python-format
+#, python-format
 msgid "Sorry, there was an error saving this dashboard: %s"
-msgstr ""
-"Beim Abrufen von Datenbankinformationen ist leider ein Fehler "
-"aufgetreten: %s"
+msgstr "Leider ist beim Speichern dieses Dashboards ein Fehler aufgetreten: %s"
 
 #: superset-frontend/src/dashboard/components/menu/ShareMenuItems/index.tsx:55
 #: superset-frontend/src/explore/components/ExploreActionButtons.tsx:115
@@ -11473,9 +11400,8 @@ msgid "Sort"
 msgstr "Sortieren"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts:92
-#, fuzzy
 msgid "Sort Bars"
-msgstr "Diagramm importieren"
+msgstr "Balken sortieren"
 
 #: superset-frontend/plugins/legacy-plugin-chart-horizon/src/controlPanel.ts:42
 #: superset-frontend/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts:45
@@ -11501,14 +11427,12 @@ msgid "Sort Metric"
 msgstr "Sortiermetrik"
 
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:251
-#, fuzzy
 msgid "Sort X Axis"
-msgstr "X-Achsenbeschriftung drehen"
+msgstr "X-Achse sortieren"
 
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:263
-#, fuzzy, python-format
 msgid "Sort Y Axis"
-msgstr "Sortieren nach %s"
+msgstr "Y-Achse sortieren"
 
 #: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:1188
 #: superset-frontend/src/explore/components/controls/FilterBoxItemControl/index.jsx:205
@@ -11518,7 +11442,7 @@ msgstr "Aufsteigend sortieren"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts:95
 msgid "Sort bars by x labels."
-msgstr ""
+msgstr "Sortieren Sie Balken nach x-Beschriftungen."
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:125
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:369
@@ -11551,9 +11475,8 @@ msgid "Sort columns alphabetically"
 msgstr "Spalten alphabetisch sortieren"
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:257
-#, fuzzy
 msgid "Sort columns by"
-msgstr "Keine Spalten"
+msgstr "Spalten sortieren nach"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/legacySortBy.tsx:29
 #: superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx:337
@@ -11573,9 +11496,8 @@ msgid "Sort metric"
 msgstr "Metrik anzeigen"
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:229
-#, fuzzy
 msgid "Sort rows by"
-msgstr "Sortieren nach"
+msgstr "Zeilen sortieren nach"
 
 #: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:1181
 msgid "Sort type"
@@ -11590,9 +11512,8 @@ msgstr "Quelle"
 #: superset-frontend/plugins/legacy-plugin-chart-force-directed/src/controlPanel.ts:104
 #: superset-frontend/plugins/legacy-plugin-chart-sankey-loop/src/controlPanel.ts:43
 #: superset-frontend/plugins/legacy-plugin-chart-sankey/src/controlPanel.ts:33
-#, fuzzy
 msgid "Source / Target"
-msgstr "Datenquellen-Bezeichnung"
+msgstr "Quelle / Ziel"
 
 #: superset-frontend/src/SqlLab/components/HighlightedSql/index.tsx:76
 msgid "Source SQL"
@@ -11607,9 +11528,8 @@ msgid "Spatial"
 msgstr "Raumbezug"
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:90
-#, fuzzy
 msgid "Specific Date/Time"
-msgstr "Kehren Sie zu bestimmtem Zeitpunkt zurück."
+msgstr "Spezifisches Datum/Uhrzeit"
 
 #: superset/views/database/forms.py:127 superset/views/database/forms.py:286
 #: superset/views/database/forms.py:414
@@ -11649,23 +11569,20 @@ msgstr "Reihen übereinander stapeln"
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/index.ts:84
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/index.ts:83
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/index.ts:68
-#, fuzzy
 msgid "Stacked"
-msgstr "Backend"
+msgstr "Gestapelt"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:305
 msgid "Stacked Bars"
 msgstr "Gestapelte Balken"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Area/controlPanel.ts:52
-#, fuzzy
 msgid "Stacked Style"
-msgstr "Gestapelte Balken"
+msgstr "Gestapelter Stil"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Area/index.js:37
-#, fuzzy
 msgid "Stacked style"
-msgstr "Gestapelte Balken"
+msgstr "Gestapelter Stil"
 
 #: superset-frontend/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:88
 msgid "Standard time series"
@@ -11713,7 +11630,7 @@ msgstr "Zustand"
 #: superset-frontend/plugins/legacy-plugin-chart-paired-t-test/src/index.js:30
 #: superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/index.ts:55
 msgid "Statistical"
-msgstr ""
+msgstr "Statistisch"
 
 #: superset-frontend/src/views/CRUD/alert/AlertList.tsx:399
 #: superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx:302
@@ -11747,9 +11664,8 @@ msgid "Strength to pull the graph toward center"
 msgstr "Stärke, mit der Graph in Richtung Mitte gezogen wird"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Area/index.js:36
-#, fuzzy, python-format
 msgid "Stretched style"
-msgstr "%s abgerufen"
+msgstr "Gestreckter Stil"
 
 #: superset/views/database/forms.py:273
 msgid "Strings used for sheet names (default is the first sheet)."
@@ -11760,7 +11676,7 @@ msgstr ""
 #: superset-frontend/plugins/plugin-chart-echarts/src/Graph/index.ts:45
 #: superset-frontend/plugins/plugin-chart-echarts/src/Tree/index.ts:45
 msgid "Structural"
-msgstr ""
+msgstr "Strukturell"
 
 #: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:621
 msgid "Style"
@@ -11772,16 +11688,15 @@ msgstr "Enden des Fortschrittsbalkens mit einer runden Kappe versehen"
 
 #: superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:56
 msgid "Subdomain"
-msgstr ""
+msgstr "Subdomain"
 
 #: superset-frontend/plugins/legacy-preset-chart-big-number/src/BigNumberTotal/controlPanel.ts:46
-#, fuzzy
 msgid "Subheader"
-msgstr "Header"
+msgstr "Untertitel"
 
 #: superset-frontend/plugins/legacy-preset-chart-big-number/src/sharedControls.ts:62
 msgid "Subheader Font Size"
-msgstr ""
+msgstr "Schriftgröße Untertitel"
 
 #: superset-frontend/src/SqlLab/components/QueryTable/index.jsx:63
 #: superset-frontend/src/views/CRUD/alert/AlertList.tsx:54
@@ -11802,9 +11717,8 @@ msgid "Sunburst"
 msgstr "Sunburst"
 
 #: superset-frontend/plugins/legacy-plugin-chart-sunburst/src/index.js:32
-#, fuzzy
 msgid "Sunburst Chart"
-msgstr "Superset Diagramm"
+msgstr "Sunburst Diagramm"
 
 #: superset-frontend/src/components/CronPicker/CronPicker.tsx:56
 msgid "Sunday"
@@ -11823,11 +11737,11 @@ msgstr "Superset Diagramm"
 msgid "Superset dashboard"
 msgstr "Superset Dashboard"
 
-#: superset/errors.py:105
+#: superset/errors.py:106
 msgid "Superset encountered an error while running a command."
 msgstr "Superset hat beim Ausführen eines Befehls einen Fehler festgestellt."
 
-#: superset/errors.py:106
+#: superset/errors.py:107
 msgid "Superset encountered an unexpected error."
 msgstr "Superset hat einen unerwarteten Fehler festgestellt."
 
@@ -11837,16 +11751,15 @@ msgstr "Unterstützte Datenbanken"
 
 #: superset-frontend/plugins/legacy-plugin-chart-sankey/src/index.js:34
 msgid "Survey Responses"
-msgstr ""
+msgstr "Umfrage-Antworten"
 
 #: superset-frontend/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.ts:112
 msgid "Swap Groups and Columns"
-msgstr ""
+msgstr "Gruppen und Spalten tauschen"
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:175
-#, fuzzy
 msgid "Swap rows and columns"
-msgstr "Alle Spalten anzeigen"
+msgstr "Zeilen und Spalten vertauschen"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/index.ts:59
 msgid ""
@@ -11854,6 +11767,9 @@ msgid ""
 "line, scatter, and bar charts. This viz type has many customization "
 "options as well."
 msgstr ""
+"Schweizer Taschenmesser zur Visualisierung von Zeitreihendaten. Wählen "
+"Sie zwischen Schritt-, Linien-, Punkt- und Balkendiagrammen. Dieser "
+"Visualisierungstyp verfügt auch über viele Anpassungsoptionen."
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:210
 msgid "Symbol"
@@ -11899,9 +11815,8 @@ msgstr "Tabellenname"
 
 #: superset-frontend/src/dashboard/util/newComponentFactory.js:56
 #: superset-frontend/src/dashboard/util/newComponentFactory.js:57
-#, fuzzy
 msgid "Tab title"
-msgstr "Diagrammtitel"
+msgstr "Registerkartentitel"
 
 #: superset-frontend/plugins/legacy-plugin-chart-pivot-table/src/index.js:25
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/index.ts:50
@@ -11914,7 +11829,7 @@ msgstr "Diagrammtitel"
 msgid "Table"
 msgstr "Tabelle"
 
-#: superset/views/core.py:1761
+#: superset/views/core.py:1778
 #, python-format
 msgid "Table %(table)s wasn't found in the database %(db)s"
 msgstr "Tabelle %(table)s wurde in der Datenbank nicht gefunden %(db)s"
@@ -11963,6 +11878,8 @@ msgid ""
 "Table that visualizes paired t-tests, which are used to understand "
 "statistical differences between groups."
 msgstr ""
+"Tabelle, die gepaarte t-Tests visualisiert, die verwendet werden, um "
+"statistische Unterschiede zwischen Gruppen zu verstehen."
 
 #: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:269
 #: superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:324
@@ -11979,7 +11896,7 @@ msgstr "Reiter"
 #: superset-frontend/plugins/plugin-chart-table/src/index.ts:50
 #: superset-frontend/src/visualizations/TimeTable/TimeTableChartPlugin.ts:34
 msgid "Tabular"
-msgstr ""
+msgstr "Tabellarisch"
 
 #: superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx:607
 msgid "Tags"
@@ -11990,6 +11907,8 @@ msgid ""
 "Take your data points, and group them into \"bins\" to see where the "
 "densest areas of information lie"
 msgstr ""
+"Gruppieren Sie Ihre Datenpunkte in Klassen, um zu sehen, wo die "
+"dichtesten Informationsbereiche liegen"
 
 #: superset-frontend/plugins/legacy-plugin-chart-chord/src/controlPanel.ts:66
 #: superset-frontend/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:62
@@ -11998,7 +11917,7 @@ msgstr "Ziel"
 
 #: superset-frontend/plugins/legacy-plugin-chart-treemap/src/controlPanel.ts:67
 msgid "Target aspect ratio for treemap tiles."
-msgstr ""
+msgstr "Ziel-Seitenverhältnis für Treemap-Kacheln."
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx:86
 msgid "Target category"
@@ -12023,6 +11942,8 @@ msgid ""
 "Templated link, it's possible to include {{ metric }} or other values "
 "coming from the controls."
 msgstr ""
+"Vorlagen-Link. Es ist möglich, {{ metric }} oder andere Werte aus den "
+"Steuerelementen einzuschließen."
 
 #: superset/models/sql_types/base.py:54
 #, python-format
@@ -12048,9 +11969,8 @@ msgid "Test connection"
 msgstr "Verbindungstest"
 
 #: superset-frontend/src/visualizations/TimeTable/TimeTableChartPlugin.ts:35
-#, fuzzy
 msgid "Text"
-msgstr "Weiter"
+msgstr "Text"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:105
 msgid "Text align"
@@ -12068,7 +11988,7 @@ msgstr ""
 "Das CSS für einzelne Dashboards kann hier oder in der Dashboard-Ansicht "
 "geändert werden, wo Änderungen sofort sichtbar sind"
 
-#: superset/errors.py:118
+#: superset/errors.py:119
 msgid ""
 "The CTAS (create table as select) doesn't have a SELECT statement at the "
 "end. Please make sure your query has a SELECT as its last statement. "
@@ -12113,7 +12033,7 @@ msgstr ""
 "werden. Wenn ein Knoten mehr als einer Kategorie zugeordnet ist, wird nur"
 " die erste verwendet."
 
-#: superset/common/query_context_processor.py:449
+#: superset/common/query_context_processor.py:453
 msgid "The chart does not exist"
 msgstr "Das Diagramm ist nicht vorhanden"
 
@@ -12127,10 +12047,18 @@ msgid ""
 " relative proportion is important, consider using a bar or other chart "
 "type instead."
 msgstr ""
+"Der Klassiker. Großartig, um zu zeigen, wie viel von einem Unternehmen "
+"jeder Investor bekommt, welche Demografie Ihrem Blog folgt oder welcher "
+"Teil des Budgets in den militärisch-industriellen Komplex fließt.\n"
+"\n"
+"Kreisdiagramme können schwierig zu interpretieren sein. Wenn die Klarheit"
+" des relativen Anteils wichtig ist, sollten Sie stattdessen die "
+"Verwendung eines Balkens oder eines anderen Diagrammtyps in Betracht "
+"ziehen."
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:261
 msgid "The color for points and clusters in RGB"
-msgstr ""
+msgstr "Die Farbe für Punkte und Cluster in RGB"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:478
 #: superset-frontend/src/explore/controls.jsx:484
@@ -12145,7 +12073,7 @@ msgstr ""
 "Das Farbschema wird vom zugehörigen Dashboard bestimmt.\n"
 "              Bearbeiten Sie das Farbschema in den Dashboardeigenschaften."
 
-#: superset/errors.py:99
+#: superset/errors.py:100
 msgid "The column was deleted or renamed in the database."
 msgstr "Die Spalte wurde in der Datenbank gelöscht oder umbenannt."
 
@@ -12153,7 +12081,7 @@ msgstr "Die Spalte wurde in der Datenbank gelöscht oder umbenannt."
 msgid ""
 "The country code standard that Superset should expect to find in the "
 "[country] column"
-msgstr ""
+msgstr "Der Ländercodestandard, den Superset in der Spalte [Land] erwarten sollte"
 
 #: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:327
 msgid "The dashboard has been saved"
@@ -12186,11 +12114,11 @@ msgstr ""
 "diese Datenbank zugreifen. Sind Sie sicher, dass Sie fortfahren möchten? "
 "Durch das Löschen der Datenbank werden diese Objekte ungültig."
 
-#: superset/errors.py:126
+#: superset/errors.py:127
 msgid "The database is currently running too many queries."
 msgstr "Die Datenbank führt derzeit zu viele Abfragen aus."
 
-#: superset/errors.py:93
+#: superset/errors.py:94
 msgid "The database is under an unusual load."
 msgstr "Die Datenbank ist ungewöhnlich belastet."
 
@@ -12203,15 +12131,15 @@ msgstr ""
 "gefunden. Wenden Sie sich an eine*n Administrator*in, um weitere "
 "Unterstützung zu erhalten, oder versuchen Sie es erneut."
 
-#: superset/errors.py:94
+#: superset/errors.py:95
 msgid "The database returned an unexpected error."
 msgstr "Die Datenbank hat einen unerwarteten Fehler zurückgegeben."
 
-#: superset/errors.py:138
+#: superset/errors.py:139
 msgid "The database was deleted."
 msgstr "Die Datenbank wurde gelöscht."
 
-#: superset/views/core.py:2085 superset/views/core.py:2155
+#: superset/views/core.py:2102 superset/views/core.py:2172
 msgid "The database was not found."
 msgstr "Datenbank nicht gefunden."
 
@@ -12258,11 +12186,10 @@ msgstr ""
 "gelöscht."
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:1283
-#, fuzzy
 msgid "The datasource couldn't be loaded"
-msgstr "Datensatz konnte nicht aktualisiert werden."
+msgstr "Datenquelle konnte nicht geladen werden"
 
-#: superset/errors.py:92
+#: superset/errors.py:93
 msgid "The datasource is too large to query."
 msgstr "Die Datenquelle ist zu groß, um sie abzufragen."
 
@@ -12276,7 +12203,7 @@ msgstr ""
 
 #: superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:104
 msgid "The distance between cells, in pixels"
-msgstr ""
+msgstr "Der Abstand zwischen Zellen in Pixel"
 
 #: superset-frontend/src/components/Datasource/DatasourceEditor.jsx:772
 msgid "The duration of time in seconds before the cache is invalidated"
@@ -12337,7 +12264,7 @@ msgstr ""
 "Der Host ist ungültig. Bitte überprüfen Sie, ob dieses Feld korrekt "
 "eingegeben wurde."
 
-#: superset/errors.py:104
+#: superset/errors.py:105
 msgid "The host might be down, and can't be reached on the provided port."
 msgstr ""
 "Der Host ist möglicherweise außer Betrieb und kann über den angegebenen "
@@ -12351,7 +12278,7 @@ msgstr ""
 msgid "The hostname \"%(hostname)s\" cannot be resolved."
 msgstr "Der Hostname \"%(hostname)s\" kann nicht aufgelöst werden."
 
-#: superset/errors.py:102
+#: superset/errors.py:103
 msgid "The hostname provided can't be resolved."
 msgstr "Der angegebene Hostname kann nicht aufgelöst werden."
 
@@ -12446,7 +12373,7 @@ msgstr ""
 
 #: superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:130
 msgid "The number color \"steps\""
-msgstr ""
+msgstr "Die Anzahl Farbabstufungen"
 
 #: superset-frontend/src/components/Datasource/DatasourceEditor.jsx:781
 msgid ""
@@ -12516,7 +12443,7 @@ msgstr ""
 msgid "The number of seconds before expiring the cache"
 msgstr "Die Anzahl der Sekunden vor Ablauf des Caches"
 
-#: superset/errors.py:128
+#: superset/errors.py:129
 msgid "The object does not exist in the given database."
 msgstr "Das Objekt existiert nicht in der angegebenen Datenbank."
 
@@ -12536,7 +12463,7 @@ msgstr ""
 "Das für den Benutzer*innennamen \"%(username)s\" angegebene Kennwort ist "
 "falsch."
 
-#: superset/errors.py:108
+#: superset/errors.py:109
 msgid "The password provided when connecting to a database is not valid."
 msgstr ""
 "Das Kennwort, das beim Herstellen einer Datenbankverbindung angegeben "
@@ -12571,7 +12498,6 @@ msgstr ""
 "Bedarf nach dem Import manuell hinzugefügt werden sollten."
 
 #: superset-frontend/src/views/CRUD/data/dataset/constants.ts:23
-#, fuzzy
 msgid ""
 "The passwords for the databases below are needed in order to import them "
 "together with the datasets. Please note that the \"Secure Extra\" and "
@@ -12623,10 +12549,15 @@ msgid ""
 "            Click on the info bubble for more details on accepted "
 "\"freq\" expressions."
 msgstr ""
+"Die Periodizität, über die die Zeit pilotiert werden soll. Benutzer "
+"können\n"
+"            ein“ Pandas\" Offset-Alias angeben.\n"
+"            Klicken Sie auf die Infoblase, um weitere Informationen zu "
+"akzeptierten \"freq\"-Ausdrücken zu erhalten."
 
 #: superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:118
 msgid "The pixel radius"
-msgstr ""
+msgstr "Der Pixelradius"
 
 #: superset-frontend/src/components/Datasource/DatasourceEditor.jsx:977
 msgid ""
@@ -12638,7 +12569,7 @@ msgstr ""
 "das Diagramm dieser logischen Superset-Tabelle zugeordnet ist welche auf "
 "die hier angegebene physische Tabelle verweist."
 
-#: superset/errors.py:103
+#: superset/errors.py:104
 msgid "The port is closed."
 msgstr "Der Port ist geschlossen."
 
@@ -12646,23 +12577,23 @@ msgstr "Der Port ist geschlossen."
 msgid "The port must be a whole number less than or equal to 65535."
 msgstr "Der Port muss eine ganze Zahl kleiner oder gleich 65535 sein."
 
-#: superset/errors.py:136
+#: superset/errors.py:137
 msgid "The port number is invalid."
 msgstr "Die Port-Nummer ist ungültig."
 
 #: superset-frontend/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts:57
 msgid "The primary metric is used to define the arc segment sizes"
-msgstr ""
+msgstr "Die primäre Metrik wird verwendet, um die Bogensegmentgrößen zu definieren"
 
-#: superset/views/core.py:2330
+#: superset/views/core.py:2347
 msgid "The provided `rows` argument is not a valid integer."
 msgstr "Das angegebene Argument 'rows' ist keine gültige ganze Zahl."
 
-#: superset/errors.py:131
+#: superset/errors.py:132
 msgid "The query associated with the results was deleted."
 msgstr "Die den Ergebnissen zugeordnete Abfrage wurde gelöscht."
 
-#: superset/views/core.py:2280
+#: superset/views/core.py:2297
 msgid ""
 "The query associated with these results could not be find. You need to "
 "re-run the original query."
@@ -12675,11 +12606,10 @@ msgid "The query contains one or more malformed template parameters."
 msgstr "Die Abfrage enthält einen oder mehrere fehlerhafte Vorlagenparameter."
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:106
-#, fuzzy
 msgid "The query couldn't be loaded"
-msgstr "Gespeicherte Abfragen konnten nicht gelöscht werden."
+msgstr "Die Abfrage konnte nicht geladen werden"
 
-#: superset/errors.py:129
+#: superset/errors.py:130
 msgid "The query has a syntax error."
 msgstr "Die Abfrage weist einen Syntaxfehler auf."
 
@@ -12702,6 +12632,9 @@ msgid ""
 "to turn off clustering, but beware that a large number of points (>1000) "
 "will cause lag."
 msgstr ""
+"Der Radius (in Pixel), den der Algorithmus zum Definieren eines Clusters "
+"verwendet. Wählen Sie 0, um das Clustering zu deaktivieren, aber beachten"
+" Sie, dass eine große Anzahl von Punkten (>1000) zu Verzögerungen führt."
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:110
 msgid ""
@@ -12709,17 +12642,19 @@ msgid ""
 "a numerical column or `Auto`, which scales the point based on the largest"
 " cluster"
 msgstr ""
+"Der Radius einzelner Punkte (die sich nicht in einem Cluster befinden). "
+"Entweder eine numerische Spalte oder \"Auto\", die den Punkt basierend "
+"auf dem größten Cluster skaliert"
 
 #: superset-frontend/src/reports/actions/reports.js:111
-#, fuzzy
 msgid "The report has been created"
-msgstr "Der Datensatz wurde gespeichert"
+msgstr "Der Report wurde erstellt"
 
-#: superset/errors.py:130
+#: superset/errors.py:131
 msgid "The results backend no longer has the data from the query."
 msgstr "Das Ergebnis-Backend verfügt nicht mehr über die Daten aus der Abfrage."
 
-#: superset/errors.py:132
+#: superset/errors.py:133
 msgid ""
 "The results stored in the backend were stored in a different format, and "
 "no longer can be deserialized."
@@ -12753,19 +12688,19 @@ msgstr ""
 "Das Schema \"%(schema_name)s\" existiert nicht. Zum Ausführen dieser "
 "Abfrage muss ein gültiges Schema verwendet werden."
 
-#: superset/errors.py:111
+#: superset/errors.py:112
 msgid "The schema was deleted or renamed in the database."
 msgstr "Das Schema wurde in der Datenbank gelöscht oder umbenannt."
 
 #: superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:92
 msgid "The size of the square cell, in pixels"
-msgstr ""
+msgstr "Die Größe der quadratischen Zelle in Pixel"
 
-#: superset/errors.py:114
+#: superset/errors.py:115
 msgid "The submitted payload has the incorrect format."
 msgstr "Die übermittelte Nutzlast hat das falsche Format."
 
-#: superset/errors.py:115
+#: superset/errors.py:116
 msgid "The submitted payload has the incorrect schema."
 msgstr "Die übermittelte Nutzlast hat das falsche Schema."
 
@@ -12796,7 +12731,7 @@ msgstr ""
 "Konfigurationsprozesses sollten Sie nun auf die Schaltfläche Bearbeiten "
 "neben der neuen Tabelle klicken, um sie zu konfigurieren."
 
-#: superset/errors.py:100
+#: superset/errors.py:101
 msgid "The table was deleted or renamed in the database."
 msgstr "Die Tabelle wurde in der Datenbank gelöscht oder umbenannt."
 
@@ -12861,10 +12796,12 @@ msgid ""
 "The time unit for each block. Should be a smaller unit than "
 "domain_granularity. Should be larger or equal to Time Grain"
 msgstr ""
+"Die Zeiteinheit für jeden Block. Sollte eine kleinere Einheit als "
+"domain_granularity sein. Sollte größer oder gleich Zeitgranularität sein"
 
 #: superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:49
 msgid "The time unit used for the grouping of blocks"
-msgstr ""
+msgstr "Die Zeiteinheit, die für die Gruppierung von Blöcken verwendet wird"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:170
 #: superset-frontend/src/explore/controls.jsx:202
@@ -12872,9 +12809,8 @@ msgid "The type of visualization to display"
 msgstr "Der anzuzeigende Visualisierungstyp"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:135
-#, fuzzy
 msgid "The unit of measure for the specified point radius"
-msgstr "Mittelwert der Werte über einen bestimmten Zeitraum"
+msgstr "Die Maßeinheit für den angegebenen Punktradius"
 
 #: superset/views/core.py:183
 msgid "The user seems to have been deleted"
@@ -12885,7 +12821,7 @@ msgstr "Der/die Benutzer*in scheint gelöscht worden zu sein"
 msgid "The username \"%(username)s\" does not exist."
 msgstr "Der Benutzer*innenname \"%(username)s\" existiert nicht."
 
-#: superset/errors.py:107
+#: superset/errors.py:108
 msgid "The username provided when connecting to a database is not valid."
 msgstr ""
 "Der Benutzer*innenname, der beim Herstellen einer Datenbankverbindung "
@@ -12922,7 +12858,7 @@ msgstr "In diesem Dashboard gibt es keine Filter."
 msgid "There are unsaved changes."
 msgstr "Ungesicherte Änderungen vorhanden."
 
-#: superset/errors.py:95
+#: superset/errors.py:96
 msgid ""
 "There is a syntax error in the SQL query. Perhaps there was a misspelling"
 " or a typo."
@@ -12943,11 +12879,13 @@ msgid ""
 "There is not enough space for this component. Try decreasing its width, "
 "or increasing the destination width."
 msgstr ""
+"Für diese Komponente ist nicht genügend Platz vorhanden. Versuchen Sie, "
+"die Breite zu verringern oder die Zielbreite zu erhöhen."
 
 #: superset-frontend/src/views/CRUD/hooks.ts:522
-#, fuzzy, python-format
+#, python-format
 msgid "There was an error fetching the favorite status: %s"
-msgstr "Beim Abrufen Ihrer gespeicherten Abfragen gab es ein Problem: %s"
+msgstr "Beim Abrufen des Favoritenstatus ist ein Problem aufgetreten: %s"
 
 #: superset-frontend/src/views/CRUD/utils.tsx:181
 msgid "There was an error fetching your recent activity:"
@@ -12962,9 +12900,9 @@ msgid "There was an error loading the tables"
 msgstr "Beim Laden der Tabellen ist ein Fehler aufgetreten"
 
 #: superset-frontend/src/views/CRUD/hooks.ts:543
-#, fuzzy, python-format
+#, python-format
 msgid "There was an error saving the favorite status: %s"
-msgstr "Beim Laden der Tabellen ist ein Fehler aufgetreten"
+msgstr "Beim Speichern des Favoritenstatus ist ein Fehler aufgetreten: %s"
 
 #: superset-frontend/src/SqlLab/components/ShareSqlLabQuery/index.tsx:61
 msgid "There was an error with your request"
@@ -13028,19 +12966,20 @@ msgid "There was an issue deleting: %s"
 msgstr "Beim Löschen ist ein Problem aufgetreten: %s"
 
 #: superset-frontend/src/dashboard/actions/dashboardState.js:100
-#, fuzzy
 msgid "There was an issue favoriting this dashboard."
-msgstr "Beim Löschen der ausgewählten Dashboards ist ein Problem aufgetreten: "
+msgstr "Es gab ein Problem dabei, dieses Dashboard zu den Favoriten hinzuzufügen."
 
 #: superset-frontend/src/reports/actions/reports.js:68
-#, fuzzy, python-format
 msgid "There was an issue fetching reports attached to this dashboard."
-msgstr "Beim Abrufen Ihrer Dashboards gab es Probleme: %s"
+msgstr ""
+"Es gab ein Problem beim Abrufen von Reports, die an dieses Dashboard "
+"angehängt waren."
 
 #: superset-frontend/src/dashboard/actions/dashboardState.js:79
-#, fuzzy, python-format
 msgid "There was an issue fetching the favorite status of this dashboard."
-msgstr "Beim Abrufen Ihrer Dashboards gab es Probleme: %s"
+msgstr ""
+"Beim Abrufen des Favoritenstatus dieses Dashboards ist ein Problem "
+"aufgetreten."
 
 #: superset-frontend/src/views/CRUD/welcome/Welcome.tsx:195
 #, python-format
@@ -13141,11 +13080,13 @@ msgstr ""
 
 #: superset-frontend/src/dashboard/actions/dashboardLayout.js:258
 msgid "This chart has been moved to a different filter scope."
-msgstr ""
+msgstr "Dieses Diagramm wurde in einen anderen Filterbereich verschoben."
 
 #: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.ts:56
 msgid "This chart might be incompatible with the filter (datasets don't match)"
 msgstr ""
+"Dieses Diagramm ist möglicherweise nicht mit dem Filter kompatibel "
+"(Datensätze stimmen nicht überein)"
 
 #: superset-frontend/src/explore/components/controls/ColorSchemeControl/index.jsx:127
 msgid ""
@@ -13191,14 +13132,12 @@ msgstr ""
 "veröffentlichen."
 
 #: superset-frontend/src/dashboard/actions/dashboardState.js:125
-#, fuzzy
 msgid "This dashboard is now hidden"
-msgstr "Das Ändern dieses Dashboards ist verboten"
+msgstr "Dieses Dashboard ist nun verborgen"
 
 #: superset-frontend/src/dashboard/actions/dashboardState.js:124
-#, fuzzy
 msgid "This dashboard is now published"
-msgstr "Das Ändern dieses Dashboards ist verboten"
+msgstr "Dieses Dashboard ist jetzt veröffentlicht"
 
 #: superset-frontend/src/dashboard/components/PublishedStatus/index.jsx:43
 msgid "This dashboard is published. Click to make it a draft."
@@ -13215,9 +13154,8 @@ msgstr ""
 "neu, um die neueste Version zu erhalten."
 
 #: superset-frontend/src/dashboard/actions/dashboardState.js:231
-#, fuzzy
 msgid "This dashboard was saved successfully."
-msgstr "Dashboard wurde erfolgreich gespeichert"
+msgstr "Dieses Dashboard wurde erfolgreich gespeichert."
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx:77
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx:401
@@ -13226,9 +13164,8 @@ msgid "This defines the element to be plotted on the chart"
 msgstr "Definiert das Element, das im Diagramm dargestellt werden soll"
 
 #: superset-frontend/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts:82
-#, fuzzy
 msgid "This defines the level of the hierarchy"
-msgstr "Definiert das Element, das im Diagramm dargestellt werden soll"
+msgstr "Dies definiert die Ebene der Hierarchie"
 
 #: superset/views/alerts.py:232 superset/views/schedules.py:253
 #: superset/views/schedules.py:334
@@ -13344,7 +13281,7 @@ msgstr "Ausgelöst durch:"
 
 #: superset-frontend/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts:74
 msgid "Threshold alpha level for determining significance"
-msgstr ""
+msgstr "Schwellenwert für Alpha-Level zur Bestimmung der Signifikanz"
 
 #: superset-frontend/src/components/CronPicker/CronPicker.tsx:60
 msgid "Thursday"
@@ -13373,9 +13310,8 @@ msgid "Time"
 msgstr "Zeit"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/constants.ts:25
-#, fuzzy
 msgid "Time Column"
-msgstr "Zeitspalten"
+msgstr "Zeitspalte"
 
 #: superset-frontend/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:303
 #: superset-frontend/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx:186
@@ -13384,17 +13320,14 @@ msgid "Time Comparison"
 msgstr "Zeitvergleich"
 
 #: superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:141
-#, fuzzy
 msgid "Time Format"
 msgstr "Zeitformat"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/constants.ts:26
-#, fuzzy
 msgid "Time Grain"
 msgstr "Zeitgranularität"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/constants.ts:28
-#, fuzzy
 msgid "Time Granularity"
 msgstr "Zeitgranularität"
 
@@ -13403,9 +13336,8 @@ msgid "Time Offset"
 msgstr "Zeitversatz"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/constants.ts:24
-#, fuzzy
 msgid "Time Range"
-msgstr "Zeitbereich"
+msgstr "Zeitraum"
 
 #: superset-frontend/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:86
 msgid "Time Series"
@@ -13475,7 +13407,7 @@ msgstr "Zeitspalte \"%(col)s\" ist im Datensatz nicht vorhanden"
 
 #: superset-frontend/src/filters/components/TimeColumn/index.ts:29
 msgid "Time column filter plugin"
-msgstr ""
+msgstr "Zeitspalten-Filter-Plugin"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/sections/advancedAnalytics.tsx:88
 #: superset-frontend/src/explore/controlPanels/sections.tsx:201
@@ -13520,16 +13452,14 @@ msgid "Time grain"
 msgstr "Zeitgranularität"
 
 #: superset-frontend/src/filters/components/TimeGrain/index.ts:29
-#, fuzzy
 msgid "Time grain filter plugin"
-msgstr "Zeiteinteilung fehlt"
+msgstr "Zeitgranularität-Plugin"
 
 #: superset/utils/pandas_postprocessing.py:815
 msgid "Time grain missing"
 msgstr "Zeiteinteilung fehlt"
 
 #: superset-frontend/src/explore/constants.ts:117
-#, fuzzy
 msgid "Time granularity"
 msgstr "Zeitgranularität"
 
@@ -13581,9 +13511,8 @@ msgstr ""
 "ago] oder [%(human_readable)s later] an."
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/index.ts:75
-#, fuzzy
 msgid "Time-series Area Chart"
-msgstr "Zeitreihen - Balkendiagramm"
+msgstr "Zeitreihen-Flächendiagramm"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/index.ts:65
 msgid ""
@@ -13591,46 +13520,46 @@ msgid ""
 "variables with the same scale, but area charts stack the metrics on top "
 "of each other. An area chart in Superset can be stream, stack, or expand."
 msgstr ""
+"Zeitreihen-Flächendiagramme ähneln Liniendiagrammen insofern, als sie "
+"Variablen mit der gleichen Skala darstellen, aber Flächendiagramme "
+"stapeln die Metriken übereinander. Ein Flächendiagramm in Superset kann "
+"streamen, stapeln oder erweitern."
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bar/index.js:35
-#, fuzzy
 msgid "Time-series Bar Chart"
 msgstr "Zeitreihen - Balkendiagramm"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/index.ts:75
-#, fuzzy
 msgid "Time-series Bar Chart v2"
-msgstr "Zeitreihen - Balkendiagramm"
+msgstr "Zeitreihen-Balkendiagramm v2"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/index.ts:61
 msgid ""
 "Time-series Bar Charts are used to show the changes in a metric over time"
 " as a series of bars."
 msgstr ""
+"Zeitreihen-Balkendiagramme werden verwendet, um die Änderungen in einer "
+"Metrik im Laufe der Zeit als eine Reihe von Balken anzuzeigen."
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/index.ts:69
-#, fuzzy
 msgid "Time-series Chart"
-msgstr "Zeitreihen - Balkendiagramm"
+msgstr "Zeitreihendiagramm"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/index.ts:70
-#, fuzzy
 msgid "Time-series Line Chart"
 msgstr "Zeitreihen - Liniendiagramm"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Compare/index.js:30
-#, fuzzy
 msgid "Time-series Percent Change"
 msgstr "Zeitreihen - Prozentuale Veränderung"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/TimePivot/index.js:28
-#, fuzzy
 msgid "Time-series Period Pivot"
 msgstr "Zeitreihen - Perioden-Pivot"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/index.ts:69
 msgid "Time-series Scatter Plot"
-msgstr ""
+msgstr "Zeitreihen-Streudiagramm"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/index.ts:59
 msgid ""
@@ -13638,21 +13567,27 @@ msgid ""
 " and the points are connected in order. It shows a statistical "
 "relationship between two variables."
 msgstr ""
+"Das Zeitreihen-Streudiagramm stellt die Zeit auf der horizontalen Achse "
+"in linearen Einheiten dar, und die Punkte sind in der richtigen "
+"Reihenfolge verbunden. Es zeigt eine statistische Beziehung zwischen zwei"
+" Variablen."
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/SmoothLine/index.ts:69
-#, fuzzy
 msgid "Time-series Smooth Line"
-msgstr "Zeitserienspalte"
+msgstr "Zeitreihe Glatte Linie"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/SmoothLine/index.ts:59
 msgid ""
 "Time-series Smooth-line is a variation of line chart. Without angles and "
 "hard edges, Smooth-line looks more smarter and more professional."
 msgstr ""
+"Zeitreihe Glatte Linie ist eine Variation des Liniendiagramms. Ohne "
+"Winkel und harte Kanten sieht Smooth-line raffinierter und "
+"professioneller aus."
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/index.ts:60
 msgid "Time-series Stepped Line"
-msgstr ""
+msgstr "Zeitreihen-Stufenlinie"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/index.ts:50
 msgid ""
@@ -13661,11 +13596,15 @@ msgid ""
 "points. A step chart can be useful when you want to show the changes that"
 " occur at irregular intervals."
 msgstr ""
+"Zeitreihen-Stufenliniendiagramm (auch Schrittdiagramm genannt) ist eine "
+"Variation des Liniendiagramms, wobei die Linie jedoch eine Reihe von "
+"Schritten zwischen Datenpunkten bildet. Ein Schrittdiagramm kann nützlich"
+" sein, wenn Sie die Änderungen anzeigen möchten, die in unregelmäßigen "
+"Abständen auftreten."
 
 #: superset-frontend/src/visualizations/TimeTable/TimeTableChartPlugin.ts:25
-#, fuzzy
 msgid "Time-series Table"
-msgstr "Zeitreihen - Gestapelt"
+msgstr "Zeitreihentabelle"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/index.ts:60
 msgid ""
@@ -13674,13 +13613,17 @@ msgid ""
 " information as a series of data points connected by straight line "
 "segments. It is a basic type of chart common in many fields."
 msgstr ""
+"Das Zeitreihen-Liniendiagramm wird verwendet, um wiederholte Messungen in"
+" regelmäßigen Zeitintervallen zu visualisieren. Liniendiagramm ist ein "
+"Diagrammtyp, der Informationen als eine Reihe von Datenpunkten anzeigt, "
+"die durch gerade Liniensegmente verbunden sind. Es ist ein grundlegender "
+"Diagrammtyp, der in vielen Bereichen üblich ist."
 
 #: superset-frontend/src/components/ErrorMessage/TimeoutErrorMessage.tsx:98
 msgid "Timeout error"
 msgstr "Zeitüberschreitung"
 
 #: superset-frontend/plugins/legacy-preset-chart-big-number/src/BigNumberTotal/controlPanel.ts:60
-#, fuzzy
 msgid "Timestamp Format"
 msgstr "Zeitstempelformat"
 
@@ -13704,9 +13647,8 @@ msgstr "Zeitzonen-Auswahl"
 
 #: superset-frontend/plugins/legacy-preset-chart-big-number/src/sharedControls.ts:35
 #: superset-frontend/plugins/legacy-preset-chart-big-number/src/sharedControls.ts:69
-#, fuzzy
 msgid "Tiny"
-msgstr "in"
+msgstr "Sehr klein"
 
 #: superset-frontend/src/dashboard/components/PropertiesModal/index.jsx:502
 #: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/DividerConfigForm.tsx:42
@@ -13742,9 +13684,8 @@ msgid "Toggle chart description"
 msgstr "Diagramm-Beschreibung umschalten"
 
 #: superset-frontend/src/visualizations/FilterBox/FilterBoxChartPlugin.js:25
-#, fuzzy
 msgid "Tools"
-msgstr "Rollen"
+msgstr "Werkzeuge"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx:184
 msgid "Tooltip"
@@ -13759,7 +13700,6 @@ msgid "Tooltip time format"
 msgstr "Tooltip-Zeitformat"
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:289
-#, fuzzy
 msgid "Top"
 msgstr "Oben"
 
@@ -13785,24 +13725,23 @@ msgstr "Auftrag verfolgen"
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/index.ts:67
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/index.ts:76
 msgid "Transformable"
-msgstr ""
+msgstr "Transportierbar"
 
 #: superset-frontend/src/dashboard/util/backgroundStyleOptions.ts:25
 msgid "Transparent"
-msgstr ""
+msgstr "Transparent"
 
 #: superset-frontend/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.ts:110
 msgid "Transpose Pivot"
-msgstr ""
+msgstr "Pivot transponieren"
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:173
 msgid "Transpose pivot"
-msgstr ""
+msgstr "Pivot transponieren"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Tree/index.ts:39
-#, fuzzy
 msgid "Tree Chart"
-msgstr "Flächendiagramm"
+msgstr "Baumdiagramm"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:117
 msgid "Tree layout"
@@ -13818,9 +13757,8 @@ msgid "Treemap"
 msgstr "Treemap"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Treemap/index.ts:56
-#, fuzzy
 msgid "Treemap v2"
-msgstr "Treemap"
+msgstr "Treemap v2"
 
 #: superset-frontend/plugins/legacy-plugin-chart-calendar/src/index.js:37
 #: superset-frontend/plugins/legacy-plugin-chart-rose/src/index.js:37
@@ -13831,9 +13769,8 @@ msgstr "Treemap"
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Compare/index.js:40
 #: superset-frontend/plugins/plugin-chart-echarts/src/Funnel/index.ts:59
 #: superset-frontend/src/visualizations/TimeTable/TimeTableChartPlugin.ts:36
-#, fuzzy
 msgid "Trend"
-msgstr "Rot"
+msgstr "Trend"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:226
 msgid "Triangle"
@@ -13923,13 +13860,12 @@ msgstr "Geben Sie ein oder wählen Sie [%s] aus."
 #: superset-frontend/src/filters/components/Time/controlPanel.ts:45
 #: superset-frontend/src/filters/components/TimeColumn/controlPanel.ts:25
 #: superset-frontend/src/filters/components/TimeGrain/controlPanel.ts:25
-#, fuzzy
 msgid "UI Configuration"
-msgstr "Filterkonfiguration"
+msgstr "UI Konfiguration"
 
 #: superset-frontend/src/explore/controlPanels/TimeTable.js:51
 msgid "URL"
-msgstr ""
+msgstr "URL"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/sections/sections.tsx:76
 msgid "URL Parameters"
@@ -13950,6 +13886,8 @@ msgstr "URL Titelform"
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:531
 msgid "Unable to add a new tab to the backend. Please contact your administrator."
 msgstr ""
+"Dem Backend kann keine neue Registerkarte hinzugefügt werden. Wenden Sie "
+"sich an Ihre*n Administrator*in."
 
 #: superset/db_engine_specs/presto.py:218
 #, python-format
@@ -13976,18 +13914,27 @@ msgid ""
 "Unable to migrate query editor state to backend. Superset will retry "
 "later. Please contact your administrator if this problem persists."
 msgstr ""
+"Der Status des Abfrage-Editors kann nicht zum Backend übertragen werden. "
+"Superset wird es später erneut versuchen. Wenden Sie sich an Ihre*n "
+"Administrator*in, wenn dieses Problem weiterhin besteht."
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:452
 msgid ""
 "Unable to migrate query state to backend. Superset will retry later. "
 "Please contact your administrator if this problem persists."
 msgstr ""
+"Der Abfragestatus kann nicht zum Backend übertragen werden. Superset wird"
+" es später erneut versuchen. Wenden Sie sich an Ihre*n Administrator*in, "
+"wenn dieses Problem weiterhin besteht."
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:434
 msgid ""
 "Unable to migrate table schema state to backend. Superset will retry "
 "later. Please contact your administrator if this problem persists."
 msgstr ""
+"Der Tabellenschemastatus kann nicht zum Backend übertragen werden. "
+"Superset wird es später erneut versuchen. Wenden Sie sich an Ihre*n "
+"Administrator*in, wenn dieses Problem weiterhin besteht."
 
 #: superset/connectors/sqla/views.py:641
 #, python-format
@@ -14052,9 +13999,8 @@ msgstr ""
 " Details"
 
 #: superset-frontend/src/utils/getClientErrorObject.ts:55
-#, fuzzy
 msgid "Unexpected error: "
-msgstr "Unerwarteter Fehler"
+msgstr "Unerwarteter Fehler:"
 
 #: superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx:95
 msgid "Unknown"
@@ -14080,14 +14026,12 @@ msgstr "Unbekannte Spalte in ORDER BY verwendet: %(col)s"
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:349
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:389
-#, fuzzy
 msgid "Unknown error"
-msgstr "Unbekannter Presto-Fehler"
+msgstr "Unbekannter Fehler"
 
 #: superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/utils/index.ts:45
-#, fuzzy
 msgid "Unknown value"
-msgstr "Status unbekannt"
+msgstr "Unbekannter Wert"
 
 #: superset/jinja_context.py:347
 #, python-format
@@ -14148,9 +14092,8 @@ msgid "Update"
 msgstr "Aktualisieren"
 
 #: superset-frontend/src/chart/chartReducer.ts:82
-#, fuzzy
 msgid "Updating chart was stopped"
-msgstr "Abfrage wurde angehalten"
+msgstr "Aktualisierung des Diagramms wurde abgebrochen"
 
 #: superset/templates/superset/import_dashboards.html:63
 msgid "Upload"
@@ -14195,9 +14138,8 @@ msgid "Use a log scale"
 msgstr "Verwenden einer Logarithmischen Skala"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bubble/controlPanel.ts:107
-#, fuzzy
 msgid "Use a log scale for the X-axis"
-msgstr "Logarithmische Skala für die Y-Achse verwenden"
+msgstr "Logarithmische Skala für die X-Achse verwenden"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:230
 msgid "Use a log scale for the Y-axis"
@@ -14214,10 +14156,12 @@ msgstr "Verwenden des Legacy-Datenquellen-Editors"
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:85
 msgid "Use metrics as a top level group for columns or for rows"
 msgstr ""
+"Verwenden von Metriken als Gruppe der obersten Ebene für Spalten oder "
+"Zeilen"
 
 #: superset-frontend/src/filters/components/Range/controlPanel.ts:68
 msgid "Use only a single value."
-msgstr ""
+msgstr "Verwenden Sie nur einen einzigen Wert."
 
 #: superset-frontend/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx:124
 msgid "Use the Advanced Analytics options below"
@@ -14259,6 +14203,13 @@ msgid ""
 "  This chart is being deprecated and we recommend checking out Pivot "
 "Table V2 instead!"
 msgstr ""
+"Wird verwendet, um einen Datensatz zusammenzufassen, indem mehrere "
+"Statistiken entlang zweier Achsen gruppiert werden. Beispiele: "
+"Verkaufszahlen nach Region und Monat, Aufgaben nach Status und "
+"Beauftragtem, aktive Nutzer nach Alter und Standort.\n"
+"\n"
+"Dieses Diagramm ist überholt, und wir empfehlen stattdessen, Pivot Table "
+"V2 auszuprobieren!"
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/index.ts:51
 msgid ""
@@ -14267,6 +14218,11 @@ msgid ""
 "status and assignee, active users by age and location. Not the most "
 "visually stunning visualization, but highly informative and versatile."
 msgstr ""
+"Wird verwendet, um einen Datensatz zusammenzufassen, indem mehrere "
+"Statistiken entlang zweier Achsen gruppiert werden. Beispiele: "
+"Verkaufszahlen nach Region und Monat, Aufgaben nach Status und "
+"Beauftragtem, aktive Nutzer nach Alter und Standort. Nicht die visuell "
+"beeindruckendste Visualisierung, aber sehr informativ und vielseitig."
 
 #: superset-frontend/src/components/Menu/MenuRight.tsx:158
 #: superset-frontend/src/views/CRUD/data/query/QueryList.tsx:275
@@ -14281,12 +14237,11 @@ msgstr "Nutzer*in"
 msgid "User Roles"
 msgstr "Nutzer*innen-Rollen"
 
-#: superset/errors.py:112
+#: superset/errors.py:113
 msgid "User doesn't have the proper permissions."
 msgstr "Benutzer*in verfügt nicht über die richtigen Berechtigungen."
 
 #: superset-frontend/src/filters/components/Select/controlPanel.ts:94
-#, fuzzy
 msgid "User must select a value before applying the filter"
 msgstr "Benutzer*in muss einen Wert für diesen Filter auswählen"
 
@@ -14299,7 +14254,6 @@ msgstr "Benutzer*in muss einen Wert für diesen Filter auswählen"
 #: superset-frontend/src/filters/components/Time/controlPanel.ts:56
 #: superset-frontend/src/filters/components/TimeColumn/controlPanel.ts:36
 #: superset-frontend/src/filters/components/TimeGrain/controlPanel.ts:36
-#, fuzzy
 msgid "User must select a value for this filter."
 msgstr "Benutzer*in muss einen Wert für diesen Filter auswählen"
 
@@ -14318,6 +14272,9 @@ msgid ""
 "position of the dial represents the progress and the terminal value in "
 "the gauge represents the target value."
 msgstr ""
+"Verwendet ein Tachometer, um den Fortschritt einer Metrik in Richtung "
+"eines Ziels anzuzeigen. Die Position des Zifferblatts stellt den "
+"Fortschritt und der Endwert im Tachometer den Zielwert dar."
 
 #: superset-frontend/plugins/legacy-plugin-chart-sunburst/src/index.js:28
 msgid ""
@@ -14326,6 +14283,11 @@ msgid ""
 "the stages a value took. Useful for multi-stage, multi-group visualizing "
 "funnels and pipelines."
 msgstr ""
+"Verwendet Kreise, um den Datenfluss durch verschiedene Phasen eines "
+"Systems zu visualisieren. Bewegen Sie den Mauszeiger über einzelne Pfade "
+"in der Visualisierung, um die Phasen zu verstehen, die ein Wert "
+"durchlaufen hat. Nützlich für die Visualisierung von Trichtern und "
+"Pipelines in mehreren Gruppen."
 
 #: superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx:294
 #: superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx:1186
@@ -14335,19 +14297,16 @@ msgid "Value"
 msgstr "Wert"
 
 #: superset-frontend/plugins/legacy-plugin-chart-horizon/src/controlPanel.ts:91
-#, fuzzy
 msgid "Value Domain"
-msgstr "Wertformat"
+msgstr "Wertebereich"
 
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:329
-#, fuzzy
 msgid "Value Format"
 msgstr "Wertformat"
 
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:235
-#, fuzzy
 msgid "Value bounds"
-msgstr "Intervallgrenzen"
+msgstr "Wertgrenzen"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:165
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:206
@@ -14365,9 +14324,8 @@ msgid "Value must be greater than 0"
 msgstr "Der Wert muss größer als 0 sein"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Area/index.js:39
-#, fuzzy
 msgid "Vehicle Types"
-msgstr "Serientyp"
+msgstr "Fahrzeugtypen"
 
 #: superset/connectors/druid/views.py:189
 #: superset/connectors/druid/views.py:238 superset/connectors/sqla/views.py:144
@@ -14386,13 +14344,12 @@ msgstr "Versionsnummer"
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bar/index.js:41
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js:48
 #: superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/index.ts:84
-#, fuzzy
 msgid "Vertical"
-msgstr "virtuell"
+msgstr "Vertikal"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Area/index.js:38
 msgid "Video game consoles"
-msgstr ""
+msgstr "Videospielkonsolen"
 
 #: superset-frontend/src/views/CRUD/welcome/ChartTable.tsx:217
 #: superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx:219
@@ -14439,9 +14396,8 @@ msgid "Viewed %s"
 msgstr "%s angesehen"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:268
-#, fuzzy
 msgid "Viewport"
-msgstr "Report"
+msgstr "Ansichtsfenster"
 
 #: superset-frontend/src/components/Datasource/DatasourceEditor.jsx:133
 msgid "Virtual (SQL)"
@@ -14465,7 +14421,7 @@ msgstr "Virtuelle Datensatzabfrage muss schreibgeschützt sein"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:192
 msgid "Visual Tweaks"
-msgstr ""
+msgstr "Visuelle Optimierungen"
 
 #: superset-frontend/src/dashboard/components/AddSliceCard.jsx:132
 msgid "Visualization"
@@ -14487,6 +14443,9 @@ msgid ""
 " visualized using its own line of points and each metric is represented "
 "as an edge in the chart."
 msgstr ""
+"Visualisieren Sie einen parallelen Satz von Metriken über mehrere Gruppen"
+" hinweg. Jede Gruppe wird mit einer eigenen Punktlinie visualisiert und "
+"jede Metrik wird als Kante im Diagramm dargestellt."
 
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/index.js:30
 msgid ""
@@ -14494,18 +14453,27 @@ msgid ""
 "showcasing the correlation or strength between two groups. Color is used "
 "to emphasize the strength of the link between each pair of groups."
 msgstr ""
+"Visualisieren Sie eine verwandte Metrik über Gruppenpaare hinweg. "
+"Heatmaps zeichnen sich dadurch aus, dass sie die Korrelation oder Stärke "
+"zwischen zwei Gruppen darstellen. Farbe wird verwendet, um die Stärke der"
+" Verbindung zwischen jedem Gruppenpaar zu betonen."
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bar/index.js:31
 msgid ""
 "Visualize how a metric changes over time using bars. Add a group by "
 "column to visualize group level metrics and how they change over time."
 msgstr ""
+"Visualisieren Sie mithilfe von Balken, wie sich eine Metrik im Laufe der "
+"Zeit ändert. Fügen Sie eine Gruppe nach Spalte hinzu, um Metriken auf "
+"Gruppenebene und deren Änderung im Laufe der Zeit zu visualisieren."
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Tree/index.ts:35
 msgid ""
 "Visualize multiple levels of hierarchy using a familiar tree-like "
 "structure."
 msgstr ""
+"Visualisieren Sie mehrere Hierarchieebenen mit einer vertrauten "
+"baumartigen Struktur."
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/index.ts:58
 msgid ""
@@ -14513,6 +14481,9 @@ msgid ""
 "Note that each time series can be visualized differently (e.g. 1 using "
 "bars and 1 using a line)."
 msgstr ""
+"Visualisieren Sie zwei verschiedene Zeitreihen mit demselben x-Achsen-"
+"Zeitbereich. Beachten Sie, dass jede Zeitreihe unterschiedlich "
+"visualisiert werden kann (z. B. 1 mit Balken und 1 mit einer Linie)."
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/LineMulti/index.js:27
 msgid ""
@@ -14520,12 +14491,18 @@ msgid ""
 "This chart is being deprecated and we recommend using the Mixed "
 "Timeseries Chart instead!"
 msgstr ""
+"Visualisieren Sie zwei verschiedene Zeitreihen mit demselben x-Achsen-"
+"Zeitbereich. Dieses Diagramm ist überholt und wir empfehlen stattdessen, "
+"das Gemischte Zeitreihen-Diagramm zu verwenden!"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/DualLine/index.js:27
 msgid ""
 "Visualizes 2 metrics as line plots using the same x-axis. This chart is "
 "useful for comparing metrics across the same time range."
 msgstr ""
+"Visualisiert 2 Metriken als Liniendiagramme mit derselben x-Achse. Dieses"
+" Diagramm ist nützlich, um Metriken über den gleichen Zeitraum zu "
+"vergleichen."
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bubble/index.js:27
 msgid ""
@@ -14533,6 +14510,9 @@ msgid ""
 "axis, Y axis, and bubble size). Bubbles from the same group can be "
 "showcased using bubble color."
 msgstr ""
+"Visualisiert eine Metrik über drei Datendimensionen in einem einzelnen "
+"Diagramm (X-Achse, Y-Achse und Blasengröße). Blasen aus derselben Gruppe "
+"können mit Blasenfarbe präsentiert werden."
 
 #: superset-frontend/plugins/legacy-plugin-chart-calendar/src/index.js:27
 msgid ""
@@ -14540,6 +14520,10 @@ msgid ""
 " calendar view. Gray values are used to indicate missing values and the "
 "linear color scheme is used to encode the magnitude of each day's value."
 msgstr ""
+"Visualisiert, wie sich eine Metrik im Laufe der Zeit mithilfe einer "
+"Farbskala und einer Kalenderansicht verändert hat. Grauwerte werden "
+"verwendet, um fehlende Werte anzuzeigen, und das lineare Farbschema wird "
+"verwendet, um den Betrag jedes Tageswerts zu kodieren."
 
 #: superset-frontend/plugins/legacy-plugin-chart-country-map/src/index.js:27
 msgid ""
@@ -14548,6 +14532,11 @@ msgid ""
 "subdivision's value is elevated when you hover over the corresponding "
 "geographic boundary."
 msgstr ""
+"Visualisiert, wie sich eine einzelne Metrik zwischen den wichtigsten "
+"Unterteilungen eines Landes (Bundesstaaten, Provinzen usw.) auf einer "
+"Chlorplethenkarte unterscheidet. Der Wert jeder Unterteilung wird erhöht,"
+" wenn Sie den Mauszeiger über die entsprechende geografische Grenze "
+"bewegen."
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Compare/index.js:27
 msgid ""
@@ -14555,6 +14544,9 @@ msgid ""
 "chart is being deprecated and we recommend using the Time-series Chart "
 "instead."
 msgstr ""
+"Visualisiert viele verschiedene Zeitreihenobjekte in einem einzigen "
+"Diagramm. Dieses Diagramm ist überholt, und wir empfehlen, stattdessen "
+"das Zeitreihendiagramm zu verwenden."
 
 #: superset-frontend/plugins/legacy-plugin-chart-sankey/src/index.js:29
 msgid ""
@@ -14563,12 +14555,18 @@ msgid ""
 "layers. The thickness of the bars or edges represent the metric being "
 "visualized."
 msgstr ""
+"Visualisiert den Fluss der Werte verschiedener Gruppen durch verschiedene"
+" Phasen eines Systems. Neue Stufen in der Pipeline werden als Knoten oder"
+" Layer visualisiert. Die Dicke der Balken oder Kanten stellt die Metrik "
+"dar, die visualisiert wird."
 
 #: superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/index.ts:35
 msgid ""
 "Visualizes the words in a column that appear the most often. Bigger font "
 "corresponds to higher frequency."
 msgstr ""
+"Visualisiert die Wörter in einer Spalte, die am häufigsten vorkommen. "
+"Größere Schrift entspricht einer höheren Frequenz."
 
 #: superset/viz.py:133
 msgid "Viz is missing a datasource"
@@ -14634,7 +14632,7 @@ msgstr ""
 
 #: superset-frontend/src/reports/actions/reports.js:156
 msgid "We were unable to active or deactivate this report."
-msgstr ""
+msgstr "Wir konnten diesen Bericht nicht aktivieren oder deaktivieren."
 
 #: superset/db_engine_specs/redshift.py:86
 #, python-format
@@ -14657,7 +14655,7 @@ msgstr ""
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Radar/index.ts:60
 msgid "Web"
-msgstr ""
+msgstr "Web"
 
 #: superset-frontend/src/components/CronPicker/CronPicker.tsx:59
 msgid "Wednesday"
@@ -14684,9 +14682,9 @@ msgid "Week_ending Sunday"
 msgstr "Woche endet am Sonntag"
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:67
-#, fuzzy, python-format
+#, python-format
 msgid "Weeks %s"
-msgstr "Woche"
+msgstr "Wochen %s"
 
 #: superset-frontend/src/components/ErrorMessage/TimeoutErrorMessage.tsx:52
 #, python-format
@@ -14726,6 +14724,8 @@ msgstr ""
 #: superset-frontend/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts:76
 msgid "When a secondary metric is provided, a linear color scale is used."
 msgstr ""
+"Wenn eine sekundäre Metrik bereitgestellt wird, wird eine lineare "
+"Farbskala verwendet."
 
 #: superset/views/database/mixins.py:120
 msgid ""
@@ -14744,6 +14744,8 @@ msgstr ""
 #: superset-frontend/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts:71
 msgid "When only a primary metric is provided, a categorical color scale is used."
 msgstr ""
+"Wenn nur eine primäre Metrik bereitgestellt wird, wird eine kategoriale "
+"Farbpalette verwendet."
 
 #: superset-frontend/src/components/Datasource/DatasourceEditor.jsx:898
 msgid ""
@@ -14810,9 +14812,8 @@ msgstr ""
 "werden sollen"
 
 #: superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx:739
-#, fuzzy
 msgid "Whether to always show the annotation label"
-msgstr "Ob der Zeiger angezeigt werden soll"
+msgstr "Ob die Anmerkungs-Beschriftung immer angezeigt werden soll"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Gauge/controlPanel.tsx:192
 msgid "Whether to animate the progress and the value or just display them"
@@ -14821,6 +14822,8 @@ msgstr "Ob der Fortschritt und der Wert animiert oder nur angezeigt werden solle
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:317
 msgid "Whether to apply a normal distribution based on rank on the color scale"
 msgstr ""
+"Ob eine Normalverteilung basierend auf dem Rang auf der Farbskala "
+"angewendet werden soll"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:138
 #: superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx:442
@@ -14839,14 +14842,12 @@ msgid "Whether to display a legend for the chart"
 msgstr "Ob eine Legende für das Diagramm angezeigt werden soll"
 
 #: superset-frontend/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts:83
-#, fuzzy
 msgid "Whether to display bubbles on top of countries"
-msgstr "Ob der Zeitstempel angezeigt werden soll"
+msgstr "Ob Blasen über Ländern angezeigt werden sollen"
 
 #: superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/src/controlPanel.ts:60
-#, fuzzy
 msgid "Whether to display the interactive data table"
-msgstr "Ob die interaktive Zeitbereichs-Auswahl angezeigt werden soll"
+msgstr "Ob die interaktive Datentabelle angezeigt werden soll"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Funnel/controlPanel.tsx:130
 #: superset-frontend/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx:152
@@ -14860,6 +14861,9 @@ msgid ""
 "Whether to display the labels. Note that the label only displays when the"
 " the 5% threshold."
 msgstr ""
+"Ob die Beschriftungen angezeigt werden sollen. Beachten Sie, dass die "
+"Beschriftung nur angezeigt wird, wenn der Schwellenwert von 5 % erreicht "
+"ist."
 
 #: superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:157
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:278
@@ -14869,9 +14873,8 @@ msgid "Whether to display the legend (toggles)"
 msgstr "Ob die Legende angezeigt werden soll (Wechselschalter)"
 
 #: superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts:181
-#, fuzzy
 msgid "Whether to display the metric name as a title"
-msgstr "Ob die Trendlinie angezeigt werden soll"
+msgstr "Ob der Metrikname als Titel angezeigt werden soll"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:273
 msgid "Whether to display the min and max values of the X-axis"
@@ -14912,9 +14915,8 @@ msgstr ""
 " soll."
 
 #: superset-frontend/plugins/legacy-preset-chart-big-number/src/BigNumberTotal/controlPanel.ts:63
-#, fuzzy
 msgid "Whether to format the timestamp"
-msgstr "Ob der Zeitstempel angezeigt werden soll"
+msgstr "Ob der Zeitstempel formatiert werden soll"
 
 #: superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx:406
 msgid "Whether to include a client-side search box"
@@ -14925,9 +14927,8 @@ msgid "Whether to include a time filter"
 msgstr "Ob ein Zeitfilter eingebunden werden soll"
 
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:289
-#, fuzzy
 msgid "Whether to include the percentage in the tooltip"
-msgstr "Ob ein Zeitfilter eingebunden werden soll"
+msgstr "Ob der Prozentsatz in Tooltip aufgenommen werden soll"
 
 #: superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx:326
 msgid "Whether to include the time granularity as defined in the time section"
@@ -14935,7 +14936,7 @@ msgstr "Ob die im Zeitabschnitt definierte Zeitgranularität einbezogen werden s
 
 #: superset-frontend/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts:155
 msgid "Whether to make the histogram cumulative"
-msgstr ""
+msgstr "Ob das Histogramm kumulativ dargestellt werden soll"
 
 #: superset/connectors/sqla/views.py:94
 msgid ""
@@ -14946,9 +14947,8 @@ msgstr ""
 " gemacht werden soll, muss die Spalte DATETIME oder DATETIME-ähnlich sein"
 
 #: superset-frontend/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts:143
-#, fuzzy
 msgid "Whether to normalize the histogram"
-msgstr "Ob der Zeitstempel angezeigt werden soll"
+msgstr "Ob das Histogramm normalisiert werden soll"
 
 #: superset-frontend/src/components/Datasource/DatasourceEditor.jsx:709
 msgid "Whether to populate autocomplete filters options"
@@ -15042,7 +15042,7 @@ msgstr ""
 
 #: superset-frontend/plugins/legacy-plugin-chart-country-map/src/controlPanel.ts:43
 msgid "Which country to plot the map for?"
-msgstr ""
+msgstr "Für welches Land soll die Karte geplottet werden?"
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx:197
 msgid "Which relatives to highlight on hover"
@@ -15050,14 +15050,12 @@ msgstr "Welche Verwandten beim Überfahren mit der Maus hervorgehoben werden sol
 
 #: superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts:51
 #: superset-frontend/plugins/preset-chart-xy/src/BoxPlot/controlPanel.ts:45
-#, fuzzy
 msgid "Whisker/outlier options"
-msgstr "Diagramm-Optionen"
+msgstr "Whisker/Ausreißer-Optionen"
 
 #: superset-frontend/src/dashboard/util/backgroundStyleOptions.ts:30
-#, fuzzy
 msgid "White"
-msgstr "Titel"
+msgstr "Weiß"
 
 #: superset-frontend/src/explore/components/EmbedCodeButton.jsx:130
 msgid "Width"
@@ -15073,17 +15071,16 @@ msgstr "Fenster muss > 0 sein"
 
 #: superset-frontend/plugins/legacy-preset-chart-big-number/src/BigNumberTotal/index.ts:36
 msgid "With a subheader"
-msgstr ""
+msgstr "Mit einem Untertitel"
 
 #: superset-frontend/plugins/plugin-chart-word-cloud/src/legacyPlugin/index.ts:29
 #: superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/index.ts:39
 msgid "Word Cloud"
-msgstr ""
+msgstr "Wortwolke"
 
 #: superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.ts:80
-#, fuzzy
 msgid "Word Rotation"
-msgstr "Anmerkungen hinzufügen"
+msgstr "Wort-Rotation"
 
 #: superset-frontend/src/views/CRUD/alert/AlertList.tsx:55
 msgid "Working"
@@ -15147,9 +15144,8 @@ msgid "X Axis Title"
 msgstr "Titel der X-Achse"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bubble/controlPanel.ts:104
-#, fuzzy
 msgid "X Log Scale"
-msgstr "Verwenden einer Logarithmischen Skala"
+msgstr "X-Log-Skala"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:201
 #: superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts:78
@@ -15162,9 +15158,8 @@ msgid "X bounds"
 msgstr "X-Grenzen"
 
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:114
-#, fuzzy
 msgid "XScale Interval"
-msgstr "Konfidenzintervall"
+msgstr "X-Skalen-Intervall"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:102
 msgid "Y 2 bounds"
@@ -15201,11 +15196,11 @@ msgstr "Y-Achse"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/DualLine/controlPanel.ts:40
 msgid "Y Axis 1"
-msgstr ""
+msgstr "Y-Achse 1"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/DualLine/controlPanel.ts:50
 msgid "Y Axis 2"
-msgstr ""
+msgstr "Y-Achse 2"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx:254
 msgid "Y Axis 2 Bounds"
@@ -15233,13 +15228,12 @@ msgid "Y Axis Label"
 msgstr "Y Achsenbeschriftung"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:88
-#, fuzzy
 msgid "Y Axis Left"
-msgstr "Titel der Y-Achse"
+msgstr "Y-Achse links"
 
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts:123
 msgid "Y Axis Right"
-msgstr ""
+msgstr "Y-Achse rechts"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/sections/chartTitle.tsx:65
 msgid "Y Axis Title"
@@ -15254,18 +15248,17 @@ msgid "Y bounds"
 msgstr "Y-Grenzen"
 
 #: superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts:130
-#, fuzzy
 msgid "YScale Interval"
-msgstr "Konfidenzintervall"
+msgstr "Y-Skalen-Intervall"
 
 #: superset/db_engine_specs/base.py:100
 msgid "Year"
 msgstr "Jahr"
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:70
-#, fuzzy, python-format
+#, python-format
 msgid "Years %s"
-msgstr "Jahr"
+msgstr "Jahre %s"
 
 #: superset-frontend/src/views/CRUD/chart/ChartList.tsx:443
 #: superset-frontend/src/views/CRUD/chart/ChartList.tsx:537
@@ -15309,7 +15302,6 @@ msgstr ""
 "Arbeit verlieren. Sind Sie sicher, dass Sie diese überschreiben möchten?"
 
 #: superset-frontend/src/views/CRUD/data/dataset/constants.ts:30
-#, fuzzy
 msgid ""
 "You are importing one or more datasets that already exist. Overwriting "
 "might cause you to lose some of your work. Are you sure you want to "
@@ -15329,7 +15321,7 @@ msgstr ""
 "vorhanden sind. Das Überschreiben kann dazu führen, dass Sie einen Teil "
 "Ihrer Arbeit verlieren. Sind Sie sicher, dass Sie überschreiben möchten?"
 
-#: superset/views/core.py:2175
+#: superset/views/core.py:2192
 msgid ""
 "You are not authorized to fetch samples from this table. If you think "
 "this is an error, please reach out to your administrator."
@@ -15338,7 +15330,7 @@ msgstr ""
 "Sie der Meinung sind, dass dies ein Fehler ist, wenden Sie sich bitte an "
 "Ihre*n Administrator*in."
 
-#: superset/views/core.py:2295
+#: superset/views/core.py:2312
 msgid ""
 "You are not authorized to see this query. If you think this is an error, "
 "please reach out to your administrator."
@@ -15380,6 +15372,8 @@ msgstr ""
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js:366
 msgid "You cannot use 45° tick layout along with the time range filter"
 msgstr ""
+"Sie können das 45°-Strich-Layout nicht zusammen mit dem "
+"Zeitbereichsfilter verwenden"
 
 #: superset/viz.py:696
 msgid ""
@@ -15408,9 +15402,8 @@ msgstr ""
 "%(name)s."
 
 #: superset-frontend/src/dashboard/actions/dashboardState.js:133
-#, fuzzy
 msgid "You do not have permissions to edit this dashboard."
-msgstr "Sie haben keine Zugriff auf diese Datenquelle"
+msgstr "Sie haben keine Berechtigungen zum Bearbeiten dieses Dashboards."
 
 #: superset/dashboards/commands/exceptions.py:86
 msgid "You don't have access to this dashboard."
@@ -15421,9 +15414,8 @@ msgid "You don't have any favorites yet!"
 msgstr "Sie haben noch keine Favoriten!"
 
 #: superset/key_value/commands/exceptions.py:45
-#, fuzzy
 msgid "You don't have permission to modify the value."
-msgstr "Sie sind nicht berechtigt, dieses Diagramm zu bearbeiten"
+msgstr "Sie sind nicht berechtigt, den Wert zu ändern."
 
 #: superset/views/core.py:618 superset/views/core.py:823
 #: superset/views/core.py:829 superset/views/core.py:999
@@ -15462,49 +15454,44 @@ msgstr ""
 "speichern."
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:876
-#, fuzzy
 msgid "Your query could not be saved"
-msgstr "Gespeicherte Abfragen konnten nicht gelöscht werden."
+msgstr "Ihre Abfrage konnte nicht gespeichert werden"
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:166
-#, fuzzy
 msgid "Your query could not be scheduled"
-msgstr "Gespeicherte Abfragen konnten nicht gelöscht werden."
+msgstr "Ihre Abfrage konnte nicht eingeplant werden"
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:892
-#, fuzzy
 msgid "Your query could not be updated"
-msgstr "Diagramm konnte nicht aktualisiert werden."
+msgstr "Ihre Abfrage konnte nicht aktualisiert werden."
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:159
 msgid ""
 "Your query has been scheduled. To see details of your query, navigate to "
 "Saved queries"
 msgstr ""
+"Ihre Abfrage wurde geplant. Um Details zu Ihrer Abfrage anzuzeigen, "
+"navigieren Sie zu Gespeicherte Abfragen"
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:872
-#, fuzzy
 msgid "Your query was saved"
-msgstr "Abfrage wurde angehalten"
+msgstr "Ihre Abfrage wurde gespeichert"
 
 #: superset-frontend/src/SqlLab/actions/sqlLab.js:888
-#, fuzzy
 msgid "Your query was updated"
-msgstr "Abfrage wurde angehalten"
+msgstr "Ihre Abfrage wurde angehalten"
 
 #: superset-frontend/src/reports/actions/reports.js:172
-#, fuzzy
 msgid "Your report could not be deleted"
-msgstr "Diagramm konnte nicht gelöscht werden."
+msgstr "Ihr Report konnte nicht gelöscht werden"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:306
-#, fuzzy
 msgid "Zoom"
-msgstr "Unten"
+msgstr "Zoom"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:310
 msgid "Zoom level of the map"
-msgstr ""
+msgstr "Zoomstufe der Karte"
 
 #: superset/tasks/schedules.py:658
 #, python-format
@@ -15552,6 +15539,9 @@ msgid ""
 "against the primary metric. When omitted, the color is categorical and "
 "based on labels"
 msgstr ""
+"[optional] Diese sekundäre Metrik wird verwendet, um die Farbe als "
+"Verhältnis zur primären Metrik zu definieren. Wenn keine angegeben, "
+"werden diskrete Farben verwendet, die auf den Beschriftungen basieren"
 
 #: superset/utils/pandas_postprocessing.py:519
 msgid "`compare_columns` must have the same length as `source_columns`."
@@ -15573,6 +15563,10 @@ msgid ""
 "aggregated with the aggregator. Non-numerical columns will be used to "
 "label points. Leave empty to get a count of points in each cluster."
 msgstr ""
+"'count' ist COUNT(*), wenn ein ‚GROUP BY’ verwendet wird. Numerische "
+"Spalten werden mit der Aggregatfunktion aggregiert. Nicht numerische "
+"Spalten werden verwendet, um Punkte zu beschriften. Falls leer, wird die "
+"Anzahl der Punkte in jedem Cluster zurückgegeben."
 
 #: superset/common/query_object.py:388
 msgid "`operation` property of post processing object undefined"
@@ -15666,9 +15660,8 @@ msgid "cached"
 msgstr "gecached"
 
 #: superset-frontend/packages/superset-ui-core/src/validator/validateNonEmpty.ts:29
-#, fuzzy
 msgid "cannot be empty"
-msgstr "Filterwertliste darf nicht leer sein"
+msgstr "darf nicht leer sein"
 
 #: superset-frontend/src/SqlLab/components/ExploreResultsButton/index.jsx:143
 msgid ""
@@ -15906,6 +15899,8 @@ msgid ""
 "image-rendering CSS attribute of the canvas object that defines how the "
 "browser scales up the image"
 msgstr ""
+"CSS-Attribut zum Rendern von Bildern des Canvas-Objekts, das definiert, "
+"wie der Browser das Bild hochskaliert"
 
 #: superset-frontend/src/components/CronPicker/CronPicker.tsx:44
 msgid "in"
@@ -15918,12 +15913,12 @@ msgstr " "
 #: superset-frontend/packages/superset-ui-core/src/validator/legacyValidateNumber.ts:28
 #: superset-frontend/packages/superset-ui-core/src/validator/validateNumber.ts:32
 msgid "is expected to be a number"
-msgstr ""
+msgstr "wird als Zahl erwartet"
 
 #: superset-frontend/packages/superset-ui-core/src/validator/legacyValidateInteger.ts:31
 #: superset-frontend/packages/superset-ui-core/src/validator/validateInteger.ts:32
 msgid "is expected to be an integer"
-msgstr ""
+msgstr "wird als Ganzzahl erwartet"
 
 #: superset-frontend/src/profile/components/UserInfo.tsx:64
 msgid "joined"
@@ -15936,42 +15931,36 @@ msgstr "JSON ist ungültig"
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:233
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:261
 msgid "key a-z"
-msgstr ""
+msgstr "Schlüssel a-z"
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:234
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:262
 msgid "key z-a"
-msgstr ""
+msgstr "Schlüssel z-a"
 
 #: superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts:152
-#, fuzzy
 msgid "label"
-msgstr "Label"
+msgstr "Beschriftung"
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:39
-#, fuzzy
 msgid "last day"
-msgstr "Samstag"
+msgstr "Gestern"
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:41
-#, fuzzy
 msgid "last month"
-msgstr "Monat"
+msgstr "letzter Monat"
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:42
-#, fuzzy
 msgid "last quarter"
-msgstr "Quartal"
+msgstr "letztes Quartal"
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:40
-#, fuzzy
 msgid "last week"
-msgstr "Woche"
+msgstr "letzte Woche"
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:43
-#, fuzzy
 msgid "last year"
-msgstr "Cluster"
+msgstr "letztes Jahr"
 
 #: superset-frontend/src/SqlLab/components/TableElement/index.tsx:120
 msgid "latest partition:"
@@ -16020,7 +16009,7 @@ msgstr "Muss einen Wert haben"
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/LineMulti/index.js:34
 #: superset-frontend/plugins/legacy-preset-chart-nvd3/src/TimePivot/index.js:29
 msgid "nvd3"
-msgstr ""
+msgstr "nvd3"
 
 #: superset-frontend/src/components/CronPicker/CronPicker.tsx:45
 #: superset-frontend/src/components/CronPicker/CronPicker.tsx:46
@@ -16033,12 +16022,11 @@ msgstr "ORDER BY-Spalte muss angegeben werden"
 
 #: superset-frontend/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts:85
 msgid "p-value precision"
-msgstr ""
+msgstr "p-Wert-Präzision"
 
 #: superset-frontend/plugins/plugin-chart-table/src/consts.ts:26
-#, fuzzy
 msgid "page_size.all"
-msgstr "page_size.show"
+msgstr "page_size.all"
 
 #: superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx:159
 msgid "page_size.entries"
@@ -16062,15 +16050,15 @@ msgstr ""
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:53
 msgid "previous calendar month"
-msgstr ""
+msgstr "vorheriger Kalendermonat"
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:50
 msgid "previous calendar week"
-msgstr ""
+msgstr "vorherige Kalenderwoche"
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts:56
 msgid "previous calendar year"
-msgstr ""
+msgstr "vorheriges Kalenderjahr"
 
 #: superset-frontend/src/views/CRUD/dashboard/DashboardCard.tsx:153
 msgid "published"
@@ -16135,6 +16123,9 @@ msgid ""
 " scale; change: Show changes compared to the first data point in each "
 "series"
 msgstr ""
+"Serie: Behandeln Sie jede Serie unabhängig voneinander; insgesamt: Alle "
+"Serien verwenden den gleichen Maßstab; Änderung: Änderungen im Vergleich "
+"zum ersten Datenpunkt in jeder Datenreihe anzeigen"
 
 #: superset-frontend/src/explore/components/controls/TextAreaControl.jsx:92
 msgid "textarea"
@@ -16155,15 +16146,13 @@ msgstr ""
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:235
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:263
-#, fuzzy
 msgid "value ascending"
-msgstr "Aufsteigend sortieren"
+msgstr "Wert aufsteigend"
 
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:236
 #: superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx:264
-#, fuzzy
 msgid "value descending"
-msgstr "Absteigend sortieren"
+msgstr "Wert absteigend"
 
 #: superset-frontend/src/components/Datasource/DatasourceEditor.jsx:857
 msgid "virtual"


### PR DESCRIPTION
### SUMMARY
This PR adds messages which are now extracted from js/ts files again (see #17673). 

Note: there are still messages which are not extracted, like e.g. those in `superset-frontend/temporary_superset_ui` subfolders. Is it intended not to have them extracted by now or should these folders be added to babel.cfg as well?

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
n.a.

### TESTING INSTRUCTIONS
1. add `   "de": {"flag": "de", "name": "Deutsch"},` to the list of LANGUAGES
2. start superset an switch to Germann (Deutsch)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
