### PR TITLE
fix(explore): Pie chart label formatting when series is temporal

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -88,9 +88,6 @@ export function formatSeriesName(
   if (name === undefined || name === null) {
     return NULL_STRING;
   }
-  if (typeof name === 'number') {
-    return numberFormatter ? numberFormatter(name) : name.toString();
-  }
   if (typeof name === 'boolean') {
     return name.toString();
   }
@@ -98,6 +95,9 @@ export function formatSeriesName(
     const d = name instanceof Date ? name : new Date(name);
 
     return timeFormatter ? timeFormatter(d) : d.toISOString();
+  }
+  if (typeof name === 'number') {
+    return numberFormatter ? numberFormatter(name) : name.toString();
   }
   return name;
 }


### PR DESCRIPTION
### SUMMARY
When the label formatting was deciding whether to use number formatter or time formatter, it first checked if value is a number and if not, it checked if value is Date or column type is temporal. Timestamp values are numbers, so the first condition was true and number formatter was being used for timestamps. This PR switches the order of checks so that we first check if column is temporal.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see linked issue
After:
![image](https://user-images.githubusercontent.com/15073128/151553415-b7e6de4f-25dc-436c-b16a-4977f4b0e937.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Create a Pie chart
2. Select a temporal column as group by
3. Verify that label names are formatted properly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [] Has associated issue: #13293
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @rusackas 

https://app.shortcut.com/preset/story/34104/gh-13293-prod-37-pie-chart-date-format