### PR TITLE
chore: bump react-resize-detector

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -168,7 +168,7 @@
     "react-loadable": "^5.5.0",
     "react-markdown": "^4.3.1",
     "react-redux": "^7.2.0",
-    "react-resize-detector": "^6.0.1-rc.1",
+    "react-resize-detector": "^6.7.6",
     "react-reverse-portal": "^2.0.1",
     "react-router-dom": "^5.1.2",
     "react-search-input": "^0.11.3",


### PR DESCRIPTION
### SUMMARY
We are currently using an old release candidate 6.0.1-rc.1 of `react-resize-detector` (1 year old) that officially only supports React 17. In addition to bumping it to the latest official release (v. 6.7.6), v. 6.3.3 reintroduced support for v.16, which is what Superset is currently on (https://github.com/maslianok/react-resize-detector/releases):

![image](https://user-images.githubusercontent.com/33317356/146180960-05da9e40-db22-4b5c-a167-da1d72923602.png)

Tested resizing Explore view (only place where the package is used) to ensure that it works correctly.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
