### PR TITLE
fix(dashboard): commit update once

### DIFF
--- a/superset/dashboards/commands/update.py
+++ b/superset/dashboards/commands/update.py
@@ -34,6 +34,7 @@ from superset.dashboards.commands.exceptions import (
 )
 from superset.dashboards.dao import DashboardDAO
 from superset.exceptions import SupersetSecurityException
+from superset.extensions import db
 from superset.models.dashboard import Dashboard
 from superset.views.base import check_ownership
 
@@ -51,13 +52,14 @@ class UpdateDashboardCommand(UpdateMixin, BaseCommand):
         self.validate()
         try:
             dashboard = DashboardDAO.update(self._model, self._properties, commit=False)
-            dashboard = DashboardDAO.update_charts_owners(dashboard, commit=True)
+            dashboard = DashboardDAO.update_charts_owners(dashboard, commit=False)
             if self._properties.get("json_metadata"):
                 dashboard = DashboardDAO.set_dash_metadata(
                     dashboard,
                     data=json.loads(self._properties.get("json_metadata", "{}")),
-                    commit=True,
+                    commit=False,
                 )
+            db.session.commit()
         except DAOUpdateFailedError as ex:
             logger.exception(ex.exception)
             raise DashboardUpdateFailedError() from ex


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Recent changes to dashboard updates caused incorrect partial updates to be committed, resulting in malformed json in some db engines (mysql) and breaking dashboards that contained non ascii characters in headers or custom chart titles. This PR ensures that we only commit when all updates are complete.

This issue emerged in #17570. I verified that #17766 seemed to fix the problem in a test env, but it turns out this problem is likely db specific, so it did not actually address the root cause.

The root cause:
* `DashboardDAO.update` updates all properties naively, including `json_metadata`, which includes `positions`
* `DashboardDAO.update_charts_owners` _commits the changes done in `DashboardDAO.update`_. Something goes wrong when committing a string with emojis, resulting in a truncated `dashboard.json_metadata` for mysql.
* `DashboardDAO.set_dash_metadata` fetches `dashboard.params_dict`, which fails to parse due to malformed json. Error is thrown.

Other locations where we save json with emojis inadvertently use `json.dumps(json.loads(...))` to encode the emojis in a mysql-friendly way, so we didn't see this before.

### TESTING INSTRUCTIONS
Verified change locally with mysql db.

### ADDITIONAL INFORMATION
@geido @kgabryje @graceguo-supercat @etr2460 
