### PR TITLE
fix(helm): pin correct psycopg2 version

### DIFF
--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
   - name: craig-rueda
     email: craig@craigrueda.com
     url: https://github.com/craig-rueda
-version: 0.5.3
+version: 0.5.4
 dependencies:
 - name: postgresql
   version: 10.2.0

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -36,8 +36,8 @@ bootstrapScript: |
   #!/bin/bash
   rm -rf /var/lib/apt/lists/* && \
   pip install \
-    psycopg2==2.8.5 \
-    redis==3.2.1 && \
+    psycopg2-binary==2.9.1 \
+    redis==3.5.3 && \
   if [ ! -f ~/bootstrap ]; then echo "Running Superset with uid {{ .Values.runAsUser }}" > ~/bootstrap; fi
 
 ## The name of the secret which we will use to generate a superset_config.py file

--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,7 @@ setup(
         "mysql": ["mysqlclient>=2.1.0, <3"],
         "oracle": ["cx-Oracle>8.0.0, <8.1"],
         "pinot": ["pinotdb>=0.3.3, <0.4"],
-        "postgres": ["psycopg2-binary==2.8.5"],
+        "postgres": ["psycopg2-binary==2.9.1"],
         "presto": ["pyhive[presto]>=0.4.0"],
         "trino": ["sqlalchemy-trino>=0.2"],
         "prophet": ["prophet>=1.0.1, <1.1", "pystan<3.0"],


### PR DESCRIPTION
### SUMMARY
Recently the psycopg2 version was bumped from 2.8 to 2.9 in #17290, which caused a regression that was fixed in #17713 . However, the psycopg2 versions were not bumped on `setup.py` or on the Helm chart. This updates the version of psycopg2 to 2.9.1 throughout the application, and also fixes the inconsistent redis version (bycatch).

Closes #17997

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
