### PR TITLE
fix: undefined error when adding extra sequential color scheme

### DIFF
--- a/superset-frontend/src/setup/setupColors.ts
+++ b/superset-frontend/src/setup/setupColors.ts
@@ -78,11 +78,7 @@ export default function setupColors(
   registerColorSchemes(
     // @ts-ignore
     getSequentialSchemeRegistry(),
-    [
-      ...SequentialCommon,
-      ...SequentialD3,
-      ...extraSequentialColorSchemes.map(s => new SequentialScheme(s)),
-    ],
+    [...SequentialCommon, ...SequentialD3, ...extraSequentialColorSchemes],
     'superset_seq_1',
   );
 }


### PR DESCRIPTION
### SUMMARY
Due to calling the constructor of SequentialScheme twice, we were getting some unexpected behaviour when extra sequential colour scheme was defined.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://user-images.githubusercontent.com/15073128/150828839-ab409e7c-2dd9-43c2-8075-0d438ee24e66.png)

After:
![image](https://user-images.githubusercontent.com/15073128/150828186-75e3e20d-bf59-4ee4-ae5a-82fd8f7eac51.png)


### TESTING INSTRUCTIONS
1. Create new chart using world map viz type
2. Choose metrics for country and color
3. Click run
4. Verify that chart renders correctly and that color scheme picker works

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

https://app.shortcut.com/preset/story/35859/preset-2022-3-dev-only-charts-chart-with-world-map-vizualization-type-are-broken-with-unexpected-error

CC @rusackas @jinghua-qa