### PR TITLE
refactor: remove redundant propTypes in ColumnElement

### DIFF
--- a/superset-frontend/src/SqlLab/components/ColumnElement/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ColumnElement/index.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { FC } from 'react';
+import React from 'react';
 import { ClassNames } from '@emotion/react';
 import { styled, useTheme } from '@superset-ui/core';
 import { Tooltip } from 'src/components/Tooltip';
@@ -75,7 +75,7 @@ interface ColumnElementProps {
   };
 }
 
-const ColumnElement: FC<ColumnElementProps> = ({ column }) => {
+const ColumnElement = ({ column }: ColumnElementProps) => {
   let columnName: React.ReactNode = column.name;
   let icons;
   if (column.keys && column.keys.length > 0) {

--- a/superset-frontend/src/SqlLab/components/ColumnElement/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ColumnElement/index.tsx
@@ -69,14 +69,14 @@ export type ColumnKeyTypeType = keyof typeof tooltipTitleMap;
 
 interface ColumnElementProps {
   column: {
-    name: React.ReactNode;
+    name: string;
     keys?: { type: ColumnKeyTypeType }[];
     type: string;
   };
 }
 
 const ColumnElement: FC<ColumnElementProps> = ({ column }) => {
-  let columnName = column.name;
+  let columnName: React.ReactNode = column.name;
   let icons;
   if (column.keys && column.keys.length > 0) {
     columnName = <strong>{column.name}</strong>;

--- a/superset-frontend/src/SqlLab/components/ColumnElement/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ColumnElement/index.tsx
@@ -16,16 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, { FC } from 'react';
 import { ClassNames } from '@emotion/react';
 import { styled, useTheme } from '@superset-ui/core';
-
 import { Tooltip } from 'src/components/Tooltip';
-
-const propTypes = {
-  column: PropTypes.object.isRequired,
-};
 
 const StyledTooltip = (props: any) => {
   const theme = useTheme();
@@ -64,6 +58,7 @@ const iconMap = {
   fk: 'fa-link',
   index: 'fa-bookmark',
 };
+
 const tooltipTitleMap = {
   pk: 'Primary key',
   fk: 'Foreign key',
@@ -74,14 +69,14 @@ export type ColumnKeyTypeType = keyof typeof tooltipTitleMap;
 
 interface ColumnElementProps {
   column: {
-    name: string;
+    name: React.ReactNode;
     keys?: { type: ColumnKeyTypeType }[];
     type: string;
   };
 }
 
-export default function ColumnElement({ column }: ColumnElementProps) {
-  let columnName: React.ReactNode = column.name;
+const ColumnElement: FC<ColumnElementProps> = ({ column }) => {
+  let columnName = column.name;
   let icons;
   if (column.keys && column.keys.length > 0) {
     columnName = <strong>{column.name}</strong>;
@@ -115,5 +110,6 @@ export default function ColumnElement({ column }: ColumnElementProps) {
       </div>
     </div>
   );
-}
-ColumnElement.propTypes = propTypes;
+};
+
+export default ColumnElement;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Refactoring ColumnElement component and remove redundant propTypes code

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
