### PR TITLE
fix(listview): add nowrap to view mode container

### DIFF
--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -136,6 +136,7 @@ const bulkSelectColumnConfig = {
 const ViewModeContainer = styled.div`
   padding-right: ${({ theme }) => theme.gridUnit * 4}px;
   margin-top: ${({ theme }) => theme.gridUnit * 5 + 1}px;
+  white-space: nowrap;
   display: inline-block;
 
   .toggle-button {


### PR DESCRIPTION
### SUMMARY
Add `white-space: nowrap;` to the listview view mode container to prevent the buttons from line wrapping.

### AFTER
![image](https://user-images.githubusercontent.com/33317356/151976188-de0f2d36-fe2c-40f8-93f7-1a0e5d60861f.png)

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/151976227-b8942403-dcef-4e28-b633-287d3fd22c0c.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #18239
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
