### PR TITLE
chore(plugin-chart-table): move adhoc filters control closer to the metrics

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -259,6 +259,7 @@ const config: ControlPanelConfig = {
             },
           },
         ],
+        ['adhoc_filters'],
         [
           {
             name: 'timeseries_limit_metric',
@@ -359,7 +360,6 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        ['adhoc_filters'],
         emitFilterControl,
       ],
     },


### PR DESCRIPTION
### SUMMARY
In most charts adhoc filters control is placed next to the metrics controls. This PR moves adhoc filters control from the bottom of control panel, so that it's next to the metrics for consistency with other charts.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://user-images.githubusercontent.com/15073128/146538186-a208cb99-979f-4cb1-ad76-59abc46fc3a7.png)

After:
![image](https://user-images.githubusercontent.com/15073128/146538145-c76219c0-1d02-43e2-b130-1b42d18a6259.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @kasiazjc