### PR TITLE
fix(Dashboard): Copy dashboard with duplicating charts 500 error

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/save.test.js
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/save.test.js
@@ -74,7 +74,9 @@ describe('Dashboard save action', () => {
       .trigger('mouseenter')
       .click();
 
-    cy.get('[data-test="grid-container"]').find('.treemap').should('not.exist');
+    cy.get('[data-test="grid-container"]')
+      .find('.box_plot')
+      .should('not.exist');
 
     cy.intercept('PUT', '/api/v1/dashboard/**').as('putDashboardRequest');
     cy.get('[data-test="dashboard-header"]')
@@ -88,9 +90,9 @@ describe('Dashboard save action', () => {
       .find('[aria-label="edit-alt"]')
       .click();
 
-    // deleted treemap should still not exist
+    // deleted boxplot should still not exist
     cy.get('[data-test="grid-container"]')
-      .find('.treemap', { timeout: 20000 })
+      .find('.box_plot', { timeout: 20000 })
       .should('not.exist');
   });
 

--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -347,7 +347,7 @@ export function saveDashboardRequest(data, id, saveType) {
         .catch(response => onError(response));
     }
     // changing the data as the endpoint requires
-    const copyData = cleanedData;
+    const copyData = { ...cleanedData };
     if (copyData.metadata) {
       delete copyData.metadata;
     }


### PR DESCRIPTION
### SUMMARY
Fixes an issue introduced by PR #17570 that was causing a 500 error in the backend when copying a dashboard with the "also copy (duplicate) charts" option.

### TESTING INSTRUCTIONS
1. Open a Dashboard
2. Save the dashboard as a new one and tick "also copy (duplicate) charts"
3. Observe the behavior

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
