### PR TITLE
refactor: migrate DeleteComponentButton to TypeScript

### DIFF
--- a/superset-frontend/src/dashboard/components/DeleteComponentButton.tsx
+++ b/superset-frontend/src/dashboard/components/DeleteComponentButton.tsx
@@ -26,7 +26,7 @@ type DeleteComponentButtonProps = {
 
 class DeleteComponentButton extends React.PureComponent<DeleteComponentButtonProps> {
   render() {
-    const { onDelete = () => {} } = this.props;
+    const { onDelete } = this.props;
     return (
       <IconButton onClick={onDelete} icon={<Icons.Trash iconSize="xl" />} />
     );

--- a/superset-frontend/src/dashboard/components/DeleteComponentButton.tsx
+++ b/superset-frontend/src/dashboard/components/DeleteComponentButton.tsx
@@ -16,18 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, { MouseEventHandler } from 'react';
 import Icons from 'src/components/Icons';
 import IconButton from './IconButton';
 
-const propTypes = {
-  onDelete: PropTypes.func.isRequired,
-};
+interface DeleteComponentButtonProps {
+  onDelete: MouseEventHandler<HTMLDivElement>;
+}
 
-const defaultProps = {};
-
-export default class DeleteComponentButton extends React.PureComponent {
+class DeleteComponentButton extends React.PureComponent<DeleteComponentButtonProps> {
   render() {
     const { onDelete } = this.props;
     return (
@@ -36,5 +33,4 @@ export default class DeleteComponentButton extends React.PureComponent {
   }
 }
 
-DeleteComponentButton.propTypes = propTypes;
-DeleteComponentButton.defaultProps = defaultProps;
+export default DeleteComponentButton;

--- a/superset-frontend/src/dashboard/components/DeleteComponentButton.tsx
+++ b/superset-frontend/src/dashboard/components/DeleteComponentButton.tsx
@@ -20,9 +20,9 @@ import React, { MouseEventHandler } from 'react';
 import Icons from 'src/components/Icons';
 import IconButton from './IconButton';
 
-interface DeleteComponentButtonProps {
+type DeleteComponentButtonProps = {
   onDelete: MouseEventHandler<HTMLDivElement>;
-}
+};
 
 class DeleteComponentButton extends React.PureComponent<DeleteComponentButtonProps> {
   render() {
@@ -34,3 +34,4 @@ class DeleteComponentButton extends React.PureComponent<DeleteComponentButtonPro
 }
 
 export default DeleteComponentButton;
+export { DeleteComponentButtonProps };

--- a/superset-frontend/src/dashboard/components/DeleteComponentButton.tsx
+++ b/superset-frontend/src/dashboard/components/DeleteComponentButton.tsx
@@ -24,13 +24,8 @@ type DeleteComponentButtonProps = {
   onDelete: MouseEventHandler<HTMLDivElement>;
 };
 
-class DeleteComponentButton extends React.PureComponent<DeleteComponentButtonProps> {
-  render() {
-    const { onDelete } = this.props;
-    return (
-      <IconButton onClick={onDelete} icon={<Icons.Trash iconSize="xl" />} />
-    );
-  }
-}
+const DeleteComponentButton: React.FC<DeleteComponentButtonProps> = ({
+  onDelete,
+}) => <IconButton onClick={onDelete} icon={<Icons.Trash iconSize="xl" />} />;
 
 export default DeleteComponentButton;

--- a/superset-frontend/src/dashboard/components/DeleteComponentButton.tsx
+++ b/superset-frontend/src/dashboard/components/DeleteComponentButton.tsx
@@ -26,7 +26,7 @@ type DeleteComponentButtonProps = {
 
 class DeleteComponentButton extends React.PureComponent<DeleteComponentButtonProps> {
   render() {
-    const { onDelete } = this.props;
+    const { onDelete = () => {} } = this.props;
     return (
       <IconButton onClick={onDelete} icon={<Icons.Trash iconSize="xl" />} />
     );

--- a/superset-frontend/src/dashboard/components/DeleteComponentButton.tsx
+++ b/superset-frontend/src/dashboard/components/DeleteComponentButton.tsx
@@ -34,4 +34,3 @@ class DeleteComponentButton extends React.PureComponent<DeleteComponentButtonPro
 }
 
 export default DeleteComponentButton;
-export { DeleteComponentButtonProps };


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Migrated DeleteComponentButton to TypeScript to apply direction outlined in #18100 .

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No changes

### TESTING INSTRUCTIONS
The storybook can be used to verify those changes.

### ADDITIONAL INFORMATION
- [x] Has associated issue: #18100
- [ ] Required feature flags: no
- [ ] Changes UI: no
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API: no
- [ ] Removes existing feature or API: no

@ad-m , @zhaoyongjie , @kristw