### PR TITLE
docs: fixed URL for contributing landing page

### DIFF
--- a/docs/docs/Contributing/contributing-page.mdx
+++ b/docs/docs/Contributing/contributing-page.mdx
@@ -1,8 +1,7 @@
 ---
-name: General Resources
-menu: Contributing
-route: /docs/contributing/contribution-guidelines
-index: 1
+title: Contributing to Superset
+hide_title: true
+sidebar_position: 1
 version: 1
 ---
 


### PR DESCRIPTION
Minor tweak to URL for one of the docs pages