### PR TITLE
chore: bump FAB to 3.4.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -77,7 +77,7 @@ flask==1.1.4
     #   flask-openid
     #   flask-sqlalchemy
     #   flask-wtf
-flask-appbuilder==3.4.1
+flask-appbuilder==3.4.3
     # via apache-superset
 flask-babel==1.0.0
     # via flask-appbuilder

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         "cryptography>=3.3.2",
         "deprecation>=2.1.0, <2.2.0",
         "flask>=1.1.0, <2.0.0",
-        "flask-appbuilder>=3.4.1, <4.0.0",
+        "flask-appbuilder>=3.4.3, <4.0.0",
         "flask-caching>=1.10.0",
         "flask-compress",
         "flask-talisman",


### PR DESCRIPTION
### SUMMARY
Bump FAB to 3.4.3 with the following improvements:

```
fix: openapi on and off config flag (#1770) [Daniel Vaz Gaspar]
fix: data not defined in azure oauth (#1769) [Dalton Pearson]
fix: Handle authorize_access_token exception (#1766) [Michał Konarski]
fix: Set role and confirm password while adding user mandatory (#1758) [Mayur]
fix: required roles on user form not showing error msg (#1772) [Daniel Vaz Gaspar]
fix: make servers be actual servers on swagger, full endpoint paths (#1773) [Daniel Vaz Gaspar]
docs: adds missing config key FAB_OPENAPI_SERVERS (#1776)
```

### TESTING INSTRUCTIONS
Normal Superset bootstrap, verify the security views and DB authentication

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
