### PR TITLE
fix(docs): load correctly image for "Create New Chart"

### DIFF
--- a/docs/src/pages/docs/Creating Charts and Dashboards/exploring-data.mdx
+++ b/docs/src/pages/docs/Creating Charts and Dashboards/exploring-data.mdx
@@ -115,7 +115,7 @@ tutorial_flights again as a datasource, then click on the visualization type to 
 visualization menu. Select the **Pivot Table v2** visualization (you can filter by entering text in the
 search box) and then **Create New Chart**.
 
-<img src="/images/create_pivot_2.png" />
+<img src="/images/create_pivot_v2.png" />
 
 In the **Time** section, keep the Time Column as Travel Date (this is selected automatically, as we
 only have one time column in our dataset). Then select Time Grain to be month as having daily data


### PR DESCRIPTION
### SUMMARY

Image reference is invalid. Filename include is addiction "v". See https://github.com/apache/superset/blob/master/docs/static/images/create_pivot_v2.png . 

File `/images/create_pivot_2.png` does not exist, but exist `/images/create_pivot_v2.png`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: 
![obraz](https://user-images.githubusercontent.com/3618479/150167162-d953963f-cb96-4059-ae81-050589fb6636.png)

See also at https://superset.apache.org/docs/creating-charts-dashboards/exploring-data 

### TESTING INSTRUCTIONS

Build frontend & vist `/creating-charts-dashboards/exploring-data` page

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: no
- [x] Required feature flags: no
- [x] Changes UI: no
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351)): no
  - [x] Migration is atomic, supports rollback & is backwards-compatible: N/A
  - [x] Confirm DB migration upgrade and downgrade tested: N/A
  - [x] Runtime estimates and downtime expectations provided: N/A
- [x] Introduces new feature or API: no
- [x] Removes existing feature or API: no
