### PR TITLE
feat(explore): Keep or reset chart config after datasource change

### DIFF
--- a/superset-frontend/src/explore/components/ControlPanelAlert.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelAlert.tsx
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import { styled } from '@superset-ui/core';
+import Button from 'src/components/Button';
+
+interface ControlPanelAlertI {
+  title: string;
+  bodyText: string;
+  primaryButtonAction: (e: React.MouseEvent) => void;
+  secondaryButtonAction?: (e: React.MouseEvent) => void;
+  primaryButtonText: string;
+  secondaryButtonText?: string;
+  type: 'info' | 'warning';
+}
+
+const AlertContainer = styled.div`
+  margin: ${({ theme }) => theme.gridUnit * 4}px;
+  padding: ${({ theme }) => theme.gridUnit * 4}px;
+
+  border: ${({ theme }) => `1px solid ${theme.colors.info.base}`};
+  background-color: ${({ theme }) => theme.colors.info.light2};
+  border-radius: 2px;
+
+  color: ${({ theme }) => theme.colors.info.dark2};
+  font-size: ${({ theme }) => theme.typography.sizes.s};
+
+  &.alert-type-warning {
+    border-color: ${({ theme }) => theme.colors.alert.base};
+    background-color: ${({ theme }) => theme.colors.alert.light2};
+
+    p {
+      color: ${({ theme }) => theme.colors.alert.dark2};
+    }
+  }
+`;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  button {
+    line-height: 1;
+  }
+`;
+
+const Title = styled.p`
+  font-weight: ${({ theme }) => theme.typography.weights.bold};
+`;
+
+export const ControlPanelAlert = ({
+  title,
+  bodyText,
+  primaryButtonAction,
+  secondaryButtonAction,
+  primaryButtonText,
+  secondaryButtonText,
+  type = 'info',
+}: ControlPanelAlertI) => (
+  <AlertContainer className={`alert-type-${type}`}>
+    <Title>{title}</Title>
+    <p>{bodyText}</p>
+    <ButtonContainer>
+      {secondaryButtonAction && secondaryButtonText && (
+        <Button
+          buttonStyle="link"
+          buttonSize="small"
+          onClick={secondaryButtonAction}
+        >
+          {secondaryButtonText}
+        </Button>
+      )}
+      <Button
+        buttonStyle={type === 'warning' ? 'warning' : 'primary'}
+        buttonSize="small"
+        onClick={primaryButtonAction}
+      >
+        {primaryButtonText}
+      </Button>
+    </ButtonContainer>
+  </AlertContainer>
+);

--- a/superset-frontend/src/explore/components/ControlPanelAlert.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelAlert.tsx
@@ -21,7 +21,7 @@ import React from 'react';
 import { styled } from '@superset-ui/core';
 import Button from 'src/components/Button';
 
-interface ControlPanelAlertI {
+interface ControlPanelAlertProps {
   title: string;
   bodyText: string;
   primaryButtonAction: (e: React.MouseEvent) => void;
@@ -72,7 +72,7 @@ export const ControlPanelAlert = ({
   primaryButtonText,
   secondaryButtonText,
   type = 'info',
-}: ControlPanelAlertI) => (
+}: ControlPanelAlertProps) => (
   <AlertContainer className={`alert-type-${type}`}>
     <Title>{title}</Title>
     <p>{bodyText}</p>

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.test.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { styledShallow as shallow } from 'spec/helpers/theming';
+import { render, screen } from 'spec/helpers/testing-library';
 import {
   DatasourceType,
   getChartControlPanelRegistry,
@@ -30,9 +30,7 @@ import {
   ControlPanelsContainerProps,
 } from 'src/explore/components/ControlPanelsContainer';
 
-describe('ControlPanelsContainer', () => {
-  let wrapper;
-
+describe('ControlPanelsContainer2', () => {
   beforeAll(() => {
     getChartControlPanelRegistry().registerValue('table', {
       controlPanelSections: [
@@ -96,9 +94,9 @@ describe('ControlPanelsContainer', () => {
   }
 
   it('renders ControlPanelSections', () => {
-    wrapper = shallow(<ControlPanelsContainer {...getDefaultProps()} />);
+    render(<ControlPanelsContainer {...getDefaultProps()} />);
     expect(
-      wrapper.find('[data-test="collapsible-control-panel"]'),
-    ).toHaveLength(5);
+      screen.getAllByTestId('collapsible-control-panel-header'),
+    ).toHaveLength(4);
   });
 });

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -17,7 +17,13 @@
  * under the License.
  */
 /* eslint camelcase: 0 */
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import {
   ensureIsArray,
   t,
@@ -196,6 +202,8 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
   >([]);
   const [showDatasourceAlert, setShowDatasourceAlert] = useState(false);
 
+  const containerRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     if (
       prevDatasource &&
@@ -203,6 +211,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
         props.exploreState.datasource?.type !== prevDatasource.type)
     ) {
       setShowDatasourceAlert(true);
+      containerRef.current?.scrollTo(0, 0);
     }
   }, [
     props.exploreState.datasource?.id,
@@ -428,7 +437,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
   const showCustomizeTab = customizeSections.length > 0;
 
   return (
-    <Styles>
+    <Styles ref={containerRef}>
       <ControlPanelsTabs
         id="controlSections"
         data-test="control-tabs"

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -399,9 +399,9 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
     () =>
       hasControlsTransferred ? (
         <ControlPanelAlert
-          title={t('Keep settings and filters?')}
+          title={t('Keep control settings?')}
           bodyText={t(
-            'You’ve changed the chart vizualisation. The data relevant to this chart type was maintained.',
+            "You've changed datasets. Any controls with data (columns, metrics) that match this new dataset have been retained.",
           )}
           primaryButtonAction={handleContinueClick}
           secondaryButtonAction={handleClearFormClick}
@@ -413,7 +413,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
         <ControlPanelAlert
           title={t('No form settings were maintained')}
           bodyText={t(
-            'We were unable to maintain the filters and metrics you had applied to the previous dataset.',
+            'We were unable to carry over any controls when switching to this new dataset.',
           )}
           primaryButtonAction={handleContinueClick}
           primaryButtonText={t('Continue')}

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -21,6 +21,7 @@ import React, {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -188,18 +189,6 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
 
   const prevDatasource = usePrevious(props.exploreState.datasource);
 
-  const [expandedQuerySections, setExpandedQuerySections] = useState<string[]>(
-    [],
-  );
-  const [expandedCustomizeSections, setExpandedCustomizeSections] = useState<
-    string[]
-  >([]);
-  const [querySections, setQuerySections] = useState<
-    ControlPanelSectionConfig[]
-  >([]);
-  const [customizeSections, setCustomizeSections] = useState<
-    ControlPanelSectionConfig[]
-  >([]);
   const [showDatasourceAlert, setShowDatasourceAlert] = useState(false);
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -219,22 +208,24 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
     prevDatasource,
   ]);
 
-  useEffect(() => {
-    const {
-      expandedQuerySections: newExpandedQuerySections,
-      expandedCustomizeSections: newExpandedCustomizeSections,
-      querySections: newQuerySections,
-      customizeSections: newCustomizeSections,
-    } = getState(
+  const {
+    expandedQuerySections,
+    expandedCustomizeSections,
+    querySections,
+    customizeSections,
+  } = useMemo(
+    () =>
+      getState(
+        props.form_data.viz_type,
+        props.exploreState.datasource,
+        props.datasource_type,
+      ),
+    [
+      props.form_data.datasource,
       props.form_data.viz_type,
-      props.exploreState.datasource,
       props.datasource_type,
-    );
-    setExpandedQuerySections(newExpandedQuerySections);
-    setExpandedCustomizeSections(newExpandedCustomizeSections);
-    setQuerySections(newQuerySections);
-    setCustomizeSections(newCustomizeSections);
-  }, [props.form_data.datasource, props.form_data.viz_type]);
+    ],
+  );
 
   const resetTransferredControls = useCallback(() => {
     ensureIsArray(props.exploreState.controlsTransferred).forEach(controlName =>
@@ -446,12 +437,10 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
         <Tabs.TabPane key="query" tab={t('Data')}>
           <Collapse
             bordered
-            activeKey={expandedQuerySections}
+            defaultActiveKey={expandedQuerySections}
             expandIconPosition="right"
-            onChange={selection => {
-              setExpandedQuerySections(ensureIsArray(selection));
-            }}
             ghost
+            key={`query-sections-${props.form_data.datasource}-${props.form_data.viz_type}`}
           >
             {showDatasourceAlert && <DatasourceAlert />}
             {querySections.map(renderControlPanelSection)}
@@ -461,12 +450,10 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
           <Tabs.TabPane key="display" tab={t('Customize')}>
             <Collapse
               bordered
-              activeKey={expandedCustomizeSections}
+              defaultActiveKey={expandedCustomizeSections}
               expandIconPosition="right"
-              onChange={selection => {
-                setExpandedCustomizeSections(ensureIsArray(selection));
-              }}
               ghost
+              key={`customize-sections-${props.form_data.datasource}-${props.form_data.viz_type}`}
             >
               {customizeSections.map(renderControlPanelSection)}
             </Collapse>

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -18,8 +18,7 @@
  */
 /* eslint camelcase: 0 */
 import React, { useCallback, useContext, useEffect, useState } from 'react';
-import { bindActionCreators } from 'redux';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import {
   ensureIsArray,
   t,
@@ -46,10 +45,7 @@ import Loading from 'src/components/Loading';
 
 import { usePrevious } from 'src/hooks/usePrevious';
 import { getSectionsToRender } from 'src/explore/controlUtils';
-import {
-  ExploreActions,
-  exploreActions,
-} from 'src/explore/actions/exploreActions';
+import { ExploreActions } from 'src/explore/actions/exploreActions';
 import { ExplorePageState } from 'src/explore/reducers/getInitialState';
 import { ChartState } from 'src/explore/types';
 
@@ -184,8 +180,6 @@ function getState(
 
 export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
   const pluginContext = useContext(PluginContext);
-  const dispatch = useDispatch();
-  const actions = bindActionCreators(exploreActions, dispatch);
   const exploreState = useSelector<
     ExplorePageState,
     ExplorePageState['explore']
@@ -236,9 +230,12 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
 
   const resetTransferredControls = useCallback(() => {
     ensureIsArray(exploreState.controlsTransferred).forEach(controlName =>
-      actions.setControlValue(controlName, props.controls[controlName].default),
+      props.actions.setControlValue(
+        controlName,
+        props.controls[controlName].default,
+      ),
     );
-  }, [actions, exploreState.controlsTransferred, props.controls]);
+  }, [props.actions, exploreState.controlsTransferred, props.controls]);
 
   const handleClearFormClick = useCallback(() => {
     resetTransferredControls();
@@ -283,7 +280,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
         key={`control-${name}`}
         name={name}
         validationErrors={validationErrors}
-        actions={actions}
+        actions={props.actions}
         {...restProps}
       />
     );

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -260,7 +260,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
       // re-render, we only run this when the chart plugin explicitly ask for this.
       ...(config.mapStateToProps?.length === 3
         ? // @ts-ignore /* The typing accuses of having an extra parameter. I didn't remove it because I believe it could be an error in the types and not in the code */
-          config.mapStateToProps(exploreState, controls[name], chart)
+          config.mapStateToProps(props.exploreState, controls[name], chart)
         : // for other controls, `mapStateToProps` is already run in
           // controlUtils/getControlState.ts
           undefined),

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -246,7 +246,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
   }, []);
 
   const renderControl = ({ name, config }: CustomControlItem) => {
-    const { controls, chart } = props;
+    const { controls, chart, exploreState } = props;
     const { visibility } = config;
 
     // If the control item is not an object, we have to look up the control data from
@@ -259,8 +259,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
       // state, too. Since it's may be expensive to run mapStateToProps for every
       // re-render, we only run this when the chart plugin explicitly ask for this.
       ...(config.mapStateToProps?.length === 3
-        ? // @ts-ignore /* The typing accuses of having an extra parameter. I didn't remove it because I believe it could be an error in the types and not in the code */
-          config.mapStateToProps(props.exploreState, controls[name], chart)
+        ? config.mapStateToProps(exploreState, controls[name], chart)
         : // for other controls, `mapStateToProps` is already run in
           // controlUtils/getControlState.ts
           undefined),

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -612,6 +612,7 @@ function ExploreViewContainer(props) {
           actions={props.actions}
           form_data={props.form_data}
           controls={props.controls}
+          chart={props.chart}
           datasource_type={props.datasource_type}
           isDatasourceMetaLoading={props.isDatasourceMetaLoading}
         />

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -609,6 +609,7 @@ function ExploreViewContainer(props) {
           datasourceType={props.datasource_type}
         />
         <ConnectedControlPanelsContainer
+          exploreState={props.exploreState}
           actions={props.actions}
           form_data={props.form_data}
           controls={props.controls}
@@ -674,6 +675,7 @@ function mapStateToProps(state) {
     ownState: dataMask[form_data.slice_id ?? 0]?.ownState, // 0 - unsaved chart
     impressionId,
     user: explore.user,
+    exploreState: explore,
     reports,
   };
 }

--- a/superset-frontend/src/explore/controlUtils/getControlValuesCompatibleWithDatasource.ts
+++ b/superset-frontend/src/explore/controlUtils/getControlValuesCompatibleWithDatasource.ts
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  ControlState,
+  DatasourceMeta,
+  Metric,
+} from '@superset-ui/chart-controls';
+import {
+  Column,
+  isAdhocMetricSimple,
+  isSavedMetric,
+  isSimpleAdhocFilter,
+  JsonValue,
+  SimpleAdhocFilter,
+} from '@superset-ui/core';
+import AdhocMetric from 'src/explore/components/controls/MetricControl/AdhocMetric';
+
+const isControlValueCompatibleWithDatasource = (
+  datasource: DatasourceMeta,
+  controlState: ControlState,
+  value: any,
+) => {
+  if (controlState.options && typeof value === 'string') {
+    if (
+      (Array.isArray(controlState.options) &&
+        controlState.options.some(
+          (option: [string | number, string]) => option[0] === value,
+        )) ||
+      value in controlState.options
+    ) {
+      return datasource.columns.some(column => column.column_name === value);
+    }
+  }
+  if (
+    controlState.savedMetrics &&
+    isSavedMetric(value) &&
+    controlState.savedMetrics.some(
+      (savedMetric: Metric) => savedMetric.metric_name === value,
+    )
+  ) {
+    return datasource.metrics.some(
+      (metric: Metric) => metric.metric_name === value,
+    );
+  }
+  if (
+    controlState.columns &&
+    (isAdhocMetricSimple(value) || isSimpleAdhocFilter(value)) &&
+    controlState.columns.some(
+      (column: Column) =>
+        column.column_name === (value as AdhocMetric).column?.column_name ||
+        column.column_name === (value as SimpleAdhocFilter).subject,
+    )
+  ) {
+    return datasource.columns.some(
+      (column: Column) =>
+        column.column_name === (value as AdhocMetric).column?.column_name ||
+        column.column_name === (value as SimpleAdhocFilter).subject,
+    );
+  }
+  return false;
+};
+
+export const getControlValuesCompatibleWithDatasource = (
+  datasource: DatasourceMeta,
+  controlState: ControlState,
+  value: JsonValue,
+) => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (Array.isArray(value)) {
+    const compatibleValues = value.filter(val =>
+      isControlValueCompatibleWithDatasource(datasource, controlState, val),
+    );
+    return compatibleValues.length > 0
+      ? compatibleValues
+      : controlState.default;
+  }
+  return isControlValueCompatibleWithDatasource(datasource, controlState, value)
+    ? value
+    : controlState.default;
+};

--- a/superset-frontend/src/explore/controlUtils/index.ts
+++ b/superset-frontend/src/explore/controlUtils/index.ts
@@ -20,3 +20,4 @@ export * from './getSectionsToRender';
 export * from './getControlConfig';
 export * from './getControlState';
 export * from './getFormDataFromControls';
+export * from './getControlValuesCompatibleWithDatasource';

--- a/superset-frontend/src/explore/reducers/getInitialState.ts
+++ b/superset-frontend/src/explore/reducers/getInitialState.ts
@@ -36,7 +36,7 @@ import {
   applyMapStateToPropsToControl,
 } from 'src/explore/controlUtils';
 
-export interface ExlorePageBootstrapData extends JsonObject {
+export interface ExplorePageBootstrapData extends JsonObject {
   can_add: boolean;
   can_download: boolean;
   can_overwrite: boolean;
@@ -53,7 +53,7 @@ export interface ExlorePageBootstrapData extends JsonObject {
 }
 
 export default function getInitialState(
-  bootstrapData: ExlorePageBootstrapData,
+  bootstrapData: ExplorePageBootstrapData,
 ) {
   const { form_data: initialFormData } = bootstrapData;
   const { slice } = bootstrapData;
@@ -76,6 +76,7 @@ export default function getInitialState(
       bootstrapData,
       initialFormData,
     ) as ControlStateMapping,
+    controlsTransferred: [],
   };
 
   // apply initial mapStateToProps for all controls, must execute AFTER


### PR DESCRIPTION
### SUMMARY
Currently, when user switches datasource, controls such as metrics, group by, filters etc. are being reset. This PR changes that behaviour - after switching datasource, controls that use columns or saved metrics that are present in both previous and current datasource are preserved. After that, we display an alert that let's user decide if they want to reset the chart config or keep the changes. If there were no controls using columns nor metrics that matched the new dataset, we display a "warning" alert that informs user that chart config was reset.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/15073128/151549614-98b0baa9-2635-4c33-8908-1f255ba5ae0b.mov

https://user-images.githubusercontent.com/15073128/151549652-ff6caa55-23e4-494c-9e27-96084863f9f9.mov

EDIT: new copy
![image](https://user-images.githubusercontent.com/15073128/151557817-7f0a648d-59a6-41cc-8f7c-6d44f2e7fb1e.png)
![image](https://user-images.githubusercontent.com/15073128/151557877-c7b5ab9f-9f7c-4772-8339-0f108efbbf4d.png)

### TESTING INSTRUCTIONS
0. Turn on drag and drop feature flag
1. Open a chart
2. Add some columns and metrics to controls
3. Change dataset
4. If some of the columns or metrics that you used in controls are present in the new dataset, those controls should keep their state and an info alert should appear with 2 button - "Clear form" and "Continue". Clicking "Continue" should close the alert, clicking "Clear form" should reset the controls and close the alert.
5. If none of the columns or metrics that you used in controls are present in the new dataset, a warning alert should appear with button "Continue", that closes the alert.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #17010 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @kasiazjc

https://app.shortcut.com/preset/story/34087/gh-17010-prod-95-keep-chart-config-when-changing-data-source