### PR TITLE
feat(explore): Allow using time formatter on temporal columns in data table

### DIFF
--- a/superset-frontend/spec/helpers/testing-library.tsx
+++ b/superset-frontend/spec/helpers/testing-library.tsx
@@ -19,6 +19,7 @@
 import '@testing-library/jest-dom/extend-expect';
 import React, { ReactNode, ReactElement } from 'react';
 import { render, RenderOptions } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
 import { ThemeProvider, supersetTheme } from '@superset-ui/core';
 import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
@@ -82,6 +83,9 @@ function createWrapper(options?: Options) {
 const customRender = (ui: ReactElement, options?: Options) =>
   render(ui, { wrapper: createWrapper(options), ...options });
 
+const customRenderHook = (callback: (props: any) => any, options?: Options) =>
+  renderHook(callback, { wrapper: createWrapper(options), ...options });
+
 export function sleep(time: number) {
   return new Promise(resolve => {
     setTimeout(resolve, time);
@@ -89,4 +93,4 @@ export function sleep(time: number) {
 }
 
 export * from '@testing-library/react';
-export { customRender as render };
+export { customRender as render, customRenderHook as renderHook };

--- a/superset-frontend/spec/helpers/testing-library.tsx
+++ b/superset-frontend/spec/helpers/testing-library.tsx
@@ -19,7 +19,6 @@
 import '@testing-library/jest-dom/extend-expect';
 import React, { ReactNode, ReactElement } from 'react';
 import { render, RenderOptions } from '@testing-library/react';
-import { renderHook } from '@testing-library/react-hooks';
 import { ThemeProvider, supersetTheme } from '@superset-ui/core';
 import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
@@ -83,9 +82,6 @@ function createWrapper(options?: Options) {
 const customRender = (ui: ReactElement, options?: Options) =>
   render(ui, { wrapper: createWrapper(options), ...options });
 
-const customRenderHook = (callback: (props: any) => any, options?: Options) =>
-  renderHook(callback, { wrapper: createWrapper(options), ...options });
-
 export function sleep(time: number) {
   return new Promise(resolve => {
     setTimeout(resolve, time);
@@ -93,4 +89,4 @@ export function sleep(time: number) {
 }
 
 export * from '@testing-library/react';
-export { customRender as render, customRenderHook as renderHook };
+export { customRender as render };

--- a/superset-frontend/src/explore/actions/exploreActions.ts
+++ b/superset-frontend/src/explore/actions/exploreActions.ts
@@ -140,6 +140,30 @@ export function sliceUpdated(slice: Slice) {
   return { type: SLICE_UPDATED, slice };
 }
 
+export const SET_TIME_FORMATTED_COLUMN = 'SET_TIME_FORMATTED_COLUMN';
+export function setTimeFormattedColumn(
+  datasourceId: string,
+  columnName: string,
+) {
+  return {
+    type: SET_TIME_FORMATTED_COLUMN,
+    datasourceId,
+    columnName,
+  };
+}
+
+export const UNSET_TIME_FORMATTED_COLUMN = 'UNSET_TIME_FORMATTED_COLUMN';
+export function unsetTimeFormattedColumn(
+  datasourceId: string,
+  columnIndex: number,
+) {
+  return {
+    type: UNSET_TIME_FORMATTED_COLUMN,
+    datasourceId,
+    columnIndex,
+  };
+}
+
 export const exploreActions = {
   ...toastActions,
   setDatasourceType,
@@ -155,6 +179,8 @@ export const exploreActions = {
   updateChartTitle,
   createNewSlice,
   sliceUpdated,
+  setTimeFormattedColumn,
+  unsetTimeFormattedColumn,
 };
 
 export type ExploreActions = typeof exploreActions;

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -47,7 +47,6 @@ import {
   setTimeFormattedColumn,
   unsetTimeFormattedColumn,
 } from 'src/explore/actions/exploreActions';
-import { useTimeFormattedColumns } from '../useTimeFormattedColumns';
 
 export const CopyButton = styled(Button)`
   font-size: ${({ theme }) => theme.typography.sizes.s}px;
@@ -269,11 +268,10 @@ export const useTableColumns = (
   coltypes?: GenericDataType[],
   data?: Record<string, any>[],
   datasourceId?: string,
+  timeFormattedColumns: string[] = [],
   moreConfigs?: { [key: string]: Partial<Column> },
-) => {
-  const timeFormattedColumns = useTimeFormattedColumns(datasourceId);
-
-  return useMemo(
+) =>
+  useMemo(
     () =>
       colnames && data?.length
         ? colnames
@@ -315,4 +313,3 @@ export const useTableColumns = (
         : [],
     [colnames, data, coltypes, datasourceId, moreConfigs, timeFormattedColumns],
   );
-};

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -148,14 +148,12 @@ const FormatPickerLabel = styled.span`
   text-transform: uppercase;
 `;
 
-const DataTableHeaderCell = ({
+const DataTableTemporalHeaderCell = ({
   columnName,
-  type,
   datasourceId,
   timeFormattedColumnIndex,
 }: {
   columnName: string;
-  type?: GenericDataType;
   datasourceId?: string;
   timeFormattedColumnIndex: number;
 }) => {
@@ -213,7 +211,7 @@ const DataTableHeaderCell = ({
     [datasourceId, isColumnTimeFormatted, onChange],
   );
 
-  return type === GenericDataType.TEMPORAL && datasourceId ? (
+  return datasourceId ? (
     <span>
       <Popover
         overlayClassName="column-formatting-popover"
@@ -270,7 +268,9 @@ export const useTableColumns = (
   moreConfigs?: { [key: string]: Partial<Column> },
 ) => {
   const timeFormattedColumns = useSelector<ExplorePageState, string[]>(state =>
-    datasourceId ? state.explore.timeFormattedColumns[datasourceId] ?? [] : [],
+    datasourceId
+      ? state.explore.timeFormattedColumns?.[datasourceId] ?? []
+      : [],
   );
 
   return useMemo(
@@ -287,14 +287,16 @@ export const useTableColumns = (
                 id: key,
                 accessor: row => row[key],
                 // When the key is empty, have to give a string of length greater than 0
-                Header: (
-                  <DataTableHeaderCell
-                    columnName={key}
-                    type={coltypes?.[index]}
-                    datasourceId={datasourceId}
-                    timeFormattedColumnIndex={timeFormattedColumnIndex}
-                  />
-                ),
+                Header:
+                  coltypes?.[index] === GenericDataType.TEMPORAL ? (
+                    <DataTableTemporalHeaderCell
+                      columnName={key}
+                      datasourceId={datasourceId}
+                      timeFormattedColumnIndex={timeFormattedColumnIndex}
+                    />
+                  ) : (
+                    key
+                  ),
                 Cell: ({ value }) => {
                   if (value === true) {
                     return BOOL_TRUE_DISPLAY;

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -117,7 +117,7 @@ export const RowCount = ({
 
 enum FormatPickerValue {
   Formatted,
-  Epoch,
+  Original,
 }
 
 const FormatPicker = ({
@@ -129,7 +129,7 @@ const FormatPicker = ({
 }) => (
   <Radio.Group value={value} onChange={onChange}>
     <Space direction="vertical">
-      <Radio value={FormatPickerValue.Epoch}>{t('Original value')}</Radio>
+      <Radio value={FormatPickerValue.Original}>{t('Original value')}</Radio>
       <Radio value={FormatPickerValue.Formatted}>{t('Formatted date')}</Radio>
     </Space>
   </Radio.Group>
@@ -167,7 +167,10 @@ const DataTableTemporalHeaderCell = ({
       if (!datasourceId) {
         return;
       }
-      if (e.target.value === FormatPickerValue.Epoch && isColumnTimeFormatted) {
+      if (
+        e.target.value === FormatPickerValue.Original &&
+        isColumnTimeFormatted
+      ) {
         dispatch(
           unsetTimeFormattedColumn(datasourceId, timeFormattedColumnIndex),
         );
@@ -204,7 +207,7 @@ const DataTableTemporalHeaderCell = ({
             value={
               isColumnTimeFormatted
                 ? FormatPickerValue.Formatted
-                : FormatPickerValue.Epoch
+                : FormatPickerValue.Original
             }
           />
         </FormatPickerContainer>

--- a/superset-frontend/src/explore/components/DataTableControl/useTableColumns.test.ts
+++ b/superset-frontend/src/explore/components/DataTableControl/useTableColumns.test.ts
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { GenericDataType } from '@superset-ui/core';
 import { renderHook } from '@testing-library/react-hooks';
 import { BOOL_FALSE_DISPLAY, BOOL_TRUE_DISPLAY } from 'src/constants';
 import { useTableColumns } from '.';
@@ -43,9 +44,15 @@ const data = [
   },
 ];
 const all_columns = ['col01', 'col02', 'col03', asciiKey, unicodeKey];
+const coltypes = [
+  GenericDataType.BOOLEAN,
+  GenericDataType.BOOLEAN,
+  GenericDataType.STRING,
+  GenericDataType.STRING,
+];
 
 test('useTableColumns with no options', () => {
-  const hook = renderHook(() => useTableColumns(all_columns, data));
+  const hook = renderHook(() => useTableColumns(all_columns, coltypes, data));
   expect(hook.result.current).toEqual([
     {
       Cell: expect.any(Function),
@@ -84,7 +91,9 @@ test('useTableColumns with no options', () => {
 
 test('use only the first record columns', () => {
   const newData = [data[3], data[0]];
-  const hook = renderHook(() => useTableColumns(all_columns, newData));
+  const hook = renderHook(() =>
+    useTableColumns(all_columns, coltypes, newData),
+  );
   expect(hook.result.current).toEqual([
     {
       Cell: expect.any(Function),
@@ -136,7 +145,9 @@ test('use only the first record columns', () => {
 
 test('useTableColumns with options', () => {
   const hook = renderHook(() =>
-    useTableColumns(all_columns, data, { col01: { id: 'ID' } }),
+    useTableColumns(all_columns, coltypes, data, undefined, {
+      col01: { id: 'ID' },
+    }),
   );
   expect(hook.result.current).toEqual([
     {

--- a/superset-frontend/src/explore/components/DataTableControl/useTableColumns.test.ts
+++ b/superset-frontend/src/explore/components/DataTableControl/useTableColumns.test.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { GenericDataType } from '@superset-ui/core';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from 'spec/helpers/testing-library';
 import { BOOL_FALSE_DISPLAY, BOOL_TRUE_DISPLAY } from 'src/constants';
 import { useTableColumns } from '.';
 
@@ -52,27 +52,33 @@ const coltypes = [
 ];
 
 test('useTableColumns with no options', () => {
-  const hook = renderHook(() => useTableColumns(all_columns, coltypes, data));
+  const hook = renderHook(() => useTableColumns(all_columns, coltypes, data), {
+    useRedux: true,
+  });
   expect(hook.result.current).toEqual([
     {
       Cell: expect.any(Function),
       Header: 'col01',
       accessor: expect.any(Function),
+      id: 'col01',
     },
     {
       Cell: expect.any(Function),
       Header: 'col02',
       accessor: expect.any(Function),
+      id: 'col02',
     },
     {
       Cell: expect.any(Function),
       Header: asciiKey,
       accessor: expect.any(Function),
+      id: asciiKey,
     },
     {
       Cell: expect.any(Function),
       Header: unicodeKey,
       accessor: expect.any(Function),
+      id: unicodeKey,
     },
   ]);
   hook.result.current.forEach((col: JsonObject) => {
@@ -91,34 +97,40 @@ test('useTableColumns with no options', () => {
 
 test('use only the first record columns', () => {
   const newData = [data[3], data[0]];
-  const hook = renderHook(() =>
-    useTableColumns(all_columns, coltypes, newData),
+  const hook = renderHook(
+    () => useTableColumns(all_columns, coltypes, newData),
+    { useRedux: true },
   );
   expect(hook.result.current).toEqual([
     {
       Cell: expect.any(Function),
       Header: 'col01',
       accessor: expect.any(Function),
+      id: 'col01',
     },
     {
       Cell: expect.any(Function),
       Header: 'col02',
       accessor: expect.any(Function),
+      id: 'col02',
     },
     {
       Cell: expect.any(Function),
       Header: 'col03',
       accessor: expect.any(Function),
+      id: 'col03',
     },
     {
       Cell: expect.any(Function),
       Header: asciiKey,
       accessor: expect.any(Function),
+      id: asciiKey,
     },
     {
       Cell: expect.any(Function),
       Header: unicodeKey,
       accessor: expect.any(Function),
+      id: unicodeKey,
     },
   ]);
 
@@ -144,10 +156,12 @@ test('use only the first record columns', () => {
 });
 
 test('useTableColumns with options', () => {
-  const hook = renderHook(() =>
-    useTableColumns(all_columns, coltypes, data, undefined, {
-      col01: { id: 'ID' },
-    }),
+  const hook = renderHook(
+    () =>
+      useTableColumns(all_columns, coltypes, data, undefined, {
+        col01: { id: 'ID' },
+      }),
+    { useRedux: true },
   );
   expect(hook.result.current).toEqual([
     {
@@ -160,16 +174,19 @@ test('useTableColumns with options', () => {
       Cell: expect.any(Function),
       Header: 'col02',
       accessor: expect.any(Function),
+      id: 'col02',
     },
     {
       Cell: expect.any(Function),
       Header: asciiKey,
       accessor: expect.any(Function),
+      id: asciiKey,
     },
     {
       Cell: expect.any(Function),
       Header: unicodeKey,
       accessor: expect.any(Function),
+      id: unicodeKey,
     },
   ]);
   hook.result.current.forEach((col: JsonObject) => {

--- a/superset-frontend/src/explore/components/DataTableControl/useTableColumns.test.ts
+++ b/superset-frontend/src/explore/components/DataTableControl/useTableColumns.test.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { GenericDataType } from '@superset-ui/core';
-import { renderHook } from 'spec/helpers/testing-library';
+import { renderHook } from '@testing-library/react-hooks';
 import { BOOL_FALSE_DISPLAY, BOOL_TRUE_DISPLAY } from 'src/constants';
 import { useTableColumns } from '.';
 
@@ -52,9 +52,7 @@ const coltypes = [
 ];
 
 test('useTableColumns with no options', () => {
-  const hook = renderHook(() => useTableColumns(all_columns, coltypes, data), {
-    useRedux: true,
-  });
+  const hook = renderHook(() => useTableColumns(all_columns, coltypes, data));
   expect(hook.result.current).toEqual([
     {
       Cell: expect.any(Function),
@@ -97,9 +95,8 @@ test('useTableColumns with no options', () => {
 
 test('use only the first record columns', () => {
   const newData = [data[3], data[0]];
-  const hook = renderHook(
-    () => useTableColumns(all_columns, coltypes, newData),
-    { useRedux: true },
+  const hook = renderHook(() =>
+    useTableColumns(all_columns, coltypes, newData),
   );
   expect(hook.result.current).toEqual([
     {
@@ -156,12 +153,10 @@ test('use only the first record columns', () => {
 });
 
 test('useTableColumns with options', () => {
-  const hook = renderHook(
-    () =>
-      useTableColumns(all_columns, coltypes, data, undefined, {
-        col01: { id: 'ID' },
-      }),
-    { useRedux: true },
+  const hook = renderHook(() =>
+    useTableColumns(all_columns, coltypes, data, undefined, [], {
+      col01: { id: 'ID' },
+    }),
   );
   expect(hook.result.current).toEqual([
     {

--- a/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.test.tsx
@@ -131,6 +131,13 @@ test('Should copy data table content correctly', async () => {
     />,
     {
       useRedux: true,
+      initialState: {
+        explore: {
+          timeFormattedColumns: {
+            '34__table': ['__timestamp'],
+          },
+        },
+      },
     },
   );
   userEvent.click(await screen.findByText('Data'));

--- a/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.test.tsx
@@ -105,7 +105,13 @@ test('Should copy data table content correctly', async () => {
   fetchMock.post(
     'glob:*/api/v1/chart/data?form_data=%7B%22slice_id%22%3A456%7D',
     {
-      result: [{ data: [{ __timestamp: 1230768000000, genre: 'Action' }] }],
+      result: [
+        {
+          data: [{ __timestamp: 1230768000000, genre: 'Action' }],
+          colnames: ['__timestamp', 'genre'],
+          coltypes: [2, 1],
+        },
+      ],
     },
   );
   const copyToClipboardSpy = jest.spyOn(copyUtils, 'default');
@@ -118,6 +124,7 @@ test('Should copy data table content correctly', async () => {
         queriesResponse: [
           {
             colnames: ['__timestamp', 'genre'],
+            coltypes: [2, 1],
           },
         ],
       }}

--- a/superset-frontend/src/explore/components/DataTablesPane/index.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/index.tsx
@@ -116,6 +116,7 @@ interface DataTableProps {
   datasource: string | undefined;
   filterText: string;
   data: object[] | undefined;
+  timeFormattedColumns: string[] | undefined;
   isLoading: boolean;
   error: string | undefined;
   errorMessage: React.ReactElement | undefined;
@@ -127,13 +128,20 @@ const DataTable = ({
   datasource,
   filterText,
   data,
+  timeFormattedColumns,
   isLoading,
   error,
   errorMessage,
 }: DataTableProps) => {
   // this is to preserve the order of the columns, even if there are integer values,
   // while also only grabbing the first column's keys
-  const columns = useTableColumns(columnNames, columnTypes, data, datasource);
+  const columns = useTableColumns(
+    columnNames,
+    columnTypes,
+    data,
+    datasource,
+    timeFormattedColumns,
+  );
   const filteredData = useFilteredTableData(filterText, data);
 
   if (isLoading) {
@@ -406,6 +414,7 @@ export const DataTablesPane = ({
                     isLoading={isLoading[RESULT_TYPES.results]}
                     data={data[RESULT_TYPES.results]}
                     datasource={queryFormData?.datasource}
+                    timeFormattedColumns={timeFormattedColumns}
                     columnNames={columnNames[RESULT_TYPES.results]}
                     columnTypes={columnTypes[RESULT_TYPES.results]}
                     filterText={filterText}
@@ -421,6 +430,7 @@ export const DataTablesPane = ({
                     isLoading={isLoading[RESULT_TYPES.samples]}
                     data={data[RESULT_TYPES.samples]}
                     datasource={queryFormData?.datasource}
+                    timeFormattedColumns={timeFormattedColumns}
                     columnNames={columnNames[RESULT_TYPES.samples]}
                     columnTypes={columnTypes[RESULT_TYPES.samples]}
                     filterText={filterText}

--- a/superset-frontend/src/explore/components/useTimeFormattedColumns.ts
+++ b/superset-frontend/src/explore/components/useTimeFormattedColumns.ts
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useSelector } from 'react-redux';
+import { ExplorePageState } from '../reducers/getInitialState';
+
+export const useTimeFormattedColumns = (datasourceId?: string) =>
+  useSelector<ExplorePageState, string[]>(state =>
+    datasourceId
+      ? state.explore.timeFormattedColumns?.[datasourceId] ?? []
+      : [],
+  );

--- a/superset-frontend/src/explore/reducers/exploreReducer.js
+++ b/superset-frontend/src/explore/reducers/exploreReducer.js
@@ -238,17 +238,15 @@ export default function exploreReducer(state = {}, action) {
       };
     },
     [actions.SET_TIME_FORMATTED_COLUMN]() {
-      const newTimeFormattedColumns = { ...state.timeFormattedColumns };
       const { datasourceId, columnName } = action;
+      const newTimeFormattedColumns = { ...state.timeFormattedColumns };
+      const newTimeFormattedColumnsForDatasource = ensureIsArray(
+        newTimeFormattedColumns[datasourceId],
+      ).slice();
 
-      if (Array.isArray(newTimeFormattedColumns[action.datasourceId])) {
-        newTimeFormattedColumns[datasourceId] = [
-          ...newTimeFormattedColumns[datasourceId],
-          columnName,
-        ];
-      } else {
-        newTimeFormattedColumns[datasourceId] = [columnName];
-      }
+      newTimeFormattedColumnsForDatasource.push(columnName);
+      newTimeFormattedColumns[datasourceId] =
+        newTimeFormattedColumnsForDatasource;
       setItem(
         LocalStorageKeys.explore__data_table_time_formatted_columns,
         newTimeFormattedColumns,
@@ -256,18 +254,18 @@ export default function exploreReducer(state = {}, action) {
       return { ...state, timeFormattedColumns: newTimeFormattedColumns };
     },
     [actions.UNSET_TIME_FORMATTED_COLUMN]() {
-      const newTimeFormattedColumns = { ...state.timeFormattedColumns };
       const { datasourceId, columnIndex } = action;
+      const newTimeFormattedColumns = { ...state.timeFormattedColumns };
+      const newTimeFormattedColumnsForDatasource = ensureIsArray(
+        newTimeFormattedColumns[datasourceId],
+      ).slice();
 
-      if (Array.isArray(newTimeFormattedColumns[datasourceId])) {
-        newTimeFormattedColumns[datasourceId] = [
-          ...newTimeFormattedColumns[datasourceId].slice(0, columnIndex),
-          ...newTimeFormattedColumns[datasourceId].slice(columnIndex + 1),
-        ];
+      newTimeFormattedColumnsForDatasource.splice(columnIndex, 1);
+      newTimeFormattedColumns[datasourceId] =
+        newTimeFormattedColumnsForDatasource;
 
-        if (newTimeFormattedColumns[datasourceId].length === 0) {
-          delete newTimeFormattedColumns[datasourceId];
-        }
+      if (newTimeFormattedColumnsForDatasource.length === 0) {
+        delete newTimeFormattedColumns[datasourceId];
       }
       setItem(
         LocalStorageKeys.explore__data_table_time_formatted_columns,

--- a/superset-frontend/src/explore/reducers/exploreReducer.js
+++ b/superset-frontend/src/explore/reducers/exploreReducer.js
@@ -28,6 +28,7 @@ import {
   getControlValuesCompatibleWithDatasource,
 } from 'src/explore/controlUtils';
 import * as actions from 'src/explore/actions/exploreActions';
+import { LocalStorageKeys, setItem } from 'src/utils/localStorageHelpers';
 
 export default function exploreReducer(state = {}, action) {
   const actionHandlers = {
@@ -236,7 +237,46 @@ export default function exploreReducer(state = {}, action) {
         sliceName: action.slice.slice_name ?? state.sliceName,
       };
     },
+    [actions.SET_TIME_FORMATTED_COLUMN]() {
+      const newTimeFormattedColumns = { ...state.timeFormattedColumns };
+      const { datasourceId, columnName } = action;
+
+      if (Array.isArray(newTimeFormattedColumns[action.datasourceId])) {
+        newTimeFormattedColumns[datasourceId] = [
+          ...newTimeFormattedColumns[datasourceId],
+          columnName,
+        ];
+      } else {
+        newTimeFormattedColumns[datasourceId] = [columnName];
+      }
+      setItem(
+        LocalStorageKeys.explore__data_table_time_formatted_columns,
+        newTimeFormattedColumns,
+      );
+      return { ...state, timeFormattedColumns: newTimeFormattedColumns };
+    },
+    [actions.UNSET_TIME_FORMATTED_COLUMN]() {
+      const newTimeFormattedColumns = { ...state.timeFormattedColumns };
+      const { datasourceId, columnIndex } = action;
+
+      if (Array.isArray(newTimeFormattedColumns[datasourceId])) {
+        newTimeFormattedColumns[datasourceId] = [
+          ...newTimeFormattedColumns[datasourceId].slice(0, columnIndex),
+          ...newTimeFormattedColumns[datasourceId].slice(columnIndex + 1),
+        ];
+
+        if (newTimeFormattedColumns[datasourceId].length === 0) {
+          delete newTimeFormattedColumns[datasourceId];
+        }
+      }
+      setItem(
+        LocalStorageKeys.explore__data_table_time_formatted_columns,
+        newTimeFormattedColumns,
+      );
+      return { ...state, timeFormattedColumns: newTimeFormattedColumns };
+    },
   };
+
   if (action.type in actionHandlers) {
     return actionHandlers[action.type]();
   }

--- a/superset-frontend/src/explore/reducers/getInitialState.ts
+++ b/superset-frontend/src/explore/reducers/getInitialState.ts
@@ -35,6 +35,7 @@ import {
   getFormDataFromControls,
   applyMapStateToPropsToControl,
 } from 'src/explore/controlUtils';
+import { getItem, LocalStorageKeys } from 'src/utils/localStorageHelpers';
 
 export interface ExplorePageBootstrapData extends JsonObject {
   can_add: boolean;
@@ -77,6 +78,10 @@ export default function getInitialState(
       initialFormData,
     ) as ControlStateMapping,
     controlsTransferred: [],
+    timeFormattedColumns: getItem(
+      LocalStorageKeys.explore__data_table_time_formatted_columns,
+      {},
+    ),
   };
 
   // apply initial mapStateToProps for all controls, must execute AFTER

--- a/superset-frontend/src/utils/common.js
+++ b/superset-frontend/src/utils/common.js
@@ -20,6 +20,7 @@ import {
   SupersetClient,
   getTimeFormatter,
   TimeFormats,
+  ensureIsArray,
 } from '@superset-ui/core';
 
 // ATTENTION: If you change any constants, make sure to also change constants.py
@@ -107,18 +108,24 @@ export function prepareCopyToClipboardTabularData(data, columns) {
   return result;
 }
 
-export function applyFormattingToTabularData(data) {
-  if (!data || data.length === 0 || !('__timestamp' in data[0])) {
+export function applyFormattingToTabularData(data, timeFormattedColumns) {
+  if (
+    !data ||
+    data.length === 0 ||
+    ensureIsArray(timeFormattedColumns).length === 0
+  ) {
     return data;
   }
+
   return data.map(row => ({
     ...row,
     /* eslint-disable no-underscore-dangle */
-    __timestamp:
-      row.__timestamp === 0 || row.__timestamp
-        ? DATETIME_FORMATTER(new Date(row.__timestamp))
-        : row.__timestamp,
-    /* eslint-enable no-underscore-dangle */
+    ...timeFormattedColumns.reduce((acc, colName) => {
+      if (row[colName] !== null && row[colName] !== undefined) {
+        acc[colName] = DATETIME_FORMATTER(row[colName]);
+      }
+      return acc;
+    }, {}),
   }));
 }
 

--- a/superset-frontend/src/utils/common.test.jsx
+++ b/superset-frontend/src/utils/common.test.jsx
@@ -63,29 +63,72 @@ describe('utils/common', () => {
   describe('applyFormattingToTabularData', () => {
     it('does not mutate empty array', () => {
       const data = [];
-      expect(applyFormattingToTabularData(data)).toEqual(data);
+      expect(applyFormattingToTabularData(data, [])).toEqual(data);
     });
     it('does not mutate array without temporal column', () => {
       const data = [
         { column1: 'lorem', column2: 'ipsum' },
         { column1: 'dolor', column2: 'sit', column3: 'amet' },
       ];
-      expect(applyFormattingToTabularData(data)).toEqual(data);
+      expect(applyFormattingToTabularData(data, [])).toEqual(data);
     });
-    it('changes formatting of temporal column', () => {
+    it('changes formatting of columns selected for formatting', () => {
       const originalData = [
-        { __timestamp: null, column1: 'lorem' },
-        { __timestamp: 0, column1: 'ipsum' },
-        { __timestamp: 1594285437771, column1: 'dolor' },
-        { __timestamp: 1594285441675, column1: 'sit' },
+        {
+          __timestamp: null,
+          column1: 'lorem',
+          column2: 1590014060000,
+          column3: 1507680000000,
+        },
+        {
+          __timestamp: 0,
+          column1: 'ipsum',
+          column2: 1590075817000,
+          column3: 1513641600000,
+        },
+        {
+          __timestamp: 1594285437771,
+          column1: 'dolor',
+          column2: 1591062977000,
+          column3: 1516924800000,
+        },
+        {
+          __timestamp: 1594285441675,
+          column1: 'sit',
+          column2: 1591397351000,
+          column3: 1518566400000,
+        },
       ];
+      const timeFormattedColumns = ['__timestamp', 'column3'];
       const expectedData = [
-        { __timestamp: null, column1: 'lorem' },
-        { __timestamp: '1970-01-01 00:00:00', column1: 'ipsum' },
-        { __timestamp: '2020-07-09 09:03:57', column1: 'dolor' },
-        { __timestamp: '2020-07-09 09:04:01', column1: 'sit' },
+        {
+          __timestamp: null,
+          column1: 'lorem',
+          column2: 1590014060000,
+          column3: '2017-10-11 00:00:00',
+        },
+        {
+          __timestamp: '1970-01-01 00:00:00',
+          column1: 'ipsum',
+          column2: 1590075817000,
+          column3: '2017-12-19 00:00:00',
+        },
+        {
+          __timestamp: '2020-07-09 09:03:57',
+          column1: 'dolor',
+          column2: 1591062977000,
+          column3: '2018-01-26 00:00:00',
+        },
+        {
+          __timestamp: '2020-07-09 09:04:01',
+          column1: 'sit',
+          column2: 1591397351000,
+          column3: '2018-02-14 00:00:00',
+        },
       ];
-      expect(applyFormattingToTabularData(originalData)).toEqual(expectedData);
+      expect(
+        applyFormattingToTabularData(originalData, timeFormattedColumns),
+      ).toEqual(expectedData);
     });
   });
 });

--- a/superset-frontend/src/utils/localStorageHelpers.ts
+++ b/superset-frontend/src/utils/localStorageHelpers.ts
@@ -49,6 +49,7 @@ export enum LocalStorageKeys {
    * sqllab__is_autocomplete_enabled
    */
   sqllab__is_autocomplete_enabled = 'sqllab__is_autocomplete_enabled',
+  explore__data_table_time_formatted_columns = 'explore__data_table_time_formatted_columns',
 }
 
 export type LocalStorageValues = {
@@ -62,6 +63,7 @@ export type LocalStorageValues = {
   homepage_collapse_state: string[];
   homepage_activity_filter: SetTabType | null;
   sqllab__is_autocomplete_enabled: boolean;
+  explore__data_table_time_formatted_columns: Record<string, string[]>;
 };
 
 export function getItem<K extends LocalStorageKeys>(

--- a/superset/common/query_actions.py
+++ b/superset/common/query_actions.py
@@ -129,7 +129,11 @@ def _get_full(
     ] + rejected_time_columns
 
     if result_type == ChartDataResultType.RESULTS and status != QueryStatus.FAILED:
-        return {"data": payload.get("data")}
+        return {
+            "data": payload.get("data"),
+            "colnames": payload.get("colnames"),
+            "coltypes": payload.get("coltypes"),
+        }
     return payload
 
 
@@ -152,7 +156,7 @@ def _get_results(
     query_context: "QueryContext", query_obj: "QueryObject", force_cached: bool = False
 ) -> Dict[str, Any]:
     payload = _get_full(query_context, query_obj, force_cached)
-    return {"data": payload.get("data"), "error": payload.get("error")}
+    return payload
 
 
 _result_type_functions: Dict[

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -449,10 +449,12 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         payload = viz_obj.get_df_payload()
         if viz_obj.has_error(payload):
             return json_error_response(payload=payload, status=400)
-        return self.json_response({"data": payload["df"].to_dict("records")})
+        return self.json_response(
+            {"data": payload["df"].to_dict("records"), "colnames": payload["colnames"]}
+        )
 
     def get_samples(self, viz_obj: BaseViz) -> FlaskResponse:
-        return self.json_response({"data": viz_obj.get_samples()})
+        return self.json_response(viz_obj.get_samples())
 
     @staticmethod
     def send_data_payload_response(viz_obj: BaseViz, payload: Any) -> FlaskResponse:

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -452,7 +452,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         return self.json_response(
             {
                 "data": payload["df"].to_dict("records"),
-                "colnames": payload["colnames"],
+                "colnames": payload.get("colnames"),
                 "coltypes": payload.get("coltypes"),
             },
         )

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -450,7 +450,11 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         if viz_obj.has_error(payload):
             return json_error_response(payload=payload, status=400)
         return self.json_response(
-            {"data": payload["df"].to_dict("records"), "colnames": payload["colnames"]}
+            {
+                "data": payload["df"].to_dict("records"),
+                "colnames": payload["colnames"],
+                "coltypes": payload.get("coltypes"),
+            },
         )
 
     def get_samples(self, viz_obj: BaseViz) -> FlaskResponse:

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -244,7 +244,7 @@ class BaseViz:  # pylint: disable=too-many-public-methods
             )
         return df
 
-    def get_samples(self) -> List[Dict[str, Any]]:
+    def get_samples(self) -> Dict[str, Any]:
         query_obj = self.query_obj()
         query_obj.update(
             {
@@ -258,8 +258,11 @@ class BaseViz:  # pylint: disable=too-many-public-methods
                 "to_dttm": None,
             }
         )
-        df = self.get_df_payload(query_obj)["df"]  # leverage caching logic
-        return df.to_dict(orient="records")
+        payload = self.get_df_payload(query_obj)  # leverage caching logic
+        return {
+            "data": payload["df"].to_dict(orient="records"),
+            "colnames": payload["colnames"],
+        }
 
     def get_df(self, query_obj: Optional[QueryObjectDict] = None) -> pd.DataFrame:
         """Returns a pandas dataframe based on the query object"""
@@ -621,6 +624,7 @@ class BaseViz:  # pylint: disable=too-many-public-methods
             "status": self.status,
             "stacktrace": stacktrace,
             "rowcount": len(df.index) if df is not None else 0,
+            "colnames": list(df.columns) if df is not None else None,
         }
 
     @staticmethod

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -261,7 +261,7 @@ class BaseViz:  # pylint: disable=too-many-public-methods
         payload = self.get_df_payload(query_obj)  # leverage caching logic
         return {
             "data": payload["df"].to_dict(orient="records"),
-            "colnames": payload["colnames"],
+            "colnames": payload.get("colnames"),
             "coltypes": payload.get("coltypes"),
         }
 

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -262,6 +262,7 @@ class BaseViz:  # pylint: disable=too-many-public-methods
         return {
             "data": payload["df"].to_dict(orient="records"),
             "colnames": payload["colnames"],
+            "coltypes": payload.get("coltypes"),
         }
 
     def get_df(self, query_obj: Optional[QueryObjectDict] = None) -> pd.DataFrame:
@@ -625,6 +626,7 @@ class BaseViz:  # pylint: disable=too-many-public-methods
             "stacktrace": stacktrace,
             "rowcount": len(df.index) if df is not None else 0,
             "colnames": list(df.columns) if df is not None else None,
+            "coltypes": utils.extract_dataframe_dtypes(df, self.datasource),
         }
 
     @staticmethod

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -626,7 +626,9 @@ class BaseViz:  # pylint: disable=too-many-public-methods
             "stacktrace": stacktrace,
             "rowcount": len(df.index) if df is not None else 0,
             "colnames": list(df.columns) if df is not None else None,
-            "coltypes": utils.extract_dataframe_dtypes(df, self.datasource),
+            "coltypes": utils.extract_dataframe_dtypes(df, self.datasource)
+            if df is not None
+            else None,
         }
 
     @staticmethod


### PR DESCRIPTION
### SUMMARY
Enable switching between displaying epoch (original value) and time formatted value (format: YYYY-mm-dd HH:MM:SS).

Temporal columns in data table (tabs "Data" and "Samples") now have a clickable "gear" icon, which opens a popover that allows switching between 2 display modes. 

Selected display mode is specific to each column - user can select different display modes for each temporal column. The selection is also specific to datasource, meaning if there are temporal columns that have the same name in 2 datasources, those columns can have different display modes.

Selection is saved in local storage - when user reloads the page, changes hart config etc., it will be persisted.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/15073128/152353312-3abe36c5-1f23-4e72-8afc-991471b7722f.mov

### TESTING INSTRUCTIONS
1. Create a chart with some temporal columns
2. Open data table below the chart - temporal columns should have "gear" icons on their left sides
3. Click the icon and select "Formatted time"
4. Verify that the displayed values for that column have changed from long numbers to human readable dates
5. Reload the page, verify that your selections have been saved
6. Switch between datasources, verify that the selections are specific for each datasource
7. Perform the above testing instructions for charts using V1 API and legacy API

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

https://app.shortcut.com/preset/story/33355/explore-south-table-timestamp-column-in-data-panel-did-not-show-correctly

CC @rusackas @jinghua-qa @kasiazjc