### PR TITLE
fix: sqllab schema select error msg

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
@@ -39,9 +39,9 @@ interface actionsTypes {
   addTable: (queryEditor: any, value: any, schema: any) => void;
   setDatabases: (arg0: any) => {};
   addDangerToast: (msg: string) => void;
-  queryEditorSetSchema: (schema?: string) => void;
-  queryEditorSetSchemaOptions: () => void;
-  queryEditorSetTableOptions: (options: Array<any>) => void;
+  queryEditorSetSchema: (queryEditor: any, schema?: string) => void;
+  queryEditorSetSchemaOptions: (queryEditor: any, options: Array<any>) => void;
+  queryEditorSetTableOptions: (queryEditor: any, options: Array<any>) => void;
   resetState: () => void;
 }
 
@@ -91,6 +91,18 @@ export default function SqlEditorLeftBar({
     actions.queryEditorSetFunctionNames(queryEditor, dbId);
   };
 
+  const onSchemaChange = (schema?: string) => {
+    if (schema) {
+      actions.queryEditorSetSchema(queryEditor, schema);
+    }
+  };
+
+  const onSchemasLoad = (options: Array<any>) => {
+    if (options) {
+      actions.queryEditorSetTableOptions(queryEditor, options);
+    }
+  };
+
   const onTableChange = (tableName: string, schemaName: string) => {
     if (tableName && schemaName) {
       actions.addTable(queryEditor, tableName, schemaName);
@@ -108,6 +120,12 @@ export default function SqlEditorLeftBar({
         actions.expandTable(table);
       }
     });
+  };
+
+  const onTablesLoad = (options: Array<any>) => {
+    if (options) {
+      actions.queryEditorSetTableOptions(queryEditor, options);
+    }
   };
 
   const renderExpandIconWithTooltip = ({ isActive }: { isActive: boolean }) => (
@@ -139,10 +157,10 @@ export default function SqlEditorLeftBar({
         getDbList={actions.setDatabases}
         handleError={actions.addDangerToast}
         onDbChange={onDbChange}
-        onSchemaChange={actions.queryEditorSetSchema}
-        onSchemasLoad={actions.queryEditorSetSchemaOptions}
+        onSchemaChange={onSchemaChange}
+        onSchemasLoad={onSchemasLoad}
         onTableChange={onTableChange}
-        onTablesLoad={actions.queryEditorSetTableOptions}
+        onTablesLoad={onTablesLoad}
         schema={queryEditor.schema}
         sqlLabMode
       />

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -86,7 +86,7 @@ interface TableSelectorProps {
   isDatabaseSelectEnabled?: boolean;
   onDbChange?: (db: DatabaseObject) => void;
   onSchemaChange?: (schema?: string) => void;
-  onSchemasLoad?: () => void;
+  onSchemasLoad?: (options: Array<any>) => void;
   onTableChange?: (tableName?: string, schema?: string) => void;
   onTablesLoad?: (options: Array<any>) => void;
   readOnly?: boolean;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Partially fixes https://github.com/apache/superset/issues/18184.
root cause is the lack of **queryEditor** parameter.
fix design is to add a wrapper in **SqlEditorLeftBar** to pass the **queryEditor** parameter.
```
 ...
 const onSchemaChange = (schema?: string) => {
    if (schema) {
      actions.queryEditorSetSchema(queryEditor, schema);
    }
  };
 ...
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![4k3yz-necia](https://user-images.githubusercontent.com/95735472/152695808-50b475b2-ae60-4712-891f-3aa2a950bf85.gif)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
![mfsz8-bvzvu](https://user-images.githubusercontent.com/95735472/152695783-2ffdf470-7c74-42cc-a07f-af45e52996af.gif)


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
