### PR TITLE
fix(native-filters): apply default value correctly when it's set

### DIFF
--- a/superset-frontend/src/dataMask/reducer.ts
+++ b/superset-frontend/src/dataMask/reducer.ts
@@ -61,7 +61,7 @@ export function getInitialDataMask(
   } as DataMaskWithId;
 }
 
-async function fillNativeFilters(
+function fillNativeFilters(
   filterConfig: FilterConfiguration,
   mergedDataMask: DataMaskStateWithId,
   draftDataMask: DataMaskStateWithId,
@@ -139,8 +139,6 @@ const dataMaskReducer = produce(
           action.filterConfig ?? [],
           cleanState,
           draft,
-          // @ts-ignore
-          action.data.dataMask,
           action.filters,
         );
         return cleanState;


### PR DESCRIPTION
### SUMMARY
Due to a mistake in passing arguments to `dataMask/reducer/fillNativeFilters` function (we were passing undefined variable instead of data mask), default value wasn't applied correctly to native filters. This PR fixes this issue.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see linked issue
After:

https://user-images.githubusercontent.com/15073128/148766331-f3c5c33c-846a-4154-855e-45d2d9e43ac3.mov

### TESTING INSTRUCTIONS
Follow the repro steps from linked issue

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes #17950 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @jinghua-qa @rosemarie-chiu @rusackas 

https://app.shortcut.com/preset/story/34609/native-filter-filter-has-default-value-isn-t-applied-and-visible-after-save