### PR TITLE
feat: allow assets to be managed externally

### DIFF
--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -110,6 +110,8 @@ class BaseDatasource(
     params = Column(String(1000))
     perm = Column(String(1000))
     schema_perm = Column(String(1000))
+    is_managed_externally = Column(Boolean, default=False)
+    external_url = Column(Text, nullable=True)
 
     sql: Optional[str] = None
     owners: List[User]

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -110,7 +110,7 @@ class BaseDatasource(
     params = Column(String(1000))
     perm = Column(String(1000))
     schema_perm = Column(String(1000))
-    is_managed_externally = Column(Boolean, default=False)
+    is_managed_externally = Column(Boolean, nullable=False, default=False)
     external_url = Column(Text, nullable=True)
 
     sql: Optional[str] = None

--- a/superset/migrations/versions/5fd49410a97a_add_columns_for_external_management.py
+++ b/superset/migrations/versions/5fd49410a97a_add_columns_for_external_management.py
@@ -1,0 +1,80 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Add columns for external management
+
+Revision ID: 5fd49410a97a
+Revises: c53bae8f08dd
+Create Date: 2022-01-19 07:34:20.594786
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "5fd49410a97a"
+down_revision = "c53bae8f08dd"
+
+import sqlalchemy as sa
+from alembic import op
+
+
+def upgrade():
+    with op.batch_alter_table("dashboards") as batch_op:
+        batch_op.add_column(
+            sa.Column("is_managed_externally", sa.Boolean(), nullable=True)
+        )
+        batch_op.add_column(sa.Column("external_url", sa.Text(), nullable=True))
+
+    with op.batch_alter_table("datasources") as batch_op:
+        batch_op.add_column(
+            sa.Column("is_managed_externally", sa.Boolean(), nullable=True)
+        )
+        batch_op.add_column(sa.Column("external_url", sa.Text(), nullable=True))
+
+    with op.batch_alter_table("dbs") as batch_op:
+        batch_op.add_column(
+            sa.Column("is_managed_externally", sa.Boolean(), nullable=True)
+        )
+        batch_op.add_column(sa.Column("external_url", sa.Text(), nullable=True))
+
+    with op.batch_alter_table("slices") as batch_op:
+        batch_op.add_column(
+            sa.Column("is_managed_externally", sa.Boolean(), nullable=True)
+        )
+        batch_op.add_column(sa.Column("external_url", sa.Text(), nullable=True))
+
+    with op.batch_alter_table("tables") as batch_op:
+        batch_op.add_column(
+            sa.Column("is_managed_externally", sa.Boolean(), nullable=True)
+        )
+        batch_op.add_column(sa.Column("external_url", sa.Text(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("tables") as batch_op:
+        batch_op.drop_column("external_url")
+        batch_op.drop_column("is_managed_externally")
+    with op.batch_alter_table("slices") as batch_op:
+        batch_op.drop_column("external_url")
+        batch_op.drop_column("is_managed_externally")
+    with op.batch_alter_table("dbs") as batch_op:
+        batch_op.drop_column("external_url")
+        batch_op.drop_column("is_managed_externally")
+    with op.batch_alter_table("datasources") as batch_op:
+        batch_op.drop_column("external_url")
+        batch_op.drop_column("is_managed_externally")
+    with op.batch_alter_table("dashboards") as batch_op:
+        batch_op.drop_column("external_url")
+        batch_op.drop_column("is_managed_externally")

--- a/superset/migrations/versions/5fd49410a97a_add_columns_for_external_management.py
+++ b/superset/migrations/versions/5fd49410a97a_add_columns_for_external_management.py
@@ -33,31 +33,56 @@ from alembic import op
 def upgrade():
     with op.batch_alter_table("dashboards") as batch_op:
         batch_op.add_column(
-            sa.Column("is_managed_externally", sa.Boolean(), nullable=True)
+            sa.Column(
+                "is_managed_externally",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
         )
         batch_op.add_column(sa.Column("external_url", sa.Text(), nullable=True))
 
     with op.batch_alter_table("datasources") as batch_op:
         batch_op.add_column(
-            sa.Column("is_managed_externally", sa.Boolean(), nullable=True)
+            sa.Column(
+                "is_managed_externally",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
         )
         batch_op.add_column(sa.Column("external_url", sa.Text(), nullable=True))
 
     with op.batch_alter_table("dbs") as batch_op:
         batch_op.add_column(
-            sa.Column("is_managed_externally", sa.Boolean(), nullable=True)
+            sa.Column(
+                "is_managed_externally",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
         )
         batch_op.add_column(sa.Column("external_url", sa.Text(), nullable=True))
 
     with op.batch_alter_table("slices") as batch_op:
         batch_op.add_column(
-            sa.Column("is_managed_externally", sa.Boolean(), nullable=True)
+            sa.Column(
+                "is_managed_externally",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
         )
         batch_op.add_column(sa.Column("external_url", sa.Text(), nullable=True))
 
     with op.batch_alter_table("tables") as batch_op:
         batch_op.add_column(
-            sa.Column("is_managed_externally", sa.Boolean(), nullable=True)
+            sa.Column(
+                "is_managed_externally",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
         )
         batch_op.add_column(sa.Column("external_url", sa.Text(), nullable=True))
 

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -151,7 +151,7 @@ class Database(
     encrypted_extra = Column(encrypted_field_factory.create(Text), nullable=True)
     impersonate_user = Column(Boolean, default=False)
     server_cert = Column(encrypted_field_factory.create(Text), nullable=True)
-    is_managed_externally = Column(Boolean, default=False)
+    is_managed_externally = Column(Boolean, nullable=False, default=False)
     external_url = Column(Text, nullable=True)
 
     export_fields = [

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -151,6 +151,9 @@ class Database(
     encrypted_extra = Column(encrypted_field_factory.create(Text), nullable=True)
     impersonate_user = Column(Boolean, default=False)
     server_cert = Column(encrypted_field_factory.create(Text), nullable=True)
+    is_managed_externally = Column(Boolean, default=False)
+    external_url = Column(Text, nullable=True)
+
     export_fields = [
         "database_name",
         "sqlalchemy_uri",

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -149,7 +149,7 @@ class Dashboard(Model, AuditMixinNullable, ImportExportMixin):
     slices = relationship(Slice, secondary=dashboard_slices, backref="dashboards")
     owners = relationship(security_manager.user_model, secondary=dashboard_user)
     published = Column(Boolean, default=False)
-    is_managed_externally = Column(Boolean, default=False)
+    is_managed_externally = Column(Boolean, nullable=False, default=False)
     external_url = Column(Text, nullable=True)
     roles = relationship(security_manager.role_model, secondary=DashboardRoles)
     _filter_sets = relationship(

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -149,6 +149,8 @@ class Dashboard(Model, AuditMixinNullable, ImportExportMixin):
     slices = relationship(Slice, secondary=dashboard_slices, backref="dashboards")
     owners = relationship(security_manager.user_model, secondary=dashboard_user)
     published = Column(Boolean, default=False)
+    is_managed_externally = Column(Boolean, default=False)
+    external_url = Column(Text, nullable=True)
     roles = relationship(security_manager.role_model, secondary=DashboardRoles)
     _filter_sets = relationship(
         "FilterSet", back_populates="dashboard", cascade="all, delete"

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -341,7 +341,7 @@ class ImportExportMixin:
         self.params = json.dumps(params)
 
     def reset_ownership(self) -> None:
-        """ object will belong to the user the current user """
+        """object will belong to the user the current user"""
         # make sure the object doesn't have relations to a user
         # it will be filled by appbuilder on save
         self.created_by = None

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -92,7 +92,7 @@ class Slice(  # pylint: disable=too-many-public-methods
     last_saved_by_fk = Column(Integer, ForeignKey("ab_user.id"), nullable=True)
     certified_by = Column(Text)
     certification_details = Column(Text)
-    is_managed_externally = Column(Boolean, default=False)
+    is_managed_externally = Column(Boolean, nullable=False, default=False)
     external_url = Column(Text, nullable=True)
     last_saved_by = relationship(
         security_manager.user_model, foreign_keys=[last_saved_by_fk]

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -25,7 +25,16 @@ import sqlalchemy as sqla
 from flask_appbuilder import Model
 from flask_appbuilder.models.decorators import renders
 from markupsafe import escape, Markup
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Table, Text
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Table,
+    Text,
+)
 from sqlalchemy.engine.base import Connection
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.mapper import Mapper
@@ -83,6 +92,8 @@ class Slice(  # pylint: disable=too-many-public-methods
     last_saved_by_fk = Column(Integer, ForeignKey("ab_user.id"), nullable=True)
     certified_by = Column(Text)
     certification_details = Column(Text)
+    is_managed_externally = Column(Boolean, default=False)
+    external_url = Column(Text, nullable=True)
     last_saved_by = relationship(
         security_manager.user_model, foreign_keys=[last_saved_by_fk]
     )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

There's been increasing interest in managing superset assets (databases, datasets, charts, dashboards) externally. An immediate use case that is possible today is creating a directory with YAML files from the new import/export format:

```
repo/metadata.yaml
repo/databases/db.yaml
repo/datasets/db/dataset.yaml
repo/charts/chart.yaml
repo/dashboards/dash.yaml
```

And then periodically syncing the directory to Superset with:

```bash
superset import-directory /path/to/repo
```

Even though this works, users are still able to modify these assets in the UI, introducing unintended modifications, as well as frustration for the users when those changes are reverted in the next sync.

In addition to the import/export scenario, people have been syncing model (and metric!) definitions [from DBT to Superset](https://github.com/slidoapp/dbt-superset-lineage/) (as well as from Superset to DBT). Users have also shown interest in syncing from [Supergrain](https://www.supergrain.com/) and [Transform](https://transform.co/).

This PR introduces 2 new columns to databases, datasets, charts and dashboards:

1. `is_managed_externally`: a boolean defaulting to "false".
2. `external_url`: a nullable string representing an URL pointing to more information about the resource.

There are no UI changes in this PR, but I'm planning following PRs that modify the CRUD dialogs (and the backend) to prevent editing the resources when `is_managed_externally` is true. In the future we could also add an affordance using `external_url`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

None.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Ran the migration script:

```
Results:

Current: 0.28 s
10+: 0.29 s
100+: 0.27 s
1000+: 0.31 s
10000+: 0.27 s
100000+: 0.36 s
1000000+: 0.91 s
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [X] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [X] Migration is atomic, supports rollback & is backwards-compatible
  - [X] Confirm DB migration upgrade and downgrade tested
  - [X] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API