### PR TITLE
fix(sqla): avoid unnecessary groupby in samples request

### DIFF
--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -598,7 +598,10 @@ class ChartDataBoxplotOptionsSchema(ChartDataPostProcessingOperationOptionsSchem
         description="Aggregate expressions. Metrics can be passed as both "
         "references to datasource metrics (strings), or ad-hoc metrics"
         "which are defined only within the query object. See "
-        "`ChartDataAdhocMetricSchema` for the structure of ad-hoc metrics.",
+        "`ChartDataAdhocMetricSchema` for the structure of ad-hoc metrics. "
+        "When metrics is undefined or null, the query is executed without a groupby. "
+        "However, when metrics is an array (length >= 0), a groupby clause is added to "
+        "the query.",
         allow_none=True,
     )
 

--- a/superset/common/query_actions.py
+++ b/superset/common/query_actions.py
@@ -140,7 +140,7 @@ def _get_samples(
     query_obj = copy.copy(query_obj)
     query_obj.is_timeseries = False
     query_obj.orderby = []
-    query_obj.metrics = []
+    query_obj.metrics = None
     query_obj.post_processing = []
     query_obj.columns = [o.column_name for o in datasource.columns]
     query_obj.from_dttm = None

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -154,6 +154,7 @@ class TestPostChartDataApi(BaseTestChartDataApi):
 
         # assert
         self.assert_row_count(rv, expected_row_count)
+        assert "GROUP BY" not in rv.json["result"][0]["query"]
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     @mock.patch(
@@ -184,6 +185,7 @@ class TestPostChartDataApi(BaseTestChartDataApi):
 
         # assert
         self.assert_row_count(rv, expected_row_count)
+        assert "GROUP BY" not in rv.json["result"][0]["query"]
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     @mock.patch(
@@ -200,6 +202,7 @@ class TestPostChartDataApi(BaseTestChartDataApi):
 
         # assert
         self.assert_row_count(rv, expected_row_count)
+        assert "GROUP BY" not in rv.json["result"][0]["query"]
 
     def test_with_incorrect_result_type__400(self):
         self.query_context_payload["result_type"] = "qwerty"


### PR DESCRIPTION
### SUMMARY
When requesting samples from a dataset, a `GROUP BY` was incorrectly added to the query due to the `metrics` parameter in the `QueryObject` being set to an empty list. This adds unnecessary computational expense to the query and doesn't reflect the raw data correctly by hiding potential duplicates in the underlying data. This PR fixes the bug, adds assertions to existing tests to ensure the sample query is executed without a `GROUP BY` clause and adds instructions to the API spec on what the difference is between a `null` vs empty array for the `metrics` parameter.

### TESTING INSTRUCTIONS
1. Go to explore and open the Network tab in the Chrome debugger 
2. Click on "Samples"
3. Notice that the query in the chart data request previously included a `GROUP BY` clause.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
