### PR TITLE
fix: echarts area regression via bumping to 0.18.22

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -40,7 +40,7 @@
         "@superset-ui/legacy-preset-chart-big-number": "^0.18.19",
         "@superset-ui/legacy-preset-chart-deckgl": "^0.4.13",
         "@superset-ui/legacy-preset-chart-nvd3": "^0.18.19",
-        "@superset-ui/plugin-chart-echarts": "^0.18.19",
+        "@superset-ui/plugin-chart-echarts": "^0.18.22",
         "@superset-ui/plugin-chart-pivot-table": "^0.18.19",
         "@superset-ui/plugin-chart-table": "^0.18.19",
         "@superset-ui/plugin-chart-word-cloud": "^0.18.19",
@@ -11452,17 +11452,123 @@
       }
     },
     "node_modules/@superset-ui/plugin-chart-echarts": {
-      "version": "0.18.19",
-      "integrity": "sha512-qYNM//6b5+EewIejs+jSn76plahDFPlwHtyX1v0k2+WaSZM6GguT7sYW8a2dFG6mW4Jz7EchCSHwk7fs5DN7Iw==",
+      "version": "0.18.25",
+      "resolved": "https://registry.npmjs.org/@superset-ui/plugin-chart-echarts/-/plugin-chart-echarts-0.18.25.tgz",
+      "integrity": "sha512-vh9fu6UXh5EaFYpVpKf+LtRGyAykIANZfCVi5QhsfezSnfPlzDMaSJEDvEYACIayWMMcYzjzc87jrbyenHu3Mw==",
       "dependencies": {
-        "@superset-ui/chart-controls": "0.18.19",
-        "@superset-ui/core": "0.18.19",
+        "@superset-ui/chart-controls": "0.18.25",
+        "@superset-ui/core": "0.18.25",
         "d3-array": "^1.2.0",
         "echarts": "^5.2.2",
         "lodash": "^4.17.15"
       },
       "peerDependencies": {
         "react": "^16.13.1"
+      }
+    },
+    "node_modules/@superset-ui/plugin-chart-echarts/node_modules/@superset-ui/chart-controls": {
+      "version": "0.18.25",
+      "resolved": "https://registry.npmjs.org/@superset-ui/chart-controls/-/chart-controls-0.18.25.tgz",
+      "integrity": "sha512-zi2DJ2cTpgR1HugPX3yBHJAaBo7XYhodgZqj0BsKNMoexrLvHyPYsN+cw5xXFE1Q1ZyeKtQBB5m41+CKKfwQYw==",
+      "dependencies": {
+        "@react-icons/all-files": "^4.1.0",
+        "@superset-ui/core": "0.18.25",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@types/react": "*",
+        "antd": "^4.9.4",
+        "react": "^16.13.1",
+        "react-dom": "^16.13.1"
+      }
+    },
+    "node_modules/@superset-ui/plugin-chart-echarts/node_modules/@superset-ui/core": {
+      "version": "0.18.25",
+      "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.18.25.tgz",
+      "integrity": "sha512-b5ACrOuwriJ0SEQdsJuZYQfg+CjgfW2ZcVI3f0r8gK5HWmJnma5fBzc2VM/NGd0JIpCQSgfgoyXaVeFEXXD+dQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2",
+        "@types/d3-format": "^1.3.0",
+        "@types/d3-interpolate": "^1.3.1",
+        "@types/d3-scale": "^2.1.1",
+        "@types/d3-time": "^1.0.9",
+        "@types/d3-time-format": "^2.1.0",
+        "@types/lodash": "^4.14.149",
+        "@types/math-expression-evaluator": "^1.2.1",
+        "@types/rison": "0.0.6",
+        "@types/seedrandom": "^2.4.28",
+        "@vx/responsive": "^0.0.199",
+        "csstype": "^2.6.4",
+        "d3-format": "^1.3.2",
+        "d3-interpolate": "^1.4.0",
+        "d3-scale": "^3.0.0",
+        "d3-time": "^1.0.10",
+        "d3-time-format": "^2.2.0",
+        "fetch-retry": "^4.0.1",
+        "jed": "^1.1.1",
+        "lodash": "^4.17.11",
+        "math-expression-evaluator": "^1.3.8",
+        "pretty-ms": "^7.0.0",
+        "react-error-boundary": "^1.2.5",
+        "react-markdown": "^4.3.1",
+        "reselect": "^4.0.0",
+        "rison": "^0.1.1",
+        "seedrandom": "^3.0.5",
+        "whatwg-fetch": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@emotion/cache": "^11.4.0",
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "*",
+        "@types/react-loadable": "*",
+        "react": "^16.13.1",
+        "react-loadable": "^5.5.0"
+      }
+    },
+    "node_modules/@superset-ui/plugin-chart-echarts/node_modules/@vx/responsive": {
+      "version": "0.0.199",
+      "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.199.tgz",
+      "integrity": "sha512-ONrmLUAG+8wzD3cn/EmsuZh6JHeyejqup3ZsV25t04VaVJAVQAJukAfNdH8YiwSJu0zSo+txkBTfrnOmFyQLOw==",
+      "dependencies": {
+        "@types/lodash": "^4.14.146",
+        "@types/react": "*",
+        "lodash": "^4.17.10",
+        "prop-types": "^15.6.1",
+        "resize-observer-polyfill": "1.5.1"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0-0 || ^16.0.0-0"
+      }
+    },
+    "node_modules/@superset-ui/plugin-chart-echarts/node_modules/d3-scale": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
+      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
+      "dependencies": {
+        "d3-array": "^2.3.0",
+        "d3-format": "1 - 2",
+        "d3-interpolate": "1.2.0 - 2",
+        "d3-time": "^2.1.1",
+        "d3-time-format": "2 - 3"
+      }
+    },
+    "node_modules/@superset-ui/plugin-chart-echarts/node_modules/d3-scale/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/@superset-ui/plugin-chart-echarts/node_modules/d3-scale/node_modules/d3-time": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "dependencies": {
+        "d3-array": "2"
       }
     },
     "node_modules/@superset-ui/plugin-chart-pivot-table": {
@@ -47952,14 +48058,105 @@
       }
     },
     "@superset-ui/plugin-chart-echarts": {
-      "version": "0.18.19",
-      "integrity": "sha512-qYNM//6b5+EewIejs+jSn76plahDFPlwHtyX1v0k2+WaSZM6GguT7sYW8a2dFG6mW4Jz7EchCSHwk7fs5DN7Iw==",
+      "version": "0.18.25",
+      "resolved": "https://registry.npmjs.org/@superset-ui/plugin-chart-echarts/-/plugin-chart-echarts-0.18.25.tgz",
+      "integrity": "sha512-vh9fu6UXh5EaFYpVpKf+LtRGyAykIANZfCVi5QhsfezSnfPlzDMaSJEDvEYACIayWMMcYzjzc87jrbyenHu3Mw==",
       "requires": {
-        "@superset-ui/chart-controls": "0.18.19",
-        "@superset-ui/core": "0.18.19",
+        "@superset-ui/chart-controls": "0.18.25",
+        "@superset-ui/core": "0.18.25",
         "d3-array": "^1.2.0",
         "echarts": "^5.2.2",
         "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "@superset-ui/chart-controls": {
+          "version": "0.18.25",
+          "resolved": "https://registry.npmjs.org/@superset-ui/chart-controls/-/chart-controls-0.18.25.tgz",
+          "integrity": "sha512-zi2DJ2cTpgR1HugPX3yBHJAaBo7XYhodgZqj0BsKNMoexrLvHyPYsN+cw5xXFE1Q1ZyeKtQBB5m41+CKKfwQYw==",
+          "requires": {
+            "@react-icons/all-files": "^4.1.0",
+            "@superset-ui/core": "0.18.25",
+            "lodash": "^4.17.15",
+            "prop-types": "^15.7.2"
+          }
+        },
+        "@superset-ui/core": {
+          "version": "0.18.25",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.18.25.tgz",
+          "integrity": "sha512-b5ACrOuwriJ0SEQdsJuZYQfg+CjgfW2ZcVI3f0r8gK5HWmJnma5fBzc2VM/NGd0JIpCQSgfgoyXaVeFEXXD+dQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@types/math-expression-evaluator": "^1.2.1",
+            "@types/rison": "0.0.6",
+            "@types/seedrandom": "^2.4.28",
+            "@vx/responsive": "^0.0.199",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "math-expression-evaluator": "^1.3.8",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "react-markdown": "^4.3.1",
+            "reselect": "^4.0.0",
+            "rison": "^0.1.1",
+            "seedrandom": "^3.0.5",
+            "whatwg-fetch": "^3.0.0"
+          }
+        },
+        "@vx/responsive": {
+          "version": "0.0.199",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.199.tgz",
+          "integrity": "sha512-ONrmLUAG+8wzD3cn/EmsuZh6JHeyejqup3ZsV25t04VaVJAVQAJukAfNdH8YiwSJu0zSo+txkBTfrnOmFyQLOw==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
+        },
+        "d3-scale": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
+          "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
+          "requires": {
+            "d3-array": "^2.3.0",
+            "d3-format": "1 - 2",
+            "d3-interpolate": "1.2.0 - 2",
+            "d3-time": "^2.1.1",
+            "d3-time-format": "2 - 3"
+          },
+          "dependencies": {
+            "d3-array": {
+              "version": "2.12.1",
+              "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+              "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+              "requires": {
+                "internmap": "^1.0.0"
+              }
+            },
+            "d3-time": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+              "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+              "requires": {
+                "d3-array": "2"
+              }
+            }
+          }
+        }
       }
     },
     "@superset-ui/plugin-chart-pivot-table": {

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -92,7 +92,7 @@
     "@superset-ui/legacy-preset-chart-big-number": "^0.18.19",
     "@superset-ui/legacy-preset-chart-deckgl": "^0.4.13",
     "@superset-ui/legacy-preset-chart-nvd3": "^0.18.19",
-    "@superset-ui/plugin-chart-echarts": "^0.18.19",
+    "@superset-ui/plugin-chart-echarts": "^0.18.22",
     "@superset-ui/plugin-chart-pivot-table": "^0.18.19",
     "@superset-ui/plugin-chart-table": "^0.18.19",
     "@superset-ui/plugin-chart-word-cloud": "^0.18.19",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Attempting to resolve https://github.com/apache/superset/issues/18129 by bumping the Echarts package to 0.18.22. Note that this PR is against a branch I made based on the 1.4.0RC4 tag. Hopefully this commit can be applied cleanly to that release.

Not the usual process, but `master` has moved on to monorepo since that release was cut, so this requires a bit of time traveling gymnastics to fix/test.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![image](https://user-images.githubusercontent.com/812905/151299733-0565d0f9-fef9-4f78-aae0-1f1b1017eee1.png)

After:
![image](https://user-images.githubusercontent.com/812905/151299309-eab10fee-b39c-4101-8650-6e11f43b5441.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #18129
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
