### PR TITLE
fix(alert): remove extra < character in email report

### DIFF
--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -106,7 +106,6 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
                 f"""<div class="image">
                     <img width="1000px" src="cid:{msgid}">
                 </div>
-                <
                 """
             )
         img_tag = "".join(img_tags)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Remove extra `<` character in the alert email.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1005" alt="Screen_Shot_2022-01-28_at_11_24_30_PM" src="https://user-images.githubusercontent.com/27990562/151653353-b87f4786-025e-43d4-82d4-1f3bc122e20e.png">



### TESTING INSTRUCTIONS
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #17749 

