### PR TITLE
feat: Add toast for successful table or schema refreshes in Sqllab

### DIFF
--- a/superset-frontend/src/components/DatabaseSelector/DatabaseSelector.test.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/DatabaseSelector.test.tsx
@@ -169,14 +169,14 @@ beforeEach(() => {
 
 test('Should render', async () => {
   const props = createProps();
-  render(<DatabaseSelector {...props} />);
+  render(<DatabaseSelector {...props} />, { useRedux: true });
   expect(await screen.findByTestId('DatabaseSelector')).toBeInTheDocument();
 });
 
 test('Refresh should work', async () => {
   const props = createProps();
 
-  render(<DatabaseSelector {...props} />);
+  render(<DatabaseSelector {...props} />, { useRedux: true });
 
   const select = screen.getByRole('combobox', {
     name: 'Select schema or type schema name',
@@ -211,7 +211,7 @@ test('Refresh should work', async () => {
 
 test('Should database select display options', async () => {
   const props = createProps();
-  render(<DatabaseSelector {...props} />);
+  render(<DatabaseSelector {...props} />, { useRedux: true });
   const select = screen.getByRole('combobox', {
     name: 'Select database or type database name',
   });
@@ -222,7 +222,7 @@ test('Should database select display options', async () => {
 
 test('Should schema select display options', async () => {
   const props = createProps();
-  render(<DatabaseSelector {...props} />);
+  render(<DatabaseSelector {...props} />, { useRedux: true });
   const select = screen.getByRole('combobox', {
     name: 'Select schema or type schema name',
   });
@@ -238,7 +238,7 @@ test('Should schema select display options', async () => {
 
 test('Sends the correct db when changing the database', async () => {
   const props = createProps();
-  render(<DatabaseSelector {...props} />);
+  render(<DatabaseSelector {...props} />, { useRedux: true });
   const select = screen.getByRole('combobox', {
     name: 'Select database or type database name',
   });
@@ -259,7 +259,7 @@ test('Sends the correct db when changing the database', async () => {
 
 test('Sends the correct schema when changing the schema', async () => {
   const props = createProps();
-  render(<DatabaseSelector {...props} />);
+  render(<DatabaseSelector {...props} />, { useRedux: true });
   const select = screen.getByRole('combobox', {
     name: 'Select schema or type schema name',
   });

--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -225,7 +225,7 @@ export default function DatabaseSelector({
           }
           setSchemaOptions(options);
           setLoadingSchemas(false);
-          addSuccessToast('List refreshed');
+          if (refresh > 0) addSuccessToast('List refreshed');
         })
         .catch(() => {
           setLoadingSchemas(false);

--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -23,6 +23,7 @@ import { Select } from 'src/components';
 import Label from 'src/components/Label';
 import { FormLabel } from 'src/components/Form';
 import RefreshLabel from 'src/components/RefreshLabel';
+import { useToasts } from 'src/components/MessageToasts/withToasts';
 
 const DatabaseSelectorWrapper = styled.div`
   ${({ theme }) => `
@@ -144,7 +145,7 @@ export default function DatabaseSelector({
     schema ? { label: schema, value: schema } : undefined,
   );
   const [refresh, setRefresh] = useState(0);
-
+  const { addSuccessToast } = useToasts();
   const loadDatabases = useMemo(
     () =>
       async (
@@ -224,6 +225,7 @@ export default function DatabaseSelector({
           }
           setSchemaOptions(options);
           setLoadingSchemas(false);
+          addSuccessToast('List refreshed');
         })
         .catch(() => {
           setLoadingSchemas(false);

--- a/superset-frontend/src/components/TableSelector/TableSelector.test.tsx
+++ b/superset-frontend/src/components/TableSelector/TableSelector.test.tsx
@@ -52,7 +52,7 @@ beforeAll(() => {
 
 test('renders with default props', async () => {
   const props = createProps();
-  render(<TableSelector {...props} />);
+  render(<TableSelector {...props} />, { useRedux: true });
   const databaseSelect = screen.getByRole('combobox', {
     name: 'Select database or type database name',
   });
@@ -71,7 +71,7 @@ test('renders with default props', async () => {
 
 test('renders table options', async () => {
   const props = createProps();
-  render(<TableSelector {...props} />);
+  render(<TableSelector {...props} />, { useRedux: true });
   const tableSelect = screen.getByRole('combobox', {
     name: 'Select table or type table name',
   });
@@ -86,7 +86,7 @@ test('renders table options', async () => {
 
 test('renders disabled without schema', async () => {
   const props = createProps();
-  render(<TableSelector {...props} schema={undefined} />);
+  render(<TableSelector {...props} schema={undefined} />, { useRedux: true });
   const tableSelect = screen.getByRole('combobox', {
     name: 'Select table or type table name',
   });

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -214,7 +214,7 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
           setTableOptions(options);
           setCurrentTable(currentTable);
           setLoadingTables(false);
-          addSuccessToast('List updated');
+          if (forceRefresh) addSuccessToast('List updated');
         })
         .catch(e => {
           setLoadingTables(false);

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -180,7 +180,6 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
   }, [database]);
 
   useEffect(() => {
-    console.log('hi');
     if (currentDatabase && currentSchema) {
       setLoadingTables(true);
       const encodedSchema = encodeURIComponent(currentSchema);

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -33,6 +33,7 @@ import DatabaseSelector, {
 import RefreshLabel from 'src/components/RefreshLabel';
 import CertifiedBadge from 'src/components/CertifiedBadge';
 import WarningIconWithTooltip from 'src/components/WarningIconWithTooltip';
+import { useToasts } from 'src/components/MessageToasts/withToasts';
 
 const TableSelectorWrapper = styled.div`
   ${({ theme }) => `
@@ -167,6 +168,7 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
   const [previousRefresh, setPreviousRefresh] = useState(0);
   const [loadingTables, setLoadingTables] = useState(false);
   const [tableOptions, setTableOptions] = useState<TableOption[]>([]);
+  const { addSuccessToast } = useToasts();
 
   useEffect(() => {
     // reset selections
@@ -178,6 +180,7 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
   }, [database]);
 
   useEffect(() => {
+    console.log('hi');
     if (currentDatabase && currentSchema) {
       setLoadingTables(true);
       const encodedSchema = encodeURIComponent(currentSchema);
@@ -212,6 +215,7 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
           setTableOptions(options);
           setCurrentTable(currentTable);
           setLoadingTables(false);
+          addSuccessToast('List updated');
         })
         .catch(e => {
           setLoadingTables(false);


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Before users weren't notified if the table or schemas were properly refreshed. So adding toast to inform the users on successful state of refresh.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

https://user-images.githubusercontent.com/27827808/151053833-d2740de8-c12a-4d31-b5d9-7a4631130402.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
