### PR TITLE
fix: sqllab schema select error msg

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -775,8 +775,10 @@ export function queryEditorSetDb(queryEditor, dbId) {
 }
 
 export function queryEditorSetSchema(queryEditor, schema) {
+  console.log('queryEditor', typeof queryEditor, '---schema -->', schema)
   return function (dispatch) {
-    const sync = isFeatureEnabled(FeatureFlag.SQLLAB_BACKEND_PERSISTENCE)
+    console.log('featureflag *******', isFeatureEnabled(FeatureFlag.SQLLAB_BACKEND_PERSISTENCE))
+    const sync = isFeatureEnabled(FeatureFlag.SQLLAB_BACKEND_PERSISTENCE) && typeof queryEditor === 'object'
       ? SupersetClient.put({
           endpoint: encodeURI(`/tabstateview/${queryEditor.id}`),
           postPayload: { schema },

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -776,12 +776,14 @@ export function queryEditorSetDb(queryEditor, dbId) {
 
 export function queryEditorSetSchema(queryEditor, schema) {
   return function (dispatch) {
-    const sync = isFeatureEnabled(FeatureFlag.SQLLAB_BACKEND_PERSISTENCE) && typeof queryEditor === 'object'
-      ? SupersetClient.put({
-          endpoint: encodeURI(`/tabstateview/${queryEditor.id}`),
-          postPayload: { schema },
-        })
-      : Promise.resolve();
+    const sync =
+      isFeatureEnabled(FeatureFlag.SQLLAB_BACKEND_PERSISTENCE) &&
+      typeof queryEditor === 'object'
+        ? SupersetClient.put({
+            endpoint: encodeURI(`/tabstateview/${queryEditor.id}`),
+            postPayload: { schema },
+          })
+        : Promise.resolve();
 
     return sync
       .then(() =>

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -775,9 +775,7 @@ export function queryEditorSetDb(queryEditor, dbId) {
 }
 
 export function queryEditorSetSchema(queryEditor, schema) {
-  console.log('queryEditor', typeof queryEditor, '---schema -->', schema)
   return function (dispatch) {
-    console.log('featureflag *******', isFeatureEnabled(FeatureFlag.SQLLAB_BACKEND_PERSISTENCE))
     const sync = isFeatureEnabled(FeatureFlag.SQLLAB_BACKEND_PERSISTENCE) && typeof queryEditor === 'object'
       ? SupersetClient.put({
           endpoint: encodeURI(`/tabstateview/${queryEditor.id}`),


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This pr fixes and issue where if the sqllab backend persistence flag is on the param being passed into the dispatch function is not always a object and will subsequently caused the call to fail.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before
<img width="1611" alt="Screen Shot 2022-02-02 at 9 33 35 PM" src="https://user-images.githubusercontent.com/17326228/152287156-fa6bd5f9-44ca-4a1b-a490-8fffa9f278c6.png">

after

https://user-images.githubusercontent.com/17326228/152286717-1aa52a70-643a-428e-b5af-f9715383b57e.mov




### TESTING INSTRUCTIONS
Go to sql lab and click the schema and database selects. The error toast should not show.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
