### PR TITLE
fix(sql): unable to filter text with quotes

### DIFF
--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 import json
-import re
 from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, Hashable, List, Optional, Set, Type, Union

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -401,10 +401,6 @@ class BaseDatasource(
             if isinstance(value, str):
                 value = value.strip("\t\n")
 
-                quotes_value = re.findall(r"['|\"](.*?)['|\"]", value)
-                if len(quotes_value) == 1 and quotes_value[0] == value.strip("'\""):
-                    value = value.strip("'\"")
-
                 if target_column_type == utils.GenericDataType.NUMERIC:
                     # For backwards compatibility and edge cases
                     # where a column data type might have changed

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import json
+import re
 from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, Hashable, List, Optional, Set, Type, Union
@@ -398,7 +399,11 @@ class BaseDatasource(
             ):
                 return datetime.utcfromtimestamp(value / 1000)
             if isinstance(value, str):
-                value = value.strip("\t\n ")
+                value = value.strip("\t\n")
+
+                quotes_value = re.findall(r"['|\"](.*?)['|\"]", value)
+                if len(quotes_value) == 1 and quotes_value[0] == value.strip("'\""):
+                    value = value.strip("'\"")
 
                 if target_column_type == utils.GenericDataType.NUMERIC:
                     # For backwards compatibility and edge cases

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -398,7 +398,7 @@ class BaseDatasource(
             ):
                 return datetime.utcfromtimestamp(value / 1000)
             if isinstance(value, str):
-                value = value.strip("\t\n'\"")
+                value = value.strip("\t\n ")
 
                 if target_column_type == utils.GenericDataType.NUMERIC:
                     # For backwards compatibility and edge cases

--- a/tests/integration_tests/druid_func_tests.py
+++ b/tests/integration_tests/druid_func_tests.py
@@ -359,7 +359,7 @@ class TestDruidFunc(SupersetTestCase):
         col = DruidColumn(column_name="A")
         column_dict = {"A": col}
         res = DruidDatasource.get_filters([filtr], [], column_dict)
-        self.assertEqual("a", res.filter["filter"]["value"])
+        self.assertEqual('"a"', res.filter["filter"]["value"])
 
     @unittest.skipUnless(
         SupersetTestCase.is_module_installed("pydruid"), "pydruid not installed"

--- a/tests/integration_tests/druid_func_tests.py
+++ b/tests/integration_tests/druid_func_tests.py
@@ -364,16 +364,6 @@ class TestDruidFunc(SupersetTestCase):
     @unittest.skipUnless(
         SupersetTestCase.is_module_installed("pydruid"), "pydruid not installed"
     )
-    def test_get_filters_keeps_values_if_not_between_in_quotes(self):
-        filtr = {"col": "A", "op": "in", "val": ["'a'b"]}
-        col = DruidColumn(column_name="A")
-        column_dict = {"A": col}
-        res = DruidDatasource.get_filters([filtr], [], column_dict)
-        self.assertEqual("'a'b", res.filter["filter"]["value"])
-
-    @unittest.skipUnless(
-        SupersetTestCase.is_module_installed("pydruid"), "pydruid not installed"
-    )
     def test_get_filters_keeps_trailing_spaces(self):
         filtr = {"col": "A", "op": "in", "val": ["a "]}
         col = DruidColumn(column_name="A")

--- a/tests/integration_tests/druid_func_tests.py
+++ b/tests/integration_tests/druid_func_tests.py
@@ -365,7 +365,7 @@ class TestDruidFunc(SupersetTestCase):
         SupersetTestCase.is_module_installed("pydruid"), "pydruid not installed"
     )
     def test_get_filters_keeps_values_if_not_between_in_quotes(self):
-        filtr = {"col": "A", "op": "in", "val": ['"a"b']}
+        filtr = {"col": "A", "op": "in", "val": ["'a'b"]}
         col = DruidColumn(column_name="A")
         column_dict = {"A": col}
         res = DruidDatasource.get_filters([filtr], [], column_dict)

--- a/tests/integration_tests/druid_func_tests.py
+++ b/tests/integration_tests/druid_func_tests.py
@@ -364,6 +364,16 @@ class TestDruidFunc(SupersetTestCase):
     @unittest.skipUnless(
         SupersetTestCase.is_module_installed("pydruid"), "pydruid not installed"
     )
+    def test_get_filters_keeps_values_if_not_between_in_quotes(self):
+        filtr = {"col": "A", "op": "in", "val": ['"a"b']}
+        col = DruidColumn(column_name="A")
+        column_dict = {"A": col}
+        res = DruidDatasource.get_filters([filtr], [], column_dict)
+        self.assertEqual("'a'b", res.filter["filter"]["value"])
+
+    @unittest.skipUnless(
+        SupersetTestCase.is_module_installed("pydruid"), "pydruid not installed"
+    )
     def test_get_filters_keeps_trailing_spaces(self):
         filtr = {"col": "A", "op": "in", "val": ["a "]}
         col = DruidColumn(column_name="A")

--- a/tests/integration_tests/druid_func_tests_sip38.py
+++ b/tests/integration_tests/druid_func_tests_sip38.py
@@ -364,7 +364,7 @@ class TestDruidFunc(SupersetTestCase):
         col = DruidColumn(column_name="A")
         column_dict = {"A": col}
         res = DruidDatasource.get_filters([filtr], [], column_dict)
-        self.assertEqual("a", res.filter["filter"]["value"])
+        self.assertEqual('"a"', res.filter["filter"]["value"])
 
     @unittest.skipUnless(
         SupersetTestCase.is_module_installed("pydruid"), "pydruid not installed"

--- a/tests/integration_tests/query_context_tests.py
+++ b/tests/integration_tests/query_context_tests.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import datetime
+import logging
 import re
 import time
 from typing import Any, Dict
@@ -380,7 +381,7 @@ class TestQueryContext(SupersetTestCase):
         assert re.search(r'[`"\[]?num[`"\]]? IS NOT NULL', sql_text)
         assert re.search(
             r"""NOT \([`"\[]?name[`"\]]? IS NULL[\s\n]* """
-            r"""OR [`"\[]?name[`"\]]? IN \('abc'\)\)""",
+            r"""OR [`"\[]?name[`"\]]? IN \('"abc"'\)\)""",
             sql_text,
         )
 

--- a/tests/integration_tests/query_context_tests.py
+++ b/tests/integration_tests/query_context_tests.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 import datetime
-import logging
 import re
 import time
 from typing import Any, Dict

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -550,6 +550,29 @@ class TestDatabaseModel(SupersetTestCase):
         )
         assert result_object.df["count"][0] == 4
 
+    def test_values_in_quotes(self):
+        table = SqlaTable(
+            table_name="test_quotes_in_column",
+            sql=(
+                "SELECT '\"text in double quotes\"' as name "
+                "UNION SELECT '''text in single quotes''' "
+                "UNION SELECT 'double quotes \" in text' "
+                "UNION SELECT 'single quotes '' in text' "
+            ),
+            database=get_example_database(),
+        )
+        TableColumn(column_name="name", type="VARCHAR(255)", table=table)
+
+        rv = table.values_for_column(column_name="name", limit=10000,)
+
+        for item in [
+            '"text in double quotes"',
+            "'text in single quotes'",
+            'double quotes " in text',
+            "single quotes ' in text",
+        ]:
+            assert item in rv
+
 
 @pytest.mark.parametrize(
     "row,dimension,result",

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -584,7 +584,7 @@ def test_filter_on_text_column(text_column_table):
     )
     assert result_object.df["count"][0] == 1
 
-    # should filter text with single quotes
+    # should filter text with double quote
     result_object = table.query(
         {
             "metrics": ["count"],
@@ -594,7 +594,7 @@ def test_filter_on_text_column(text_column_table):
     )
     assert result_object.df["count"][0] == 1
 
-    # should filter text with double quotes
+    # should filter text with single quote
     result_object = table.query(
         {
             "metrics": ["count"],

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -47,6 +47,7 @@ from tests.integration_tests.fixtures.birth_names_dashboard import (
     load_birth_names_dashboard_with_slices,
     load_birth_names_data,
 )
+from tests.integration_tests.test_app import app
 
 from .base_tests import SupersetTestCase
 
@@ -475,103 +476,133 @@ class TestDatabaseModel(SupersetTestCase):
         db.session.delete(database)
         db.session.commit()
 
-    def test_values_for_column(self):
+
+@pytest.fixture
+def text_column_table():
+    with app.app_context():
         table = SqlaTable(
-            table_name="test_null_in_column",
+            table_name="text_column_table",
             sql=(
                 "SELECT 'foo' as foo "
                 "UNION SELECT '' "
                 "UNION SELECT NULL "
-                "UNION SELECT 'null'"
-            ),
-            database=get_example_database(),
-        )
-        TableColumn(column_name="foo", type="VARCHAR(255)", table=table)
-        SqlMetric(metric_name="count", expression="count(*)", table=table)
-
-        # null value, empty string and text should be retrieved
-        with_null = table.values_for_column(column_name="foo", limit=10000)
-        assert None in with_null
-        assert len(with_null) == 4
-
-        # null value should be replaced
-        result_object = table.query(
-            {
-                "metrics": ["count"],
-                "filter": [{"col": "foo", "val": [NULL_STRING], "op": "IN"}],
-                "is_timeseries": False,
-            }
-        )
-        assert result_object.df["count"][0] == 1
-
-        # also accept None value
-        result_object = table.query(
-            {
-                "metrics": ["count"],
-                "filter": [{"col": "foo", "val": [None], "op": "IN"}],
-                "is_timeseries": False,
-            }
-        )
-        assert result_object.df["count"][0] == 1
-
-        # empty string should be replaced
-        result_object = table.query(
-            {
-                "metrics": ["count"],
-                "filter": [{"col": "foo", "val": [EMPTY_STRING], "op": "IN"}],
-                "is_timeseries": False,
-            }
-        )
-        assert result_object.df["count"][0] == 1
-
-        # also accept "" string
-        result_object = table.query(
-            {
-                "metrics": ["count"],
-                "filter": [{"col": "foo", "val": [""], "op": "IN"}],
-                "is_timeseries": False,
-            }
-        )
-        assert result_object.df["count"][0] == 1
-
-        # both replaced
-        result_object = table.query(
-            {
-                "metrics": ["count"],
-                "filter": [
-                    {
-                        "col": "foo",
-                        "val": [EMPTY_STRING, NULL_STRING, "null", "foo"],
-                        "op": "IN",
-                    }
-                ],
-                "is_timeseries": False,
-            }
-        )
-        assert result_object.df["count"][0] == 4
-
-    def test_values_in_quotes(self):
-        table = SqlaTable(
-            table_name="test_quotes_in_column",
-            sql=(
-                "SELECT '\"text in double quotes\"' as name "
+                "UNION SELECT 'null' "
+                "UNION SELECT '\"text in double quotes\"' "
                 "UNION SELECT '''text in single quotes''' "
                 "UNION SELECT 'double quotes \" in text' "
                 "UNION SELECT 'single quotes '' in text' "
             ),
             database=get_example_database(),
         )
-        TableColumn(column_name="name", type="VARCHAR(255)", table=table)
+        TableColumn(column_name="foo", type="VARCHAR(255)", table=table)
+        SqlMetric(metric_name="count", expression="count(*)", table=table)
+        yield table
 
-        rv = table.values_for_column(column_name="name", limit=10000,)
 
-        for item in [
-            '"text in double quotes"',
-            "'text in single quotes'",
-            'double quotes " in text',
-            "single quotes ' in text",
-        ]:
-            assert item in rv
+def test_values_for_column_on_text_column(text_column_table):
+    # null value, empty string and text should be retrieved
+    with_null = text_column_table.values_for_column(column_name="foo", limit=10000)
+    assert None in with_null
+    assert len(with_null) == 8
+
+
+def test_filter_on_text_column(text_column_table):
+    table = text_column_table
+    # null value should be replaced
+    result_object = table.query(
+        {
+            "metrics": ["count"],
+            "filter": [{"col": "foo", "val": [NULL_STRING], "op": "IN"}],
+            "is_timeseries": False,
+        }
+    )
+    assert result_object.df["count"][0] == 1
+
+    # also accept None value
+    result_object = table.query(
+        {
+            "metrics": ["count"],
+            "filter": [{"col": "foo", "val": [None], "op": "IN"}],
+            "is_timeseries": False,
+        }
+    )
+    assert result_object.df["count"][0] == 1
+
+    # empty string should be replaced
+    result_object = table.query(
+        {
+            "metrics": ["count"],
+            "filter": [{"col": "foo", "val": [EMPTY_STRING], "op": "IN"}],
+            "is_timeseries": False,
+        }
+    )
+    assert result_object.df["count"][0] == 1
+
+    # also accept "" string
+    result_object = table.query(
+        {
+            "metrics": ["count"],
+            "filter": [{"col": "foo", "val": [""], "op": "IN"}],
+            "is_timeseries": False,
+        }
+    )
+    assert result_object.df["count"][0] == 1
+
+    # both replaced
+    result_object = table.query(
+        {
+            "metrics": ["count"],
+            "filter": [
+                {
+                    "col": "foo",
+                    "val": [EMPTY_STRING, NULL_STRING, "null", "foo"],
+                    "op": "IN",
+                }
+            ],
+            "is_timeseries": False,
+        }
+    )
+    assert result_object.df["count"][0] == 4
+
+    # should filter text in double quotes
+    result_object = table.query(
+        {
+            "metrics": ["count"],
+            "filter": [{"col": "foo", "val": ['"text in double quotes"'], "op": "IN",}],
+            "is_timeseries": False,
+        }
+    )
+    assert result_object.df["count"][0] == 1
+
+    # should filter text in single quotes
+    result_object = table.query(
+        {
+            "metrics": ["count"],
+            "filter": [{"col": "foo", "val": ["'text in single quotes'"], "op": "IN",}],
+            "is_timeseries": False,
+        }
+    )
+    assert result_object.df["count"][0] == 1
+
+    # should filter text with single quotes
+    result_object = table.query(
+        {
+            "metrics": ["count"],
+            "filter": [{"col": "foo", "val": ['double quotes " in text'], "op": "IN",}],
+            "is_timeseries": False,
+        }
+    )
+    assert result_object.df["count"][0] == 1
+
+    # should filter text with double quotes
+    result_object = table.query(
+        {
+            "metrics": ["count"],
+            "filter": [{"col": "foo", "val": ["single quotes ' in text"], "op": "IN",}],
+            "is_timeseries": False,
+        }
+    )
+    assert result_object.df["count"][0] == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes the problem that the double/single quote will be dropped in SQL query when using filters.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### Before

<img width="1426" alt="image" src="https://user-images.githubusercontent.com/2016594/151537087-eeecf8c2-86aa-4bec-b590-6d825a58d01f.png">


### After

<img width="1432" alt="image" src="https://user-images.githubusercontent.com/2016594/151536827-9b6d1504-2000-48fb-b675-cc6885dbc8e2.png">

<img width="1433" alt="image" src="https://user-images.githubusercontent.com/2016594/151536883-4d5ffd94-f55b-4169-827e-001deb6a138b.png">




### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:  Fixes https://github.com/apache/superset/issues/11639
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
