### PR TITLE
fix: map schemes json to SequentialScheme (#17812)

### DIFF
--- a/superset-frontend/src/setup/setupColors.ts
+++ b/superset-frontend/src/setup/setupColors.ts
@@ -69,7 +69,11 @@ export default function setupColors(
   registerColorSchemes(
     // @ts-ignore
     getSequentialSchemeRegistry(),
-    [...SequentialCommon, ...SequentialD3, ...extraSequentialColorSchemes],
+    [
+      ...SequentialCommon,
+      ...SequentialD3,
+      ...extraSequentialColorSchemes.map(s => new SequentialScheme(s)),
+    ],
     'superset_seq_1',
   );
 }


### PR DESCRIPTION
### SUMMARY
In setupColor, json EXTRA_SEQUENTIAL_COLOR_SCHEMES schemes are mapped to SequentialScheme. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="320" alt="grafik" src="https://user-images.githubusercontent.com/2187389/146642134-6c210da8-9983-4413-8f53-be672391d7f0.png">

After:
<img width="250" alt="grafik" src="https://user-images.githubusercontent.com/2187389/146644185-f318a166-9230-4d4c-8bff-c518e5682820.png">


### TESTING INSTRUCTIONS
1. In superset_config.py, define EXTRA_SEQUENTIAL_COLOR_SCHEMES, e.g. like
```python
  EXTRA_SEQUENTIAL_COLOR_SCHEMES =[
    {
         "id": 'mySequentialScheme',
         "description": 'myDescription',
         "label": 'myLabel',
         "isDiverging": False,
         "colors":
          ['#dfdeeb', '#cac8dd', '#b5b2d0', '#a09dc2', 
           '#8d8ab6', '#7c79ab',
           '#6b69a0', '#5a5995', '#464889', '#2e367b']
    }
]
```
2. start superset
3. create a chart e.g. DeckGL polygon chart
3. In chart editor, Switch to Customize tab
4. See color dropdown which includes custom color scheme

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #17812
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
