### PR TITLE
feat: bypass cache on screenshots for alerts

### DIFF
--- a/superset-frontend/src/chart/Chart.jsx
+++ b/superset-frontend/src/chart/Chart.jsx
@@ -51,6 +51,7 @@ const propTypes = {
   timeout: PropTypes.number,
   vizType: PropTypes.string.isRequired,
   triggerRender: PropTypes.bool,
+  force: PropTypes.bool,
   isFiltersInitialized: PropTypes.bool,
   isDeactivatedViz: PropTypes.bool,
   // state
@@ -84,6 +85,7 @@ const defaultProps = {
   dashboardId: null,
   chartStackTrace: null,
   isDeactivatedViz: false,
+  force: false,
 };
 
 const Styles = styled.div`
@@ -143,7 +145,7 @@ class Chart extends React.PureComponent {
       // Load saved chart with a GET request
       this.props.actions.getSavedChart(
         this.props.formData,
-        false,
+        this.props.force,
         this.props.timeout,
         this.props.chartId,
         this.props.dashboardId,
@@ -153,7 +155,7 @@ class Chart extends React.PureComponent {
       // Create chart with POST request
       this.props.actions.postChartFormData(
         this.props.formData,
-        false,
+        this.props.force,
         this.props.timeout,
         this.props.chartId,
         this.props.dashboardId,

--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -51,6 +51,7 @@ const propTypes = {
   form_data: PropTypes.object,
   ownState: PropTypes.object,
   standalone: PropTypes.number,
+  force: PropTypes.bool,
   timeout: PropTypes.number,
   refreshOverlayVisible: PropTypes.bool,
   chart: chartPropShape,
@@ -134,7 +135,7 @@ const ExploreChartPanel = props => {
       if (slice && slice.query_context === null) {
         const queryContext = buildV1ChartDataPayload({
           formData: slice.form_data,
-          force: false,
+          force: props.force,
           resultFormat: 'json',
           resultType: 'full',
           setDataMask: null,
@@ -230,6 +231,7 @@ const ExploreChartPanel = props => {
           chartId={chart.id}
           chartStatus={chart.chartStatus}
           triggerRender={props.triggerRender}
+          force={props.force}
           datasource={props.datasource}
           errorMessage={props.errorMessage}
           formData={props.form_data}

--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -72,6 +72,7 @@ const propTypes = {
   forcedHeight: PropTypes.string,
   form_data: PropTypes.object.isRequired,
   standalone: PropTypes.number.isRequired,
+  force: PropTypes.bool,
   timeout: PropTypes.number,
   impressionId: PropTypes.string,
   vizType: PropTypes.string,
@@ -206,6 +207,8 @@ function ExploreViewContainer(props) {
         formData,
         props.standalone ? URL_PARAMS.standalone.name : null,
         false,
+        {},
+        props.force,
       );
 
       try {
@@ -224,7 +227,7 @@ function ExploreViewContainer(props) {
         );
       }
     },
-    [props.form_data, props.standalone],
+    [props.form_data, props.standalone, props.force],
   );
 
   const handlePopstate = useCallback(() => {
@@ -233,7 +236,7 @@ function ExploreViewContainer(props) {
       props.actions.setExploreControls(formData);
       props.actions.postChartFormData(
         formData,
-        false,
+        props.force,
         props.timeout,
         props.chart.id,
       );
@@ -643,6 +646,7 @@ function mapStateToProps(state) {
     table_name: form_data.datasource_name,
     vizType: form_data.viz_type,
     standalone: explore.standalone,
+    force: explore.force,
     forcedHeight: explore.forced_height,
     chart,
     timeout: explore.common.conf.SUPERSET_WEBSERVER_TIMEOUT,

--- a/superset-frontend/src/explore/exploreUtils/getExploreLongUrl.test.ts
+++ b/superset-frontend/src/explore/exploreUtils/getExploreLongUrl.test.ts
@@ -45,12 +45,27 @@ test('Get url when endpointType:standalone', () => {
   expect(
     getExploreLongUrl(
       params.formData,
-      params.endpointType,
+      'standalone',
       params.allowOverflow,
       params.extraSearch,
     ),
   ).toBe(
-    '/superset/explore/?same=any-string&form_data=%7B%22datasource%22%3A%22datasource%22%2C%22viz_type%22%3A%22viz_type%22%7D',
+    '/superset/explore/?same=any-string&form_data=%7B%22datasource%22%3A%22datasource%22%2C%22viz_type%22%3A%22viz_type%22%7D&standalone=1',
+  );
+});
+
+test('Get url when endpointType:standalone and force:true', () => {
+  const params = createParams();
+  expect(
+    getExploreLongUrl(
+      params.formData,
+      'standalone',
+      params.allowOverflow,
+      params.extraSearch,
+      true,
+    ),
+  ).toBe(
+    '/superset/explore/?same=any-string&form_data=%7B%22datasource%22%3A%22datasource%22%2C%22viz_type%22%3A%22viz_type%22%7D&force=1&standalone=1',
   );
 });
 

--- a/superset-frontend/src/explore/exploreUtils/index.js
+++ b/superset-frontend/src/explore/exploreUtils/index.js
@@ -99,6 +99,7 @@ export function getExploreLongUrl(
   endpointType,
   allowOverflow = true,
   extraSearch = {},
+  force = false,
 ) {
   if (!formData.datasource) {
     return null;
@@ -112,6 +113,9 @@ export function getExploreLongUrl(
   });
   search.form_data = safeStringify(formData);
   if (endpointType === URL_PARAMS.standalone.name) {
+    if (force) {
+      search.force = '1';
+    }
     search.standalone = DashboardStandaloneMode.HIDE_NAV;
   }
   const url = uri.directory(directory).search(search).toString();
@@ -120,9 +124,15 @@ export function getExploreLongUrl(
       datasource: formData.datasource,
       viz_type: formData.viz_type,
     };
-    return getExploreLongUrl(minimalFormData, endpointType, false, {
-      URL_IS_TOO_LONG_TO_SHARE: null,
-    });
+    return getExploreLongUrl(
+      minimalFormData,
+      endpointType,
+      false,
+      {
+        URL_IS_TOO_LONG_TO_SHARE: null,
+      },
+      force,
+    );
   }
   return url;
 }

--- a/superset-frontend/src/explore/reducers/getInitialState.ts
+++ b/superset-frontend/src/explore/reducers/getInitialState.ts
@@ -48,6 +48,7 @@ export interface ExlorePageBootstrapData extends JsonObject {
   form_data: QueryFormData;
   slice: Slice | null;
   standalone: boolean;
+  force: boolean;
   user: UserWithPermissionsAndRoles;
 }
 

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -303,7 +303,7 @@ class ReservedUrlParameters(str, Enum):
     @staticmethod
     def is_standalone_mode() -> Optional[bool]:
         standalone_param = request.args.get(ReservedUrlParameters.STANDALONE.value)
-        standalone: Optional[bool] = (
+        standalone: Optional[bool] = bool(
             standalone_param and standalone_param != "false" and standalone_param != "0"
         )
         return standalone

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -107,11 +107,6 @@ class WebDriverProxy:
     def get_screenshot(
         self, url: str, element_name: str, user: "User"
     ) -> Optional[bytes]:
-        params = {"standalone": DashboardStandaloneMode.REPORT.value}
-        req = PreparedRequest()
-        req.prepare_url(url, params)
-        url = req.url or ""
-
         driver = self.auth(user)
         driver.set_window_size(*self._window)
         driver.get(url)

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -21,7 +21,6 @@ from time import sleep
 from typing import Any, Dict, Optional, Tuple, TYPE_CHECKING
 
 from flask import current_app
-from requests.models import PreparedRequest
 from selenium.common.exceptions import (
     StaleElementReferenceException,
     TimeoutException,

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -842,6 +842,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
                 query_context,
             )
         standalone_mode = ReservedUrlParameters.is_standalone_mode()
+        force = request.args.get("force") in {"force", "1", "true"}
         dummy_datasource_data: Dict[str, Any] = {
             "type": datasource_type,
             "name": datasource_name,
@@ -866,6 +867,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             "datasource_type": datasource_type,
             "slice": slc.data if slc else None,
             "standalone": standalone_mode,
+            "force": force,
             "user": bootstrap_user_data(g.user, include_perms=True),
             "forced_height": request.args.get("height"),
             "common": common_bootstrap_payload(),

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -663,6 +663,43 @@ def test_email_chart_report_schedule(
 
 
 @pytest.mark.usefixtures(
+    "load_birth_names_dashboard_with_slices", "create_alert_email_chart"
+)
+@patch("superset.reports.notifications.email.send_email_smtp")
+@patch("superset.utils.screenshots.ChartScreenshot.get_screenshot")
+def test_email_chart_alert_schedule(
+    screenshot_mock, email_mock, create_alert_email_chart,
+):
+    """
+    ExecuteReport Command: Test chart email alert schedule with screenshot
+    """
+    # setup screenshot mock
+    screenshot_mock.return_value = SCREENSHOT_FILE
+
+    with freeze_time("2020-01-01T00:00:00Z"):
+        AsyncExecuteReportScheduleCommand(
+            TEST_ID, create_alert_email_chart.id, datetime.utcnow()
+        ).run()
+
+        notification_targets = get_target_from_report_schedule(create_alert_email_chart)
+        # assert that the link sent is correct
+        assert (
+            '<a href="http://0.0.0.0:8080/superset/explore/?'
+            "form_data=%7B%22slice_id%22%3A+"
+            f"{create_alert_email_chart.chart.id}%7D&"
+            'standalone=true&force=true">Explore in Superset</a>'
+            in email_mock.call_args[0][2]
+        )
+        # Assert the email smtp address
+        assert email_mock.call_args[0][0] == notification_targets[0]
+        # Assert the email inline screenshot
+        smtp_images = email_mock.call_args[1]["images"]
+        assert smtp_images[list(smtp_images.keys())[0]] == SCREENSHOT_FILE
+        # Assert logs are correct
+        assert_log(ReportState.SUCCESS)
+
+
+@pytest.mark.usefixtures(
     "load_birth_names_dashboard_with_slices", "create_report_email_chart"
 )
 @patch("superset.reports.notifications.email.send_email_smtp")

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -647,8 +647,10 @@ def test_email_chart_report_schedule(
         )
         # assert that the link sent is correct
         assert (
-            f'<a href="http://0.0.0.0:8080/superset/slice/'
-            f'{create_report_email_chart.chart.id}/">Explore in Superset</a>'
+            '<a href="http://0.0.0.0:8080/superset/explore/?'
+            "form_data=%7B%22slice_id%22%3A+"
+            f"{create_report_email_chart.chart.id}%7D&"
+            'standalone=true&force=false">Explore in Superset</a>'
             in email_mock.call_args[0][2]
         )
         # Assert the email smtp address
@@ -713,8 +715,10 @@ def test_email_chart_report_schedule_with_csv(
         )
         # assert that the link sent is correct
         assert (
-            f'<a href="http://0.0.0.0:8080/superset/slice/'
-            f'{create_report_email_chart_with_csv.chart.id}/">Explore in Superset</a>'
+            '<a href="http://0.0.0.0:8080/superset/explore/?'
+            "form_data=%7B%22slice_id%22%3A+"
+            f"{create_report_email_chart_with_csv.chart.id}%7D&"
+            'standalone=true&force=false">Explore in Superset</a>'
             in email_mock.call_args[0][2]
         )
         # Assert the email smtp address


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When creating a screenshot for an alert we should bypass the cache. This PR changes the alert jobs to pass `force=true` when fetching a screenshot, and also implements the logic to carry the `force` parameter through the stack.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

I added unit tests to the backend and frontend.

To test locally:

1. Set up an alert that triggers (eg, `SELECT COUNT(*) FROM bart_lines` and `>0`).
2. Check that the celery worker takes a screenshot with `?force=true` (you can see it in the logs).
3. Click the link, the image should open fullscreen and bypassing the cache.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
