### PR TITLE
fix: handle null values in time-series table

### DIFF
--- a/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
+++ b/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
@@ -192,14 +192,17 @@ const TimeTable = ({
         } else {
           v = reversedEntries[timeLag][valueField];
         }
-        if (column.comparisonType === 'diff') {
-          v = recent - v;
-        } else if (column.comparisonType === 'perc') {
-          v = recent / v;
-        } else if (column.comparisonType === 'perc_change') {
-          v = recent / v - 1;
+        if (typeof v === 'number' || typeof recent === 'number') {
+          if (column.comparisonType === 'diff') {
+            v = recent - v;
+          } else if (column.comparisonType === 'perc') {
+            v = recent / v;
+          } else if (column.comparisonType === 'perc_change') {
+            v = recent / v - 1;
+          }
+        } else {
+          v = 'N/A';
         }
-        v = v || 0;
       } else if (column.colType === 'contrib') {
         // contribution to column total
         v =


### PR DESCRIPTION

### SUMMARY
In Time-Series table viz, user can choose `Time Comparison` type to build a table column, and select a gap between times to compare:
<img width="358" alt="Screen Shot 2022-01-13 at 4 00 58 PM" src="https://user-images.githubusercontent.com/27990562/149427851-387fb454-675e-46a2-97e5-db655fa9e2a0.png">

But in some cases, for one or more given time spots, some of the metric values could be null, it will make Time Comparison feature not available. In the current code, chart display unavailable data as `0`, which is not accurate, and users can not distinguish the cases where the actual comparison value is `0`. See a real example screenshot below. Note: we will show a **dot** in sparkline if there is a value in the given time spot.

This PR is trying to fix these unavailable time-comparison values. instead of showing number `0`, i will display text `N/A`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**before:**
<img width="786" alt="Screen Shot 2022-01-13 at 12 24 50 PM" src="https://user-images.githubusercontent.com/27990562/149428647-4c6d77c5-d877-47ed-a62c-3eb5928dd016.png">

**after:**
<img width="927" alt="Screen Shot 2022-01-13 at 12 30 28 PM" src="https://user-images.githubusercontent.com/27990562/149428731-c63f7873-2193-4bf8-930e-9a986251f18b.png">




### TESTING INSTRUCTIONS
CI and manual test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
