### PR TITLE
fix: import typeddict from extensions

### DIFF
--- a/superset/dashboards/filter_state/commands/entry.py
+++ b/superset/dashboards/filter_state/commands/entry.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import TypedDict
+from typing_extensions import TypedDict
 
 
 class Entry(TypedDict):


### PR DESCRIPTION
### SUMMARY
`TypedDict` was only added to Python 3.8, so as long as we're still supporting Python 3.7, we need to import it from `typing_extensions`. Fixes #17802

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
