### PR TITLE
refactor: migrate Sqleditorleftbar component from jsx to tsx

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
@@ -31,7 +31,7 @@ interface AntdPanelProps {
   isActive?: boolean;
 }
 
-interface ISqlEditorLeftBarProps {
+interface SqlEditorLeftBarProps {
   actions: {
     queryEditorSetDb: (queryEditor: QueryEditor, dbId: number) => void;
     queryEditorSetFunctionNames: (
@@ -83,7 +83,7 @@ const collapseStyles = (theme: SupersetTheme) => css`
   }
 `;
 
-const SqlEditorLeftBar: FC<ISqlEditorLeftBarProps> = ({
+const SqlEditorLeftBar: FC<SqlEditorLeftBarProps> = ({
   actions,
   database,
   height = 500,

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
@@ -16,40 +16,41 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, { FC } from 'react';
 import Button from 'src/components/Button';
-import { t, styled, css } from '@superset-ui/core';
+import { t, styled, css, SupersetTheme } from '@superset-ui/core';
 import Collapse from 'src/components/Collapse';
 import Icons from 'src/components/Icons';
 import TableSelector from 'src/components/TableSelector';
 import { IconTooltip } from 'src/components/IconTooltip';
+import { DatabaseObject } from 'src/components/DatabaseSelector';
+import { QueryEditor } from 'src/SqlLab/types';
 import TableElement from '../TableElement';
 
-const propTypes = {
-  queryEditor: PropTypes.object.isRequired,
-  height: PropTypes.number,
-  tables: PropTypes.array,
-  actions: PropTypes.object,
-  database: PropTypes.object,
-  offline: PropTypes.bool,
-};
-
-const defaultProps = {
-  actions: {},
-  height: 500,
-  offline: false,
-  tables: [],
-};
+interface ISqlEditorLeftBarProps {
+  actions: {
+    queryEditorSetDb: (queryEditor: QueryEditor, dbId: number) => void;
+    queryEditorSetFunctionNames: (
+      queryEditor: QueryEditor,
+      dbId: number,
+    ) => void;
+    addTable: (queryEditor: QueryEditor, value: string, schema: string) => void;
+  };
+  queryEditor: QueryEditor;
+  height?: number;
+  tables?: any[];
+  database?: DatabaseObject;
+  offline?: boolean;
+}
 
 const StyledScrollbarContainer = styled.div`
   flex: 1 1 auto;
   overflow: auto;
 `;
 
-const collapseStyles = css`
+const collapseStyles = (theme: SupersetTheme) => css`
   .ant-collapse-item {
-    margin-bottom: ${({ theme }) => theme.gridUnit * 3}px;
+    margin-bottom: ${theme.gridUnit * 3}px;
   }
   .ant-collapse-header {
     padding: 0px !important;
@@ -57,30 +58,30 @@ const collapseStyles = css`
     align-items: center;
   }
   .ant-collapse-content-box {
-    padding: 0px ${({ theme }) => theme.gridUnit * 4}px 0px 0px !important;
+    padding: 0px ${theme.gridUnit * 4}px 0px 0px !important;
   }
   .ant-collapse-arrow {
-    top: ${({ theme }) => theme.gridUnit * 2}px !important;
-    color: ${({ theme }) => theme.colors.primary.dark1} !important;
+    top: ${theme.gridUnit * 2}px !important;
+    color: ${theme.colors.primary.dark1} !important;
     &: hover {
-      color: ${({ theme }) => theme.colors.primary.dark2} !important;
+      color: ${theme.colors.primary.dark2} !important;
     }
   }
 `;
 
-export default function SqlEditorLeftBar({
+const SqlEditorLeftBar: FC<ISqlEditorLeftBarProps> = ({
   actions,
   database,
-  height,
+  height = 500,
   queryEditor,
-  tables: tb,
-}) {
-  const onDbChange = db => {
+  tables: tb = [],
+}) => {
+  const onDbChange = (db: DatabaseObject) => {
     actions.queryEditorSetDb(queryEditor, db.id);
     actions.queryEditorSetFunctionNames(queryEditor, db.id);
   };
 
-  const onTableChange = (tableName, schemaName) => {
+  const onTableChange = (tableName: string, schemaName: string) => {
     if (tableName && schemaName) {
       actions.addTable(queryEditor, tableName, schemaName);
     }
@@ -168,7 +169,6 @@ export default function SqlEditorLeftBar({
       )}
     </div>
   );
-}
+};
 
-SqlEditorLeftBar.propTypes = propTypes;
-SqlEditorLeftBar.defaultProps = defaultProps;
+export default SqlEditorLeftBar;

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
@@ -25,7 +25,7 @@ import TableSelector from 'src/components/TableSelector';
 import { IconTooltip } from 'src/components/IconTooltip';
 import { DatabaseObject } from 'src/components/DatabaseSelector';
 import { QueryEditor } from 'src/SqlLab/types';
-import TableElement from '../TableElement';
+import TableElement, { Table } from '../TableElement';
 
 interface ISqlEditorLeftBarProps {
   actions: {
@@ -35,6 +35,12 @@ interface ISqlEditorLeftBarProps {
       dbId: number,
     ) => void;
     addTable: (queryEditor: QueryEditor, value: string, schema: string) => void;
+    setDatabases?: (arg0: any) => {};
+    addDangerToast: (msg: string) => void;
+    queryEditorSetSchema?: (schema?: string) => void;
+    queryEditorSetSchemaOptions?: () => void;
+    removeDataPreview: (table: Table) => void;
+    removeTable: (table: Table) => void;
   };
   queryEditor: QueryEditor;
   height?: number;

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
@@ -27,6 +27,10 @@ import { DatabaseObject } from 'src/components/DatabaseSelector';
 import { QueryEditor } from 'src/SqlLab/types';
 import TableElement, { Table } from '../TableElement';
 
+interface AntdPanelProps {
+  isActive?: boolean;
+}
+
 interface ISqlEditorLeftBarProps {
   actions: {
     queryEditorSetDb: (queryEditor: QueryEditor, dbId: number) => void;
@@ -35,10 +39,14 @@ interface ISqlEditorLeftBarProps {
       dbId: number,
     ) => void;
     addTable: (queryEditor: QueryEditor, value: string, schema: string) => void;
+    collapseTable: (table: Table) => void;
+    expandTable: (table: Table) => void;
     setDatabases?: (arg0: any) => {};
     addDangerToast: (msg: string) => void;
     queryEditorSetSchema?: (schema?: string) => void;
     queryEditorSetSchemaOptions?: () => void;
+    queryEditorSetTableOptions?: (options: Array<any>) => void;
+    resetState: () => void;
     removeDataPreview: (table: Table) => void;
     removeTable: (table: Table) => void;
   };
@@ -93,7 +101,7 @@ const SqlEditorLeftBar: FC<ISqlEditorLeftBarProps> = ({
     }
   };
 
-  const onToggleTable = tables => {
+  const onToggleTable = (tables: Table[]) => {
     tb.forEach(table => {
       if (!tables.includes(table.id.toString()) && table.expanded) {
         actions.collapseTable(table);
@@ -103,7 +111,7 @@ const SqlEditorLeftBar: FC<ISqlEditorLeftBarProps> = ({
     });
   };
 
-  const renderExpandIconWithTooltip = ({ isActive }) => (
+  const renderExpandIconWithTooltip = ({ isActive }: AntdPanelProps) => (
     <IconTooltip
       css={css`
         transform: rotate(90deg);
@@ -129,7 +137,6 @@ const SqlEditorLeftBar: FC<ISqlEditorLeftBarProps> = ({
     <div className="SqlEditorLeftBar">
       <TableSelector
         database={database}
-        dbId={queryEditor.dbId}
         getDbList={actions.setDatabases}
         handleError={actions.addDangerToast}
         onDbChange={onDbChange}
@@ -152,7 +159,7 @@ const SqlEditorLeftBar: FC<ISqlEditorLeftBarProps> = ({
             activeKey={tb
               .filter(({ expanded }) => expanded)
               .map(({ id }) => id)}
-            css={collapseStyles}
+            css={theme => collapseStyles(theme)}
             expandIconPosition="right"
             ghost
             onChange={onToggleTable}

--- a/superset-frontend/src/SqlLab/components/TableElement/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement/index.tsx
@@ -37,7 +37,7 @@ interface Column {
   type: string;
 }
 
-interface Table {
+export interface Table {
   id: string;
   name: string;
   partitions?: {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Migrated Sqleditorleftbar to TypeScript to apply direction outlined in #18100 .
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #18100
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
