### PR TITLE
chore: update fixtures scope that are loading data into the analytical db

### DIFF
--- a/tests/integration_tests/access_tests.py
+++ b/tests/integration_tests/access_tests.py
@@ -24,13 +24,13 @@ import pytest
 from sqlalchemy import inspect
 
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices,
+    load_world_bank_dashboard_with_slices, load_world_bank_data
 )
 from tests.integration_tests.fixtures.energy_dashboard import (
-    load_energy_table_with_slice,
+    load_energy_table_with_slice, load_energy_table_data
 )
 from tests.integration_tests.test_app import app  # isort:skip
 from superset import db, security_manager

--- a/tests/integration_tests/access_tests.py
+++ b/tests/integration_tests/access_tests.py
@@ -24,13 +24,16 @@ import pytest
 from sqlalchemy import inspect
 
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices, load_world_bank_data
+    load_world_bank_dashboard_with_slices,
+    load_world_bank_data,
 )
 from tests.integration_tests.fixtures.energy_dashboard import (
-    load_energy_table_with_slice, load_energy_table_data
+    load_energy_table_with_slice,
+    load_energy_table_data,
 )
 from tests.integration_tests.test_app import app  # isort:skip
 from superset import db, security_manager

--- a/tests/integration_tests/base_api_tests.py
+++ b/tests/integration_tests/base_api_tests.py
@@ -17,7 +17,8 @@
 # isort:skip_file
 import json
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices, load_world_bank_data
+    load_world_bank_dashboard_with_slices,
+    load_world_bank_data,
 )
 
 import pytest

--- a/tests/integration_tests/base_api_tests.py
+++ b/tests/integration_tests/base_api_tests.py
@@ -17,7 +17,7 @@
 # isort:skip_file
 import json
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices,
+    load_world_bank_dashboard_with_slices, load_world_bank_data
 )
 
 import pytest

--- a/tests/integration_tests/cache_tests.py
+++ b/tests/integration_tests/cache_tests.py
@@ -23,7 +23,8 @@ from superset import app, db
 from superset.common.db_query_status import QueryStatus
 from superset.extensions import cache_manager
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 
 from .base_tests import SupersetTestCase

--- a/tests/integration_tests/cache_tests.py
+++ b/tests/integration_tests/cache_tests.py
@@ -23,7 +23,7 @@ from superset import app, db
 from superset.common.db_query_status import QueryStatus
 from superset.extensions import cache_manager
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 
 from .base_tests import SupersetTestCase

--- a/tests/integration_tests/celery_tests.py
+++ b/tests/integration_tests/celery_tests.py
@@ -24,7 +24,7 @@ import time
 import unittest.mock as mock
 from typing import Optional
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 
 import pytest

--- a/tests/integration_tests/celery_tests.py
+++ b/tests/integration_tests/celery_tests.py
@@ -24,7 +24,8 @@ import time
 import unittest.mock as mock
 from typing import Optional
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 
 import pytest

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -39,10 +39,10 @@ from superset.utils.core import get_example_default_schema
 from tests.integration_tests.base_api_tests import ApiOwnersTestCaseMixin
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 from tests.integration_tests.fixtures.energy_dashboard import (
-    load_energy_table_with_slice,
+    load_energy_table_with_slice, load_energy_table_data
 )
 from tests.integration_tests.fixtures.importexport import (
     chart_config,
@@ -52,10 +52,10 @@ from tests.integration_tests.fixtures.importexport import (
     dataset_metadata_config,
 )
 from tests.integration_tests.fixtures.unicode_dashboard import (
-    load_unicode_dashboard_with_slice,
+    load_unicode_dashboard_with_slice, load_unicode_data
 )
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices,
+    load_world_bank_dashboard_with_slices, load_world_bank_data
 )
 from tests.integration_tests.insert_chart_mixin import InsertChartMixin
 from tests.integration_tests.test_app import app

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -39,10 +39,12 @@ from superset.utils.core import get_example_default_schema
 from tests.integration_tests.base_api_tests import ApiOwnersTestCaseMixin
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 from tests.integration_tests.fixtures.energy_dashboard import (
-    load_energy_table_with_slice, load_energy_table_data
+    load_energy_table_with_slice,
+    load_energy_table_data,
 )
 from tests.integration_tests.fixtures.importexport import (
     chart_config,
@@ -52,10 +54,12 @@ from tests.integration_tests.fixtures.importexport import (
     dataset_metadata_config,
 )
 from tests.integration_tests.fixtures.unicode_dashboard import (
-    load_unicode_dashboard_with_slice, load_unicode_data
+    load_unicode_dashboard_with_slice,
+    load_unicode_data,
 )
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices, load_world_bank_data
+    load_world_bank_dashboard_with_slices,
+    load_world_bank_data,
 )
 from tests.integration_tests.insert_chart_mixin import InsertChartMixin
 from tests.integration_tests.test_app import app

--- a/tests/integration_tests/charts/commands_tests.py
+++ b/tests/integration_tests/charts/commands_tests.py
@@ -34,7 +34,7 @@ from superset.models.core import Database
 from superset.models.slice import Slice
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.energy_dashboard import (
-    load_energy_table_with_slice,
+    load_energy_table_with_slice, load_energy_table_data
 )
 from tests.integration_tests.fixtures.importexport import (
     chart_config,

--- a/tests/integration_tests/charts/commands_tests.py
+++ b/tests/integration_tests/charts/commands_tests.py
@@ -34,7 +34,8 @@ from superset.models.core import Database
 from superset.models.slice import Slice
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.energy_dashboard import (
-    load_energy_table_with_slice, load_energy_table_data
+    load_energy_table_data,
+    load_energy_table_with_slice,
 )
 from tests.integration_tests.fixtures.importexport import (
     chart_config,

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -31,7 +31,7 @@ from tests.integration_tests.base_tests import (
 )
 from tests.integration_tests.annotation_layers.fixtures import create_annotation_layers
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 from tests.integration_tests.test_app import app
 

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -31,7 +31,8 @@ from tests.integration_tests.base_tests import (
 )
 from tests.integration_tests.annotation_layers.fixtures import create_annotation_layers
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 from tests.integration_tests.test_app import app
 

--- a/tests/integration_tests/charts/schema_tests.py
+++ b/tests/integration_tests/charts/schema_tests.py
@@ -25,7 +25,8 @@ from tests.integration_tests.test_app import app
 from superset.charts.schemas import ChartDataQueryContextSchema
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 from tests.integration_tests.fixtures.query_context import get_query_context
 

--- a/tests/integration_tests/charts/schema_tests.py
+++ b/tests/integration_tests/charts/schema_tests.py
@@ -25,7 +25,7 @@ from tests.integration_tests.test_app import app
 from superset.charts.schemas import ChartDataQueryContextSchema
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 from tests.integration_tests.fixtures.query_context import get_query_context
 

--- a/tests/integration_tests/cli_tests.py
+++ b/tests/integration_tests/cli_tests.py
@@ -29,7 +29,8 @@ from freezegun import freeze_time
 import superset.cli
 from superset import app
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 
 logger = logging.getLogger(__name__)

--- a/tests/integration_tests/cli_tests.py
+++ b/tests/integration_tests/cli_tests.py
@@ -29,7 +29,7 @@ from freezegun import freeze_time
 import superset.cli
 from superset import app
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 
 logger = logging.getLogger(__name__)

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -38,7 +38,7 @@ def app_context():
         yield
 
 
-@pytest.fixture(autouse=True, scope="package")
+@pytest.fixture(autouse=True, scope="session")
 def setup_sample_data() -> Any:
     # TODO(john-bodley): Determine a cleaner way of setting up the sample data without
     # relying on `tests.integration_tests.test_app.app` leveraging an  `app` fixture which is purposely

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -38,7 +38,7 @@ def app_context():
         yield
 
 
-@pytest.fixture(autouse=True, scope="session")
+@pytest.fixture(autouse=True, scope="package")
 def setup_sample_data() -> Any:
     # TODO(john-bodley): Determine a cleaner way of setting up the sample data without
     # relying on `tests.integration_tests.test_app.app` leveraging an  `app` fixture which is purposely

--- a/tests/integration_tests/core_tests.py
+++ b/tests/integration_tests/core_tests.py
@@ -26,7 +26,8 @@ import logging
 from typing import Dict, List
 from urllib.parse import quote
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 
 import pytest
@@ -43,7 +44,8 @@ from superset.models.cache import CacheKey
 from superset.utils.core import get_example_database
 from tests.integration_tests.conftest import with_feature_flags
 from tests.integration_tests.fixtures.energy_dashboard import (
-    load_energy_table_with_slice, load_energy_table_data
+    load_energy_table_with_slice,
+    load_energy_table_data,
 )
 from tests.integration_tests.test_app import app
 import superset.views.utils
@@ -72,7 +74,8 @@ from superset.views.database.views import DatabaseView
 
 from .base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices, load_world_bank_data
+    load_world_bank_dashboard_with_slices,
+    load_world_bank_data,
 )
 
 logger = logging.getLogger(__name__)

--- a/tests/integration_tests/core_tests.py
+++ b/tests/integration_tests/core_tests.py
@@ -26,7 +26,7 @@ import logging
 from typing import Dict, List
 from urllib.parse import quote
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 
 import pytest
@@ -43,7 +43,7 @@ from superset.models.cache import CacheKey
 from superset.utils.core import get_example_database
 from tests.integration_tests.conftest import with_feature_flags
 from tests.integration_tests.fixtures.energy_dashboard import (
-    load_energy_table_with_slice,
+    load_energy_table_with_slice, load_energy_table_data
 )
 from tests.integration_tests.test_app import app
 import superset.views.utils
@@ -72,7 +72,7 @@ from superset.views.database.views import DatabaseView
 
 from .base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices,
+    load_world_bank_dashboard_with_slices, load_world_bank_data
 )
 
 logger = logging.getLogger(__name__)

--- a/tests/integration_tests/dashboard_tests.py
+++ b/tests/integration_tests/dashboard_tests.py
@@ -32,17 +32,21 @@ from superset.models import core as models
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 from tests.integration_tests.fixtures.energy_dashboard import (
-    load_energy_table_with_slice, load_energy_table_data
+    load_energy_table_with_slice,
+    load_energy_table_data,
 )
 from tests.integration_tests.fixtures.public_role import public_role_like_gamma
 from tests.integration_tests.fixtures.unicode_dashboard import (
     load_unicode_dashboard_with_position,
+    load_unicode_data,
 )
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices, load_world_bank_data
+    load_world_bank_dashboard_with_slices,
+    load_world_bank_data,
 )
 
 from .base_tests import SupersetTestCase

--- a/tests/integration_tests/dashboard_tests.py
+++ b/tests/integration_tests/dashboard_tests.py
@@ -32,17 +32,17 @@ from superset.models import core as models
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 from tests.integration_tests.fixtures.energy_dashboard import (
-    load_energy_table_with_slice,
+    load_energy_table_with_slice, load_energy_table_data
 )
 from tests.integration_tests.fixtures.public_role import public_role_like_gamma
 from tests.integration_tests.fixtures.unicode_dashboard import (
     load_unicode_dashboard_with_position,
 )
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices,
+    load_world_bank_dashboard_with_slices, load_world_bank_data
 )
 
 from .base_tests import SupersetTestCase

--- a/tests/integration_tests/dashboard_utils.py
+++ b/tests/integration_tests/dashboard_utils.py
@@ -41,27 +41,14 @@ def get_table(
     )
 
 
-def create_table_for_dashboard(
-    df: DataFrame,
+def create_table_metadata(
     table_name: str,
     database: Database,
-    dtype: Dict[str, Any],
     table_description: str = "",
     fetch_values_predicate: Optional[str] = None,
     schema: Optional[str] = None,
 ) -> SqlaTable:
     schema = schema or get_example_default_schema()
-
-    df.to_sql(
-        table_name,
-        database.get_sqla_engine(),
-        if_exists="replace",
-        chunksize=500,
-        dtype=dtype,
-        index=False,
-        method="multi",
-        schema=schema,
-    )
 
     table = get_table(table_name, database, schema)
     if not table:

--- a/tests/integration_tests/dashboard_utils.py
+++ b/tests/integration_tests/dashboard_utils.py
@@ -30,15 +30,15 @@ from superset.utils.core import get_example_default_schema
 
 
 def get_table(
-    table_name: str,
-    database: Database,
-    schema: Optional[str] = None,
+    table_name: str, database: Database, schema: Optional[str] = None,
 ):
     schema = schema or get_example_default_schema()
     table_source = ConnectorRegistry.sources["table"]
-    return db.session.query(table_source).filter_by(
-        database_id=database.id, schema=schema, table_name=table_name
-    ).one_or_none()
+    return (
+        db.session.query(table_source)
+        .filter_by(database_id=database.id, schema=schema, table_name=table_name)
+        .one_or_none()
+    )
 
 
 def create_table_for_dashboard(

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -52,10 +52,12 @@ from tests.integration_tests.fixtures.importexport import (
 )
 from tests.integration_tests.utils.get_dashboards import get_dashboards_ids
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices, load_world_bank_data
+    load_world_bank_dashboard_with_slices,
+    load_world_bank_data,
 )
 
 DASHBOARDS_FIXTURE_COUNT = 10

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -52,10 +52,10 @@ from tests.integration_tests.fixtures.importexport import (
 )
 from tests.integration_tests.utils.get_dashboards import get_dashboards_ids
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices,
+    load_world_bank_dashboard_with_slices, load_world_bank_data
 )
 
 DASHBOARDS_FIXTURE_COUNT = 10

--- a/tests/integration_tests/dashboards/commands_tests.py
+++ b/tests/integration_tests/dashboards/commands_tests.py
@@ -47,7 +47,7 @@ from tests.integration_tests.fixtures.importexport import (
     dataset_metadata_config,
 )
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices,
+    load_world_bank_dashboard_with_slices, load_world_bank_data
 )
 
 

--- a/tests/integration_tests/dashboards/commands_tests.py
+++ b/tests/integration_tests/dashboards/commands_tests.py
@@ -47,7 +47,8 @@ from tests.integration_tests.fixtures.importexport import (
     dataset_metadata_config,
 )
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices, load_world_bank_data
+    load_world_bank_dashboard_with_slices,
+    load_world_bank_data,
 )
 
 

--- a/tests/integration_tests/dashboards/dao_tests.py
+++ b/tests/integration_tests/dashboards/dao_tests.py
@@ -27,7 +27,8 @@ from superset.dashboards.dao import DashboardDAO
 from superset.models.dashboard import Dashboard
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices, load_world_bank_data
+    load_world_bank_dashboard_with_slices,
+    load_world_bank_data,
 )
 
 

--- a/tests/integration_tests/dashboards/dao_tests.py
+++ b/tests/integration_tests/dashboards/dao_tests.py
@@ -27,7 +27,7 @@ from superset.dashboards.dao import DashboardDAO
 from superset.models.dashboard import Dashboard
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices,
+    load_world_bank_dashboard_with_slices, load_world_bank_data
 )
 
 

--- a/tests/integration_tests/dashboards/filter_state/api_tests.py
+++ b/tests/integration_tests/dashboards/filter_state/api_tests.py
@@ -29,7 +29,8 @@ from superset.key_value.utils import cache_key
 from superset.models.dashboard import Dashboard
 from tests.integration_tests.base_tests import login
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices, load_world_bank_data
+    load_world_bank_dashboard_with_slices,
+    load_world_bank_data,
 )
 from tests.integration_tests.test_app import app
 

--- a/tests/integration_tests/dashboards/filter_state/api_tests.py
+++ b/tests/integration_tests/dashboards/filter_state/api_tests.py
@@ -29,7 +29,7 @@ from superset.key_value.utils import cache_key
 from superset.models.dashboard import Dashboard
 from tests.integration_tests.base_tests import login
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices,
+    load_world_bank_dashboard_with_slices, load_world_bank_data
 )
 from tests.integration_tests.test_app import app
 

--- a/tests/integration_tests/dashboards/security/security_dataset_tests.py
+++ b/tests/integration_tests/dashboards/security/security_dataset_tests.py
@@ -28,7 +28,8 @@ from tests.integration_tests.dashboards.consts import *
 from tests.integration_tests.dashboards.dashboard_test_utils import *
 from tests.integration_tests.dashboards.superset_factory_util import *
 from tests.integration_tests.fixtures.energy_dashboard import (
-    load_energy_table_with_slice, load_energy_table_data
+    load_energy_table_data,
+    load_energy_table_with_slice,
 )
 
 

--- a/tests/integration_tests/dashboards/security/security_dataset_tests.py
+++ b/tests/integration_tests/dashboards/security/security_dataset_tests.py
@@ -28,7 +28,7 @@ from tests.integration_tests.dashboards.consts import *
 from tests.integration_tests.dashboards.dashboard_test_utils import *
 from tests.integration_tests.dashboards.superset_factory_util import *
 from tests.integration_tests.fixtures.energy_dashboard import (
-    load_energy_table_with_slice,
+    load_energy_table_with_slice, load_energy_table_data
 )
 
 

--- a/tests/integration_tests/dashboards/security/security_rbac_tests.py
+++ b/tests/integration_tests/dashboards/security/security_rbac_tests.py
@@ -31,7 +31,7 @@ from tests.integration_tests.dashboards.superset_factory_util import (
     create_slice_to_db,
 )
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 from tests.integration_tests.fixtures.public_role import public_role_like_gamma
 from tests.integration_tests.fixtures.query_context import get_query_context

--- a/tests/integration_tests/dashboards/security/security_rbac_tests.py
+++ b/tests/integration_tests/dashboards/security/security_rbac_tests.py
@@ -31,7 +31,8 @@ from tests.integration_tests.dashboards.superset_factory_util import (
     create_slice_to_db,
 )
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 from tests.integration_tests.fixtures.public_role import public_role_like_gamma
 from tests.integration_tests.fixtures.query_context import get_query_context

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -46,14 +46,17 @@ from superset.models.reports import ReportSchedule, ReportScheduleType
 from superset.utils.core import get_example_database, get_main_database
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 from tests.integration_tests.fixtures.certificates import ssl_certificate
 from tests.integration_tests.fixtures.energy_dashboard import (
-    load_energy_table_with_slice, load_energy_table_data
+    load_energy_table_with_slice,
+    load_energy_table_data,
 )
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices, load_world_bank_data
+    load_world_bank_dashboard_with_slices,
+    load_world_bank_data,
 )
 from tests.integration_tests.fixtures.importexport import (
     database_config,
@@ -63,6 +66,7 @@ from tests.integration_tests.fixtures.importexport import (
 )
 from tests.integration_tests.fixtures.unicode_dashboard import (
     load_unicode_dashboard_with_position,
+    load_unicode_data,
 )
 from tests.integration_tests.test_app import app
 

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -46,14 +46,14 @@ from superset.models.reports import ReportSchedule, ReportScheduleType
 from superset.utils.core import get_example_database, get_main_database
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 from tests.integration_tests.fixtures.certificates import ssl_certificate
 from tests.integration_tests.fixtures.energy_dashboard import (
-    load_energy_table_with_slice,
+    load_energy_table_with_slice, load_energy_table_data
 )
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices,
+    load_world_bank_dashboard_with_slices, load_world_bank_data
 )
 from tests.integration_tests.fixtures.importexport import (
     database_config,

--- a/tests/integration_tests/databases/commands_tests.py
+++ b/tests/integration_tests/databases/commands_tests.py
@@ -43,10 +43,12 @@ from superset.models.core import Database
 from superset.utils.core import backend, get_example_database
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 from tests.integration_tests.fixtures.energy_dashboard import (
-    load_energy_table_with_slice, load_energy_table_data
+    load_energy_table_data,
+    load_energy_table_with_slice,
 )
 from tests.integration_tests.fixtures.importexport import (
     database_config,

--- a/tests/integration_tests/databases/commands_tests.py
+++ b/tests/integration_tests/databases/commands_tests.py
@@ -43,10 +43,10 @@ from superset.models.core import Database
 from superset.utils.core import backend, get_example_database
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 from tests.integration_tests.fixtures.energy_dashboard import (
-    load_energy_table_with_slice,
+    load_energy_table_with_slice, load_energy_table_data
 )
 from tests.integration_tests.fixtures.importexport import (
     database_config,

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -45,10 +45,10 @@ from superset.utils.dict_import_export import export_to_dict
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.conftest import CTAS_SCHEMA_NAME
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 from tests.integration_tests.fixtures.energy_dashboard import (
-    load_energy_table_with_slice,
+    load_energy_table_with_slice, load_energy_table_data
 )
 from tests.integration_tests.fixtures.importexport import (
     database_config,

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -45,10 +45,12 @@ from superset.utils.dict_import_export import export_to_dict
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.conftest import CTAS_SCHEMA_NAME
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 from tests.integration_tests.fixtures.energy_dashboard import (
-    load_energy_table_with_slice, load_energy_table_data
+    load_energy_table_data,
+    load_energy_table_with_slice,
 )
 from tests.integration_tests.fixtures.importexport import (
     database_config,

--- a/tests/integration_tests/datasets/commands_tests.py
+++ b/tests/integration_tests/datasets/commands_tests.py
@@ -33,7 +33,7 @@ from superset.models.core import Database
 from superset.utils.core import get_example_database, get_example_default_schema
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.energy_dashboard import (
-    load_energy_table_with_slice,
+    load_energy_table_with_slice, load_energy_table_data
 )
 from tests.integration_tests.fixtures.importexport import (
     database_config,
@@ -44,7 +44,7 @@ from tests.integration_tests.fixtures.importexport import (
     dataset_ui_export,
 )
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices,
+    load_world_bank_dashboard_with_slices, load_world_bank_data
 )
 
 

--- a/tests/integration_tests/datasets/commands_tests.py
+++ b/tests/integration_tests/datasets/commands_tests.py
@@ -33,7 +33,8 @@ from superset.models.core import Database
 from superset.utils.core import get_example_database, get_example_default_schema
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.energy_dashboard import (
-    load_energy_table_with_slice, load_energy_table_data
+    load_energy_table_data,
+    load_energy_table_with_slice,
 )
 from tests.integration_tests.fixtures.importexport import (
     database_config,
@@ -44,7 +45,8 @@ from tests.integration_tests.fixtures.importexport import (
     dataset_ui_export,
 )
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices, load_world_bank_data
+    load_world_bank_dashboard_with_slices,
+    load_world_bank_data,
 )
 
 

--- a/tests/integration_tests/datasource_tests.py
+++ b/tests/integration_tests/datasource_tests.py
@@ -30,7 +30,7 @@ from superset.models.core import Database
 from superset.utils.core import get_example_database, get_example_default_schema
 from tests.integration_tests.base_tests import db_insert_temp_object, SupersetTestCase
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 from tests.integration_tests.fixtures.datasource import get_datasource_post
 

--- a/tests/integration_tests/datasource_tests.py
+++ b/tests/integration_tests/datasource_tests.py
@@ -30,7 +30,8 @@ from superset.models.core import Database
 from superset.utils.core import get_example_database, get_example_default_schema
 from tests.integration_tests.base_tests import db_insert_temp_object, SupersetTestCase
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 from tests.integration_tests.fixtures.datasource import get_datasource_post
 

--- a/tests/integration_tests/db_engine_specs/base_engine_spec_tests.py
+++ b/tests/integration_tests/db_engine_specs/base_engine_spec_tests.py
@@ -35,8 +35,14 @@ from superset.utils.core import get_example_database
 from tests.integration_tests.db_engine_specs.base_tests import TestDbEngineSpec
 from tests.integration_tests.test_app import app
 
-from ..fixtures.birth_names_dashboard import load_birth_names_dashboard_with_slices
-from ..fixtures.energy_dashboard import load_energy_table_with_slice
+from ..fixtures.birth_names_dashboard import (
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
+)
+from ..fixtures.energy_dashboard import (
+    load_energy_table_data,
+    load_energy_table_with_slice,
+)
 from ..fixtures.pyodbcRow import Row
 
 

--- a/tests/integration_tests/db_engine_specs/bigquery_tests.py
+++ b/tests/integration_tests/db_engine_specs/bigquery_tests.py
@@ -28,7 +28,8 @@ from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.sql_parse import Table
 from tests.integration_tests.db_engine_specs.base_tests import TestDbEngineSpec
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 
 

--- a/tests/integration_tests/db_engine_specs/bigquery_tests.py
+++ b/tests/integration_tests/db_engine_specs/bigquery_tests.py
@@ -28,7 +28,7 @@ from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.sql_parse import Table
 from tests.integration_tests.db_engine_specs.base_tests import TestDbEngineSpec
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 
 

--- a/tests/integration_tests/fixtures/__init__.py
+++ b/tests/integration_tests/fixtures/__init__.py
@@ -19,7 +19,7 @@ from .birth_names_dashboard import (
     load_birth_names_dashboard_with_slices,
     load_birth_names_dashboard_with_slices_module_scope,
 )
-from .energy_dashboard import load_energy_table_with_slice, load_energy_table_data
+from .energy_dashboard import load_energy_table_data, load_energy_table_with_slice
 from .public_role import public_role_like_gamma, public_role_like_test_role
 from .unicode_dashboard import (
     load_unicode_dashboard_with_position,

--- a/tests/integration_tests/fixtures/__init__.py
+++ b/tests/integration_tests/fixtures/__init__.py
@@ -19,7 +19,7 @@ from .birth_names_dashboard import (
     load_birth_names_dashboard_with_slices,
     load_birth_names_dashboard_with_slices_module_scope,
 )
-from .energy_dashboard import load_energy_table_with_slice
+from .energy_dashboard import load_energy_table_with_slice, load_energy_table_data
 from .public_role import public_role_like_gamma, public_role_like_test_role
 from .unicode_dashboard import (
     load_unicode_dashboard_with_position,

--- a/tests/integration_tests/fixtures/birth_names_dashboard.py
+++ b/tests/integration_tests/fixtures/birth_names_dashboard.py
@@ -37,6 +37,27 @@ from tests.integration_tests.test_app import app
 
 BIRTH_NAMES_TBL_NAME = "birth_names"
 
+
+@pytest.fixture(scope="session")
+def _load_data():
+    with app.app_context():
+        database = get_example_database()
+        df = _get_dataframe(database)
+        dtype = {
+            "ds": DateTime if database.backend != "presto" else String(255),
+            "gender": String(16),
+            "state": String(10),
+            "name": String(255),
+        }
+        _create_table(
+            df=df,
+            table_name=BIRTH_NAMES_TBL_NAME,
+            database=database,
+            dtype=dtype,
+            fetch_values_predicate="123 = 123",
+        )
+
+
 @pytest.fixture()
 def load_birth_names_dashboard_with_slices(_load_data):
     dash_id_to_delete, slices_ids_to_delete = _create_dashboards()
@@ -61,26 +82,6 @@ def _create_dashboards():
     slices_ids_to_delete = [slice.id for slice in slices]
     dash_id_to_delete = dash.id
     return dash_id_to_delete, slices_ids_to_delete
-
-
-@pytest.fixture(scope="session")
-def _load_data():
-    with app.app_context():
-        database = get_example_database()
-        df = _get_dataframe(database)
-        dtype = {
-            "ds": DateTime if database.backend != "presto" else String(255),
-            "gender": String(16),
-            "state": String(10),
-            "name": String(255),
-        }
-        _create_table(
-            df=df,
-            table_name=BIRTH_NAMES_TBL_NAME,
-            database=database,
-            dtype=dtype,
-            fetch_values_predicate="123 = 123",
-        )
 
 
 def _create_table(

--- a/tests/integration_tests/fixtures/birth_names_dashboard.py
+++ b/tests/integration_tests/fixtures/birth_names_dashboard.py
@@ -58,6 +58,10 @@ def load_birth_names_data():
             dtype=dtype,
             fetch_values_predicate="123 = 123",
         )
+    yield
+    with app.app_context():
+        engine = get_example_database().get_sqla_engine()
+        engine.execute("DROP TABLE IF EXISTS birth_names")
 
 
 @pytest.fixture()
@@ -122,8 +126,6 @@ def _cleanup(dash_id: int, slices_ids: List[int]) -> None:
     columns = [column for column in datasource.columns]
     metrics = [metric for metric in datasource.metrics]
 
-    engine = get_example_database().get_sqla_engine()
-    engine.execute("DROP TABLE IF EXISTS birth_names")
     for column in columns:
         db.session.delete(column)
     for metric in metrics:

--- a/tests/integration_tests/fixtures/birth_names_dashboard.py
+++ b/tests/integration_tests/fixtures/birth_names_dashboard.py
@@ -23,7 +23,7 @@ from typing import Any, Dict, List, Optional
 import pandas as pd
 import pytest
 from pandas import DataFrame
-from sqlalchemy import DateTime, String, TIMESTAMP
+from sqlalchemy import DateTime, String
 
 from superset import ConnectorRegistry, db
 from superset.connectors.sqla.models import SqlaTable
@@ -39,7 +39,7 @@ BIRTH_NAMES_TBL_NAME = "birth_names"
 
 
 @pytest.fixture(scope="session")
-def _load_data():
+def load_birth_names_data():
     with app.app_context():
         database = get_example_database()
         df = _get_dataframe(database)
@@ -59,7 +59,7 @@ def _load_data():
 
 
 @pytest.fixture()
-def load_birth_names_dashboard_with_slices(_load_data):
+def load_birth_names_dashboard_with_slices(load_birth_names_data):
     dash_id_to_delete, slices_ids_to_delete = _create_dashboards()
     yield
     with app.app_context():
@@ -67,7 +67,7 @@ def load_birth_names_dashboard_with_slices(_load_data):
 
 
 @pytest.fixture(scope="module")
-def load_birth_names_dashboard_with_slices_module_scope(_load_data):
+def load_birth_names_dashboard_with_slices_module_scope(load_birth_names_data):
     dash_id_to_delete, slices_ids_to_delete = _create_dashboards()
     yield
     with app.app_context():

--- a/tests/integration_tests/fixtures/birth_names_dashboard.py
+++ b/tests/integration_tests/fixtures/birth_names_dashboard.py
@@ -31,8 +31,10 @@ from superset.models.core import Database
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.utils.core import get_example_database, get_example_default_schema
-from tests.integration_tests.dashboard_utils import create_table_for_dashboard, \
-    get_table
+from tests.integration_tests.dashboard_utils import (
+    create_table_for_dashboard,
+    get_table,
+)
 from tests.integration_tests.test_app import app
 
 BIRTH_NAMES_TBL_NAME = "birth_names"
@@ -60,22 +62,23 @@ def load_birth_names_data():
 
 @pytest.fixture()
 def load_birth_names_dashboard_with_slices(load_birth_names_data):
-    dash_id_to_delete, slices_ids_to_delete = _create_dashboards()
-    yield
     with app.app_context():
+        dash_id_to_delete, slices_ids_to_delete = _create_dashboards()
+        yield
         _cleanup(dash_id_to_delete, slices_ids_to_delete)
 
 
 @pytest.fixture(scope="module")
 def load_birth_names_dashboard_with_slices_module_scope(load_birth_names_data):
-    dash_id_to_delete, slices_ids_to_delete = _create_dashboards()
-    yield
     with app.app_context():
+        dash_id_to_delete, slices_ids_to_delete = _create_dashboards()
+        yield
         _cleanup(dash_id_to_delete, slices_ids_to_delete)
 
 
 def _create_dashboards():
     from superset.examples.birth_names import create_dashboard, create_slices
+
     table = get_table(BIRTH_NAMES_TBL_NAME, get_example_database())
     slices, _ = create_slices(table, admin_owner=False)
     dash = create_dashboard(slices)

--- a/tests/integration_tests/fixtures/birth_names_dashboard.py
+++ b/tests/integration_tests/fixtures/birth_names_dashboard.py
@@ -31,29 +31,40 @@ from superset.models.core import Database
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.utils.core import get_example_database, get_example_default_schema
-from tests.integration_tests.dashboard_utils import create_table_for_dashboard
+from tests.integration_tests.dashboard_utils import create_table_for_dashboard, \
+    get_table
 from tests.integration_tests.test_app import app
 
+BIRTH_NAMES_TBL_NAME = "birth_names"
 
 @pytest.fixture()
-def load_birth_names_dashboard_with_slices():
-    dash_id_to_delete, slices_ids_to_delete = _load_data()
+def load_birth_names_dashboard_with_slices(_load_data):
+    dash_id_to_delete, slices_ids_to_delete = _create_dashboards()
     yield
     with app.app_context():
         _cleanup(dash_id_to_delete, slices_ids_to_delete)
 
 
 @pytest.fixture(scope="module")
-def load_birth_names_dashboard_with_slices_module_scope():
-    dash_id_to_delete, slices_ids_to_delete = _load_data()
+def load_birth_names_dashboard_with_slices_module_scope(_load_data):
+    dash_id_to_delete, slices_ids_to_delete = _create_dashboards()
     yield
     with app.app_context():
         _cleanup(dash_id_to_delete, slices_ids_to_delete)
 
 
-def _load_data():
-    table_name = "birth_names"
+def _create_dashboards():
+    from superset.examples.birth_names import create_dashboard, create_slices
+    table = get_table(BIRTH_NAMES_TBL_NAME, get_example_database())
+    slices, _ = create_slices(table, admin_owner=False)
+    dash = create_dashboard(slices)
+    slices_ids_to_delete = [slice.id for slice in slices]
+    dash_id_to_delete = dash.id
+    return dash_id_to_delete, slices_ids_to_delete
 
+
+@pytest.fixture(scope="session")
+def _load_data():
     with app.app_context():
         database = get_example_database()
         df = _get_dataframe(database)
@@ -63,21 +74,13 @@ def _load_data():
             "state": String(10),
             "name": String(255),
         }
-        table = _create_table(
+        _create_table(
             df=df,
-            table_name=table_name,
+            table_name=BIRTH_NAMES_TBL_NAME,
             database=database,
             dtype=dtype,
             fetch_values_predicate="123 = 123",
         )
-
-        from superset.examples.birth_names import create_dashboard, create_slices
-
-        slices, _ = create_slices(table, admin_owner=False)
-        dash = create_dashboard(slices)
-        slices_ids_to_delete = [slice.id for slice in slices]
-        dash_id_to_delete = dash.id
-        return dash_id_to_delete, slices_ids_to_delete
 
 
 def _create_table(

--- a/tests/integration_tests/fixtures/energy_dashboard.py
+++ b/tests/integration_tests/fixtures/energy_dashboard.py
@@ -69,7 +69,9 @@ def _get_dataframe():
 
 def _create_energy_table():
     table = create_table_metadata(
-        table_name=ENERGY_USAGE_TBL_NAME, database=get_example_database(),
+        table_name=ENERGY_USAGE_TBL_NAME,
+        database=get_example_database(),
+        table_description="Energy consumption",
     )
     table.fetch_metadata()
 

--- a/tests/integration_tests/fixtures/energy_dashboard.py
+++ b/tests/integration_tests/fixtures/energy_dashboard.py
@@ -45,6 +45,7 @@ def load_energy_table_data():
             if_exists="replace",
             chunksize=500,
             index=False,
+            dtype={"source": String(255), "target": String(255), "value": Float()},
             method="multi",
             schema=get_example_default_schema(),
         )

--- a/tests/integration_tests/fixtures/energy_dashboard.py
+++ b/tests/integration_tests/fixtures/energy_dashboard.py
@@ -48,6 +48,11 @@ def load_energy_table_data():
         create_table_for_dashboard(
             df, ENERGY_USAGE_TBL_NAME, database, schema, table_description
         )
+    yield
+    with app.app_context():
+        engine = get_example_database().get_sqla_engine()
+        engine.execute("DROP TABLE IF EXISTS energy_usage")
+
 
 
 @pytest.fixture()
@@ -101,8 +106,6 @@ def _create_and_commit_energy_slice(
 
 
 def _cleanup() -> None:
-    engine = get_example_database().get_sqla_engine()
-    engine.execute("DROP TABLE IF EXISTS energy_usage")
     for slice_data in _get_energy_slices():
         slice = (
             db.session.query(Slice)

--- a/tests/integration_tests/fixtures/energy_dashboard.py
+++ b/tests/integration_tests/fixtures/energy_dashboard.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 import random
-import textwrap
 from typing import Dict, Set
 
 import pandas as pd

--- a/tests/integration_tests/fixtures/energy_dashboard.py
+++ b/tests/integration_tests/fixtures/energy_dashboard.py
@@ -27,7 +27,8 @@ from superset.models.slice import Slice
 from superset.utils.core import get_example_database
 from tests.integration_tests.dashboard_utils import (
     create_slice,
-    create_table_for_dashboard, get_table,
+    create_table_for_dashboard,
+    get_table,
 )
 from tests.integration_tests.test_app import app
 
@@ -39,13 +40,14 @@ ENERGY_USAGE_TBL_NAME = "energy_usage"
 
 @pytest.fixture(scope="session")
 def load_energy_table_data():
-    database = get_example_database()
-    table_description = "Energy consumption"
-    df = _get_dataframe()
-    schema = {"source": String(255), "target": String(255), "value": Float()}
-    create_table_for_dashboard(
-        df, ENERGY_USAGE_TBL_NAME, database, schema, table_description
-    )
+    with app.app_context():
+        database = get_example_database()
+        table_description = "Energy consumption"
+        df = _get_dataframe()
+        schema = {"source": String(255), "target": String(255), "value": Float()}
+        create_table_for_dashboard(
+            df, ENERGY_USAGE_TBL_NAME, database, schema, table_description
+        )
 
 
 @pytest.fixture()

--- a/tests/integration_tests/fixtures/unicode_dashboard.py
+++ b/tests/integration_tests/fixtures/unicode_dashboard.py
@@ -16,7 +16,6 @@
 # under the License.
 import pandas as pd
 import pytest
-from pandas import DataFrame
 from sqlalchemy import String
 
 from superset import db

--- a/tests/integration_tests/fixtures/unicode_dashboard.py
+++ b/tests/integration_tests/fixtures/unicode_dashboard.py
@@ -26,22 +26,23 @@ from superset.utils.core import get_example_database
 from tests.integration_tests.dashboard_utils import (
     create_dashboard,
     create_slice,
-    create_table_for_dashboard, get_table,
+    create_table_for_dashboard,
+    get_table,
 )
 from tests.integration_tests.test_app import app
-
 
 UNICODE_TBL_NAME = "unicode_test"
 
 
 @pytest.fixture(scope="session")
 def load_unicode_data():
-    database = get_example_database()
-    dtype = {
-        "phrase": String(500),
-    }
-    df = _get_dataframe()
-    create_table_for_dashboard(df, UNICODE_TBL_NAME, database, dtype)
+    with app.app_context():
+        database = get_example_database()
+        dtype = {
+            "phrase": String(500),
+        }
+        df = _get_dataframe()
+        create_table_for_dashboard(df, UNICODE_TBL_NAME, database, dtype)
 
 
 @pytest.fixture()
@@ -50,7 +51,6 @@ def load_unicode_dashboard_with_slice(load_unicode_data):
     with app.app_context():
         dash = _create_unicode_dashboard(slice_name, None)
         yield
-
         _cleanup(dash, slice_name)
 
 
@@ -82,9 +82,7 @@ def _get_unicode_data():
     ]
 
 
-def _create_unicode_dashboard(
-    slice_title: str, position: str
-) -> Dashboard:
+def _create_unicode_dashboard(slice_title: str, position: str) -> Dashboard:
     table = get_table(UNICODE_TBL_NAME, get_example_database())
     table.fetch_metadata()
 

--- a/tests/integration_tests/fixtures/unicode_dashboard.py
+++ b/tests/integration_tests/fixtures/unicode_dashboard.py
@@ -44,6 +44,11 @@ def load_unicode_data():
         df = _get_dataframe()
         create_table_for_dashboard(df, UNICODE_TBL_NAME, database, dtype)
 
+    yield
+    with app.app_context():
+        engine = get_example_database().get_sqla_engine()
+        engine.execute("DROP TABLE IF EXISTS unicode_test")
+
 
 @pytest.fixture()
 def load_unicode_dashboard_with_slice(load_unicode_data):
@@ -103,8 +108,6 @@ def _create_and_commit_unicode_slice(table: SqlaTable, title: str):
 
 
 def _cleanup(dash: Dashboard, slice_name: str) -> None:
-    engine = get_example_database().get_sqla_engine()
-    engine.execute("DROP TABLE IF EXISTS unicode_test")
     db.session.delete(dash)
     if slice_name:
         slice = db.session.query(Slice).filter_by(slice_name=slice_name).one_or_none()

--- a/tests/integration_tests/fixtures/world_bank_dashboard.py
+++ b/tests/integration_tests/fixtures/world_bank_dashboard.py
@@ -53,6 +53,11 @@ def load_world_bank_data():
         }
         create_table_for_dashboard(df, WB_HEALTH_POPULATION, database, dtype)
 
+    yield
+    with app.app_context():
+        engine = get_example_database().get_sqla_engine()
+        engine.execute("DROP TABLE IF EXISTS wb_health_population")
+
 
 @pytest.fixture()
 def load_world_bank_dashboard_with_slices(load_world_bank_data):
@@ -116,8 +121,6 @@ def _create_world_bank_dashboard(table: SqlaTable, slices: List[Slice]) -> Dashb
 
 
 def _cleanup(dash_id: int, slices_ids: List[int]) -> None:
-    engine = get_example_database().get_sqla_engine()
-    engine.execute("DROP TABLE IF EXISTS wb_health_population")
     dash = db.session.query(Dashboard).filter_by(id=dash_id).first()
     db.session.delete(dash)
     for slice_id in slices_ids:

--- a/tests/integration_tests/fixtures/world_bank_dashboard.py
+++ b/tests/integration_tests/fixtures/world_bank_dashboard.py
@@ -22,53 +22,58 @@ from typing import Any, Dict, List
 import pandas as pd
 import pytest
 from pandas import DataFrame
-from sqlalchemy import DateTime, String, TIMESTAMP
+from sqlalchemy import DateTime, String
 
 from superset import db
 from superset.connectors.sqla.models import SqlaTable
 from superset.models.core import Database
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
-from superset.utils.core import get_example_database, get_example_default_schema
+from superset.utils.core import get_example_database
 from tests.integration_tests.dashboard_utils import (
     create_dashboard,
-    create_table_for_dashboard,
+    create_table_for_dashboard, get_table,
 )
 from tests.integration_tests.test_app import app
 
 
+WB_HEALTH_POPULATION = "wb_health_population"
+
+
+@pytest.fixture(scope="session")
+def load_world_bank_data():
+    database = get_example_database()
+    df = _get_dataframe(database)
+    dtype = {
+        "year": DateTime if database.backend != "presto" else String(255),
+        "country_code": String(3),
+        "country_name": String(255),
+        "region": String(255),
+    }
+    create_table_for_dashboard(
+        df, WB_HEALTH_POPULATION, database, dtype
+    )
+
+
 @pytest.fixture()
-def load_world_bank_dashboard_with_slices():
-    dash_id_to_delete, slices_ids_to_delete = _load_data()
+def load_world_bank_dashboard_with_slices(load_world_bank_data):
+    dash_id_to_delete, slices_ids_to_delete = create_dashboard()
     yield
     with app.app_context():
         _cleanup(dash_id_to_delete, slices_ids_to_delete)
 
 
 @pytest.fixture(scope="module")
-def load_world_bank_dashboard_with_slices_module_scope():
-    dash_id_to_delete, slices_ids_to_delete = _load_data()
+def load_world_bank_dashboard_with_slices_module_scope(load_world_bank_data):
+    dash_id_to_delete, slices_ids_to_delete = create_dashboard()
     yield
     with app.app_context():
         _cleanup(dash_id_to_delete, slices_ids_to_delete)
 
 
-def _load_data():
-    table_name = "wb_health_population"
-
+def create_dashboard():
     with app.app_context():
-        database = get_example_database()
-        schema = get_example_default_schema()
-        df = _get_dataframe(database)
-        dtype = {
-            "year": DateTime if database.backend != "presto" else String(255),
-            "country_code": String(3),
-            "country_name": String(255),
-            "region": String(255),
-        }
-        table = create_table_for_dashboard(
-            df, table_name, database, dtype, schema=schema
-        )
+        table = get_table(WB_HEALTH_POPULATION, get_example_database())
         slices = _create_world_bank_slices(table)
         dash = _create_world_bank_dashboard(table, slices)
         slices_ids_to_delete = [slice.id for slice in slices]

--- a/tests/integration_tests/import_export_tests.py
+++ b/tests/integration_tests/import_export_tests.py
@@ -19,7 +19,8 @@
 import json
 import unittest
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 
 import pytest
@@ -27,7 +28,8 @@ from flask import g
 from sqlalchemy.orm.session import make_transient
 
 from tests.integration_tests.fixtures.energy_dashboard import (
-    load_energy_table_with_slice, load_energy_table_data
+    load_energy_table_with_slice,
+    load_energy_table_data,
 )
 from tests.integration_tests.test_app import app
 from superset.dashboards.commands.importers.v0 import decode_dashboards
@@ -46,7 +48,8 @@ from superset.models.slice import Slice
 from superset.utils.core import get_example_database, get_example_default_schema
 
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices, load_world_bank_data
+    load_world_bank_dashboard_with_slices,
+    load_world_bank_data,
 )
 from .base_tests import SupersetTestCase
 

--- a/tests/integration_tests/import_export_tests.py
+++ b/tests/integration_tests/import_export_tests.py
@@ -19,7 +19,7 @@
 import json
 import unittest
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 
 import pytest
@@ -27,7 +27,7 @@ from flask import g
 from sqlalchemy.orm.session import make_transient
 
 from tests.integration_tests.fixtures.energy_dashboard import (
-    load_energy_table_with_slice,
+    load_energy_table_with_slice, load_energy_table_data
 )
 from tests.integration_tests.test_app import app
 from superset.dashboards.commands.importers.v0 import decode_dashboards
@@ -46,7 +46,7 @@ from superset.models.slice import Slice
 from superset.utils.core import get_example_database, get_example_default_schema
 
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices,
+    load_world_bank_dashboard_with_slices, load_world_bank_data
 )
 from .base_tests import SupersetTestCase
 

--- a/tests/integration_tests/model_tests.py
+++ b/tests/integration_tests/model_tests.py
@@ -21,7 +21,8 @@ from unittest import mock
 
 from superset.exceptions import SupersetException
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 
 import pytest
@@ -38,7 +39,10 @@ from superset.models.sql_types.base import literal_dttm_type_factory
 from superset.utils.core import get_example_database
 
 from .base_tests import SupersetTestCase
-from .fixtures.energy_dashboard import load_energy_table_with_slice
+from .fixtures.energy_dashboard import (
+    load_energy_table_with_slice,
+    load_energy_table_data,
+)
 
 
 class TestDatabaseModel(SupersetTestCase):

--- a/tests/integration_tests/model_tests.py
+++ b/tests/integration_tests/model_tests.py
@@ -21,7 +21,7 @@ from unittest import mock
 
 from superset.exceptions import SupersetException
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 
 import pytest

--- a/tests/integration_tests/query_context_tests.py
+++ b/tests/integration_tests/query_context_tests.py
@@ -33,7 +33,8 @@ from superset.extensions import cache_manager
 from superset.utils.core import AdhocMetricExpressionType, backend, TimeRangeEndpoint
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 from tests.integration_tests.fixtures.query_context import get_query_context
 

--- a/tests/integration_tests/query_context_tests.py
+++ b/tests/integration_tests/query_context_tests.py
@@ -33,7 +33,7 @@ from superset.extensions import cache_manager
 from superset.utils.core import AdhocMetricExpressionType, backend, TimeRangeEndpoint
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 from tests.integration_tests.fixtures.query_context import get_query_context
 

--- a/tests/integration_tests/reports/api_tests.py
+++ b/tests/integration_tests/reports/api_tests.py
@@ -42,7 +42,7 @@ from superset.utils.core import get_example_database
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.conftest import with_feature_flags
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 from tests.integration_tests.reports.utils import insert_report_schedule
 

--- a/tests/integration_tests/reports/api_tests.py
+++ b/tests/integration_tests/reports/api_tests.py
@@ -42,7 +42,8 @@ from superset.utils.core import get_example_database
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.conftest import with_feature_flags
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 from tests.integration_tests.reports.utils import insert_report_schedule
 

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -58,7 +58,7 @@ from superset.reports.commands.execute import AsyncExecuteReportScheduleCommand
 from superset.reports.commands.log_prune import AsyncPruneReportScheduleLogCommand
 from superset.utils.core import get_example_database
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 from tests.integration_tests.fixtures.world_bank_dashboard import (
     load_world_bank_dashboard_with_slices_module_scope,

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -58,10 +58,12 @@ from superset.reports.commands.execute import AsyncExecuteReportScheduleCommand
 from superset.reports.commands.log_prune import AsyncPruneReportScheduleLogCommand
 from superset.utils.core import get_example_database
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 from tests.integration_tests.fixtures.world_bank_dashboard import (
     load_world_bank_dashboard_with_slices_module_scope,
+    load_world_bank_data,
 )
 from tests.integration_tests.reports.utils import insert_report_schedule
 from tests.integration_tests.test_app import app

--- a/tests/integration_tests/schedules_test.py
+++ b/tests/integration_tests/schedules_test.py
@@ -25,7 +25,7 @@ from selenium.common.exceptions import WebDriverException
 from slack import errors, WebClient
 
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices,
+    load_world_bank_dashboard_with_slices, load_world_bank_data
 )
 from tests.integration_tests.test_app import app
 from superset import db

--- a/tests/integration_tests/schedules_test.py
+++ b/tests/integration_tests/schedules_test.py
@@ -25,7 +25,8 @@ from selenium.common.exceptions import WebDriverException
 from slack import errors, WebClient
 
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices, load_world_bank_data
+    load_world_bank_dashboard_with_slices,
+    load_world_bank_data,
 )
 from tests.integration_tests.test_app import app
 from superset import db

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -47,20 +47,20 @@ from superset.views.access_requests import AccessRequestsModelView
 
 from .base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 from tests.integration_tests.fixtures.energy_dashboard import (
-    load_energy_table_with_slice,
+    load_energy_table_with_slice, load_energy_table_data
 )
 from tests.integration_tests.fixtures.public_role import (
     public_role_like_gamma,
     public_role_like_test_role,
 )
 from tests.integration_tests.fixtures.unicode_dashboard import (
-    load_unicode_dashboard_with_slice,
+    load_unicode_dashboard_with_slice, load_unicode_data
 )
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices,
+    load_world_bank_dashboard_with_slices, load_world_bank_data
 )
 
 NEW_SECURITY_CONVERGE_VIEWS = (

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -47,20 +47,24 @@ from superset.views.access_requests import AccessRequestsModelView
 
 from .base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 from tests.integration_tests.fixtures.energy_dashboard import (
-    load_energy_table_with_slice, load_energy_table_data
+    load_energy_table_with_slice,
+    load_energy_table_data,
 )
 from tests.integration_tests.fixtures.public_role import (
     public_role_like_gamma,
     public_role_like_test_role,
 )
 from tests.integration_tests.fixtures.unicode_dashboard import (
-    load_unicode_dashboard_with_slice, load_unicode_data
+    load_unicode_dashboard_with_slice,
+    load_unicode_data,
 )
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices, load_world_bank_data
+    load_world_bank_dashboard_with_slices,
+    load_world_bank_data,
 )
 
 NEW_SECURITY_CONVERGE_VIEWS = (

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -43,7 +43,8 @@ from superset.utils.core import (
     TemporalType,
 )
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 
 from .base_tests import SupersetTestCase

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -43,7 +43,7 @@ from superset.utils.core import (
     TemporalType,
 )
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 
 from .base_tests import SupersetTestCase

--- a/tests/integration_tests/sqllab_tests.py
+++ b/tests/integration_tests/sqllab_tests.py
@@ -57,7 +57,7 @@ from superset.utils.core import (
 from .base_tests import SupersetTestCase
 from .conftest import CTAS_SCHEMA_NAME
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 
 QUERY_1 = "SELECT * FROM birth_names LIMIT 1"

--- a/tests/integration_tests/sqllab_tests.py
+++ b/tests/integration_tests/sqllab_tests.py
@@ -57,7 +57,8 @@ from superset.utils.core import (
 from .base_tests import SupersetTestCase
 from .conftest import CTAS_SCHEMA_NAME
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 
 QUERY_1 = "SELECT * FROM birth_names LIMIT 1"

--- a/tests/integration_tests/strategy_tests.py
+++ b/tests/integration_tests/strategy_tests.py
@@ -20,7 +20,7 @@ import datetime
 import json
 from unittest.mock import MagicMock
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 
 from sqlalchemy import String, Date, Float

--- a/tests/integration_tests/strategy_tests.py
+++ b/tests/integration_tests/strategy_tests.py
@@ -20,7 +20,8 @@ import datetime
 import json
 from unittest.mock import MagicMock
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 
 from sqlalchemy import String, Date, Float
@@ -42,8 +43,11 @@ from superset.tasks.cache import (
 )
 
 from .base_tests import SupersetTestCase
-from .dashboard_utils import create_dashboard, create_slice, create_table_for_dashboard
-from .fixtures.unicode_dashboard import load_unicode_dashboard_with_slice
+from .dashboard_utils import create_dashboard, create_slice, create_table_metadata
+from .fixtures.unicode_dashboard import (
+    load_unicode_dashboard_with_slice,
+    load_unicode_data,
+)
 
 URL_PREFIX = "http://0.0.0.0:8081"
 

--- a/tests/integration_tests/tasks/async_queries_tests.py
+++ b/tests/integration_tests/tasks/async_queries_tests.py
@@ -34,7 +34,8 @@ from superset.tasks.async_queries import (
 )
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 from tests.integration_tests.fixtures.query_context import get_query_context
 from tests.integration_tests.test_app import app

--- a/tests/integration_tests/tasks/async_queries_tests.py
+++ b/tests/integration_tests/tasks/async_queries_tests.py
@@ -34,7 +34,7 @@ from superset.tasks.async_queries import (
 )
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 from tests.integration_tests.fixtures.query_context import get_query_context
 from tests.integration_tests.test_app import app

--- a/tests/integration_tests/utils_tests.py
+++ b/tests/integration_tests/utils_tests.py
@@ -25,7 +25,8 @@ import re
 from typing import Any, Tuple, List, Optional
 from unittest.mock import Mock, patch
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices, load_birth_names_data
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
 )
 
 import numpy as np
@@ -80,7 +81,8 @@ from superset.views.utils import (
 )
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices, load_world_bank_data
+    load_world_bank_dashboard_with_slices,
+    load_world_bank_data,
 )
 
 from .fixtures.certificates import ssl_certificate

--- a/tests/integration_tests/utils_tests.py
+++ b/tests/integration_tests/utils_tests.py
@@ -25,7 +25,7 @@ import re
 from typing import Any, Tuple, List, Optional
 from unittest.mock import Mock, patch
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
+    load_birth_names_dashboard_with_slices, load_birth_names_data
 )
 
 import numpy as np
@@ -80,7 +80,7 @@ from superset.views.utils import (
 )
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.world_bank_dashboard import (
-    load_world_bank_dashboard_with_slices,
+    load_world_bank_dashboard_with_slices, load_world_bank_data
 )
 
 from .fixtures.certificates import ssl_certificate

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ setenv =
     postgres: SUPERSET__SQLALCHEMY_DATABASE_URI = postgresql+psycopg2://superset:superset@localhost/test
     sqlite: SUPERSET__SQLALCHEMY_DATABASE_URI = sqlite:////{envtmpdir}/superset.db
     mysql-presto: SUPERSET__SQLALCHEMY_DATABASE_URI = mysql://mysqluser:mysqluserpassword@localhost/superset?charset=utf8
-    # docker run -p 8080:8080 --name presto prestosql/presto
+    # docker run -p 8080:8080 --name presto starburstdata/presto
     mysql-presto: SUPERSET__SQLALCHEMY_EXAMPLES_URI = presto://localhost:8080/memory/default
     # based on https://github.com/big-data-europe/docker-hadoop
     # clone the repo & run docker-compose up -d to test locally


### PR DESCRIPTION
### SUMMARY
Play with fixture scopes to see if tests will be faster
Hive and presto DBs are slow, we should load test data only once rather than do it for every module / test function

Speed improvements:
Python Presto/Hive / test-postgres-presto (3.8)  38m vs 92 m
Python Presto/Hive / test-postgres-hive 39m vs 53 m


There are probably other tests as well that can benefit from a similar improvement