### PR TITLE
chore: bump echarts to 5.3.0

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -31658,12 +31658,12 @@
       }
     },
     "node_modules/echarts": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.2.2.tgz",
-      "integrity": "sha512-yxuBfeIH5c+0FsoRP60w4De6omXhA06c7eUYBsC1ykB6Ys2yK5fSteIYWvkJ4xJVLQgCvAdO8C4mN6MLeJpBaw==",
+      "version": "5.3.0-rc.1",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.3.0-rc.1.tgz",
+      "integrity": "sha512-peaOPUjw8eigntRLWQr63vPUJvZSzt2VMV2iRPG24R+XOGLCYaajzeqa4kmn/9MJmgTdcgtU7gJMqesmrsFFtA==",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "5.2.1"
+        "zrender": "5.3.0"
       }
     },
     "node_modules/echarts/node_modules/tslib": {
@@ -58561,9 +58561,9 @@
       }
     },
     "node_modules/zrender": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.2.1.tgz",
-      "integrity": "sha512-M3bPGZuyLTNBC6LiNKXJwSCtglMp8XUEqEBG+2MdICDI3d1s500Y4P0CzldQGsqpRVB7fkvf3BKQQRxsEaTlsw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.3.0.tgz",
+      "integrity": "sha512-Ln2QB5uqI1ftNYMtCRxd+XDq6MOttLgam2tmhKAVA+j0ko47UT+VNlDvKTkqe4K2sJhBvB0EhYNLebqlCTjatQ==",
       "dependencies": {
         "tslib": "2.3.0"
       }
@@ -59699,7 +59699,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "d3-array": "^1.2.0",
-        "echarts": "^5.2.2",
+        "echarts": "^5.3.0-rc.1",
         "lodash": "^4.17.15",
         "moment": "^2.26.0"
       },
@@ -76498,7 +76498,7 @@
       "version": "file:plugins/plugin-chart-echarts",
       "requires": {
         "d3-array": "^1.2.0",
-        "echarts": "^5.2.2",
+        "echarts": "^5.3.0-rc.1",
         "lodash": "^4.17.15",
         "moment": "^2.26.0"
       }
@@ -84839,12 +84839,12 @@
       }
     },
     "echarts": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.2.2.tgz",
-      "integrity": "sha512-yxuBfeIH5c+0FsoRP60w4De6omXhA06c7eUYBsC1ykB6Ys2yK5fSteIYWvkJ4xJVLQgCvAdO8C4mN6MLeJpBaw==",
+      "version": "5.3.0-rc.1",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.3.0-rc.1.tgz",
+      "integrity": "sha512-peaOPUjw8eigntRLWQr63vPUJvZSzt2VMV2iRPG24R+XOGLCYaajzeqa4kmn/9MJmgTdcgtU7gJMqesmrsFFtA==",
       "requires": {
         "tslib": "2.3.0",
-        "zrender": "5.2.1"
+        "zrender": "5.3.0"
       },
       "dependencies": {
         "tslib": {
@@ -105702,9 +105702,9 @@
       }
     },
     "zrender": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.2.1.tgz",
-      "integrity": "sha512-M3bPGZuyLTNBC6LiNKXJwSCtglMp8XUEqEBG+2MdICDI3d1s500Y4P0CzldQGsqpRVB7fkvf3BKQQRxsEaTlsw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.3.0.tgz",
+      "integrity": "sha512-Ln2QB5uqI1ftNYMtCRxd+XDq6MOttLgam2tmhKAVA+j0ko47UT+VNlDvKTkqe4K2sJhBvB0EhYNLebqlCTjatQ==",
       "requires": {
         "tslib": "2.3.0"
       },

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -31658,9 +31658,9 @@
       }
     },
     "node_modules/echarts": {
-      "version": "5.3.0-rc.1",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.3.0-rc.1.tgz",
-      "integrity": "sha512-peaOPUjw8eigntRLWQr63vPUJvZSzt2VMV2iRPG24R+XOGLCYaajzeqa4kmn/9MJmgTdcgtU7gJMqesmrsFFtA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.3.0.tgz",
+      "integrity": "sha512-zENufmwFE6WjM+24tW3xQq4ICqQtI0CGj4bDVDNd3BK3LtaA/5wBp+64ykIyKy3QElz0cieKqSYP4FX9Lv9MwQ==",
       "dependencies": {
         "tslib": "2.3.0",
         "zrender": "5.3.0"
@@ -59699,7 +59699,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "d3-array": "^1.2.0",
-        "echarts": "^5.3.0-rc.1",
+        "echarts": "^5.3.0",
         "lodash": "^4.17.15",
         "moment": "^2.26.0"
       },
@@ -76498,7 +76498,7 @@
       "version": "file:plugins/plugin-chart-echarts",
       "requires": {
         "d3-array": "^1.2.0",
-        "echarts": "^5.3.0-rc.1",
+        "echarts": "^5.3.0",
         "lodash": "^4.17.15",
         "moment": "^2.26.0"
       }
@@ -84839,9 +84839,9 @@
       }
     },
     "echarts": {
-      "version": "5.3.0-rc.1",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.3.0-rc.1.tgz",
-      "integrity": "sha512-peaOPUjw8eigntRLWQr63vPUJvZSzt2VMV2iRPG24R+XOGLCYaajzeqa4kmn/9MJmgTdcgtU7gJMqesmrsFFtA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.3.0.tgz",
+      "integrity": "sha512-zENufmwFE6WjM+24tW3xQq4ICqQtI0CGj4bDVDNd3BK3LtaA/5wBp+64ykIyKy3QElz0cieKqSYP4FX9Lv9MwQ==",
       "requires": {
         "tslib": "2.3.0",
         "zrender": "5.3.0"

--- a/superset-frontend/plugins/plugin-chart-echarts/package.json
+++ b/superset-frontend/plugins/plugin-chart-echarts/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "d3-array": "^1.2.0",
-    "echarts": "^5.2.2",
+    "echarts": "^5.3.0-rc.1",
     "lodash": "^4.17.15",
     "moment": "^2.26.0"
   },

--- a/superset-frontend/plugins/plugin-chart-echarts/package.json
+++ b/superset-frontend/plugins/plugin-chart-echarts/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "d3-array": "^1.2.0",
-    "echarts": "^5.3.0-rc.1",
+    "echarts": "^5.3.0",
     "lodash": "^4.17.15",
     "moment": "^2.26.0"
   },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -244,6 +244,7 @@ function createCustomizeSection(
             [1, t('Secondary')],
           ],
           default: yAxisIndex,
+          clearable: false,
           renderTrigger: true,
           description: t('Primary or secondary y-axis'),
         },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -266,6 +266,7 @@ export default function transformProps(
   }, {}) as Record<string, DataRecordValue[]>;
 
   const { setDataMask = () => {} } = hooks;
+  const alignTicks = yAxisIndex !== yAxisIndexB;
 
   const echartOptions: EChartsCoreOption = {
     useUTC: true,
@@ -296,6 +297,7 @@ export default function transformProps(
         name: yAxisTitle,
         nameGap: yAxisTitleMargin,
         nameLocation: yAxisTitlePosition === 'Left' ? 'middle' : 'end',
+        alignTicks,
       },
       {
         ...defaultYAxis,
@@ -308,6 +310,7 @@ export default function transformProps(
         axisLabel: { formatter: formatterSecondary },
         scale: truncateYAxis,
         name: yAxisTitleSecondary,
+        alignTicks,
       },
     ],
     tooltip: {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -198,7 +198,15 @@ export function transformSeries(
             opacity: opacity * areaOpacity,
           }
         : undefined,
-    emphasis,
+    emphasis: {
+      // bold on hover as required since 5.3.0 to retain backwards feature parity:
+      // https://apache.github.io/echarts-handbook/en/basics/release-note/5-3-0/#removing-the-default-bolding-emphasis-effect-in-the-line-chart
+      // TODO: should consider only adding emphasis to currently hovered series
+      lineStyle: {
+        width: 'bolder',
+      },
+      ...emphasis,
+    },
     showSymbol,
     symbolSize: markerSize,
     label: {


### PR DESCRIPTION
### SUMMARY
Bump ECharts to 5.3.0. See changelog here: https://apache.github.io/echarts-handbook/en/basics/release-note/5-3-0/ . Changes:
- Feature: Implement `alignAxis` on Mixed Timeseries chart to align y-axes when using dual axes.
- Feature parity with previous version: add `lineStyle` to default emphasis on Timeseries charts to retain bolding of series when hoving the chart (added TODO to revisit this later).

### AFTER
See how the major y-axis tick marks are now aligned:
![image](https://user-images.githubusercontent.com/33317356/150975491-601064f2-8a72-4b7d-8021-eeaa58f4b45c.png)

### BEFORE
Same data, ticks are unaligned:
![image](https://user-images.githubusercontent.com/33317356/150975562-adafaeed-9f7c-4556-915b-a14d0a01316d.png)

Changelog: https://apache.github.io/echarts-handbook/en/basics/release-note/5-3-0/

TODO: upgrade npm package when package is released.

### TESTING INSTRUCTIONS
1. Create new Mixed Timeseries chart using example FCC dataset
2. Use `COUNT(*)` as metric on first query, `COUNT(*) / 700.0` as metric on second query.
3. Set axis of second query to "Secondary"

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
