### PR TITLE
fix: Assign an owner when creating a dataset from a csv, excel or tabular

### DIFF
--- a/superset/views/database/views.py
+++ b/superset/views/database/views.py
@@ -223,7 +223,7 @@ class CsvToDatabaseView(SimpleFormView):
                 sqla_table = SqlaTable(table_name=csv_table.table)
                 sqla_table.database = expore_database
                 sqla_table.database_id = database.id
-                sqla_table.user_id = g.user.get_id()
+                sqla_table.owners = [g.user]
                 sqla_table.schema = csv_table.schema
                 sqla_table.fetch_metadata()
                 db.session.add(sqla_table)
@@ -369,7 +369,7 @@ class ExcelToDatabaseView(SimpleFormView):
                 sqla_table = SqlaTable(table_name=excel_table.table)
                 sqla_table.database = expore_database
                 sqla_table.database_id = database.id
-                sqla_table.user_id = g.user.get_id()
+                sqla_table.owners = [g.user]
                 sqla_table.schema = excel_table.schema
                 sqla_table.fetch_metadata()
                 db.session.add(sqla_table)
@@ -521,7 +521,7 @@ class ColumnarToDatabaseView(SimpleFormView):
                 sqla_table = SqlaTable(table_name=columnar_table.table)
                 sqla_table.database = expore_database
                 sqla_table.database_id = database.id
-                sqla_table.user_id = g.user.get_id()
+                sqla_table.owners = [g.user]
                 sqla_table.schema = columnar_table.schema
                 sqla_table.fetch_metadata()
                 db.session.add(sqla_table)

--- a/tests/integration_tests/csv_upload_tests.py
+++ b/tests/integration_tests/csv_upload_tests.py
@@ -424,8 +424,9 @@ def test_import_excel(mock_event_logger):
     assert data == [(0, "john", 1), (1, "paul", 2)]
 
     # ensure user is assigned as an owner
-    table = SupersetTestCase.get_table(name=EXCEL_UPLOAD_TABLE, schema=None)
-    assert security_manager.find_user("admin") in table.owners
+    # Disabling the following to troubleshoot a broken test upstream
+    # table = SupersetTestCase.get_table(name=EXCEL_UPLOAD_TABLE, schema=None)
+    # assert security_manager.find_user("admin") in table.owners
 
 
 @pytest.mark.usefixtures("setup_csv_upload")

--- a/tests/integration_tests/csv_upload_tests.py
+++ b/tests/integration_tests/csv_upload_tests.py
@@ -142,13 +142,12 @@ def upload_csv(filename: str, table_name: str, extra: Optional[Dict[str, str]] =
 def upload_excel(
     filename: str, table_name: str, extra: Optional[Dict[str, str]] = None
 ):
-
-    csv_upload_db_id = get_upload_db().id
+    excel_upload_db_id = get_upload_db().id
     schema = utils.get_example_default_schema()
     form_data = {
         "excel_file": open(filename, "rb"),
         "name": table_name,
-        "con": csv_upload_db_id,
+        "con": excel_upload_db_id,
         "sheet_name": "Sheet1",
         "if_exists": "fail",
         "index_label": "test_label",

--- a/tests/integration_tests/csv_upload_tests.py
+++ b/tests/integration_tests/csv_upload_tests.py
@@ -379,10 +379,12 @@ def test_import_excel(mock_event_logger):
     if utils.backend() == "hive":
         pytest.skip("Hive doesn't excel upload.")
 
+    schema = utils.get_example_default_schema()
+    full_table_name = f"{schema}.{EXCEL_UPLOAD_TABLE}" if schema else EXCEL_UPLOAD_TABLE
     test_db = get_upload_db()
 
     success_msg = (
-        f'Excel file "{EXCEL_FILENAME}" uploaded to table "{EXCEL_UPLOAD_TABLE}"'
+        f'Excel file "{EXCEL_FILENAME}" uploaded to table "{full_table_name}"'
     )
 
     # initial upload with fail mode
@@ -391,7 +393,7 @@ def test_import_excel(mock_event_logger):
     mock_event_logger.assert_called_with(
         action="successful_excel_upload",
         database=test_db.name,
-        schema=None,
+        schema=schema,
         table=EXCEL_UPLOAD_TABLE,
     )
 
@@ -415,7 +417,7 @@ def test_import_excel(mock_event_logger):
     mock_event_logger.assert_called_with(
         action="successful_excel_upload",
         database=test_db.name,
-        schema=None,
+        schema=schema,
         table=EXCEL_UPLOAD_TABLE,
     )
 

--- a/tests/integration_tests/csv_upload_tests.py
+++ b/tests/integration_tests/csv_upload_tests.py
@@ -391,6 +391,10 @@ def test_import_excel(mock_event_logger):
         table=EXCEL_UPLOAD_TABLE,
     )
 
+    # ensure user is assigned as an owner
+    table = SupersetTestCase.get_table(name=EXCEL_UPLOAD_TABLE)
+    assert security_manager.find_user("admin") in table.owners
+
     # upload again with fail mode; should fail
     fail_msg = f'Unable to upload Excel file "{EXCEL_FILENAME}" to table "{EXCEL_UPLOAD_TABLE}"'
     resp = upload_excel(EXCEL_FILENAME, EXCEL_UPLOAD_TABLE)
@@ -422,11 +426,6 @@ def test_import_excel(mock_event_logger):
         .fetchall()
     )
     assert data == [(0, "john", 1), (1, "paul", 2)]
-
-    # ensure user is assigned as an owner
-    # Disabling the following to troubleshoot a broken test upstream
-    # table = SupersetTestCase.get_table(name=EXCEL_UPLOAD_TABLE, schema=None)
-    # assert security_manager.find_user("admin") in table.owners
 
 
 @pytest.mark.usefixtures("setup_csv_upload")

--- a/tests/integration_tests/csv_upload_tests.py
+++ b/tests/integration_tests/csv_upload_tests.py
@@ -383,9 +383,7 @@ def test_import_excel(mock_event_logger):
     full_table_name = f"{schema}.{EXCEL_UPLOAD_TABLE}" if schema else EXCEL_UPLOAD_TABLE
     test_db = get_upload_db()
 
-    success_msg = (
-        f'Excel file "{EXCEL_FILENAME}" uploaded to table "{full_table_name}"'
-    )
+    success_msg = f'Excel file "{EXCEL_FILENAME}" uploaded to table "{full_table_name}"'
 
     # initial upload with fail mode
     resp = upload_excel(EXCEL_FILENAME, EXCEL_UPLOAD_TABLE)
@@ -396,6 +394,10 @@ def test_import_excel(mock_event_logger):
         schema=schema,
         table=EXCEL_UPLOAD_TABLE,
     )
+
+    # ensure user is assigned as an owner
+    table = SupersetTestCase.get_table(name=EXCEL_UPLOAD_TABLE)
+    assert security_manager.find_user("admin") in table.owners
 
     # upload again with fail mode; should fail
     fail_msg = f'Unable to upload Excel file "{EXCEL_FILENAME}" to table "{EXCEL_UPLOAD_TABLE}"'
@@ -428,10 +430,6 @@ def test_import_excel(mock_event_logger):
         .fetchall()
     )
     assert data == [(0, "john", 1), (1, "paul", 2)]
-
-    # ensure user is assigned as an owner
-    table = SupersetTestCase.get_table(name=EXCEL_UPLOAD_TABLE)
-    assert security_manager.find_user("admin") in table.owners
 
 
 @pytest.mark.usefixtures("setup_csv_upload")

--- a/tests/integration_tests/csv_upload_tests.py
+++ b/tests/integration_tests/csv_upload_tests.py
@@ -28,6 +28,7 @@ import pandas as pd
 import pytest
 
 from superset.sql_parse import Table
+from superset import security_manager
 from tests.integration_tests.conftest import ADMIN_SCHEMA_NAME
 from tests.integration_tests.test_app import app  # isort:skip
 from superset import db
@@ -362,6 +363,10 @@ def test_import_csv(mock_event_logger):
     data = engine.execute(f"SELECT * from {CSV_UPLOAD_TABLE}").fetchall()
     assert data == [("john", 1, "x"), ("paul", 2, None)]
 
+    # ensure user is assigned as an owner
+    assert security_manager.find_user("admin") in table.owners
+
+
 
 @pytest.mark.usefixtures("setup_csv_upload")
 @pytest.mark.usefixtures("create_excel_files")
@@ -418,6 +423,10 @@ def test_import_excel(mock_event_logger):
         .fetchall()
     )
     assert data == [(0, "john", 1), (1, "paul", 2)]
+
+    # ensure user is assigned as an owner
+    table = SupersetTestCase.get_table(name=EXCEL_UPLOAD_TABLE)
+    assert security_manager.find_user("admin") in table.owners
 
 
 @pytest.mark.usefixtures("setup_csv_upload")
@@ -498,3 +507,8 @@ def test_import_parquet(mock_event_logger):
         .fetchall()
     )
     assert data == [("john", 1), ("paul", 2), ("max", 3), ("bob", 4)]
+
+    # ensure user is assigned as an owner
+    table = SupersetTestCase.get_table(name=PARQUET_UPLOAD_TABLE)
+    assert security_manager.find_user("admin") in table.owners
+

--- a/tests/integration_tests/csv_upload_tests.py
+++ b/tests/integration_tests/csv_upload_tests.py
@@ -367,7 +367,6 @@ def test_import_csv(mock_event_logger):
     assert data == [("john", 1, "x"), ("paul", 2, None)]
 
 
-
 @pytest.mark.usefixtures("setup_csv_upload")
 @pytest.mark.usefixtures("create_excel_files")
 @mock.patch("superset.db_engine_specs.hive.upload_to_s3", mock_upload_to_s3)

--- a/tests/integration_tests/csv_upload_tests.py
+++ b/tests/integration_tests/csv_upload_tests.py
@@ -424,7 +424,7 @@ def test_import_excel(mock_event_logger):
     assert data == [(0, "john", 1), (1, "paul", 2)]
 
     # ensure user is assigned as an owner
-    table = SupersetTestCase.get_table(name=EXCEL_UPLOAD_TABLE)
+    table = SupersetTestCase.get_table(name=EXCEL_UPLOAD_TABLE, schema=None)
     assert security_manager.find_user("admin") in table.owners
 
 

--- a/tests/integration_tests/csv_upload_tests.py
+++ b/tests/integration_tests/csv_upload_tests.py
@@ -346,6 +346,9 @@ def test_import_csv(mock_event_logger):
     # make sure the new column name is reflected in the table metadata
     assert "d" in table.column_names
 
+    # ensure user is assigned as an owner
+    assert security_manager.find_user("admin") in table.owners
+
     # null values are set
     upload_csv(
         CSV_FILENAME2,
@@ -362,9 +365,6 @@ def test_import_csv(mock_event_logger):
     # make sure that john and empty string are replaced with None
     data = engine.execute(f"SELECT * from {CSV_UPLOAD_TABLE}").fetchall()
     assert data == [("john", 1, "x"), ("paul", 2, None)]
-
-    # ensure user is assigned as an owner
-    assert security_manager.find_user("admin") in table.owners
 
 
 
@@ -475,9 +475,12 @@ def test_import_parquet(mock_event_logger):
     )
     assert success_msg_f1 in resp
 
-    # make sure only specified column name was read
     table = SupersetTestCase.get_table(name=PARQUET_UPLOAD_TABLE, schema=None)
+    # make sure only specified column name was read
     assert "b" not in table.column_names
+
+    # ensure user is assigned as an owner
+    assert security_manager.find_user("admin") in table.owners
 
     # upload again with replace mode
     resp = upload_columnar(
@@ -507,8 +510,3 @@ def test_import_parquet(mock_event_logger):
         .fetchall()
     )
     assert data == [("john", 1), ("paul", 2), ("max", 3), ("bob", 4)]
-
-    # ensure user is assigned as an owner
-    table = SupersetTestCase.get_table(name=PARQUET_UPLOAD_TABLE)
-    assert security_manager.find_user("admin") in table.owners
-


### PR DESCRIPTION
### SUMMARY
The existing code has a bug and no owner gets assigned when a dataset was created from a data upload. The fix assigns the current user as the owner when creating a dataset from a csv, excel or tabular.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TESTING INSTRUCTIONS
1. Ensure you have a defined database that allows data upload
2. From the Data drop-down menu in the top menu bar, select Upload a CSV
3. Enter appropriate values and hit SAVE.
4. Find the dataset created in /tablemodelview/list/ and click the Edit icon.
5. In the Settings tab of the dialog, under Owners, the user who uploaded the data is listed.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
