### PR TITLE
feat: smart tooltip in datasourcepanel

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
@@ -27,7 +27,6 @@ import { ColumnMeta } from '../types';
 export type ColumnOptionProps = {
   column: ColumnMeta;
   showType?: boolean;
-  showTooltip?: boolean;
   labelRef?: React.RefObject<any>;
 };
 
@@ -41,7 +40,6 @@ export function ColumnOption({
   column,
   labelRef,
   showType = false,
-  showTooltip = true,
 }: ColumnOptionProps) {
   const { expression, column_name, type_generic } = column;
   const hasExpression = expression && expression !== column_name;
@@ -57,10 +55,10 @@ export function ColumnOption({
           details={column.certification_details}
         />
       )}
-      {showTooltip ? (
+      {column.verbose_name ? (
         <Tooltip
           id="metric-name-tooltip"
-          title={column.verbose_name || column.column_name}
+          title={column.column_name}
           trigger={['hover']}
           placement="top"
         >
@@ -68,12 +66,12 @@ export function ColumnOption({
             className="m-r-5 option-label column-option-label"
             ref={labelRef}
           >
-            {column.verbose_name || column.column_name}
+            {column.verbose_name}
           </span>
         </Tooltip>
       ) : (
         <span className="m-r-5 option-label column-option-label" ref={labelRef}>
-          {column.verbose_name || column.column_name}
+          {column.column_name}
         </span>
       )}
       {column.description && (

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
@@ -16,13 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { styled } from '@superset-ui/core';
 import { Tooltip } from './Tooltip';
 import { ColumnTypeLabel } from './ColumnTypeLabel';
 import InfoTooltipWithTrigger from './InfoTooltipWithTrigger';
 import CertifiedIconWithTooltip from './CertifiedIconWithTooltip';
 import { ColumnMeta } from '../types';
+import { getColumnLabelText, getColumnTooltipText } from './labelUtils';
 
 export type ColumnOptionProps = {
   column: ColumnMeta;
@@ -44,6 +45,11 @@ export function ColumnOption({
   const { expression, column_name, type_generic } = column;
   const hasExpression = expression && expression !== column_name;
   const type = hasExpression ? 'expression' : type_generic;
+  const [tooltipText, setTooltipText] = useState(column.column_name);
+
+  useEffect(() => {
+    setTooltipText(getColumnTooltipText(column, labelRef));
+  }, [labelRef, column]);
 
   return (
     <StyleOverrides>
@@ -55,25 +61,17 @@ export function ColumnOption({
           details={column.certification_details}
         />
       )}
-      {column.verbose_name ? (
-        <Tooltip
-          id="metric-name-tooltip"
-          title={column.column_name}
-          trigger={['hover']}
-          placement="top"
-        >
-          <span
-            className="m-r-5 option-label column-option-label"
-            ref={labelRef}
-          >
-            {column.verbose_name}
-          </span>
-        </Tooltip>
-      ) : (
+      <Tooltip
+        id="metric-name-tooltip"
+        title={tooltipText}
+        trigger={['hover']}
+        placement="top"
+      >
         <span className="m-r-5 option-label column-option-label" ref={labelRef}>
-          {column.column_name}
+          {getColumnLabelText(column)}
         </span>
-      )}
+      </Tooltip>
+
       {column.description && (
         <InfoTooltipWithTrigger
           className="m-r-5 text-muted"

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
@@ -16,14 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, ReactNode } from 'react';
 import { styled } from '@superset-ui/core';
 import { Tooltip } from './Tooltip';
 import { ColumnTypeLabel } from './ColumnTypeLabel';
 import InfoTooltipWithTrigger from './InfoTooltipWithTrigger';
 import CertifiedIconWithTooltip from './CertifiedIconWithTooltip';
 import { ColumnMeta } from '../types';
-import { getColumnLabelText, getColumnTooltipText } from './labelUtils';
+import { getColumnLabelText, getColumnTooltipNode } from './labelUtils';
 
 export type ColumnOptionProps = {
   column: ColumnMeta;
@@ -45,10 +45,10 @@ export function ColumnOption({
   const { expression, column_name, type_generic } = column;
   const hasExpression = expression && expression !== column_name;
   const type = hasExpression ? 'expression' : type_generic;
-  const [tooltipText, setTooltipText] = useState(column.column_name);
+  const [tooltipText, setTooltipText] = useState<ReactNode>(column.column_name);
 
   useEffect(() => {
-    setTooltipText(getColumnTooltipText(column, labelRef));
+    setTooltipText(getColumnTooltipNode(column, labelRef));
   }, [labelRef, column]);
 
   return (

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
@@ -37,7 +37,6 @@ export interface MetricOptionProps {
   openInNewWindow?: boolean;
   showFormula?: boolean;
   showType?: boolean;
-  showTooltip?: boolean;
   url?: string;
   labelRef?: React.RefObject<any>;
 }
@@ -48,7 +47,6 @@ export function MetricOption({
   openInNewWindow = false,
   showFormula = true,
   showType = false,
-  showTooltip = true,
   url = '',
 }: MetricOptionProps) {
   const verbose = metric.verbose_name || metric.metric_name || metric.label;
@@ -72,10 +70,10 @@ export function MetricOption({
           details={metric.certification_details}
         />
       )}
-      {showTooltip ? (
+      {metric.metric_name ? (
         <Tooltip
           id="metric-name-tooltip"
-          title={verbose}
+          title={metric.metric_name}
           trigger={['hover']}
           placement="top"
         >

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
@@ -22,7 +22,7 @@ import InfoTooltipWithTrigger from './InfoTooltipWithTrigger';
 import { ColumnTypeLabel } from './ColumnTypeLabel';
 import CertifiedIconWithTooltip from './CertifiedIconWithTooltip';
 import Tooltip from './Tooltip';
-import { getMeticTooltipNode } from './labelUtils';
+import { getMetricTooltipNode } from './labelUtils';
 
 const FlexRowContainer = styled.div`
   align-items: center;
@@ -64,7 +64,7 @@ export function MetricOption({
   const [tooltipText, setTooltipText] = useState<ReactNode>(metric.metric_name);
 
   useEffect(() => {
-    setTooltipText(getMeticTooltipNode(metric, labelRef));
+    setTooltipText(getMetricTooltipNode(metric, labelRef));
   }, [labelRef, metric]);
 
   return (

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
@@ -16,13 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, ReactNode } from 'react';
 import { styled, Metric, SafeMarkdown } from '@superset-ui/core';
 import InfoTooltipWithTrigger from './InfoTooltipWithTrigger';
 import { ColumnTypeLabel } from './ColumnTypeLabel';
 import CertifiedIconWithTooltip from './CertifiedIconWithTooltip';
 import Tooltip from './Tooltip';
-import { getMeticTooltipText } from './labelUtils';
+import { getMeticTooltipNode } from './labelUtils';
 
 const FlexRowContainer = styled.div`
   align-items: center;
@@ -61,10 +61,10 @@ export function MetricOption({
 
   const warningMarkdown = metric.warning_markdown || metric.warning_text;
 
-  const [tooltipText, setTooltipText] = useState(metric.metric_name);
+  const [tooltipText, setTooltipText] = useState<ReactNode>(metric.metric_name);
 
   useEffect(() => {
-    setTooltipText(getMeticTooltipText(metric, labelRef));
+    setTooltipText(getMeticTooltipNode(metric, labelRef));
   }, [labelRef, metric]);
 
   return (

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
@@ -16,12 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { styled, Metric, SafeMarkdown } from '@superset-ui/core';
 import InfoTooltipWithTrigger from './InfoTooltipWithTrigger';
 import { ColumnTypeLabel } from './ColumnTypeLabel';
 import CertifiedIconWithTooltip from './CertifiedIconWithTooltip';
 import Tooltip from './Tooltip';
+import { getMeticTooltipText } from './labelUtils';
 
 const FlexRowContainer = styled.div`
   align-items: center;
@@ -60,6 +61,12 @@ export function MetricOption({
 
   const warningMarkdown = metric.warning_markdown || metric.warning_text;
 
+  const [tooltipText, setTooltipText] = useState(metric.metric_name);
+
+  useEffect(() => {
+    setTooltipText(getMeticTooltipText(metric, labelRef));
+  }, [labelRef, metric]);
+
   return (
     <FlexRowContainer className="metric-option">
       {showType && <ColumnTypeLabel type="expression" />}
@@ -70,22 +77,16 @@ export function MetricOption({
           details={metric.certification_details}
         />
       )}
-      {metric.metric_name ? (
-        <Tooltip
-          id="metric-name-tooltip"
-          title={metric.metric_name}
-          trigger={['hover']}
-          placement="top"
-        >
-          <span className="option-label metric-option-label" ref={labelRef}>
-            {link}
-          </span>
-        </Tooltip>
-      ) : (
+      <Tooltip
+        id="metric-name-tooltip"
+        title={tooltipText}
+        trigger={['hover']}
+        placement="top"
+      >
         <span className="option-label metric-option-label" ref={labelRef}>
           {link}
         </span>
-      )}
+      </Tooltip>
       {metric.description && (
         <InfoTooltipWithTrigger
           className="text-muted"

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.ts
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { t } from '@superset-ui/core';
 import { ColumnMeta, Metric } from '@superset-ui/chart-controls';
 
 export const isLabelTruncated = (labelRef?: React.RefObject<any>): boolean =>
@@ -38,10 +39,10 @@ export const getColumnTooltipText = (
   }
 
   if (isLabelTruncated(labelRef) && column.verbose_name) {
-    return `verbose name: ${column.verbose_name}`;
+    return t('verbose name: %s', column.verbose_name);
   }
 
-  return `column name: ${column.column_name}`;
+  return t('column name: %s', column.column_name);
 };
 
 type MetricType = Omit<Metric, 'id'> & { label?: string };
@@ -56,12 +57,12 @@ export const getMeticTooltipText = (
   }
 
   if (isLabelTruncated(labelRef) && metric.verbose_name) {
-    return `verbose name: ${metric.verbose_name}`;
+    return t('verbose name: %s', metric.verbose_name);
   }
 
   if (isLabelTruncated(labelRef) && metric.label) {
-    return `label name: ${metric.label}`;
+    return t('label name: %s', metric.label);
   }
 
-  return `metric name: ${metric.metric_name}`;
+  return t('metric name: %s', metric.metric_name);
 };

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.ts
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { ColumnMeta, Metric } from '@superset-ui/chart-controls';
+
+export const isLabelTruncated = (labelRef?: React.RefObject<any>): boolean =>
+  !!(
+    labelRef &&
+    labelRef.current &&
+    labelRef.current.scrollWidth > labelRef.current.clientWidth
+  );
+
+export const getColumnLabelText = (column: ColumnMeta): string =>
+  column.verbose_name || column.column_name;
+
+export const getColumnTooltipText = (
+  column: ColumnMeta,
+  labelRef?: React.RefObject<any>,
+): string => {
+  // don't show tooltip if it hasn't verbose_name and hasn't truncated
+  if (!column.verbose_name && !isLabelTruncated(labelRef)) {
+    return '';
+  }
+
+  if (isLabelTruncated(labelRef) && column.verbose_name) {
+    return `verbose name: ${column.verbose_name}`;
+  }
+
+  return `column name: ${column.column_name}`;
+};
+
+type MetricType = Omit<Metric, 'id'> & { label?: string };
+
+export const getMeticTooltipText = (
+  metric: MetricType,
+  labelRef?: React.RefObject<any>,
+): string => {
+  // don't show tooltip if it hasn't verbose_name, label and hasn't truncated
+  if (!metric.verbose_name && !metric.label && !isLabelTruncated(labelRef)) {
+    return '';
+  }
+
+  if (isLabelTruncated(labelRef) && metric.verbose_name) {
+    return `verbose name: ${metric.verbose_name}`;
+  }
+
+  if (isLabelTruncated(labelRef) && metric.label) {
+    return `label name: ${metric.label}`;
+  }
+
+  return `metric name: ${metric.metric_name}`;
+};

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.tsx
@@ -16,6 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import React, { ReactNode } from 'react';
+
 import { t } from '@superset-ui/core';
 import { ColumnMeta, Metric } from '@superset-ui/chart-controls';
 
@@ -29,35 +31,46 @@ export const isLabelTruncated = (labelRef?: React.RefObject<any>): boolean =>
 export const getColumnLabelText = (column: ColumnMeta): string =>
   column.verbose_name || column.column_name;
 
-export const getColumnTooltipText = (
+export const getColumnTooltipNode = (
   column: ColumnMeta,
   labelRef?: React.RefObject<any>,
-): string => {
+): ReactNode => {
   // don't show tooltip if it hasn't verbose_name and hasn't truncated
   if (!column.verbose_name && !isLabelTruncated(labelRef)) {
-    return '';
+    return null;
   }
 
-  if (isLabelTruncated(labelRef) && column.verbose_name) {
-    return t('verbose name: %s', column.verbose_name);
+  if (column.verbose_name) {
+    return (
+      <>
+        <div>{t('column name: %s', column.column_name)}</div>
+        <div>{t('verbose name: %s', column.verbose_name)}</div>
+      </>
+    );
   }
 
+  // show column name in tooltip when column truncated
   return t('column name: %s', column.column_name);
 };
 
 type MetricType = Omit<Metric, 'id'> & { label?: string };
 
-export const getMeticTooltipText = (
+export const getMeticTooltipNode = (
   metric: MetricType,
   labelRef?: React.RefObject<any>,
-): string => {
+): ReactNode => {
   // don't show tooltip if it hasn't verbose_name, label and hasn't truncated
   if (!metric.verbose_name && !metric.label && !isLabelTruncated(labelRef)) {
-    return '';
+    return null;
   }
 
-  if (isLabelTruncated(labelRef) && metric.verbose_name) {
-    return t('verbose name: %s', metric.verbose_name);
+  if (metric.verbose_name) {
+    return (
+      <>
+        <div>{t('metric name: %s', metric.metric_name)}</div>
+        <div>{t('verbose name: %s', metric.verbose_name)}</div>
+      </>
+    );
   }
 
   if (isLabelTruncated(labelRef) && metric.label) {

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.tsx
@@ -55,7 +55,7 @@ export const getColumnTooltipNode = (
 
 type MetricType = Omit<Metric, 'id'> & { label?: string };
 
-export const getMeticTooltipNode = (
+export const getMetricTooltipNode = (
   metric: MetricType,
   labelRef?: React.RefObject<any>,
 ): ReactNode => {

--- a/superset-frontend/packages/superset-ui-chart-controls/test/components/labelUtils.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/components/labelUtils.test.tsx
@@ -16,10 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import React from 'react';
+
 import {
   getColumnLabelText,
-  getColumnTooltipText,
-  getMeticTooltipText,
+  getColumnTooltipNode,
+  getMeticTooltipNode,
 } from '../../src/components/labelUtils';
 
 test("should get column name when column doesn't have verbose_name", () => {
@@ -42,10 +44,10 @@ test('should get verbose name when column have verbose_name', () => {
   ).toBe('verbose name');
 });
 
-test('should get empty string as tooltip', () => {
+test('should get null as tooltip', () => {
   const ref = { current: { scrollWidth: 100, clientWidth: 100 } };
   expect(
-    getColumnTooltipText(
+    getColumnTooltipNode(
       {
         id: 123,
         column_name: 'column name',
@@ -53,13 +55,20 @@ test('should get empty string as tooltip', () => {
       },
       ref,
     ),
-  ).toBe('');
+  ).toBe(null);
 });
 
 test('should get column name as tooltip when it verbose name', () => {
+  const rvNode = (
+    <>
+      <div>column name: column name</div>
+      <div>verbose name: verbose name</div>
+    </>
+  );
+
   const ref = { current: { scrollWidth: 100, clientWidth: 100 } };
   expect(
-    getColumnTooltipText(
+    getColumnTooltipNode(
       {
         id: 123,
         column_name: 'column name',
@@ -67,13 +76,13 @@ test('should get column name as tooltip when it verbose name', () => {
       },
       ref,
     ),
-  ).toBe('column name: column name');
+  ).toStrictEqual(rvNode);
 });
 
 test('should get column name as tooltip if it overflowed', () => {
   const ref = { current: { scrollWidth: 200, clientWidth: 100 } };
   expect(
-    getColumnTooltipText(
+    getColumnTooltipNode(
       {
         id: 123,
         column_name: 'long long long long column name',
@@ -85,9 +94,16 @@ test('should get column name as tooltip if it overflowed', () => {
 });
 
 test('should get verbose name as tooltip if it overflowed', () => {
+  const rvNode = (
+    <>
+      <div>column name: long long long long column name</div>
+      <div>verbose name: long long long long verbose name</div>
+    </>
+  );
+
   const ref = { current: { scrollWidth: 200, clientWidth: 100 } };
   expect(
-    getColumnTooltipText(
+    getColumnTooltipNode(
       {
         id: 123,
         column_name: 'long long long long column name',
@@ -95,13 +111,13 @@ test('should get verbose name as tooltip if it overflowed', () => {
       },
       ref,
     ),
-  ).toBe('verbose name: long long long long verbose name');
+  ).toStrictEqual(rvNode);
 });
 
-test('should get empty string as tooltip in metric', () => {
+test('should get null as tooltip in metric', () => {
   const ref = { current: { scrollWidth: 100, clientWidth: 100 } };
   expect(
-    getMeticTooltipText(
+    getMeticTooltipNode(
       {
         metric_name: 'count',
         label: '',
@@ -109,13 +125,20 @@ test('should get empty string as tooltip in metric', () => {
       },
       ref,
     ),
-  ).toBe('');
+  ).toBe(null);
 });
 
 test('should get metric name(sql alias) as tooltip in metric', () => {
+  const rvNode = (
+    <>
+      <div>metric name: count</div>
+      <div>verbose name: count(*)</div>
+    </>
+  );
+
   const ref = { current: { scrollWidth: 100, clientWidth: 100 } };
   expect(
-    getMeticTooltipText(
+    getMeticTooltipNode(
       {
         metric_name: 'count',
         label: 'count(*)',
@@ -123,13 +146,20 @@ test('should get metric name(sql alias) as tooltip in metric', () => {
       },
       ref,
     ),
-  ).toBe('metric name: count');
+  ).toStrictEqual(rvNode);
 });
 
 test('should get verbose name as tooltip in metric if it overflowed', () => {
+  const rvNode = (
+    <>
+      <div>metric name: count</div>
+      <div>verbose name: longlonglonglonglong verbose metric</div>
+    </>
+  );
+
   const ref = { current: { scrollWidth: 200, clientWidth: 100 } };
   expect(
-    getMeticTooltipText(
+    getMeticTooltipNode(
       {
         metric_name: 'count',
         label: '',
@@ -137,13 +167,13 @@ test('should get verbose name as tooltip in metric if it overflowed', () => {
       },
       ref,
     ),
-  ).toBe('verbose name: longlonglonglonglong verbose metric');
+  ).toStrictEqual(rvNode);
 });
 
 test('should get label name as tooltip in metric if it overflowed', () => {
   const ref = { current: { scrollWidth: 200, clientWidth: 100 } };
   expect(
-    getMeticTooltipText(
+    getMeticTooltipNode(
       {
         metric_name: 'count',
         label: 'longlonglonglonglong metric label',

--- a/superset-frontend/packages/superset-ui-chart-controls/test/components/labelUtils.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/components/labelUtils.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  getColumnLabelText,
+  getColumnTooltipText,
+  getMeticTooltipText,
+} from '../../src/components/labelUtils';
+
+test("should get column name when column doesn't have verbose_name", () => {
+  expect(
+    getColumnLabelText({
+      id: 123,
+      column_name: 'column name',
+      verbose_name: '',
+    }),
+  ).toBe('column name');
+});
+
+test('should get verbose name when column have verbose_name', () => {
+  expect(
+    getColumnLabelText({
+      id: 123,
+      column_name: 'column name',
+      verbose_name: 'verbose name',
+    }),
+  ).toBe('verbose name');
+});
+
+test('should get empty string as tooltip', () => {
+  const ref = { current: { scrollWidth: 100, clientWidth: 100 } };
+  expect(
+    getColumnTooltipText(
+      {
+        id: 123,
+        column_name: 'column name',
+        verbose_name: '',
+      },
+      ref,
+    ),
+  ).toBe('');
+});
+
+test('should get column name as tooltip when it verbose name', () => {
+  const ref = { current: { scrollWidth: 100, clientWidth: 100 } };
+  expect(
+    getColumnTooltipText(
+      {
+        id: 123,
+        column_name: 'column name',
+        verbose_name: 'verbose name',
+      },
+      ref,
+    ),
+  ).toBe('column name: column name');
+});
+
+test('should get column name as tooltip if it overflowed', () => {
+  const ref = { current: { scrollWidth: 200, clientWidth: 100 } };
+  expect(
+    getColumnTooltipText(
+      {
+        id: 123,
+        column_name: 'long long long long column name',
+        verbose_name: '',
+      },
+      ref,
+    ),
+  ).toBe('column name: long long long long column name');
+});
+
+test('should get verbose name as tooltip if it overflowed', () => {
+  const ref = { current: { scrollWidth: 200, clientWidth: 100 } };
+  expect(
+    getColumnTooltipText(
+      {
+        id: 123,
+        column_name: 'long long long long column name',
+        verbose_name: 'long long long long verbose name',
+      },
+      ref,
+    ),
+  ).toBe('verbose name: long long long long verbose name');
+});
+
+test('should get empty string as tooltip in metric', () => {
+  const ref = { current: { scrollWidth: 100, clientWidth: 100 } };
+  expect(
+    getMeticTooltipText(
+      {
+        metric_name: 'count',
+        label: '',
+        verbose_name: '',
+      },
+      ref,
+    ),
+  ).toBe('');
+});
+
+test('should get metric name(sql alias) as tooltip in metric', () => {
+  const ref = { current: { scrollWidth: 100, clientWidth: 100 } };
+  expect(
+    getMeticTooltipText(
+      {
+        metric_name: 'count',
+        label: 'count(*)',
+        verbose_name: 'count(*)',
+      },
+      ref,
+    ),
+  ).toBe('metric name: count');
+});
+
+test('should get verbose name as tooltip in metric if it overflowed', () => {
+  const ref = { current: { scrollWidth: 200, clientWidth: 100 } };
+  expect(
+    getMeticTooltipText(
+      {
+        metric_name: 'count',
+        label: '',
+        verbose_name: 'longlonglonglonglong verbose metric',
+      },
+      ref,
+    ),
+  ).toBe('verbose name: longlonglonglonglong verbose metric');
+});
+
+test('should get label name as tooltip in metric if it overflowed', () => {
+  const ref = { current: { scrollWidth: 200, clientWidth: 100 } };
+  expect(
+    getMeticTooltipText(
+      {
+        metric_name: 'count',
+        label: 'longlonglonglonglong metric label',
+        verbose_name: '',
+      },
+      ref,
+    ),
+  ).toBe('label name: longlonglonglonglong metric label');
+});

--- a/superset-frontend/packages/superset-ui-chart-controls/test/components/labelUtils.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/components/labelUtils.test.tsx
@@ -21,7 +21,7 @@ import React from 'react';
 import {
   getColumnLabelText,
   getColumnTooltipNode,
-  getMeticTooltipNode,
+  getMetricTooltipNode,
 } from '../../src/components/labelUtils';
 
 test("should get column name when column doesn't have verbose_name", () => {
@@ -58,7 +58,7 @@ test('should get null as tooltip', () => {
   ).toBe(null);
 });
 
-test('should get column name as tooltip when it verbose name', () => {
+test('should get column name and verbose name when it has a verbose name', () => {
   const rvNode = (
     <>
       <div>column name: column name</div>
@@ -93,7 +93,7 @@ test('should get column name as tooltip if it overflowed', () => {
   ).toBe('column name: long long long long column name');
 });
 
-test('should get verbose name as tooltip if it overflowed', () => {
+test('should get column name and verbose name as tooltip if it overflowed', () => {
   const rvNode = (
     <>
       <div>column name: long long long long column name</div>
@@ -117,7 +117,7 @@ test('should get verbose name as tooltip if it overflowed', () => {
 test('should get null as tooltip in metric', () => {
   const ref = { current: { scrollWidth: 100, clientWidth: 100 } };
   expect(
-    getMeticTooltipNode(
+    getMetricTooltipNode(
       {
         metric_name: 'count',
         label: '',
@@ -128,7 +128,7 @@ test('should get null as tooltip in metric', () => {
   ).toBe(null);
 });
 
-test('should get metric name(sql alias) as tooltip in metric', () => {
+test('should get metric name and verbose name as tooltip in metric', () => {
   const rvNode = (
     <>
       <div>metric name: count</div>
@@ -138,7 +138,7 @@ test('should get metric name(sql alias) as tooltip in metric', () => {
 
   const ref = { current: { scrollWidth: 100, clientWidth: 100 } };
   expect(
-    getMeticTooltipNode(
+    getMetricTooltipNode(
       {
         metric_name: 'count',
         label: 'count(*)',
@@ -149,7 +149,7 @@ test('should get metric name(sql alias) as tooltip in metric', () => {
   ).toStrictEqual(rvNode);
 });
 
-test('should get verbose name as tooltip in metric if it overflowed', () => {
+test('should get metric name and verbose name in tooltip if it overflowed', () => {
   const rvNode = (
     <>
       <div>metric name: count</div>
@@ -159,7 +159,7 @@ test('should get verbose name as tooltip in metric if it overflowed', () => {
 
   const ref = { current: { scrollWidth: 200, clientWidth: 100 } };
   expect(
-    getMeticTooltipNode(
+    getMetricTooltipNode(
       {
         metric_name: 'count',
         label: '',
@@ -173,7 +173,7 @@ test('should get verbose name as tooltip in metric if it overflowed', () => {
 test('should get label name as tooltip in metric if it overflowed', () => {
   const ref = { current: { scrollWidth: 200, clientWidth: 100 } };
   expect(
-    getMeticTooltipNode(
+    getMetricTooltipNode(
       {
         metric_name: 'count',
         label: 'longlonglonglonglong metric label',

--- a/superset-frontend/packages/superset-ui-chart-controls/test/shared-controls/emitFilterControl.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/shared-controls/emitFilterControl.test.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { emitFilterControl } from '../../src/shared-controls/emitFilterControl';
+import { emitFilterControl } from '@superset-ui/chart-controls';
 
 describe('isFeatureFlagEnabled', () => {
   it('returns empty array for unset feature flag', () => {

--- a/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
@@ -45,6 +45,8 @@ export interface Props {
     datasource: DatasourceControl;
   };
   actions: Partial<ExploreActions> & Pick<ExploreActions, 'setControlValue'>;
+  // we use this props control force update when this panel resize
+  shouldForceUpdate?: number;
 }
 
 const Button = styled.button`
@@ -141,6 +143,7 @@ export default function DataSourcePanel({
   datasource,
   controls: { datasource: datasourceControl },
   actions,
+  shouldForceUpdate,
 }: Props) {
   const { columns: _columns, metrics } = datasource;
 
@@ -288,7 +291,10 @@ export default function DataSourcePanel({
                 )}
               </div>
               {metricSlice.map(m => (
-                <LabelContainer key={m.metric_name} className="column">
+                <LabelContainer
+                  key={m.metric_name + String(shouldForceUpdate)}
+                  className="column"
+                >
                   {enableExploreDnd ? (
                     <DatasourcePanelDragOption
                       value={m}
@@ -321,7 +327,10 @@ export default function DataSourcePanel({
                 )}
               </div>
               {columnSlice.map(col => (
-                <LabelContainer key={col.column_name} className="column">
+                <LabelContainer
+                  key={col.column_name + String(shouldForceUpdate)}
+                  className="column"
+                >
                   {enableExploreDnd ? (
                     <DatasourcePanelDragOption
                       value={col}
@@ -355,6 +364,7 @@ export default function DataSourcePanel({
       search,
       showAllColumns,
       showAllMetrics,
+      shouldForceUpdate,
     ],
   );
 

--- a/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
@@ -123,32 +123,11 @@ const LabelContainer = (props: {
   className: string;
 }) => {
   const labelRef = useRef<HTMLDivElement>(null);
-  const [showTooltip, setShowTooltip] = useState(true);
-  const isLabelTruncated = () =>
-    !!(
-      labelRef &&
-      labelRef.current &&
-      labelRef.current.scrollWidth > labelRef.current.clientWidth
-    );
-  const handleShowTooltip = () => {
-    const shouldShowTooltip = isLabelTruncated();
-    if (shouldShowTooltip !== showTooltip) {
-      setShowTooltip(shouldShowTooltip);
-    }
-  };
-  const handleResetTooltip = () => {
-    setShowTooltip(true);
-  };
   const extendedProps = {
     labelRef,
-    showTooltip,
   };
   return (
-    <LabelWrapper
-      onMouseEnter={handleShowTooltip}
-      onMouseLeave={handleResetTooltip}
-      className={props.className}
-    >
+    <LabelWrapper className={props.className}>
       {React.cloneElement(props.children, extendedProps)}
     </LabelWrapper>
   );

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -210,7 +210,7 @@ function ExploreViewContainer(props) {
 
   const [showingModal, setShowingModal] = useState(false);
   const [isCollapsed, setIsCollapsed] = useState(false);
-  const [shouldForceUpdate, setshouldForceUpdate] = useState(-1);
+  const [shouldForceUpdate, setShouldForceUpdate] = useState(-1);
 
   const theme = useTheme();
   const width = `${windowSize.width}px`;
@@ -528,7 +528,7 @@ function ExploreViewContainer(props) {
       )}
       <Resizable
         onResizeStop={(evt, direction, ref, d) => {
-          setshouldForceUpdate(d?.width);
+          setShouldForceUpdate(d?.width);
           setSidebarWidths(LocalStorageKeys.datasource_width, d);
         }}
         defaultSize={{

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -210,6 +210,7 @@ function ExploreViewContainer(props) {
 
   const [showingModal, setShowingModal] = useState(false);
   const [isCollapsed, setIsCollapsed] = useState(false);
+  const [shouldForceUpdate, setshouldForceUpdate] = useState(-1);
 
   const theme = useTheme();
   const width = `${windowSize.width}px`;
@@ -526,9 +527,10 @@ function ExploreViewContainer(props) {
         />
       )}
       <Resizable
-        onResizeStop={(evt, direction, ref, d) =>
-          setSidebarWidths(LocalStorageKeys.datasource_width, d)
-        }
+        onResizeStop={(evt, direction, ref, d) => {
+          setshouldForceUpdate(d?.width);
+          setSidebarWidths(LocalStorageKeys.datasource_width, d);
+        }}
         defaultSize={{
           width: getSidebarWidths(LocalStorageKeys.datasource_width),
           height: '100%',
@@ -559,6 +561,7 @@ function ExploreViewContainer(props) {
           datasource={props.datasource}
           controls={props.controls}
           actions={props.actions}
+          shouldForceUpdate={shouldForceUpdate}
         />
       </Resizable>
       {isCollapsed ? (

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/OptionWrapper.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/OptionWrapper.tsx
@@ -144,7 +144,6 @@ export default function OptionWrapper(
       <StyledColumnOption
         column={transformedCol as ColumnMeta}
         labelRef={labelRef}
-        showTooltip={!!shouldShowTooltip}
         showType
       />
     );

--- a/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
+++ b/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
@@ -280,13 +280,7 @@ export const OptionControlLabel = ({
         labelRef.current.scrollWidth > labelRef.current.clientWidth);
 
     if (savedMetric && hasMetricName) {
-      return (
-        <StyledMetricOption
-          metric={savedMetric}
-          labelRef={labelRef}
-          showTooltip={!!shouldShowTooltip}
-        />
-      );
+      return <StyledMetricOption metric={savedMetric} labelRef={labelRef} />;
     }
     if (!shouldShowTooltip) {
       return <LabelText ref={labelRef}>{label}</LabelText>;


### PR DESCRIPTION
### SUMMARY
This PR intends to resolve 2 potential issues in the current Superset
1. there is no chance to show `column name` and `metric name` in the datapanel if defining a verbose name for these.

https://user-images.githubusercontent.com/2016594/149963508-ae31c00d-5c2b-4964-9bd8-cc8b4bc70913.mov

2. `superset-frontend/src/explore/components/DatasourcePanel/index.tsx::LabelContainer`  will re-render when we trigger from onMouseLeave or onMouseEnter event. 

This simple experiment can prove it.

```
(superset) yongjie.zhao@:superset-frontend$ git diff
diff --git a/superset-frontend/src/explore/components/DatasourcePanel/index.tsx b/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
index 0a3cf7b76..57b9627a1 100644
--- a/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
@@ -122,6 +122,7 @@ const LabelContainer = (props: {
   children: React.ReactElement;
   className: string;
 }) => {
+  console.log("Hey, i'm Label Container");
   const labelRef = useRef<HTMLDivElement>(null);
   const [showTooltip, setShowTooltip] = useState(true);
   const isLabelTruncated = () =>
```


https://user-images.githubusercontent.com/2016594/149965431-9d8f7694-a5f4-414d-8c69-0e82c4213803.mov

closes: https://github.com/apache/superset/issues/13252


This PR removed some redundant logic to fix this.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### After 

#### default tooltip
https://user-images.githubusercontent.com/2016594/152765983-842df5ad-1a9c-4e47-9e30-ffb4dca3284a.mov

#### add verbose name



https://user-images.githubusercontent.com/2016594/152766822-d60622bf-06ab-4f0a-9c78-ceecda671a1b.mov






### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. First and foremost, create a virtual dataset in SQLlab and open it in explore.
```
SELECT 
'foo' as supersupersupersupersuper_long_column,
'foo' as short_column
```
2. (default) verify that 
a) There is a tooltip on the `supersupersupersupersuper_long_column`
b) There isn't a tooltip on the `short_column`
c) There isn't a tooltip on the `count`
d) there aren't tooltips when you scale datasouce-panel up.

3. verify verbose name name
a) tooltip will **always** appear column(metric) name **and** verbose name if you set verbose name in columns or metrics(except verbose truncated)


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes: https://github.com/apache/superset/issues/13252
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
