### PR TITLE
chore: fixing annoying warning about escaping in Emotion styling

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/ReactNVD3.jsx
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/ReactNVD3.jsx
@@ -44,7 +44,8 @@ NVD3.propTypes = {
 };
 
 export default styled(NVD3)`
-  .superset-legacy-chart-nvd3-dist-bar, .superset-legacy-chart-nvd3-bar {
+  .superset-legacy-chart-nvd3-dist-bar,
+  .superset-legacy-chart-nvd3-bar {
     overflow-x: auto !important;
     svg {
       &.nvd3-svg {

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/ReactNVD3.jsx
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/ReactNVD3.jsx
@@ -165,7 +165,7 @@ export default styled(NVD3)`
     padding: 8px;
     color: #fff;
     &:after {
-      content: '\25BC';
+      content: '\\25BC';
       font-size: ${({ theme }) => theme.typography.sizes.m};
       color: #484848;
       position: absolute;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There's been a little console warning that's been annoying me. So here's the one-character PR to make it go away! :D
<img width="800" alt="Screen Shot 2022-01-07 at 6 04 19 PM" src="https://user-images.githubusercontent.com/812905/148625968-61132585-754f-4a8a-a9d0-6bf6c54884ca.png">

Now it's gone!

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
I made an annotation and tried to look for the entity (black pointing down triangle), but could not spot either the entity, nor any change from this PR. I'm not sure this styling has any effect at all. I think these annotations need a style/UX overhaul anyway ¯\\\_(ツ)_/¯ I'm pretty sure this PR is safe enough.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
