### PR TITLE
fix: extra column in metrics

### DIFF
--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -157,6 +157,17 @@ class ImportV1ColumnSchema(Schema):
 
 
 class ImportV1MetricSchema(Schema):
+    # pylint: disable=no-self-use, unused-argument
+    @pre_load
+    def fix_extra(self, data: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:
+        """
+        Fix for extra initially beeing exported as a string.
+        """
+        if isinstance(data.get("extra"), str):
+            data["extra"] = json.loads(data["extra"])
+
+        return data
+
     metric_name = fields.String(required=True)
     verbose_name = fields.String(allow_none=True)
     metric_type = fields.String(allow_none=True)

--- a/tests/unit_tests/datasets/commands/export_test.py
+++ b/tests/unit_tests/datasets/commands/export_test.py
@@ -49,7 +49,11 @@ def test_export(app_context: None, session: Session) -> None:
         ),
     ]
     metrics = [
-        SqlMetric(metric_name="cnt", expression="COUNT(*)"),
+        SqlMetric(
+            metric_name="cnt",
+            expression="COUNT(*)",
+            extra=json.dumps({"warning_markdown": None}),
+        ),
     ]
 
     sqla_table = SqlaTable(
@@ -108,7 +112,8 @@ metrics:
   expression: COUNT(*)
   description: null
   d3format: null
-  extra: null
+  extra:
+    warning_markdown: null
   warning_text: null
 columns:
 - column_name: profit

--- a/tests/unit_tests/datasets/commands/importers/v1/import_test.py
+++ b/tests/unit_tests/datasets/commands/importers/v1/import_test.py
@@ -68,7 +68,7 @@ def test_import_(app_context: None, session: Session) -> None:
                 "expression": "COUNT(*)",
                 "description": None,
                 "d3format": None,
-                "extra": None,
+                "extra": {"warning_markdown": None},
                 "warning_text": None,
             }
         ],
@@ -115,7 +115,7 @@ def test_import_(app_context: None, session: Session) -> None:
     assert sqla_table.metrics[0].expression == "COUNT(*)"
     assert sqla_table.metrics[0].description is None
     assert sqla_table.metrics[0].d3format is None
-    assert sqla_table.metrics[0].extra is None
+    assert sqla_table.metrics[0].extra == '{"warning_markdown": null}'
     assert sqla_table.metrics[0].warning_text is None
     assert len(sqla_table.columns) == 1
     assert sqla_table.columns[0].column_name == "profit"
@@ -169,7 +169,18 @@ def test_import_column_extra_is_string(app_context: None, session: Session) -> N
         "fetch_values_predicate": "foo IN (1, 2)",
         "extra": '{"warning_markdown": "*WARNING*"}',
         "uuid": dataset_uuid,
-        "metrics": [],
+        "metrics": [
+            {
+                "metric_name": "cnt",
+                "verbose_name": None,
+                "metric_type": None,
+                "expression": "COUNT(*)",
+                "description": None,
+                "d3format": None,
+                "extra": '{"warning_markdown": null}',
+                "warning_text": None,
+            }
+        ],
         "columns": [
             {
                 "column_name": "profit",
@@ -193,5 +204,6 @@ def test_import_column_extra_is_string(app_context: None, session: Session) -> N
     dataset_config["database_id"] = database.id
     sqla_table = import_dataset(session, dataset_config)
 
+    assert sqla_table.metrics[0].extra == '{"warning_markdown": null}'
     assert sqla_table.columns[0].extra == '{"certified_by": "User"}'
     assert sqla_table.extra == '{"warning_markdown": "*WARNING*"}'


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Similar to (and stacked upon) https://github.com/apache/superset/pull/17740, this handles the `extra` column in dataset metrics.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
