### PR TITLE
fix: import dashboard stale filter_scopes

### DIFF
--- a/superset/dashboards/commands/importers/v1/utils.py
+++ b/superset/dashboards/commands/importers/v1/utils.py
@@ -84,6 +84,7 @@ def update_id_refs(  # pylint: disable=too-many-locals
         metadata["filter_scopes"] = {
             str(id_map[int(old_id)]): columns
             for old_id, columns in metadata["filter_scopes"].items()
+            if int(old_id) in id_map
         }
 
         # now update columns to use new IDs:
@@ -107,6 +108,7 @@ def update_id_refs(  # pylint: disable=too-many-locals
             {
                 str(id_map[int(old_id)]): value
                 for old_id, value in default_filters.items()
+                if int(old_id) in id_map
             }
         )
 

--- a/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
@@ -45,7 +45,10 @@ def test_update_id_refs_immune_missing(  # pylint: disable=invalid-name
             },
         },
         "metadata": {
-            "filter_scopes": {"101": {"filter_name": {"immune": [102, 103],},},},
+            "filter_scopes": {
+                "101": {"filter_name": {"immune": [102, 103]}},
+                "104": {"filter_name": {"immune": [102, 103]}},
+            },
         },
         "native_filter_configuration": [],
     }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Max found a bug when importing a dashboard that had a stale `filter_scope` (pointing to a chart that was removed). This PR fixes it, allowing the dashboard to be imported.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Added unit test covering the regression.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
