### PR TITLE
fix: exclude node_modules from ts tracking

### DIFF
--- a/scripts/generate_frontend_ts_tasklist.js
+++ b/scripts/generate_frontend_ts_tasklist.js
@@ -68,6 +68,7 @@ while (directories.length) {
   directories = directories.concat(
     getDirectories("./")
       .reverse() // For ABC order when pushed into the Array
+      .filter((name) => name !== "node_modules") // Don't include node_modules in our packages
       .map((directory) => `${curDirectory}/${directory}`)
   );
   process.chdir(DEFAULT_DIRECTORY);


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This script didn't work as expected now that we have packages inside the superset monorepo. We don't need to track TS usage in deps, so filter out the node_modules directory

### TESTING INSTRUCTIONS
Run the script

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @betodealmeida @ktmud @graceguo-supercat 