### PR TITLE
fix(mssql): support cte in virtual tables

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -292,6 +292,11 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     # But for backward compatibility, False by default
     allows_hidden_cc_in_orderby = False
 
+    # Whether allow CTE as subquery or regular CTE
+    # If True, then it will allow  in subquery ,
+    # if False it will allow as regular CTE
+    allows_cte_in_subquery = True
+
     force_column_alias_quotes = False
     arraysize = 0
     max_column_name_length = 0

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -690,10 +690,9 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
 
             # extract rest of the SQLs after CTE
             remainder = u"".join(str(tok) for tok in p.tokens[idx:])
-
-            __query = "WITH " + tok.value + ", __query as ( " + remainder + ")"
-            __query = sqlparse.format(__query, reindent=True, keyword_case='upper')
+            __query = "WITH " + tok.value + ",\n__query as (" + remainder + ")"
             return __query
+        
         return None
 
     @classmethod

--- a/superset/db_engine_specs/mssql.py
+++ b/superset/db_engine_specs/mssql.py
@@ -24,8 +24,6 @@ from flask_babel import gettext as __
 from superset.db_engine_specs.base import BaseEngineSpec, LimitMethod
 from superset.errors import SupersetErrorType
 from superset.utils import core as utils
-import sqlparse
-from sqlparse.tokens import Keyword, CTE
 
 logger = logging.getLogger(__name__)
 

--- a/superset/db_engine_specs/mssql.py
+++ b/superset/db_engine_specs/mssql.py
@@ -137,36 +137,6 @@ class MssqlEngineSpec(BaseEngineSpec):
             )
         return f"{cls.engine} error: {cls._extract_error_message(ex)}"
 
-    @classmethod
-    def get_cte_query(cls, sql) -> Optional[str]:
-        """
-            Returns the wrapped CTE
-        """
-        if not cls.allows_cte_in_subquery:
-            p = sqlparse.parse(sql)[0]
-
-            # The first meaningful token for CTE will be with WITH
-            idx, tok = p.token_next(-1, skip_ws=True, skip_cm=True)
-            if not (tok and tok.ttype == CTE):
-                return None
-            idx, tok = p.token_next(idx)
-            idx = p.token_index(tok) + 1
-
-            # extarct rest of the SQLs after CTE
-            remainder = u"".join(str(tok) for tok in p.tokens[idx:])
-
-            __query = "WITH " + tok.value + ", __query as ( " + remainder + ")"
-            __query = sqlparse.format(__query, reindent=True, keyword_case='upper')
-            return __query
-        return None
-
-    @classmethod
-    def test_cte_sql(cls):
-        sql = """
-        select * from currency
-        """
-        sql = cls.get_cte_prequery(sql)
-        print(sql)
 
 class AzureSynapseSpec(MssqlEngineSpec):
     engine = "mssql"

--- a/superset/db_engine_specs/mssql.py
+++ b/superset/db_engine_specs/mssql.py
@@ -24,6 +24,8 @@ from flask_babel import gettext as __
 from superset.db_engine_specs.base import BaseEngineSpec, LimitMethod
 from superset.errors import SupersetErrorType
 from superset.utils import core as utils
+import sqlparse
+from sqlparse.tokens import Keyword, CTE
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +49,7 @@ class MssqlEngineSpec(BaseEngineSpec):
     engine_name = "Microsoft SQL Server"
     limit_method = LimitMethod.WRAP_SQL
     max_column_name_length = 128
+    allows_cte_in_subquery = False
 
     _time_grain_expressions = {
         None: "{col}",
@@ -134,6 +137,36 @@ class MssqlEngineSpec(BaseEngineSpec):
             )
         return f"{cls.engine} error: {cls._extract_error_message(ex)}"
 
+    @classmethod
+    def get_cte_query(cls, sql) -> Optional[str]:
+        """
+            Returns the wrapped CTE
+        """
+        if not cls.allows_cte_in_subquery:
+            p = sqlparse.parse(sql)[0]
+
+            # The first meaningful token for CTE will be with WITH
+            idx, tok = p.token_next(-1, skip_ws=True, skip_cm=True)
+            if not (tok and tok.ttype == CTE):
+                return None
+            idx, tok = p.token_next(idx)
+            idx = p.token_index(tok) + 1
+
+            # extarct rest of the SQLs after CTE
+            remainder = u"".join(str(tok) for tok in p.tokens[idx:])
+
+            __query = "WITH " + tok.value + ", __query as ( " + remainder + ")"
+            __query = sqlparse.format(__query, reindent=True, keyword_case='upper')
+            return __query
+        return None
+
+    @classmethod
+    def test_cte_sql(cls):
+        sql = """
+        select * from currency
+        """
+        sql = cls.get_cte_prequery(sql)
+        print(sql)
 
 class AzureSynapseSpec(MssqlEngineSpec):
     engine = "mssql"

--- a/tests/integration_tests/core_tests.py
+++ b/tests/integration_tests/core_tests.py
@@ -925,7 +925,7 @@ class TestCore(SupersetTestCase):
             sql=commented_query,
             database=get_example_database(),
         )
-        rendered_query = str(table.get_from_clause())
+        rendered_query = str(table.get_from_clause()[0])
         self.assertEqual(clean_query, rendered_query)
 
     def test_slice_payload_no_datasource(self):

--- a/tests/unit_tests/db_engine_specs/test_mssql.py
+++ b/tests/unit_tests/db_engine_specs/test_mssql.py
@@ -186,20 +186,24 @@ def test_column_datatype_to_string(
         (
             dedent(
                 """
-with currency as
-(
+with currency as (
 select 'INR' as cur
+),
+currency_2 as (
+select 'EUR' as cur
 )
-select * from currency
+select * from currency union all select * from currency_2
 """
             ),
             dedent(
-                """WITH currency as
-(
+                """WITH currency as (
 select 'INR' as cur
 ),
+currency_2 as (
+select 'EUR' as cur
+),
 __cte AS (
-select * from currency
+select * from currency union all select * from currency_2
 )"""
             ),
         ),

--- a/tests/unit_tests/db_engine_specs/test_mssql.py
+++ b/tests/unit_tests/db_engine_specs/test_mssql.py
@@ -179,6 +179,40 @@ def test_column_datatype_to_string(
     actual = MssqlEngineSpec.column_datatype_to_string(original, mssql.dialect())
     assert actual == expected
 
+@pytest.mark.parametrize(
+    "original,expected",
+    [
+        ("with currency as\n"
+            "(\n"
+            "select 'INR' as cur\n"
+            ")\n"
+            "select * from currency\n"
+            , "WITH currency as\n"
+            "(\n"
+            "select 'INR' as cur\n"
+            "),\n"
+            "__query as (\n"
+              "select * from currency\n"
+              ")",),
+        ("SELECT 1 as cnt", None,),
+        ("select 'INR' as cur\n"
+            "union\n"
+            "select 'AUD' as cur\n"
+            "union \n"
+            "select 'USD' as cur\n", None)
+    ],
+)
+def test_cte_query_parsing(
+    app_context: AppContext, original: TypeEngine, expected: str
+) -> None:
+        from superset.db_engine_specs.mssql import MssqlEngineSpec
+
+        actual = MssqlEngineSpec.get_cte_query(original)
+        print(original)
+        print(expected)
+        print(actual)
+        assert actual == expected
+
 
 def test_extract_errors(app_context: AppContext) -> None:
     """

--- a/tests/unit_tests/db_engine_specs/test_mssql.py
+++ b/tests/unit_tests/db_engine_specs/test_mssql.py
@@ -179,39 +179,52 @@ def test_column_datatype_to_string(
     actual = MssqlEngineSpec.column_datatype_to_string(original, mssql.dialect())
     assert actual == expected
 
+
 @pytest.mark.parametrize(
     "original,expected",
     [
-        ("with currency as\n"
-            "(\n"
-            "select 'INR' as cur\n"
-            ")\n"
-            "select * from currency\n"
-            , "WITH currency as\n"
-            "(\n"
-            "select 'INR' as cur\n"
-            "),\n"
-            "__query as (\n"
-              "select * from currency\n"
-              ")",),
+        (
+            dedent(
+                """
+with currency as
+(
+select 'INR' as cur
+)
+select * from currency
+"""
+            ),
+            dedent(
+                """WITH currency as
+(
+select 'INR' as cur
+),
+__cte AS (
+select * from currency
+)"""
+            ),
+        ),
         ("SELECT 1 as cnt", None,),
-        ("select 'INR' as cur\n"
-            "union\n"
-            "select 'AUD' as cur\n"
-            "union \n"
-            "select 'USD' as cur\n", None)
+        (
+            dedent(
+                """
+select 'INR' as cur
+union
+select 'AUD' as cur
+union
+select 'USD' as cur
+"""
+            ),
+            None,
+        ),
     ],
 )
 def test_cte_query_parsing(
     app_context: AppContext, original: TypeEngine, expected: str
 ) -> None:
-        from superset.db_engine_specs.mssql import MssqlEngineSpec
+    from superset.db_engine_specs.mssql import MssqlEngineSpec
 
-        actual = MssqlEngineSpec.get_cte_query(original)
-        print(original)
-        print(expected)
-        print(actual)
-        assert actual == expected
+    actual = MssqlEngineSpec.get_cte_query(original)
+    assert actual == expected
 
 
 def test_extract_errors(app_context: AppContext) -> None:


### PR DESCRIPTION
### SUMMARY
Superset was not allowing to run CTE based SQLs on MSSQL while creating virtual tables, because MSSQL is not supporting CTE in subquery. Always the CTE sql should be at the top. Hence added the fix to make the SQL to run as same as CTE, this feature can be used for all the databases. Added a new flag called "allows_cte_in_subquery" , if it's True, Superset will parse CTE as Subquery and run it else Superset will run the CTE as same as it is. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![Feb-10-2022 13-21-58](https://user-images.githubusercontent.com/31705464/153363856-155ba3b0-05ec-4eeb-9b9e-cfd947d15813.gif)

### TESTING INSTRUCTIONS
Added unit test case, unit test case can be run against mssql dbengine using below command
tox -e sqlite tests/unit_tests/db_engine_specs/test_mssql.py


