### PR TITLE
ci: make presto hive tests to cover only chartData and sqljson

### DIFF
--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Python unit tests (PostgreSQL)
         if: steps.check.outcome == 'failure'
         run: |
-          ./scripts/python_tests.sh -m "chart_data_flow or sql_json_flow"
+          ./scripts/python_tests.sh -m 'chart_data_flow or sql_json_flow'
       - name: Upload code coverage
         if: steps.check.outcome == 'failure'
         run: |
@@ -158,7 +158,7 @@ jobs:
       - name: Python unit tests (PostgreSQL)
         if: steps.check.outcome == 'failure'
         run: |
-          ./scripts/python_tests.sh -m "chart_data_flow or sql_json_flow"
+          ./scripts/python_tests.sh -m 'chart_data_flow or sql_json_flow'
       - name: Upload code coverage
         if: steps.check.outcome == 'failure'
         run: |

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Python unit tests (PostgreSQL)
         if: steps.check.outcome == 'failure'
         run: |
-          ./scripts/python_tests.sh
+          ./scripts/python_tests.sh -m "chart_data_flow or sql_json_flow"
       - name: Upload code coverage
         if: steps.check.outcome == 'failure'
         run: |
@@ -158,7 +158,7 @@ jobs:
       - name: Python unit tests (PostgreSQL)
         if: steps.check.outcome == 'failure'
         run: |
-          ./scripts/python_tests.sh
+          ./scripts/python_tests.sh -m "chart_data_flow or sql_json_flow"
       - name: Upload code coverage
         if: steps.check.outcome == 'failure'
         run: |

--- a/scripts/python_tests.sh
+++ b/scripts/python_tests.sh
@@ -31,4 +31,4 @@ superset db upgrade
 superset init
 
 echo "Running tests"
-pytest --durations=0 --maxfail=1 --cov=superset $@
+pytest --maxfail=1 --cov=superset "$@"

--- a/scripts/python_tests.sh
+++ b/scripts/python_tests.sh
@@ -31,4 +31,5 @@ superset db upgrade
 superset init
 
 echo "Running tests"
-pytest --maxfail=1 --cov=superset "$@"
+
+pytest --durations=0 --maxfail=1 --cov=superset "$@"

--- a/tests/integration_tests/sqllab_tests.py
+++ b/tests/integration_tests/sqllab_tests.py
@@ -65,6 +65,7 @@ QUERY_1 = "SELECT * FROM birth_names LIMIT 1"
 QUERY_2 = "SELECT * FROM NO_TABLE"
 QUERY_3 = "SELECT * FROM birth_names LIMIT 10"
 
+
 @pytest.mark.sql_json_flow
 class TestSqlLab(SupersetTestCase):
     """Testings for Sql Lab"""

--- a/tests/integration_tests/sqllab_tests.py
+++ b/tests/integration_tests/sqllab_tests.py
@@ -65,7 +65,7 @@ QUERY_1 = "SELECT * FROM birth_names LIMIT 1"
 QUERY_2 = "SELECT * FROM NO_TABLE"
 QUERY_3 = "SELECT * FROM birth_names LIMIT 10"
 
-
+@pytest.mark.sql_json_flow
 class TestSqlLab(SupersetTestCase):
     """Testings for Sql Lab"""
 


### PR DESCRIPTION
### SUMMARY
there have been a few attempts already to avoid the flakiness of the presto hive tests
in addition, we know that the original intention of that workflow was to test out the engine part of presto and hive
therefore we can just limit the tests the chart/data and sql_json API's which are executing the data querying part of superset

https://github.com/apache/superset/pull/17772
resolves https://github.com/apache/superset/issues/17750

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
