### PR TITLE
refactor: migrate EmbedCodeButton to TypeScript

### DIFF
--- a/superset-frontend/src/explore/components/EmbdeCodeButton.stories.tsx
+++ b/superset-frontend/src/explore/components/EmbdeCodeButton.stories.tsx
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import EmbedCodeButton from './EmbedCodeButton';
+
+export default {
+  title: 'EmbedCodeButton',
+  component: EmbedCodeButton,
+};
+
+export const EmbedCodeButtonGallery = () => <EmbedCodeButton />;

--- a/superset-frontend/src/explore/components/EmbedCodeButton.tsx
+++ b/superset-frontend/src/explore/components/EmbedCodeButton.tsx
@@ -26,8 +26,18 @@ import { Tooltip } from 'src/components/Tooltip';
 import CopyToClipboard from 'src/components/CopyToClipboard';
 import { URL_PARAMS } from 'src/constants';
 
-export default class EmbedCodeButton extends React.Component {
-  constructor(props) {
+export type EmbedCodeButtonProps = {};
+
+type EmbedCodeButtonState = {
+  height: string;
+  width: string;
+};
+
+export default class EmbedCodeButton extends React.Component<
+  EmbedCodeButtonProps,
+  EmbedCodeButtonState
+> {
+  constructor(props: EmbedCodeButtonProps) {
     super(props);
     this.state = {
       height: '400',
@@ -36,7 +46,7 @@ export default class EmbedCodeButton extends React.Component {
     this.handleInputChange = this.handleInputChange.bind(this);
   }
 
-  handleInputChange(e) {
+  handleInputChange(e: React.ChangeEvent<HTMLInputElement>) {
     const { value, name } = e.currentTarget;
     const data = {};
     data[name] = value;
@@ -68,7 +78,7 @@ export default class EmbedCodeButton extends React.Component {
               data-test="embed-code-textarea"
               name="embedCode"
               value={html}
-              rows="4"
+              rows={4}
               readOnly
               className="form-control input-sm"
               style={{ resize: 'vertical' }}

--- a/superset-frontend/src/explore/components/ExploreActionButtons.tsx
+++ b/superset-frontend/src/explore/components/ExploreActionButtons.tsx
@@ -39,15 +39,15 @@ type ActionButtonProps = {
   'data-test'?: string;
 };
 
-type ExploreActionButtonsProps = {
+export type ExploreActionButtonsProps = {
   actions: { redirectSQLLab: () => void; openPropertiesModal: () => void };
   canDownloadCSV: boolean;
   chartStatus: string;
   latestQueryFormData: QueryFormData;
   queriesResponse: {};
   slice: { slice_name: string };
-  addDangerToast: Function;
-  addSuccessToast: Function;
+  addSuccessToast: (msg: string) => void;
+  addDangerToast: (msg: string) => void;
 };
 
 const VIZ_TYPES_PIVOTABLE = ['pivot_table', 'pivot_table_v2'];


### PR DESCRIPTION
### SUMMARY

Migrated EmbedCodeButton to TypeScript to apply direction outlined in #18100 .

In addition, added a new story to visualize that component.
 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

![obraz](https://user-images.githubusercontent.com/3618479/150437046-65a5a2d2-cfa0-4fc7-b680-670b2e2c9a9f.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Storybook can be used to verify those changes.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: see #18100
- [x] Required feature flags: no
- [x] Changes UI: no
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351)): no
  - [x] Migration is atomic, supports rollback & is backwards-compatible: N/A
  - [x] Confirm DB migration upgrade and downgrade tested: N/A
  - [x] Runtime estimates and downtime expectations provided: N/A
- [x] Introduces new feature or API: no
- [x] Removes existing feature or API: no

@kgabryje , @asadUllah58, @mik-laj You might be interested in this PR!