### PR TITLE
chore(explore): make adhoc columns available without UX BETA ff

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -59,7 +59,6 @@ interface ColumnSelectPopoverProps {
   setLabel: (title: string) => void;
   getCurrentTab: (tab: string) => void;
   label: string;
-  isAdhocColumnsEnabled: boolean;
 }
 
 const getInitialColumnValues = (
@@ -85,7 +84,6 @@ const ColumnSelectPopover = ({
   setLabel,
   getCurrentTab,
   label,
-  isAdhocColumnsEnabled,
 }: ColumnSelectPopoverProps) => {
   const [initialLabel] = useState(label);
   const [initialAdhocColumn, initialCalculatedColumn, initialSimpleColumn] =
@@ -279,28 +277,27 @@ const ColumnSelectPopover = ({
             />
           </FormItem>
         </Tabs.TabPane>
-        {isAdhocColumnsEnabled && (
-          <Tabs.TabPane key="sqlExpression" tab={t('Custom SQL')}>
-            <SQLEditor
-              value={
-                adhocColumn?.sqlExpression ||
-                selectedSimpleColumn?.column_name ||
-                selectedCalculatedColumn?.expression
-              }
-              onFocus={onSqlEditorFocus}
-              showLoadingForImport
-              onChange={onSqlExpressionChange}
-              width="100%"
-              height={`${POPOVER_INITIAL_HEIGHT - 80}px`}
-              showGutter={false}
-              editorProps={{ $blockScrolling: true }}
-              enableLiveAutocompletion
-              className="filter-sql-editor"
-              wrapEnabled
-              ref={sqlEditorRef}
-            />
-          </Tabs.TabPane>
-        )}
+
+        <Tabs.TabPane key="sqlExpression" tab={t('Custom SQL')}>
+          <SQLEditor
+            value={
+              adhocColumn?.sqlExpression ||
+              selectedSimpleColumn?.column_name ||
+              selectedCalculatedColumn?.expression
+            }
+            onFocus={onSqlEditorFocus}
+            showLoadingForImport
+            onChange={onSqlExpressionChange}
+            width="100%"
+            height={`${POPOVER_INITIAL_HEIGHT - 80}px`}
+            showGutter={false}
+            editorProps={{ $blockScrolling: true }}
+            enableLiveAutocompletion
+            className="filter-sql-editor"
+            wrapEnabled
+            ref={sqlEditorRef}
+          />
+        </Tabs.TabPane>
       </Tabs>
       <div>
         <Button buttonSize="small" onClick={onResetStateAndClose} cta>

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.tsx
@@ -17,12 +17,7 @@
  * under the License.
  */
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import {
-  AdhocColumn,
-  FeatureFlag,
-  isFeatureEnabled,
-  t,
-} from '@superset-ui/core';
+import { AdhocColumn, t } from '@superset-ui/core';
 import {
   ColumnMeta,
   isAdhocColumn,

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.tsx
@@ -47,8 +47,6 @@ interface ColumnSelectPopoverTriggerProps {
 const defaultPopoverLabel = t('My column');
 const editableTitleTab = 'sqlExpression';
 
-const isAdhocColumnsEnabled = isFeatureEnabled(FeatureFlag.UX_BETA);
-
 const ColumnSelectPopoverTrigger = ({
   columns,
   editedColumn,
@@ -109,7 +107,6 @@ const ColumnSelectPopoverTrigger = ({
           label={popoverLabel}
           setLabel={setPopoverLabel}
           getCurrentTab={getCurrentTab}
-          isAdhocColumnsEnabled={isAdhocColumnsEnabled}
         />
       </ExplorePopoverContent>
     ),
@@ -148,7 +145,7 @@ const ColumnSelectPopoverTrigger = ({
       defaultVisible={visible}
       visible={visible}
       onVisibleChange={handleTogglePopover}
-      title={isAdhocColumnsEnabled && popoverTitle}
+      title={popoverTitle}
       destroyTooltipOnHide
     >
       {children}


### PR DESCRIPTION
### SUMMARY
The feature introduced in https://github.com/apache/superset/pull/17379 was available only with UX BETA feature flag enabled. Since we received positive feedback from the users who tried the feature out, it's time to make it available to everyone!
This PR removes the dependency on UX BETA feature flag. To learn more about the feature, check out the linked PR 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/15073128/148074995-94331d87-f9fd-4a7f-8fe4-476b12295990.png)

### TESTING INSTRUCTIONS
0. Disable UX_BETA feature flag and enable drag and drop feature flag
1. Create a chart 
2. Verify that adhoc columns feature is available and works as described in https://github.com/apache/superset/pull/17379

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @rusackas  @jinghua-qa @rosemarie-chiu 