### PR TITLE
chore: migrate ErrorBoundary component from jsx to tsx

### DIFF
--- a/superset-frontend/src/components/ErrorBoundary/index.tsx
+++ b/superset-frontend/src/components/ErrorBoundary/index.tsx
@@ -31,7 +31,7 @@ export default class ErrorBoundary extends React.Component<
   { error: Error | null; info: React.ErrorInfo | null }
 > {
   static defaultProps = {
-    onError: () => { },
+    onError: () => {},
     showMessage: true,
   };
 

--- a/superset-frontend/src/components/ErrorBoundary/index.tsx
+++ b/superset-frontend/src/components/ErrorBoundary/index.tsx
@@ -17,27 +17,30 @@
  * under the License.
  */
 import React from 'react';
-import PropTypes from 'prop-types';
 import { t } from '@superset-ui/core';
 import ErrorMessageWithStackTrace from 'src/components/ErrorMessage/ErrorMessageWithStackTrace';
 
-const propTypes = {
-  children: PropTypes.node.isRequired,
-  onError: PropTypes.func,
-  showMessage: PropTypes.bool,
-};
-const defaultProps = {
-  onError: () => {},
-  showMessage: true,
-};
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  onError?: Function;
+  showMessage?: boolean;
+}
 
-export default class ErrorBoundary extends React.Component {
-  constructor(props) {
+export default class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  { error: Error | null; info: React.ErrorInfo | null }
+> {
+  static defaultProps = {
+    onError: () => { },
+    showMessage: true,
+  };
+
+  constructor(props: ErrorBoundaryProps) {
     super(props);
     this.state = { error: null, info: null };
   }
 
-  componentDidCatch(error, info) {
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
     if (this.props.onError) this.props.onError(error, info);
     this.setState({ error, info });
   }
@@ -66,5 +69,3 @@ export default class ErrorBoundary extends React.Component {
     return this.props.children;
   }
 }
-ErrorBoundary.propTypes = propTypes;
-ErrorBoundary.defaultProps = defaultProps;

--- a/superset-frontend/src/components/ErrorBoundary/index.tsx
+++ b/superset-frontend/src/components/ErrorBoundary/index.tsx
@@ -26,9 +26,14 @@ interface ErrorBoundaryProps {
   showMessage?: boolean;
 }
 
+interface ErrorBoundaryState {
+  error: Error | null;
+  info: React.ErrorInfo | null;
+}
+
 export default class ErrorBoundary extends React.Component<
   ErrorBoundaryProps,
-  { error: Error | null; info: React.ErrorInfo | null }
+  ErrorBoundaryState
 > {
   static defaultProps = {
     onError: () => {},

--- a/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
@@ -55,7 +55,7 @@ const ErrorAlertDiv = styled.div<{ level: ErrorLevel }>`
   }
 `;
 
-const ErrorModal = styled(Modal) <{ level: ErrorLevel }>`
+const ErrorModal = styled(Modal)<{ level: ErrorLevel }>`
   color: ${({ level, theme }) => theme.colors[level].dark2};
   overflow-wrap: break-word;
 

--- a/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
@@ -55,7 +55,7 @@ const ErrorAlertDiv = styled.div<{ level: ErrorLevel }>`
   }
 `;
 
-const ErrorModal = styled(Modal)<{ level: ErrorLevel }>`
+const ErrorModal = styled(Modal) <{ level: ErrorLevel }>`
   color: ${({ level, theme }) => theme.colors[level].dark2};
   overflow-wrap: break-word;
 
@@ -82,7 +82,7 @@ const LeftSideContent = styled.div`
 
 interface ErrorAlertProps {
   body: ReactNode;
-  copyText?: string;
+  copyText?: string | JSX.Element;
   level: ErrorLevel;
   source?: ErrorSource;
   subtitle: ReactNode;

--- a/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
@@ -30,8 +30,8 @@ type Props = {
   error?: SupersetError;
   link?: string;
   subtitle?: React.ReactNode;
-  copyText?: string;
-  stackTrace?: string;
+  copyText?: string | JSX.Element;
+  stackTrace?: string | null;
   source?: ErrorSource;
 };
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

PR for migrating `ErrorBoundary` class based react component from JSX to TSX

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] #10004
- [x] Enhancement (new features, refinement)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### SOURCES REFFERED

- [Convert React Prop Types to interface in TypeScript](https://www.benmvp.com/blog/react-prop-types-with-typescript/)
- [componentDidCatch() - react documentation](https://reactjs.org/docs/react-component.html#componentdidcatch)
- [Type check for `error` and `info` used as state properties in react error boundary](https://gist.github.com/andywer/800f3f25ce3698e8f8b5f1e79fed5c9c)
