### PR TITLE
fix(alembic): Making Alembic logger config optional

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -103,6 +103,11 @@ def _try_json_readsha(filepath: str, length: int) -> Optional[str]:
         return None
 
 
+#
+# If True, we will skip the call to load the logger config found in alembic.init
+#
+ALEMBIC_SKIP_LOG_CONFIG = False
+
 # Depending on the context in which this config is loaded, the
 # version_info.json file may or may not be available, as it is
 # generated on install via setup.py. In the event that we're

--- a/superset/migrations/env.py
+++ b/superset/migrations/env.py
@@ -16,6 +16,7 @@
 # under the License.
 import logging
 from logging.config import fileConfig
+from os import getenv
 from typing import List
 
 from alembic import context
@@ -31,7 +32,9 @@ config = context.config
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
-fileConfig(config.config_file_name)
+if not getenv("ALEMBIC_SKIP_LOG_CONFIG"):
+    # Skip loading logger config if the user has this envvar set
+    fileConfig(config.config_file_name)
 logger = logging.getLogger("alembic.env")
 
 DATABASE_URI = current_app.config["SQLALCHEMY_DATABASE_URI"]

--- a/superset/migrations/env.py
+++ b/superset/migrations/env.py
@@ -16,7 +16,6 @@
 # under the License.
 import logging
 from logging.config import fileConfig
-from os import getenv
 from typing import List
 
 from alembic import context
@@ -32,8 +31,8 @@ config = context.config
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
-if not getenv("ALEMBIC_SKIP_LOG_CONFIG"):
-    # Skip loading logger config if the user has this envvar set
+if not current_app.config["ALEMBIC_SKIP_LOG_CONFIG"]:
+    # Skip loading logger config if the user has this config set
     fileConfig(config.config_file_name)
 logger = logging.getLogger("alembic.env")
 


### PR DESCRIPTION
### SUMMARY
The default Alembic `env.py` file explicitly loads its own logger configuration, which overwrites any other settings that users may have set elsewhere. This PR adds an optional envvar that can be used to disable this behavior.

