### PR TITLE
feat: datasource access to allow more granular access to tables on SQL Lab

### DIFF
--- a/superset/databases/filters.py
+++ b/superset/databases/filters.py
@@ -27,19 +27,30 @@ class DatabaseFilter(BaseFilter):
     # TODO(bogdan): consider caching.
     def schema_access_databases(self) -> Set[str]:  # noqa pylint: disable=no-self-use
         return {
-            security_manager.unpack_schema_perm(vm)[0]
+            security_manager.unpack_perm(vm)[0]
             for vm in security_manager.user_view_menu_names("schema_access")
+        }
+
+    def datasource_access_databases(  # noqa pylint: disable=no-self-use
+        self,
+    ) -> Set[str]:
+        return {
+            security_manager.unpack_perm(vm)[0]
+            for vm in security_manager.user_view_menu_names("datasource_access")
         }
 
     def apply(self, query: Query, value: Any) -> Query:
         if security_manager.can_access_all_databases():
             return query
         database_perms = security_manager.user_view_menu_names("database_access")
-        # TODO(bogdan): consider adding datasource access here as well.
         schema_access_databases = self.schema_access_databases()
+
+        datasource_access_databases = self.datasource_access_databases()
+
         return query.filter(
             or_(
                 self.model.perm.in_(database_perms),
                 self.model.database_name.in_(schema_access_databases),
+                self.model.database_name.in_(datasource_access_databases),
             )
         )

--- a/superset/databases/filters.py
+++ b/superset/databases/filters.py
@@ -45,7 +45,6 @@ class DatabaseFilter(BaseFilter):
         return query.filter(
             or_(
                 self.model.perm.in_(database_perms),
-                self.model.database_name.in_(schema_access_databases),
-                self.model.database_name.in_(datasource_access_databases),
+               self.model.database_name.in_([*schema_access_databases, *datasource_access_databases]),
             )
         )

--- a/superset/databases/filters.py
+++ b/superset/databases/filters.py
@@ -45,6 +45,8 @@ class DatabaseFilter(BaseFilter):
         return query.filter(
             or_(
                 self.model.perm.in_(database_perms),
-               self.model.database_name.in_([*schema_access_databases, *datasource_access_databases]),
+                self.model.database_name.in_(
+                    [*schema_access_databases, *datasource_access_databases]
+                ),
             )
         )

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -237,7 +237,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
 
         return None
 
-    def unpack_schema_perm(  # pylint: disable=no-self-use
+    def unpack_perm(  # pylint: disable=no-self-use
         self, schema_permission: str
     ) -> Tuple[str, str]:
         # [database_name].[schema_name]
@@ -532,7 +532,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
 
         # schema_access
         accessible_schemas = {
-            self.unpack_schema_perm(s)[1]
+            self.unpack_perm(s)[1]
             for s in self.user_view_menu_names("schema_access")
             if s.startswith(f"[{database}].")
         }
@@ -582,7 +582,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         )
         if schema:
             names = {d.table_name for d in user_datasources if d.schema == schema}
-            return [d for d in datasource_names if d in names]
+            return [d for d in datasource_names if d.table in names]
 
         full_names = {d.full_name for d in user_datasources}
         return [d for d in datasource_names if f"[{database}].[{d}]" in full_names]

--- a/tests/integration_tests/core_tests.py
+++ b/tests/integration_tests/core_tests.py
@@ -195,6 +195,31 @@ class TestCore(SupersetTestCase):
         gamma_user.roles.remove(security_manager.find_role(role_name))
         session.commit()
 
+    @pytest.mark.usefixtures("load_energy_table_with_slice")
+    def test_get_superset_tables_not_allowed_with_out_permissions(self):
+        session = db.session
+        table_name = "energy_usage"
+        role_name = "dummy_role_no_table_access"
+        self.logout()
+        self.login(username="gamma")
+        gamma_user = security_manager.find_user(username="gamma")
+        security_manager.add_role(role_name)
+        dummy_role = security_manager.find_role(role_name)
+        gamma_user.roles.append(dummy_role)
+
+        session.commit()
+
+        example_db = utils.get_example_database()
+        schema_name = self.default_schema_backend_map[example_db.backend]
+        uri = f"superset/tables/{example_db.id}/{schema_name}/{table_name}/"
+        rv = self.client.get(uri)
+        self.assertEqual(rv.status_code, 404)
+
+        # cleanup
+        gamma_user = security_manager.find_user(username="gamma")
+        gamma_user.roles.remove(security_manager.find_role(role_name))
+        session.commit()
+
     def test_get_superset_tables_substr(self):
         example_db = utils.get_example_database()
         if example_db.backend in {"presto", "hive"}:

--- a/tests/integration_tests/core_tests.py
+++ b/tests/integration_tests/core_tests.py
@@ -161,6 +161,40 @@ class TestCore(SupersetTestCase):
         rv = self.client.get(uri)
         self.assertEqual(rv.status_code, 404)
 
+    @pytest.mark.usefixtures("load_energy_table_with_slice")
+    def test_get_superset_tables_allowed(self):
+        session = db.session
+        table_name = "energy_usage"
+        role_name = "dummy_role"
+        self.logout()
+        self.login(username="gamma")
+        gamma_user = security_manager.find_user(username="gamma")
+        security_manager.add_role(role_name)
+        dummy_role = security_manager.find_role(role_name)
+        gamma_user.roles.append(dummy_role)
+
+        tbl_id = self.table_ids.get(table_name)
+        table = db.session.query(SqlaTable).filter(SqlaTable.id == tbl_id).first()
+        table_perm = table.perm
+
+        security_manager.add_permission_role(
+            dummy_role,
+            security_manager.find_permission_view_menu("datasource_access", table_perm),
+        )
+
+        session.commit()
+
+        example_db = utils.get_example_database()
+        schema_name = self.default_schema_backend_map[example_db.backend]
+        uri = f"superset/tables/{example_db.id}/{schema_name}/{table_name}/"
+        rv = self.client.get(uri)
+        self.assertEqual(rv.status_code, 200)
+
+        # cleanup
+        gamma_user = security_manager.find_user(username="gamma")
+        gamma_user.roles.remove(security_manager.find_role(role_name))
+        session.commit()
+
     def test_get_superset_tables_substr(self):
         example_db = utils.get_example_database()
         if example_db.backend in {"presto", "hive"}:

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -223,8 +223,10 @@ class TestDatasetApi(SupersetTestCase):
         rv = self.client.get(uri)
         assert rv.status_code == 200
         response = json.loads(rv.data.decode("utf-8"))
-        assert response["count"] == 0
-        assert response["result"] == []
+
+        assert response["count"] == 1
+        main_db = get_main_database()
+        assert filter(lambda x: x.text == main_db, response["result"]) != []
 
     @pytest.mark.usefixtures("load_energy_table_with_slice")
     def test_get_dataset_item(self):


### PR DESCRIPTION

### SUMMARY

We'd like to have a more granular access to tables on SQL Lab, which currently can only be done at schema or database level. This PR would then tackle the [story](https://github.com/apache/superset/issues/18014) we raised a couple of days ago.

### TESTING INSTRUCTIONS
Assign a datasource permission to a role and check that users with that role can only query that particular datasource.

### ADDITIONAL INFORMATION
- [x] Has associated issue: https://github.com/apache/superset/issues/18014
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
