### PR TITLE
fix: call op.get_bind() inside the function, not on import

### DIFF
--- a/superset/migrations/versions/abe27eaf93db_add_extra_config_column_to_alerts.py
+++ b/superset/migrations/versions/abe27eaf93db_add_extra_config_column_to_alerts.py
@@ -31,12 +31,12 @@ from alembic import op
 from sqlalchemy import String
 from sqlalchemy.sql import column, table
 
-connection = op.get_bind()
 
 report_schedule = table("report_schedule", column("extra", String))
 
 
 def upgrade():
+    connection = op.get_bind()
     with op.batch_alter_table("report_schedule") as batch_op:
         batch_op.add_column(
             sa.Column("extra", sa.Text(), nullable=True, default="{}",),

--- a/superset/migrations/versions/abe27eaf93db_add_extra_config_column_to_alerts.py
+++ b/superset/migrations/versions/abe27eaf93db_add_extra_config_column_to_alerts.py
@@ -31,7 +31,6 @@ from alembic import op
 from sqlalchemy import String
 from sqlalchemy.sql import column, table
 
-
 report_schedule = table("report_schedule", column("extra", String))
 
 


### PR DESCRIPTION
### SUMMARY
fix: call op.get_bind() inside the function, not on import
Error log:
```
s/abe27eaf93db_add_extra_config_column_to_alerts.py", line 34, in <module>
    connection = op.get_bind()
  File "<string>", line 7, in get_bind
  File "/srv/yaps/mounts/superset/superset_build/bcf71bd610347f780fa22f8365c6a015a70248e5-a38d46655a6ec6c4745dd039486ca598/dropbox/apx/superset/superset_cli.runfiles/__main__/thirdparty/superset_python3/pip/alembic/alembic-cpython-38/lib/alembic/util/langhelpers.py", line 78, in _name_error
    raise NameError(
NameError: Can't invoke function 'get_bind', as the proxy object has not yet been established for the Alembic 'Operations' class.  Try placing this code inside a callable.
```