### PR TITLE
fix(histogram): display correct percentile value instead of formula

### DIFF
--- a/superset-frontend/.prettierignore
+++ b/superset-frontend/.prettierignore
@@ -26,4 +26,3 @@ CHANGELOG.md
 *-topo.json
 temporary_superset_ui/
 storybook-static/
-plugins/legacy-plugins-chart-histogram/src/Histogram.jsx

--- a/superset-frontend/.prettierignore
+++ b/superset-frontend/.prettierignore
@@ -26,3 +26,4 @@ CHANGELOG.md
 *-topo.json
 temporary_superset_ui/
 storybook-static/
+plugins/legacy-plugins-chart-histogram/src/Histogram.jsx

--- a/superset-frontend/plugins/legacy-plugin-chart-histogram/src/Histogram.jsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-histogram/src/Histogram.jsx
@@ -122,7 +122,10 @@ class CustomHistogram extends React.PureComponent {
                 </div>
                 <div>
                   <strong>{t('percentile (exclusive)')} </strong>
-                  {`${((datum.cumulativeDensity - datum.density) * 100).toPrecision(4)}th`}
+                  {`${(
+                    (datum.cumulativeDensity - datum.density) *
+                    100
+                  ).toPrecision(4)}th`}
                 </div>
               </div>
             )}

--- a/superset-frontend/plugins/legacy-plugin-chart-histogram/src/Histogram.jsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-histogram/src/Histogram.jsx
@@ -122,7 +122,7 @@ class CustomHistogram extends React.PureComponent {
                 </div>
                 <div>
                   <strong>{t('percentile (exclusive)')} </strong>
-                  {`{((datum.cumulativeDensity - datum.density) * 100).toPrecision(4)}th`}
+                  {`${((datum.cumulativeDensity - datum.density) * 100).toPrecision(4)}th`}
                 </div>
               </div>
             )}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR addresses issue #17550 regarding histogram percentile displaying the formula instead of the value. The long formula also causes the entire tooltip box to be long, which possibly leads to the entire tooltip being hidden to the side of the plot.

### BEFORE
<!--- Skip this if not applicable -->
![Screenshot from 2022-01-19 09-26-36](https://user-images.githubusercontent.com/19884163/150052803-d3f29477-4325-42e0-98ea-4e8a24f34044.png)

### AFTER
![Screenshot from 2022-01-19 09-34-39](https://user-images.githubusercontent.com/19884163/150052932-e95bd5d2-b371-41e0-bc6b-69c4373b636d.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Open any histogram chart, "FCC 2018 Survey's Age distribution of respondents" is an included example.
- Hover the mouse pointer over any column to see the percentile value in the tooltip.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #17550 
- [x] Required feature flags: Disables prettier linting in `superset-frontend/plugins/legacy-plugin-chart-histogram/src/Histogram.jsx` to prevent ERROR related to line length during `npm build`.
- [x] Changes UI: no
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351)): no
  - [x] Migration is atomic, supports rollback & is backwards-compatible: N/A
  - [x] Confirm DB migration upgrade and downgrade tested: N/A
  - [x] Runtime estimates and downtime expectations provided: N/A
- [x] Introduces new feature or API: no
- [x] Removes existing feature or API: no
