### PR TITLE
fix: force_screenshot migration

### DIFF
--- a/superset/migrations/versions/bb38f40aa3ff_add_force_screenshot_to_alerts_reports.py
+++ b/superset/migrations/versions/bb38f40aa3ff_add_force_screenshot_to_alerts_reports.py
@@ -41,6 +41,7 @@ class ReportSchedule(Base):
     id = sa.Column(sa.Integer, primary_key=True)
     type = sa.Column(sa.String(50), nullable=False)
     force_screenshot = sa.Column(sa.Boolean, default=False)
+    chart_id = sa.Column(sa.Integer, nullable=True)
 
 
 def upgrade():


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The migration was failing because `chart_id` was not present in the `ReportSchedule` model defined in the migration.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Create an alert.
2. Downgrade to the version before the broken migration: `superset db downgrade 31bb738bd1d2`
3. Upgrade the DB: `superset db upgrade`
4. Verify that the column `force_screenshot` was added, and has the value true for the created alert:

```sql
SELECT force_screenshot FROM report_schedule;
 force_screenshot
------------------
 t
(1 row)
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
