### PR TITLE
refactor: remove unused ts-jest

### DIFF
--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -50,26 +50,9 @@ module.exports = {
     'dist/',
   ],
   coverageReporters: ['lcov', 'json-summary', 'html'],
-  transform: {
-    '^.+\\.jsx?$': 'babel-jest',
-    // ts-jest doesn't work with `--coverage`. @superset-ui/core should
-    // 100% coverage, so we use babel-jest in packages and plugins.
-    '(plugins|packages)\\/.+\\.tsx?$': 'babel-jest',
-    '(((?!(plugins|packages)).)*)\\/.+\\.tsx?$': 'ts-jest',
-  },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   snapshotSerializers: ['@emotion/jest/enzyme-serializer'],
   globals: {
-    'ts-jest': {
-      babelConfig: true,
-      // todo: duo to packages/**/test and plugins/**/test lack of type checking
-      // turning off checking in Jest.
-      // https://kulshekhar.github.io/ts-jest/docs/getting-started/options/isolatedModules
-      isolatedModules: true,
-      diagnostics: {
-        warnOnly: true,
-      },
-    },
     __DEV__: true,
     caches: true,
   },

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -319,7 +319,6 @@
     "style-loader": "^3.2.1",
     "thread-loader": "^3.0.4",
     "transform-loader": "^0.2.4",
-    "ts-jest": "^26.4.2",
     "ts-loader": "^9.2.5",
     "typescript": "^4.5.4",
     "webpack": "^5.52.1",

--- a/superset-frontend/src/components/Select/DeprecatedSelect.tsx
+++ b/superset-frontend/src/components/Select/DeprecatedSelect.tsx
@@ -26,19 +26,19 @@ import BasicSelect, {
   SelectComponentsConfig,
   components as defaultComponents,
   createFilter,
+  Props as SelectProps,
 } from 'react-select';
 import Async from 'react-select/async';
 import Creatable from 'react-select/creatable';
 import AsyncCreatable from 'react-select/async-creatable';
 
-import { SelectComponents } from 'react-select/src/components';
+import type { SelectComponents } from 'react-select/src/components';
 import {
   SortableContainer,
   SortableElement,
   SortableContainerProps,
 } from 'react-sortable-hoc';
 import arrayMove from 'array-move';
-import { Props as SelectProps } from 'react-select/src/Select';
 import { useTheme } from '@superset-ui/core';
 import {
   WindowedSelectComponentType,

--- a/superset-frontend/src/components/Select/styles.tsx
+++ b/superset-frontend/src/components/Select/styles.tsx
@@ -25,10 +25,10 @@ import {
   SelectComponentsConfig,
   components as defaultComponents,
   InputProps as ReactSelectInputProps,
+  Props as SelectProps,
 } from 'react-select';
-import { Props as SelectProps } from 'react-select/src/Select';
-import { colors as reactSelectColors } from 'react-select/src/theme';
-import { DeepNonNullable } from 'react-select/src/components';
+import type { colors as reactSelectColors } from 'react-select/src/theme';
+import type { DeepNonNullable } from 'react-select/src/components';
 import { OptionType } from 'antd/lib/select';
 import { SupersetStyledSelectProps } from './DeprecatedSelect';
 


### PR DESCRIPTION
### SUMMARY
Currenttly, `ts-jest` is just used to import some `esm` module from `react-select/src`. We can use `import type` to avoid it, so we can remove `ts-jest` and keep [default transform](https://jestjs.io/docs/configuration#transform-objectstring-pathtotransformer--pathtotransformer-object) in `jest.config.js`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
