### PR TITLE
fix(filter-sets): 404 on dashboard load

### DIFF
--- a/superset-frontend/src/dashboard/actions/nativeFilters.ts
+++ b/superset-frontend/src/dashboard/actions/nativeFilters.ts
@@ -204,8 +204,7 @@ export interface SetBootstrapData {
 }
 
 export const getFilterSets =
-  () => async (dispatch: Dispatch, getState: () => RootState) => {
-    const dashboardId = getState().dashboardInfo.id;
+  (dashboardId: number) => async (dispatch: Dispatch) => {
     const fetchFilterSets = makeApi<
       null,
       {
@@ -271,7 +270,7 @@ export const createFilterSet =
     dispatch({
       type: CREATE_FILTER_SET_COMPLETE,
     });
-    dispatch(getFilterSets());
+    dispatch(getFilterSets(dashboardId));
   };
 
 export const updateFilterSet =
@@ -308,7 +307,7 @@ export const updateFilterSet =
     dispatch({
       type: UPDATE_FILTER_SET_COMPLETE,
     });
-    dispatch(getFilterSets());
+    dispatch(getFilterSets(dashboardId));
   };
 
 export const deleteFilterSet =
@@ -329,7 +328,7 @@ export const deleteFilterSet =
     dispatch({
       type: DELETE_FILTER_SET_COMPLETE,
     });
-    dispatch(getFilterSets());
+    dispatch(getFilterSets(dashboardId));
   };
 
 export const SET_FOCUSED_NATIVE_FILTER = 'SET_FOCUSED_NATIVE_FILTER';

--- a/superset-frontend/src/dashboard/containers/DashboardPage.tsx
+++ b/superset-frontend/src/dashboard/containers/DashboardPage.tsx
@@ -158,7 +158,7 @@ const DashboardPage: FC = () => {
         isDashboardHydrated.current = true;
         if (isFeatureEnabled(FeatureFlag.DASHBOARD_NATIVE_FILTERS_SET)) {
           // only initialize filterset once
-          dispatch(getFilterSets());
+          dispatch(getFilterSets(id));
         }
       }
       dispatch(hydrateDashboard(dashboard, charts, filterboxMigrationState));


### PR DESCRIPTION
### SUMMARY
Currently loading a dashboard with the `DASHBOARD_NATIVE_FILTER_SETS` feature flag enabled triggers a 404 to the `filtersets` dashboard endpoint. This is most likely due to a race condition which is caused by the dashboard state not being available in Redux yet when the filter set request is dispatched. This adds the dashboard id to the `getFilterSets` action to ensure that the caller already has the id available.

# AFTER
After the change the filter set request results in a 200 with the correct dashboard id:
![image](https://user-images.githubusercontent.com/33317356/146336982-a62a0152-6506-49e1-9ec0-fe565e117fce.png)

# BEFORE
Before the change, loading a dashboard always triggers a 404 to the filter set endpoint:
![image](https://user-images.githubusercontent.com/33317356/146337083-98c271c0-ce71-4462-930c-9d427efe9366.png)

### TESTING INSTRUCTIONS
1. Enable "DASHBOARD_NATIVE_FILTER_SETS" feature flag.
2. Enter a dashboard
3. Observe a 404 to the filter set endpoint

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
