### PR TITLE
fix: [WIP] fixing modal height to max out at viewport height

### DIFF
--- a/superset-frontend/src/components/Modal/Modal.tsx
+++ b/superset-frontend/src/components/Modal/Modal.tsx
@@ -91,9 +91,20 @@ export const StyledModal = styled(BaseModal)<StyledModalProps>`
       max-width: ${maxWidth ?? '900px'};
       padding-left: ${theme.gridUnit * 3}px;
       padding-right: ${theme.gridUnit * 3}px;
+      padding-bottom: 0;
+      top: 0;
     `}
 
+  .ant-modal-content {
+    display: flex;
+    flex-direction: column;
+    max-height: ${({ theme }) => 'calc(100vh - ' + theme.gridUnit * 8 + 'px)'};
+    margin-bottom: ${({ theme }) => theme.gridUnit * 4}px;
+    margin-top: ${({ theme }) => theme.gridUnit * 4}px;
+  }
+
   .ant-modal-header {
+    flex: 0 0 auto;
     background-color: ${({ theme }) => theme.colors.grayscale.light4};
     border-radius: ${({ theme }) => theme.borderRadius}px
       ${({ theme }) => theme.borderRadius}px 0 0;
@@ -121,11 +132,13 @@ export const StyledModal = styled(BaseModal)<StyledModalProps>`
   }
 
   .ant-modal-body {
+    flex: 0 1 100vh;
     padding: ${({ theme }) => theme.gridUnit * 4}px;
     overflow: auto;
     ${({ resizable, height }) => !resizable && height && `height: ${height};`}
   }
   .ant-modal-footer {
+    flex: 0 0 1;
     border-top: ${({ theme }) => theme.gridUnit / 4}px solid
       ${({ theme }) => theme.colors.grayscale.light2};
     padding: ${({ theme }) => theme.gridUnit * 4}px;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTitlePane.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTitlePane.tsx
@@ -55,6 +55,8 @@ const StyledAddBox = styled.div`
   ${({ theme }) => `
   cursor: pointer;
   margin: ${theme.gridUnit * 4}px;
+  position: sticky;
+  bottom: ${theme.gridUnit * 4}px;
   &:hover {
     color: ${theme.colors.primary.base};
   }


### PR DESCRIPTION
Some modals are too tall, or too far from the top, to show the action buttons at the bottom of the modal. This pins the modal to the top of the viewport, and makes the modal max out at the viewport height. Using flexbox, the modal header/footer take the space they need, and the modal body will scroll if needed.

The native filters configuration modal had an `+ add` button that would scroll offscreen because of this change. This PR also addresses that by making it sticky at the bottom. There may be other little modal layout oddities... I'll try to take a QA sweep before calling this one ready to merge.

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
