### PR TITLE
fix(dashboard): scope status of native filter not update

### DIFF
--- a/superset-frontend/src/dashboard/actions/hydrate.js
+++ b/superset-frontend/src/dashboard/actions/hydrate.js
@@ -70,7 +70,7 @@ export const hydrateDashboard =
     dataMaskApplied,
   ) =>
   (dispatch, getState) => {
-    const { user, common } = getState();
+    const { user, common, dashboardState } = getState();
 
     const { metadata } = dashboardData;
     const regularUrlParams = extractUrlParams('regular');
@@ -406,7 +406,7 @@ export const hydrateDashboard =
           maxUndoHistoryExceeded: false,
           lastModifiedTime: dashboardData.changed_on,
           isRefreshing: false,
-          activeTabs: [],
+          activeTabs: dashboardState?.activeTabs || [],
           filterboxMigrationState,
         },
         dashboardLayout,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Since the scope status of native filter is related to active tab, I found that when the user goes to the dashboard from the dashboard list, the active tab state from `useSelector` would be empty, even though react component has updated the active tab state. Eventually I found that `hydrateDashboard` would reset this state but the expectation was that it would not be reset.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### before
https://user-images.githubusercontent.com/81597121/149433547-fcd17a72-866a-4110-8904-c442965efb8e.mp4
### after


https://user-images.githubusercontent.com/11830681/149542029-bd01660a-f17f-4004-b1cf-2a29e1736824.mov



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/18040
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
