### PR TITLE
fix(Select): options in the select component will be overwritten due to timing of React.setState

### DIFF
--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -641,30 +641,35 @@ const Select = ({
 
   useEffect(() => {
     if (selectValue) {
-      const array = Array.isArray(selectValue)
-        ? (selectValue as AntdLabeledValue[])
-        : [selectValue as AntdLabeledValue | string | number];
-      const options: AntdLabeledValue[] = [];
-      const isLabeledValue = isAsync || labelInValue;
-      array.forEach(element => {
-        const found = selectOptions.find((option: { value: string | number }) =>
-          isLabeledValue
-            ? option.value === (element as AntdLabeledValue).value
-            : option.value === element,
-        );
-        if (!found) {
-          options.push(
-            isLabeledValue
-              ? (element as AntdLabeledValue)
-              : ({ value: element, label: element } as AntdLabeledValue),
+      setSelectOptions(selectOptions => {
+        const array = Array.isArray(selectValue)
+          ? (selectValue as AntdLabeledValue[])
+          : [selectValue as AntdLabeledValue | string | number];
+        const options: AntdLabeledValue[] = [];
+        const isLabeledValue = isAsync || labelInValue;
+        array.forEach(element => {
+          const found = selectOptions.find(
+            (option: { value: string | number }) =>
+              isLabeledValue
+                ? option.value === (element as AntdLabeledValue).value
+                : option.value === element,
           );
+          if (!found) {
+            options.push(
+              isLabeledValue
+                ? (element as AntdLabeledValue)
+                : ({ value: element, label: element } as AntdLabeledValue),
+            );
+          }
+        });
+        if (options.length > 0) {
+          return [...options, ...selectOptions];
         }
+        // return same options won't trigger a re-render
+        return selectOptions;
       });
-      if (options.length > 0) {
-        setSelectOptions([...options, ...selectOptions]);
-      }
     }
-  }, [labelInValue, isAsync, selectOptions, selectValue]);
+  }, [labelInValue, isAsync, selectValue]);
 
   // Stop the invocation of the debounced function after unmounting
   useEffect(() => () => handleOnSearch.cancel(), [handleOnSearch]);


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fix the problem that when user undo delete of a native filter, the options under column is gone. The root cause is due to the **setState** mechanism of the react hook. In the Select component, there is one case that we update the component `selectOptions` which based on the incoming props:
```
useEffect(() => {
    fetchedQueries.current.clear();
    setSelectOptions(
      options && Array.isArray(options) ? options : EMPTY_OPTIONS,
    );
    setAllValuesLoaded(false);
}, [options]);
```
and a logic we use `useEffect` to update `selectOptions`:
```
 useEffect(() => {
    if (selectValue) {
      // ...
      if (options.length > 0) {
        setSelectOptions([...options, ...selectOptions]);
      }
    }
}, [labelInValue, isAsync, selectOptions, selectValue]);
```
So there is a problem that `useEffect` knows the state has changed, but the value taken at this time is still the old value.

The solution is we can pass an updater function to transform it so we can use the pending state.  see https://beta.reactjs.org/reference/usestate#passing-an-updater-function-to-setstate.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### before
https://user-images.githubusercontent.com/81597121/135208961-d9acdead-f57a-4ae7-9283-82e613bf3486.mov
### after

https://user-images.githubusercontent.com/11830681/148423959-55dca159-b34d-4bc6-9e03-e33ef787c9a2.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/16887
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
