### PR TITLE
feat: update time comparison choices (again)

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/sections/advancedAnalytics.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/sections/advancedAnalytics.tsx
@@ -103,6 +103,8 @@ export const advancedAnalyticsControls: ControlPanelSectionConfig = {
             '1 year ago',
             '104 weeks ago',
             '2 years ago',
+            '156 weeks ago',
+            '3 years ago',
           ]),
           description: t(
             'Overlay one or more timeseries from a ' +

--- a/superset-frontend/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx
@@ -320,6 +320,8 @@ const config: ControlPanelConfig = {
                 '1 year',
                 '104 weeks',
                 '2 years',
+                '156 weeks',
+                '3 years',
               ]),
               description: t(
                 'Overlay one or more timeseries from a ' +

--- a/superset-frontend/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx
@@ -203,6 +203,8 @@ const config: ControlPanelConfig = {
                 '1 year',
                 '104 weeks',
                 '2 years',
+                '156 weeks',
+                '3 years',
               ]),
               description: t(
                 'Overlay one or more timeseries from a ' +

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx
@@ -453,6 +453,8 @@ export const timeSeriesSection: ControlPanelSectionConfig[] = [
               '1 year',
               '104 weeks',
               '2 years',
+              '156 weeks',
+              '3 years',
             ]),
             description: t(
               'Overlay one or more timeseries from a ' +

--- a/superset-frontend/src/explore/controlPanels/sections.tsx
+++ b/superset-frontend/src/explore/controlPanels/sections.tsx
@@ -218,6 +218,8 @@ export const NVD3TimeSeries: ControlPanelSectionConfig[] = [
               '1 year',
               '104 weeks',
               '2 years',
+              '156 weeks',
+              '3 years',
             ]),
             description: t(
               'Overlay one or more timeseries from a ' +


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Similar to #11294, this PR adds Y/3Y time comparison choices to make it faster to compare with pre-pandemic times.

We can make this change custom to our deployment, but thought it might be useful for all? We could remove these options later.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

@graceguo-supercat @etr2460 
