### PR TITLE
chore: move react to peerDeps

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -13,7 +13,7 @@
         "plugins/*"
       ],
       "dependencies": {
-        "@ant-design/icons": "^4.2.2",
+        "@ant-design/icons": "^4.7.0",
         "@babel/runtime-corejs3": "^7.12.5",
         "@data-ui/sparkline": "^0.0.84",
         "@emotion/babel-preset-css-prop": "^11.2.0",
@@ -304,36 +304,50 @@
       }
     },
     "node_modules/@ant-design/colors": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-3.2.2.tgz",
-      "integrity": "sha512-YKgNbG2dlzqMhA9NtI3/pbY16m3Yl/EeWBRa+lB1X1YaYxHrxNexiQYCLTWO/uDvAjLFMEDU+zR901waBtMtjQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-6.0.0.tgz",
+      "integrity": "sha512-qAZRvPzfdWHtfameEGP2Qvuf838NhergR35o+EuVyB5XvSA98xod5r4utvi4TJ3ywmevm290g9nsCG5MryrdWQ==",
       "dependencies": {
-        "tinycolor2": "^1.4.1"
+        "@ctrl/tinycolor": "^3.4.0"
       }
     },
     "node_modules/@ant-design/icons": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-4.2.2.tgz",
-      "integrity": "sha512-DrVV+wcupnHS7PehJ6KiTcJtAR5c25UMgjGECCc6pUT9rsvw0AuYG+a4HDjfxEQuDqKTHwW+oX/nIvCymyLE8Q==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-4.7.0.tgz",
+      "integrity": "sha512-aoB4Z7JA431rt6d4u+8xcNPPCrdufSRMUOpxa1ab6mz1JCQZOEVolj2WVs/tDFmN62zzK30mNelEsprLYsSF3g==",
       "dependencies": {
-        "@ant-design/colors": "^3.1.0",
-        "@ant-design/icons-svg": "^4.0.0",
-        "@babel/runtime": "^7.10.4",
+        "@ant-design/colors": "^6.0.0",
+        "@ant-design/icons-svg": "^4.2.1",
+        "@babel/runtime": "^7.11.2",
         "classnames": "^2.2.6",
-        "insert-css": "^2.0.0",
-        "rc-util": "^5.0.1"
+        "rc-util": "^5.9.4"
       },
       "engines": {
         "node": ">=8"
       },
       "peerDependencies": {
-        "react": "16.x"
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
       }
     },
     "node_modules/@ant-design/icons-svg": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.1.0.tgz",
-      "integrity": "sha512-Fi03PfuUqRs76aI3UWYpP864lkrfPo0hluwGqh7NJdLhvH4iRDc3jbJqZIvRDLHKbXrvAfPPV3+zjUccfFvWOQ=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.2.1.tgz",
+      "integrity": "sha512-EB0iwlKDGpG93hW8f85CTJTs4SvMX7tt5ceupvhALp1IF44SeUFOMhKUOYqpsoYWQKAOuTRDMqn75rEaKDp0Xw=="
+    },
+    "node_modules/@ant-design/icons/node_modules/rc-util": {
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.16.1.tgz",
+      "integrity": "sha512-kSCyytvdb3aRxQacS/71ta6c+kBWvM1v8/2h9d/HaNWauc3qB8pLnF20PJ8NajkNN8gb+rR1l0eWO+D4Pz+LLQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "react-is": "^16.12.0",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
     },
     "node_modules/@ant-design/react-slick": {
       "version": "0.27.14",
@@ -2689,9 +2703,9 @@
       }
     },
     "node_modules/@ctrl/tinycolor": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.3.1.tgz",
-      "integrity": "sha512-jUJrjU62MUgHDSu5JfONfgRM2V7GfN5KknsygfIbxwRZXGeayIzxk4O9GiYgEAr9DG5HJThTF5+a5x3wtrOKzQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.4.0.tgz",
+      "integrity": "sha512-JZButFdZ1+/xAfpguQHoabIXkcqRRKpMrWKBkpEZZyxfY9C1DpADFB8PEqGSTeFr135SaTRfKqGKx5xSCLI7ZQ==",
       "engines": {
         "node": ">=10"
       }
@@ -24069,12 +24083,6 @@
         "react": "^0.14 || ^15.0.0 || ^16.0.0-alpha"
       }
     },
-    "node_modules/airbnb-prop-types/node_modules/react-is": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-      "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==",
-      "dev": true
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -24375,25 +24383,6 @@
         "@ctrl/tinycolor": "^3.3.1"
       }
     },
-    "node_modules/antd/node_modules/@ant-design/icons": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-4.3.0.tgz",
-      "integrity": "sha512-UoIbw4oz/L/msbkgqs2nls2KP7XNKScOxVR54wRrWwnXOzJaGNwwSdYjHQz+5ETf8C53YPpzMOnRX99LFCdeIQ==",
-      "dependencies": {
-        "@ant-design/colors": "^5.0.0",
-        "@ant-design/icons-svg": "^4.0.0",
-        "@babel/runtime": "^7.11.2",
-        "classnames": "^2.2.6",
-        "insert-css": "^2.0.0",
-        "rc-util": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "react": ">=16.0.0"
-      }
-    },
     "node_modules/antd/node_modules/rc-util": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.5.1.tgz",
@@ -24406,11 +24395,6 @@
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
       }
-    },
-    "node_modules/antd/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/any-observable": {
       "version": "0.3.0",
@@ -32166,12 +32150,6 @@
         "react-dom": "^16.0.0-0"
       }
     },
-    "node_modules/enzyme-adapter-react-16/node_modules/react-is": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-      "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==",
-      "dev": true
-    },
     "node_modules/enzyme-adapter-react-16/node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -32226,12 +32204,6 @@
       "peerDependencies": {
         "enzyme": "^3.4.0"
       }
-    },
-    "node_modules/enzyme-to-json/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
     },
     "node_modules/enzyme/node_modules/object-inspect": {
       "version": "1.6.0",
@@ -36873,11 +36845,6 @@
         "react-is": "^16.7.0"
       }
     },
-    "node_modules/hoist-non-react-statics/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -37809,11 +37776,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/insert-css": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/insert-css/-/insert-css-2.0.0.tgz",
-      "integrity": "sha1-610Ql7dUL0x56jBg067gfQU4gPQ="
     },
     "node_modules/internal-ip": {
       "version": "6.2.0",
@@ -47146,11 +47108,6 @@
         "reflect.ownkeys": "^0.2.0"
       }
     },
-    "node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
     "node_modules/property-information": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
@@ -47509,11 +47466,6 @@
         "react-dom": ">=16.9.0"
       }
     },
-    "node_modules/rc-align/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
     "node_modules/rc-cascader": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-1.4.0.tgz",
@@ -47566,11 +47518,6 @@
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
       }
-    },
-    "node_modules/rc-collapse/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/rc-dialog": {
       "version": "8.4.5",
@@ -47709,11 +47656,6 @@
         "react-dom": ">=16.9.0"
       }
     },
-    "node_modules/rc-menu/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
     "node_modules/rc-motion": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.4.1.tgz",
@@ -47740,11 +47682,6 @@
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
       }
-    },
-    "node_modules/rc-motion/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/rc-notification": {
       "version": "4.5.4",
@@ -47811,11 +47748,6 @@
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
       }
-    },
-    "node_modules/rc-picker/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/rc-progress": {
       "version": "3.1.1",
@@ -47965,11 +47897,6 @@
         "react-dom": ">=16.9.0"
       }
     },
-    "node_modules/rc-table/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
     "node_modules/rc-tabs": {
       "version": "11.7.2",
       "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-11.7.2.tgz",
@@ -48002,11 +47929,6 @@
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
       }
-    },
-    "node_modules/rc-tabs/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/rc-textarea": {
       "version": "0.3.2",
@@ -48095,11 +48017,6 @@
         "react-dom": ">=16.9.0"
       }
     },
-    "node_modules/rc-trigger/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
     "node_modules/rc-upload": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-3.3.4.tgz",
@@ -48127,11 +48044,6 @@
         "react-dom": ">=16.9.0"
       }
     },
-    "node_modules/rc-upload/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
     "node_modules/rc-util": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.0.6.tgz",
@@ -48140,11 +48052,6 @@
         "react-is": "^16.12.0",
         "shallowequal": "^1.1.0"
       }
-    },
-    "node_modules/rc-util/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/rc-virtual-list": {
       "version": "3.2.3",
@@ -48175,11 +48082,6 @@
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
       }
-    },
-    "node_modules/rc-virtual-list/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/re-resizable": {
       "version": "6.6.1",
@@ -48876,9 +48778,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "16.6.3",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.3.tgz",
-      "integrity": "sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA=="
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-js-cron": {
       "version": "1.2.0",
@@ -49069,11 +48971,6 @@
         "react": "^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/react-markdown/node_modules/react-is": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
-      "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
-    },
     "node_modules/react-move": {
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/react-move/-/react-move-2.9.1.tgz",
@@ -49139,11 +49036,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/react-redux/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-refresh": {
       "version": "0.8.3",
@@ -49434,12 +49326,6 @@
       "peerDependencies": {
         "react": "^16.0.0"
       }
-    },
-    "node_modules/react-test-renderer/node_modules/react-is": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-      "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==",
-      "dev": true
     },
     "node_modules/react-textarea-autosize": {
       "version": "8.3.3",
@@ -58607,17 +58493,17 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@react-icons/all-files": "^4.1.0",
-        "lodash": "^4.17.15",
-        "prop-types": "^15.7.2"
+        "lodash": "^4.17.15"
       },
       "peerDependencies": {
-        "@emotion/react": "^11.4.1",
+        "@emotion/react": "*",
         "@superset-ui/core": "*",
-        "@types/enzyme": "^3.10.5",
+        "@types/enzyme": "*",
         "@types/react": "*",
-        "antd": "^4.9.4",
-        "react": "^16.13.1",
-        "react-dom": "^16.13.1"
+        "antd": "*",
+        "prop-types": "*",
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "packages/superset-ui-core": {
@@ -58664,13 +58550,13 @@
         "resize-observer-polyfill": "1.5.1"
       },
       "peerDependencies": {
-        "@emotion/cache": "^11.4.0",
-        "@emotion/react": "^11.4.1",
-        "@emotion/styled": "^11.3.0",
+        "@emotion/cache": "*",
+        "@emotion/react": "*",
+        "@emotion/styled": "*",
         "@types/react": "*",
         "@types/react-loadable": "*",
-        "react": "^16.13.1",
-        "react-loadable": "^5.5.0"
+        "react": "*",
+        "react-loadable": "*"
       }
     },
     "packages/superset-ui-core/node_modules/@vx/responsive": {
@@ -58746,9 +58632,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@data-ui/event-flow": "^0.0.84",
-        "@emotion/cache": "^11.4.0",
-        "@emotion/react": "^11.4.1",
-        "@emotion/styled": "^11.3.0",
         "@react-icons/all-files": "^4.1.0",
         "@storybook/addon-actions": "^6.3.12",
         "@storybook/addon-knobs": "^6.3.1",
@@ -58763,8 +58646,6 @@
         "global-box": "^1.2.0",
         "jquery": "^3.4.1",
         "memoize-one": "^5.1.1",
-        "react": "^16.13.1",
-        "react-dom": "^16.13.1",
         "react-loadable": "^5.5.0",
         "react-resizable": "^3.0.4",
         "storybook-addon-jsx": "^7.3.14"
@@ -58778,6 +58659,9 @@
         "typescript": "^4.5.4"
       },
       "peerDependencies": {
+        "@emotion/cache": "*",
+        "@emotion/react": "*",
+        "@emotion/styled": "*",
         "@encodable/color": "=1.1.1",
         "@superset-ui/core": "*",
         "@superset-ui/legacy-plugin-chart-calendar": "*",
@@ -58805,7 +58689,9 @@
         "@superset-ui/plugin-chart-echarts": "*",
         "@superset-ui/plugin-chart-table": "*",
         "@superset-ui/plugin-chart-word-cloud": "*",
-        "@superset-ui/preset-chart-xy": "*"
+        "@superset-ui/preset-chart-xy": "*",
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "packages/superset-ui-demo/node_modules/@superset-ui/legacy-plugin-chart-time-table": {
@@ -59187,13 +59073,13 @@
       "dependencies": {
         "d3-array": "^2.0.3",
         "d3-selection": "^1.4.0",
-        "d3-tip": "^0.9.1",
-        "prop-types": "^15.6.2"
+        "d3-tip": "^0.9.1"
       },
       "peerDependencies": {
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
-        "react": "^16.13.1"
+        "prop-types": "*",
+        "react": "*"
       }
     },
     "plugins/legacy-plugin-chart-calendar/node_modules/d3-array": {
@@ -59210,12 +59096,12 @@
       "license": "Apache-2.0",
       "dependencies": {
         "d3": "^3.5.17",
-        "prop-types": "^15.6.2",
-        "react": "^16.13.1"
+        "prop-types": "^15.6.2"
       },
       "peerDependencies": {
         "@superset-ui/chart-controls": "*",
-        "@superset-ui/core": "*"
+        "@superset-ui/core": "*",
+        "react": "*"
       }
     },
     "plugins/legacy-plugin-chart-country-map": {
@@ -59224,12 +59110,12 @@
       "license": "Apache-2.0",
       "dependencies": {
         "d3": "^3.5.17",
-        "d3-array": "^2.0.3",
-        "prop-types": "^15.6.2"
+        "d3-array": "^2.0.3"
       },
       "peerDependencies": {
         "@superset-ui/chart-controls": "*",
-        "@superset-ui/core": "*"
+        "@superset-ui/core": "*",
+        "prop-types": "*"
       }
     },
     "plugins/legacy-plugin-chart-country-map/node_modules/d3-array": {
@@ -59245,13 +59131,13 @@
       "version": "0.18.25",
       "license": "Apache-2.0",
       "dependencies": {
-        "@data-ui/event-flow": "^0.0.84",
-        "prop-types": "^15.6.2"
+        "@data-ui/event-flow": "^0.0.84"
       },
       "peerDependencies": {
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
-        "react": "^15 || ^16"
+        "prop-types": "*",
+        "react": "*"
       }
     },
     "plugins/legacy-plugin-chart-force-directed": {
@@ -59259,13 +59145,13 @@
       "version": "0.18.25",
       "license": "Apache-2.0",
       "dependencies": {
-        "d3": "^3.5.17",
-        "prop-types": "^15.7.2"
+        "d3": "^3.5.17"
       },
       "peerDependencies": {
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
-        "react": "^16.13.1"
+        "prop-types": "^15.7.2",
+        "react": "*"
       }
     },
     "plugins/legacy-plugin-chart-heatmap": {
@@ -59275,12 +59161,12 @@
       "dependencies": {
         "d3": "^3.5.17",
         "d3-svg-legend": "^1.x",
-        "d3-tip": "^0.9.1",
-        "prop-types": "^15.6.2"
+        "d3-tip": "^0.9.1"
       },
       "peerDependencies": {
         "@superset-ui/chart-controls": "*",
-        "@superset-ui/core": "*"
+        "@superset-ui/core": "*",
+        "prop-types": "*"
       }
     },
     "plugins/legacy-plugin-chart-histogram": {
@@ -59292,13 +59178,13 @@
         "@data-ui/theme": "^0.0.84",
         "@vx/legend": "^0.0.198",
         "@vx/responsive": "^0.0.199",
-        "@vx/scale": "^0.0.197",
-        "prop-types": "^15.6.2"
+        "@vx/scale": "^0.0.197"
       },
       "peerDependencies": {
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
-        "react": "^15 || ^16"
+        "prop-types": "*",
+        "react": "*"
       }
     },
     "plugins/legacy-plugin-chart-histogram/node_modules/@vx/group": {
@@ -59361,13 +59247,13 @@
       "license": "Apache-2.0",
       "dependencies": {
         "d3-array": "^2.0.3",
-        "d3-scale": "^3.0.1",
-        "prop-types": "^15.6.2"
+        "d3-scale": "^3.0.1"
       },
       "peerDependencies": {
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
-        "react": "^15 || ^16"
+        "prop-types": "*",
+        "react": "*"
       }
     },
     "plugins/legacy-plugin-chart-horizon/node_modules/d3-array": {
@@ -59403,7 +59289,6 @@
       "version": "0.18.25",
       "license": "Apache-2.0",
       "dependencies": {
-        "prop-types": "^15.6.2",
         "react-map-gl": "^4.0.10",
         "supercluster": "^4.1.1",
         "viewport-mercator-project": "^6.1.1"
@@ -59412,7 +59297,8 @@
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
         "mapbox-gl": "*",
-        "react": "^15 || ^16"
+        "prop-types": "*",
+        "react": "*"
       }
     },
     "plugins/legacy-plugin-chart-paired-t-test": {
@@ -59421,13 +59307,13 @@
       "license": "Apache-2.0",
       "dependencies": {
         "distributions": "^1.0.0",
-        "prop-types": "^15.6.2",
         "reactable": "^1.1.0"
       },
       "peerDependencies": {
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
-        "react": "^15 || ^16"
+        "prop-types": "*",
+        "react": "*"
       }
     },
     "plugins/legacy-plugin-chart-parallel-coordinates": {
@@ -59435,13 +59321,13 @@
       "version": "0.18.25",
       "license": "Apache-2.0",
       "dependencies": {
-        "d3": "^3.5.17",
-        "prop-types": "^15.7.2"
+        "d3": "^3.5.17"
       },
       "peerDependencies": {
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
-        "react": "^16.13.1"
+        "prop-types": "*",
+        "react": "*"
       }
     },
     "plugins/legacy-plugin-chart-partition": {
@@ -59450,14 +59336,14 @@
       "license": "Apache-2.0",
       "dependencies": {
         "d3": "^3.5.17",
-        "d3-hierarchy": "^1.1.8",
-        "prop-types": "^15.6.2"
+        "d3-hierarchy": "^1.1.8"
       },
       "peerDependencies": {
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
         "enzyme": "*",
-        "react": "^16.13.1"
+        "prop-types": "*",
+        "react": "*"
       }
     },
     "plugins/legacy-plugin-chart-pivot-table": {
@@ -59466,12 +59352,12 @@
       "license": "Apache-2.0",
       "dependencies": {
         "d3": "^3.5.17",
-        "datatables.net-bs": "^1.11.3",
-        "prop-types": "^15.6.2"
+        "datatables.net-bs": "^1.11.3"
       },
       "peerDependencies": {
         "@superset-ui/chart-controls": "*",
-        "@superset-ui/core": "*"
+        "@superset-ui/core": "*",
+        "prop-types": "*"
       }
     },
     "plugins/legacy-plugin-chart-rose": {
@@ -59480,13 +59366,13 @@
       "license": "Apache-2.0",
       "dependencies": {
         "d3": "^3.5.17",
-        "nvd3": "1.8.6",
-        "prop-types": "^15.6.2"
+        "nvd3": "1.8.6"
       },
       "peerDependencies": {
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
-        "react": "^16.13.1"
+        "prop-types": "*",
+        "react": "*"
       }
     },
     "plugins/legacy-plugin-chart-sankey": {
@@ -59495,13 +59381,13 @@
       "license": "Apache-2.0",
       "dependencies": {
         "d3": "^3.5.17",
-        "d3-sankey": "^0.4.2",
-        "prop-types": "^15.6.2"
+        "d3-sankey": "^0.4.2"
       },
       "peerDependencies": {
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
-        "react": "^16.13.1"
+        "prop-types": "*",
+        "react": "*"
       }
     },
     "plugins/legacy-plugin-chart-sankey-loop": {
@@ -59510,12 +59396,12 @@
       "license": "Apache-2.0",
       "dependencies": {
         "d3-sankey-diagram": "^0.7.3",
-        "d3-selection": "^1.4.0",
-        "prop-types": "^15.6.2"
+        "d3-selection": "^1.4.0"
       },
       "peerDependencies": {
         "@superset-ui/chart-controls": "*",
-        "@superset-ui/core": "*"
+        "@superset-ui/core": "*",
+        "prop-types": "*"
       }
     },
     "plugins/legacy-plugin-chart-sunburst": {
@@ -59523,12 +59409,12 @@
       "version": "0.18.25",
       "license": "Apache-2.0",
       "dependencies": {
-        "d3": "^3.5.17",
-        "prop-types": "^15.6.2"
+        "d3": "^3.5.17"
       },
       "peerDependencies": {
         "@superset-ui/chart-controls": "*",
-        "@superset-ui/core": "*"
+        "@superset-ui/core": "*",
+        "prop-types": "*"
       }
     },
     "plugins/legacy-plugin-chart-time-table": {
@@ -59553,12 +59439,12 @@
       "license": "Apache-2.0",
       "dependencies": {
         "d3-hierarchy": "^1.1.8",
-        "d3-selection": "^1.4.0",
-        "prop-types": "^15.6.2"
+        "d3-selection": "^1.4.0"
       },
       "peerDependencies": {
         "@superset-ui/chart-controls": "*",
-        "@superset-ui/core": "*"
+        "@superset-ui/core": "*",
+        "prop-types": "*"
       }
     },
     "plugins/legacy-plugin-chart-world-map": {
@@ -59569,13 +59455,13 @@
         "d3": "^3.5.17",
         "d3-array": "^2.4.0",
         "d3-color": "^1.4.1",
-        "datamaps": "^0.5.8",
-        "prop-types": "^15.6.2"
+        "datamaps": "^0.5.8"
       },
       "peerDependencies": {
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
-        "react": "^16.13.1"
+        "prop-types": "*",
+        "react": "*"
       }
     },
     "plugins/legacy-plugin-chart-world-map/node_modules/d3-array": {
@@ -59630,9 +59516,9 @@
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
         "mapbox-gl": "*",
-        "react": "^16.13.1",
-        "react-dom": "^16.13.1",
-        "react-map-gl": "^4.0.10"
+        "react": "*",
+        "react-dom": "*",
+        "react-map-gl": "*"
       }
     },
     "plugins/legacy-preset-chart-deckgl/node_modules/d3-scale": {
@@ -59684,13 +59570,13 @@
         "lodash": "^4.17.11",
         "moment": "^2.20.1",
         "nvd3-fork": "^2.0.5",
-        "prop-types": "^15.6.2",
         "urijs": "^1.18.10"
       },
       "peerDependencies": {
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
-        "react": "^15 || ^16"
+        "prop-types": "*",
+        "react": "*"
       }
     },
     "plugins/plugin-chart-echarts": {
@@ -59706,7 +59592,7 @@
       "peerDependencies": {
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
-        "react": "^16.13.1"
+        "react": "*"
       }
     },
     "plugins/plugin-chart-pivot-table": {
@@ -59719,12 +59605,12 @@
         "jest": "^26.0.1"
       },
       "peerDependencies": {
-        "@ant-design/icons": "^4.2.2",
+        "@ant-design/icons": "*",
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
         "prop-types": "*",
-        "react": "^16.13.1",
-        "react-dom": "^16.13.1"
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "plugins/plugin-chart-table": {
@@ -59747,8 +59633,8 @@
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
         "@types/react": "*",
-        "react": "^16.13.1",
-        "react-dom": "^16.13.1"
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "plugins/plugin-chart-table/node_modules/d3-array": {
@@ -59774,7 +59660,7 @@
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
         "@types/react": "*",
-        "react": "^16.13.1"
+        "react": "*"
       }
     },
     "plugins/plugin-chart-word-cloud/node_modules/d3-array": {
@@ -59823,7 +59709,7 @@
       "peerDependencies": {
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
-        "react": "^16.2"
+        "react": "*"
       }
     },
     "plugins/preset-chart-xy/node_modules/@vx/axis": {
@@ -59974,30 +59860,41 @@
       }
     },
     "@ant-design/colors": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-3.2.2.tgz",
-      "integrity": "sha512-YKgNbG2dlzqMhA9NtI3/pbY16m3Yl/EeWBRa+lB1X1YaYxHrxNexiQYCLTWO/uDvAjLFMEDU+zR901waBtMtjQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-6.0.0.tgz",
+      "integrity": "sha512-qAZRvPzfdWHtfameEGP2Qvuf838NhergR35o+EuVyB5XvSA98xod5r4utvi4TJ3ywmevm290g9nsCG5MryrdWQ==",
       "requires": {
-        "tinycolor2": "^1.4.1"
+        "@ctrl/tinycolor": "^3.4.0"
       }
     },
     "@ant-design/icons": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-4.2.2.tgz",
-      "integrity": "sha512-DrVV+wcupnHS7PehJ6KiTcJtAR5c25UMgjGECCc6pUT9rsvw0AuYG+a4HDjfxEQuDqKTHwW+oX/nIvCymyLE8Q==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-4.7.0.tgz",
+      "integrity": "sha512-aoB4Z7JA431rt6d4u+8xcNPPCrdufSRMUOpxa1ab6mz1JCQZOEVolj2WVs/tDFmN62zzK30mNelEsprLYsSF3g==",
       "requires": {
-        "@ant-design/colors": "^3.1.0",
-        "@ant-design/icons-svg": "^4.0.0",
-        "@babel/runtime": "^7.10.4",
+        "@ant-design/colors": "^6.0.0",
+        "@ant-design/icons-svg": "^4.2.1",
+        "@babel/runtime": "^7.11.2",
         "classnames": "^2.2.6",
-        "insert-css": "^2.0.0",
-        "rc-util": "^5.0.1"
+        "rc-util": "^5.9.4"
+      },
+      "dependencies": {
+        "rc-util": {
+          "version": "5.16.1",
+          "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.16.1.tgz",
+          "integrity": "sha512-kSCyytvdb3aRxQacS/71ta6c+kBWvM1v8/2h9d/HaNWauc3qB8pLnF20PJ8NajkNN8gb+rR1l0eWO+D4Pz+LLQ==",
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "react-is": "^16.12.0",
+            "shallowequal": "^1.1.0"
+          }
+        }
       }
     },
     "@ant-design/icons-svg": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.1.0.tgz",
-      "integrity": "sha512-Fi03PfuUqRs76aI3UWYpP864lkrfPo0hluwGqh7NJdLhvH4iRDc3jbJqZIvRDLHKbXrvAfPPV3+zjUccfFvWOQ=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.2.1.tgz",
+      "integrity": "sha512-EB0iwlKDGpG93hW8f85CTJTs4SvMX7tt5ceupvhALp1IF44SeUFOMhKUOYqpsoYWQKAOuTRDMqn75rEaKDp0Xw=="
     },
     "@ant-design/react-slick": {
       "version": "0.27.14",
@@ -61616,9 +61513,9 @@
       }
     },
     "@ctrl/tinycolor": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.3.1.tgz",
-      "integrity": "sha512-jUJrjU62MUgHDSu5JfONfgRM2V7GfN5KknsygfIbxwRZXGeayIzxk4O9GiYgEAr9DG5HJThTF5+a5x3wtrOKzQ=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.4.0.tgz",
+      "integrity": "sha512-JZButFdZ1+/xAfpguQHoabIXkcqRRKpMrWKBkpEZZyxfY9C1DpADFB8PEqGSTeFr135SaTRfKqGKx5xSCLI7ZQ=="
     },
     "@cypress/mount-utils": {
       "version": "1.0.2",
@@ -75717,8 +75614,7 @@
       "version": "file:packages/superset-ui-chart-controls",
       "requires": {
         "@react-icons/all-files": "^4.1.0",
-        "lodash": "^4.17.15",
-        "prop-types": "^15.7.2"
+        "lodash": "^4.17.15"
       }
     },
     "@superset-ui/core": {
@@ -75828,9 +75724,6 @@
       "requires": {
         "@babel/core": "^7.9.0",
         "@data-ui/event-flow": "^0.0.84",
-        "@emotion/cache": "^11.4.0",
-        "@emotion/react": "^11.4.1",
-        "@emotion/styled": "^11.3.0",
         "@react-icons/all-files": "^4.1.0",
         "@storybook/addon-actions": "^6.3.12",
         "@storybook/addon-knobs": "^6.3.1",
@@ -75848,8 +75741,6 @@
         "global-box": "^1.2.0",
         "jquery": "^3.4.1",
         "memoize-one": "^5.1.1",
-        "react": "^16.13.1",
-        "react-dom": "^16.13.1",
         "react-loadable": "^5.5.0",
         "react-resizable": "^3.0.4",
         "storybook-addon-jsx": "^7.3.14",
@@ -76158,8 +76049,7 @@
       "requires": {
         "d3-array": "^2.0.3",
         "d3-selection": "^1.4.0",
-        "d3-tip": "^0.9.1",
-        "prop-types": "^15.6.2"
+        "d3-tip": "^0.9.1"
       },
       "dependencies": {
         "d3-array": {
@@ -76176,16 +76066,14 @@
       "version": "file:plugins/legacy-plugin-chart-chord",
       "requires": {
         "d3": "^3.5.17",
-        "prop-types": "^15.6.2",
-        "react": "^16.13.1"
+        "prop-types": "^15.6.2"
       }
     },
     "@superset-ui/legacy-plugin-chart-country-map": {
       "version": "file:plugins/legacy-plugin-chart-country-map",
       "requires": {
         "d3": "^3.5.17",
-        "d3-array": "^2.0.3",
-        "prop-types": "^15.6.2"
+        "d3-array": "^2.0.3"
       },
       "dependencies": {
         "d3-array": {
@@ -76201,15 +76089,13 @@
     "@superset-ui/legacy-plugin-chart-event-flow": {
       "version": "file:plugins/legacy-plugin-chart-event-flow",
       "requires": {
-        "@data-ui/event-flow": "^0.0.84",
-        "prop-types": "^15.6.2"
+        "@data-ui/event-flow": "^0.0.84"
       }
     },
     "@superset-ui/legacy-plugin-chart-force-directed": {
       "version": "file:plugins/legacy-plugin-chart-force-directed",
       "requires": {
-        "d3": "^3.5.17",
-        "prop-types": "^15.7.2"
+        "d3": "^3.5.17"
       }
     },
     "@superset-ui/legacy-plugin-chart-heatmap": {
@@ -76217,8 +76103,7 @@
       "requires": {
         "d3": "^3.5.17",
         "d3-svg-legend": "^1.x",
-        "d3-tip": "^0.9.1",
-        "prop-types": "^15.6.2"
+        "d3-tip": "^0.9.1"
       }
     },
     "@superset-ui/legacy-plugin-chart-histogram": {
@@ -76228,8 +76113,7 @@
         "@data-ui/theme": "^0.0.84",
         "@vx/legend": "^0.0.198",
         "@vx/responsive": "^0.0.199",
-        "@vx/scale": "^0.0.197",
-        "prop-types": "^15.6.2"
+        "@vx/scale": "^0.0.197"
       },
       "dependencies": {
         "@vx/group": {
@@ -76283,8 +76167,7 @@
       "version": "file:plugins/legacy-plugin-chart-horizon",
       "requires": {
         "d3-array": "^2.0.3",
-        "d3-scale": "^3.0.1",
-        "prop-types": "^15.6.2"
+        "d3-scale": "^3.0.1"
       },
       "dependencies": {
         "d3-array": {
@@ -76320,7 +76203,6 @@
     "@superset-ui/legacy-plugin-chart-map-box": {
       "version": "file:plugins/legacy-plugin-chart-map-box",
       "requires": {
-        "prop-types": "^15.6.2",
         "react-map-gl": "^4.0.10",
         "supercluster": "^4.1.1",
         "viewport-mercator-project": "^6.1.1"
@@ -76330,70 +76212,61 @@
       "version": "file:plugins/legacy-plugin-chart-paired-t-test",
       "requires": {
         "distributions": "^1.0.0",
-        "prop-types": "^15.6.2",
         "reactable": "^1.1.0"
       }
     },
     "@superset-ui/legacy-plugin-chart-parallel-coordinates": {
       "version": "file:plugins/legacy-plugin-chart-parallel-coordinates",
       "requires": {
-        "d3": "^3.5.17",
-        "prop-types": "^15.7.2"
+        "d3": "^3.5.17"
       }
     },
     "@superset-ui/legacy-plugin-chart-partition": {
       "version": "file:plugins/legacy-plugin-chart-partition",
       "requires": {
         "d3": "^3.5.17",
-        "d3-hierarchy": "^1.1.8",
-        "prop-types": "^15.6.2"
+        "d3-hierarchy": "^1.1.8"
       }
     },
     "@superset-ui/legacy-plugin-chart-pivot-table": {
       "version": "file:plugins/legacy-plugin-chart-pivot-table",
       "requires": {
         "d3": "^3.5.17",
-        "datatables.net-bs": "^1.11.3",
-        "prop-types": "^15.6.2"
+        "datatables.net-bs": "^1.11.3"
       }
     },
     "@superset-ui/legacy-plugin-chart-rose": {
       "version": "file:plugins/legacy-plugin-chart-rose",
       "requires": {
         "d3": "^3.5.17",
-        "nvd3": "1.8.6",
-        "prop-types": "^15.6.2"
+        "nvd3": "1.8.6"
       }
     },
     "@superset-ui/legacy-plugin-chart-sankey": {
       "version": "file:plugins/legacy-plugin-chart-sankey",
       "requires": {
         "d3": "^3.5.17",
-        "d3-sankey": "^0.4.2",
-        "prop-types": "^15.6.2"
+        "d3-sankey": "^0.4.2"
       }
     },
     "@superset-ui/legacy-plugin-chart-sankey-loop": {
       "version": "file:plugins/legacy-plugin-chart-sankey-loop",
       "requires": {
         "d3-sankey-diagram": "^0.7.3",
-        "d3-selection": "^1.4.0",
-        "prop-types": "^15.6.2"
+        "d3-selection": "^1.4.0"
       }
     },
     "@superset-ui/legacy-plugin-chart-sunburst": {
       "version": "file:plugins/legacy-plugin-chart-sunburst",
       "requires": {
-        "d3": "^3.5.17",
-        "prop-types": "^15.6.2"
+        "d3": "^3.5.17"
       }
     },
     "@superset-ui/legacy-plugin-chart-treemap": {
       "version": "file:plugins/legacy-plugin-chart-treemap",
       "requires": {
         "d3-hierarchy": "^1.1.8",
-        "d3-selection": "^1.4.0",
-        "prop-types": "^15.6.2"
+        "d3-selection": "^1.4.0"
       }
     },
     "@superset-ui/legacy-plugin-chart-world-map": {
@@ -76402,8 +76275,7 @@
         "d3": "^3.5.17",
         "d3-array": "^2.4.0",
         "d3-color": "^1.4.1",
-        "datamaps": "^0.5.8",
-        "prop-types": "^15.6.2"
+        "datamaps": "^0.5.8"
       },
       "dependencies": {
         "d3-array": {
@@ -76490,7 +76362,6 @@
         "lodash": "^4.17.11",
         "moment": "^2.20.1",
         "nvd3-fork": "^2.0.5",
-        "prop-types": "^15.6.2",
         "urijs": "^1.18.10"
       }
     },
@@ -78915,14 +78786,6 @@
         "prop-types": "^15.7.2",
         "prop-types-exact": "^1.2.0",
         "react-is": "^16.9.0"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-          "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==",
-          "dev": true
-        }
       }
     },
     "ajv": {
@@ -79153,19 +79016,6 @@
             "@ctrl/tinycolor": "^3.3.1"
           }
         },
-        "@ant-design/icons": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-4.3.0.tgz",
-          "integrity": "sha512-UoIbw4oz/L/msbkgqs2nls2KP7XNKScOxVR54wRrWwnXOzJaGNwwSdYjHQz+5ETf8C53YPpzMOnRX99LFCdeIQ==",
-          "requires": {
-            "@ant-design/colors": "^5.0.0",
-            "@ant-design/icons-svg": "^4.0.0",
-            "@babel/runtime": "^7.11.2",
-            "classnames": "^2.2.6",
-            "insert-css": "^2.0.0",
-            "rc-util": "^5.0.1"
-          }
-        },
         "rc-util": {
           "version": "5.5.1",
           "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.5.1.tgz",
@@ -79174,11 +79024,6 @@
             "react-is": "^16.12.0",
             "shallowequal": "^1.1.0"
           }
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },
@@ -85263,12 +85108,6 @@
         "semver": "^5.7.0"
       },
       "dependencies": {
-        "react-is": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-          "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==",
-          "dev": true
-        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -85309,14 +85148,6 @@
       "requires": {
         "lodash": "^4.17.15",
         "react-is": "^16.12.0"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-          "dev": true
-        }
       }
     },
     "err-code": {
@@ -88828,13 +88659,6 @@
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
       "requires": {
         "react-is": "^16.7.0"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        }
       }
     },
     "homedir-polyfill": {
@@ -89558,11 +89382,6 @@
           }
         }
       }
-    },
-    "insert-css": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/insert-css/-/insert-css-2.0.0.tgz",
-      "integrity": "sha1-610Ql7dUL0x56jBg067gfQU4gPQ="
     },
     "internal-ip": {
       "version": "6.2.0",
@@ -96844,13 +96663,6 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.8.1"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        }
       }
     },
     "prop-types-exact": {
@@ -97161,11 +96973,6 @@
             "react-is": "^16.12.0",
             "shallowequal": "^1.1.0"
           }
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },
@@ -97209,11 +97016,6 @@
             "react-is": "^16.12.0",
             "shallowequal": "^1.1.0"
           }
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },
@@ -97317,11 +97119,6 @@
             "react-is": "^16.12.0",
             "shallowequal": "^1.1.0"
           }
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },
@@ -97343,11 +97140,6 @@
             "react-is": "^16.12.0",
             "shallowequal": "^1.1.0"
           }
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },
@@ -97394,11 +97186,6 @@
             "react-is": "^16.12.0",
             "shallowequal": "^1.1.0"
           }
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },
@@ -97498,11 +97285,6 @@
             "react-is": "^16.12.0",
             "shallowequal": "^1.1.0"
           }
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },
@@ -97527,11 +97309,6 @@
             "react-is": "^16.12.0",
             "shallowequal": "^1.1.0"
           }
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },
@@ -97599,11 +97376,6 @@
             "react-is": "^16.12.0",
             "shallowequal": "^1.1.0"
           }
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },
@@ -97625,11 +97397,6 @@
             "react-is": "^16.12.0",
             "shallowequal": "^1.1.0"
           }
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },
@@ -97640,13 +97407,6 @@
       "requires": {
         "react-is": "^16.12.0",
         "shallowequal": "^1.1.0"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        }
       }
     },
     "rc-virtual-list": {
@@ -97667,11 +97427,6 @@
             "react-is": "^16.12.0",
             "shallowequal": "^1.1.0"
           }
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },
@@ -98205,9 +97960,9 @@
       }
     },
     "react-is": {
-      "version": "16.6.3",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.3.tgz",
-      "integrity": "sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA=="
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-js-cron": {
       "version": "1.2.0",
@@ -98361,13 +98116,6 @@
         "unified": "^6.1.5",
         "unist-util-visit": "^1.3.0",
         "xtend": "^4.0.1"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "16.12.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
-          "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
-        }
       }
     },
     "react-move": {
@@ -98411,13 +98159,6 @@
         "loose-envify": "^1.4.0",
         "prop-types": "^15.7.2",
         "react-is": "^16.9.0"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        }
       }
     },
     "react-refresh": {
@@ -98660,14 +98401,6 @@
         "prop-types": "^15.6.2",
         "react-is": "^16.9.0",
         "scheduler": "^0.15.0"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-          "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==",
-          "dev": true
-        }
       }
     },
     "react-textarea-autosize": {

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -73,7 +73,7 @@
     "last 3 edge versions"
   ],
   "dependencies": {
-    "@ant-design/icons": "^4.2.2",
+    "@ant-design/icons": "^4.7.0",
     "@babel/runtime-corejs3": "^7.12.5",
     "@data-ui/sparkline": "^0.0.84",
     "@emotion/babel-preset-css-prop": "^11.2.0",

--- a/superset-frontend/packages/superset-ui-chart-controls/package.json
+++ b/superset-frontend/packages/superset-ui-chart-controls/package.json
@@ -27,16 +27,16 @@
   },
   "dependencies": {
     "@react-icons/all-files": "^4.1.0",
-    "lodash": "^4.17.15",
-    "prop-types": "^15.7.2"
+    "lodash": "^4.17.15"
   },
   "peerDependencies": {
-    "@emotion/react": "^11.4.1",
+    "@emotion/react": "*",
     "@superset-ui/core": "*",
     "@types/react": "*",
-    "antd": "^4.9.4",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
-    "@types/enzyme": "^3.10.5"
+    "antd": "*",
+    "react": "*",
+    "react-dom": "*",
+    "@types/enzyme": "*",
+    "prop-types": "*"
   }
 }

--- a/superset-frontend/packages/superset-ui-core/package.json
+++ b/superset-frontend/packages/superset-ui-core/package.json
@@ -65,12 +65,12 @@
     "whatwg-fetch": "^3.0.0"
   },
   "peerDependencies": {
-    "@emotion/cache": "^11.4.0",
-    "@emotion/react": "^11.4.1",
-    "@emotion/styled": "^11.3.0",
+    "@emotion/cache": "*",
+    "@emotion/react": "*",
+    "@emotion/styled": "*",
     "@types/react": "*",
     "@types/react-loadable": "*",
-    "react": "^16.13.1",
-    "react-loadable": "^5.5.0"
+    "react": "*",
+    "react-loadable": "*"
   }
 }

--- a/superset-frontend/packages/superset-ui-demo/package.json
+++ b/superset-frontend/packages/superset-ui-demo/package.json
@@ -31,9 +31,6 @@
   "homepage": "https://github.com/apache-superset/superset-ui#readme",
   "dependencies": {
     "@data-ui/event-flow": "^0.0.84",
-    "@emotion/cache": "^11.4.0",
-    "@emotion/react": "^11.4.1",
-    "@emotion/styled": "^11.3.0",
     "@react-icons/all-files": "^4.1.0",
     "@storybook/addon-actions": "^6.3.12",
     "@storybook/addon-knobs": "^6.3.1",
@@ -48,8 +45,6 @@
     "global-box": "^1.2.0",
     "jquery": "^3.4.1",
     "memoize-one": "^5.1.1",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
     "react-loadable": "^5.5.0",
     "react-resizable": "^3.0.4",
     "storybook-addon-jsx": "^7.3.14"
@@ -90,6 +85,11 @@
     "@superset-ui/plugin-chart-echarts": "*",
     "@superset-ui/plugin-chart-table": "*",
     "@superset-ui/plugin-chart-word-cloud": "*",
-    "@superset-ui/preset-chart-xy": "*"
+    "@superset-ui/preset-chart-xy": "*",
+    "react": "*",
+    "react-dom": "*",
+    "@emotion/cache": "*",
+    "@emotion/react": "*",
+    "@emotion/styled": "*"
   }
 }

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/package.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/package.json
@@ -30,12 +30,12 @@
   "dependencies": {
     "d3-array": "^2.0.3",
     "d3-selection": "^1.4.0",
-    "d3-tip": "^0.9.1",
-    "prop-types": "^15.6.2"
+    "d3-tip": "^0.9.1"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
-    "react": "^16.13.1"
+    "react": "*",
+    "prop-types": "*"
   }
 }

--- a/superset-frontend/plugins/legacy-plugin-chart-chord/package.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-chord/package.json
@@ -29,11 +29,11 @@
   },
   "dependencies": {
     "d3": "^3.5.17",
-    "prop-types": "^15.6.2",
-    "react": "^16.13.1"
+    "prop-types": "^15.6.2"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
-    "@superset-ui/core": "*"
+    "@superset-ui/core": "*",
+    "react": "*"
   }
 }

--- a/superset-frontend/plugins/legacy-plugin-chart-country-map/package.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-country-map/package.json
@@ -29,11 +29,11 @@
   },
   "dependencies": {
     "d3": "^3.5.17",
-    "d3-array": "^2.0.3",
-    "prop-types": "^15.6.2"
+    "d3-array": "^2.0.3"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
-    "@superset-ui/core": "*"
+    "@superset-ui/core": "*",
+    "prop-types": "*"
   }
 }

--- a/superset-frontend/plugins/legacy-plugin-chart-event-flow/package.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-event-flow/package.json
@@ -28,12 +28,12 @@
     "access": "public"
   },
   "dependencies": {
-    "@data-ui/event-flow": "^0.0.84",
-    "prop-types": "^15.6.2"
+    "@data-ui/event-flow": "^0.0.84"
   },
   "peerDependencies": {
-    "react": "^15 || ^16",
+    "react": "*",
     "@superset-ui/chart-controls": "*",
-    "@superset-ui/core": "*"
+    "@superset-ui/core": "*",
+    "prop-types": "*"
   }
 }

--- a/superset-frontend/plugins/legacy-plugin-chart-force-directed/package.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-force-directed/package.json
@@ -28,12 +28,12 @@
     "access": "public"
   },
   "dependencies": {
-    "d3": "^3.5.17",
-    "prop-types": "^15.7.2"
+    "d3": "^3.5.17"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
-    "react": "^16.13.1"
+    "react": "*",
+    "prop-types": "^15.7.2"
   }
 }

--- a/superset-frontend/plugins/legacy-plugin-chart-heatmap/package.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-heatmap/package.json
@@ -30,11 +30,11 @@
   "dependencies": {
     "d3": "^3.5.17",
     "d3-svg-legend": "^1.x",
-    "d3-tip": "^0.9.1",
-    "prop-types": "^15.6.2"
+    "d3-tip": "^0.9.1"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
-    "@superset-ui/core": "*"
+    "@superset-ui/core": "*",
+    "prop-types": "*"
   }
 }

--- a/superset-frontend/plugins/legacy-plugin-chart-histogram/package.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-histogram/package.json
@@ -32,12 +32,12 @@
     "@data-ui/theme": "^0.0.84",
     "@vx/legend": "^0.0.198",
     "@vx/responsive": "^0.0.199",
-    "@vx/scale": "^0.0.197",
-    "prop-types": "^15.6.2"
+    "@vx/scale": "^0.0.197"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
-    "react": "^15 || ^16"
+    "react": "*",
+    "prop-types": "*"
   }
 }

--- a/superset-frontend/plugins/legacy-plugin-chart-horizon/package.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-horizon/package.json
@@ -29,12 +29,12 @@
   },
   "dependencies": {
     "d3-array": "^2.0.3",
-    "d3-scale": "^3.0.1",
-    "prop-types": "^15.6.2"
+    "d3-scale": "^3.0.1"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
-    "react": "^15 || ^16"
+    "react": "*",
+    "prop-types": "*"
   }
 }

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/package.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/package.json
@@ -28,7 +28,6 @@
     "access": "public"
   },
   "dependencies": {
-    "prop-types": "^15.6.2",
     "react-map-gl": "^4.0.10",
     "supercluster": "^4.1.1",
     "viewport-mercator-project": "^6.1.1"
@@ -36,7 +35,8 @@
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
-    "react": "^15 || ^16",
-    "mapbox-gl": "*"
+    "react": "*",
+    "mapbox-gl": "*",
+    "prop-types": "*"
   }
 }

--- a/superset-frontend/plugins/legacy-plugin-chart-paired-t-test/package.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-paired-t-test/package.json
@@ -29,12 +29,12 @@
   },
   "dependencies": {
     "distributions": "^1.0.0",
-    "prop-types": "^15.6.2",
     "reactable": "^1.1.0"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
-    "react": "^15 || ^16"
+    "react": "*",
+    "prop-types": "*"
   }
 }

--- a/superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/package.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/package.json
@@ -28,12 +28,12 @@
     "access": "public"
   },
   "dependencies": {
-    "d3": "^3.5.17",
-    "prop-types": "^15.7.2"
+    "d3": "^3.5.17"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
-    "react": "^16.13.1"
+    "prop-types": "*",
+    "react": "*"
   }
 }

--- a/superset-frontend/plugins/legacy-plugin-chart-partition/package.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-partition/package.json
@@ -29,13 +29,13 @@
   },
   "dependencies": {
     "d3": "^3.5.17",
-    "d3-hierarchy": "^1.1.8",
-    "prop-types": "^15.6.2"
+    "d3-hierarchy": "^1.1.8"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
-    "react": "^16.13.1",
-    "enzyme": "*"
+    "react": "*",
+    "enzyme": "*",
+    "prop-types": "*"
   }
 }

--- a/superset-frontend/plugins/legacy-plugin-chart-pivot-table/package.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-pivot-table/package.json
@@ -29,11 +29,11 @@
   },
   "dependencies": {
     "d3": "^3.5.17",
-    "datatables.net-bs": "^1.11.3",
-    "prop-types": "^15.6.2"
+    "datatables.net-bs": "^1.11.3"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
-    "@superset-ui/core": "*"
+    "@superset-ui/core": "*",
+    "prop-types": "*"
   }
 }

--- a/superset-frontend/plugins/legacy-plugin-chart-rose/package.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-rose/package.json
@@ -29,12 +29,12 @@
   },
   "dependencies": {
     "d3": "^3.5.17",
-    "nvd3": "1.8.6",
-    "prop-types": "^15.6.2"
+    "nvd3": "1.8.6"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
-    "react": "^16.13.1"
+    "react": "*",
+    "prop-types": "*"
   }
 }

--- a/superset-frontend/plugins/legacy-plugin-chart-sankey-loop/package.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-sankey-loop/package.json
@@ -29,11 +29,11 @@
   },
   "dependencies": {
     "d3-sankey-diagram": "^0.7.3",
-    "d3-selection": "^1.4.0",
-    "prop-types": "^15.6.2"
+    "d3-selection": "^1.4.0"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
-    "@superset-ui/core": "*"
+    "@superset-ui/core": "*",
+    "prop-types": "*"
   }
 }

--- a/superset-frontend/plugins/legacy-plugin-chart-sankey/package.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-sankey/package.json
@@ -29,12 +29,12 @@
   },
   "dependencies": {
     "d3": "^3.5.17",
-    "d3-sankey": "^0.4.2",
-    "prop-types": "^15.6.2"
+    "d3-sankey": "^0.4.2"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
-    "react": "^16.13.1"
+    "react": "*",
+    "prop-types": "*"
   }
 }

--- a/superset-frontend/plugins/legacy-plugin-chart-sunburst/package.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-sunburst/package.json
@@ -28,11 +28,11 @@
     "access": "public"
   },
   "dependencies": {
-    "d3": "^3.5.17",
-    "prop-types": "^15.6.2"
+    "d3": "^3.5.17"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
-    "@superset-ui/core": "*"
+    "@superset-ui/core": "*",
+    "prop-types": "*"
   }
 }

--- a/superset-frontend/plugins/legacy-plugin-chart-treemap/package.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-treemap/package.json
@@ -29,11 +29,11 @@
   },
   "dependencies": {
     "d3-hierarchy": "^1.1.8",
-    "d3-selection": "^1.4.0",
-    "prop-types": "^15.6.2"
+    "d3-selection": "^1.4.0"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
-    "@superset-ui/core": "*"
+    "@superset-ui/core": "*",
+    "prop-types": "*"
   }
 }

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/package.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/package.json
@@ -31,12 +31,12 @@
     "d3": "^3.5.17",
     "d3-array": "^2.4.0",
     "d3-color": "^1.4.1",
-    "datamaps": "^0.5.8",
-    "prop-types": "^15.6.2"
+    "datamaps": "^0.5.8"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
-    "react": "^16.13.1"
+    "react": "*",
+    "prop-types": "*"
   }
 }

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/package.json
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/package.json
@@ -43,9 +43,9 @@
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
-    "react-map-gl": "^4.0.10",
+    "react": "*",
+    "react-dom": "*",
+    "react-map-gl": "*",
     "mapbox-gl": "*"
   },
   "publishConfig": {

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/package.json
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/package.json
@@ -36,12 +36,12 @@
     "lodash": "^4.17.11",
     "moment": "^2.20.1",
     "nvd3-fork": "^2.0.5",
-    "prop-types": "^15.6.2",
     "urijs": "^1.18.10"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
-    "react": "^15 || ^16"
+    "react": "*",
+    "prop-types": "*"
   }
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/package.json
+++ b/superset-frontend/plugins/plugin-chart-echarts/package.json
@@ -34,6 +34,6 @@
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
-    "react": "^16.13.1"
+    "react": "*"
   }
 }

--- a/superset-frontend/plugins/plugin-chart-pivot-table/package.json
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/package.json
@@ -29,9 +29,9 @@
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
-    "@ant-design/icons": "^4.2.2",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
+    "@ant-design/icons": "*",
+    "react": "*",
+    "react-dom": "*",
     "prop-types": "*"
   },
   "devDependencies": {

--- a/superset-frontend/plugins/plugin-chart-table/package.json
+++ b/superset-frontend/plugins/plugin-chart-table/package.json
@@ -41,7 +41,7 @@
     "@types/react": "*",
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react": "*",
+    "react-dom": "*"
   }
 }

--- a/superset-frontend/plugins/plugin-chart-word-cloud/package.json
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/package.json
@@ -38,6 +38,6 @@
     "@types/react": "*",
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
-    "react": "^16.13.1"
+    "react": "*"
   }
 }

--- a/superset-frontend/plugins/preset-chart-xy/package.json
+++ b/superset-frontend/plugins/preset-chart-xy/package.json
@@ -42,6 +42,6 @@
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
-    "react": "^16.2"
+    "react": "*"
   }
 }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR 
1. moved React to peerDependencies in plugins.
2. changed "range version" to "any version" in peerDeps
3. update "@ant-design/icons": "^4.2.2" to "@ant-design/icons": "^4.7.0"

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
CI
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
