### PR TITLE
fix(plugin-chart-table): sort alphanumeric columns case insensitive

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
@@ -44,6 +44,7 @@ import SelectPageSize, {
 import SimplePagination from './components/Pagination';
 import useSticky from './hooks/useSticky';
 import { PAGE_SIZE_OPTIONS } from '../consts';
+import { sortAlphanumericCaseInsensitive } from './utils/sortAlphanumericCaseInsensitive';
 
 export interface DataTableProps<D extends object> extends TableOptions<D> {
   tableClassName?: string;
@@ -67,6 +68,10 @@ export interface DataTableProps<D extends object> extends TableOptions<D> {
 export interface RenderHTMLCellProps extends HTMLProps<HTMLTableCellElement> {
   cellContent: ReactNode;
 }
+
+const sortTypes = {
+  alphanumeric: sortAlphanumericCaseInsensitive,
+};
 
 // Be sure to pass our updateMyData and the skipReset option
 export default function DataTable<D extends object>({
@@ -174,6 +179,7 @@ export default function DataTable<D extends object>({
       initialState,
       getTableSize: defaultGetTableSize,
       globalFilter: defaultGlobalFilter,
+      sortTypes,
       ...moreUseTableOptions,
     },
     ...tableHooks,

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/utils/sortAlphanumericCaseInsensitive.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/utils/sortAlphanumericCaseInsensitive.ts
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Row } from 'react-table';
+
+export const sortAlphanumericCaseInsensitive = <D extends {}>(
+  rowA: Row<D>,
+  rowB: Row<D>,
+  columnId: string,
+) => {
+  const valueA = rowA.values[columnId];
+  const valueB = rowB.values[columnId];
+
+  if (!valueA || typeof valueA !== 'string') {
+    return -1;
+  }
+  if (!valueB || typeof valueB !== 'string') {
+    return 1;
+  }
+  return valueA.localeCompare(valueB) > 0 ? 1 : -1;
+};

--- a/superset-frontend/plugins/plugin-chart-table/test/sortAlphanumericCaseInsensitive.test.ts
+++ b/superset-frontend/plugins/plugin-chart-table/test/sortAlphanumericCaseInsensitive.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { sortAlphanumericCaseInsensitive } from '../src/DataTable/utils/sortAlphanumericCaseInsensitive';
+
+const testData = [
+  {
+    values: {
+      col: 'test value',
+    },
+  },
+  {
+    values: {
+      col: 'a lowercase test value',
+    },
+  },
+  {
+    values: {
+      col: '5',
+    },
+  },
+  {
+    values: {
+      col: NaN,
+    },
+  },
+  {
+    values: {
+      col: '1234',
+    },
+  },
+  {
+    values: {
+      col: Infinity,
+    },
+  },
+  {
+    values: {
+      col: '.!# value starting with non-letter characters',
+    },
+  },
+  {
+    values: {
+      col: 'An uppercase test value',
+    },
+  },
+  {
+    values: {
+      col: undefined,
+    },
+  },
+  {
+    values: {
+      col: null,
+    },
+  },
+];
+
+describe('sortAlphanumericCaseInsensitive', () => {
+  it('Sort rows', () => {
+    const sorted = [...testData].sort((a, b) =>
+      // @ts-ignore
+      sortAlphanumericCaseInsensitive(a, b, 'col'),
+    );
+
+    expect(sorted).toEqual([
+      {
+        values: {
+          col: null,
+        },
+      },
+      {
+        values: {
+          col: undefined,
+        },
+      },
+      {
+        values: {
+          col: Infinity,
+        },
+      },
+      {
+        values: {
+          col: NaN,
+        },
+      },
+      {
+        values: {
+          col: '.!# value starting with non-letter characters',
+        },
+      },
+      {
+        values: {
+          col: '1234',
+        },
+      },
+      {
+        values: {
+          col: '5',
+        },
+      },
+      {
+        values: {
+          col: 'a lowercase test value',
+        },
+      },
+      {
+        values: {
+          col: 'An uppercase test value',
+        },
+      },
+      {
+        values: {
+          col: 'test value',
+        },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
### SUMMARY
This PR makes sorting of alphanumeric columns case insensitive.

Order of sorting before (ascending):
1. Non-letter characters (.!, etc.), undefined, null
2. Capital letters A-Z
3. Lowercase letters a-z
4. Numbers

Order of sorting after (ascending):
1. Non-letter characters (.!, etc.), undefined, null
2. Numbers
3. Letters case insensitive Aa-Zz

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/15073128/146221618-a30ce9cd-f4ac-4f9b-b11e-9fee30932dd4.mov

After:

https://user-images.githubusercontent.com/15073128/146221733-c2c65430-9e62-460c-be19-174d8bfeafd6.mov

### TESTING INSTRUCTIONS
1. Create a table chart with alphanumeric columns
2. Verify that sorting is case insensitive

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @rusackas 
https://app.shortcut.com/preset/story/25784/column-sort-should-be-case-insensitive