### PR TITLE
fix(tests): Remove walrus operator for Python 3.7 compatiblity

### DIFF
--- a/tests/example_data/data_loading/pandas/pandas_data_loader.py
+++ b/tests/example_data/data_loading/pandas/pandas_data_loader.py
@@ -74,8 +74,10 @@ class PandasDataLoader(DataLoader):
         return inspect(self._db_engine).default_schema_name
 
     def _take_data_types(self, table: Table) -> Optional[Dict[str, str]]:
-        if metadata_table := table.table_metadata:
-            if types := metadata_table.types:
+        metadata_table = table.table_metadata
+        if metadata_table:
+            types = metadata_table.types
+            if types:
                 return types
         return None
 


### PR DESCRIPTION
### SUMMARY

A new feature called assignment expressions has been added to Python v3.8. A new syntactical operator— “The Walrus Operator” is part of it. The syntax of it is not backward compatible.

The minimum Python version supported by Apache Superset is 3.7, so we can not use any v3.8+ non-backward compatible features of Python.

https://github.com/apache/superset/blob/568b8e160fc8f3d2965ec3ac8a6d0fd6f20a860f/setup.py#L172-L176

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

That code was introduced 9 days ago on master via #18060. PR was created by @ofekisr and accepted by @amitmiran137. Could you take a look here?