### PR TITLE
fix(translation): include babel-compile in Dockerfile (#17876)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,8 @@ COPY superset /app/superset
 COPY setup.py MANIFEST.in README.md /app/
 RUN cd /app \
         && chown -R superset:superset * \
-        && pip install -e .
+        && pip install -e . \
+        && flask fab babel-compile --target superset/translations
 
 COPY ./docker/run-server.sh /usr/bin/
 


### PR DESCRIPTION
### SUMMARY
Adds babel-compile step in Dockerfile.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After:
<img width="1672" alt="image" src="https://user-images.githubusercontent.com/2187389/147451376-46d4976e-514c-4142-97e5-8e46500c618f.png">

### TESTING INSTRUCTIONS
1. Enable a rather complete language in superset_config_docker.py:
```
BABEL_DEFAULT_LOCALE = "de"
LANGUAGES = {
    "de": {"flag": "de", "name": "Deutsch"},
    "en": {"flag": "us", "name": "English"},
}
```
2. build docker images via `docker build -t apache/superset:latest-dev .`
3. Start superset via `docker-compose -f docker-compose-non-dev.yml' up -d`
4. Open http://localhost:8088/ 
5. See formerly untranslated messages now translated


### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #17876 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
