### PR TITLE
fix(postgres): remove redundant tz factory

### DIFF
--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -50,12 +50,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger()
 
 
-# Replace psycopg2.tz.FixedOffsetTimezone with pytz, which is serializable by PyArrow
-# https://github.com/stub42/pytz/blob/b70911542755aeeea7b5a9e066df5e1c87e8f2c8/src/pytz/reference.py#L25
-class FixedOffsetTimezone(_FixedOffset):
-    pass
-
-
 # Regular expressions to catch custom errors
 CONNECTION_INVALID_USERNAME_REGEX = re.compile(
     'role "(?P<username>.*?)" does not exist'
@@ -168,7 +162,6 @@ class PostgresBaseEngineSpec(BaseEngineSpec):
     def fetch_data(
         cls, cursor: Any, limit: Optional[int] = None
     ) -> List[Tuple[Any, ...]]:
-        cursor.tzinfo_factory = FixedOffsetTimezone
         if not cursor.description:
             return []
         return super().fetch_data(cursor, limit)

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -32,7 +32,6 @@ from typing import (
 )
 
 from flask_babel import gettext as __
-from pytz import _FixedOffset
 from sqlalchemy.dialects.postgresql import ARRAY, DOUBLE_PRECISION, ENUM, JSON
 from sqlalchemy.dialects.postgresql.base import PGInspector
 from sqlalchemy.types import String, TypeEngine


### PR DESCRIPTION
### SUMMARY
A recent PR #17290 bumped Psycopg2 from 2.8.5 to 2.9.1, which features many changes to how timezones are handled: https://www.psycopg.org/articles/2021/06/16/psycopg-29-released/. Most notable is the change replacing the internal `FixedOffsetTimezone` class with the regular `datetime.timezone` when creating `datetime` objects, which is the "normal behavior" when working with datetimes. As a consequence, the constructor call to `cursor.tzinfo_factory` previously received the offset in minutes, while it now receives it as a `datetime.timedelta` object. As the custom `FixedOffsetTimezone` was only needed to make the timezone serializable by PyArrow, we can now remove it, as `datetime` objects containing a `timezone` `tzinfo` are serializable by PyArrow:

```python
>>> import pyarrow as pa
>>> from datetime import datetime, timezone
>>> buf = pa.serialize(datetime(year=2021, month=1, day=1, tzinfo=timezone.utc)).to_buffer()
sys:1: FutureWarning: 'pyarrow.serialize' is deprecated as of 2.0.0 and will be removed in a future version. Use pickle or the pyarrow IPC functionality instead.
>>> pa.deserialize(buf)
sys:1: FutureWarning: 'pyarrow.deserialize' is deprecated as of 2.0.0 and will be removed in a future version. Use pickle or the pyarrow IPC functionality instead.
datetime.datetime(2021, 12, 10, 0, 0)
```

### AFTER
Now running the query `SELECT TO_TIMESTAMP('2019-12-10 01:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
` works just fine:
![image](https://user-images.githubusercontent.com/33317356/145578695-02313d69-a6f3-44ac-a122-0e2d55370831.png)

### BEFORE
Previously it failed with the following error:
![image](https://user-images.githubusercontent.com/33317356/145578799-f5bf9f5c-da20-477e-90a1-77cf2219595c.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
