### PR TITLE
fix: revert #17654 to fix subselect table name parsing

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -318,11 +318,6 @@ class ParsedQuery:
 
         table_name_preceding_token = False
 
-        # If the table name is a reserved word (eg, "table_name") it won't be returned. We
-        # fix this by ensuring that at least one identifier is returned after the FROM
-        # before stopping on a keyword.
-        has_processed_identifier = False
-
         for item in token.tokens:
             if item.is_group and (
                 not self._is_identifier(item) or isinstance(item.tokens[0], Parenthesis)
@@ -336,25 +331,16 @@ class ParsedQuery:
                 table_name_preceding_token = True
                 continue
 
-            # If we haven't processed any identifiers it means the table name is a
-            # reserved keyword (eg, "table_name") and we shouldn't skip it.
-            if item.ttype in Keyword and has_processed_identifier:
+            if item.ttype in Keyword:
                 table_name_preceding_token = False
                 continue
             if table_name_preceding_token:
                 if isinstance(item, Identifier):
                     self._process_tokenlist(item)
-                    has_processed_identifier = True
                 elif isinstance(item, IdentifierList):
                     for token2 in item.get_identifiers():
                         if isinstance(token2, TokenList):
                             self._process_tokenlist(token2)
-                    has_processed_identifier = True
-                elif item.ttype in Keyword:
-                    # convert into an identifier
-                    fixed = Identifier([Token(Name, item.value)])
-                    self._process_tokenlist(fixed)
-                    has_processed_identifier = True
             elif isinstance(item, IdentifierList):
                 if any(not self._is_identifier(token2) for token2 in item.tokens):
                     self._extract_from_token(item)

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -45,11 +45,11 @@ def test_table() -> None:
 
     Special characters in the table, schema, or catalog name should be escaped correctly.
     """
-    assert str(Table("table_name")) == "table_name"
-    assert str(Table("table_name", "schema_name")) == "schema_name.table_name"
+    assert str(Table("tbname")) == "tbname"
+    assert str(Table("tbname", "schemaname")) == "schemaname.tbname"
     assert (
-        str(Table("table_name", "schema_name", "catalog_name"))
-        == "catalog_name.schema_name.table_name"
+        str(Table("tbname", "schemaname", "catalogname"))
+        == "catalogname.schemaname.tbname"
     )
     assert (
         str(Table("table.name", "schema/name", "catalog\nname"))
@@ -534,22 +534,6 @@ def test_extract_tables_multistatement() -> None:
     assert extract_tables("SELECT * FROM t1; SELECT * FROM t2;") == {
         Table("t1"),
         Table("t2"),
-    }
-
-
-def test_extract_tables_keyword() -> None:
-    """
-    Test that table names that are keywords work as expected.
-
-    If the table name is a ``sqlparse`` reserved keyword (eg, "table_name") the parser
-    needs extra logic to identify it.
-    """
-    assert extract_tables("SELECT * FROM table_name") == {Table("table_name")}
-    assert extract_tables("SELECT * FROM table_name AS foo") == {Table("table_name")}
-
-    # these 3 are considered keywords
-    assert extract_tables("SELECT * FROM catalog_name.schema_name.table_name") == {
-        Table("table_name", "schema_name", "catalog_name")
     }
 
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Manually reverting https://github.com/apache/superset/pull/17654 since it doesn't revert cleanly. We need to revert this because it broke parsing table names from subselects. Ideally we could fix forward, but this seems pretty tricky, so putting up the revert PR for now

See https://github.com/apache/superset/pull/17654#issuecomment-1009487562:
it looks like this PR broke parsing table names from queries with sub selects. Here's a repro case:
```sql
SELECT *
   FROM
     (SELECT 1 as foo, 2 as bar)
   ORDER BY foo ASC, bar
```

ParsedQuery now thinks that `ORDER BY` and `bar` are tables:
![Screen Shot 2022-01-10 at 4 36 36 PM](https://user-images.githubusercontent.com/7409244/148861079-a086fa6a-5198-4f99-910b-3ce77948d195.png)

Do you think this is something you could easily fix, or should we consider reverting this PR? I could possibly look into fixing myself, but the sql parse codebase is something i'm a bit nervous about jumping into


### TESTING INSTRUCTIONS
CI, unit tests, verify in superset shell that parsing subselects works now
```
>>> from superset.sql_parse import ParsedQuery
>>> sql = """SELECT *
   FROM
     (SELECT 1 as foo, 2 as bar)
   ORDER BY foo ASC, bar"""
>>> ParsedQuery(sql).tables
set()
>>> sql = """SELECT *
   FROM
     (SELECT 1 as foo, 2 as bar from tbname)
   ORDER BY foo ASC, bar"""
>>> ParsedQuery(sql).tables
{Table(table='tbname', schema=None, catalog=None)}
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @betodealmeida @john-bodley