### PR TITLE
feat: Better extension-fields for docker-compose* + no default names

### DIFF
--- a/docker-compose-non-dev.yml
+++ b/docker-compose-non-dev.yml
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-
 # paste via https://docs.docker.com/compose/compose-file/compose-file-v3/#extension-fields
 x-base:
   &base

--- a/docker-compose-non-dev.yml
+++ b/docker-compose-non-dev.yml
@@ -14,14 +14,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-x-superset-image: &superset-image apache/superset:latest-dev
-x-superset-depends-on: &superset-depends-on
-  - db
-  - redis
-x-superset-volumes: &superset-volumes
-  # /app/pythonpath_docker will be appended to the PYTHONPATH in the final container
-  - ./docker:/app/docker
-  - superset_home:/app/superset_home
+
+
+# paste via https://docs.docker.com/compose/compose-file/compose-file-v3/#extension-fields
+x-base:
+  &base
+  image: apache/superset:latest-dev
+  env_file: docker/.env-non-dev
+  restart: unless-stopped
+  depends_on:
+    - db
+    - redis
+  user: root
+  volumes:
+    - ./docker:/app/docker
+    - superset_home:/app/superset_home
 
 version: "3.7"
 services:
@@ -35,51 +42,28 @@ services:
   db:
     env_file: docker/.env-non-dev
     image: postgres:10
-    container_name: superset_db
     restart: unless-stopped
     volumes:
       - db_home:/var/lib/postgresql/data
 
   superset:
-    env_file: docker/.env-non-dev
-    image: *superset-image
+    <<: *base
     container_name: superset_app
     command: ["/app/docker/docker-bootstrap.sh", "app-gunicorn"]
-    user: "root"
-    restart: unless-stopped
     ports:
       - 8088:8088
-    depends_on: *superset-depends-on
-    volumes: *superset-volumes
 
   superset-init:
-    image: *superset-image
-    container_name: superset_init
+    <<: *base
     command: ["/app/docker/docker-init.sh"]
-    env_file: docker/.env-non-dev
-    depends_on: *superset-depends-on
-    user: "root"
-    volumes: *superset-volumes
 
   superset-worker:
-    image: *superset-image
-    container_name: superset_worker
+    <<: *base
     command: ["/app/docker/docker-bootstrap.sh", "worker"]
-    env_file: docker/.env-non-dev
-    restart: unless-stopped
-    depends_on: *superset-depends-on
-    user: "root"
-    volumes: *superset-volumes
 
   superset-worker-beat:
-    image: *superset-image
-    container_name: superset_worker_beat
+    <<: *base
     command: ["/app/docker/docker-bootstrap.sh", "beat"]
-    env_file: docker/.env-non-dev
-    restart: unless-stopped
-    depends_on: *superset-depends-on
-    user: "root"
-    volumes: *superset-volumes
 
 volumes:
   superset_home:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,18 +14,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-x-superset-image: &superset-image apache/superset:latest-dev
-x-superset-user: &superset-user root
-x-superset-depends-on: &superset-depends-on
-  - db
-  - redis
-x-superset-volumes: &superset-volumes
-  # /app/pythonpath_docker will be appended to the PYTHONPATH in the final container
-  - ./docker:/app/docker
-  - ./superset:/app/superset
-  - ./superset-frontend:/app/superset-frontend
-  - superset_home:/app/superset_home
-  - ./tests:/app/tests
+
+# paste via https://docs.docker.com/compose/compose-file/compose-file-v3/#extension-fields
+x-base:
+  &base
+  image: apache/superset:latest-dev
+  env_file: docker/.env
+  restart: unless-stopped
+  depends_on:
+    - db
+    - redis
+  user: root
+  volumes:
+    - ./docker:/app/docker
+    - ./superset:/app/superset
+    - ./superset-frontend:/app/superset-frontend
+    - superset_home:/app/superset_home
+    - ./tests:/app/tests
+  
 
 version: "3.7"
 services:
@@ -49,21 +55,15 @@ services:
       - db_home:/var/lib/postgresql/data
 
   superset:
-    env_file: docker/.env
-    image: *superset-image
+    <<: *base
     container_name: superset_app
     command: ["/app/docker/docker-bootstrap.sh", "app"]
-    restart: unless-stopped
     ports:
       - 8088:8088
-    user: *superset-user
-    depends_on: *superset-depends-on
-    volumes: *superset-volumes
     environment:
       CYPRESS_CONFIG: "${CYPRESS_CONFIG}"
 
   superset-websocket:
-    container_name: superset_websocket
     build: ./superset-websocket
     image: superset-websocket
     ports:
@@ -91,52 +91,30 @@ services:
       - REDIS_SSL=false
 
   superset-init:
-    image: *superset-image
-    container_name: superset_init
+    <<: *base
     command: ["/app/docker/docker-init.sh"]
-    env_file: docker/.env
-    depends_on: *superset-depends-on
-    user: *superset-user
-    volumes: *superset-volumes
     environment:
       CYPRESS_CONFIG: "${CYPRESS_CONFIG}"
 
   superset-node:
+    <<: *base
     image: node:16
-    container_name: superset_node
     command: ["/app/docker/docker-frontend.sh"]
-    env_file: docker/.env
-    depends_on: *superset-depends-on
-    volumes: *superset-volumes
 
   superset-worker:
-    image: *superset-image
-    container_name: superset_worker
+    <<: *base
     command: ["/app/docker/docker-bootstrap.sh", "worker"]
-    env_file: docker/.env
-    restart: unless-stopped
-    depends_on: *superset-depends-on
-    user: *superset-user
-    volumes: *superset-volumes
     # Bump memory limit if processing selenium / thumbails on superset-worker
     # mem_limit: 2038m
     # mem_reservation: 128M
 
   superset-worker-beat:
-    image: *superset-image
-    container_name: superset_worker_beat
+    <<: *base
     command: ["/app/docker/docker-bootstrap.sh", "beat"]
-    env_file: docker/.env
-    restart: unless-stopped
-    depends_on: *superset-depends-on
-    user: *superset-user
-    volumes: *superset-volumes
 
   superset-tests-worker:
-    image: *superset-image
-    container_name: superset_tests_worker
+    <<: *base
     command: ["/app/docker/docker-bootstrap.sh", "worker"]
-    env_file: docker/.env
     environment:
       DATABASE_HOST: localhost
       DATABASE_DB: test
@@ -144,9 +122,6 @@ services:
       REDIS_RESULTS_DB: 3
       REDIS_HOST: localhost
     network_mode: host
-    depends_on: *superset-depends-on
-    user: *superset-user
-    volumes: *superset-volumes
 
 volumes:
   superset_home:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,6 @@ x-base:
     - ./superset-frontend:/app/superset-frontend
     - superset_home:/app/superset_home
     - ./tests:/app/tests
-  
 
 version: "3.7"
 services:


### PR DESCRIPTION
### SUMMARY
Default container names are already the "-" -> "_" versions of the service names.
<<: *name can be used to template more efficiently and avoid code duplication

### TESTING INSTRUCTIONS
```
docker-compose up
docker-compose -f docker-compose-non-dev.yml up
```
Results in the same as before

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
