### PR TITLE
fix(DeckGL): Fix issue with Javascript handlers in DeckGL plugin

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -183,7 +183,8 @@
     "shortid": "^2.2.6",
     "urijs": "^1.19.6",
     "use-immer": "^0.6.0",
-    "use-query-params": "^1.1.9"
+    "use-query-params": "^1.1.9",
+    "vm-browserify": "^1.0.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.10",

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -295,7 +295,7 @@ const config = {
     extensions: ['.ts', '.tsx', '.js', '.jsx', '.yml'],
     fallback: {
       fs: false,
-      vm: false,
+      vm: require.resolve('vm-browserify'),
       path: false,
     },
   },


### PR DESCRIPTION

### SUMMARY
Javascript data interceptor, Javascript tooltip generator and Javascript onclick href handlers throw error (runInNewContext is not a function) in 1.4 due to missing vm dependency. This change resolves the issue.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
Create or open a DeckGL chart that has one of the JS handlers  (data interceptor, tooltip generator and/or onclick href) configured. Without this fix, the chart will show an error condition once one of the handlers run.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
