### PR TITLE
fix(sqllab): Dancing Tooltip in SQL editor dropdown

### DIFF
--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor/index.tsx
@@ -99,7 +99,7 @@ function TemplateParamsEditor({
           title={t('Edit template parameters')}
           trigger={['hover']}
         >
-          <div role="button">
+          <div role="button" css={{ width: 'inherit' }}>
             {t('Parameters ')}
             <Badge count={paramCount} />
             {!isValid && (


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I stopped the dancing tooltip in the SQL editor dropdown's "Parameters" option by setting its button's width to `inherit`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### BEFORE:
![dancingTooltip](https://user-images.githubusercontent.com/55605634/148163099-eb913c44-d441-4133-b016-4b75340fc1eb.gif)

#### AFTER:
![putTooltipInTheCorner](https://user-images.githubusercontent.com/55605634/148163092-d322bc67-f446-41e8-b9f8-3fa8c0eb62d0.gif)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- In SQL Lab, click the "three dots" dropdown at the bottom-right of the editor
- Hover over "Parameters"
- Observe the non-dancing tooltip

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
