### PR TITLE
chore: remove redundant process polyfill from webpack config

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -308,7 +308,6 @@
     "node-fetch": "^2.6.1",
     "prettier": "^2.4.1",
     "prettier-plugin-packagejson": "^2.2.15",
-    "process": "^0.11.10",
     "react-resizable": "^3.0.4",
     "react-test-renderer": "^16.9.0",
     "redux-mock-store": "^1.5.4",

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -73,10 +73,6 @@ if (!isDevMode) {
 }
 
 const plugins = [
-  new webpack.ProvidePlugin({
-    process: 'process/browser',
-  }),
-
   // creates a manifest.json mapping of name to hashed output used in template files
   new WebpackManifestPlugin({
     publicPath: output.publicPath,


### PR DESCRIPTION
### SUMMARY
Removes `process` polyfill dependency and webpack config for providing `process` variable in browser - we don't use it anywhere.
The only usage of `process` in the frontend code is `process.env.WEBPACK_MODE` - to provide it, we use webpack's `DefinePlugin`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
Everything should work as before.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
