### PR TITLE
fix(plugin-chart-echarts): area chart opacity bug

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -40,7 +40,7 @@
         "@superset-ui/legacy-preset-chart-big-number": "^0.18.19",
         "@superset-ui/legacy-preset-chart-deckgl": "^0.4.13",
         "@superset-ui/legacy-preset-chart-nvd3": "^0.18.19",
-        "@superset-ui/plugin-chart-echarts": "^0.18.19",
+        "@superset-ui/plugin-chart-echarts": "^0.18.19-1",
         "@superset-ui/plugin-chart-pivot-table": "^0.18.19",
         "@superset-ui/plugin-chart-table": "^0.18.19",
         "@superset-ui/plugin-chart-word-cloud": "^0.18.19",
@@ -11452,8 +11452,9 @@
       }
     },
     "node_modules/@superset-ui/plugin-chart-echarts": {
-      "version": "0.18.19",
-      "integrity": "sha512-qYNM//6b5+EewIejs+jSn76plahDFPlwHtyX1v0k2+WaSZM6GguT7sYW8a2dFG6mW4Jz7EchCSHwk7fs5DN7Iw==",
+      "version": "0.18.19-1",
+      "resolved": "https://registry.npmjs.org/@superset-ui/plugin-chart-echarts/-/plugin-chart-echarts-0.18.19-1.tgz",
+      "integrity": "sha512-4nXvANZWPAicWPaRXJwiR6rsVrMZaAYzzvIexgRbZ4BZaydrCSAuCNs33lGuKHBAwQLTxpfVPnbQJchsbLartA==",
       "dependencies": {
         "@superset-ui/chart-controls": "0.18.19",
         "@superset-ui/core": "0.18.19",
@@ -47952,8 +47953,9 @@
       }
     },
     "@superset-ui/plugin-chart-echarts": {
-      "version": "0.18.19",
-      "integrity": "sha512-qYNM//6b5+EewIejs+jSn76plahDFPlwHtyX1v0k2+WaSZM6GguT7sYW8a2dFG6mW4Jz7EchCSHwk7fs5DN7Iw==",
+      "version": "0.18.19-1",
+      "resolved": "https://registry.npmjs.org/@superset-ui/plugin-chart-echarts/-/plugin-chart-echarts-0.18.19-1.tgz",
+      "integrity": "sha512-4nXvANZWPAicWPaRXJwiR6rsVrMZaAYzzvIexgRbZ4BZaydrCSAuCNs33lGuKHBAwQLTxpfVPnbQJchsbLartA==",
       "requires": {
         "@superset-ui/chart-controls": "0.18.19",
         "@superset-ui/core": "0.18.19",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -92,7 +92,7 @@
     "@superset-ui/legacy-preset-chart-big-number": "^0.18.19",
     "@superset-ui/legacy-preset-chart-deckgl": "^0.4.13",
     "@superset-ui/legacy-preset-chart-nvd3": "^0.18.19",
-    "@superset-ui/plugin-chart-echarts": "^0.18.19",
+    "@superset-ui/plugin-chart-echarts": "^0.18.19-1",
     "@superset-ui/plugin-chart-pivot-table": "^0.18.19",
     "@superset-ui/plugin-chart-table": "^0.18.19",
     "@superset-ui/plugin-chart-word-cloud": "^0.18.19",


### PR DESCRIPTION
### SUMMARY
Cherry-pick https://github.com/apache-superset/superset-ui/pull/1464 into the 1.4 branch using a custom post-release of the 0.18.19 `@superset-ui/plugin-chart-echarts` release.

### SCREENSHOTS
With the fix, ECharts area charts now work as expected:
![image](https://user-images.githubusercontent.com/33317356/152314836-12f39c2a-2d9b-4018-b20f-04946525094f.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #18129
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
