### PR TITLE
fix(docs): update clickhouse.mdx

### DIFF
--- a/docs/src/pages/docs/Connecting to Databases/clickhouse.mdx
+++ b/docs/src/pages/docs/Connecting to Databases/clickhouse.mdx
@@ -23,7 +23,7 @@ clickhouse-sqlalchemy>=0.1.6
 ```
 
 The recommended connector library for Clickhouse is
-[sqlalchemy-clickhouse](https://github.com/cloudflare/sqlalchemy-clickhouse).
+[clickhouse-sqlalchemy](https://github.com/xzkostyan/clickhouse-sqlalchemy).
 
 The expected connection string is formatted as follows:
 


### PR DESCRIPTION
There is a contradiction on this page - the requirements show `clickhouse-sqlalchemy` and then there is this sentence stating that the recommended connector is `sqlalchemy-clickhouse`, which is somewhat of an abandoned driver that is not seeing any activity in Github. I would suggest either removing the sentence about "recommended connector" or changing the link (as I have done in this PR).

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
