### PR TITLE
fix: Missing columns in data panel in Explore for Mixed Time-Series

### DIFF
--- a/superset-frontend/src/explore/components/DataTablesPane/index.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/index.tsx
@@ -247,12 +247,21 @@ export const DataTablesPane = ({
               [resultType]: json.result[0].data,
             }));
           }
-          const checkCols = json?.result[0]?.data?.length
-            ? Object.keys(json.result[0].data[0])
-            : null;
+
+          const checkCols = json?.result.reduce(
+            (prevCols: string[], res: { data: Record<string, any>[] }) => {
+              const firstDataRow = res?.data?.[0];
+              const cols = firstDataRow ? Object.keys(firstDataRow) : [];
+              if (cols.length) {
+                return [...new Set([...prevCols, ...cols])];
+              }
+              return prevCols;
+            },
+            [],
+          );
           setColumnNames(prevColumnNames => ({
             ...prevColumnNames,
-            [resultType]: json.result[0].columns || checkCols,
+            [resultType]: checkCols,
           }));
           setIsLoading(prevIsLoading => ({
             ...prevIsLoading,

--- a/superset-frontend/src/explore/exploreUtils/index.js
+++ b/superset-frontend/src/explore/exploreUtils/index.js
@@ -286,8 +286,7 @@ export const exportChart = ({
       ownState,
     });
   }
-  console.log('PAYLOAD', payload);
-  console.log('URL', url);
+
   postForm(url, payload);
 };
 

--- a/superset-frontend/src/explore/exploreUtils/index.js
+++ b/superset-frontend/src/explore/exploreUtils/index.js
@@ -286,6 +286,8 @@ export const exportChart = ({
       ownState,
     });
   }
+  console.log('PAYLOAD', payload);
+  console.log('URL', url);
   postForm(url, payload);
 };
 


### PR DESCRIPTION
### SUMMARY
Partially fixes #17960

This PR fixes an issue for which only the columns from the first query in the response would be printed in the data panel.

### BEFORE

![image](https://user-images.githubusercontent.com/28984703/150923498-11bc7a70-3c94-4c42-8b52-cf3851b45075.png)

### AFTER

<img width="1353" alt="Screen Shot 2022-02-04 at 18 06 02" src="https://user-images.githubusercontent.com/60598000/152562136-987b2764-5fce-438e-874d-dcdaefd22769.png">


### TESTING INSTRUCTIONS
1. Create a Mixed Time-Series chart
2. Fill the metrics for Query A and B
3. Make sure both columns are showing in the data panel

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #17960
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
