### PR TITLE
fix(docs): Correction of proper names format in README

### DIFF
--- a/docs/src/pages/docs/introduction.mdx
+++ b/docs/src/pages/docs/introduction.mdx
@@ -16,9 +16,9 @@ Here are a **few different ways you can get started with Superset**:
 - Download the latest Superset version from [Pypi here](https://pypi.org/project/apache-superset/)
 - Setup Superset locally with one command
 using [Docker Compose](installation/installing-superset-using-docker-compose)
-- Download the [Docker image](https://hub.docker.com/r/apache/superset) from Dockerhub
+- Download the [Docker image](https://hub.docker.com/r/apache/superset) from Docker Hub
 - Install the latest version of Superset
-[from Github](https://github.com/apache/superset/tree/latest)
+[from GitHub](https://github.com/apache/superset/tree/latest)
 
 Superset provides:
 


### PR DESCRIPTION
### SUMMARY

I changed format of some proper names.

See:

* for GitHub see footer of that website: 
![obraz](https://user-images.githubusercontent.com/3618479/150135131-086271a0-2323-46d5-8bbd-4907ad9b77ad.png)
* for Docker Hub see https://www.docker.com/products/docker-hub
  
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

N/A

### ADDITIONAL INFORMATION

- [x] Has associated issue: no
- [x] Required feature flags: no
- [x] Changes UI: no
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351)): no
  - [x] Migration is atomic, supports rollback & is backwards-compatible: N/A
  - [x] Confirm DB migration upgrade and downgrade tested: N/A
  - [x] Runtime estimates and downtime expectations provided: N/A
- [x] Introduces new feature or API: no
- [x] Removes existing feature or API: no