### PR TITLE
docs: close bracket on helm chart reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ how to set up a development environment.
 - [Documentation for Superset End-Users (by Preset)](https://docs.preset.io/docs/terminology)
 - Deploying Superset
   - [Official Docker image](https://hub.docker.com/r/apache/superset)
-  - [Helm Chart](https://github.com/apache/superset/tree/master/helm/superset
+  - [Helm Chart](https://github.com/apache/superset/tree/master/helm/superset)
 - Recordings of Past [Superset Community Events](https://preset.io/events)
   - [Live Demo: Interactive Time-series Analysis with Druid and Superset](https://preset.io/events/2021-03-02-interactive-time-series-analysis-with-druid-and-superset/)
   - [Live Demo: Visualizing MongoDB and Pinot Data using Trino](https://preset.io/events/2021-04-13-visualizing-mongodb-and-pinot-data-using-trino/)


### PR DESCRIPTION
### SUMMARY
This is a minor Markdown change in the README to close brackets on the Helm charts reference so that it will be properly presented as a hyperlink

This is a minor improvement to make the README more polished for readers

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before
![before](https://user-images.githubusercontent.com/12024098/148653153-86e2cb97-610a-4e03-aabb-21b5384322e9.png)

After
![after](https://user-images.githubusercontent.com/12024098/148653159-76ce4cfc-9b95-46ef-9d63-0ca0c5a1e0ae.png)

No tests were created or modified because this is documentation written in Markdown