### PR TITLE
chore: allow sqla docs to use supersettext

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/SqlAlchemyForm.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/SqlAlchemyForm.tsx
@@ -19,7 +19,6 @@
 import React, { EventHandler, ChangeEvent, MouseEvent } from 'react';
 import { t, SupersetTheme } from '@superset-ui/core';
 import SupersetText from 'src/utils/textUtils';
-// import SupersetText, { SupersetTextType, st } from 'src/utils/textUtils';
 import Button from 'src/components/Button';
 import { StyledInputContainer, wideButton } from './styles';
 

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/SqlAlchemyForm.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/SqlAlchemyForm.tsx
@@ -18,6 +18,8 @@
  */
 import React, { EventHandler, ChangeEvent, MouseEvent } from 'react';
 import { t, SupersetTheme } from '@superset-ui/core';
+import SupersetText from 'src/utils/textUtils';
+// import SupersetText, { SupersetTextType, st } from 'src/utils/textUtils';
 import Button from 'src/components/Button';
 import { StyledInputContainer, wideButton } from './styles';
 
@@ -37,67 +39,76 @@ const SqlAlchemyTab = ({
   conf: { SQLALCHEMY_DOCS_URL: string; SQLALCHEMY_DISPLAY_TEXT: string };
   isEditMode?: boolean;
   testInProgress?: boolean;
-}) => (
-  <>
-    <StyledInputContainer>
-      <div className="control-label">
-        {t('Display Name')}
-        <span className="required">*</span>
-      </div>
-      <div className="input-container">
-        <input
-          type="text"
-          name="database_name"
-          data-test="database-name-input"
-          value={db?.database_name || ''}
-          placeholder={t('Name your database')}
-          onChange={onInputChange}
-        />
-      </div>
-      <div className="helper">
-        {t('Pick a name to help you identify this database.')}
-      </div>
-    </StyledInputContainer>
-    <StyledInputContainer>
-      <div className="control-label">
-        {t('SQLAlchemy URI')}
-        <span className="required">*</span>
-      </div>
-      <div className="input-container">
-        <input
-          type="text"
-          name="sqlalchemy_uri"
-          data-test="sqlalchemy-uri-input"
-          value={db?.sqlalchemy_uri || ''}
-          autoComplete="off"
-          placeholder={t(
-            'dialect+driver://username:password@host:port/database',
-          )}
-          onChange={onInputChange}
-        />
-      </div>
-      <div className="helper">
-        {t('Refer to the')}{' '}
-        <a
-          href={conf?.SQLALCHEMY_DOCS_URL ?? ''}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {conf?.SQLALCHEMY_DISPLAY_TEXT ?? ''}
-        </a>{' '}
-        {t('for more information on how to structure your URI.')}
-      </div>
-    </StyledInputContainer>
-    <Button
-      onClick={testConnection}
-      disabled={testInProgress}
-      cta
-      buttonStyle="link"
-      css={(theme: SupersetTheme) => wideButton(theme)}
-    >
-      {t('Test connection')}
-    </Button>
-  </>
-);
-
+}) => {
+  let fallbackDocsUrl;
+  let fallbackDisplayText;
+  if (SupersetText) {
+    fallbackDocsUrl =
+      SupersetText.DB_MODAL_SQLALCHEMY_FORM?.SQLALCHEMY_DOCS_URL;
+    fallbackDisplayText =
+      SupersetText.DB_MODAL_SQLALCHEMY_FORM?.SQLALCHEMY_DOCS_URL;
+  }
+  return (
+    <>
+      <StyledInputContainer>
+        <div className="control-label">
+          {t('Display Name')}
+          <span className="required">*</span>
+        </div>
+        <div className="input-container">
+          <input
+            type="text"
+            name="database_name"
+            data-test="database-name-input"
+            value={db?.database_name || ''}
+            placeholder={t('Name your database')}
+            onChange={onInputChange}
+          />
+        </div>
+        <div className="helper">
+          {t('Pick a name to help you identify this database.')}
+        </div>
+      </StyledInputContainer>
+      <StyledInputContainer>
+        <div className="control-label">
+          {t('SQLAlchemy URI')}
+          <span className="required">*</span>
+        </div>
+        <div className="input-container">
+          <input
+            type="text"
+            name="sqlalchemy_uri"
+            data-test="sqlalchemy-uri-input"
+            value={db?.sqlalchemy_uri || ''}
+            autoComplete="off"
+            placeholder={t(
+              'dialect+driver://username:password@host:port/database',
+            )}
+            onChange={onInputChange}
+          />
+        </div>
+        <div className="helper">
+          {t('Refer to the')}{' '}
+          <a
+            href={fallbackDocsUrl || conf?.SQLALCHEMY_DOCS_URL || ''}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {fallbackDisplayText || conf?.SQLALCHEMY_DISPLAY_TEXT || ''}
+          </a>{' '}
+          {t('for more information on how to structure your URI.')}
+        </div>
+      </StyledInputContainer>
+      <Button
+        onClick={testConnection}
+        disabled={testInProgress}
+        cta
+        buttonStyle="link"
+        css={(theme: SupersetTheme) => wideButton(theme)}
+      >
+        {t('Test connection')}
+      </Button>
+    </>
+  );
+};
 export default SqlAlchemyTab;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This pr is to allow SupersetText module texts to take precedent when it exits in the database connection modal.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
