### PR TITLE
fix(plugin-chart-echarts): use verbose x-axis name when defined

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -127,7 +127,7 @@ export default function transformProps(
   }: EchartsTimeseriesFormData = { ...DEFAULT_FORM_DATA, ...formData };
   const colorScale = CategoricalColorNamespace.getScale(colorScheme as string);
   const rebasedData = rebaseTimeseriesDatum(data, verboseMap);
-  const xAxisCol = xAxisOrig || DTTM_ALIAS;
+  const xAxisCol = verboseMap[xAxisOrig] || xAxisOrig || DTTM_ALIAS;
   const rawSeries = extractSeries(rebasedData, {
     fillNeighborValue: stack && !forecastEnabled ? 0 : undefined,
     xAxis: xAxisCol,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### AFTER
Now x-axis columns with a verbose name work as expected:
![image](https://user-images.githubusercontent.com/33317356/151556139-c163d420-7df6-43d6-8d60-0a4eab4aa80c.png)

### BEFORE
Before the x-axis in the series data would be undefined, causing a broken chart:
![image](https://user-images.githubusercontent.com/33317356/151556227-eb75560a-1887-407c-a5d5-8a6ea3b9a7a4.png)

### TESTING INSTRUCTIONS
1. Enable `GENERIC_AXES` feature flag
2. Open the FCC examples dataset
3. Create an ECharts Line, Bar or other similar chart with "Ethnic minority" sa the x-axis.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
