### PR TITLE
ci: Add CI for docs v2

### DIFF
--- a/.github/workflows/superset-docs-v2.yml
+++ b/.github/workflows/superset-docs-v2.yml
@@ -1,0 +1,31 @@
+name: Docs v2
+
+on:
+  push:
+    paths:
+      - "docs-v2/**"
+      - .github/workflows/superset-docs-v2.yml
+  pull_request:
+    paths:
+      - "docs-v2/**"
+      - .github/workflows/superset-docs-v2.yml
+
+jobs:
+  build-deploy:
+    name: Build & Deploy
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: docs-v2
+    steps:
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - name: yarn install
+        run: |
+          yarn install --immutable --immutable-cache --check-cache
+      - name: yarn build
+        run: |
+          yarn build


### PR DESCRIPTION
### SUMMARY

To ensure that our docs v2 build successfully every commit I suggest adding initial CI setup.

I can imagine applying some linting rules for documentation eg. validate links, validate referenced images (see #18090), but we need to start somewhere.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

You can see on GitHub Actions the results of the associated CI job.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

@geido, could you take a look?
