### PR TITLE
fix: New Members per Month time range

### DIFF
--- a/superset/examples/configs/charts/New_Members_per_Month.yaml
+++ b/superset/examples/configs/charts/New_Members_per_Month.yaml
@@ -56,7 +56,7 @@ params:
   start_y_axis_at_zero: true
   subheader_font_size: 0.15
   time_grain_sqla: P1M
-  time_range: Last year
+  time_range: No filter
   time_range_endpoints:
   - inclusive
   - exclusive


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The "New Members per Month" chart in the examples has a default time range without data.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

![Screenshot 2021-12-16 at 10-28-11  DEV  New Members per Month](https://user-images.githubusercontent.com/1534870/146428179-a5183073-61cc-48d4-9b42-ed84050f491a.png)

After:

![Screenshot 2021-12-16 at 10-25-51  DEV  New Members per Month](https://user-images.githubusercontent.com/1534870/146428188-4be071f3-f1ea-471c-9df3-b97f0a1d3ad3.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Run `superset load-examples`, the "Slack Dashboard" should show the chart with data.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
