### PR TITLE
chore: Adding more viz category mappings for viz picker

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bar/index.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bar/index.js
@@ -35,6 +35,7 @@ const metadata = new ChartMetadata({
   name: t('Time-series Bar Chart'),
   supportedAnnotationTypes: [ANNOTATION_TYPES.INTERVAL, ANNOTATION_TYPES.EVENT],
   tags: [
+    t('Bar'),
     t('Time'),
     t('Trend'),
     t('Stacked'),

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bar/index.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bar/index.js
@@ -43,6 +43,7 @@ const metadata = new ChartMetadata({
     t('Percentages'),
     t('Proportional'),
     t('Advanced-Analytics'),
+    t('nvd3'),
   ],
   thumbnail,
   useLegacyApi: true,

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js
@@ -38,6 +38,7 @@ const metadata = new ChartMetadata({
   name: t('Bar Chart'),
   tags: [
     t('Additive'),
+    t('Bar'),
     t('Categorical'),
     t('Comparison'),
     t('Discrete'),

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/DualLine/index.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/DualLine/index.js
@@ -28,7 +28,7 @@ const metadata = new ChartMetadata({
     'Visualizes 2 metrics as line plots using the same x-axis. This chart is useful for comparing metrics across the same time range.',
   ),
   name: t('Dual Line Chart'),
-  tags: [t('Legacy')],
+  tags: [t('Legacy'), t('nvd3')],
   thumbnail,
   useLegacyApi: true,
 });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Two bar charts weren't in the `# Bar` category, and two nvd3 charts weren't in the `# nvd3` category.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
