### PR TITLE
fix(TextAreaControl): Unable to edit Javascript in DeckGL Scatterplot plugin advanced section

### DIFF
--- a/superset-frontend/src/explore/components/controls/TextAreaControl.jsx
+++ b/superset-frontend/src/explore/components/controls/TextAreaControl.jsx
@@ -59,7 +59,7 @@ const defaultProps = {
 
 export default class TextAreaControl extends React.Component {
   onControlChange(value) {
-     this.props.onChange(value);
+    this.props.onChange(value);
   }
 
   renderEditor(inModal = false) {

--- a/superset-frontend/src/explore/components/controls/TextAreaControl.jsx
+++ b/superset-frontend/src/explore/components/controls/TextAreaControl.jsx
@@ -58,9 +58,8 @@ const defaultProps = {
 };
 
 export default class TextAreaControl extends React.Component {
-  onControlChange(event) {
-    const { value } = event.target;
-    this.props.onChange(value);
+  onControlChange(value) {
+     this.props.onChange(value);
   }
 
   renderEditor(inModal = false) {
@@ -76,7 +75,6 @@ export default class TextAreaControl extends React.Component {
           style={style}
           minLines={minLines}
           maxLines={inModal ? 1000 : this.props.maxLines}
-          onChange={this.props.onChange}
           width="100%"
           height={`${minLines}em`}
           editorProps={{ $blockScrolling: true }}
@@ -84,6 +82,7 @@ export default class TextAreaControl extends React.Component {
           readOnly={this.props.readOnly}
           key={this.props.name}
           {...this.props}
+          onChange={this.onControlChange.bind(this)}
         />
       );
     }


### PR DESCRIPTION

### SUMMARY
This fix resolves an issue where Javascript fields could not be edited in the DeckGL Scatterplot advanced section because of incompatible argument types passed to the onChange handler. The incompatible arguments (object provided, string expected) resulted in exceptions being raised in the onChange handler.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF


### TESTING INSTRUCTIONS
In release 1.4, when editing any of the Javascipt handlers in the DeckGL Scatterplot advanced section, characters would be inserted multiple times and the text cursor would be repositioned to the end of the text with every character entered. This makes editing the text area impossible. 

With this fix applied, the text area is editable as expected.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
