### PR TITLE
fix: null dates in table chart

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/utils/formatValue.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/utils/formatValue.ts
@@ -23,6 +23,7 @@ import {
   getNumberFormatter,
 } from '@superset-ui/core';
 import { DataColumnMeta } from '../types';
+import DateWithFormatter from './DateWithFormatter';
 
 const xss = new FilterXSS({
   whiteList: {
@@ -62,7 +63,12 @@ function formatValue(
     return [false, ''];
   }
   // render null as `N/A`
-  if (value === null) {
+  if (
+    value === null ||
+    // null values in temporal columns are wrapped in a Date object, so make sure we
+    // handle them here too
+    (value instanceof DateWithFormatter && value.input === null)
+  ) {
     return [false, 'N/A'];
   }
   if (formatter) {

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -76,7 +76,7 @@ describe('plugin-chart-table', () => {
       );
       tree = wrap.render(); // returns a CheerioWrapper with jQuery-like API
       const cells = tree.find('td');
-      expect(cells).toHaveLength(8);
+      expect(cells).toHaveLength(12);
       expect(cells.eq(0).text()).toEqual('2020-01-01 12:34:56');
       expect(cells.eq(1).text()).toEqual('Michael');
       // number is not in `metrics` list, so it should output raw value
@@ -85,6 +85,7 @@ describe('plugin-chart-table', () => {
       // should not render column with `.` in name as `undefined`
       expect(cells.eq(3).text()).toEqual('foo');
       expect(cells.eq(6).text()).toEqual('2467');
+      expect(cells.eq(8).text()).toEqual('N/A');
     });
 
     it('render advanced data', () => {

--- a/superset-frontend/plugins/plugin-chart-table/test/testData.ts
+++ b/superset-frontend/plugins/plugin-chart-table/test/testData.ts
@@ -111,6 +111,13 @@ const basic: TableChartProps = {
           '%pct_nice': 0.00001,
           'abc.com': 'bar',
         },
+        {
+          __timestamp: null,
+          name: 'Maria',
+          sum__num: 12342,
+          '%pct_nice': 0.341,
+          'abc.com': 'baz',
+        },
       ],
     },
   ],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Currently, when a date is null and it's in a temporal column, it renders as `1970-01-01` instead of `N/A`. This PR fixes it

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Test dataset (generated in SQL Lab):
![Screen Shot 2022-01-07 at 7 36 27 PM](https://user-images.githubusercontent.com/7409244/148630688-a9260a93-7fe8-43b6-820d-37e63c605feb.png)

Table chart before fix:
![Screen Shot 2022-01-07 at 7 37 06 PM](https://user-images.githubusercontent.com/7409244/148630693-ea361d96-956d-45a8-8aac-52c26a523375.png)

Table chart after fix:
![Screen Shot 2022-01-07 at 7 36 38 PM](https://user-images.githubusercontent.com/7409244/148630694-eb0aa409-f0e1-4f4a-b281-c0c3e31bb0f0.png)


### TESTING INSTRUCTIONS
CI, new unit test, create a dataset with a temporal column in dev, add at least one row with null, ensure it renders as N/A

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @ktmud @graceguo-supercat @michael-s-molina @rusackas 