### PR TITLE
chore: run cypress frontend by webpack-dev-server

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -33,6 +33,7 @@
     "plugins/*"
   ],
   "scripts": {
+    "_dev-server": "cross-env NODE_OPTIONS=--max_old_space_size=4096 NODE_ENV=development BABEL_ENV=development webpack server --mode=development",
     "_lint": "eslint --ignore-path=.eslintignore --ext .js,.jsx,.ts,tsx .",
     "_prettier": "prettier './({src,spec,cypress-base,plugins,packages}/**/*{.js,.jsx,.ts,.tsx,.css,.less,.scss,.sass}|package.json)'",
     "build": "cross-env NODE_OPTIONS=--max_old_space_size=8192 NODE_ENV=production BABEL_ENV=\"${BABEL_ENV:=production}\" webpack --mode=production --color",
@@ -42,8 +43,11 @@
     "check-translation": "prettier --check ../superset/translations/**/LC_MESSAGES/*.json",
     "clean-translation": "prettier --write ../superset/translations/**/LC_MESSAGES/*.json",
     "cover": "cross-env NODE_ENV=test jest --coverage",
+    "cypress-debug": "cd cypress-base && npm run cypress-debug",
+    "cypress-dev-server": "cross-env supersetPort=8081 npm run _dev-server -- --port=8088",
+    "cypress-flask-server": "flask run -p 8081 --with-threads --reload --debugger",
     "dev": "webpack --mode=development --color --watch",
-    "dev-server": "cross-env NODE_ENV=development BABEL_ENV=development node --max_old_space_size=4096 ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --mode=development",
+    "dev-server": "npm run _dev-server",
     "format": "npm run _prettier -- --write",
     "lint": "npm run _lint && npm run type",
     "lint-fix": "npm run _lint -- --fix && npm run type",

--- a/superset-frontend/webpack.proxy-config.js
+++ b/superset-frontend/webpack.proxy-config.js
@@ -21,7 +21,11 @@ const zlib = require('zlib');
 // eslint-disable-next-line import/no-extraneous-dependencies
 const parsedArgs = require('yargs').argv;
 
-const { supersetPort = 8088, superset: supersetUrl = null } = parsedArgs;
+// system environment variables will override CLI arguments
+const { supersetPort = 8088, superset: supersetUrl = null } = {
+  ...parsedArgs,
+  ...process.env,
+};
 const backend = (supersetUrl || `http://localhost:${supersetPort}`).replace(
   '//+$/',
   '',


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Sometimes we might run cypress in `webpack-dev-server`. This PR

1. introduce a new command `npm run cypress-dev-server`.
2. introduce a new command `npm run cypress-debug`.
3. introduce a new command `npm run cypress-flask-server`
2. replace `node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js` with `webpack server`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
N/A

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
