### PR TITLE
fix(dashboard): scope status of filter not update in dashboard metadata

### DIFF
--- a/superset-frontend/src/dashboard/actions/nativeFilters.ts
+++ b/superset-frontend/src/dashboard/actions/nativeFilters.ts
@@ -188,9 +188,20 @@ export const setInScopeStatusOfFilters =
       type: SET_IN_SCOPE_STATUS_OF_FILTERS,
       filterConfig: filtersWithScopes,
     });
-    // also need to update dashboard metadata native_filter_configuration
+    // need to update native_filter_configuration in the dashboard metadata
     const { metadata } = getState().dashboardInfo;
-    metadata.native_filter_configuration = filtersWithScopes;
+    const filterConfig: FilterConfiguration =
+      metadata.native_filter_configuration;
+    const mergedFilterConfig = filterConfig.map(filter => {
+      const filterWithScope = filtersWithScopes.find(
+        scope => scope.id === filter.id,
+      );
+      if (!filterWithScope) {
+        return filter;
+      }
+      return { ...filterWithScope, ...filter };
+    });
+    metadata.native_filter_configuration = mergedFilterConfig;
     dispatch(
       dashboardInfoChanged({
         metadata,

--- a/superset-frontend/src/dashboard/actions/nativeFilters.ts
+++ b/superset-frontend/src/dashboard/actions/nativeFilters.ts
@@ -188,6 +188,14 @@ export const setInScopeStatusOfFilters =
       type: SET_IN_SCOPE_STATUS_OF_FILTERS,
       filterConfig: filtersWithScopes,
     });
+    // also need to update dashboard metadata native_filter_configuration
+    const { metadata } = getState().dashboardInfo;
+    metadata.native_filter_configuration = filtersWithScopes;
+    dispatch(
+      dashboardInfoChanged({
+        metadata,
+      }),
+    );
   };
 
 type BootstrapData = {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes the problem that the scope status of filter which adds to the dashboard is not updated in the dashboard json metadata, steps to reproduce:
1.  add a nativeFilter to the dashboard
2. edit dashboard and see the json metadata
3.  metadata don't have field `chartsInScope` and `filterConfig`

It will cause the incorrect scope status if we update the native filter via json metadata like this issue  https://github.com/apache/superset/issues/17932
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### before

https://user-images.githubusercontent.com/11830681/148345707-509eecf8-086c-422a-9472-957b5bd4b72e.mov



### after


https://user-images.githubusercontent.com/11830681/148345724-a86cc1b5-b96b-46a8-9e6e-0007b8bf33d6.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes https://github.com/apache/superset/issues/17932
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
