### PR TITLE
fix: Add mexico back to country map

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-country-map/src/countries.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-country-map/src/countries.ts
@@ -47,6 +47,7 @@ import lithuania from './countries/lithuania.geojson';
 import nigeria from './countries/nigeria.geojson';
 import norway from './countries/norway.geojson';
 import malaysia from './countries/malaysia.geojson';
+import mexico from './countries/mexico.geojson';
 import morocco from './countries/morocco.geojson';
 import myanmar from './countries/myanmar.geojson';
 import netherlands from './countries/netherlands.geojson';
@@ -104,6 +105,7 @@ export const countries = {
   liechtenstein,
   lithuania,
   malaysia,
+  mexico,
   morocco,
   myanmar,
   netherlands,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
https://github.com/apache/superset/pull/18081 accidentally removed mexico from the map (probably a bad merge resolution). Adding it back

### TESTING INSTRUCTIONS
CI

to: @ktmud @zhaoyongjie 
