### PR TITLE
fix(CRUD/listviews): Errors with rison and search strings using special characters

### DIFF
--- a/superset-frontend/src/components/ListView/Filters/Search.tsx
+++ b/superset-frontend/src/components/ListView/Filters/Search.tsx
@@ -51,8 +51,7 @@ export default function SearchFilter({
   const [value, setValue] = useState(initialValue || '');
   const handleSubmit = () => {
     if (value) {
-      // encode plus signs to prevent them from being converted into a space
-      onSubmit(value.trim().replace(/\+/g, '%2B'));
+      onSubmit(value.trim());
     }
   };
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/superset-frontend/src/components/ListView/utils.ts
+++ b/superset-frontend/src/components/ListView/utils.ts
@@ -46,10 +46,17 @@ import {
 } from './types';
 
 // Define custom RisonParam for proper encoding/decoding; note that
-// plus symbols should be encoded to avoid being converted into a space
+// %, &, +, and # must be encoded to avoid breaking the url
 const RisonParam: QueryParamConfig<string, any> = {
   encode: (data?: any | null) =>
-    data === undefined ? undefined : rison.encode(data).replace(/\+/g, '%2B'),
+    data === undefined
+      ? undefined
+      : rison
+          .encode(data)
+          .replace(/%/g, '%25')
+          .replace(/&/g, '%26')
+          .replace(/\+/g, '%2B')
+          .replace(/#/g, '%23'),
   decode: (dataStr?: string | string[]) =>
     dataStr === undefined || Array.isArray(dataStr)
       ? undefined

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -75,7 +75,7 @@ const fetchTimeRange = async (
   timeRange: string,
   endpoints?: TimeRangeEndpoints,
 ) => {
-  const query = rison.encode(timeRange);
+  const query = rison.encode_uri(timeRange);
   const endpoint = `/api/v1/time_range/?q=${query}`;
   try {
     const response = await SupersetClient.get({ endpoint });

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -674,7 +674,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
   const loadDashboardOptions = useMemo(
     () =>
       (input = '', page: number, pageSize: number) => {
-        const query = rison.encode({
+        const query = rison.encode_uri({
           filter: input,
           page,
           page_size: pageSize,
@@ -748,7 +748,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
   const loadChartOptions = useMemo(
     () =>
       (input = '', page: number, pageSize: number) => {
-        const query = rison.encode({
+        const query = rison.encode_uri({
           filter: input,
           page,
           page_size: pageSize,

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -147,7 +147,7 @@ export function useListViewResource<D extends object = any>(
               : value,
         }));
 
-      const queryParams = rison.encode({
+      const queryParams = rison.encode_uri({
         order_column: sortBy[0].id,
         order_direction: sortBy[0].desc ? 'desc' : 'asc',
         page: pageIndex,

--- a/superset-frontend/src/views/CRUD/utils.test.tsx
+++ b/superset-frontend/src/views/CRUD/utils.test.tsx
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import rison from 'rison';
 import {
   isNeedsPassword,
   isAlreadyExists,
@@ -170,4 +171,22 @@ test('does not ask for password when the import type is wrong', () => {
     ],
   };
   expect(hasTerminalValidation(error.errors)).toBe(true);
+});
+
+test('successfully modified rison to encode correctly', () => {
+  const problemCharacters = '& # ? ^ { } [ ] | " = + `';
+
+  const testObject = problemCharacters.split(' ').reduce((a, c) => {
+    // eslint-disable-next-line no-param-reassign
+    a[c] = c;
+    return a;
+  }, {});
+
+  const actualEncoding = rison.encode(testObject);
+
+  const expectedEncoding =
+    "('\"':'\"','#':'#','&':'&','+':'+','=':'=','?':'?','[':'[',']':']','^':'^','`':'`','{':'{','|':'|','}':'}')";
+
+  expect(actualEncoding).toEqual(expectedEncoding);
+  expect(rison.decode(actualEncoding)).toEqual(testObject);
 });

--- a/superset-frontend/src/views/CRUD/utils.test.tsx
+++ b/superset-frontend/src/views/CRUD/utils.test.tsx
@@ -176,17 +176,13 @@ test('does not ask for password when the import type is wrong', () => {
 test('successfully modified rison to encode correctly', () => {
   const problemCharacters = '& # ? ^ { } [ ] | " = + `';
 
-  const testObject = problemCharacters.split(' ').reduce((a, c) => {
-    // eslint-disable-next-line no-param-reassign
-    a[c] = c;
-    return a;
-  }, {});
+  problemCharacters.split(' ').forEach(char => {
+    const testObject = { test: char };
 
-  const actualEncoding = rison.encode(testObject);
+    const actualEncoding = rison.encode(testObject);
+    const expectedEncoding = `(test:'${char}')`; // Ex: (test:'&')
 
-  const expectedEncoding =
-    "('\"':'\"','#':'#','&':'&','+':'+','=':'=','?':'?','[':'[',']':']','^':'^','`':'`','{':'{','|':'|','}':'}')";
-
-  expect(actualEncoding).toEqual(expectedEncoding);
-  expect(rison.decode(actualEncoding)).toEqual(testObject);
+    expect(actualEncoding).toEqual(expectedEncoding);
+    expect(rison.decode(actualEncoding)).toEqual(testObject);
+  });
 });

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -33,8 +33,8 @@ import { FetchDataConfig } from 'src/components/ListView';
 import SupersetText from 'src/utils/textUtils';
 import { Dashboard, Filters } from './types';
 
-// Modifies the rison encoding slightly to match the backend's
-// rison encoding/decoding. Applies globally. Code pulled from rison.js
+// Modifies the rison encoding slightly to match the backend's rison encoding/decoding. Applies globally.
+// Code pulled from rison.js (https://github.com/Nanonid/rison), rison is licensed under the MIT license.
 (() => {
   const risonRef: {
     not_idchar: string;

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -35,7 +35,7 @@ import { Dashboard, Filters } from './types';
 
 // Modifies the rison encoding slightly to match the backend's
 // rison encoding/decoding. Applies globally. Code pulled from rison.js
-const fixRisonEncodeDecode = () => {
+(() => {
   const risonRef: {
     not_idchar: string;
     not_idstart: string;
@@ -60,9 +60,7 @@ const fixRisonEncodeDecode = () => {
 
   risonRef.id_ok = new RegExp(`^${idrx}$`);
   risonRef.next_id = new RegExp(idrx, 'g');
-};
-
-fixRisonEncodeDecode();
+})();
 
 const createFetchResourceMethod =
   (method: string) =>

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -33,6 +33,37 @@ import { FetchDataConfig } from 'src/components/ListView';
 import SupersetText from 'src/utils/textUtils';
 import { Dashboard, Filters } from './types';
 
+// Modifies the rison encoding slightly to match the backend's
+// rison encoding/decoding. Applies globally. Code pulled from rison.js
+const fixRisonEncodeDecode = () => {
+  const risonRef: {
+    not_idchar: string;
+    not_idstart: string;
+    id_ok: RegExp;
+    next_id: RegExp;
+  } = rison as any;
+
+  const l = [];
+  for (let hi = 0; hi < 16; hi += 1) {
+    for (let lo = 0; lo < 16; lo += 1) {
+      if (hi + lo === 0) continue;
+      const c = String.fromCharCode(hi * 16 + lo);
+      if (!/\w|[-_./~]/.test(c))
+        l.push(`\\u00${hi.toString(16)}${lo.toString(16)}`);
+    }
+  }
+
+  risonRef.not_idchar = l.join('');
+  risonRef.not_idstart = '-0123456789';
+
+  const idrx = `[^${risonRef.not_idstart}${risonRef.not_idchar}][^${risonRef.not_idchar}]*`;
+
+  risonRef.id_ok = new RegExp(`^${idrx}$`);
+  risonRef.next_id = new RegExp(idrx, 'g');
+};
+
+fixRisonEncodeDecode();
+
 const createFetchResourceMethod =
   (method: string) =>
   (
@@ -43,7 +74,7 @@ const createFetchResourceMethod =
   ) =>
   async (filterValue = '', page: number, pageSize: number) => {
     const resourceEndpoint = `/api/v1/${resource}/${method}/${relation}`;
-    const queryParams = rison.encode({
+    const queryParams = rison.encode_uri({
       filter: filterValue,
       page,
       page_size: pageSize,


### PR DESCRIPTION
### SUMMARY

### Short description:

Fixes an issue with rison caused by differences of encoding/decoding between front end and back end dependencies.

Also, fixes some issues caused by sending and/or retrieving URLs without cleaning/encoding potential URL breaking syntax added by the user.

Involves these issues #17288 and #13708

---
### Detailed Description:

This mostly comes down to three problems:
1. The JavaScript rison encodes/decodes in a slightly different way than the Python rison does
2. rison's encode method doesn't URL encode by default so URL queries can be broken by the user's input
3. When we retrieve a query string appended to a route (Refresh the page during a search), it gets read as a URL. So certain characters can break the URL and cause rison to try to read incomplete or improperly encoded/decoded strings.

### 1. Rison encode/decode:
This might seem complicated at first but it really comes down to a difference in a single Regular Expression (regex).

To put it very simply, rison is a way to make a string from an object. It aims to make this string as compact, human-readable, and URL-friendly as possible. Read more about it [here](https://github.com/Nanonid/rison).

It will take this:
```javascript
{ filters: [{ value: 'string' }, { value: 100 }] }
```
and turn it into this:
```javascript
(filters:!((value:string),(value:100)))
```

- Both the JS rison and Python rison **can** encode any object thrown at it
- Both the JS rison and Python rison **can** decode any string that _they_ encoded
- Both the JS rison and Python rison **can't** decode all strings that the _other_ has encoded

So what is happening?

The answer comes down to the regex that I mentioned. 

Both of them have a function that builds a string of characters to be used in the regex that decides whether a character can be a valid "id". An id is any value being used as a rison value. (filters, value, 'string', and 100 are all ids in the previous examples)

Rison has reserved values that can't be used as ids but a "string" value that is passed can have _any_ characters inside of it as long as it has 'single quotes' around it. Rison encode will provide these 'single quotes' around any value that contains a character that it has reserved or restricted for its syntax.  This helps rison know a value is a string and thus parse the reserved characters correctly.

The regex expression is what decides this and will fail to decode the string if it determines that single quotes weren't added correctly because it sees it as invalid syntax.

So why is the regex different?

I don't know the motivation behind this but as I mentioned, there is a loop that builds the string in the JS rison and the Python rison. Both of these loops build the same string.

But for some reason, the JS rison overwrites this string with a different hard typed one immediately after it is made.

JS:
```javascript
(function () {
    var l = [];
    for (var hi = 0; hi < 16; hi++) {
        for (var lo = 0; lo < 16; lo++) {
            if (hi+lo === 0) continue;
            var c = String.fromCharCode(hi*16 + lo);
            if (! /\w|[-_.\/~]/.test(c))
                l.push('\\u00' + hi.toString(16) + lo.toString(16));
        }
    }
    rison.not_idchar = l.join('');  // <<--- Where it is added
})();
//rison.not_idchar  = " \t\r\n\"<>[]{}'!=:(),*@$;&";
rison.not_idchar  = " '!:(),*@$"; // <<--- Where it is reassigned
```

Python:
```python
NOT_IDCHAR = ''.join([c for c in (chr(i) for i in range(127))
                      if not (c.isalnum()
                              or c in IDCHAR_PUNCTUATION)])

# ^^^ Good ol python code not doing anything weird ^^^
```

So all we need to do is change that id_char variable on the javascript rison and update it's regex. Then we have the javascript rison encoding the same way that the python rison is expecting it to be. 

This fixes the issues that cause a 400 error when searching for these symbols by themselves 
```
& # ? ^ { } [ ] | " = + `
```

### My implementation

I will admit that I do not believe this is the best possible implementation. I just wanted to provide a solution and get feedback to hopefully find a better way. This is a pretty unique problem and there are a ton of different directions we could go with the fix.

What I have in this PR is a fix that will take the rison global object that gets created and mutates the regex properties on it to make it work with the backend decoding.

I just took the code from rison where it is creating the regex and then overwrote the properties that use it.

```javascript
// Modifies the rison encoding slightly to match the backend's
// rison encoding/decoding. Applies globally. Code pulled from rison.js
(() => {
  const risonRef: {
    not_idchar: string;
    not_idstart: string;
    id_ok: RegExp;
    next_id: RegExp;
  } = rison as any;

  const l = [];
  for (let hi = 0; hi < 16; hi += 1) {
    for (let lo = 0; lo < 16; lo += 1) {
      if (hi + lo === 0) continue;
      const c = String.fromCharCode(hi * 16 + lo);
      if (!/\w|[-_./~]/.test(c))
        l.push(`\\u00${hi.toString(16)}${lo.toString(16)}`);
    }
  }

  risonRef.not_idchar = l.join('');
  risonRef.not_idstart = '-0123456789';

  const idrx = `[^${risonRef.not_idstart}${risonRef.not_idchar}][^${risonRef.not_idchar}]*`;

  risonRef.id_ok = new RegExp(`^${idrx}$`);
  risonRef.next_id = new RegExp(idrx, 'g');
})();
```

My problem with my solution is that it is feels hacky and it doesn't feel like there is a good place for this code to live. I put it in `CRUD/utils.tsx` because it seemed like the right choice.

There is also the issue of this code being immediately executed out in the open and not being clearly contained anywhere.

Alternative options:
- Somehow intercept and modify rison before it ever gets imported into react ( I couldn't figure this out )
- Fork the rison repo and modify that one line to get this to work as expected ( who will maintain the fork and the node module? )
- Have a local Superset specific rison package live inside the project and change that one line of code ( feels like overkill for a single line of difference )
- Use Json instead of rison for these calls ( not sure how this would look but Flask App Builder rison decorator has a fall back to json so this is an option )
- Parse the encoded rison strings and modify them to work correctly. ( This will have to be done on all calls containing user input. Also if a new call containing user input is added we will need to do this to it, in other words it's repetitive )

---

### 2. Rison encode being URL friendly

Rison encode is URL friendly but it is not perfect when it comes to URLs and rison knows this. So it provided a way to safely send URLs in the form of an alternate encode method called `encode_uri`. Using this is not always necessary but it is useful when you are unsure about the data that is being provided in your string like when user input is involved. [Here](https://github.com/Nanonid/rison#interaction-with-uri--encoding) is where it is talked about in the README.

So I switched to encode_uri for the API calls that are building strings that may have user input.

This fixes the Fatal Errors that are returned from the backend when a search string includes & or # or includes a percent encoded value like a single quote (%27). This also prevents the user from being able to search using percent encoded values. For example, if you currently search %27%26%27 ('&') in any of the list-views it will actually return the results that include an ampersand.

---

### 3. URL encoding for QueryParams
Another simple explanation here. The list views use QueryParams to put the query string in the browser URL for search/filter persistence. This is done so you can do things like refresh the page or press the forward and back button without it completely removing the filters, sort orders, etc that you set. At least that's what I believe it is being used for.

Looks like this:
```
chart/list/?filters=(slice_name:hello)&pageIndex=0&sortColumn=changed_on_delta_humanized&sortOrder=desc&viewMode=card
```

This part of it is rison:
```
(slice_name:hello)
```

QueryParams allows you to set custom encoding/decoding for certain Params but it will still always read from the params as a URL before it decodes. So this means that non percent encoded symbols that can break URLs ( &, #, and unexpected percent encoded strings) will cause issues. 

This is what is causing the current page breaking Fatal Error that happens on the list views when searching for an & by itself.

This is the same fatal error that was happening on the backend but this time it is on the front end.

I opted to not use the rison.encode_uri method for this because it doesn't keep the string that clean and will percent encode a little too much if certain characters are passed to it. I felt that since the user can see this query in their browser that the best approach would be to keep the percent encoding minimal. 

So the fix here is to encode only the characters that cause problems by using some String.replace() methods after using rison.encode()

```javascript
          rison.encode(data)
          .replace(/%/g, '%25')
          .replace(/&/g, '%26')
          .replace(/\+/g, '%2B')
          .replace(/#/g, '%23'),
```


---
### BEFORE

**Searching for &**
![Screen Shot 2022-01-31 at 12 09 59 PM](https://user-images.githubusercontent.com/31329271/151856985-d986c7d3-3aa1-4469-bd03-859431b49987.png)


**Searching for !"#$%&'()*+,-./:;<=?>@\\[\]^_`{|}~**
![Screen Shot 2022-01-31 at 12 12 41 PM](https://user-images.githubusercontent.com/31329271/151857338-c1307a10-2a7f-4a37-b765-43493e43ed24.png)

**Searching for #**
![Screen Shot 2022-01-31 at 12 56 21 PM](https://user-images.githubusercontent.com/31329271/151863464-1580630a-7e80-46ae-88d4-318595fa405e.png)

**Searching for ?**
![Screen Shot 2022-01-31 at 12 58 09 PM](https://user-images.githubusercontent.com/31329271/151863733-2da495b1-b22a-46b2-9374-df9f4e723b0c.png)

**Time range for & - 500 response**
![Screen Shot 2022-02-04 at 12 44 24 PM](https://user-images.githubusercontent.com/31329271/152594250-1df8cc0a-ee0e-4a96-ae72-70482bb770b6.png)

**Time range for # - 500 response**
![Screen Shot 2022-02-04 at 12 45 19 PM](https://user-images.githubusercontent.com/31329271/152594279-ea545e8e-c52f-4e55-9f56-98eff602b188.png)


### AFTER

**Searching for &**
![Screen Shot 2022-01-31 at 11 55 28 AM](https://user-images.githubusercontent.com/31329271/151856558-ce4a1118-8255-44e3-b73d-93c2a89ea53d.png)

**Searching for !"#$%&'()*+,-./:;<=?>@\\[\]^_`{|}~**
![Screen Shot 2022-01-31 at 11 56 11 AM](https://user-images.githubusercontent.com/31329271/151856610-6b52cec7-07cc-4d11-bf19-a1c209508162.png)

**Searching for #**
![Screen Shot 2022-01-31 at 1 03 28 PM](https://user-images.githubusercontent.com/31329271/151864533-c0c135e5-facd-4357-ac93-204a9cee82d5.png)

**Searching for ?**
![Screen Shot 2022-01-31 at 1 03 45 PM](https://user-images.githubusercontent.com/31329271/151864545-770565e4-3e1a-45b2-9e84-56a690a07060.png)

**Time range for &**
![Screen Shot 2022-02-04 at 12 48 48 PM](https://user-images.githubusercontent.com/31329271/152594292-258ddfef-93a3-4956-9734-950a261c050a.png)

**Time range for #**
![Screen Shot 2022-02-04 at 12 49 02 PM](https://user-images.githubusercontent.com/31329271/152594306-8e656442-62f3-4c8f-b9b6-0cae38ccb464.png)



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Open up Superset
- Navigate to Charts/Dashboards by clicking the tab in the top navigation bar
- You can also go to:
  -  Data -> Databases
  -  Data -> Datasets
  -  SQL Lab -> Saved Queries
  -  SQL Lab -> Query History
  -  Settings -> CSS Templates
  -  Settings -> Annotation Layers
- Try out the search bar and verify that special characters can be used in a search ( Ex: & # ? ^ { } [ ] | " = + ` )
  - & by itself shouldn't cause a fatal error crash on the client side
  - `#` should no longer cause a fatal error crash on client side after refreshing the page following a search for #
  - All the symbols should no longer cause 500 fatal error responses or 400 not a valid rison/json responses
  - All symbols should be searched by correctly - ( Except % and _ when searched by themselves. Both return all results when searched alone. % is an issue with the backend and I am not sure what is going on with _ but it could be the same issue. These already existed and were not introduced with this fix )

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #17288 and #13708
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
