### PR TITLE
feat(Select): [cosmetic] support allowTopOptions for select component

### DIFF
--- a/superset-frontend/src/components/Select/Select.test.tsx
+++ b/superset-frontend/src/components/Select/Select.test.tsx
@@ -174,6 +174,20 @@ test('displays the selected values first', async () => {
   expect(sortedOptions[1]).toHaveTextContent(option8);
 });
 
+test('displays the original order if allowTopOptions is False', async () => {
+  render(<Select {...defaultProps} mode="multiple" allowTopOptions={false} />);
+  const option3 = OPTIONS[2].label;
+  const option8 = OPTIONS[7].label;
+  await open();
+  userEvent.click(await findSelectOption(option3));
+  userEvent.click(await findSelectOption(option8));
+  await type('{esc}');
+  await open();
+  const options = await findAllSelectOptions();
+  expect(options[2]).toHaveTextContent(option3);
+  expect(options[7]).toHaveTextContent(option8);
+});
+
 test('displays the original order when unselecting', async () => {
   render(<Select {...defaultProps} mode="multiple" />);
   const option3 = OPTIONS[2].label;

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -158,6 +158,11 @@ export interface SelectProps extends PickedSelectProps {
    */
   onError?: (error: string) => void;
   sortComparator?: (a: AntdLabeledValue, b: AntdLabeledValue) => number;
+  /**
+   * It enables the user to show top selected options
+   * True by default
+   */
+  allowTopOptions?: boolean;
 }
 
 const StyledContainer = styled.div`
@@ -289,6 +294,7 @@ const Select = ({
   showSearch = true,
   sortComparator = defaultSortComparator,
   value,
+  allowTopOptions = true,
   ...props
 }: SelectProps) => {
   const isAsync = typeof options === 'function';
@@ -587,7 +593,7 @@ const Select = ({
 
     // multiple or tags mode keep the dropdown visible while selecting options
     // this waits for the dropdown to be opened before sorting the top options
-    if (!isSingleMode && isDropdownVisible) {
+    if (!isSingleMode && isDropdownVisible && allowTopOptions) {
       handleTopOptions(selectValue);
     }
   };
@@ -691,10 +697,10 @@ const Select = ({
   ]);
 
   useEffect(() => {
-    if (isSingleMode) {
+    if (isSingleMode && allowTopOptions) {
       handleTopOptions(selectValue);
     }
-  }, [handleTopOptions, isSingleMode, selectValue]);
+  }, [handleTopOptions, isSingleMode, selectValue, allowTopOptions]);
 
   useEffect(() => {
     if (loading !== undefined && loading !== isLoading) {

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -296,6 +296,7 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
         value={frame}
         onChange={onChangeFrame}
         sortComparator={propertyComparator('order')}
+        allowTopOptions={false}
       />
       {frame !== 'No filter' && <Divider />}
       {frame === 'Common' && (


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently,  the select component will place the selected option in front of the dropdown options by default, which is a convenient interaction. However, in some scenarios, the user may not want to do this( https://github.com/apache/superset/issues/15972), so we can add an option to control this behavior.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### before
![image](https://user-images.githubusercontent.com/11830681/148677322-8d41bab3-f645-48d5-8594-d9a990fb714e.png)

### after
![image](https://user-images.githubusercontent.com/11830681/148677304-3663f86f-3c66-4661-8cbc-ac93ed4b9ff8.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/15972
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
