### PR TITLE
fix: Returns 404 instead of 500 for unknown dashboard filter state keys

### DIFF
--- a/superset/dashboards/filter_state/commands/get.py
+++ b/superset/dashboards/filter_state/commands/get.py
@@ -29,6 +29,6 @@ class GetFilterStateCommand(GetKeyValueCommand):
         entry: Entry = cache_manager.filter_state_cache.get(
             cache_key(resource_id, key)
         ) or {}
-        if dashboard and entry and refresh_timeout:
+        if entry and refresh_timeout:
             cache_manager.filter_state_cache.set(key, entry)
         return entry.get("value")

--- a/superset/dashboards/filter_state/commands/get.py
+++ b/superset/dashboards/filter_state/commands/get.py
@@ -26,12 +26,9 @@ from superset.key_value.utils import cache_key
 class GetFilterStateCommand(GetKeyValueCommand):
     def get(self, resource_id: int, key: str, refresh_timeout: bool) -> Optional[str]:
         dashboard = DashboardDAO.get_by_id_or_slug(str(resource_id))
-        if dashboard:
-            entry: Entry = cache_manager.filter_state_cache.get(
-                cache_key(resource_id, key)
-            )
-            if entry:
-                if refresh_timeout:
-                    cache_manager.filter_state_cache.set(key, entry)
-                return entry["value"]
-        return None
+        entry: Entry = cache_manager.filter_state_cache.get(
+            cache_key(resource_id, key)
+        ) or {}
+        if dashboard and entry and refresh_timeout:
+            cache_manager.filter_state_cache.set(key, entry)
+        return entry.get("value")

--- a/superset/dashboards/filter_state/commands/get.py
+++ b/superset/dashboards/filter_state/commands/get.py
@@ -17,7 +17,6 @@
 from typing import Optional
 
 from superset.dashboards.dao import DashboardDAO
-from superset.dashboards.filter_state.commands.entry import Entry
 from superset.extensions import cache_manager
 from superset.key_value.commands.get import GetKeyValueCommand
 from superset.key_value.utils import cache_key

--- a/superset/dashboards/filter_state/commands/get.py
+++ b/superset/dashboards/filter_state/commands/get.py
@@ -26,9 +26,7 @@ from superset.key_value.utils import cache_key
 class GetFilterStateCommand(GetKeyValueCommand):
     def get(self, resource_id: int, key: str, refresh_timeout: bool) -> Optional[str]:
         DashboardDAO.get_by_id_or_slug(str(resource_id))
-        entry: Entry = cache_manager.filter_state_cache.get(
-            cache_key(resource_id, key)
-        ) or {}
+        entry = cache_manager.filter_state_cache.get(cache_key(resource_id, key)) or {}
         if entry and refresh_timeout:
             cache_manager.filter_state_cache.set(key, entry)
         return entry.get("value")

--- a/superset/dashboards/filter_state/commands/get.py
+++ b/superset/dashboards/filter_state/commands/get.py
@@ -25,7 +25,7 @@ from superset.key_value.utils import cache_key
 
 class GetFilterStateCommand(GetKeyValueCommand):
     def get(self, resource_id: int, key: str, refresh_timeout: bool) -> Optional[str]:
-        dashboard = DashboardDAO.get_by_id_or_slug(str(resource_id))
+        DashboardDAO.get_by_id_or_slug(str(resource_id))
         entry: Entry = cache_manager.filter_state_cache.get(
             cache_key(resource_id, key)
         ) or {}

--- a/superset/dashboards/filter_state/commands/get.py
+++ b/superset/dashboards/filter_state/commands/get.py
@@ -30,7 +30,8 @@ class GetFilterStateCommand(GetKeyValueCommand):
             entry: Entry = cache_manager.filter_state_cache.get(
                 cache_key(resource_id, key)
             )
-            if refresh_timeout:
-                cache_manager.filter_state_cache.set(key, entry)
-            return entry["value"]
+            if entry:
+                if refresh_timeout:
+                    cache_manager.filter_state_cache.set(key, entry)
+                return entry["value"]
         return None

--- a/tests/integration_tests/dashboards/filter_state/api_tests.py
+++ b/tests/integration_tests/dashboards/filter_state/api_tests.py
@@ -146,9 +146,9 @@ def test_put_not_owner(client, dashboard_id: int):
     assert resp.status_code == 403
 
 
-def test_get_key_not_found(client):
+def test_get_key_not_found(client, dashboard_id: int):
     login(client, "admin")
-    resp = client.get("unknown-key")
+    resp = client.get(f"api/v1/dashboard/{dashboard_id}/filter_state/unknown-key/")
     assert resp.status_code == 404
 
 


### PR DESCRIPTION
### SUMMARY
Returns 404 instead of 500 for unknown dashboard filter state keys.

### TESTING INSTRUCTIONS
1 - Execute all tests
2 - All tests should pass

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
