### PR TITLE
feat: a simple client

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ import io
 import json
 import os
 import subprocess
-import sys
 
 from setuptools import find_packages, setup
 
@@ -163,6 +162,8 @@ setup(
         "thumbnails": ["Pillow>=8.3.2, <9.0.0"],
         "vertica": ["sqlalchemy-vertica-python>=0.5.9, < 0.6"],
         "netezza": ["nzalchemy>=11.0.2"],
+        # client SDK
+        "client": ["yarl>=1.7.2", "beautifulsoup4>=4.10.0", "requests>=2.26.0"],
     },
     python_requires="~=3.7",
     author="Apache Software Foundation",

--- a/superset/client.py
+++ b/superset/client.py
@@ -38,7 +38,7 @@ from typing import List, Union
 
 import pandas as pd
 import requests
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup  # pylint: disable=E0401
 from yarl import URL
 
 from superset.utils.core import get_version, shortid

--- a/superset/client.py
+++ b/superset/client.py
@@ -41,7 +41,7 @@ import requests
 from bs4 import BeautifulSoup
 from yarl import URL
 
-from superset.utils.core import shortid
+from superset.utils.core import get_version, shortid
 
 
 class Database:
@@ -89,6 +89,7 @@ class Database:
             "X-CSRFToken": self.csrf_token,
             "Accept": "application/json",
             "Content-Type": "application/json",
+            "User-Agent": f"Apache Superset Client ({get_version()})",
         }
 
         response = self.session.post(url, json=data, headers=headers)

--- a/superset/client.py
+++ b/superset/client.py
@@ -1,0 +1,149 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+A simple client for running SQL queries against Superset:
+
+    >>> from superset.client import SupersetClient
+    >>> client = SupersetClient("http://localhost:8088/", "admin", "admin")
+    >>> print(client.databases)
+    [<Database "examples" (postgres)>]
+
+    >>> examples = client.databases[0]
+    >>> sql = "SELECT platform, rank FROM video_game_sales LIMIT 2"
+    >>> print(examples.run_query(sql))
+      platform  rank
+    0      Wii     1
+    1      NES     2
+
+Data is returned in a Pandas Dataframe.
+
+"""
+
+from typing import List, Union
+
+import pandas as pd
+import requests
+from bs4 import BeautifulSoup
+from yarl import URL
+
+from superset.utils.core import shortid
+
+
+class Database:
+    """
+    A database configured in Superset.
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        baseurl: Union[str, URL],
+        database_id: int,
+        name: str,
+        backend: str,
+        session: requests.Session,
+        csrf_token: str,
+    ):
+        self.baseurl = URL(baseurl)
+        self.database_id = database_id
+        self.name = name
+        self.backend = backend
+        self.session = session
+        self.csrf_token = csrf_token
+
+    def run_query(self, sql: str, limit: int = 1000) -> pd.DataFrame:
+        """
+        Run a SQL query, returning a Pandas dataframe.
+        """
+        url = self.baseurl / "superset/sql_json/"
+        data = {
+            "client_id": shortid()[:10],
+            "database_id": self.database_id,
+            "json": True,
+            "runAsync": False,
+            "schema": None,
+            "sql": sql,
+            "sql_editor_id": "1",
+            "tab": "Untitled Query 2",
+            "tmp_table_name": "",
+            "select_as_cta": False,
+            "ctas_method": "TABLE",
+            "queryLimit": limit,
+            "expand_data": True,
+        }
+        headers = {
+            "X-CSRFToken": self.csrf_token,
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+        response = self.session.post(url, json=data, headers=headers)
+        payload = response.json()
+        return pd.DataFrame(payload["data"])
+
+    def __repr__(self) -> str:
+        return f'<Database "{self.name}" ({self.backend})>'
+
+
+class SupersetClient:  # pylint: disable=too-few-public-methods
+
+    """
+    A client for running queries against Superset.
+    """
+
+    def __init__(self, baseurl: Union[str, URL], username: str, password: str):
+        # convert to URL if necessary
+        self.baseurl = URL(baseurl)
+        self.username = username
+        self.password = password
+
+        self.session = requests.Session()
+        self._do_login()
+
+    def _do_login(self) -> None:
+        """
+        Log in to get a CSRF token and cookies for the ``/superset/sql_json`` endpoint.
+        """
+        response = self.session.get(self.baseurl / "login/")
+        soup = BeautifulSoup(response.text, "html.parser")
+        self.csrf_token = soup.find("input", {"id": "csrf_token"})["value"]
+
+        # set cookies
+        self.session.post(
+            self.baseurl / "login/",
+            data=dict(username="admin", password="admin", csrf_token=self.csrf_token),
+        )
+
+    @property
+    def databases(self) -> List[Database]:
+        """
+        Return the configured databases.
+        """
+        response = self.session.get(self.baseurl / "api/v1/database")
+        payload = response.json()
+        databases = payload["result"]
+        return [
+            Database(
+                self.baseurl,
+                database["id"],
+                database["database_name"],
+                database["backend"],
+                self.session,
+                self.csrf_token,
+            )
+            for database in databases
+        ]

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -77,6 +77,7 @@ from flask_babel import gettext as __
 from flask_babel.speaklater import LazyString
 from pandas.api.types import infer_dtype
 from pandas.core.dtypes.common import is_numeric_dtype
+from pkg_resources import resource_filename
 from sqlalchemy import event, exc, inspect, select, Text
 from sqlalchemy.dialects.mysql import MEDIUMTEXT
 from sqlalchemy.engine import Connection, Engine
@@ -1788,3 +1789,22 @@ def apply_max_row_limit(limit: int, max_limit: Optional[int] = None,) -> int:
     if limit != 0:
         return min(max_limit, limit)
     return max_limit
+
+
+def get_version() -> str:
+    """
+    Return the current version of Superset.
+    """
+    version_info_file = resource_filename("superset", "static/version_info.json")
+    with open(version_info_file, encoding="utf-8") as fp:
+        contents = json.load(fp)
+        if "version" in contents:
+            return contents["version"]
+
+    package_json_file = resource_filename("superset", "static/assets/package.json")
+    with open(package_json_file, encoding="utf-8") as fp:
+        contents = json.load(fp)
+        if "version" in contents:
+            return contents["version"]
+
+    return "Unknown version"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Users often ask how to run queries against Superset programmatically, and the answer [is not trivial](https://apache-superset.slack.com/archives/C015WAZL0KH/p1613756286186400).

I added a small client called `SupersetClient` that takes care of the weird auth we use for SQL Lab (`/superset/sql_json`), simplifying the process.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

```bash
$ pip install 'superset[client]'
```

```python
>>> from superset.client import SupersetClient
>>> client = SupersetClient("http://localhost:8088/", "admin", "admin")
>>> print(client.databases)
[<Database "examples" (postgres)>]
>>> examples = client.databases[0]
>>> sql = "SELECT platform, rank FROM video_game_sales LIMIT 2"
>>> print(examples.run_query(sql))
  platform  rank
0      Wii     1
1      NES     2
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
