### PR TITLE
fix(dashboard): support input undo when editing chart title

### DIFF
--- a/superset-frontend/src/dashboard/components/UndoRedoKeyListeners/index.jsx
+++ b/superset-frontend/src/dashboard/components/UndoRedoKeyListeners/index.jsx
@@ -45,8 +45,10 @@ class UndoRedoKeyListeners extends React.PureComponent {
       const isYChar = event.key === 'y' || event.keyCode === 89;
       const isEditingMarkdown =
         document && document.querySelector('.dashboard-markdown--editing');
+      const isEditingTitle =
+        document && document.querySelector('.editable-title--editing');
 
-      if (!isEditingMarkdown && (isZChar || isYChar)) {
+      if (!isEditingMarkdown && !isEditingTitle && (isZChar || isYChar)) {
         event.preventDefault();
         const func = isZChar ? this.props.onUndo : this.props.onRedo;
         func();


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When user modifies the chart title in the dashboard, it should respond to the browser's default undo/redo action instead of the dashboard's undo event (e.g. layout changed), a similar scenario is the markdown component
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### before

https://user-images.githubusercontent.com/11830681/150646402-60a885eb-7340-48e0-8a57-2afc7b2d13f1.mov


### after

https://user-images.githubusercontent.com/11830681/150646361-471df765-4658-4b19-9f87-0a991261dd07.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/18096
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
