### PR TITLE
feat: add force option to report screenshots

### DIFF
--- a/superset-frontend/src/components/ReportModal/index.tsx
+++ b/superset-frontend/src/components/ReportModal/index.tsx
@@ -71,6 +71,7 @@ export interface ReportObject {
   validator_type: string;
   working_timeout: number;
   creation_method: string;
+  force_screenshot: boolean;
 }
 
 interface ChartObject {
@@ -227,6 +228,7 @@ const ReportModal: FunctionComponent<ReportProps> = ({
       active: true,
       report_format: currentReport?.report_format || defaultNotificationFormat,
       timezone: currentReport?.timezone,
+      force_screenshot: false,
     };
 
     if (isEditMode) {

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -154,7 +154,7 @@ const DEFAULT_ALERT = {
   sql: '',
   validator_config_json: {},
   validator_type: '',
-  force_screenshot: true,
+  force_screenshot: false,
   grace_period: undefined,
 };
 
@@ -513,7 +513,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
     const data: any = {
       ...currentAlert,
       type: isReport ? 'Report' : 'Alert',
-      force_screenshot: isReport ? 'false' : 'true',
+      force_screenshot: contentType === 'chart' && !isReport ? 'true' : 'false',
       validator_type: conditionNotNull ? 'not null' : 'operator',
       validator_config_json: conditionNotNull
         ? {}

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -154,6 +154,7 @@ const DEFAULT_ALERT = {
   sql: '',
   validator_config_json: {},
   validator_type: '',
+  force_screenshot: true,
   grace_period: undefined,
 };
 
@@ -512,6 +513,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
     const data: any = {
       ...currentAlert,
       type: isReport ? 'Report' : 'Alert',
+      force_screenshot: isReport ? 'false' : 'true',
       validator_type: conditionNotNull ? 'not null' : 'operator',
       validator_config_json: conditionNotNull
         ? {}

--- a/superset/migrations/versions/bb38f40aa3ff_add_force_screenshot_to_alerts_reports.py
+++ b/superset/migrations/versions/bb38f40aa3ff_add_force_screenshot_to_alerts_reports.py
@@ -17,14 +17,14 @@
 """Add force_screenshot to alerts/reports
 
 Revision ID: bb38f40aa3ff
-Revises: abe27eaf93db
+Revises: 31bb738bd1d2
 Create Date: 2021-12-10 19:25:29.802949
 
 """
 
 # revision identifiers, used by Alembic.
 revision = "bb38f40aa3ff"
-down_revision = "abe27eaf93db"
+down_revision = "31bb738bd1d2"
 
 import sqlalchemy as sa
 from alembic import op

--- a/superset/migrations/versions/bb38f40aa3ff_add_force_screenshot_to_alerts_reports.py
+++ b/superset/migrations/versions/bb38f40aa3ff_add_force_screenshot_to_alerts_reports.py
@@ -51,7 +51,10 @@ def upgrade():
     session = db.Session(bind=bind)
 
     for report in session.query(ReportSchedule).all():
-        report.force_screenshot = report.type == "Alert"
+        # Update existing alerts that send chart screenshots so that the cache is
+        # bypassed. We don't turn this one for dashboards because (1) it's currently
+        # not supported but also because (2) it can be very expensive.
+        report.force_screenshot = report.type == "Alert" and report.chart_id is not None
 
     session.commit()
 

--- a/superset/migrations/versions/bb38f40aa3ff_add_force_screenshot_to_alerts_reports.py
+++ b/superset/migrations/versions/bb38f40aa3ff_add_force_screenshot_to_alerts_reports.py
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Add force_screenshot to alerts/reports
+
+Revision ID: bb38f40aa3ff
+Revises: abe27eaf93db
+Create Date: 2021-12-10 19:25:29.802949
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "bb38f40aa3ff"
+down_revision = "abe27eaf93db"
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
+
+Base = declarative_base()
+
+
+class ReportSchedule(Base):
+    __tablename__ = "report_schedule"
+
+    id = sa.Column(sa.Integer, primary_key=True)
+    type = sa.Column(sa.String(50), nullable=False)
+    force_screenshot = sa.Column(sa.Boolean, default=False)
+
+
+def upgrade():
+    with op.batch_alter_table("report_schedule") as batch_op:
+        batch_op.add_column(sa.Column("force_screenshot", sa.Boolean(), default=False))
+
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for report in session.query(ReportSchedule).all():
+        report.force_screenshot = report.type == "Alert"
+
+    session.commit()
+
+
+def downgrade():
+    with op.batch_alter_table("report_schedule") as batch_op:
+        batch_op.drop_column("force_screenshot")

--- a/superset/models/reports.py
+++ b/superset/models/reports.py
@@ -148,6 +148,10 @@ class ReportSchedule(Model, AuditMixinNullable):
     # Store the selected dashboard tabs etc.
     extra = Column(Text, default="{}")
 
+    # (Reports) When generating a screenshot, bypass the cache? This is always true for
+    # Alerts.
+    force_screenshot = Column(Boolean, default=False)
+
     def __repr__(self) -> str:
         return str(self.name)
 

--- a/superset/models/reports.py
+++ b/superset/models/reports.py
@@ -148,8 +148,7 @@ class ReportSchedule(Model, AuditMixinNullable):
     # Store the selected dashboard tabs etc.
     extra = Column(Text, default="{}")
 
-    # (Reports) When generating a screenshot, bypass the cache? This is always true for
-    # Alerts.
+    # (Reports) When generating a screenshot, bypass the cache?
     force_screenshot = Column(Boolean, default=False)
 
     def __repr__(self) -> str:

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -175,7 +175,7 @@ class BaseReportState:
             user_friendly=user_friendly,
             dashboard_id_or_slug=self._report_schedule.dashboard_id,
             standalone=DashboardStandaloneMode.REPORT.value,
-            force=force,
+            # force=force,  TODO (betodealmeida) implement this
             **kwargs,
         )
 

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -148,13 +148,7 @@ class BaseReportState:
         """
         # For alerts we always want to send a fresh screenshot, bypassing
         # the cache.
-        # TODO (betodealmeida): allow to specify per report if users want
-        # to bypass the cache as well.
-        force = (
-            "true"
-            if self._report_schedule.type == ReportScheduleType.ALERT
-            else "false"
-        )
+        force = "true" if self._report_schedule.force_screenshot else "false"
 
         if self._report_schedule.chart:
             if result_format in {

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -202,6 +202,7 @@ class ReportSchedulePostSchema(Schema):
         default=ReportDataFormat.VISUALIZATION,
         validate=validate.OneOf(choices=tuple(key.value for key in ReportDataFormat)),
     )
+    force_screenshot = fields.Boolean(default=False)
 
     @validates_schema
     def validate_report_references(  # pylint: disable=unused-argument,no-self-use
@@ -292,3 +293,4 @@ class ReportSchedulePutSchema(Schema):
         default=ReportDataFormat.VISUALIZATION,
         validate=validate.OneOf(choices=tuple(key.value for key in ReportDataFormat)),
     )
+    force_screenshot = fields.Boolean(default=False)

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -368,7 +368,9 @@ def create_alert_slack_chart_success():
 
 
 @pytest.fixture(
-    params=["alert1",]
+    params=[
+        "alert1",
+    ]
 )
 def create_alert_slack_chart_grace(request):
     param_config = {
@@ -645,7 +647,9 @@ def create_invalid_sql_alert_email_chart(request):
 @patch("superset.reports.notifications.email.send_email_smtp")
 @patch("superset.utils.screenshots.ChartScreenshot.get_screenshot")
 def test_email_chart_report_schedule(
-    screenshot_mock, email_mock, create_report_email_chart,
+    screenshot_mock,
+    email_mock,
+    create_report_email_chart,
 ):
     """
     ExecuteReport Command: Test chart email report schedule with screenshot
@@ -684,7 +688,9 @@ def test_email_chart_report_schedule(
 @patch("superset.reports.notifications.email.send_email_smtp")
 @patch("superset.utils.screenshots.ChartScreenshot.get_screenshot")
 def test_email_chart_alert_schedule(
-    screenshot_mock, email_mock, create_alert_email_chart,
+    screenshot_mock,
+    email_mock,
+    create_alert_email_chart,
 ):
     """
     ExecuteReport Command: Test chart email alert schedule with screenshot
@@ -721,7 +727,9 @@ def test_email_chart_alert_schedule(
 @patch("superset.reports.notifications.email.send_email_smtp")
 @patch("superset.utils.screenshots.ChartScreenshot.get_screenshot")
 def test_email_chart_report_dry_run(
-    screenshot_mock, email_mock, create_report_email_chart,
+    screenshot_mock,
+    email_mock,
+    create_report_email_chart,
 ):
     """
     ExecuteReport Command: Test chart email report schedule dry run
@@ -746,7 +754,11 @@ def test_email_chart_report_dry_run(
 @patch("superset.reports.notifications.email.send_email_smtp")
 @patch("superset.utils.csv.get_chart_csv_data")
 def test_email_chart_report_schedule_with_csv(
-    csv_mock, email_mock, mock_open, mock_urlopen, create_report_email_chart_with_csv,
+    csv_mock,
+    email_mock,
+    mock_open,
+    mock_urlopen,
+    create_report_email_chart_with_csv,
 ):
     """
     ExecuteReport Command: Test chart email report schedule with CSV
@@ -935,7 +947,9 @@ def test_email_dashboard_report_schedule(
 @patch("superset.reports.notifications.slack.WebClient.files_upload")
 @patch("superset.utils.screenshots.ChartScreenshot.get_screenshot")
 def test_slack_chart_report_schedule(
-    screenshot_mock, file_upload_mock, create_report_slack_chart,
+    screenshot_mock,
+    file_upload_mock,
+    create_report_slack_chart,
 ):
     """
     ExecuteReport Command: Test chart slack report schedule
@@ -1154,7 +1168,9 @@ def test_report_schedule_success_grace_end(
 @patch("superset.reports.notifications.email.send_email_smtp")
 @patch("superset.utils.screenshots.ChartScreenshot.get_screenshot")
 def test_alert_limit_is_applied(
-    screenshot_mock, email_mock, create_alert_email_chart,
+    screenshot_mock,
+    email_mock,
+    create_alert_email_chart,
 ):
     """
     ExecuteReport Command: Test that all alerts apply a SQL limit to stmts
@@ -1210,7 +1226,9 @@ def test_email_dashboard_report_fails(
     ALERTS_ATTACH_REPORTS=True,
 )
 def test_slack_chart_alert(
-    screenshot_mock, email_mock, create_alert_email_chart,
+    screenshot_mock,
+    email_mock,
+    create_alert_email_chart,
 ):
     """
     ExecuteReport Command: Test chart slack alert
@@ -1267,7 +1285,9 @@ def test_slack_chart_alert_no_attachment(email_mock, create_alert_email_chart):
 @patch("superset.reports.notifications.slack.WebClient")
 @patch("superset.utils.screenshots.ChartScreenshot.get_screenshot")
 def test_slack_token_callable_chart_report(
-    screenshot_mock, slack_client_mock_class, create_report_slack_chart,
+    screenshot_mock,
+    slack_client_mock_class,
+    create_report_slack_chart,
 ):
     """
     ExecuteReport Command: Test chart slack alert (slack token callable)
@@ -1379,7 +1399,11 @@ def test_soft_timeout_screenshot(screenshot_mock, email_mock, create_alert_email
 @patch("superset.reports.notifications.email.send_email_smtp")
 @patch("superset.utils.csv.get_chart_csv_data")
 def test_soft_timeout_csv(
-    csv_mock, email_mock, mock_open, mock_urlopen, create_report_email_chart_with_csv,
+    csv_mock,
+    email_mock,
+    mock_open,
+    mock_urlopen,
+    create_report_email_chart_with_csv,
 ):
     """
     ExecuteReport Command: Test fail on generating csv
@@ -1403,7 +1427,8 @@ def test_soft_timeout_csv(
     assert email_mock.call_args[0][0] == OWNER_EMAIL
 
     assert_log(
-        ReportState.ERROR, error_message="A timeout occurred while generating a csv.",
+        ReportState.ERROR,
+        error_message="A timeout occurred while generating a csv.",
     )
 
 
@@ -1415,7 +1440,11 @@ def test_soft_timeout_csv(
 @patch("superset.reports.notifications.email.send_email_smtp")
 @patch("superset.utils.csv.get_chart_csv_data")
 def test_generate_no_csv(
-    csv_mock, email_mock, mock_open, mock_urlopen, create_report_email_chart_with_csv,
+    csv_mock,
+    email_mock,
+    mock_open,
+    mock_urlopen,
+    create_report_email_chart_with_csv,
 ):
     """
     ExecuteReport Command: Test fail on generating csv
@@ -1600,7 +1629,9 @@ def test_grace_period_error(email_mock, create_invalid_sql_alert_email_chart):
 @patch("superset.reports.notifications.email.send_email_smtp")
 @patch("superset.utils.screenshots.ChartScreenshot.get_screenshot")
 def test_grace_period_error_flap(
-    screenshot_mock, email_mock, create_invalid_sql_alert_email_chart,
+    screenshot_mock,
+    email_mock,
+    create_invalid_sql_alert_email_chart,
 ):
     """
     ExecuteReport Command: Test alert grace period on error

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -774,43 +774,6 @@ def test_email_chart_alert_schedule(
 
 
 @pytest.mark.usefixtures(
-    "load_birth_names_dashboard_with_slices", "create_alert_email_chart"
-)
-@patch("superset.reports.notifications.email.send_email_smtp")
-@patch("superset.utils.screenshots.ChartScreenshot.get_screenshot")
-def test_email_chart_alert_schedule(
-    screenshot_mock, email_mock, create_alert_email_chart,
-):
-    """
-    ExecuteReport Command: Test chart email alert schedule with screenshot
-    """
-    # setup screenshot mock
-    screenshot_mock.return_value = SCREENSHOT_FILE
-
-    with freeze_time("2020-01-01T00:00:00Z"):
-        AsyncExecuteReportScheduleCommand(
-            TEST_ID, create_alert_email_chart.id, datetime.utcnow()
-        ).run()
-
-        notification_targets = get_target_from_report_schedule(create_alert_email_chart)
-        # assert that the link sent is correct
-        assert (
-            '<a href="http://0.0.0.0:8080/superset/explore/?'
-            "form_data=%7B%22slice_id%22%3A+"
-            f"{create_alert_email_chart.chart.id}%7D&"
-            'standalone=true&force=true">Explore in Superset</a>'
-            in email_mock.call_args[0][2]
-        )
-        # Assert the email smtp address
-        assert email_mock.call_args[0][0] == notification_targets[0]
-        # Assert the email inline screenshot
-        smtp_images = email_mock.call_args[1]["images"]
-        assert smtp_images[list(smtp_images.keys())[0]] == SCREENSHOT_FILE
-        # Assert logs are correct
-        assert_log(ReportState.SUCCESS)
-
-
-@pytest.mark.usefixtures(
     "load_birth_names_dashboard_with_slices", "create_report_email_chart"
 )
 @patch("superset.reports.notifications.email.send_email_smtp")

--- a/tests/integration_tests/reports/utils.py
+++ b/tests/integration_tests/reports/utils.py
@@ -51,6 +51,7 @@ def insert_report_schedule(
     recipients: Optional[List[ReportRecipients]] = None,
     report_format: Optional[ReportDataFormat] = None,
     logs: Optional[List[ReportExecutionLog]] = None,
+    force_screenshot: bool = False,
 ) -> ReportSchedule:
     owners = owners or []
     recipients = recipients or []
@@ -75,6 +76,7 @@ def insert_report_schedule(
         logs=logs,
         last_state=last_state,
         report_format=report_format,
+        force_screenshot=force_screenshot,
     )
     db.session.add(report_schedule)
     db.session.commit()


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add a new column `force_screenshot` to the reports/alerts model. For alerts with charts this is always set to true. For reports and alerts with dashboards this is currently set to false, and is made configurable for reports in https://github.com/apache/superset/pull/17855.

When the flag is true, when generating a screenshot for the alert/report the cache will be bypassed.

Depends on https://github.com/apache/superset/pull/17695.

### MIGRATION

DB migration adds a new column `force_screenshot`, set to true for existing alerts with  charts, false otherwise.

Results:

Current: 0.34 s
10+: 0.35 s
100+: 0.39 s
1000+: 0.74 s
10000+: 3.58 s
100000+: 32.59 s
1000000+: 453.84 s

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Create a report and a alert.
2. Run `SELECT force_screenshot FROM report_schedule`, check that it's true for the alert and false for the report.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [X] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [X] Migration is atomic, supports rollback & is backwards-compatible
  - [X] Confirm DB migration upgrade and downgrade tested
  - [X] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API