### PR TITLE
fix: css template API response, less data

### DIFF
--- a/superset/css_templates/api.py
+++ b/superset/css_templates/api.py
@@ -63,7 +63,9 @@ class CssTemplateRestApi(BaseSupersetModelRestApi):
     ]
     list_columns = [
         "changed_on_delta_humanized",
-        "changed_by",
+        "changed_by.first_name",
+        "changed_by.id",
+        "changed_by.last_name",
         "created_on",
         "created_by.first_name",
         "created_by.id",

--- a/tests/integration_tests/css_templates/api_tests.py
+++ b/tests/integration_tests/css_templates/api_tests.py
@@ -38,7 +38,7 @@ class TestCssTemplateApi(SupersetTestCase):
     ) -> CssTemplate:
         admin = self.get_user(created_by_username)
         css_template = CssTemplate(
-            template_name=template_name, css=css, created_by=admin
+            template_name=template_name, css=css, created_by=admin, changed_by=admin
         )
         db.session.add(css_template)
         db.session.commit()
@@ -75,15 +75,23 @@ class TestCssTemplateApi(SupersetTestCase):
         data = json.loads(rv.data.decode("utf-8"))
         assert data["count"] == len(css_templates)
         expected_columns = [
-            "changed_on_delta_humanized",
             "changed_by",
-            "created_on",
+            "changed_on_delta_humanized",
             "created_by",
-            "template_name",
+            "created_on",
             "css",
+            "id",
+            "template_name",
         ]
-        for expected_column in expected_columns:
-            assert expected_column in data["result"][0]
+        result_columns = list(data["result"][0].keys())
+        result_columns.sort()
+        assert expected_columns == result_columns
+        created_by_columns = list(data["result"][0]["created_by"].keys())
+        created_by_columns.sort()
+        assert ["first_name", "id", "last_name"] == created_by_columns
+        changed_by_columns = list(data["result"][0]["changed_by"].keys())
+        changed_by_columns.sort()
+        assert ["first_name", "id", "last_name"] == changed_by_columns
 
     @pytest.mark.usefixtures("create_css_templates")
     def test_get_list_sort_css_template(self):


### PR DESCRIPTION
### SUMMARY

Simplifies and send less unneeded data back, on the CSS template get list REST API

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
