### PR TITLE
fix: Remove positions from json_metadata

### DIFF
--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -166,7 +166,7 @@ const PropertiesModal = ({
       setColorScheme(metadata.color_scheme);
 
       // temporary fix to remove positions from dashboards' metadata
-      if (metadata && metadata.positions) {
+      if (metadata?.positions) {
         delete metadata.positions;
       }
       setJsonMetadata(metadata ? jsonStringify(metadata) : '');

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -161,10 +161,15 @@ const PropertiesModal = ({
 
       form.setFieldsValue(dashboardInfo);
       setDashboardInfo(dashboardInfo);
-      setJsonMetadata(metadata ? jsonStringify(metadata) : '');
       setOwners(owners);
       setRoles(roles);
       setColorScheme(metadata.color_scheme);
+
+      // temporary fix to remove positions from dashboards' metadata
+      if (metadata && metadata.positions) {
+        delete metadata.positions;
+      }
+      setJsonMetadata(metadata ? jsonStringify(metadata) : '');
     },
     [form],
   );

--- a/superset/dashboards/dao.py
+++ b/superset/dashboards/dao.py
@@ -238,8 +238,9 @@ class DashboardDAO(BaseDAO):
                 if int(key) in slice_ids
             }
             md["default_filters"] = json.dumps(applicable_filters)
-        # positions have its own column, no need to store it in metadata
-        md.pop("positions", None)
+
+            # positions have its own column, no need to store it in metadata
+            md.pop("positions", None)
 
         # The css and dashboard_title properties are not part of the metadata
         # TODO (geido): remove by refactoring/deprecating save_dash endpoint

--- a/superset/dashboards/dao.py
+++ b/superset/dashboards/dao.py
@@ -238,6 +238,8 @@ class DashboardDAO(BaseDAO):
                 if int(key) in slice_ids
             }
             md["default_filters"] = json.dumps(applicable_filters)
+        # positions have its own column, no need to store it in metadata
+        md.pop("positions", None)
 
         # The css and dashboard_title properties are not part of the metadata
         # TODO (geido): remove by refactoring/deprecating save_dash endpoint


### PR DESCRIPTION
### SUMMARY
This PR is a follow-up of PR #17570 in response to the issue that was brought in revert-PR #17753. 
The changes in PR #17570 saved the `positions` in the `json_metadata` of a Dashboard even if that wasn't really necessary. It appears that very large dashboards might encounter an error as the `positions` might become too large AND/OR non-ascii characters might cause the json parsing to fail. 

This PR forcefully removes the `positions` from the metadata, while making sure that all the related logics remain in place. It also introduces a temporary fix to make sure that Dashboards currently affected by this issue should ignore the `positions` in their metadata entirely. 

### TESTING INSTRUCTIONS
1. Open a very large Dashboard
2. Edit and Save the changes
3. Make sure everything works as expected

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
