### PR TITLE
feat: don't ask for password when DB exists

### DIFF
--- a/superset/charts/commands/importers/v1/__init__.py
+++ b/superset/charts/commands/importers/v1/__init__.py
@@ -97,7 +97,7 @@ class ImportChartsCommand(ImportModelsCommand):
                 )
                 config["params"].update({"datasource": dataset.uid})
 
-                if config["query_context"]:
+                if "query_context" in config:
                     del config["query_context"]
 
                 import_chart(session, config, overwrite=overwrite)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When importing a dataset/chart/dashboard/saved query referencing databases that already exist, we shouldn't prompt for the password again.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before, every time we import something that depends on a database with a password we would prompt the user for it.

After, we no longer prompt for the password.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Create a DB connection that has a password.
2. Create a dataset and then a chart; export chart.
3. Delete the chart and import it. It will import without prompting for the password.
4. Delete everything and import the chart. It will prompt for the password before importing.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
