### PR TITLE
refactor: migrate QueryAndSaveBtns to TypeScript and add stories

### DIFF
--- a/superset-frontend/src/components/Button/index.tsx
+++ b/superset-frontend/src/components/Button/index.tsx
@@ -26,6 +26,17 @@ import { Tooltip } from 'src/components/Tooltip';
 
 export type OnClickHandler = React.MouseEventHandler<HTMLElement>;
 
+export type ButtonStyle =
+  | 'primary'
+  | 'secondary'
+  | 'tertiary'
+  | 'success'
+  | 'warning'
+  | 'danger'
+  | 'default'
+  | 'link'
+  | 'dashed';
+
 export interface ButtonProps {
   id?: string;
   className?: string;
@@ -46,16 +57,7 @@ export interface ButtonProps {
     | 'rightBottom';
   onClick?: OnClickHandler;
   disabled?: boolean;
-  buttonStyle?:
-    | 'primary'
-    | 'secondary'
-    | 'tertiary'
-    | 'success'
-    | 'warning'
-    | 'danger'
-    | 'default'
-    | 'link'
-    | 'dashed';
+  buttonStyle?: ButtonStyle;
   buttonSize?: 'default' | 'small' | 'xsmall';
   style?: CSSProperties;
   children?: React.ReactNode;

--- a/superset-frontend/src/explore/components/QueryAndSaveBtns.stories.tsx
+++ b/superset-frontend/src/explore/components/QueryAndSaveBtns.stories.tsx
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import QueryAndSaveBtns, { QueryAndSaveBtnsProps } from './QueryAndSaveBtns';
+
+export default {
+  title: 'QueryAndSaveBtns',
+  component: QueryAndSaveBtns,
+};
+
+export const InteractiveQueryAndSaveBtnsProps = (
+  args: QueryAndSaveBtnsProps,
+) => <QueryAndSaveBtns {...args} />;
+
+InteractiveQueryAndSaveBtnsProps.args = {
+  canAdd: true,
+  loading: false,
+};
+
+InteractiveQueryAndSaveBtnsProps.argTypes = {
+  onQuery: { action: 'onQuery' },
+  onSave: { action: 'onSave' },
+  onStop: { action: 'onStop' },
+};
+
+InteractiveQueryAndSaveBtnsProps.story = {
+  parameters: {
+    knobs: {
+      disable: true,
+    },
+  },
+};

--- a/superset-frontend/src/explore/components/QueryAndSaveBtns.tsx
+++ b/superset-frontend/src/explore/components/QueryAndSaveBtns.tsx
@@ -43,11 +43,11 @@ export default function QueryAndSaveBtns(props: QueryAndSaveBtnsProps) {
     chartIsStale,
     errorMessage,
   } = props;
-  let qryButtonStyle = 'tertiary' as ButtonStyle;
+  let qryButtonStyle: ButtonStyle = 'tertiary';
   if (errorMessage) {
-    qryButtonStyle = 'danger' as ButtonStyle;
+    qryButtonStyle = 'danger';
   } else if (chartIsStale) {
-    qryButtonStyle = 'primary' as ButtonStyle;
+    qryButtonStyle = 'primary';
   }
 
   const saveButtonDisabled = errorMessage ? true : loading;

--- a/superset-frontend/src/explore/components/QueryAndSaveBtns.tsx
+++ b/superset-frontend/src/explore/components/QueryAndSaveBtns.tsx
@@ -17,42 +17,37 @@
  * under the License.
  */
 import React from 'react';
-import PropTypes from 'prop-types';
 import ButtonGroup from 'src/components/ButtonGroup';
 import { t, useTheme } from '@superset-ui/core';
 
 import { Tooltip } from 'src/components/Tooltip';
-import Button from 'src/components/Button';
+import Button, { ButtonStyle, OnClickHandler } from 'src/components/Button';
 
-const propTypes = {
-  canAdd: PropTypes.bool.isRequired,
-  onQuery: PropTypes.func.isRequired,
-  onSave: PropTypes.func,
-  onStop: PropTypes.func,
-  loading: PropTypes.bool,
-  chartIsStale: PropTypes.bool,
-  errorMessage: PropTypes.node,
+export type QueryAndSaveBtnsProps = {
+  canAdd: boolean;
+  onQuery: OnClickHandler;
+  onSave: OnClickHandler;
+  onStop: OnClickHandler;
+  loading?: boolean;
+  chartIsStale?: boolean;
+  errorMessage: React.ReactElement | undefined;
 };
 
-const defaultProps = {
-  onStop: () => {},
-  onSave: () => {},
-};
-
-export default function QueryAndSaveBtns({
-  canAdd,
-  onQuery,
-  onSave,
-  onStop,
-  loading,
-  chartIsStale,
-  errorMessage,
-}) {
-  let qryButtonStyle = 'tertiary';
+export default function QueryAndSaveBtns(props: QueryAndSaveBtnsProps) {
+  const {
+    canAdd,
+    onQuery = () => {},
+    onSave = () => {},
+    onStop = () => {},
+    loading,
+    chartIsStale,
+    errorMessage,
+  } = props;
+  let qryButtonStyle = 'tertiary' as ButtonStyle;
   if (errorMessage) {
-    qryButtonStyle = 'danger';
+    qryButtonStyle = 'danger' as ButtonStyle;
   } else if (chartIsStale) {
-    qryButtonStyle = 'primary';
+    qryButtonStyle = 'primary' as ButtonStyle;
   }
 
   const saveButtonDisabled = errorMessage ? true : loading;
@@ -127,6 +122,3 @@ export default function QueryAndSaveBtns({
     </div>
   );
 }
-
-QueryAndSaveBtns.propTypes = propTypes;
-QueryAndSaveBtns.defaultProps = defaultProps;


### PR DESCRIPTION
### SUMMARY

Migrated QueryAndSaveBtns to TypeScript to apply direction outlined in #18100 .

In addition, added a new story to visualize that component.
 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

![obraz](https://user-images.githubusercontent.com/3618479/150427615-dc5a5f0d-ea67-4bbc-b455-c60e23dee77a.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Storybook can be used to verify that changes.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: see #18100
- [x] Required feature flags: no
- [x] Changes UI: no
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351)): no
  - [x] Migration is atomic, supports rollback & is backwards-compatible: N/A
  - [x] Confirm DB migration upgrade and downgrade tested: N/A
  - [x] Runtime estimates and downtime expectations provided: N/A
- [x] Introduces new feature or API: no
- [x] Removes existing feature or API: no

@kgabryje , @asadUllah58 You might be interested in this PR!