### PR TITLE
chore(sql): clean up invalid filter clause exception types

### DIFF
--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -25,7 +25,8 @@ from flask_babel import gettext as _
 from pandas import DataFrame
 
 from superset.common.chart_data import ChartDataResultType
-from superset.exceptions import QueryObjectValidationError
+from superset.exceptions import QueryObjectValidationError, SupersetQueryParseException
+from superset.sql_parse import validate_filter_clause
 from superset.typing import Column, Metric, OrderBy
 from superset.utils import pandas_postprocessing
 from superset.utils.core import (
@@ -267,6 +268,7 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
         try:
             self._validate_there_are_no_missing_series()
             self._validate_no_have_duplicate_labels()
+            self._validate_filters()
             return None
         except QueryObjectValidationError as ex:
             if raise_exceptions:
@@ -284,6 +286,15 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
                     labels=", ".join(f'"{x}"' for x in dup_labels),
                 )
             )
+
+    def _validate_filters(self) -> None:
+        for param in ("where", "having"):
+            clause = self.extras.get(param)
+            if clause:
+                try:
+                    validate_filter_clause(clause)
+                except SupersetQueryParseException as ex:
+                    raise QueryObjectValidationError(ex.message)
 
     def _validate_there_are_no_missing_series(self) -> None:
         missing_series = [col for col in self.series_columns if col not in self.columns]

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -294,7 +294,7 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
                 try:
                     validate_filter_clause(clause)
                 except SupersetQueryParseException as ex:
-                    raise QueryObjectValidationError(ex.message)
+                    raise QueryObjectValidationError(ex.message) from ex
 
     def _validate_there_are_no_missing_series(self) -> None:
         missing_series = [col for col in self.series_columns if col not in self.columns]

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -25,7 +25,10 @@ from flask_babel import gettext as _
 from pandas import DataFrame
 
 from superset.common.chart_data import ChartDataResultType
-from superset.exceptions import QueryObjectValidationError, SupersetQueryParseException
+from superset.exceptions import (
+    QueryClauseValidationException,
+    QueryObjectValidationError,
+)
 from superset.sql_parse import validate_filter_clause
 from superset.typing import Column, Metric, OrderBy
 from superset.utils import pandas_postprocessing
@@ -293,7 +296,7 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
             if clause:
                 try:
                     validate_filter_clause(clause)
-                except SupersetQueryParseException as ex:
+                except QueryClauseValidationException as ex:
                     raise QueryObjectValidationError(ex.message) from ex
 
     def _validate_there_are_no_missing_series(self) -> None:

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -32,7 +32,7 @@ from typing import (
 )
 
 from flask_babel import gettext as __
-from pytz import _FixedOffset  # type: ignore
+from pytz import _FixedOffset
 from sqlalchemy.dialects.postgresql import ARRAY, DOUBLE_PRECISION, ENUM, JSON
 from sqlalchemy.dialects.postgresql.base import PGInspector
 from sqlalchemy.types import String, TypeEngine

--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -194,7 +194,7 @@ class CacheLoadError(SupersetException):
     status = 404
 
 
-class SupersetQueryParseException(SupersetException):
+class QueryClauseValidationException(SupersetException):
     status = 400
 
 

--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -194,6 +194,10 @@ class CacheLoadError(SupersetException):
     status = 404
 
 
+class SupersetQueryParseException(SupersetException):
+    status = 400
+
+
 class DashboardImportException(SupersetException):
     pass
 

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -22,6 +22,7 @@ from urllib import parse
 
 import sqlparse
 from sqlparse.sql import (
+    Comment,
     Identifier,
     IdentifierList,
     Parenthesis,
@@ -31,6 +32,8 @@ from sqlparse.sql import (
 )
 from sqlparse.tokens import DDL, DML, Keyword, Name, Punctuation, String, Whitespace
 from sqlparse.utils import imt
+
+from superset.exceptions import SupersetQueryParseException
 
 RESULT_OPERATIONS = {"UNION", "INTERSECT", "EXCEPT", "SELECT"}
 ON_KEYWORD = "ON"
@@ -378,3 +381,24 @@ class ParsedQuery:
         for i in statement.tokens:
             str_res += str(i.value)
         return str_res
+
+
+def validate_filter_clause(clause: str) -> None:
+    if sqlparse.format(clause, strip_comments=True) != sqlparse.format(clause):
+        raise SupersetQueryParseException("Filter clause contains comment")
+
+    statements = sqlparse.parse(clause)
+    if len(statements) != 1:
+        raise SupersetQueryParseException("Filter clause contains multiple queries")
+    open_parens = 0
+
+    for token in statements[0]:
+        if token.value in (")", "("):
+            open_parens += 1 if token.value == "(" else -1
+            if open_parens < 0:
+                raise SupersetQueryParseException(
+                    "Closing unclosed parenthesis in filter clause"
+                )
+    if open_parens > 0:
+        raise SupersetQueryParseException("Unclosed parenthesis in filter clause")
+    return

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -22,7 +22,6 @@ from urllib import parse
 
 import sqlparse
 from sqlparse.sql import (
-    Comment,
     Identifier,
     IdentifierList,
     Parenthesis,
@@ -401,4 +400,3 @@ def validate_filter_clause(clause: str) -> None:
                 )
     if open_parens > 0:
         raise SupersetQueryParseException("Unclosed parenthesis in filter clause")
-    return

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -32,7 +32,7 @@ from sqlparse.sql import (
 from sqlparse.tokens import DDL, DML, Keyword, Name, Punctuation, String, Whitespace
 from sqlparse.utils import imt
 
-from superset.exceptions import SupersetQueryParseException
+from superset.exceptions import QueryClauseValidationException
 
 RESULT_OPERATIONS = {"UNION", "INTERSECT", "EXCEPT", "SELECT"}
 ON_KEYWORD = "ON"
@@ -384,19 +384,19 @@ class ParsedQuery:
 
 def validate_filter_clause(clause: str) -> None:
     if sqlparse.format(clause, strip_comments=True) != sqlparse.format(clause):
-        raise SupersetQueryParseException("Filter clause contains comment")
+        raise QueryClauseValidationException("Filter clause contains comment")
 
     statements = sqlparse.parse(clause)
     if len(statements) != 1:
-        raise SupersetQueryParseException("Filter clause contains multiple queries")
+        raise QueryClauseValidationException("Filter clause contains multiple queries")
     open_parens = 0
 
     for token in statements[0]:
         if token.value in (")", "("):
             open_parens += 1 if token.value == "(" else -1
             if open_parens < 0:
-                raise SupersetQueryParseException(
+                raise QueryClauseValidationException(
                     "Closing unclosed parenthesis in filter clause"
                 )
     if open_parens > 0:
-        raise SupersetQueryParseException("Unclosed parenthesis in filter clause")
+        raise QueryClauseValidationException("Unclosed parenthesis in filter clause")

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -382,7 +382,7 @@ class BaseViz:  # pylint: disable=too-many-public-methods
                 try:
                     validate_filter_clause(clause)
                 except SupersetQueryParseException as ex:
-                    raise QueryObjectValidationError(ex.message)
+                    raise QueryObjectValidationError(ex.message) from ex
 
         # extras are used to query elements specific to a datasource type
         # for instance the extra where clause that applies only to Tables

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -62,9 +62,9 @@ from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import (
     CacheLoadError,
     NullValueException,
+    QueryClauseValidationException,
     QueryObjectValidationError,
     SpatialException,
-    SupersetQueryParseException,
     SupersetSecurityException,
 )
 from superset.extensions import cache_manager, security_manager
@@ -381,7 +381,7 @@ class BaseViz:  # pylint: disable=too-many-public-methods
             if clause:
                 try:
                     validate_filter_clause(clause)
-                except SupersetQueryParseException as ex:
+                except QueryClauseValidationException as ex:
                     raise QueryObjectValidationError(ex.message) from ex
 
         # extras are used to query elements specific to a datasource type

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -425,6 +425,30 @@ class TestPostChartDataApi(BaseTestChartDataApi):
 
         assert rv.status_code == 400
 
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+    def test_with_invalid_where_parameter_closing_unclosed__400(self):
+        self.query_context_payload["queries"][0]["filters"] = []
+        # WHERE-clause closing unclosed parens
+        self.query_context_payload["queries"][0]["extras"][
+            "where"
+        ] = "state = 'CA') OR (state = 'NY'"
+
+        rv = self.post_assert_metric(CHART_DATA_URI, self.query_context_payload, "data")
+
+        assert rv.status_code == 400
+
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+    def test_with_invalid_having_parameter_closing_and_comment__400(self):
+        self.query_context_payload["queries"][0]["filters"] = []
+        # WHERE-clause with unclosed parens
+        self.query_context_payload["queries"][0]["extras"][
+            "having"
+        ] = "COUNT(1) = 0) UNION ALL SELECT 'abc', 1--comment"
+
+        rv = self.post_assert_metric(CHART_DATA_URI, self.query_context_payload, "data")
+
+        assert rv.status_code == 400
+
     def test_with_invalid_datasource__400(self):
         self.query_context_payload["datasource"] = "abc"
 

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -428,7 +428,6 @@ class TestPostChartDataApi(BaseTestChartDataApi):
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_with_invalid_where_parameter_closing_unclosed__400(self):
         self.query_context_payload["queries"][0]["filters"] = []
-        # WHERE-clause closing unclosed parens
         self.query_context_payload["queries"][0]["extras"][
             "where"
         ] = "state = 'CA') OR (state = 'NY'"
@@ -440,7 +439,6 @@ class TestPostChartDataApi(BaseTestChartDataApi):
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_with_invalid_having_parameter_closing_and_comment__400(self):
         self.query_context_payload["queries"][0]["filters"] = []
-        # WHERE-clause with unclosed parens
         self.query_context_payload["queries"][0]["extras"][
             "having"
         ] = "COUNT(1) = 0) UNION ALL SELECT 'abc', 1--comment"

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -23,7 +23,7 @@ from typing import Set
 import pytest
 import sqlparse
 
-from superset.exceptions import SupersetQueryParseException
+from superset.exceptions import QueryClauseValidationException
 from superset.sql_parse import (
     ParsedQuery,
     strip_comments_from_sql,
@@ -1167,35 +1167,35 @@ def test_validate_filter_clause_valid():
 
 
 def test_validate_filter_clause_closing_unclosed():
-    with pytest.raises(SupersetQueryParseException):
+    with pytest.raises(QueryClauseValidationException):
         validate_filter_clause("col1 = 1) AND (col2 = 2)")
 
 
 def test_validate_filter_clause_unclosed():
-    with pytest.raises(SupersetQueryParseException):
+    with pytest.raises(QueryClauseValidationException):
         validate_filter_clause("(col1 = 1) AND (col2 = 2")
 
 
 def test_validate_filter_clause_closing_and_unclosed():
-    with pytest.raises(SupersetQueryParseException):
+    with pytest.raises(QueryClauseValidationException):
         validate_filter_clause("col1 = 1) AND (col2 = 2")
 
 
 def test_validate_filter_clause_closing_and_unclosed_nested():
-    with pytest.raises(SupersetQueryParseException):
+    with pytest.raises(QueryClauseValidationException):
         validate_filter_clause("(col1 = 1)) AND ((col2 = 2)")
 
 
 def test_validate_filter_clause_multiple():
-    with pytest.raises(SupersetQueryParseException):
+    with pytest.raises(QueryClauseValidationException):
         validate_filter_clause("TRUE; SELECT 1")
 
 
 def test_validate_filter_clause_comment():
-    with pytest.raises(SupersetQueryParseException):
+    with pytest.raises(QueryClauseValidationException):
         validate_filter_clause("1 = 1 -- comment")
 
 
 def test_validate_filter_clause_subquery_comment():
-    with pytest.raises(SupersetQueryParseException):
+    with pytest.raises(QueryClauseValidationException):
         validate_filter_clause("(1 = 1 -- comment\n)")

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -23,13 +23,14 @@ from typing import Set
 import pytest
 import sqlparse
 
+from superset.exceptions import SupersetQueryParseException
 from superset.sql_parse import (
     ParsedQuery,
     strip_comments_from_sql,
     Table,
     validate_filter_clause,
 )
-from superset.exceptions import SupersetQueryParseException
+
 
 def extract_tables(query: str) -> Set[Table]:
     """

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -20,10 +20,16 @@
 import unittest
 from typing import Set
 
+import pytest
 import sqlparse
 
-from superset.sql_parse import ParsedQuery, strip_comments_from_sql, Table
-
+from superset.sql_parse import (
+    ParsedQuery,
+    strip_comments_from_sql,
+    Table,
+    validate_filter_clause,
+)
+from superset.exceptions import SupersetQueryParseException
 
 def extract_tables(query: str) -> Set[Table]:
     """
@@ -1144,3 +1150,51 @@ def test_strip_comments_from_sql() -> None:
         strip_comments_from_sql("SELECT '--abc' as abc, col2 FROM table1\n")
         == "SELECT '--abc' as abc, col2 FROM table1"
     )
+
+
+def test_validate_filter_clause_valid():
+    # regular clauses
+    assert validate_filter_clause("col = 1") is None
+    assert validate_filter_clause("1=\t\n1") is None
+    assert validate_filter_clause("(col = 1)") is None
+    assert validate_filter_clause("(col1 = 1) AND (col2 = 2)") is None
+
+    # Valid literal values that appear to be invalid
+    assert validate_filter_clause("col = 'col1 = 1) AND (col2 = 2'") is None
+    assert validate_filter_clause("col = 'select 1; select 2'") is None
+    assert validate_filter_clause("col = 'abc -- comment'") is None
+
+
+def test_validate_filter_clause_closing_unclosed():
+    with pytest.raises(SupersetQueryParseException):
+        validate_filter_clause("col1 = 1) AND (col2 = 2)")
+
+
+def test_validate_filter_clause_unclosed():
+    with pytest.raises(SupersetQueryParseException):
+        validate_filter_clause("(col1 = 1) AND (col2 = 2")
+
+
+def test_validate_filter_clause_closing_and_unclosed():
+    with pytest.raises(SupersetQueryParseException):
+        validate_filter_clause("col1 = 1) AND (col2 = 2")
+
+
+def test_validate_filter_clause_closing_and_unclosed_nested():
+    with pytest.raises(SupersetQueryParseException):
+        validate_filter_clause("(col1 = 1)) AND ((col2 = 2)")
+
+
+def test_validate_filter_clause_multiple():
+    with pytest.raises(SupersetQueryParseException):
+        validate_filter_clause("TRUE; SELECT 1")
+
+
+def test_validate_filter_clause_comment():
+    with pytest.raises(SupersetQueryParseException):
+        validate_filter_clause("1 = 1 -- comment")
+
+
+def test_validate_filter_clause_subquery_comment():
+    with pytest.raises(SupersetQueryParseException):
+        validate_filter_clause("(1 = 1 -- comment\n)")


### PR DESCRIPTION
### SUMMARY
Sometimes invalid query object extra parameters cause incorrect results. These are now handled correctly in the both the legacy and v1 apis.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
