### PR TITLE
feat(plugin-chart-pivot-table): support series limit

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
@@ -19,46 +19,23 @@
 import {
   buildQueryContext,
   ensureIsArray,
-  getMetricLabel,
   normalizeOrderBy,
   QueryFormColumn,
 } from '@superset-ui/core';
 import { PivotTableQueryFormData } from '../types';
 
 export default function buildQuery(formData: PivotTableQueryFormData) {
-  const {
-    groupbyColumns = [],
-    groupbyRows = [],
-    order_desc = true,
-    legacy_order_by,
-  } = formData;
+  const { groupbyColumns = [], groupbyRows = [] } = formData;
   // TODO: add deduping of AdhocColumns
   const groupbySet = new Set([
     ...ensureIsArray<QueryFormColumn>(groupbyColumns),
     ...ensureIsArray<QueryFormColumn>(groupbyRows),
   ]);
-  return buildQueryContext(formData, baseQueryObject => {
-    const queryObject = normalizeOrderBy({
+  return buildQueryContext(formData, baseQueryObject => [
+    {
       ...baseQueryObject,
-      order_desc,
-      legacy_order_by,
-    });
-    const { metrics } = queryObject;
-    const orderBy = ensureIsArray(legacy_order_by);
-    if (
-      orderBy.length &&
-      !metrics?.find(
-        metric => getMetricLabel(metric) === getMetricLabel(orderBy[0]),
-      )
-    ) {
-      metrics?.push(orderBy[0]);
-    }
-    return [
-      {
-        ...queryObject,
-        columns: [...groupbySet],
-        metrics,
-      },
-    ];
-  });
+      orderby: normalizeOrderBy(baseQueryObject).orderby,
+      columns: [...groupbySet],
+    },
+  ]);
 }

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
@@ -36,8 +36,7 @@ export default function buildQuery(formData: PivotTableQueryFormData) {
     let orderBy: QueryFormOrderBy[] | undefined;
     if (series_limit_metric) {
       orderBy = [[series_limit_metric, !order_desc]];
-    }
-    if (Array.isArray(metrics) && metrics[0]) {
+    } else if (Array.isArray(metrics) && metrics[0]) {
       orderBy = [[metrics[0], !order_desc]];
     }
     return [

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
@@ -19,8 +19,8 @@
 import {
   buildQueryContext,
   ensureIsArray,
-  normalizeOrderBy,
   QueryFormColumn,
+  QueryFormOrderBy,
 } from '@superset-ui/core';
 import { PivotTableQueryFormData } from '../types';
 
@@ -31,11 +31,21 @@ export default function buildQuery(formData: PivotTableQueryFormData) {
     ...ensureIsArray<QueryFormColumn>(groupbyColumns),
     ...ensureIsArray<QueryFormColumn>(groupbyRows),
   ]);
-  return buildQueryContext(formData, baseQueryObject => [
-    {
-      ...baseQueryObject,
-      orderby: normalizeOrderBy(baseQueryObject).orderby,
-      columns: [...groupbySet],
-    },
-  ]);
+  return buildQueryContext(formData, baseQueryObject => {
+    const { series_limit_metric, metrics, order_desc } = baseQueryObject;
+    let orderBy: QueryFormOrderBy[] | undefined;
+    if (series_limit_metric) {
+      orderBy = [[series_limit_metric, !order_desc]];
+    }
+    if (Array.isArray(metrics) && metrics[0]) {
+      orderBy = [[metrics[0], !order_desc]];
+    }
+    return [
+      {
+        ...baseQueryObject,
+        orderby: orderBy,
+        columns: [...groupbySet],
+      },
+    ];
+  });
 }

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
@@ -100,6 +100,7 @@ const config: ControlPanelConfig = {
             },
           },
         ],
+        // TODO(kgabryje): add series_columns control after control panel is redesigned to avoid clutter
         [
           {
             name: 'series_limit_metric',

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
@@ -89,7 +89,7 @@ const config: ControlPanelConfig = {
         ],
         ['adhoc_filters'],
         emitFilterControl,
-        ['limit'],
+        ['series_limit'],
         [
           {
             name: 'row_limit',
@@ -102,9 +102,9 @@ const config: ControlPanelConfig = {
         ],
         [
           {
-            name: 'timeseries_limit_metric',
+            name: 'series_limit_metric',
             config: {
-              ...sharedControls.timeseries_limit_metric,
+              ...sharedControls.series_limit_metric,
               description: t(
                 'Metric used to define how the top series are sorted if a series or cell limit is present. ' +
                   'If undefined reverts to the first metric (where appropriate).',

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
@@ -30,7 +30,6 @@ import {
   sections,
   sharedControls,
   emitFilterControl,
-  legacySortBy,
 } from '@superset-ui/chart-controls';
 import { MetricsLayoutEnum } from '../types';
 
@@ -90,15 +89,40 @@ const config: ControlPanelConfig = {
         ],
         ['adhoc_filters'],
         emitFilterControl,
+        ['limit'],
         [
           {
             name: 'row_limit',
             config: {
               ...sharedControls.row_limit,
+              label: t('Cell limit'),
+              description: t('Limits the number of cells that get retrieved.'),
             },
           },
         ],
-        ...legacySortBy,
+        [
+          {
+            name: 'timeseries_limit_metric',
+            config: {
+              ...sharedControls.timeseries_limit_metric,
+              description: t(
+                'Metric used to define how the top series are sorted if a series or cell limit is present. ' +
+                  'If undefined reverts to the first metric (where appropriate).',
+              ),
+            },
+          },
+        ],
+        [
+          {
+            name: 'order_desc',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Sort Descending'),
+              default: true,
+              description: t('Whether to sort descending or ascending'),
+            },
+          },
+        ],
       ],
     },
     {
@@ -237,14 +261,14 @@ const config: ControlPanelConfig = {
               ],
               renderTrigger: true,
               description: (
-                <React.Fragment>
+                <>
                   <div>{t('Change order of rows.')}</div>
                   <div>{t('Available sorting modes:')}</div>
                   <ul>
                     <li>{t('By key: use row names as sorting key')}</li>
                     <li>{t('By value: use metric values as sorting key')}</li>
                   </ul>
-                </React.Fragment>
+                </>
               ),
             },
           },
@@ -265,14 +289,14 @@ const config: ControlPanelConfig = {
               ],
               renderTrigger: true,
               description: (
-                <React.Fragment>
+                <>
                   <div>{t('Change order of columns.')}</div>
                   <div>{t('Available sorting modes:')}</div>
                   <ul>
                     <li>{t('By key: use column names as sorting key')}</li>
                     <li>{t('By value: use metric values as sorting key')}</li>
                   </ul>
-                </React.Fragment>
+                </>
               ),
             },
           },

--- a/superset/migrations/versions/31bb738bd1d2_move_pivot_table_v2_legacy_order_by_to_.py
+++ b/superset/migrations/versions/31bb738bd1d2_move_pivot_table_v2_legacy_order_by_to_.py
@@ -1,0 +1,95 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""move_pivot_table_v2_legacy_order_by_to_timeseries_limit_metric
+
+Revision ID: 31bb738bd1d2
+Revises: fe23025b9441
+Create Date: 2021-12-17 16:56:55.186285
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "31bb738bd1d2"
+down_revision = "fe23025b9441"
+
+
+import json
+import logging
+
+from alembic import op
+from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
+
+Base = declarative_base()
+
+logger = logging.getLogger("alembic")
+
+
+class Slice(Base):
+    __tablename__ = "slices"
+
+    id = Column(Integer, primary_key=True)
+    params = Column(Text)
+    viz_type = Column(String(250))
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    slices = session.query(Slice).filter(Slice.viz_type == "pivot_table_v2").all()
+    for slc in slices:
+        try:
+            params = json.loads(slc.params)
+            legacy_order_by = params.pop("legacy_order_by", None)
+            if legacy_order_by:
+                params["timeseries_limit_metric"] = legacy_order_by
+            slc.params = json.dumps(params, sort_keys=True)
+        except Exception as e:
+            logger.exception(
+                f"An error occurred: parsing params for slice {slc.id} failed."
+                f"You need to fix it before upgrading your DB."
+            )
+            raise e
+
+    session.commit()
+    session.close()
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    slices = session.query(Slice).filter(Slice.viz_type == "pivot_table_v2").all()
+    for slc in slices:
+        try:
+            params = json.loads(slc.params)
+            timeseries_limit_metric = params.pop("timeseries_limit_metric", None)
+            if timeseries_limit_metric:
+                params["legacy_order_by"] = timeseries_limit_metric
+            slc.params = json.dumps(params, sort_keys=True)
+        except Exception as e:
+            logger.exception(
+                f"An error occurred: parsing params for slice {slc.id} failed. "
+                "You need to fix it before downgrading your DB."
+            )
+            raise e
+
+    session.commit()
+    session.close()

--- a/superset/migrations/versions/31bb738bd1d2_move_pivot_table_v2_legacy_order_by_to_.py
+++ b/superset/migrations/versions/31bb738bd1d2_move_pivot_table_v2_legacy_order_by_to_.py
@@ -59,7 +59,7 @@ def upgrade():
             params = json.loads(slc.params)
             legacy_order_by = params.pop("legacy_order_by", None)
             if legacy_order_by:
-                params["timeseries_limit_metric"] = legacy_order_by
+                params["series_limit_metric"] = legacy_order_by
             slc.params = json.dumps(params, sort_keys=True)
         except Exception as e:
             logger.exception(
@@ -80,9 +80,9 @@ def downgrade():
     for slc in slices:
         try:
             params = json.loads(slc.params)
-            timeseries_limit_metric = params.pop("timeseries_limit_metric", None)
-            if timeseries_limit_metric:
-                params["legacy_order_by"] = timeseries_limit_metric
+            series_limit_metric = params.pop("series_limit_metric", None)
+            if series_limit_metric:
+                params["legacy_order_by"] = series_limit_metric
             slc.params = json.dumps(params, sort_keys=True)
         except Exception as e:
             logger.exception(


### PR DESCRIPTION
### SUMMARY
Support series limit along with row limit in Pivot Table v2.

Migration benchmark results:
10+: 0.38 s
100+: 0.25 s
1000+: 0.24 s
10000+: 0.36 s
100000+: 0.46 s

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://user-images.githubusercontent.com/15073128/146569777-8806be44-09e3-4125-aa04-7ff506f05538.png)

After:
![image](https://user-images.githubusercontent.com/15073128/146569631-6d18e4cc-02fc-4e0b-92d0-a8c72c0baf31.png)

### TESTING INSTRUCTIONS
1. Create a Pivot Table v2 chart
2. Set a series limit and series limit metric
3. Click run and go to View Query
4. Verify that the query contains a JOIN subquery ordered by selected series limit metric and limit equal to series limit
5. Verify that the query limit is equal to Cell limit and is ordereb by series limit metric.
6. Remove series limit metric and rerun the query
7. Verify that the query and JOIN subquery are ordered by the first selected metric in Metrics control

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #16901, #13562
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @rusackas @graceguo-supercat
