### PR TITLE
feat(docker-compose): add TAG option

### DIFF
--- a/docker-compose-non-dev.yml
+++ b/docker-compose-non-dev.yml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-x-superset-image: &superset-image apache/superset:latest-dev
+x-superset-image: &superset-image apache/superset:${TAG:-latest-dev}
 x-superset-depends-on: &superset-depends-on
   - db
   - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-x-superset-image: &superset-image apache/superset:latest-dev
+x-superset-image: &superset-image apache/superset:${TAG:-latest-dev}
 x-superset-user: &superset-user root
 x-superset-depends-on: &superset-depends-on
   - db

--- a/docs-v2/docs/connecting-to-databases/docker-add-drivers.mdx
+++ b/docs-v2/docs/connecting-to-databases/docker-add-drivers.mdx
@@ -62,6 +62,7 @@ docker-compose up
 The other option is to start Superset via Docker Compose is using the recipe in `docker-compose-non-dev.yml`, which will use pre-built frontend assets and skip the building of front-end assets:
 
 ```
+docker-compose -f docker-compose-non-dev.yml pull
 docker-compose -f docker-compose-non-dev.yml up
 ```
 

--- a/docs-v2/docs/installation/installing-superset-using-docker-compose.mdx
+++ b/docs-v2/docs/installation/installing-superset-using-docker-compose.mdx
@@ -58,10 +58,21 @@ Navigate to the folder you created in step 1:
 $ cd superset
 ```
 
-Then, run the following command:
+When working on master branch, run the following commands:
 
 ```bash
+$ docker-compose -f docker-compose-non-dev.yml pull
 $ docker-compose -f docker-compose-non-dev.yml up
+```
+
+Alternatively, you can also run a specific version of Superset by first checking out
+the branch/tag, and then starting `docker-compose` with the `TAG` variable.
+For example, to run the 1.4.0 version, run the following commands:
+
+```bash
+% git checkout 1.4.0
+$ TAG=1.4.0 docker-compose -f docker-compose-non-dev.yml pull
+$ TAG=1.4.0 docker-compose -f docker-compose-non-dev.yml up
 ```
 
 You should see a wall of logging output from the containers being launched on your machine. Once

--- a/docs/src/pages/docs/installation/index.mdx
+++ b/docs/src/pages/docs/installation/index.mdx
@@ -64,10 +64,17 @@ Then, run the following commands:
 
 ```bash
 $ docker-compose -f docker-compose-non-dev.yml pull
+$ docker-compose -f docker-compose-non-dev.yml up
 ```
 
+Alternatively, you can also run a specific version of Superset by first checking out
+the branch/tag, and then starting `docker-compose` with the `TAG` variable.
+For example, to run the 1.4.0 version, run the following commands:
+
 ```bash
-$ docker-compose -f docker-compose-non-dev.yml up
+% git checkout 1.4.0
+$ TAG=1.4.0 docker-compose -f docker-compose-non-dev.yml pull
+$ TAG=1.4.0 docker-compose -f docker-compose-non-dev.yml up
 ```
 
 You should see a wall of logging output from the containers being launched on your machine. Once


### PR DESCRIPTION
### SUMMARY

This PR adds a new environment variable `TAG` to both `docker-compose` configs to make it possible run a specific tag. In addition, the related doc changes from #18196 are copied over to the new docs site (forthcoming) to keep them in sync with the current docs.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Checkout an old release, e.g. 1.4.0
2. Apply the changes from this PR to the docker-compose yaml files
3. run `TAG=1.4.0 docker-compose -f docker-compose-non-dev.yml up` and watch the 1.4.0 version start up successfully

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
