### PR TITLE
fix(explore): ensure sample pane results by read through

### DIFF
--- a/superset-frontend/src/explore/components/DataTablesPane/index.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/index.tsx
@@ -216,7 +216,7 @@ export const DataTablesPane = ({
   );
 
   const getData = useCallback(
-    (resultType: string) => {
+    (resultType: string, force = false) => {
       setIsLoading(prevIsLoading => ({
         ...prevIsLoading,
         [resultType]: true,
@@ -226,6 +226,7 @@ export const DataTablesPane = ({
         resultFormat: 'json',
         resultType,
         ownState,
+        force,
       })
         .then(({ json }) => {
           // Only displaying the first query is currently supported
@@ -298,7 +299,7 @@ export const DataTablesPane = ({
       ...prevState,
       [RESULT_TYPES.samples]: true,
     }));
-  }, [queryFormData?.adhoc_filters, queryFormData?.datasource]);
+  }, [queryFormData?.adhoc_filters, queryFormData?.datasource, panelOpen]);
 
   useEffect(() => {
     if (queriesResponse && chartStatus === 'success') {
@@ -345,7 +346,7 @@ export const DataTablesPane = ({
         ...prevState,
         [RESULT_TYPES.samples]: false,
       }));
-      getData(RESULT_TYPES.samples);
+      getData(RESULT_TYPES.samples, true);
     }
   }, [
     panelOpen,

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -451,7 +451,11 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         return self.json_response({"data": payload["df"].to_dict("records")})
 
     def get_samples(self, viz_obj: BaseViz) -> FlaskResponse:
-        return self.json_response({"data": viz_obj.get_samples()})
+        payload = viz_obj.get_samples()
+        if viz_obj.has_error(payload):
+            payload.pop("df", None)
+            return json_error_response(payload=payload, status=400)
+        return self.json_response({"data": payload["df"].to_dict(orient="records")})
 
     @staticmethod
     def send_data_payload_response(viz_obj: BaseViz, payload: Any) -> FlaskResponse:

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -244,7 +244,7 @@ class BaseViz:  # pylint: disable=too-many-public-methods
             )
         return df
 
-    def get_samples(self) -> List[Dict[str, Any]]:
+    def get_samples(self) -> Dict[str, Any]:
         query_obj = self.query_obj()
         query_obj.update(
             {
@@ -258,8 +258,7 @@ class BaseViz:  # pylint: disable=too-many-public-methods
                 "to_dttm": None,
             }
         )
-        df = self.get_df_payload(query_obj)["df"]  # leverage caching logic
-        return df.to_dict(orient="records")
+        return self.get_df_payload(query_obj)  # leverage caching logic
 
     def get_df(self, query_obj: Optional[QueryObjectDict] = None) -> pd.DataFrame:
         """Returns a pandas dataframe based on the query object"""


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
closes: https://github.com/apache/superset/issues/17706
shortcut: https://app.shortcut.com/preset/story/33378/explore-south-tables-view-sample-will-show-no-data-when-user-drop-column-and-did-not-sync-column-in-edit-data-set

Currently, Superset generates cache key by ```query object``` that contains columns, calculated columns, metrics, etc. If a column had been removed from the source table and it hadn't been removed in Superset, it wouldn't have raised errors, it would have returned the "dirty data" from the cache system.

This PR
1. introduces ```force query``` when the user clicks `sample tab`.
2. raise an HTTP exception when happen a query error in legacy API.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### After
<img width="1366" alt="image" src="https://user-images.githubusercontent.com/2016594/146029229-92a66649-5932-460a-99e2-102417bd5735.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Go to SQLLab, make a duplicate table from the example database
```SQL
create table backup_birth_names as (select * from birth_names)
```
2. Add ```backup_birth_names``` as a Dataset
3. Go to Explore, select `table` as viz type, select `count(*)` to metric control
4. Open `data pane` and click `Samples` tab
5. Save this Chart, named by "test-chart"
6. Go to SQLLab, remove a column from the source table
```SQL
alter table backup_birth_names drop column name;
```
7. Open ```test-chart``` again
8. Open `data pane` and click `Samples` tab, you can see the error like:
![image](https://user-images.githubusercontent.com/2016594/146031169-16737d4c-4ee8-4230-97d7-c7a42722728e.png)
9. Go to `edit dataset` model, click `sync columns from source` from `columns` tab
10. Open `data pane` and click `Samples` tab, you can see the new sample from the source table.

Please use a LEGACY chart(for instance Area Chart) to test again, because there are different API from the new chart(nvd3) and the legacy chart(table, pivot table v2, echart).




### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/17706
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
