### PR TITLE
chore: bump FAB to 3.4.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -77,7 +77,7 @@ flask==1.1.4
     #   flask-openid
     #   flask-sqlalchemy
     #   flask-wtf
-flask-appbuilder==3.4.1rc2
+flask-appbuilder==3.4.1
     # via apache-superset
 flask-babel==1.0.0
     # via flask-appbuilder

--- a/scripts/python_tests.sh
+++ b/scripts/python_tests.sh
@@ -18,6 +18,7 @@
 #
 set -e
 
+export LD_PRELOAD=/lib/x86_64-linux-gnu/libstdc++.so.6
 export SUPERSET_CONFIG=${SUPERSET_CONFIG:-tests.integration_tests.superset_test_config}
 export SUPERSET_TESTENV=true
 echo "Superset config module: $SUPERSET_CONFIG"

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         "cryptography>=3.3.2",
         "deprecation>=2.1.0, <2.2.0",
         "flask>=1.1.0, <2.0.0",
-        "flask-appbuilder>=3.4.1rc2, <4.0.0",
+        "flask-appbuilder>=3.4.1, <4.0.0",
         "flask-caching>=1.10.0",
         "flask-compress",
         "flask-talisman",


### PR DESCRIPTION
### SUMMARY

Flask-AppBuilder 3.4.1 is out, we can now set superset out of RC

Release:
https://github.com/dpgaspar/Flask-AppBuilder/releases/tag/v3.4.1

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
