### PR TITLE
docs(docker compose installation): add pull command to avoid errors when installing superset using docker compose

### DIFF
--- a/docs/src/pages/docs/Connecting to Databases/docker-add-drivers.mdx
+++ b/docs/src/pages/docs/Connecting to Databases/docker-add-drivers.mdx
@@ -62,6 +62,7 @@ docker-compose up
 The other option is to start Superset via Docker Compose is using the recipe in `docker-compose-non-dev.yml`, which will use pre-built frontend assets and skip the building of front-end assets:
 
 ```
+docker-compose -f docker-compose-non-dev.yml pull
 docker-compose -f docker-compose-non-dev.yml up
 ```
 

--- a/docs/src/pages/docs/installation/index.mdx
+++ b/docs/src/pages/docs/installation/index.mdx
@@ -60,7 +60,11 @@ Navigate to the folder you created in step 1:
 $ cd superset
 ```
 
-Then, run the following command:
+Then, run the following commands:
+
+```bash
+$ docker-compose -f docker-compose-non-dev.yml pull
+```
 
 ```bash
 $ docker-compose -f docker-compose-non-dev.yml up


### PR DESCRIPTION
### SUMMARY
Add pull command to avoid errors when installing superset using docker compose. Fixes #17712.

### TESTING INSTRUCTIONS
Added screenshots with the updated documentation.

<img width="826" alt="docker-compose1" src="https://user-images.githubusercontent.com/5312198/151340596-992d8f1e-9631-46cc-ae12-e00570be03ae.png">

<img width="1200" alt="docker-compose2" src="https://user-images.githubusercontent.com/5312198/151340639-0c10670f-42d3-4354-b84f-def534caac0a.png">

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
