### PR TITLE
fix: Workaround for sqlparse issue #652

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -42,7 +42,7 @@ CTE_PREFIX = "CTE__"
 logger = logging.getLogger(__name__)
 
 
-# Workaround for https://github.com/andialbrecht/sqlparse/issues/652.
+# TODO: Workaround for https://github.com/andialbrecht/sqlparse/issues/652.
 sqlparse.keywords.SQL_REGEX.insert(
     0,
     (

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
+import re
 from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional, Set
@@ -39,6 +40,16 @@ ON_KEYWORD = "ON"
 PRECEDES_TABLE_NAME = {"FROM", "JOIN", "DESCRIBE", "WITH", "LEFT JOIN", "RIGHT JOIN"}
 CTE_PREFIX = "CTE__"
 logger = logging.getLogger(__name__)
+
+
+# Workaround for https://github.com/andialbrecht/sqlparse/issues/652.
+sqlparse.keywords.SQL_REGEX.insert(
+    0,
+    (
+        re.compile(r"'(''|\\\\|\\|[^'])*'", re.IGNORECASE | re.UNICODE).match,
+        sqlparse.tokens.String.Single,
+    ),
+)
 
 
 class CtasMethod(str, Enum):

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 sqlparse.keywords.SQL_REGEX.insert(
     0,
     (
-        re.compile(r"'(''|\\\\|\\|[^'])*'", re.IGNORECASE | re.UNICODE).match,
+        re.compile(r"'(''|\\\\|\\|[^'])*'", sqlparse.keywords.FLAGS).match,
         sqlparse.tokens.String.Single,
     ),
 )

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -1199,3 +1199,9 @@ def test_validate_filter_clause_comment():
 def test_validate_filter_clause_subquery_comment():
     with pytest.raises(QueryClauseValidationException):
         validate_filter_clause("(1 = 1 -- comment\n)")
+
+
+def test_sqlparse_issue_652():
+    stmt = sqlparse.parse(r"foo = '\' AND bar = 'baz'")[0]
+    assert len(stmt.tokens) == 5
+    assert str(stmt.tokens[0]) == "foo = '\\'"


### PR DESCRIPTION
### SUMMARY

This PR provides a proposed workaround—by way of monkey patching—to https://github.com/andialbrecht/sqlparse/issues/652 which seems to have an incorrect regex pattern when matching single string tokens which contain an escape.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Added unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
