### PR TITLE
fix: logging warning on dataframe (don't use python's warnings)

### DIFF
--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -16,13 +16,14 @@
 # under the License.
 """ Superset utilities for pandas.DataFrame.
 """
-import warnings
+import logging
 from typing import Any, Dict, List
 
 import pandas as pd
 
 from superset.utils.core import JS_MAX_INTEGER
 
+logger = logging.getLogger(__name__)
 
 def _convert_big_integers(val: Any) -> Any:
     """
@@ -43,10 +44,8 @@ def df_to_records(dframe: pd.DataFrame) -> List[Dict[str, Any]]:
     :returns: a list of dictionaries reflecting each single row of the DataFrame
     """
     if not dframe.columns.is_unique:
-        warnings.warn(
+        logger.warning(
             "DataFrame columns are not unique, some columns will be omitted.",
-            UserWarning,
-            stacklevel=2,
         )
     columns = dframe.columns
     return list(

--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -25,6 +25,7 @@ from superset.utils.core import JS_MAX_INTEGER
 
 logger = logging.getLogger(__name__)
 
+
 def _convert_big_integers(val: Any) -> Any:
     """
     Cast integers larger than ``JS_MAX_INTEGER`` to strings.
@@ -45,7 +46,7 @@ def df_to_records(dframe: pd.DataFrame) -> List[Dict[str, Any]]:
     """
     if not dframe.columns.is_unique:
         logger.warning(
-            "DataFrame columns are not unique, some columns will be omitted.",
+            "DataFrame columns are not unique, some columns will be omitted."
         )
     columns = dframe.columns
     return list(


### PR DESCRIPTION
### SUMMARY
Remove usage of python's `warnings` from the codebase, this breaks logging config from Superset. 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
