### PR TITLE
fix(textarea-control): ace editor input exception

### DIFF
--- a/superset-frontend/src/explore/components/controls/TextAreaControl.jsx
+++ b/superset-frontend/src/explore/components/controls/TextAreaControl.jsx
@@ -63,6 +63,10 @@ export default class TextAreaControl extends React.Component {
     this.props.onChange(value);
   }
 
+  onAreaEditorChange(value) {
+    this.props.onChange(value);
+  }
+
   renderEditor(inModal = false) {
     const minLines = inModal ? 40 : this.props.minLines || 12;
     if (this.props.language) {
@@ -76,7 +80,6 @@ export default class TextAreaControl extends React.Component {
           style={style}
           minLines={minLines}
           maxLines={inModal ? 1000 : this.props.maxLines}
-          onChange={this.props.onChange}
           width="100%"
           height={`${minLines}em`}
           editorProps={{ $blockScrolling: true }}
@@ -84,6 +87,7 @@ export default class TextAreaControl extends React.Component {
           readOnly={this.props.readOnly}
           key={this.props.name}
           {...this.props}
+          onChange={this.onAreaEditorChange.bind(this)}
         />
       );
     }

--- a/superset-frontend/src/explore/components/controls/TextAreaControl.test.jsx
+++ b/superset-frontend/src/explore/components/controls/TextAreaControl.test.jsx
@@ -54,4 +54,12 @@ describe('TextArea', () => {
     expect(wrapper.find(TextArea)).not.toExist();
     expect(wrapper.find(TextAreaEditor)).toExist();
   });
+
+  it('calls onAreaEditorChange when entering in the AceEditor', () => {
+    const props = { ...defaultProps };
+    props.language = 'markdown';
+    wrapper = shallow(<TextAreaControl {...props} />);
+    wrapper.simulate('change', { target: { value: 'x' } });
+    expect(defaultProps.onChange.calledWith('x')).toBe(true);
+  });
 });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR is to fix the problem that ace-editor in control panel throws an error when the user typing. The reason for this is that we use an `onChange` callback where the second parameter is an error array by default (see https://github.com/apache/superset/blob/master/superset-frontend/src/explore/components/Control.tsx#L65). But for ace-editor, the second parameter of `onChange` is an `event`, so we need to wrap it to avoid this exception.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### before

https://user-images.githubusercontent.com/11830681/150685730-d15b6283-a333-4f47-9f01-1fb0d8eb6dfc.mov

### after

https://user-images.githubusercontent.com/11830681/150685838-c969edae-84c4-446b-ba0e-ae48ff8b5434.mov



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
follow https://github.com/apache/superset/issues/18094

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/18094
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
