### PR TITLE
fix: Disable filtering on wide result sets

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -37,7 +37,9 @@ import { SaveDatasetModal } from 'src/SqlLab/components/SaveDatasetModal';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 import ProgressBar from 'src/components/ProgressBar';
 import Loading from 'src/components/Loading';
-import FilterableTable from 'src/components/FilterableTable/FilterableTable';
+import FilterableTable, {
+  MAX_COLUMNS_FOR_TABLE,
+} from 'src/components/FilterableTable/FilterableTable';
 import CopyToClipboard from 'src/components/CopyToClipboard';
 import { prepareCopyToClipboardTabularData } from 'src/utils/common';
 import { exploreChart } from 'src/explore/exploreUtils';
@@ -560,7 +562,12 @@ export default class ResultSet extends React.PureComponent<
               onChange={this.changeSearch}
               value={this.state.searchText}
               className="form-control input-sm"
-              placeholder={t('Filter results')}
+              disabled={columns.length > MAX_COLUMNS_FOR_TABLE}
+              placeholder={
+                columns.length > MAX_COLUMNS_FOR_TABLE
+                  ? t('Too many columns to filter')
+                  : t('Filter results')
+              }
             />
           )}
         </ResultSetControls>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
When the results in SQL Lab has more than 50 columns, we don't do any filtering. This isn't obvious from the UI though, since the filter box is still editable. This change disables the filter box and adds context to the placeholder when the result set has more than 50 columns

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
50 columns:
<img width="1628" alt="Screen Shot 2022-01-12 at 10 21 32 PM" src="https://user-images.githubusercontent.com/7409244/149276551-549bf743-750a-46bf-8713-0b12c4f3320a.png">

51 columns:
<img width="1629" alt="Screen Shot 2022-01-12 at 10 21 22 PM" src="https://user-images.githubusercontent.com/7409244/149276565-3c8adb6f-5734-4456-a216-12a4f57b611e.png">

### TESTING INSTRUCTIONS
Verify in testenv that results with > 50 columns have a disabled filter box

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @michael-s-molina @ktmud @graceguo-supercat @riahk 