### PR TITLE
feat: Persist SQL Lab autocomplete setting across tabs and visits

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -63,6 +63,11 @@ import {
   SQL_EDITOR_GUTTER_MARGIN,
   SQL_TOOLBAR_HEIGHT,
 } from 'src/SqlLab/constants';
+import {
+  getItem,
+  LocalStorageKeys,
+  setItem,
+} from 'src/utils/localStorageHelpers';
 import { FeatureFlag, isFeatureEnabled } from 'src/featureFlags';
 import TemplateParamsEditor from '../TemplateParamsEditor';
 import ConnectedSouthPane from '../SouthPane/state';
@@ -171,7 +176,10 @@ class SqlEditor extends React.PureComponent {
       northPercent: props.queryEditor.northPercent || INITIAL_NORTH_PERCENT,
       southPercent: props.queryEditor.southPercent || INITIAL_SOUTH_PERCENT,
       sql: props.queryEditor.sql,
-      autocompleteEnabled: true,
+      autocompleteEnabled: getItem(
+        LocalStorageKeys.sqllab__is_autocomplete_enabled,
+        true,
+      ),
       showCreateAsModal: false,
       createAs: '',
     };
@@ -365,9 +373,15 @@ class SqlEditor extends React.PureComponent {
   }
 
   handleToggleAutocompleteEnabled = () => {
-    this.setState(prevState => ({
-      autocompleteEnabled: !prevState.autocompleteEnabled,
-    }));
+    this.setState(prevState => {
+      setItem(
+        LocalStorageKeys.sqllab__is_autocomplete_enabled,
+        !prevState.autocompleteEnabled,
+      );
+      return {
+        autocompleteEnabled: !prevState.autocompleteEnabled,
+      };
+    });
   };
 
   handleWindowResize() {

--- a/superset-frontend/src/utils/localStorageHelpers.ts
+++ b/superset-frontend/src/utils/localStorageHelpers.ts
@@ -48,6 +48,7 @@ export enum LocalStorageKeys {
    * Example:
    * sqllab__is_autocomplete_enabled
    */
+  sqllab__is_autocomplete_enabled = 'sqllab__is_autocomplete_enabled',
 }
 
 export type LocalStorageValues = {
@@ -60,6 +61,7 @@ export type LocalStorageValues = {
   homepage_dashboard_filter: TableTabTypes;
   homepage_collapse_state: string[];
   homepage_activity_filter: SetTabType | null;
+  sqllab__is_autocomplete_enabled: boolean;
 };
 
 export function getItem<K extends LocalStorageKeys>(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Follows the pattern used for the filter box migration and the welcome page settings to make the SQL Lab autocomplete setting persistent across SQL Lab tabs and Superset sessions/visits

### TESTING INSTRUCTIONS
Go to SQL Lab, see autocomplete is on by default. If you disable it and switch tabs, see it disabled. If you reload the page, see it still disabled. Reenable it, reload the page, and see it still enabled

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

to: @michael-s-molina @graceguo-supercat @ktmud @rusackas 