### PR TITLE
[WIP] feat(explore): Implement using multiple time column filters in charts

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/constants.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/constants.ts
@@ -16,8 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, QueryMode, DTTM_ALIAS, GenericDataType } from '@superset-ui/core';
-import { ColumnMeta, TimeFilter } from './types';
+import {
+  t,
+  QueryMode,
+  DTTM_ALIAS,
+  GenericDataType,
+  TimeFilter,
+} from '@superset-ui/core';
+import { ColumnMeta } from './types';
 
 // eslint-disable-next-line import/prefer-default-export
 export const TIME_FILTER_LABELS = {

--- a/superset-frontend/packages/superset-ui-chart-controls/src/constants.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/constants.ts
@@ -17,13 +17,13 @@
  * under the License.
  */
 import { t, QueryMode, DTTM_ALIAS, GenericDataType } from '@superset-ui/core';
-import { ColumnMeta } from './types';
+import { ColumnMeta, TimeFilter } from './types';
 
 // eslint-disable-next-line import/prefer-default-export
 export const TIME_FILTER_LABELS = {
   time_range: t('Time Range'),
   granularity_sqla: t('Time Column'),
-  time_grain_sqla: t('Time Grain'),
+  time_grain_sqla: t('Chart time Grain'),
   druid_time_origin: t('Origin'),
   granularity: t('Time Granularity'),
 };
@@ -44,4 +44,11 @@ export const TIME_COLUMN_OPTION: ColumnMeta = {
 export const QueryModeLabel = {
   [QueryMode.aggregate]: t('Aggregate'),
   [QueryMode.raw]: t('Raw records'),
+};
+
+export const DEFAULT_DATE_FILTER: TimeFilter = {
+  timeColumn: undefined,
+  timeRange: t('No filter'),
+  isXAxis: false,
+  timeGrain: undefined,
 };

--- a/superset-frontend/packages/superset-ui-chart-controls/src/sections/sections.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/sections/sections.tsx
@@ -30,7 +30,17 @@ const baseTimeSection = {
 
 export const legacyTimeseriesTime: ControlPanelSectionConfig = {
   ...baseTimeSection,
-  controlSetRows: [['time_filter'], ['time_grain_sqla']],
+  controlSetRows: [
+    [
+      {
+        name: 'time_filter',
+        override: {
+          isTimeseries: true,
+        },
+      },
+    ],
+    ['time_grain_sqla'],
+  ],
 };
 
 export const legacyRegularTime: ControlPanelSectionConfig = {

--- a/superset-frontend/packages/superset-ui-chart-controls/src/sections/sections.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/sections/sections.tsx
@@ -30,18 +30,12 @@ const baseTimeSection = {
 
 export const legacyTimeseriesTime: ControlPanelSectionConfig = {
   ...baseTimeSection,
-  controlSetRows: [
-    ['granularity'],
-    ['druid_time_origin'],
-    ['granularity_sqla'],
-    ['time_grain_sqla'],
-    ['time_range'],
-  ],
+  controlSetRows: [['time_filter'], ['time_grain_sqla']],
 };
 
 export const legacyRegularTime: ControlPanelSectionConfig = {
   ...baseTimeSection,
-  controlSetRows: [['granularity_sqla'], ['time_range']],
+  controlSetRows: [['time_filter']],
 };
 
 export const datasourceAndVizType: ControlPanelSectionConfig = {

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -308,6 +308,35 @@ const time_grain_sqla: SharedControlConfig<'SelectControl'> = {
   }),
 };
 
+const time_filter: SharedControlConfig<'DndDateFilterControl'> = {
+  type: 'DndDateFilterControl',
+  freeForm: true,
+  label: t('Time column and range'),
+  default: [], // this value is translated, but the backend wouldn't understand a translated value?
+  description: t(
+    'The time range for the visualization. All relative times, e.g. "Last month", ' +
+      '"Last 7 days", "now", etc. are evaluated on the server using the server\'s ' +
+      'local time (sans timezone). All tooltips and placeholder times are expressed ' +
+      'in UTC (sans timezone). The timestamps are then evaluated by the database ' +
+      "using the engine's local timezone. Note one can explicitly set the timezone " +
+      'per the ISO 8601 format if specifying either the start and/or end time.',
+  ),
+  mapStateToProps: ({ datasource, form_data }) => ({
+    datasource,
+    timeColumnOptions: datasource?.columns
+      .filter(column => column.is_dttm)
+      .map(column => ({
+        value: column.column_name,
+        label: column.verbose_name ?? column.column_name,
+      })),
+    timeGrainOptions: datasource?.time_grain_sqla?.map(timeGrain => ({
+      value: timeGrain[0],
+      label: timeGrain[1],
+    })),
+    endpoints: form_data?.time_range_endpoints || null,
+  }),
+};
+
 const time_range: SharedControlConfig<'DateFilterControl'> = {
   type: 'DateFilterControl',
   freeForm: true,
@@ -504,6 +533,7 @@ const sharedControls = {
   granularity_sqla: enableExploreDnd ? dnd_granularity_sqla : granularity_sqla,
   time_grain_sqla,
   time_range,
+  time_filter,
   row_limit,
   limit,
   timeseries_limit_metric: enableExploreDnd ? dnd_sort_by : sort_by,

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -312,7 +312,8 @@ const time_filter: SharedControlConfig<'DndDateFilterControl'> = {
   type: 'DndDateFilterControl',
   freeForm: true,
   label: t('Time column and range'),
-  default: [], // this value is translated, but the backend wouldn't understand a translated value?
+  default: [],
+  isTimeseries: false,
   description: t(
     'The time range for the visualization. All relative times, e.g. "Last month", ' +
       '"Last 7 days", "now", etc. are evaluated on the server using the server\'s ' +

--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -381,15 +381,6 @@ export type ColorFormatters = {
   getColorFromValue: (value: number) => string | undefined;
 }[];
 
-export type TimeFilter = {
-  timeColumn?: string;
-  timeGrain?: string;
-  timeRange: string;
-  isXAxis?: boolean;
-};
-
-export type TimeFilters = TimeFilter[];
-
 export default {};
 
 export function isColumnMeta(

--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -385,7 +385,7 @@ export type TimeFilter = {
   timeColumn?: string;
   timeGrain?: string;
   timeRange: string;
-  isXAxis: boolean;
+  isXAxis?: boolean;
 };
 
 export type TimeFilters = TimeFilter[];

--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -61,7 +61,7 @@ export interface DatasourceMeta {
   main_dttm_col: string;
   // eg. ['["ds", true]', 'ds [asc]']
   order_by_choices?: [string, string][] | null;
-  time_grain_sqla?: string;
+  time_grain_sqla?: [string, string][];
   granularity_sqla?: string;
   datasource_name: string | null;
   description: string | null;
@@ -147,6 +147,7 @@ export type InternalControlType =
   | 'DndColumnSelect'
   | 'DndFilterSelect'
   | 'DndMetricSelect'
+  | 'DndDateFilterControl'
   | keyof SharedControlComponents; // expanded in `expandControlConfig`
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -379,6 +380,15 @@ export type ColorFormatters = {
   column: string;
   getColorFromValue: (value: number) => string | undefined;
 }[];
+
+export type TimeFilter = {
+  timeColumn?: string;
+  timeGrain?: string;
+  timeRange: string;
+  isXAxis: boolean;
+};
+
+export type TimeFilters = TimeFilter[];
 
 export default {};
 

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Time.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Time.ts
@@ -40,4 +40,13 @@ export type AppliedTimeExtras = Partial<
 export type TimeRangeEndpoint = 'unknown' | 'inclusive' | 'exclusive';
 export type TimeRangeEndpoints = [TimeRangeEndpoint, TimeRangeEndpoint];
 
+export type TimeFilter = {
+  timeColumn?: string;
+  timeGrain?: string;
+  timeRange: string;
+  isXAxis?: boolean;
+};
+
+export type TimeFilters = TimeFilter[];
+
 export default {};

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -21,7 +21,6 @@ import {
   ColumnMeta,
   InfoTooltipWithTrigger,
   Metric,
-  TimeFilter,
 } from '@superset-ui/chart-controls';
 import {
   AdhocFilter,
@@ -35,6 +34,7 @@ import {
   SupersetApiError,
   SupersetClient,
   t,
+  TimeFilter,
 } from '@superset-ui/core';
 import { FormInstance } from 'antd/lib/form';
 import { isEqual } from 'lodash';

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -21,6 +21,7 @@ import {
   ColumnMeta,
   InfoTooltipWithTrigger,
   Metric,
+  TimeFilter,
 } from '@superset-ui/chart-controls';
 import {
   AdhocFilter,
@@ -57,6 +58,7 @@ import Loading from 'src/components/Loading';
 import { addDangerToast } from 'src/components/MessageToasts/actions';
 import { Radio } from 'src/components/Radio';
 import Tabs from 'src/components/Tabs';
+import Label from 'src/components/Label';
 import { Tooltip } from 'src/components/Tooltip';
 import {
   Chart,
@@ -1112,16 +1114,31 @@ const FiltersConfigForm = (
                         ]}
                       >
                         <DateFilterControl
-                          name="time_range"
                           endpoints={['inclusive', 'exclusive']}
-                          onChange={timeRange => {
+                          dateFilter={{
+                            timeRange: formFilter?.time_range || 'No filter',
+                          }}
+                          onChange={(timeFilter: TimeFilter) => {
                             setNativeFilterFieldValues(form, filterId, {
-                              time_range: timeRange,
+                              time_range: timeFilter.timeRange,
                             });
                             forceUpdate();
                             validatePreFilter();
                           }}
-                        />
+                          showTimeColumnSection={false}
+                        >
+                          {({ label, tooltipTitle, onOpen }) => (
+                            <Tooltip placement="top" title={tooltipTitle}>
+                              <Label
+                                className="pointer"
+                                data-test="time-range-trigger"
+                                onClick={onOpen}
+                              >
+                                {label}
+                              </Label>
+                            </Tooltip>
+                          )}
+                        </DateFilterControl>
                       </StyledRowFormItem>
                     )}
                     {hasTimeRange && (

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -26,8 +26,9 @@ import {
   Datasource,
   SupersetClient,
   JsonObject,
+  TimeFilter,
 } from '@superset-ui/core';
-import { DEFAULT_DATE_FILTER, TimeFilter } from '@superset-ui/chart-controls';
+import { DEFAULT_DATE_FILTER } from '@superset-ui/chart-controls';
 import {
   buildTimeRangeString,
   CALENDAR_RANGE_VALUES_SET,

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DndDateFilterControl.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DndDateFilterControl.tsx
@@ -1,0 +1,206 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  Datasource,
+  FeatureFlag,
+  isFeatureEnabled,
+  t,
+} from '@superset-ui/core';
+import {
+  ColumnMeta,
+  DEFAULT_DATE_FILTER,
+  TimeFilter,
+  TimeFilters,
+} from '@superset-ui/chart-controls';
+import { noOp } from 'src/utils/common';
+import { DatasourcePanelDndItem } from '../../DatasourcePanel/types';
+import DateFilterLabel from './DateFilterLabel';
+import DndSelectLabel from '../DndColumnSelectControl';
+import { DndItemType } from '../../DndItemType';
+import ControlHeader from '../../ControlHeader';
+
+const DND_ACCEPTED_TYPES = [DndItemType.Column];
+
+export interface DateFilterControlI {
+  type: string;
+  datasource: Datasource;
+  name: string;
+  onChange: (timeFilters: TimeFilters) => void;
+  timeColumnOptions: { value: string; label: string }[];
+  timeGrainOptions: { value: string; label: string }[];
+  value: TimeFilters;
+}
+
+export const DndDateFilterControl = (props: DateFilterControlI) => {
+  const {
+    datasource,
+    name,
+    onChange,
+    timeColumnOptions,
+    timeGrainOptions,
+    value,
+  } = props;
+  const [newDatePopoverVisible, setNewDatePopoverVisible] = useState(false);
+  const [droppedItem, setDroppedItem] = useState<ColumnMeta | undefined>(
+    undefined,
+  );
+  const [popoversVisibility, setPopoversVisibility] = useState({});
+
+  const onRemoveFilter = useCallback(
+    (index: number) => {
+      const valuesCopy = [...value];
+      valuesCopy.splice(index, 1);
+      onChange(valuesCopy);
+    },
+    [onChange, value],
+  );
+
+  const onShiftFilters = useCallback(
+    (dragIndex: number, hoverIndex: number) => {
+      const newValues = [...value];
+      [newValues[hoverIndex], newValues[dragIndex]] = [
+        newValues[dragIndex],
+        newValues[hoverIndex],
+      ];
+      onChange(newValues);
+    },
+    [onChange, value],
+  );
+
+  const canDrop = useCallback(
+    (item: DatasourcePanelDndItem) => {
+      const columnName = (item.value as ColumnMeta).column_name;
+
+      return (
+        timeColumnOptions.some(option => option.value === columnName) &&
+        value.every(val => val.timeColumn !== columnName)
+      );
+    },
+    [timeColumnOptions, value],
+  );
+
+  const handleDrop = useCallback((item: DatasourcePanelDndItem) => {
+    setDroppedItem(item.value as ColumnMeta);
+    setNewDatePopoverVisible(true);
+  }, []);
+
+  const handleChange = useCallback(
+    (timeFilter: TimeFilter, index?: number) => {
+      let newValues = [...value];
+
+      if (timeFilter.isXAxis) {
+        newValues = newValues.map(val => ({ ...val, isXAxis: false }));
+      }
+
+      if (index === undefined) {
+        newValues = [...newValues, timeFilter];
+      } else {
+        newValues[index] = timeFilter;
+      }
+      onChange(newValues);
+    },
+    [onChange, value],
+  );
+
+  const valuesRenderer = useCallback(
+    () =>
+      value?.map((dateFilter: TimeFilter, index: number) => (
+        <DateFilterLabel
+          key={`${dateFilter.timeColumn}-${dateFilter.timeGrain}-${dateFilter.timeRange}-${dateFilter.isXAxis}-${index}`}
+          datasource={datasource}
+          index={index}
+          dateFilter={dateFilter}
+          onChange={(timeFilter: TimeFilter) => handleChange(timeFilter, index)}
+          onRemoveFilter={onRemoveFilter}
+          onShiftFilters={onShiftFilters}
+          timeGrainOptions={timeGrainOptions}
+          timeColumnOptions={timeColumnOptions}
+          setPopoverVisible={(isVisible: boolean) =>
+            setPopoversVisibility(curVisibility => ({
+              ...curVisibility,
+              [index]: isVisible,
+            }))
+          }
+          popoverVisible={popoversVisibility[index]}
+        />
+      )),
+    [
+      datasource,
+      handleChange,
+      onRemoveFilter,
+      onShiftFilters,
+      popoversVisibility,
+      timeColumnOptions,
+      timeGrainOptions,
+      value,
+    ],
+  );
+
+  const handleClickGhostButton = useCallback(() => {
+    setDroppedItem(undefined);
+    setNewDatePopoverVisible(true);
+  }, []);
+
+  const ghostButtonText = isFeatureEnabled(FeatureFlag.ENABLE_DND_WITH_CLICK_UX)
+    ? t('Drop temporal columns here or click')
+    : t('Drop temporal columns here');
+
+  const initialDateFilter: TimeFilter = useMemo(
+    () => ({
+      ...DEFAULT_DATE_FILTER,
+      timeColumn: droppedItem?.column_name,
+      isXAxis: value.length === 0,
+    }),
+    [droppedItem?.column_name, value.length],
+  );
+  return (
+    <>
+      <ControlHeader {...props} />
+      <DndSelectLabel
+        name={name}
+        onDrop={handleDrop}
+        canDrop={canDrop}
+        valuesRenderer={valuesRenderer}
+        accept={DND_ACCEPTED_TYPES}
+        ghostButtonText={ghostButtonText}
+        onClickGhostButton={
+          isFeatureEnabled(FeatureFlag.ENABLE_DND_WITH_CLICK_UX)
+            ? handleClickGhostButton
+            : undefined
+        }
+      />
+      <DateFilterLabel
+        datasource={datasource}
+        dateFilter={initialDateFilter}
+        onShiftFilters={noOp}
+        onChange={handleChange}
+        onRemoveFilter={noOp}
+        timeColumnOptions={timeColumnOptions}
+        timeGrainOptions={timeGrainOptions}
+        index={-1}
+        popoverVisible={newDatePopoverVisible}
+        setPopoverVisible={setNewDatePopoverVisible}
+      >
+        <div />
+      </DateFilterLabel>
+    </>
+  );
+};

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DndDateFilterControl.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DndDateFilterControl.tsx
@@ -23,13 +23,10 @@ import {
   FeatureFlag,
   isFeatureEnabled,
   t,
-} from '@superset-ui/core';
-import {
-  ColumnMeta,
-  DEFAULT_DATE_FILTER,
   TimeFilter,
   TimeFilters,
-} from '@superset-ui/chart-controls';
+} from '@superset-ui/core';
+import { ColumnMeta, DEFAULT_DATE_FILTER } from '@superset-ui/chart-controls';
 import { noOp } from 'src/utils/common';
 import { DatasourcePanelDndItem } from '../../DatasourcePanel/types';
 import DateFilterLabel from './DateFilterLabel';

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DndDateFilterControl.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DndDateFilterControl.tsx
@@ -91,10 +91,7 @@ export const DndDateFilterControl = (props: DateFilterControlI) => {
     (item: DatasourcePanelDndItem) => {
       const columnName = (item.value as ColumnMeta).column_name;
 
-      return (
-        timeColumnOptions.some(option => option.value === columnName) &&
-        value.every(val => val.timeColumn !== columnName)
-      );
+      return timeColumnOptions.some(option => option.value === columnName);
     },
     [timeColumnOptions, value],
   );

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DndDateFilterControl.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DndDateFilterControl.tsx
@@ -36,6 +36,7 @@ import DateFilterLabel from './DateFilterLabel';
 import DndSelectLabel from '../DndColumnSelectControl';
 import { DndItemType } from '../../DndItemType';
 import ControlHeader from '../../ControlHeader';
+import OptionWrapper from '../DndColumnSelectControl/OptionWrapper';
 
 const DND_ACCEPTED_TYPES = [DndItemType.Column];
 
@@ -47,6 +48,7 @@ export interface DateFilterControlI {
   timeColumnOptions: { value: string; label: string }[];
   timeGrainOptions: { value: string; label: string }[];
   value: TimeFilters;
+  isTimeseries?: boolean;
 }
 
 export const DndDateFilterControl = (props: DateFilterControlI) => {
@@ -57,12 +59,12 @@ export const DndDateFilterControl = (props: DateFilterControlI) => {
     timeColumnOptions,
     timeGrainOptions,
     value,
+    isTimeseries,
   } = props;
   const [newDatePopoverVisible, setNewDatePopoverVisible] = useState(false);
   const [droppedItem, setDroppedItem] = useState<ColumnMeta | undefined>(
     undefined,
   );
-  const [popoversVisibility, setPopoversVisibility] = useState({});
 
   const onRemoveFilter = useCallback(
     (index: number) => {
@@ -126,28 +128,33 @@ export const DndDateFilterControl = (props: DateFilterControlI) => {
         <DateFilterLabel
           key={`${dateFilter.timeColumn}-${dateFilter.timeGrain}-${dateFilter.timeRange}-${dateFilter.isXAxis}-${index}`}
           datasource={datasource}
-          index={index}
           dateFilter={dateFilter}
           onChange={(timeFilter: TimeFilter) => handleChange(timeFilter, index)}
           onRemoveFilter={onRemoveFilter}
           onShiftFilters={onShiftFilters}
           timeGrainOptions={timeGrainOptions}
           timeColumnOptions={timeColumnOptions}
-          setPopoverVisible={(isVisible: boolean) =>
-            setPopoversVisibility(curVisibility => ({
-              ...curVisibility,
-              [index]: isVisible,
-            }))
-          }
-          popoverVisible={popoversVisibility[index]}
-        />
+          isTimeseries={isTimeseries}
+        >
+          {({ label, tooltipTitle, onRemoveFilter, onShiftFilters }) => (
+            <OptionWrapper
+              index={index}
+              label={label}
+              tooltipTitle={tooltipTitle}
+              clickClose={onRemoveFilter}
+              onShiftOptions={onShiftFilters}
+              type={DndItemType.Column}
+              withCaret
+            />
+          )}
+        </DateFilterLabel>
       )),
     [
       datasource,
       handleChange,
+      isTimeseries,
       onRemoveFilter,
       onShiftFilters,
-      popoversVisibility,
       timeColumnOptions,
       timeGrainOptions,
       value,
@@ -167,7 +174,7 @@ export const DndDateFilterControl = (props: DateFilterControlI) => {
     () => ({
       ...DEFAULT_DATE_FILTER,
       timeColumn: droppedItem?.column_name,
-      isXAxis: value.length === 0,
+      isXAxis: isTimeseries && value.length === 0,
     }),
     [droppedItem?.column_name, value.length],
   );
@@ -195,9 +202,9 @@ export const DndDateFilterControl = (props: DateFilterControlI) => {
         onRemoveFilter={noOp}
         timeColumnOptions={timeColumnOptions}
         timeGrainOptions={timeGrainOptions}
-        index={-1}
         popoverVisible={newDatePopoverVisible}
         setPopoverVisible={setNewDatePopoverVisible}
+        isTimeseries={isTimeseries}
       >
         <div />
       </DateFilterLabel>

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/components/DateFilterPopoverContent.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/components/DateFilterPopoverContent.tsx
@@ -17,11 +17,8 @@
  * under the License.
  */
 import React, { useState } from 'react';
-import { styled, t, useTheme } from '@superset-ui/core';
-import {
-  InfoTooltipWithTrigger,
-  TimeFilter,
-} from '@superset-ui/chart-controls';
+import { styled, t, useTheme, TimeFilter } from '@superset-ui/core';
+import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
 import { Divider } from 'src/common/components';
 import Select, { propertyComparator } from 'src/components/Select/Select';
 import Icons from 'src/components/Icons';

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/components/DateFilterPopoverContent.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/components/DateFilterPopoverContent.tsx
@@ -1,0 +1,273 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { useState } from 'react';
+import { css, styled, SupersetTheme, t, useTheme } from '@superset-ui/core';
+import {
+  InfoTooltipWithTrigger,
+  TimeFilter,
+} from '@superset-ui/chart-controls';
+import { Divider } from 'src/common/components';
+import Select, { propertyComparator } from 'src/components/Select/Select';
+import Icons from 'src/components/Icons';
+import Button from 'src/components/Button';
+import { CommonFrame } from './CommonFrame';
+import { CalendarFrame } from './CalendarFrame';
+import { AdvancedFrame } from './AdvancedFrame';
+import { CustomFrame } from './CustomFrame';
+import { getDateFilterControlTestId } from '../DateFilterLabel';
+import { XAxisCheckbox } from './XAxisCheckbox';
+import { FRAME_OPTIONS } from '../utils';
+import { FrameType } from '../types';
+
+const ContentStyleWrapper = styled.div`
+  .ant-row {
+    margin-top: 8px;
+  }
+
+  .ant-input-number {
+    width: 100%;
+  }
+
+  .ant-picker {
+    padding: 4px 17px 4px;
+    border-radius: 4px;
+    width: 100%;
+  }
+
+  .ant-divider-horizontal {
+    margin: 16px 0;
+  }
+
+  .control-label {
+    font-size: 11px;
+    font-weight: 500;
+    color: #b2b2b2;
+    line-height: 16px;
+    text-transform: uppercase;
+    margin: 8px 0;
+  }
+
+  .vertical-radio {
+    display: block;
+    height: 40px;
+    line-height: 40px;
+  }
+
+  .section-title {
+    font-style: normal;
+    font-weight: 500;
+    font-size: 15px;
+    line-height: 24px;
+    margin-bottom: 8px;
+  }
+
+  .control-anchor-to {
+    margin-top: 16px;
+  }
+
+  .control-anchor-to-datetime {
+    width: 217px;
+  }
+
+  .footer {
+    text-align: right;
+  }
+`;
+
+const IconWrapper = styled.span`
+  span {
+    margin-right: ${({ theme }) => 2 * theme.gridUnit}px;
+    vertical-align: middle;
+  }
+  .text {
+    vertical-align: middle;
+  }
+  .error {
+    color: ${({ theme }) => theme.colors.error.base};
+  }
+`;
+
+const StyledSelect = styled(Select)`
+  width: 272px;
+`;
+
+interface DateFilterPopoverContentI {
+  dateFilter: TimeFilter;
+  evalResponse: string | undefined;
+  frame: FrameType;
+  guessedFrame: FrameType;
+  onChange: (val: TimeFilter) => void;
+  setFrame: (frame: FrameType) => void;
+  setShow: (val: boolean) => void;
+  setTimeRangeValue: (value: string) => void;
+  timeColumnOptions: { value: string; label: string }[];
+  timeGrainOptions: { value: string; label: string }[];
+  timeRangeValue: string;
+  validTimeRange: boolean;
+}
+export const DateFilterPopoverContent = ({
+  dateFilter,
+  evalResponse,
+  frame,
+  guessedFrame,
+  onChange,
+  setFrame,
+  setShow,
+  setTimeRangeValue,
+  timeColumnOptions,
+  timeGrainOptions,
+  timeRangeValue,
+  validTimeRange,
+}: DateFilterPopoverContentI) => {
+  const [timeGrain, setTimeGrain] = useState(dateFilter.timeGrain);
+  const [timeColumn, setTimeColumn] = useState(dateFilter.timeColumn);
+  const [isXAxis, setIsXAxis] = useState(dateFilter.isXAxis);
+
+  const theme = useTheme();
+
+  const onChangeFrame = (value: string) => {
+    if (value === 'No filter') {
+      setTimeRangeValue('No filter');
+    }
+    setFrame(value as FrameType);
+  };
+
+  function onHide() {
+    setTimeRangeValue(dateFilter.timeRange);
+    setFrame(guessedFrame);
+    setShow(false);
+  }
+
+  function onSave() {
+    onChange({ timeRange: timeRangeValue, timeColumn, timeGrain, isXAxis });
+    onHide();
+  }
+
+  return (
+    <ContentStyleWrapper>
+      <div className="control-label">
+        {t('Time column')}{' '}
+        <InfoTooltipWithTrigger
+          tooltip={t(
+            'The time column for the visualization. Note that you ' +
+              'can define arbitrary expression that return a DATETIME ' +
+              'column in the table. Also note that the ' +
+              'filter below is applied against this column or ' +
+              'expression',
+          )}
+          placement="right"
+        />
+      </div>
+      <StyledSelect
+        ariaLabel={t('Time column')}
+        options={timeColumnOptions}
+        value={timeColumn}
+        onChange={(value: string) => setTimeColumn(value)}
+      />
+      <div
+        css={(theme: SupersetTheme) => css`
+          margin: ${theme.gridUnit * 4}px 0;
+        `}
+      >
+        <XAxisCheckbox
+          setChecked={(value: boolean) => setIsXAxis(value)}
+          checked={isXAxis}
+          disabled={dateFilter.isXAxis}
+        />
+      </div>
+      <div className="control-label">
+        {t('Time grain')}{' '}
+        <InfoTooltipWithTrigger
+          tooltip={t(
+            'The time granularity for the visualization. This ' +
+              'applies a date transformation to alter ' +
+              'your time column and defines a new time granularity. ' +
+              'The options here are defined on a per database ' +
+              'engine basis in the Superset source code.',
+          )}
+          placement="right"
+        />
+      </div>
+      <StyledSelect
+        ariaLabel={t('Time grain')}
+        options={timeGrainOptions}
+        value={timeGrain}
+        onChange={(value: string) => setTimeGrain(value)}
+      />
+      <Divider />
+      <div className="control-label">{t('RANGE TYPE')}</div>
+      <StyledSelect
+        ariaLabel={t('RANGE TYPE')}
+        options={FRAME_OPTIONS}
+        value={frame}
+        onChange={onChangeFrame}
+        sortComparator={propertyComparator('order')}
+      />
+      {frame !== 'No filter' && <Divider />}
+      {frame === 'Common' && (
+        <CommonFrame value={timeRangeValue} onChange={setTimeRangeValue} />
+      )}
+      {frame === 'Calendar' && (
+        <CalendarFrame value={timeRangeValue} onChange={setTimeRangeValue} />
+      )}
+      {frame === 'Advanced' && (
+        <AdvancedFrame value={timeRangeValue} onChange={setTimeRangeValue} />
+      )}
+      {frame === 'Custom' && (
+        <CustomFrame value={timeRangeValue} onChange={setTimeRangeValue} />
+      )}
+      {frame === 'No filter' && <div data-test="no-filter" />}
+      <Divider />
+      <div>
+        <div className="section-title">{t('Actual time range')}</div>
+        {validTimeRange && <div>{evalResponse}</div>}
+        {!validTimeRange && (
+          <IconWrapper className="warning">
+            <Icons.ErrorSolidSmall iconColor={theme.colors.error.base} />
+            <span className="text error">{evalResponse}</span>
+          </IconWrapper>
+        )}
+      </div>
+      <div>
+        <Divider />
+        <div className="footer">
+          <Button
+            buttonStyle="secondary"
+            cta
+            key="cancel"
+            onClick={onHide}
+            data-test="cancel-button"
+          >
+            {t('CANCEL')}
+          </Button>
+          <Button
+            buttonStyle="primary"
+            cta
+            disabled={!validTimeRange || !timeColumn}
+            key="apply"
+            onClick={onSave}
+            {...getDateFilterControlTestId('apply-button')}
+          >
+            {t('APPLY')}
+          </Button>
+        </div>
+      </div>
+    </ContentStyleWrapper>
+  );
+};

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/components/XAxisCheckbox.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/components/XAxisCheckbox.tsx
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { styled, t, css } from '@superset-ui/core';
+import Checkbox from 'src/components/Checkbox';
+import { Tooltip } from 'src/components/Tooltip';
+import { noOp } from 'src/utils/common';
+
+const Styles = styled.div<{ disabled: boolean | undefined }>`
+  display: inline-flex;
+  align-items: center;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  line-height: 1;
+  svg,
+  span[role='checkbox'] {
+    width: ${({ theme }) => theme.gridUnit * 4}px;
+    height: ${({ theme }) => theme.gridUnit * 4}px;
+
+    path:first-child {
+      ${({ disabled, theme }) =>
+        disabled &&
+        css`
+          fill: ${theme.colors.primary.light1};
+        `}
+    }
+  }
+  .checkbox-label {
+    font-size: ${({ theme }) => theme.typography.sizes.s}px;
+    margin-left: ${({ theme }) => theme.gridUnit * 2}px;
+    color: rgba(0, 0, 0, 0.85);
+  }
+`;
+
+interface XAxisCheckboxI {
+  checked: boolean;
+  setChecked: (value: boolean | undefined) => void;
+  disabled: boolean | undefined;
+}
+export const XAxisCheckbox = ({
+  checked,
+  setChecked,
+  disabled,
+}: XAxisCheckboxI) => (
+  <Tooltip
+    title={t(
+      'In timeseries charts one time column has to be selected as X-Axis. If you want to change X-Axis, select another Time Filter.',
+    )}
+    placement="bottom"
+  >
+    <Styles
+      onClick={() => !disabled && setChecked(!checked)}
+      disabled={disabled}
+    >
+      <Checkbox checked={checked} onChange={noOp} />
+      <span className="checkbox-label">{t('Use as X-Axis')}</span>
+    </Styles>
+  </Tooltip>
+);

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/index.ts
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/index.ts
@@ -17,3 +17,4 @@
  * under the License.
  */
 export { default } from './DateFilterLabel';
+export { DndDateFilterControl } from './DndDateFilterControl';

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/OptionWrapper.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/OptionWrapper.tsx
@@ -83,6 +83,10 @@ export default function OptionWrapper(
       const { dragIndex } = item;
       const hoverIndex = index;
 
+      if (dragIndex === undefined || hoverIndex === undefined) {
+        return;
+      }
+
       // Don't replace items with themselves
       if (dragIndex === hoverIndex) {
         return;

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
@@ -25,7 +25,7 @@ export interface OptionProps {
   children?: ReactNode;
   index: number;
   label?: string;
-  tooltipTitle?: string;
+  tooltipTitle?: string | ReactNode;
   column?: ColumnMeta | AdhocColumn;
   clickClose: (index: number) => void;
   withCaret?: boolean;

--- a/superset-frontend/src/explore/components/controls/index.js
+++ b/superset-frontend/src/explore/components/controls/index.js
@@ -24,7 +24,7 @@ import CollectionControl from './CollectionControl';
 import ColorPickerControl from './ColorPickerControl';
 import ColorSchemeControl from './ColorSchemeControl';
 import DatasourceControl from './DatasourceControl';
-import DateFilterControl from './DateFilterControl';
+import DateFilterControl, { DndDateFilterControl } from './DateFilterControl';
 import FixedOrMetricControl from './FixedOrMetricControl';
 import HiddenControl from './HiddenControl';
 import SelectAsyncControl from './SelectAsyncControl';
@@ -57,6 +57,7 @@ const controlMap = {
   DateFilterControl,
   DndColumnSelectControl,
   DndColumnSelect,
+  DndDateFilterControl,
   DndFilterSelect,
   DndMetricSelect,
   FixedOrMetricControl,

--- a/superset-frontend/src/explore/reducers/exploreReducer.js
+++ b/superset-frontend/src/explore/reducers/exploreReducer.js
@@ -17,8 +17,8 @@
  * under the License.
  */
 /* eslint camelcase: 0 */
+import { DEFAULT_DATE_FILTER } from '@superset-ui/chart-controls';
 import { DYNAMIC_PLUGIN_CONTROLS_READY } from 'src/chart/chartAction';
-import { DEFAULT_TIME_RANGE } from 'src/explore/constants';
 import { getControlsState } from 'src/explore/store';
 import {
   getControlConfig,
@@ -69,7 +69,7 @@ export default function exploreReducer(state = {}, action) {
         action.datasource.type !== state.datasource.type
       ) {
         // reset time range filter to default
-        newFormData.time_range = DEFAULT_TIME_RANGE;
+        newFormData.time_range = DEFAULT_DATE_FILTER;
 
         // reset control values for column/metric related controls
         Object.entries(controls).forEach(([controlName, controlState]) => {

--- a/superset-frontend/src/filters/components/Time/TimeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Time/TimeFilterPlugin.tsx
@@ -16,8 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { styled, TimeRangeEndpoint } from '@superset-ui/core';
-import { TimeFilter } from '@superset-ui/chart-controls';
+import { styled, TimeRangeEndpoint, TimeFilter } from '@superset-ui/core';
 import React, { useCallback, useEffect } from 'react';
 import { Tooltip } from 'src/components/Tooltip';
 import Label from 'src/components/Label';

--- a/superset-frontend/src/filters/components/Time/TimeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Time/TimeFilterPlugin.tsx
@@ -17,7 +17,10 @@
  * under the License.
  */
 import { styled, TimeRangeEndpoint } from '@superset-ui/core';
+import { TimeFilter } from '@superset-ui/chart-controls';
 import React, { useCallback, useEffect } from 'react';
+import { Tooltip } from 'src/components/Tooltip';
+import Label from 'src/components/Label';
 import DateFilterControl from 'src/explore/components/controls/DateFilterControl';
 import { NO_TIME_RANGE } from 'src/explore/constants';
 import { PluginFilterTimeProps } from './types';
@@ -72,7 +75,8 @@ export default function TimeFilterPlugin(props: PluginFilterTimeProps) {
   } = props;
 
   const handleTimeRangeChange = useCallback(
-    (timeRange?: string): void => {
+    (timeFilter?: TimeFilter): void => {
+      const timeRange = timeFilter?.timeRange;
       const isSet = timeRange && timeRange !== NO_TIME_RANGE;
       setDataMask({
         extraFormData: isSet
@@ -89,11 +93,10 @@ export default function TimeFilterPlugin(props: PluginFilterTimeProps) {
   );
 
   useEffect(() => {
-    handleTimeRangeChange(filterState.value);
+    handleTimeRangeChange({ timeRange: filterState.value });
   }, [filterState.value]);
 
   return props.formData?.inView ? (
-    // @ts-ignore
     <TimeFilterStyles width={width} height={height}>
       <ControlContainer
         tabIndex={-1}
@@ -106,11 +109,24 @@ export default function TimeFilterPlugin(props: PluginFilterTimeProps) {
       >
         <DateFilterControl
           endpoints={endpoints}
-          value={filterState.value || NO_TIME_RANGE}
-          name="time_range"
+          dateFilter={{ timeRange: filterState.value || NO_TIME_RANGE }}
+          // name="time_range"
           onChange={handleTimeRangeChange}
-          type={filterState.validateStatus}
-        />
+          messageType={filterState.validateStatus}
+          showTimeColumnSection={false}
+        >
+          {({ label, tooltipTitle, onOpen }) => (
+            <Tooltip placement="top" title={tooltipTitle}>
+              <Label
+                className="pointer"
+                data-test="time-range-trigger"
+                onClick={onOpen}
+              >
+                {label}
+              </Label>
+            </Tooltip>
+          )}
+        </DateFilterControl>
       </ControlContainer>
     </TimeFilterStyles>
   ) : null;


### PR DESCRIPTION
### SUMMARY
Implements new interface for time section in Explore. Now user can use multiple time columns for filtering purposes, set one of them as X-Axis and select different time grains for each time column.

TODO: hide x-axis checkbox for non-timeseries charts, fix tests, implement backend, write a migration.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://user-images.githubusercontent.com/15073128/149919133-a523d9e4-c562-4d84-948a-968baebc13db.png)

After:
![image](https://user-images.githubusercontent.com/15073128/149918697-6538c299-27ee-4618-974d-867b7b4bcff3.png)


### TESTING INSTRUCTIONS
1. Make sure that Time filter in native filters works like before
2. Make sure that time range pre-filter in native filters config modal works as before
3. In order to properly test the feature in Explore we need to wait for backend implementation

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
