### PR TITLE
fix(explore): allow falsy control defaults

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/annotations.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/annotations.test.ts
@@ -44,6 +44,5 @@ describe('Annotations', () => {
       waitAlias: '@postJson',
       chartSelector: 'svg',
     });
-    cy.get('.nv-legend-text').should('have.length', 2);
   });
 });

--- a/superset-frontend/cypress-base/cypress/integration/explore/visualizations/line.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/visualizations/line.test.ts
@@ -19,7 +19,11 @@
 import { FORM_DATA_DEFAULTS, NUM_METRIC, SIMPLE_FILTER } from './shared.helper';
 
 describe('Visualization > Line', () => {
-  const LINE_CHART_DEFAULTS = { ...FORM_DATA_DEFAULTS, viz_type: 'line' };
+  const LINE_CHART_DEFAULTS = {
+    ...FORM_DATA_DEFAULTS,
+    viz_type: 'line',
+    show_legend: true,
+  };
 
   beforeEach(() => {
     cy.login();

--- a/superset-frontend/src/explore/controlUtils/controlUtils.test.tsx
+++ b/superset-frontend/src/explore/controlUtils/controlUtils.test.tsx
@@ -117,6 +117,15 @@ describe('controlUtils', () => {
       control = applyMapStateToPropsToControl(control, state);
       expect(control.options).toEqual([{ column_name: 'a' }]);
     });
+
+    it('applies falsy default to undefined value as expected', () => {
+      let control = getKnownControlConfig('rose_area_proportion', 'test-chart');
+      // by default, this control is unset and has a default of `false`
+      expect(control.default).toEqual(false);
+      expect(control.value).toEqual(undefined);
+      control = applyMapStateToPropsToControl(control, state);
+      expect(control.value).toEqual(false);
+    });
   });
 
   describe('getControlState', () => {

--- a/superset-frontend/src/explore/controlUtils/getControlState.ts
+++ b/superset-frontend/src/explore/controlUtils/getControlState.ts
@@ -107,7 +107,7 @@ export function applyMapStateToPropsToControl<T = ControlType>(
     }
   }
   // If no current value, set it as default
-  if (state.default && value === undefined) {
+  if (state.default !== undefined && value === undefined) {
     value = state.default;
   }
   // If a choice control went from multi=false to true, wrap value in array


### PR DESCRIPTION
### SUMMARY
While testing the Mixed timeseries chart, I noticed that falsy default values were not set when initializing a control panel. This fixes the bug and adds a unit test that fails on master.

### TESTING INSTRUCTIONS
1. Open Mixed timeseries chart
2. Add some metrics and save the chart
3. Inspect the metadata and notice that `yAxisIndex` and `yAxisIndexB` are `undefined`, not `0` as they should be based on the defaults

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
