### PR TITLE
fix(deck.gl): update view state on property changes (#17720)

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/DeckGLContainer.jsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/DeckGLContainer.jsx
@@ -63,6 +63,12 @@ export class DeckGLContainer extends React.Component {
     };
   }
 
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    if (nextProps.viewport !== this.props.viewport) {
+      this.setState({ viewState: nextProps.viewport });
+    }
+  }
+
   componentWillUnmount() {
     clearInterval(this.state.timer);
   }

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/DeckGLContainer.jsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/DeckGLContainer.jsx
@@ -22,6 +22,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { isEqual } from 'lodash';
 import { StaticMap } from 'react-map-gl';
 import DeckGL from 'deck.gl';
 import { styled } from '@superset-ui/core';
@@ -64,7 +65,7 @@ export class DeckGLContainer extends React.Component {
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
-    if (nextProps.viewport !== this.props.viewport) {
+    if (!isEqual(nextProps.viewport, this.props.viewport)) {
       this.setState({ viewState: nextProps.viewport });
     }
   }


### PR DESCRIPTION
### SUMMARY
Updates viewport state of deck.gl on filter updates

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before (screeshot 1 & 2):
<img width="933" alt="grafik" src="https://user-images.githubusercontent.com/2187389/145705448-64a28e3a-83f1-411a-97a3-9b191dabff9d.png">
<img width="931" alt="grafik" src="https://user-images.githubusercontent.com/2187389/145705464-867f1931-df1f-478f-90cd-c7ba8361bb2b.png">

After:

https://user-images.githubusercontent.com/2187389/146766468-a031dad9-b4d1-48ff-b307-dbfa2dd79417.mov


### TESTING INSTRUCTIONS
1. Create a Dashboard containing a deck.gl polygon chart (auto zoom = True) with a column included in filter 
2. Open the dahsboard => the map is zoomed according to show features (screenshot 1)
3. Change native filter value
4. The map is now zoomed to the new bounding box (see video)

### ADDITIONAL INFORMATION
- [x] Has associated issue: fixes #17720 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
