### PR TITLE
fix: change 401 response to a 403 for Security Exceptions

### DIFF
--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -149,7 +149,7 @@ class SupersetTemplateParamsErrorException(SupersetErrorFromParamsException):
 
 
 class SupersetSecurityException(SupersetErrorException):
-    status = 401
+    status = 403
 
     def __init__(
         self, error: SupersetError, payload: Optional[Dict[str, Any]] = None

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -464,7 +464,7 @@ class TestPostChartDataApi(BaseTestChartDataApi):
 
         assert rv.status_code == 400
 
-    def test_with_not_permitted_actor__401(self):
+    def test_with_not_permitted_actor__403(self):
         """
         Chart data API: Test chart data query not allowed
         """
@@ -472,7 +472,7 @@ class TestPostChartDataApi(BaseTestChartDataApi):
         self.login(username="gamma")
         rv = self.post_assert_metric(CHART_DATA_URI, self.query_context_payload, "data")
 
-        assert rv.status_code == 401
+        assert rv.status_code == 403
         assert (
             rv.json["errors"][0]["error_type"]
             == SupersetErrorType.DATASOURCE_SECURITY_ACCESS_ERROR

--- a/tests/integration_tests/dashboards/security/security_rbac_tests.py
+++ b/tests/integration_tests/dashboards/security/security_rbac_tests.py
@@ -91,7 +91,7 @@ class TestDashboardRoleBasedSecurity(BaseTestDashboardSecurity):
 
         request_payload = get_query_context("birth_names")
         rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
-        self.assertEqual(rv.status_code, 401)
+        self.assertEqual(rv.status_code, 403)
 
         # assert
         self.assert403(response)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This changes the response for security exceptions from 401 (Unauthorized) to 403 (Forbidden). This is a fix because it means when these exceptions are encountered, it will no longer redirect users to the login page, which is intended to only happen for proper 401 errors. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
