### PR TITLE
fix(explore): don't apply time range filter to Samples table

### DIFF
--- a/superset-frontend/src/explore/components/DataTablesPane/index.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/index.tsx
@@ -303,12 +303,12 @@ export const DataTablesPane = ({
   useEffect(() => {
     if (queriesResponse && chartStatus === 'success') {
       const { colnames } = queriesResponse[0];
-      setColumnNames({
-        ...columnNames,
+      setColumnNames(prevColumnNames => ({
+        ...prevColumnNames,
         [RESULT_TYPES.results]: colnames ? [...colnames] : [],
-      });
+      }));
     }
-  }, [queriesResponse]);
+  }, [queriesResponse, chartStatus]);
 
   useEffect(() => {
     if (panelOpen && isRequestPending[RESULT_TYPES.results]) {

--- a/superset/common/query_actions.py
+++ b/superset/common/query_actions.py
@@ -143,6 +143,8 @@ def _get_samples(
     query_obj.metrics = []
     query_obj.post_processing = []
     query_obj.columns = [o.column_name for o in datasource.columns]
+    query_obj.from_dttm = None
+    query_obj.to_dttm = None
     return _get_full(query_context, query_obj, force_cached)
 
 

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -254,6 +254,8 @@ class BaseViz:  # pylint: disable=too-many-public-methods
                 "orderby": [],
                 "row_limit": config["SAMPLES_ROW_LIMIT"],
                 "columns": [o.column_name for o in self.datasource.columns],
+                "from_dttm": None,
+                "to_dttm": None,
             }
         )
         df = self.get_df_payload(query_obj)["df"]  # leverage caching logic


### PR DESCRIPTION
### SUMMARY
Samples table shouldn't depend on filters set by the user. This request removes time range filter from samples query object, so that user can browse samples even when selected time range doesn't match the records.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://user-images.githubusercontent.com/15073128/145568835-159d2e43-0b6f-454f-9b3c-f599f284d142.png)

After:
![image](https://user-images.githubusercontent.com/15073128/145571972-00976b22-c089-40c2-92e0-b4f86c05140f.png)


### TESTING INSTRUCTIONS
1. Create a chart with specified time range
2. Verify that samples table is not affected by time range

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @jinghua-qa 

https://app.shortcut.com/preset/story/33425/time-range-filter-is-being-applied-to-samples-request-on-explore