### PR TITLE
chore: Port community page to Docusaurus

### DIFF
--- a/docs-v2/src/pages/community.tsx
+++ b/docs-v2/src/pages/community.tsx
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import styled from '@emotion/styled';
+import { List } from 'antd';
+import Layout from '@theme/Layout';
+
+const links = [
+  [
+    'https://join.slack.com/t/apache-superset/shared_invite/zt-uxbh5g36-AISUtHbzOXcu0BIj7kgUaw',
+    'Slack',
+    'interact with other Superset users and community members',
+  ],
+  [
+    'https://github.com/apache/superset',
+    'GitHub',
+    'create tickets to report issues, report bugs, and suggest new features',
+  ],
+  [
+    'https://lists.apache.org/list.html?dev@superset.apache.org',
+    'dev@ Mailing List',
+    'participate in conversations with committers and contributors',
+  ],
+  [
+    'https://stackoverflow.com/questions/tagged/superset+apache-superset',
+    'Stack Overflow',
+    'our growing knowledge base',
+  ],
+  [
+    'https://www.meetup.com/Global-Apache-Superset-Community-Meetup/',
+    'Superset Meetup Group',
+    'join our monthly virtual meetups and register for any upcoming events',
+  ],
+  [
+    'https://github.com/apache/superset/blob/master/RESOURCES/INTHEWILD.md',
+    'Organizations',
+    'a list of some of the organizations using Superset in production',
+  ],
+  [
+    'https://github.com/apache-superset/awesome-apache-superset',
+    'Contributors Guide',
+    'Interested in contributing? Learn how to contribute and best practices',
+  ],
+];
+
+const StyledMain = styled('main')`
+  padding-bottom: 60px;
+  padding-left: 16px;
+  padding-right: 16px;
+  section {
+    width: 100%;
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 0 0 0;
+    font-size: 17px;
+    &:first-of-type{
+      padding: 40px;
+      background-image: linear-gradient(120deg, #d6f2f8, #52c6e3);
+      border-radius: 0 0 10px;
+    }
+  }
+`;
+
+const StyledGetInvolved = styled('div')`
+  margin-bottom: 25px;
+`;
+
+const Community = () => {
+  return (
+    <Layout
+      title="Community"
+      description="Community website for Apache Superset, a data visualization and data exploration platform"
+    >
+      <StyledMain>
+        <section>
+          <h1 className="title">Community</h1>
+          Get involved in our welcoming, fast growing community!
+        </section>
+        <section className="joinCommunity">
+          <StyledGetInvolved>
+            <h2>Get involved!</h2>
+            <List
+              size="small"
+              bordered
+              dataSource={links}
+              renderItem={([href, link, post]) => (
+                <List.Item>
+                  <a href={href}>{link}</a>
+                  {' '}
+                  -
+                  {' '}
+                  {post}
+                </List.Item>
+              )}
+            />
+          </StyledGetInvolved>
+        </section>
+      </StyledMain>
+    </Layout>
+  );
+};
+
+export default Community;

--- a/docs-v2/src/pages/index.tsx
+++ b/docs-v2/src/pages/index.tsx
@@ -37,7 +37,7 @@ import { Databases } from '../resources/data';
 
 const { colors } = supersetTheme;
 
-const StyledMain = styled('div')`
+const StyledMain = styled('main')`
   text-align: center;
   .alert-color {
     color: ${colors.alert.base};


### PR DESCRIPTION
### SUMMARY
This PR ports the community page from DocZ to Docusaurus.

### AFTER
<img width="1679" alt="Screen Shot 2022-01-21 at 15 08 08" src="https://user-images.githubusercontent.com/60598000/150540908-f078f678-b3ce-4504-98a1-df1e43143e9f.png">

### TESTING INSTRUCTIONS
Make sure the community page is rendered properly

### TODO
The PMC members have been removed as they were unmaintained. The plan is to implement a functionality to pull them automatically in a future phase.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
