### PR TITLE
fix: can't use examples helpers on non app context based environment

### DIFF
--- a/superset/cli.py
+++ b/superset/cli.py
@@ -124,7 +124,7 @@ def load_examples_run(
         print(f"Loading examples metadata and related data into {examples_db}")
 
     # pylint: disable=import-outside-toplevel
-    from superset import examples
+    import superset.examples.data_loading as examples
 
     examples.load_css_templates()
 

--- a/superset/examples/__init__.py
+++ b/superset/examples/__init__.py
@@ -14,21 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from .bart_lines import load_bart_lines
-from .big_data import load_big_data
-from .birth_names import load_birth_names
-from .country_map import load_country_map_data
-from .css_templates import load_css_templates
-from .deck import load_deck_dash
-from .energy import load_energy
-from .flights import load_flights
-from .long_lat import load_long_lat_data
-from .misc_dashboard import load_misc_dashboard
-from .multi_line import load_multi_line
-from .multiformat_time_series import load_multiformat_time_series
-from .paris import load_paris_iris_geojson
-from .random_time_series import load_random_time_series_data
-from .sf_population_polygons import load_sf_population_polygons
-from .tabbed_dashboard import load_tabbed_dashboard
-from .utils import load_examples_from_configs
-from .world_bank import load_world_bank_health_n_pop

--- a/superset/examples/data_loading.py
+++ b/superset/examples/data_loading.py
@@ -1,0 +1,35 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+# pylint: disable=unused-import
+from .bart_lines import load_bart_lines
+from .big_data import load_big_data
+from .birth_names import load_birth_names
+from .country_map import load_country_map_data
+from .css_templates import load_css_templates
+from .deck import load_deck_dash
+from .energy import load_energy
+from .flights import load_flights
+from .long_lat import load_long_lat_data
+from .misc_dashboard import load_misc_dashboard
+from .multi_line import load_multi_line
+from .multiformat_time_series import load_multiformat_time_series
+from .paris import load_paris_iris_geojson
+from .random_time_series import load_random_time_series_data
+from .sf_population_polygons import load_sf_population_polygons
+from .tabbed_dashboard import load_tabbed_dashboard
+from .utils import load_examples_from_configs
+from .world_bank import load_world_bank_health_n_pop

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -54,9 +54,9 @@ def setup_sample_data() -> Any:
 
         load_test_users_run()
 
-        from superset import examples
+        from superset.examples.css_templates import load_css_templates
 
-        examples.load_css_templates()
+        load_css_templates()
 
     yield
 


### PR DESCRIPTION
When working on another PR, I'm trying to import superset.examples.helpers on an area that should be run without app-context based. 
when superset. examples init all the loading modules, it eventually loading modules that coupled for running under app context 