### PR TITLE
chore(plugin-chart-pivot-table): change order of Columns and Rows controls

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
@@ -43,21 +43,21 @@ const config: ControlPanelConfig = {
       controlSetRows: [
         [
           {
-            name: 'groupbyRows',
-            config: {
-              ...sharedControls.groupby,
-              label: t('Rows'),
-              description: t('Columns to group by on the rows'),
-            },
-          },
-        ],
-        [
-          {
             name: 'groupbyColumns',
             config: {
               ...sharedControls.groupby,
               label: t('Columns'),
               description: t('Columns to group by on the columns'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'groupbyRows',
+            config: {
+              ...sharedControls.groupby,
+              label: t('Rows'),
+              description: t('Columns to group by on the rows'),
             },
           },
         ],


### PR DESCRIPTION
### SUMMARY
Since column headers are visually above rows, it feels more logical to place the columns control above the rows control.
This PR changes the order of those controls

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://user-images.githubusercontent.com/15073128/146538819-9dae4681-fdcd-492d-8bfa-b4974f16b6b4.png)

After:
![image](https://user-images.githubusercontent.com/15073128/146539049-8778f63d-6a41-437e-8822-adea78c61170.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @kasiazjc