### PR TITLE
fix: make cache warm up work again

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -1330,7 +1330,7 @@ if CONFIG_PATH_ENV_VAR in os.environ:
 elif importlib.util.find_spec("superset_config") and not is_test():
     try:
         import superset_config  # pylint: disable=import-error
-        from superset_config import *  # pylint: disable=import-error,wildcard-import,unused-wildcard-import
+        from superset_config import *  # type: ignore # pylint: disable=import-error,wildcard-import,unused-wildcard-import
 
         print(f"Loaded your LOCAL configuration at [{superset_config.__file__}]")
     except Exception:

--- a/superset/config.py
+++ b/superset/config.py
@@ -543,6 +543,8 @@ SCREENSHOT_SELENIUM_HEADSTART = 3
 # Wait for the chart animation, in seconds
 SCREENSHOT_SELENIUM_ANIMATION_WAIT = 5
 
+CACHE_WARMUP_USER = THUMBNAIL_SELENIUM_USER
+
 # ---------------------------------------------------
 # Image and file configuration
 # ---------------------------------------------------
@@ -1328,7 +1330,7 @@ if CONFIG_PATH_ENV_VAR in os.environ:
 elif importlib.util.find_spec("superset_config") and not is_test():
     try:
         import superset_config  # pylint: disable=import-error
-        from superset_config import *  # type: ignore # pylint: disable=import-error,wildcard-import,unused-wildcard-import
+        from superset_config import *  # pylint: disable=import-error,wildcard-import,unused-wildcard-import
 
         print(f"Loaded your LOCAL configuration at [{superset_config.__file__}]")
     except Exception:

--- a/superset/config.py
+++ b/superset/config.py
@@ -543,7 +543,7 @@ SCREENSHOT_SELENIUM_HEADSTART = 3
 # Wait for the chart animation, in seconds
 SCREENSHOT_SELENIUM_ANIMATION_WAIT = 5
 
-CACHE_WARMUP_USER = THUMBNAIL_SELENIUM_USER
+CACHE_WARMUP_USER = "admin"
 
 # ---------------------------------------------------
 # Image and file configuration

--- a/superset/tasks/cache.py
+++ b/superset/tasks/cache.py
@@ -73,7 +73,7 @@ def get_form_data(
     return form_data
 
 
-def get_url(chart: Slice, extra_filters: Optional[Dict[str, Any]] = None) -> str:
+def get_url(chart: Slice) -> str:
     """Return external URL for warming up a given chart/table cache."""
     with app.test_request_context():
         baseurl = (
@@ -180,8 +180,7 @@ class TopNDashboardsStrategy(Strategy):  # pylint: disable=too-few-public-method
         dashboards = session.query(Dashboard).filter(Dashboard.id.in_(dash_ids)).all()
         for dashboard in dashboards:
             for chart in dashboard.slices:
-                form_data_with_filters = get_form_data(chart.id, dashboard)
-                urls.append(get_url(chart, form_data_with_filters))
+                urls.append(get_url(chart))
 
         return urls
 
@@ -294,10 +293,10 @@ def cache_warmup(
                 cookies = MachineAuthProvider.get_auth_cookies(user)
 
             logger.info("Fetching %s", url)
-            requests.get(url, cookies=cookies)  # pylint: disable=consider-using-with
+            requests.get(url, cookies=cookies)
             results["success"].append(url)
-        except requests.exceptions.RequestException as e:
-            logger.exception("Error warming up cache! ", e)
+        except requests.exceptions.RequestException as exc:
+            logger.exception("Error warming up cache! %s", exc)
             results["errors"].append(url)
 
     return results

--- a/tests/integration_tests/strategy_tests.py
+++ b/tests/integration_tests/strategy_tests.py
@@ -202,7 +202,12 @@ class TestCacheWarmUp(SupersetTestCase):
 
         strategy = TopNDashboardsStrategy(1)
         result = sorted(strategy.get_urls())
-        expected = sorted([f"{URL_PREFIX}{slc.url}" for slc in dash.slices])
+        expected = sorted(
+            [
+                f"{URL_PREFIX}/superset/warm_up_cache/?slice_id={slc.id}"
+                for slc in dash.slices
+            ]
+        )
         self.assertEqual(result, expected)
 
     def reset_tag(self, tag):
@@ -228,7 +233,12 @@ class TestCacheWarmUp(SupersetTestCase):
         # tag dashboard 'births' with `tag1`
         tag1 = get_tag("tag1", db.session, TagTypes.custom)
         dash = self.get_dash_by_slug("births")
-        tag1_urls = sorted([f"{URL_PREFIX}{slc.url}" for slc in dash.slices])
+        tag1_urls = sorted(
+            [
+                f"{URL_PREFIX}/superset/warm_up_cache/?slice_id={slc.id}"
+                for slc in dash.slices
+            ]
+        )
         tagged_object = TaggedObject(
             tag_id=tag1.id, object_id=dash.id, object_type=ObjectTypes.dashboard
         )
@@ -248,7 +258,7 @@ class TestCacheWarmUp(SupersetTestCase):
         # tag first slice
         dash = self.get_dash_by_slug("unicode-test")
         slc = dash.slices[0]
-        tag2_urls = [f"{URL_PREFIX}{slc.url}"]
+        tag2_urls = [f"{URL_PREFIX}/superset/warm_up_cache/?slice_id={slc.id}"]
         object_id = slc.id
         tagged_object = TaggedObject(
             tag_id=tag2.id, object_id=object_id, object_type=ObjectTypes.chart


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds authentication while calling superset/warm_up_cache endpoint with config for `CACHE_WARMUP_USER`
Changes warm up url from chart's explore url to superset/warm_up_cache
Fixes mypy errors

This does not cache thumbnails, which could be beneficial for some users.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
It was failing to cache data, as auth was missing and chart's explore url won't call data endpoint(/explore_json or /data) as requests library does not render javavscript.
Now it directly calls superset/warm_up_cache which correctly caches data if caching is set up.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Enable data caching from config
Add cache warm config in CeleryConfig -> CELERYBEAT_SCHEDULE as below
```
'cache-warmup-setting': {
                'task': 'cache-warmup',
                'schedule': timedelta(minutes=1),
                'kwargs': {'strategy_name': 'dummy'},
            },
```  
setup celery beat and worker.
check data getting cached correctly every minute.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
