### PR TITLE
fix: local warning in the frontend development

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/Tooltip.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/Tooltip.tsx
@@ -20,10 +20,10 @@
 import React from 'react';
 import { useTheme, css } from '@superset-ui/core';
 import { Tooltip as BaseTooltip } from 'antd';
-import { TooltipProps } from 'antd/lib/tooltip';
+import type { TooltipProps } from 'antd/lib/tooltip';
 import { Global } from '@emotion/react';
 
-export { TooltipProps } from 'antd/lib/tooltip';
+export type { TooltipProps } from 'antd/lib/tooltip';
 
 export const Tooltip = ({ overlayStyle, color, ...props }: TooltipProps) => {
   const theme = useTheme();

--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -18,7 +18,7 @@
  * under the License.
  */
 import React, { ReactNode, ReactText, ReactElement } from 'react';
-import {
+import type {
   AdhocColumn,
   Column,
   DatasourceType,
@@ -29,9 +29,9 @@ import {
 import { sharedControls } from './shared-controls';
 import sharedControlComponents from './shared-controls/components';
 
-export { Metric } from '@superset-ui/core';
-export { ControlFormItemSpec } from './components/ControlForm';
-export { ControlComponentProps } from './shared-controls/components/types';
+export type { Metric } from '@superset-ui/core';
+export type { ControlFormItemSpec } from './components/ControlForm';
+export type { ControlComponentProps } from './shared-controls/components/types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyDict = Record<string, any>;

--- a/superset-frontend/packages/superset-ui-core/src/chart/index.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/index.ts
@@ -31,7 +31,7 @@ export { default as getChartComponentRegistry } from './registries/ChartComponen
 export { default as getChartControlPanelRegistry } from './registries/ChartControlPanelRegistrySingleton';
 export { default as getChartMetadataRegistry } from './registries/ChartMetadataRegistrySingleton';
 export { default as getChartTransformPropsRegistry } from './registries/ChartTransformPropsRegistrySingleton';
-export { BuildQuery } from './registries/ChartBuildQueryRegistrySingleton';
+export type { BuildQuery } from './registries/ChartBuildQueryRegistrySingleton';
 
 export { default as ChartDataProvider } from './components/ChartDataProvider';
 

--- a/superset-frontend/src/common/components/index.tsx
+++ b/superset-frontend/src/common/components/index.tsx
@@ -58,13 +58,17 @@ export {
   Input as AntdInput,
 } from 'antd';
 export { Card as AntdCard } from 'antd';
-export { default as Modal, ModalProps } from 'antd/lib/modal';
-export { FormInstance } from 'antd/lib/form';
-export { RadioChangeEvent } from 'antd/lib/radio';
-export { TreeProps } from 'antd/lib/tree';
-export { default as Alert, AlertProps } from 'antd/lib/alert';
-export { default as Select, SelectProps } from 'antd/lib/select';
-export { default as List, ListItemProps } from 'antd/lib/list';
+export { default as Modal } from 'antd/lib/modal';
+export type { ModalProps } from 'antd/lib/modal';
+export type { FormInstance } from 'antd/lib/form';
+export type { RadioChangeEvent } from 'antd/lib/radio';
+export type { TreeProps } from 'antd/lib/tree';
+export { default as Alert } from 'antd/lib/alert';
+export { default as Select } from 'antd/lib/select';
+export { default as List } from 'antd/lib/list';
+export type { AlertProps } from 'antd/lib/alert';
+export type { SelectProps } from 'antd/lib/select';
+export type { ListItemProps } from 'antd/lib/list';
 
 export { default as Collapse } from 'src/components/Collapse';
 export { default as Badge } from 'src/components/Badge';

--- a/superset-frontend/src/components/Form/Form.tsx
+++ b/superset-frontend/src/components/Form/Form.tsx
@@ -33,4 +33,4 @@ export default function Form(props: FormProps) {
   return <StyledForm {...props} />;
 }
 
-export { FormProps };
+export type { FormProps };

--- a/superset-frontend/src/components/Form/index.tsx
+++ b/superset-frontend/src/components/Form/index.tsx
@@ -21,4 +21,5 @@ import FormItem from './FormItem';
 import FormLabel from './FormLabel';
 import LabeledErrorBoundInput from './LabeledErrorBoundInput';
 
-export { Form, FormItem, FormLabel, LabeledErrorBoundInput, FormProps };
+export { Form, FormItem, FormLabel, LabeledErrorBoundInput };
+export type { FormProps };

--- a/superset-frontend/src/components/Icons/index.tsx
+++ b/superset-frontend/src/components/Icons/index.tsx
@@ -165,7 +165,7 @@ IconFileNames.forEach(fileName => {
   );
 });
 
-export { IconType };
+export type { IconType };
 
 export default {
   ...AntdEnhancedIcons,

--- a/superset-frontend/src/components/Select/NativeSelect.tsx
+++ b/superset-frontend/src/components/Select/NativeSelect.tsx
@@ -20,7 +20,7 @@ import React from 'react';
 import { styled } from '@superset-ui/core';
 import Select, { SelectProps } from 'antd/lib/select';
 
-export {
+export type {
   OptionType as NativeSelectOptionType,
   SelectProps as NativeSelectProps,
 } from 'antd/lib/select';

--- a/superset-frontend/src/components/Slider/index.tsx
+++ b/superset-frontend/src/components/Slider/index.tsx
@@ -22,7 +22,7 @@ import AntDSlider, {
   SliderRangeProps,
 } from 'antd/lib/slider';
 
-export { SliderSingleProps, SliderRangeProps };
+export type { SliderSingleProps, SliderRangeProps };
 
 export default function Slider(props: SliderSingleProps | SliderRangeProps) {
   return <AntDSlider {...props} css={{ marginLeft: 0, marginRight: 0 }} />;

--- a/superset-frontend/src/components/Switch/index.tsx
+++ b/superset-frontend/src/components/Switch/index.tsx
@@ -27,4 +27,4 @@ const StyledSwitch = styled(BaseSwitch)`
 `;
 
 export const Switch = (props: SwitchProps) => <StyledSwitch {...props} />;
-export { SwitchProps };
+export type { SwitchProps };

--- a/superset-frontend/src/featureFlags.ts
+++ b/superset-frontend/src/featureFlags.ts
@@ -18,7 +18,8 @@
  */
 import { FeatureFlagMap, FeatureFlag } from '@superset-ui/core';
 
-export { FeatureFlagMap, FeatureFlag } from '@superset-ui/core';
+export { FeatureFlag } from '@superset-ui/core';
+export type { FeatureFlagMap } from '@superset-ui/core';
 
 export function initFeatureFlags(featureFlags: FeatureFlagMap) {
   if (!window.featureFlags) {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, there were a few warnings prompted when the frontend service was started locally, and this PR fixes most of them. (Three remaining)

resolved: 
```
WARNING in ./packages/superset-ui-chart-controls/src/components/Tooltip.tsx 23:0-48
export 'TooltipProps' (reexported as 'TooltipProps') was not found in 'antd/lib/tooltip' (possible exports: __esModule, default)

WARNING in ./packages/superset-ui-chart-controls/src/types.ts 1:295-338
export 'Metric' (reexported as 'Metric') was not found in '@superset-ui/core' (possible exports: AnnotationOpacity, AnnotationSourceType, AnnotationStyle, AnnotationType, ApiLegacy, ApiV1, AppSection, BRAND_COLOR, Behavior, BuildQuery, CategoricalAirbnb, CategoricalColorNamespace, CategoricalColorScale, CategoricalD3, CategoricalEcharts, CategoricalGoogle, CategoricalLyft, CategoricalPreset, CategoricalScheme, CategoricalSuperset, ChartClient, ChartDataProvider, ChartFrame, ChartMetadata, ChartPlugin, ChartProps, ColorSchemeRegistry, ComparisionType, DTTM_ALIAS, DatasourceKey, DatasourceType, EXTRA_FORM_DATA_APPEND_KEYS, EXTRA_FORM_DATA_OVERRIDE_EXTRA_KEYS, EXTRA_FORM_DATA_OVERRIDE_KEYS, EXTRA_FORM_DATA_OVERRIDE_REGULAR_KEYS, EXTRA_FORM_DATA_OVERRIDE_REGULAR_MAPPINGS, EmotionCacheProvider, ExtensibleFunction, FAST_DEBOUNCE, FeatureFlag, GenericDataType, LOCAL_PREFIX, NumberFormats, NumberFormatter, NumberFormatterRegistry, OverwritePolicy, PREVIEW_TIME, PREVIEW_VALUE, PandasAxis, Plugin, Preset, QueryMode, Registry, RegistryWithDefaultKey, RollingType, SLOW_DEBOUNCE, SafeMarkdown, SequentialCommon, SequentialD3, SequentialScheme, SuperChart, SupersetApiError, SupersetApiErrorType, SupersetClient, SupersetClientClass, ThemeProvider, TimeFormats, TimeFormatter, TimeGranularity, TooltipFrame, TooltipTable, WithLegend, __hack_reexport_AdvancedAnalytics, __hack_reexport_Column, __hack_reexport_Datasource, __hack_reexport_Metric, __hack_reexport_Query, __hack_reexport_QueryFormData, __hack_reexport_QueryResponse, __hack_reexport_Time, __hack_reexport_chart_Base, __hack_reexport_chart_QueryResponse, __hack_reexport_chart_TransformFunction, __hack_reexport_connection, __hack_reexport_dimension, __hack_reexport_jed, __hack_reexport_trasnslation, addLocaleData, addTranslation, addTranslations, buildQueryContext, buildQueryObject, callApi, computeMaxFontSize, configure, convertFilter, convertKeysToCamelCase, createD3NumberFormatter, createD3TimeFormatter, createDurationFormatter, createEmotionCache, createLoadableRenderer, createMultiFormatter, createSiAtMostNDigitFormatter, createSmartNumberFormatter, css, defineSharedModule, defineSharedModules, emotionCache, ensureIsArray, ensureIsInt, evalExpression, extractTimegrain, formatNumber, formatTime, formatTimeRange, getCategoricalSchemeRegistry, getChartBuildQueryRegistry, getChartComponentRegistry, getChartControlPanelRegistry, getChartMetadataRegistry, getChartTransformPropsRegistry, getColumnLabel, getContrastingColor, getMetricLabel, getMultipleTextDimensions, getNumberFormatter, getNumberFormatterRegistry, getSequentialSchemeRegistry, getTextDimension, getTimeFormatter, getTimeFormatterForGranularity, getTimeFormatterRegistry, getTimeRangeFormatter, isAdhocMetricSimple, isBinaryAdhocFilter, isBinaryOperator, isDefined, isDruidFormData, isEventAnnotationLayer, isFeatureEnabled, isFormulaAnnotationLayer, isIntervalAnnotationLayer, isPhysicalColumn, isPostProcessingAggregation, isPostProcessingBoxplot, isPostProcessingCompare, isPostProcessingContribution, isPostProcessingCum, isPostProcessingDiff, isPostProcessingPivot, isPostProcessingProphet, isPostProcessingResample, isPostProcessingRolling, isPostProcessingSort, isRecordAnnotationResult, isRequired, isSavedMetric, isSetAdhocFilter, isSetOperator, isSimpleAdhocFilter, isTableAnnotationLayer, isTimeseriesAnnotationLayer, isTimeseriesAnnotationResult, isUnaryAdhocFilter, isUnaryOperator, isValidExpression, jsx, legacyValidateInteger, legacyValidateNumber, logging, makeApi, makeSingleton, mergeMargin, normalizeOrderBy, parseLength, promiseTimeout, reactify, removeDuplicates, reset, resetTranslation, seed, seedRandom, smartDateDetailedFormatter, smartDateFormatter, smartDateVerboseFormatter, styled, supersetTheme, t, tn, useTheme, validateInteger, validateNonEmpty, validateNumber, withTheme)

WARNING in ./packages/superset-ui-chart-controls/src/types.ts 2:0-63
export 'ControlFormItemSpec' (reexported as 'ControlFormItemSpec') was not found in './components/ControlForm' (possible exports: ControlFormItem, ControlFormItemComponents, ControlFormRow, default)

WARNING in ./packages/superset-ui-chart-controls/src/types.ts 3:0-75
export 'ControlComponentProps' (reexported as 'ControlComponentProps') was not found in './shared-controls/components/types' (module has no exports)

WARNING in ./packages/superset-ui-core/src/chart/index.ts 31:0-75
export 'BuildQuery' (reexported as 'BuildQuery') was not found in './registries/ChartBuildQueryRegistrySingleton' (possible exports: default)

WARNING in ./src/common/components/index.tsx 29:0-62
export 'ModalProps' (reexported as 'ModalProps') was not found in 'antd/lib/modal' (possible exports: __esModule, default)

WARNING in ./src/common/components/index.tsx 30:0-45
export 'FormInstance' (reexported as 'FormInstance') was not found in 'antd/lib/form' (possible exports: __esModule, default)

WARNING in ./src/common/components/index.tsx 31:0-50
export 'RadioChangeEvent' (reexported as 'RadioChangeEvent') was not found in 'antd/lib/radio' (possible exports: Button, Group, __esModule, default)

WARNING in ./src/common/components/index.tsx 32:0-42
export 'TreeProps' (reexported as 'TreeProps') was not found in 'antd/lib/tree' (possible exports: __esModule, default)

WARNING in ./src/common/components/index.tsx 33:0-62
export 'AlertProps' (reexported as 'AlertProps') was not found in 'antd/lib/alert' (possible exports: __esModule, default)

WARNING in ./src/common/components/index.tsx 34:0-65
export 'SelectProps' (reexported as 'SelectProps') was not found in 'antd/lib/select' (possible exports: __esModule, default)

WARNING in ./src/common/components/index.tsx 35:0-63
export 'ListItemProps' (reexported as 'ListItemProps') was not found in 'antd/lib/list' (possible exports: ListConsumer, ListContext, __esModule, default)

WARNING in ./src/components/Form/Form.tsx 33:0-21
export 'FormProps' (reexported as 'FormProps') was not found in 'antd/lib/form' (possible exports: __esModule, default)

WARNING in ./src/components/Icons/index.tsx 162:0-20
export 'default' (reexported as 'IconType') was not found in './IconType' (module has no exports)

WARNING in ./src/components/Select/NativeSelect.tsx 22:0-105
export 'OptionType' (reexported as 'NativeSelectOptionType') was not found in 'antd/lib/select' (possible exports: __esModule, default)

WARNING in ./src/components/Select/NativeSelect.tsx 22:0-105
export 'SelectProps' (reexported as 'NativeSelectProps') was not found in 'antd/lib/select' (possible exports: __esModule, default)

WARNING in ./src/components/Slider/index.tsx 21:0-47
export 'SliderSingleProps' (reexported as 'SliderSingleProps') was not found in 'antd/lib/slider' (possible exports: __esModule, default)

WARNING in ./src/components/Slider/index.tsx 21:0-47
export 'SliderRangeProps' (reexported as 'SliderRangeProps') was not found in 'antd/lib/slider' (possible exports: __esModule, default)

WARNING in ./src/components/Switch/index.tsx 28:0-23
export 'SwitchProps' (reexported as 'SwitchProps') was not found in 'antd/lib/switch' (possible exports: __esModule, default)

WARNING in ./src/featureFlags.ts 1:295-359
export 'FeatureFlagMap' (reexported as 'FeatureFlagMap') was not found in '@superset-ui/core' (possible exports: AnnotationOpacity, AnnotationSourceType, AnnotationStyle, AnnotationType, ApiLegacy, ApiV1, AppSection, BRAND_COLOR, Behavior, BuildQuery, CategoricalAirbnb, CategoricalColorNamespace, CategoricalColorScale, CategoricalD3, CategoricalEcharts, CategoricalGoogle, CategoricalLyft, CategoricalPreset, CategoricalScheme, CategoricalSuperset, ChartClient, ChartDataProvider, ChartFrame, ChartMetadata, ChartPlugin, ChartProps, ColorSchemeRegistry, ComparisionType, DTTM_ALIAS, DatasourceKey, DatasourceType, EXTRA_FORM_DATA_APPEND_KEYS, EXTRA_FORM_DATA_OVERRIDE_EXTRA_KEYS, EXTRA_FORM_DATA_OVERRIDE_KEYS, EXTRA_FORM_DATA_OVERRIDE_REGULAR_KEYS, EXTRA_FORM_DATA_OVERRIDE_REGULAR_MAPPINGS, EmotionCacheProvider, ExtensibleFunction, FAST_DEBOUNCE, FeatureFlag, GenericDataType, LOCAL_PREFIX, NumberFormats, NumberFormatter, NumberFormatterRegistry, OverwritePolicy, PREVIEW_TIME, PREVIEW_VALUE, PandasAxis, Plugin, Preset, QueryMode, Registry, RegistryWithDefaultKey, RollingType, SLOW_DEBOUNCE, SafeMarkdown, SequentialCommon, SequentialD3, SequentialScheme, SuperChart, SupersetApiError, SupersetApiErrorType, SupersetClient, SupersetClientClass, ThemeProvider, TimeFormats, TimeFormatter, TimeGranularity, TooltipFrame, TooltipTable, WithLegend, __hack_reexport_AdvancedAnalytics, __hack_reexport_Column, __hack_reexport_Datasource, __hack_reexport_Metric, __hack_reexport_Query, __hack_reexport_QueryFormData, __hack_reexport_QueryResponse, __hack_reexport_Time, __hack_reexport_chart_Base, __hack_reexport_chart_QueryResponse, __hack_reexport_chart_TransformFunction, __hack_reexport_connection, __hack_reexport_dimension, __hack_reexport_jed, __hack_reexport_trasnslation, addLocaleData, addTranslation, addTranslations, buildQueryContext, buildQueryObject, callApi, computeMaxFontSize, configure, convertFilter, convertKeysToCamelCase, createD3NumberFormatter, createD3TimeFormatter, createDurationFormatter, createEmotionCache, createLoadableRenderer, createMultiFormatter, createSiAtMostNDigitFormatter, createSmartNumberFormatter, css, defineSharedModule, defineSharedModules, emotionCache, ensureIsArray, ensureIsInt, evalExpression, extractTimegrain, formatNumber, formatTime, formatTimeRange, getCategoricalSchemeRegistry, getChartBuildQueryRegistry, getChartComponentRegistry, getChartControlPanelRegistry, getChartMetadataRegistry, getChartTransformPropsRegistry, getColumnLabel, getContrastingColor, getMetricLabel, getMultipleTextDimensions, getNumberFormatter, getNumberFormatterRegistry, getSequentialSchemeRegistry, getTextDimension, getTimeFormatter, getTimeFormatterForGranularity, getTimeFormatterRegistry, getTimeRangeFormatter, isAdhocMetricSimple, isBinaryAdhocFilter, isBinaryOperator, isDefined, isDruidFormData, isEventAnnotationLayer, isFeatureEnabled, isFormulaAnnotationLayer, isIntervalAnnotationLayer, isPhysicalColumn, isPostProcessingAggregation, isPostProcessingBoxplot, isPostProcessingCompare, isPostProcessingContribution, isPostProcessingCum, isPostProcessingDiff, isPostProcessingPivot, isPostProcessingProphet, isPostProcessingResample, isPostProcessingRolling, isPostProcessingSort, isRecordAnnotationResult, isRequired, isSavedMetric, isSetAdhocFilter, isSetOperator, isSimpleAdhocFilter, isTableAnnotationLayer, isTimeseriesAnnotationLayer, isTimeseriesAnnotationResult, isUnaryAdhocFilter, isUnaryOperator, isValidExpression, jsx, legacyValidateInteger, legacyValidateNumber, logging, makeApi, makeSingleton, mergeMargin, normalizeOrderBy, parseLength, promiseTimeout, reactify, removeDuplicates, reset, resetTranslation, seed, seedRandom, smartDateDetailedFormatter, smartDateFormatter, smartDateVerboseFormatter, styled, supersetTheme, t, tn, useTheme, validateInteger, validateNonEmpty, validateNumber, withTheme)

```
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
