### PR TITLE
fix: [alert] allow decimal for alert threshold value

### DIFF
--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -1186,7 +1186,9 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                   <div className="control-label">
                     {t('Value')}{' '}
                     <InfoTooltipWithTrigger
-                      tooltip={t('Threshold value can only be integer')}
+                      tooltip={t(
+                        'Threshold value should be double precision number',
+                      )}
                     />
                     <span className="required">*</span>
                   </div>

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -54,6 +54,7 @@ import {
   Operator,
   Recipient,
 } from 'src/views/CRUD/alert/types';
+import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
 import { AlertReportCronScheduler } from './components/AlertReportCronScheduler';
 import { NotificationMethod } from './components/NotificationMethod';
 
@@ -1183,7 +1184,10 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                 </StyledInputContainer>
                 <StyledInputContainer>
                   <div className="control-label">
-                    {t('Value')}
+                    {t('Value')}{' '}
+                    <InfoTooltipWithTrigger
+                      tooltip={t('Threshold value can only be integer')}
+                    />
                     <span className="required">*</span>
                   </div>
                   <div className="input-container">

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -103,7 +103,7 @@ class ValidatorConfigJSONSchema(Schema):
         description=validator_config_json_op_description,
         validate=validate.OneOf(choices=["<", "<=", ">", ">=", "==", "!="]),
     )
-    threshold = fields.Integer()
+    threshold = fields.Float()
 
 
 class ReportRecipientConfigJSONSchema(Schema):

--- a/tests/integration_tests/alerts_tests.py
+++ b/tests/integration_tests/alerts_tests.py
@@ -266,6 +266,9 @@ def test_operator_validator(setup_database):
     # Test passing with result that equals threshold
     assert operator_validator(alert2, '{"op": "==", "threshold": 55}') is True
 
+    # Test passing with result that equals decimal threshold
+    assert operator_validator(alert2, '{"op": ">", "threshold": 54.999}') is True
+
 
 @pytest.mark.parametrize(
     "description, query, validator_type, config",

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -409,7 +409,16 @@ def create_alert_slack_chart_grace(request):
 
 
 @pytest.fixture(
-    params=["alert1", "alert2", "alert3", "alert4", "alert5", "alert6", "alert7",]
+    params=[
+        "alert1",
+        "alert2",
+        "alert3",
+        "alert4",
+        "alert5",
+        "alert6",
+        "alert7",
+        "alert8",
+    ]
 )
 def create_alert_email_chart(request):
     param_config = {
@@ -447,6 +456,11 @@ def create_alert_email_chart(request):
             "sql": "SELECT {{ 5 + 5 }} as metric",
             "validator_type": ReportScheduleValidatorType.OPERATOR,
             "validator_config_json": '{"op": "!=", "threshold": 11}',
+        },
+        "alert8": {
+            "sql": "SELECT 55 as metric",
+            "validator_type": ReportScheduleValidatorType.OPERATOR,
+            "validator_config_json": '{"op": ">", "threshold": 54.999}',
         },
     }
     with app.app_context():


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Our users typing in decimal value in alert condition threshold, and then Superset returns error message from server-side. 

This PR is to allow backend accept decimal number, and add a simple tooltip for this input field.

<img width="404" alt="Screen Shot 2021-12-15 at 3 08 55 PM" src="https://user-images.githubusercontent.com/27990562/146288617-259913fe-1eb4-400a-8a38-1b27b413fb85.png">




cc @dpgaspar 

### TESTING INSTRUCTIONS
CI and manual test.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
