### PR TITLE
fix(jest): add superset-frontend to testRegex

### DIFF
--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -18,7 +18,8 @@
  */
 
 module.exports = {
-  testRegex: '\\/(spec|src|plugins|packages)\\/.*(_spec|\\.test)\\.[jt]sx?$',
+  testRegex:
+    '\\/superset-frontend\\/(spec|src|plugins|packages)\\/.*(_spec|\\.test)\\.[jt]sx?$',
   moduleNameMapper: {
     '\\.(css|less|geojson)$': '<rootDir>/spec/__mocks__/mockExportObject.js',
     '\\.(gif|ttf|eot|png|jpg)$': '<rootDir>/spec/__mocks__/mockExportString.js',


### PR DESCRIPTION
### SUMMARY
When running Jest tests on the frontend, I noticed that it was triggering Cypress, too (which obviously were failing). When investigating further I noticed that the `testRegex` only tests for 

```regex
\/(spec|src|plugins|packages)\/.*(_spec|\.test)\.[jt]sx?$
```

which on my setup triggered pretty much every path: 😅 

```
$ pwd
/Users/ville/src/superset/superset-frontend
```

By adding `superset-frontend/` to the regex we can ensure that we don't match parent folders unless they are preceeded by `superset-frontend/`.

### AFTER
Now when I start the jest tests, the `testRegex` only matches 520 tests:
```
$ npm run test

> superset@0.0.0dev test
> cross-env NODE_ENV=test jest


 RUNS  packages/superset-ui-core/test/utils/logging.test.ts
 RUNS  packages/superset-ui-core/test/connection/callApi/callApi.test.ts
 RUNS  src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
 RUNS  plugins/plugin-chart-echarts/test/utils/forecast.test.ts
 RUNS  src/dashboard/util/dnd-reorder.test.js
 RUNS  src/dashboard/util/isValidChild.test.ts
 RUNS  packages/superset-ui-core/test/connection/callApi/callApiAndParseWithTimeout.test.ts
 RUNS  plugins/legacy-plugin-chart-sankey/lib/tests/utils.test.js
 RUNS  packages/superset-ui-core/test/time-format/utils/d3Time.test.ts
 RUNS  packages/superset-ui-core/test/color/ColorScheme.test.ts
 RUNS  plugins/legacy-plugin-chart-sankey/src/tests/utils.test.js

Test Suites: 0 of 520 total
...
```

### BEFORE
Previously it was matching 569 tests:
```
$ npm run test

> superset@0.0.0dev test
> cross-env NODE_ENV=test jest


 RUNS  cypress-base/cypress/integration/explore/visualizations/line.test.ts
 RUNS  cypress-base/cypress/integration/explore/visualizations/dist_bar.test.js
 RUNS  cypress-base/cypress/integration/explore/visualizations/sunburst.test.js
 RUNS  cypress-base/cypress/integration/explore/visualizations/pivot_table.test.js
 RUNS  cypress-base/cypress/integration/chart_list/list_view.test.ts
 RUNS  cypress-base/cypress/integration/database/modal.test.ts
 RUNS  cypress-base/cypress/integration/explore/visualizations/gauge.test.js
 RUNS  cypress-base/cypress/integration/explore/visualizations/world_map.test.js
 RUNS  packages/superset-ui-core/test/utils/logging.test.ts
 RUNS  cypress-base/cypress/integration/explore/visualizations/area.test.js
 RUNS  cypress-base/cypress/integration/chart_list/filter.test.ts

Test Suites: 0 of 569 total
...
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
