### PR TITLE
fix: fetch latest version of chromedriver for superset worker

### DIFF
--- a/docs/src/pages/docs/installation/alerts_reports.mdx
+++ b/docs/src/pages/docs/installation/alerts_reports.mdx
@@ -175,7 +175,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends ./google-chrome-stable_current_amd64.deb && \
     rm -f google-chrome-stable_current_amd64.deb
 
-RUN export CHROMEDRIVER_VERSION=$(curl --silent https://chromedriver.storage.googleapis.com/LATEST_RELEASE_88) && \
+RUN export CHROMEDRIVER_VERSION=$(curl -sS https://chromedriver.storage.googleapis.com/LATEST_RELEASE) && \
     wget -q https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip && \
     unzip chromedriver_linux64.zip -d /usr/bin && \
     chmod 755 /usr/bin/chromedriver && \

--- a/docs/src/pages/docs/installation/kubernetes.mdx
+++ b/docs/src/pages/docs/installation/kubernetes.mdx
@@ -257,10 +257,11 @@ supersetWorker:
     - |
       # Install chrome webdriver
       # See https://github.com/apache/superset/blob/4fa3b6c7185629b87c27fc2c0e5435d458f7b73d/docs/src/pages/docs/installation/email_reports.mdx
+      CHROMEDRIVER_VERSION=$(curl -sS https://chromedriver.storage.googleapis.com/LATEST_RELEASE)
       apt update
       wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
       apt install -y --no-install-recommends ./google-chrome-stable_current_amd64.deb
-      wget https://chromedriver.storage.googleapis.com/88.0.4324.96/chromedriver_linux64.zip
+      wget https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip
       unzip chromedriver_linux64.zip
       chmod +x chromedriver
       mv chromedriver /usr/bin


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fetch latest chromedriver to make it compatible with the latest chromebrowser
curl flags: -S flag to show error and -s to keep it silent.

### TESTING INSTRUCTIONS
Deploy to kubernetes with the updated config.
The shell command can also be run on a terminal to verify that it's working and being set correctly as an env variable

### ADDITIONAL INFORMATION
Fixes #17809 
- [x] Has associated issue: #17809 
- [x] Required feature flags: ALERT_REPORTS
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
