### PR TITLE
fix: failed mypy in master branch

### DIFF
--- a/.github/workflows/superset-python-misc.yml
+++ b/.github/workflows/superset-python-misc.yml
@@ -66,7 +66,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: 'requirements/integration.txt'
+          cache-dependency-path: |
+            requirements/base.txt
+            requirements/integration.txt
       - name: Install dependencies
         uses: ./.github/actions/cached-dependencies
         with:
@@ -74,6 +76,7 @@ jobs:
             apt-get-install
             pip-upgrade
             pip install wheel
+            pip install -r requirements/base.txt
             pip install -r requirements/integration.txt
       - name: pre-commit
         run: pre-commit run --all-files

--- a/superset/utils/async_query_manager.py
+++ b/superset/utils/async_query_manager.py
@@ -176,9 +176,7 @@ class AsyncQueryManager:
     ) -> List[Optional[Dict[str, Any]]]:
         stream_name = f"{self._stream_prefix}{channel}"
         start_id = increment_id(last_id) if last_id else "-"
-        results = self._redis.xrange(  # type: ignore
-            stream_name, start_id, "+", self.MAX_EVENT_COUNT
-        )
+        results = self._redis.xrange(stream_name, start_id, "+", self.MAX_EVENT_COUNT)
         return [] if not results else list(map(parse_event, results))
 
     def update_job(


### PR DESCRIPTION
### SUMMARY
it solved the failed mypy that prevents merging of new PRs

Using additional_dependencies: [types-all] in mypy pre-commit is wrong. it installs stubs types for not matching versions.
for example, it installs stub for Redis 4.1 while superset uses Redis 3.5.3
meanwhile, I added installations of superset base.txt requirements until a better solution like declaring all the required stubs packages inside a development requirements file.


