### PR TITLE
feat(explore): more toast feedback on user actions in Explore

### DIFF
--- a/superset-frontend/src/explore/components/ExploreActionButtons.tsx
+++ b/superset-frontend/src/explore/components/ExploreActionButtons.tsx
@@ -18,11 +18,13 @@
  */
 import React, { ReactElement, useState } from 'react';
 import cx from 'classnames';
+import { useDispatch } from 'react-redux';
 import { QueryFormData, t } from '@superset-ui/core';
 import Icons from 'src/components/Icons';
 import { Tooltip } from 'src/components/Tooltip';
 import copyTextToClipboard from 'src/utils/copy';
 import withToasts from 'src/components/MessageToasts/withToasts';
+import { addSuccessToast } from 'src/components/MessageToasts/actions';
 import { useUrlShortener } from 'src/hooks/useUrlShortener';
 import EmbedCodeButton from './EmbedCodeButton';
 import { exportChart, getExploreLongUrl } from '../exploreUtils';
@@ -100,6 +102,7 @@ const ExploreActionButtons = (props: ExploreActionButtonsProps) => {
     addDangerToast,
   } = props;
 
+  const dispatch = useDispatch();
   const copyTooltipText = t('Copy chart URL to clipboard');
   const [copyTooltip, setCopyTooltip] = useState(copyTooltipText);
   const longUrl = getExploreLongUrl(latestQueryFormData);
@@ -111,8 +114,14 @@ const ExploreActionButtons = (props: ExploreActionButtonsProps) => {
       const shortUrl = await getShortUrl();
       await copyTextToClipboard(shortUrl);
       setCopyTooltip(t('Copied to clipboard!'));
+      dispatch(addSuccessToast(t('Copied to clipboard!')));
     } catch (error) {
       setCopyTooltip(t('Sorry, your browser does not support copying.'));
+      dispatch(
+        addDangerToast(t('Sorry, your browser does not support copying.'), {
+          noDuplicate: true,
+        }),
+      );
     }
   };
 

--- a/superset-frontend/src/explore/components/ExploreActionButtons.tsx
+++ b/superset-frontend/src/explore/components/ExploreActionButtons.tsx
@@ -18,13 +18,11 @@
  */
 import React, { ReactElement, useState } from 'react';
 import cx from 'classnames';
-import { useDispatch } from 'react-redux';
 import { QueryFormData, t } from '@superset-ui/core';
 import Icons from 'src/components/Icons';
 import { Tooltip } from 'src/components/Tooltip';
 import copyTextToClipboard from 'src/utils/copy';
 import withToasts from 'src/components/MessageToasts/withToasts';
-import { addSuccessToast } from 'src/components/MessageToasts/actions';
 import { useUrlShortener } from 'src/hooks/useUrlShortener';
 import EmbedCodeButton from './EmbedCodeButton';
 import { exportChart, getExploreLongUrl } from '../exploreUtils';
@@ -50,6 +48,7 @@ type ExploreActionButtonsProps = {
   queriesResponse: {};
   slice: { slice_name: string };
   addDangerToast: Function;
+  addSuccessToast: Function;
 };
 
 const VIZ_TYPES_PIVOTABLE = ['pivot_table', 'pivot_table_v2'];
@@ -100,9 +99,9 @@ const ExploreActionButtons = (props: ExploreActionButtonsProps) => {
     latestQueryFormData,
     slice,
     addDangerToast,
+    addSuccessToast,
   } = props;
 
-  const dispatch = useDispatch();
   const copyTooltipText = t('Copy chart URL to clipboard');
   const [copyTooltip, setCopyTooltip] = useState(copyTooltipText);
   const longUrl = getExploreLongUrl(latestQueryFormData);
@@ -114,14 +113,10 @@ const ExploreActionButtons = (props: ExploreActionButtonsProps) => {
       const shortUrl = await getShortUrl();
       await copyTextToClipboard(shortUrl);
       setCopyTooltip(t('Copied to clipboard!'));
-      dispatch(addSuccessToast(t('Copied to clipboard!')));
+      addSuccessToast(t('Copied to clipboard!'));
     } catch (error) {
       setCopyTooltip(t('Sorry, your browser does not support copying.'));
-      dispatch(
-        addDangerToast(t('Sorry, your browser does not support copying.'), {
-          noDuplicate: true,
-        }),
-      );
+      addDangerToast(t('Sorry, your browser does not support copying.'));
     }
   };
 

--- a/superset-frontend/src/explore/components/PropertiesModal/PropertiesModal.test.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/PropertiesModal.test.tsx
@@ -22,7 +22,7 @@ import { Slice } from 'src/types/Chart';
 import { render, screen, waitFor } from 'spec/helpers/testing-library';
 import fetchMock from 'fetch-mock';
 import userEvent from '@testing-library/user-event';
-import PropertiesModal from '.';
+import PropertiesModal, { PropertiesModalProps } from '.';
 
 const createProps = () => ({
   slice: {
@@ -68,6 +68,7 @@ const createProps = () => ({
   show: true,
   onHide: jest.fn(),
   onSave: jest.fn(),
+  addSuccessToast: jest.fn(),
 });
 
 fetchMock.get('glob:*/api/v1/chart/318', {
@@ -160,7 +161,7 @@ afterAll(() => {
   fetchMock.resetBehavior();
 });
 
-const renderModal = (props: any) =>
+const renderModal = (props: PropertiesModalProps) =>
   render(<PropertiesModal {...props} />, { useRedux: true });
 
 test('Should render null when show:false', async () => {

--- a/superset-frontend/src/explore/components/PropertiesModal/PropertiesModal.test.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/PropertiesModal.test.tsx
@@ -160,10 +160,13 @@ afterAll(() => {
   fetchMock.resetBehavior();
 });
 
+const renderModal = (props: any) =>
+  render(<PropertiesModal {...props} />, { useRedux: true });
+
 test('Should render null when show:false', async () => {
   const props = createProps();
   props.show = false;
-  render(<PropertiesModal {...props} />);
+  renderModal(props);
 
   await waitFor(() => {
     expect(
@@ -174,7 +177,7 @@ test('Should render null when show:false', async () => {
 
 test('Should render when show:true', async () => {
   const props = createProps();
-  render(<PropertiesModal {...props} />);
+  renderModal(props);
 
   await waitFor(() => {
     expect(
@@ -185,7 +188,7 @@ test('Should render when show:true', async () => {
 
 test('Should have modal header', async () => {
   const props = createProps();
-  render(<PropertiesModal {...props} />);
+  renderModal(props);
 
   await waitFor(() => {
     expect(screen.getByText('Edit Chart Properties')).toBeVisible();
@@ -196,7 +199,7 @@ test('Should have modal header', async () => {
 
 test('"Close" button should call "onHide"', async () => {
   const props = createProps();
-  render(<PropertiesModal {...props} />);
+  renderModal(props);
 
   await waitFor(() => {
     expect(props.onHide).toBeCalledTimes(0);
@@ -212,7 +215,7 @@ test('"Close" button should call "onHide"', async () => {
 
 test('Should render all elements inside modal', async () => {
   const props = createProps();
-  render(<PropertiesModal {...props} />);
+  renderModal(props);
   await waitFor(() => {
     expect(screen.getAllByRole('textbox')).toHaveLength(5);
     expect(screen.getByRole('combobox')).toBeInTheDocument();
@@ -240,7 +243,7 @@ test('Should render all elements inside modal', async () => {
 
 test('Should have modal footer', async () => {
   const props = createProps();
-  render(<PropertiesModal {...props} />);
+  renderModal(props);
 
   await waitFor(() => {
     expect(screen.getByText('Cancel')).toBeVisible();
@@ -254,7 +257,7 @@ test('Should have modal footer', async () => {
 
 test('"Cancel" button should call "onHide"', async () => {
   const props = createProps();
-  render(<PropertiesModal {...props} />);
+  renderModal(props);
 
   await waitFor(() => {
     expect(props.onHide).toBeCalledTimes(0);
@@ -270,7 +273,7 @@ test('"Cancel" button should call "onHide"', async () => {
 
 test('"Save" button should call only "onSave"', async () => {
   const props = createProps();
-  render(<PropertiesModal {...props} />);
+  renderModal(props);
   await waitFor(() => {
     expect(props.onSave).toBeCalledTimes(0);
     expect(props.onHide).toBeCalledTimes(0);
@@ -294,7 +297,7 @@ test('Empty "Certified by" should clear "Certification details"', async () => {
       certified_by: '',
     },
   };
-  render(<PropertiesModal {...noCertifiedByProps} />);
+  renderModal(noCertifiedByProps);
 
   expect(
     screen.getByRole('textbox', { name: 'Certification details' }),

--- a/superset-frontend/src/explore/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/index.tsx
@@ -28,7 +28,7 @@ import Chart, { Slice } from 'src/types/Chart';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 import withToasts from 'src/components/MessageToasts/withToasts';
 
-type PropertiesModalProps = {
+export type PropertiesModalProps = {
   slice: Slice;
   show: boolean;
   onHide: () => void;

--- a/superset-frontend/src/explore/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/index.tsx
@@ -20,12 +20,14 @@ import React, { useMemo, useState, useCallback, useEffect } from 'react';
 import Modal from 'src/components/Modal';
 import { Form, Row, Col, Input, TextArea } from 'src/common/components';
 import Button from 'src/components/Button';
+import { addSuccessToast } from 'src/components/MessageToasts/actions';
 import { Select } from 'src/components';
 import { SelectValue } from 'antd/lib/select';
 import rison from 'rison';
 import { t, SupersetClient, styled } from '@superset-ui/core';
 import Chart, { Slice } from 'src/types/Chart';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
+import { useDispatch } from 'react-redux';
 
 type PropertiesModalProps = {
   slice: Slice;
@@ -59,6 +61,7 @@ export default function PropertiesModal({
   const [selectedOwners, setSelectedOwners] = useState<SelectValue | null>(
     null,
   );
+  const dispatch = useDispatch();
 
   function showError({ error, statusText, message }: any) {
     let errorText = error || statusText || t('An error has occurred');
@@ -157,6 +160,7 @@ export default function PropertiesModal({
         id: slice.slice_id,
       };
       onSave(updatedChart);
+      dispatch(addSuccessToast(t('Chart properties updated')));
       onHide();
     } catch (res) {
       const clientError = await getClientErrorObject(res);

--- a/superset-frontend/src/explore/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/index.tsx
@@ -20,14 +20,13 @@ import React, { useMemo, useState, useCallback, useEffect } from 'react';
 import Modal from 'src/components/Modal';
 import { Form, Row, Col, Input, TextArea } from 'src/common/components';
 import Button from 'src/components/Button';
-import { addSuccessToast } from 'src/components/MessageToasts/actions';
 import { Select } from 'src/components';
 import { SelectValue } from 'antd/lib/select';
 import rison from 'rison';
 import { t, SupersetClient, styled } from '@superset-ui/core';
 import Chart, { Slice } from 'src/types/Chart';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
-import { useDispatch } from 'react-redux';
+import withToasts from 'src/components/MessageToasts/withToasts';
 
 type PropertiesModalProps = {
   slice: Slice;
@@ -36,6 +35,7 @@ type PropertiesModalProps = {
   onSave: (chart: Chart) => void;
   permissionsError?: string;
   existingOwners?: SelectValue;
+  addSuccessToast: (msg: string) => void;
 };
 
 const FormItem = Form.Item;
@@ -48,11 +48,12 @@ const StyledHelpBlock = styled.span`
   margin-bottom: 0;
 `;
 
-export default function PropertiesModal({
+function PropertiesModal({
   slice,
   onHide,
   onSave,
   show,
+  addSuccessToast,
 }: PropertiesModalProps) {
   const [submitting, setSubmitting] = useState(false);
   const [form] = Form.useForm();
@@ -61,7 +62,6 @@ export default function PropertiesModal({
   const [selectedOwners, setSelectedOwners] = useState<SelectValue | null>(
     null,
   );
-  const dispatch = useDispatch();
 
   function showError({ error, statusText, message }: any) {
     let errorText = error || statusText || t('An error has occurred');
@@ -160,7 +160,7 @@ export default function PropertiesModal({
         id: slice.slice_id,
       };
       onSave(updatedChart);
-      dispatch(addSuccessToast(t('Chart properties updated')));
+      addSuccessToast(t('Chart properties updated'));
       onHide();
     } catch (res) {
       const clientError = await getClientErrorObject(res);
@@ -312,3 +312,5 @@ export default function PropertiesModal({
     </Modal>
   );
 }
+
+export default withToasts(PropertiesModal);

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -975,11 +975,11 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         if action == "saveas" and slice_add_perm:
             ChartDAO.save(slc)
             msg = _("Chart [{}] has been saved").format(slc.slice_name)
-            flash(msg, "info")
+            flash(msg, "success")
         elif action == "overwrite" and slice_overwrite_perm:
             ChartDAO.overwrite(slc)
             msg = _("Chart [{}] has been overwritten").format(slc.slice_name)
-            flash(msg, "info")
+            flash(msg, "success")
 
         # Adding slice to a dashboard if requested
         dash: Optional[Dashboard] = None
@@ -1008,7 +1008,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
                 _("Chart [{}] was added to dashboard [{}]").format(
                     slc.slice_name, dash.dashboard_title
                 ),
-                "info",
+                "success",
             )
         elif new_dashboard_name:
             # Creating and adding to a new dashboard
@@ -1030,7 +1030,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
                 _(
                     "Dashboard [{}] just got created and chart [{}] was added " "to it"
                 ).format(dash.dashboard_title, slc.slice_name),
-                "info",
+                "success",
             )
 
         if dash and slc not in dash.slices:


### PR DESCRIPTION
### SUMMARY
This PR adds new toast messages as a feedback to user actions in Explore.

1. Success/danger toast when copying chart url to clipboard succeeded/failed
2. Success toast when user edited chart properties in Explore or Chart List views
3. Change toast type from info to success when user saves chart

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1773" alt="Screenshot 2022-01-20 at 12 42 01" src="https://user-images.githubusercontent.com/15073128/150338654-3862f400-5565-4c2d-b501-f2b75a17885d.png">

<img width="1773" alt="Screenshot 2022-01-20 at 13 29 23" src="https://user-images.githubusercontent.com/15073128/150338946-417fc4bf-3242-481b-9241-2546038f6ff7.png">

https://user-images.githubusercontent.com/15073128/150338958-3af79662-eb83-4c1b-a4e3-98d4c1fd5cb2.mov

### TESTING INSTRUCTIONS
1. Copy chart url to clipboard by clicking button in the top right corner of the explore view. Verify that toast message appears.
2. Edit chart properties via Edit Properties modal in Explore or Chart List view. Verify that toast message appears.
3. Save/overwrite chart. Verify that success toast message appears.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @yousoph @rusackas 
https://app.shortcut.com/preset/story/35385/explore-system-feedback