### PR TITLE
refactor: extract json_required view decorator

### DIFF
--- a/superset/annotation_layers/annotations/api.py
+++ b/superset/annotation_layers/annotations/api.py
@@ -56,7 +56,7 @@ from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP, RouteMethod
 from superset.models.annotations import Annotation
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
-    json_required,
+    requires_json,
     statsd_metrics,
 )
 
@@ -258,7 +258,7 @@ class AnnotationRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @permission_name("post")
-    @json_required
+    @requires_json
     def post(self, pk: int) -> Response:  # pylint: disable=arguments-differ
         """Creates a new Annotation
         ---
@@ -326,7 +326,7 @@ class AnnotationRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @permission_name("put")
-    @json_required
+    @requires_json
     def put(  # pylint: disable=arguments-differ
         self, pk: int, annotation_id: int
     ) -> Response:

--- a/superset/annotation_layers/annotations/api.py
+++ b/superset/annotation_layers/annotations/api.py
@@ -54,7 +54,11 @@ from superset.annotation_layers.annotations.schemas import (
 from superset.annotation_layers.commands.exceptions import AnnotationLayerNotFoundError
 from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP, RouteMethod
 from superset.models.annotations import Annotation
-from superset.views.base_api import BaseSupersetModelRestApi, statsd_metrics
+from superset.views.base_api import (
+    BaseSupersetModelRestApi,
+    json_required,
+    statsd_metrics,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -254,6 +258,7 @@ class AnnotationRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @permission_name("post")
+    @json_required
     def post(self, pk: int) -> Response:  # pylint: disable=arguments-differ
         """Creates a new Annotation
         ---
@@ -294,8 +299,6 @@ class AnnotationRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-        if not request.is_json:
-            return self.response_400(message="Request is not JSON")
         try:
             item = self.add_model_schema.load(request.json)
             item["layer"] = pk
@@ -323,6 +326,7 @@ class AnnotationRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @permission_name("put")
+    @json_required
     def put(  # pylint: disable=arguments-differ
         self, pk: int, annotation_id: int
     ) -> Response:
@@ -370,8 +374,6 @@ class AnnotationRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-        if not request.is_json:
-            return self.response_400(message="Request is not JSON")
         try:
             item = self.edit_model_schema.load(request.json)
             item["layer"] = pk

--- a/superset/annotation_layers/api.py
+++ b/superset/annotation_layers/api.py
@@ -49,7 +49,11 @@ from superset.annotation_layers.schemas import (
 from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP, RouteMethod
 from superset.extensions import event_logger
 from superset.models.annotations import AnnotationLayer
-from superset.views.base_api import BaseSupersetModelRestApi, statsd_metrics
+from superset.views.base_api import (
+    BaseSupersetModelRestApi,
+    json_required,
+    statsd_metrics,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -171,6 +175,7 @@ class AnnotationLayerRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
         log_to_statsd=False,
     )
+    @json_required
     def post(self) -> Response:
         """Creates a new Annotation Layer
         ---
@@ -205,8 +210,6 @@ class AnnotationLayerRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-        if not request.is_json:
-            return self.response_400(message="Request is not JSON")
         try:
             item = self.add_model_schema.load(request.json)
         # This validates custom Schema with custom validations
@@ -237,6 +240,7 @@ class AnnotationLayerRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.put",
         log_to_statsd=False,
     )
+    @json_required
     def put(self, pk: int) -> Response:
         """Updates an Annotation Layer
         ---
@@ -277,8 +281,6 @@ class AnnotationLayerRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-        if not request.is_json:
-            return self.response_400(message="Request is not JSON")
         try:
             item = self.edit_model_schema.load(request.json)
             item["layer"] = pk

--- a/superset/annotation_layers/api.py
+++ b/superset/annotation_layers/api.py
@@ -51,7 +51,7 @@ from superset.extensions import event_logger
 from superset.models.annotations import AnnotationLayer
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
-    json_required,
+    requires_json,
     statsd_metrics,
 )
 
@@ -175,7 +175,7 @@ class AnnotationLayerRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
         log_to_statsd=False,
     )
-    @json_required
+    @requires_json
     def post(self) -> Response:
         """Creates a new Annotation Layer
         ---
@@ -240,7 +240,7 @@ class AnnotationLayerRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.put",
         log_to_statsd=False,
     )
-    @json_required
+    @requires_json
     def put(self, pk: int) -> Response:
         """Updates an Annotation Layer
         ---

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -74,8 +74,8 @@ from superset.utils.screenshots import ChartScreenshot
 from superset.utils.urls import get_url_path
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
-    json_required,
     RelatedFieldFilter,
+    requires_json,
     statsd_metrics,
 )
 from superset.views.filters import FilterRelatedOwners
@@ -240,7 +240,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
         log_to_statsd=False,
     )
-    @json_required
+    @requires_json
     def post(self) -> Response:
         """Creates a new Chart
         ---
@@ -302,7 +302,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.put",
         log_to_statsd=False,
     )
-    @json_required
+    @requires_json
     def put(self, pk: int) -> Response:
         """Changes a Chart
         ---

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -74,6 +74,7 @@ from superset.utils.screenshots import ChartScreenshot
 from superset.utils.urls import get_url_path
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
+    json_required,
     RelatedFieldFilter,
     statsd_metrics,
 )
@@ -239,6 +240,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
         log_to_statsd=False,
     )
+    @json_required
     def post(self) -> Response:
         """Creates a new Chart
         ---
@@ -273,8 +275,6 @@ class ChartRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-        if not request.is_json:
-            return self.response_400(message="Request is not JSON")
         try:
             item = self.add_model_schema.load(request.json)
         # This validates custom Schema with custom validations
@@ -302,6 +302,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.put",
         log_to_statsd=False,
     )
+    @json_required
     def put(self, pk: int) -> Response:
         """Changes a Chart
         ---
@@ -345,8 +346,6 @@ class ChartRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-        if not request.is_json:
-            return self.response_400(message="Request is not JSON")
         try:
             item = self.edit_model_schema.load(request.json)
         # This validates custom Schema with custom validations

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -75,6 +75,7 @@ from superset.utils.urls import get_url_path
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
     RelatedFieldFilter,
+    requires_form_data,
     requires_json,
     statsd_metrics,
 )
@@ -819,6 +820,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.import_",
         log_to_statsd=False,
     )
+    @requires_form_data
     def import_(self) -> Response:
         """Import chart(s) with associated datasets and databases
         ---

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -80,6 +80,7 @@ from superset.utils.urls import get_url_path
 from superset.views.base import generate_download_headers
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
+    json_required,
     RelatedFieldFilter,
     statsd_metrics,
 )
@@ -430,6 +431,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
         log_to_statsd=False,
     )
+    @json_required
     def post(self) -> Response:
         """Creates a new Dashboard
         ---
@@ -466,8 +468,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-        if not request.is_json:
-            return self.response_400(message="Request is not JSON")
         try:
             item = self.add_model_schema.load(request.json)
         # This validates custom Schema with custom validations
@@ -495,6 +495,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.put",
         log_to_statsd=False,
     )
+    @json_required
     def put(self, pk: int) -> Response:
         """Changes a Dashboard
         ---
@@ -540,8 +541,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-        if not request.is_json:
-            return self.response_400(message="Request is not JSON")
         try:
             item = self.edit_model_schema.load(request.json)
         # This validates custom Schema with custom validations

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -81,6 +81,7 @@ from superset.views.base import generate_download_headers
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
     RelatedFieldFilter,
+    requires_form_data,
     requires_json,
     statsd_metrics,
 )
@@ -926,6 +927,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.import_",
         log_to_statsd=False,
     )
+    @requires_form_data
     def import_(self) -> Response:
         """Import dashboard(s) with associated charts/datasets/databases
         ---

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -80,8 +80,8 @@ from superset.utils.urls import get_url_path
 from superset.views.base import generate_download_headers
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
-    json_required,
     RelatedFieldFilter,
+    requires_json,
     statsd_metrics,
 )
 from superset.views.filters import FilterRelatedOwners
@@ -431,7 +431,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
         log_to_statsd=False,
     )
-    @json_required
+    @requires_json
     def post(self) -> Response:
         """Creates a new Dashboard
         ---
@@ -495,7 +495,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.put",
         log_to_statsd=False,
     )
-    @json_required
+    @requires_json
     def put(self, pk: int) -> Response:
         """Changes a Dashboard
         ---

--- a/superset/dashboards/filter_sets/api.py
+++ b/superset/dashboards/filter_sets/api.py
@@ -62,7 +62,11 @@ from superset.dashboards.filter_sets.schemas import (
 )
 from superset.extensions import event_logger
 from superset.models.filter_set import FilterSet
-from superset.views.base_api import BaseSupersetModelRestApi, statsd_metrics
+from superset.views.base_api import (
+    BaseSupersetModelRestApi,
+    json_required,
+    statsd_metrics,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -193,6 +197,7 @@ class FilterSetRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
         log_to_statsd=False,
     )
+    @json_required
     def post(self, dashboard_id: int) -> Response:
         """
             Creates a new Dashboard's Filter Set
@@ -236,8 +241,6 @@ class FilterSetRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-        if not request.is_json:
-            return self.response_400(message="Request is not JSON")
         try:
             item = self.add_model_schema.load(request.json)
             new_model = CreateFilterSetCommand(g.user, dashboard_id, item).run()
@@ -261,6 +264,7 @@ class FilterSetRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.put",
         log_to_statsd=False,
     )
+    @json_required
     def put(self, dashboard_id: int, pk: int) -> Response:
         """Changes a Dashboard's Filter set
         ---
@@ -308,8 +312,6 @@ class FilterSetRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-        if not request.is_json:
-            return self.response_400(message="Request is not JSON")
         try:
             item = self.edit_model_schema.load(request.json)
             changed_model = UpdateFilterSetCommand(g.user, dashboard_id, pk, item).run()

--- a/superset/dashboards/filter_sets/api.py
+++ b/superset/dashboards/filter_sets/api.py
@@ -64,7 +64,7 @@ from superset.extensions import event_logger
 from superset.models.filter_set import FilterSet
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
-    json_required,
+    requires_json,
     statsd_metrics,
 )
 
@@ -197,7 +197,7 @@ class FilterSetRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
         log_to_statsd=False,
     )
-    @json_required
+    @requires_json
     def post(self, dashboard_id: int) -> Response:
         """
             Creates a new Dashboard's Filter Set
@@ -264,7 +264,7 @@ class FilterSetRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.put",
         log_to_statsd=False,
     )
-    @json_required
+    @requires_json
     def put(self, dashboard_id: int, pk: int) -> Response:
         """Changes a Dashboard's Filter set
         ---

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -75,7 +75,7 @@ from superset.typing import FlaskResponse
 from superset.utils.core import error_msg_from_exception
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
-    json_required,
+    requires_json,
     statsd_metrics,
 )
 
@@ -205,7 +205,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
         log_to_statsd=False,
     )
-    @json_required
+    @requires_json
     def post(self) -> Response:
         """Creates a new Database
         ---
@@ -279,7 +279,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.put",
         log_to_statsd=False,
     )
-    @json_required
+    @requires_json
     def put(self, pk: int) -> Response:
         """Changes a Database
         ---
@@ -594,7 +594,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         f".test_connection",
         log_to_statsd=False,
     )
-    @json_required
+    @requires_json
     def test_connection(self) -> FlaskResponse:
         """Tests a database connection
         ---
@@ -985,7 +985,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         f".validate_parameters",
         log_to_statsd=False,
     )
-    @json_required
+    @requires_json
     def validate_parameters(self) -> FlaskResponse:
         """validates database connection parameters
         ---

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -75,6 +75,7 @@ from superset.typing import FlaskResponse
 from superset.utils.core import error_msg_from_exception
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
+    requires_form_data,
     requires_json,
     statsd_metrics,
 )
@@ -774,6 +775,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.import_",
         log_to_statsd=False,
     )
+    @requires_form_data
     def import_(self) -> Response:
         """Import database(s) with associated datasets
         ---

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -73,7 +73,11 @@ from superset.extensions import security_manager
 from superset.models.core import Database
 from superset.typing import FlaskResponse
 from superset.utils.core import error_msg_from_exception
-from superset.views.base_api import BaseSupersetModelRestApi, statsd_metrics
+from superset.views.base_api import (
+    BaseSupersetModelRestApi,
+    json_required,
+    statsd_metrics,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -201,6 +205,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
         log_to_statsd=False,
     )
+    @json_required
     def post(self) -> Response:
         """Creates a new Database
         ---
@@ -237,9 +242,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-
-        if not request.is_json:
-            return self.response_400(message="Request is not JSON")
         try:
             item = self.add_model_schema.load(request.json)
         # This validates custom Schema with custom validations
@@ -277,6 +279,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.put",
         log_to_statsd=False,
     )
+    @json_required
     def put(self, pk: int) -> Response:
         """Changes a Database
         ---
@@ -320,8 +323,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-        if not request.is_json:
-            return self.response_400(message="Request is not JSON")
         try:
             item = self.edit_model_schema.load(request.json)
         # This validates custom Schema with custom validations
@@ -593,6 +594,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         f".test_connection",
         log_to_statsd=False,
     )
+    @json_required
     def test_connection(self) -> FlaskResponse:
         """Tests a database connection
         ---
@@ -623,8 +625,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-        if not request.is_json:
-            return self.response_400(message="Request is not JSON")
         try:
             item = DatabaseTestConnectionSchema().load(request.json)
         # This validates custom Schema with custom validations
@@ -985,6 +985,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         f".validate_parameters",
         log_to_statsd=False,
     )
+    @json_required
     def validate_parameters(self) -> FlaskResponse:
         """validates database connection parameters
         ---
@@ -1015,9 +1016,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-        if not request.is_json:
-            raise InvalidPayloadFormatError("Request is not JSON")
-
         try:
             payload = DatabaseValidateParametersSchema().load(request.json)
         except ValidationError as ex:

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -68,7 +68,6 @@ from superset.databases.schemas import (
 from superset.databases.utils import get_table_metadata
 from superset.db_engine_specs import get_available_engine_specs
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
-from superset.exceptions import InvalidPayloadFormatError
 from superset.extensions import security_manager
 from superset.models.core import Database
 from superset.typing import FlaskResponse

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -65,6 +65,7 @@ from superset.views.base import DatasourceFilter, generate_download_headers
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
     RelatedFieldFilter,
+    requires_form_data,
     requires_json,
     statsd_metrics,
 )
@@ -679,6 +680,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.import_",
         log_to_statsd=False,
     )
+    @requires_form_data
     def import_(self) -> Response:
         """Import dataset(s) with associated databases
         ---

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -64,6 +64,7 @@ from superset.utils.core import parse_boolean_string
 from superset.views.base import DatasourceFilter, generate_download_headers
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
+    json_required,
     RelatedFieldFilter,
     statsd_metrics,
 )
@@ -206,6 +207,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
         log_to_statsd=False,
     )
+    @json_required
     def post(self) -> Response:
         """Creates a new Dataset
         ---
@@ -240,8 +242,6 @@ class DatasetRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-        if not request.is_json:
-            return self.response_400(message="Request is not JSON")
         try:
             item = self.add_model_schema.load(request.json)
         # This validates custom Schema with custom validations
@@ -270,6 +270,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.put",
         log_to_statsd=False,
     )
+    @json_required
     def put(self, pk: int) -> Response:
         """Changes a Dataset
         ---
@@ -322,8 +323,6 @@ class DatasetRestApi(BaseSupersetModelRestApi):
             if "override_columns" in request.args
             else False
         )
-        if not request.is_json:
-            return self.response_400(message="Request is not JSON")
         try:
             item = self.edit_model_schema.load(request.json)
         # This validates custom Schema with custom validations

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -64,8 +64,8 @@ from superset.utils.core import parse_boolean_string
 from superset.views.base import DatasourceFilter, generate_download_headers
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
-    json_required,
     RelatedFieldFilter,
+    requires_json,
     statsd_metrics,
 )
 from superset.views.filters import FilterRelatedOwners
@@ -207,7 +207,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
         log_to_statsd=False,
     )
-    @json_required
+    @requires_json
     def post(self) -> Response:
         """Creates a new Dataset
         ---
@@ -270,7 +270,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.put",
         log_to_statsd=False,
     )
-    @json_required
+    @requires_json
     def put(self, pk: int) -> Response:
         """Changes a Dataset
         ---

--- a/superset/explore/form_data/api.py
+++ b/superset/explore/form_data/api.py
@@ -30,7 +30,6 @@ from superset.datasets.commands.exceptions import (
     DatasetAccessDeniedError,
     DatasetNotFoundError,
 )
-from superset.exceptions import InvalidPayloadFormatError
 from superset.explore.form_data.commands.create import CreateFormDataCommand
 from superset.explore.form_data.commands.delete import DeleteFormDataCommand
 from superset.explore.form_data.commands.get import GetFormDataCommand

--- a/superset/explore/form_data/api.py
+++ b/superset/explore/form_data/api.py
@@ -39,7 +39,7 @@ from superset.explore.form_data.commands.update import UpdateFormDataCommand
 from superset.explore.form_data.schemas import FormDataPostSchema, FormDataPutSchema
 from superset.extensions import event_logger
 from superset.key_value.commands.exceptions import KeyValueAccessDeniedError
-from superset.views.base_api import json_required
+from superset.views.base_api import requires_json
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +67,7 @@ class ExploreFormDataRestApi(BaseApi, ABC):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
         log_to_statsd=False,
     )
-    @json_required
+    @requires_json
     def post(self) -> Response:
         """Stores a new form_data.
         ---
@@ -128,7 +128,7 @@ class ExploreFormDataRestApi(BaseApi, ABC):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.put",
         log_to_statsd=False,
     )
-    @json_required
+    @requires_json
     def put(self, key: str) -> Response:
         """Updates an existing form_data.
         ---

--- a/superset/explore/form_data/api.py
+++ b/superset/explore/form_data/api.py
@@ -39,6 +39,7 @@ from superset.explore.form_data.commands.update import UpdateFormDataCommand
 from superset.explore.form_data.schemas import FormDataPostSchema, FormDataPutSchema
 from superset.extensions import event_logger
 from superset.key_value.commands.exceptions import KeyValueAccessDeniedError
+from superset.views.base_api import json_required
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +67,7 @@ class ExploreFormDataRestApi(BaseApi, ABC):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
         log_to_statsd=False,
     )
+    @json_required
     def post(self) -> Response:
         """Stores a new form_data.
         ---
@@ -98,8 +100,6 @@ class ExploreFormDataRestApi(BaseApi, ABC):
             500:
               $ref: '#/components/responses/500'
         """
-        if not request.is_json:
-            raise InvalidPayloadFormatError("Request is not JSON")
         try:
             item = self.add_model_schema.load(request.json)
             args = CommandParameters(
@@ -128,6 +128,7 @@ class ExploreFormDataRestApi(BaseApi, ABC):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.put",
         log_to_statsd=False,
     )
+    @json_required
     def put(self, key: str) -> Response:
         """Updates an existing form_data.
         ---
@@ -167,8 +168,6 @@ class ExploreFormDataRestApi(BaseApi, ABC):
             500:
               $ref: '#/components/responses/500'
         """
-        if not request.is_json:
-            raise InvalidPayloadFormatError("Request is not JSON")
         try:
             item = self.edit_model_schema.load(request.json)
             args = CommandParameters(

--- a/superset/key_value/api.py
+++ b/superset/key_value/api.py
@@ -37,7 +37,6 @@ from superset.datasets.commands.exceptions import (
     DatasetAccessDeniedError,
     DatasetNotFoundError,
 )
-from superset.exceptions import InvalidPayloadFormatError
 from superset.key_value.commands.exceptions import KeyValueAccessDeniedError
 from superset.key_value.commands.parameters import CommandParameters
 from superset.key_value.schemas import KeyValuePostSchema, KeyValuePutSchema

--- a/superset/key_value/api.py
+++ b/superset/key_value/api.py
@@ -41,7 +41,7 @@ from superset.exceptions import InvalidPayloadFormatError
 from superset.key_value.commands.exceptions import KeyValueAccessDeniedError
 from superset.key_value.commands.parameters import CommandParameters
 from superset.key_value.schemas import KeyValuePostSchema, KeyValuePutSchema
-from superset.views.base_api import json_required
+from superset.views.base_api import requires_json
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +70,7 @@ class KeyValueRestApi(BaseApi, ABC):
             pass
         super().add_apispec_components(api_spec)
 
-    @json_required
+    @requires_json
     def post(self, pk: int) -> Response:
         try:
             item = self.add_model_schema.load(request.json)
@@ -94,7 +94,7 @@ class KeyValueRestApi(BaseApi, ABC):
         except (ChartNotFoundError, DashboardNotFoundError, DatasetNotFoundError) as ex:
             return self.response(404, message=str(ex))
 
-    @json_required
+    @requires_json
     def put(self, pk: int, key: str) -> Response:
         try:
             item = self.edit_model_schema.load(request.json)

--- a/superset/key_value/api.py
+++ b/superset/key_value/api.py
@@ -41,6 +41,7 @@ from superset.exceptions import InvalidPayloadFormatError
 from superset.key_value.commands.exceptions import KeyValueAccessDeniedError
 from superset.key_value.commands.parameters import CommandParameters
 from superset.key_value.schemas import KeyValuePostSchema, KeyValuePutSchema
+from superset.views.base_api import json_required
 
 logger = logging.getLogger(__name__)
 
@@ -69,9 +70,8 @@ class KeyValueRestApi(BaseApi, ABC):
             pass
         super().add_apispec_components(api_spec)
 
+    @json_required
     def post(self, pk: int) -> Response:
-        if not request.is_json:
-            raise InvalidPayloadFormatError("Request is not JSON")
         try:
             item = self.add_model_schema.load(request.json)
             args = CommandParameters(
@@ -94,9 +94,8 @@ class KeyValueRestApi(BaseApi, ABC):
         except (ChartNotFoundError, DashboardNotFoundError, DatasetNotFoundError) as ex:
             return self.response(404, message=str(ex))
 
+    @json_required
     def put(self, pk: int, key: str) -> Response:
-        if not request.is_json:
-            raise InvalidPayloadFormatError("Request is not JSON")
         try:
             item = self.edit_model_schema.load(request.json)
             args = CommandParameters(

--- a/superset/queries/saved_queries/api.py
+++ b/superset/queries/saved_queries/api.py
@@ -53,7 +53,7 @@ from superset.queries.saved_queries.schemas import (
     get_export_ids_schema,
     openapi_spec_methods_override,
 )
-from superset.views.base_api import BaseSupersetModelRestApi, statsd_metrics
+from superset.views.base_api import BaseSupersetModelRestApi, requires_form_data, statsd_metrics
 
 logger = logging.getLogger(__name__)
 
@@ -272,6 +272,7 @@ class SavedQueryRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.import_",
         log_to_statsd=False,
     )
+    @requires_form_data
     def import_(self) -> Response:
         """Import Saved Queries with associated databases
         ---

--- a/superset/queries/saved_queries/api.py
+++ b/superset/queries/saved_queries/api.py
@@ -53,7 +53,11 @@ from superset.queries.saved_queries.schemas import (
     get_export_ids_schema,
     openapi_spec_methods_override,
 )
-from superset.views.base_api import BaseSupersetModelRestApi, requires_form_data, statsd_metrics
+from superset.views.base_api import (
+    BaseSupersetModelRestApi,
+    requires_form_data,
+    statsd_metrics,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -52,8 +52,8 @@ from superset.reports.schemas import (
 )
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
-    json_required,
     RelatedFieldFilter,
+    requires_json,
     statsd_metrics,
 )
 from superset.views.filters import FilterRelatedOwners
@@ -276,7 +276,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
     @protect()
     @statsd_metrics
     @permission_name("post")
-    @json_required
+    @requires_json
     def post(self) -> Response:
         """Creates a new Report Schedule
         ---
@@ -337,7 +337,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @permission_name("put")
-    @json_required
+    @requires_json
     def put(self, pk: int) -> Response:
         """Updates an Report Schedule
         ---

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -52,6 +52,7 @@ from superset.reports.schemas import (
 )
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
+    json_required,
     RelatedFieldFilter,
     statsd_metrics,
 )
@@ -275,6 +276,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
     @protect()
     @statsd_metrics
     @permission_name("post")
+    @json_required
     def post(self) -> Response:
         """Creates a new Report Schedule
         ---
@@ -309,8 +311,6 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-        if not request.is_json:
-            return self.response_400(message="Request is not JSON")
         try:
             item = self.add_model_schema.load(request.json)
         # This validates custom Schema with custom validations
@@ -337,6 +337,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @permission_name("put")
+    @json_required
     def put(self, pk: int) -> Response:
         """Updates an Report Schedule
         ---
@@ -379,8 +380,6 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-        if not request.is_json:
-            return self.response_400(message="Request is not JSON")
         try:
             item = self.edit_model_schema.load(request.json)
         # This validates custom Schema with custom validations

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -29,6 +29,7 @@ from marshmallow import fields, Schema
 from sqlalchemy import and_, distinct, func
 from sqlalchemy.orm.query import Query
 
+from superset.exceptions import InvalidPayloadFormatError
 from superset.extensions import db, event_logger, security_manager
 from superset.models.core import FavStar
 from superset.models.dashboard import Dashboard
@@ -77,10 +78,11 @@ def requires_json(f: Callable[..., Any]) -> Callable[..., Any]:
 
     def wraps(self: "BaseSupersetModelRestApi", *args: Any, **kwargs: Any) -> Response:
         if not request.is_json:
-            return self.response_400(message="Request is not JSON")
+            raise InvalidPayloadFormatError(message="Request is not JSON")
         return f(self, *args, **kwargs)
 
     return functools.update_wrapper(wraps, f)
+
 
 def requires_form_data(f: Callable[..., Any]) -> Callable[..., Any]:
     """
@@ -88,8 +90,10 @@ def requires_form_data(f: Callable[..., Any]) -> Callable[..., Any]:
     """
 
     def wraps(self: "BaseSupersetModelRestApi", *args: Any, **kwargs: Any) -> Response:
-        if not request.mimetype == 'multipart/form-data':
-            return self.response_400(message="Request MIME type is not 'multipart/form-data'")
+        if not request.mimetype == "multipart/form-data":
+            raise InvalidPayloadFormatError(
+                message="Request MIME type is not 'multipart/form-data'"
+            )
         return f(self, *args, **kwargs)
 
     return functools.update_wrapper(wraps, f)

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -70,7 +70,7 @@ class DistincResponseSchema(Schema):
     result = fields.List(fields.Nested(DistinctResultResponseSchema))
 
 
-def json_required(f: Callable[..., Any]) -> Callable[..., Any]:
+def requires_json(f: Callable[..., Any]) -> Callable[..., Any]:
     """
     Require JSON-like formatted request to the REST API
     """

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -82,6 +82,18 @@ def requires_json(f: Callable[..., Any]) -> Callable[..., Any]:
 
     return functools.update_wrapper(wraps, f)
 
+def requires_form_data(f: Callable[..., Any]) -> Callable[..., Any]:
+    """
+    Require 'multipart/form-data' as request MIME type
+    """
+
+    def wraps(self: "BaseSupersetModelRestApi", *args: Any, **kwargs: Any) -> Response:
+        if not request.mimetype == 'multipart/form-data':
+            return self.response_400(message="Request MIME type is not 'multipart/form-data'")
+        return f(self, *args, **kwargs)
+
+    return functools.update_wrapper(wraps, f)
+
 
 def statsd_metrics(f: Callable[..., Any]) -> Callable[..., Any]:
     """

--- a/tests/integration_tests/base_api_tests.py
+++ b/tests/integration_tests/base_api_tests.py
@@ -29,7 +29,7 @@ import tests.integration_tests.test_app
 from superset import db, security_manager
 from superset.extensions import appbuilder
 from superset.models.dashboard import Dashboard
-from superset.views.base_api import BaseSupersetModelRestApi
+from superset.views.base_api import BaseSupersetModelRestApi, json_required
 
 from .base_tests import SupersetTestCase
 
@@ -153,6 +153,19 @@ class TestBaseModelRestApi(SupersetTestCase):
             }
         }
         self.assertEqual(response, expected_response)
+
+    def test_refuse_invalid_format_request(self):
+        """
+        API: Test invalid format of request
+
+        We want to make sure that non-JSON request are refused
+        """
+        self.login(username="admin")
+        uri = "api/v1/report/"  # endpoint decorated with @json_required
+        rv = self.client.post(
+            uri, data="a: value\nb: 1\n", content_type="application/yaml"
+        )
+        self.assertEqual(rv.status_code, 400)
 
     @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
     def test_default_missing_declaration_put(self):

--- a/tests/integration_tests/base_api_tests.py
+++ b/tests/integration_tests/base_api_tests.py
@@ -29,7 +29,7 @@ import tests.integration_tests.test_app
 from superset import db, security_manager
 from superset.extensions import appbuilder
 from superset.models.dashboard import Dashboard
-from superset.views.base_api import BaseSupersetModelRestApi, json_required
+from superset.views.base_api import BaseSupersetModelRestApi, requires_json
 
 from .base_tests import SupersetTestCase
 
@@ -161,7 +161,7 @@ class TestBaseModelRestApi(SupersetTestCase):
         We want to make sure that non-JSON request are refused
         """
         self.login(username="admin")
-        uri = "api/v1/report/"  # endpoint decorated with @json_required
+        uri = "api/v1/report/"  # endpoint decorated with @requires_json
         rv = self.client.post(
             uri, data="a: value\nb: 1\n", content_type="application/yaml"
         )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

During review #18151 there was a comment about code duplication of snippet like:

```python
        if not request.is_json:
            raise InvalidPayloadFormatError("Request is not JSON")
```

> Do we have a decorator for this? Might want to add one if not yet.

_Originally posted by @ktmud in https://github.com/apache/superset/pull/18151#discussion_r791180093_

I would like to get familiar with part of the codebase of the project written in Python, so I perceived that as a good first issue for a new contributor.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Python test handle all scenarios. I added a new one integration tests to verify behaviour of extracted decorator.
 
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: #18151
- [ ] Required feature flags: NO
- [ ] Changes UI: NO
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351)): NO
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API: NO
- [ ] Removes existing feature or API: NO

@ktmud, @michael-s-molina Can I request reviews? I am aware this is a trivial change, but I want to try to grab the project style & structure to be able to make bigger changes, and the beginning has to be somewhere.