### PR TITLE
fix: accept null params for validation

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2395,7 +2395,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         schema = request.form.get("schema") or None
         template_params = json.loads(request.form.get("templateParams") or "{}")
 
-        if len(template_params) > 0:
+        if template_params is not None and len(template_params) > 0:
             # TODO: factor the Database object out of template rendering
             #       or provide it as mydb so we can render template params
             #       without having to also persist a Query ORM object.

--- a/tests/integration_tests/base_tests.py
+++ b/tests/integration_tests/base_tests.py
@@ -458,6 +458,7 @@ class SupersetTestCase(TestCase):
         user_name=None,
         raise_on_error=False,
         database_name="examples",
+        template_params=None,
     ):
         if user_name:
             self.logout()
@@ -466,7 +467,12 @@ class SupersetTestCase(TestCase):
         resp = self.get_json_resp(
             "/superset/validate_sql_json/",
             raise_on_error=False,
-            data=dict(database_id=dbid, sql=sql, client_id=client_id),
+            data=dict(
+                database_id=dbid,
+                sql=sql,
+                client_id=client_id,
+                templateParams=template_params,
+            ),
         )
         if raise_on_error and "error" in resp:
             raise Exception("validate_sql failed")


### PR DESCRIPTION
### SUMMARY
If a null value is passed into the template Params for sql lab, the validation blows up.

json.loads("null") returns None.

### TESTING INSTRUCTIONS
Type `null` for a template param and type in the sql lab editor and watch the network requests. The `validate_sql_json` requests should not be 500s.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
