### PR TITLE
fix: Keep Report modal open when there's an error

### DIFF
--- a/superset-frontend/src/components/ReportModal/index.tsx
+++ b/superset-frontend/src/components/ReportModal/index.tsx
@@ -25,6 +25,7 @@ import React, {
   FunctionComponent,
 } from 'react';
 import { t, SupersetTheme } from '@superset-ui/core';
+import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 import { bindActionCreators } from 'redux';
 import { connect, useDispatch, useSelector } from 'react-redux';
 import { addReport, editReport } from 'src/reports/actions/reports';
@@ -72,6 +73,7 @@ export interface ReportObject {
   working_timeout: number;
   creation_method: string;
   force_screenshot: boolean;
+  error?: string;
 }
 
 interface ChartObject {
@@ -88,8 +90,6 @@ interface ChartObject {
 }
 
 interface ReportProps {
-  addDangerToast: (msg: string) => void;
-  addSuccessToast: (msg: string) => void;
   addReport: (report?: ReportObject) => {};
   onHide: () => {};
   onReportAdd: (report?: ReportObject) => {};
@@ -111,6 +111,7 @@ enum ActionType {
   inputChange,
   fetched,
   reset,
+  error,
 }
 
 type ReportActionType =
@@ -124,6 +125,12 @@ type ReportActionType =
     }
   | {
       type: ActionType.reset;
+    }
+  | {
+      type: ActionType.error;
+      payload: {
+        name: string[];
+      };
     };
 
 const TEXT_BASED_VISUALIZATION_TYPES = [
@@ -161,6 +168,11 @@ const reportReducer = (
       };
     case ActionType.reset:
       return { ...initialState };
+    case ActionType.error:
+      return {
+        ...state,
+        error: action.payload.name[0],
+      };
     default:
       return state;
   }
@@ -181,11 +193,10 @@ const ReportModal: FunctionComponent<ReportProps> = ({
   const [currentReport, setCurrentReport] = useReducer<
     Reducer<Partial<ReportObject> | null, ReportActionType>
   >(reportReducer, null);
-  const onChange = useCallback((type: any, payload: any) => {
+  const onReducerChange = useCallback((type: any, payload: any) => {
     setCurrentReport({ type, payload });
   }, []);
-  const [error, setError] = useState<CronError>();
-  // const [isLoading, setLoading] = useState<boolean>(false);
+  const [cronError, setCronError] = useState<CronError>();
   const dispatch = useDispatch();
   // Report fetch logic
   const reports = useSelector<any, AlertObject>(state => state.reports);
@@ -205,9 +216,7 @@ const ReportModal: FunctionComponent<ReportProps> = ({
       });
     }
   }, [reports]);
-  const onClose = () => {
-    onHide();
-  };
+
   const onSave = async () => {
     // Create new Report
     const newReportValues: Partial<ReportObject> = {
@@ -235,15 +244,19 @@ const ReportModal: FunctionComponent<ReportProps> = ({
       await dispatch(
         editReport(currentReport?.id, newReportValues as ReportObject),
       );
+      onHide();
     } else {
-      await dispatch(addReport(newReportValues as ReportObject));
+      try {
+        await dispatch(addReport(newReportValues as ReportObject));
+        onHide();
+      } catch (e) {
+        const parsedError = await getClientErrorObject(e);
+        const errorMessage = parsedError.message;
+        onReducerChange(ActionType.error, errorMessage);
+      }
     }
 
-    if (onReportAdd) {
-      onReportAdd();
-    }
-
-    onClose();
+    if (onReportAdd) onReportAdd();
   };
 
   const wrappedTitle = (
@@ -257,7 +270,7 @@ const ReportModal: FunctionComponent<ReportProps> = ({
 
   const renderModalFooter = (
     <>
-      <StyledFooterButton key="back" onClick={onClose}>
+      <StyledFooterButton key="back" onClick={onHide}>
         {t('Cancel')}
       </StyledFooterButton>
       <StyledFooterButton
@@ -279,7 +292,7 @@ const ReportModal: FunctionComponent<ReportProps> = ({
       <div className="inline-container">
         <StyledRadioGroup
           onChange={(event: RadioChangeEvent) => {
-            onChange(ActionType.inputChange, {
+            onReducerChange(ActionType.inputChange, {
               name: 'report_format',
               value: event.target.value,
             });
@@ -305,7 +318,7 @@ const ReportModal: FunctionComponent<ReportProps> = ({
   return (
     <StyledModal
       show={show}
-      onHide={onClose}
+      onHide={onHide}
       title={wrappedTitle}
       footer={renderModalFooter}
       width="432"
@@ -316,18 +329,16 @@ const ReportModal: FunctionComponent<ReportProps> = ({
           id="name"
           name="name"
           value={currentReport?.name || ''}
-          placeholder="Weekly Report"
+          placeholder={t('Weekly Report')}
           required
           validationMethods={{
             onChange: ({ target }: { target: HTMLInputElement }) =>
-              onChange(ActionType.inputChange, {
+              onReducerChange(ActionType.inputChange, {
                 name: target.name,
                 value: target.value,
               }),
           }}
-          errorMessage={
-            currentReport?.name === 'error' ? t('REPORT NAME ERROR') : ''
-          }
+          errorMessage={currentReport?.error || ''}
           label="Report Name"
           data-test="report-name-test"
         />
@@ -338,16 +349,16 @@ const ReportModal: FunctionComponent<ReportProps> = ({
           value={currentReport?.description || ''}
           validationMethods={{
             onChange: ({ target }: { target: HTMLInputElement }) =>
-              onChange(ActionType.inputChange, {
+              onReducerChange(ActionType.inputChange, {
                 name: target.name,
                 value: target.value,
               }),
           }}
-          errorMessage={
-            currentReport?.description === 'error' ? t('DESCRIPTION ERROR') : ''
-          }
-          label="Description"
-          placeholder="Include a description that will be sent with your report"
+          errorMessage=""
+          label={t('Description')}
+          placeholder={t(
+            'Include a description that will be sent with your report',
+          )}
           css={noBottomMargin}
           data-test="report-description-test"
         />
@@ -363,16 +374,16 @@ const ReportModal: FunctionComponent<ReportProps> = ({
 
         <StyledCronPicker
           clearButton={false}
-          value={currentReport?.crontab || '0 12 * * 1'}
+          value={t(currentReport?.crontab || '0 12 * * 1')}
           setValue={(newValue: string) => {
-            onChange(ActionType.inputChange, {
+            onReducerChange(ActionType.inputChange, {
               name: 'crontab',
               value: newValue,
             });
           }}
-          onError={setError}
+          onError={setCronError}
         />
-        <StyledCronError>{error}</StyledCronError>
+        <StyledCronError>{cronError}</StyledCronError>
         <div
           className="control-label"
           css={(theme: SupersetTheme) => TimezoneHeaderStyle(theme)}

--- a/superset-frontend/src/reports/actions/reports.js
+++ b/superset-frontend/src/reports/actions/reports.js
@@ -19,7 +19,6 @@
 /* eslint camelcase: 0 */
 import { t, SupersetClient } from '@superset-ui/core';
 import rison from 'rison';
-import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 import {
   addDangerToast,
   addSuccessToast,
@@ -105,22 +104,10 @@ export const addReport = report => dispatch =>
   SupersetClient.post({
     endpoint: `/api/v1/report/`,
     jsonPayload: report,
-  })
-    .then(({ json }) => {
-      dispatch({ type: ADD_REPORT, json });
-      dispatch(addSuccessToast(t('The report has been created')));
-    })
-    .catch(async e => {
-      const parsedError = await getClientErrorObject(e);
-      const errorMessage = parsedError.message;
-      const errorArr = Object.keys(errorMessage);
-      const error = errorMessage[errorArr[0]];
-      dispatch(
-        addDangerToast(
-          t('An error occurred while editing this report: %s', error),
-        ),
-      );
-    });
+  }).then(({ json }) => {
+    dispatch({ type: ADD_REPORT, json });
+    dispatch(addSuccessToast(t('The report has been created')));
+  });
 
 export const EDIT_REPORT = 'EDIT_REPORT';
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The report modal was only using toasts for responses - error or success - so the user would have to reopen the modal to fix an errored report. The error is now brought into the modal directly and displayed underneath the name field, and will not close until the error is corrected.

Note: The name field is currently the only field that takes this type of error. The cron scheduler is the only other thing that has an error in this modal, and it has its own separate error handling already set up.

Note II: I also did some code cleanup in the report modal.

### ANIMATED MOV
<!--- Skip this if not applicable -->
This demonstrates the modal correctly staying open and closing and also keeping correct values in the following events:
- Create new report
  - With error occurring first
- Edit existing report
- Delete existing report
- Create a new report after deleting
  - A clean un-errored creation

https://user-images.githubusercontent.com/55605634/148836701-411716b2-064d-4b07-b4e9-c805a4f658b0.mov

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Create new report
  - With error occurring first
- Edit existing report
- Delete existing report
- Create a new report after deleting
  - A clean un-errored creation
- Observe that the modal stays open when there's an error and closes when there is not
  - Also observe that the modal keeps all the correct values throughout these events.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
