### PR TITLE
chore: Docusaurus throw on broken links

### DIFF
--- a/docs-v2/docs/connecting-to-databases/bigquery.mdx
+++ b/docs-v2/docs/connecting-to-databases/bigquery.mdx
@@ -12,7 +12,7 @@ The recommended connector library for BigQuery is
 
 ### Install BigQuery Driver
 
-Follow the steps [here](/docs/databases/dockeradddrivers) about how to
+Follow the steps [here](/docs/connecting-to-databases/docker-add-drivers) about how to
 install new database drivers when setting up Superset locally via docker-compose.
 
 ```

--- a/docs-v2/docs/connecting-to-databases/docker-add-drivers.mdx
+++ b/docs-v2/docs/connecting-to-databases/docker-add-drivers.mdx
@@ -20,7 +20,7 @@ with the recommended connector library for each database.
 
 ### 1. Determine the driver you need
 
-To figure out how to install the [database driver](/docs/databases/installing-database-drivers) of your choice.
+To figure out how to install the [database driver](/docs/connecting-to-databases/installing-database-drivers) of your choice.
 
 In the example, we'll walk through the process of installing a MySQL driver in Superset.
 

--- a/docs-v2/docs/connecting-to-databases/installing-database-drivers.mdx
+++ b/docs-v2/docs/connecting-to-databases/installing-database-drivers.mdx
@@ -10,7 +10,7 @@ version: 1
 Superset requires a Python DB-API database driver and a SQLAlchemy
 dialect to be installed for each datastore you want to connect to.
 
-You can read more [here](/docs/connecting-to-databases/dockeradddrivers) about how to
+You can read more [here](/docs/connecting-to-databases/docker-add-drivers) about how to
 install new database drivers into your Superset configuration.
 
 ### Supported Databases and Dependencies

--- a/docs-v2/docusaurus.config.js
+++ b/docs-v2/docusaurus.config.js
@@ -30,8 +30,8 @@ const config = {
     'Apache Superset is a modern data exploration and visualization platform',
   url: 'https://superset.apache.org',
   baseUrl: '/',
-  onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
+  onBrokenLinks: 'throw',
+  onBrokenMarkdownLinks: 'throw',
   favicon: 'img/favicon.ico',
   organizationName: 'apache', // Usually your GitHub org/user name.
   projectName: 'superset', // Usually your repo name.


### PR DESCRIPTION
### SUMMARY
This PR brings back the configuration of broken links to throw errors when found. This should guarantee that the docs will always have working links. 

This PR also fixes some additional broken links found during the build, that should now succeed without any error.

### TESTING INSTRUCTIONS
1. Build the docs with `npm run build`
2. Make sure the build is successful

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
