### PR TITLE
fix: Default values getting cleared in native filters form

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
@@ -399,12 +399,12 @@ export function FiltersConfigModal({
         const didChangeFilterName =
           changes.filters &&
           Object.values(changes.filters).some(
-            (filter: any) => filter.name !== null,
+            (filter: any) => filter.name && filter.name !== null,
           );
         const didChangeSectionTitle =
           changes.filters &&
           Object.values(changes.filters).some(
-            (filter: any) => filter.title !== null,
+            (filter: any) => filter.title && filter.title !== null,
           );
         if (didChangeFilterName || didChangeSectionTitle) {
           // we only need to set this if a name/title changed


### PR DESCRIPTION
### SUMMARY
Fixes #18149

This PR fixes an issue for which existing default values were cleared after searching. It should also reduce the number of renders as the state was triggered unnecessarily.

### BEFORE

https://user-images.githubusercontent.com/60598000/150779993-ac602f0c-61e4-4064-a9f7-55d41812228e.mp4

### AFTER

https://user-images.githubusercontent.com/60598000/151223068-9bc5ed0b-4c28-4625-8eb1-229edcc39428.mp4

### TESTING INSTRUCTIONS
1. Open a Dashboard
2. Set default values in native filters
3. Try to search for a new value
4. Make sure the previously selected values do not disappear

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #18149
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
