### PR TITLE
fix(Explore): Force different color for same metrics in Mixed Time-Series

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -175,27 +175,26 @@ export default function transformProps(
       stack,
       yAxisIndex,
       filterState,
+      seriesKey: entry.name,
     });
     if (transformedSeries) series.push(transformedSeries);
   });
 
   rawSeriesB.forEach(entry => {
-    const transformedSeries = transformSeries(
-      entry,
-      colorScale,
-      {
-        area: areaB,
-        markerEnabled: markerEnabledB,
-        markerSize: markerSizeB,
-        areaOpacity: opacityB,
-        seriesType: seriesTypeB,
-        showValue: showValueB,
-        stack: stackB,
-        yAxisIndex: yAxisIndexB,
-        filterState,
-      },
-      rawSeriesA,
-    );
+    const transformedSeries = transformSeries(entry, colorScale, {
+      area: areaB,
+      markerEnabled: markerEnabledB,
+      markerSize: markerSizeB,
+      areaOpacity: opacityB,
+      seriesType: seriesTypeB,
+      showValue: showValueB,
+      stack: stackB,
+      yAxisIndex: yAxisIndexB,
+      filterState,
+      seriesKey: primarySeries.has(entry.name as string)
+        ? `${entry.name} (1)`
+        : entry.name,
+    });
     if (transformedSeries) series.push(transformedSeries);
   });
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -165,37 +165,37 @@ export default function transformProps(
   );
 
   rawSeriesA.forEach(entry => {
-    const transformedSeries = transformSeries(
-      entry,
-      colorScale,
-      {
-        area,
-        markerEnabled,
-        markerSize,
-        areaOpacity: opacity,
-        seriesType,
-        showValue,
-        stack,
-        yAxisIndex,
-        filterState,
-      },
-      rawSeriesB,
-    );
+    const transformedSeries = transformSeries(entry, colorScale, {
+      area,
+      markerEnabled,
+      markerSize,
+      areaOpacity: opacity,
+      seriesType,
+      showValue,
+      stack,
+      yAxisIndex,
+      filterState,
+    });
     if (transformedSeries) series.push(transformedSeries);
   });
 
   rawSeriesB.forEach(entry => {
-    const transformedSeries = transformSeries(entry, colorScale, {
-      area: areaB,
-      markerEnabled: markerEnabledB,
-      markerSize: markerSizeB,
-      areaOpacity: opacityB,
-      seriesType: seriesTypeB,
-      showValue: showValueB,
-      stack: stackB,
-      yAxisIndex: yAxisIndexB,
-      filterState,
-    });
+    const transformedSeries = transformSeries(
+      entry,
+      colorScale,
+      {
+        area: areaB,
+        markerEnabled: markerEnabledB,
+        markerSize: markerSizeB,
+        areaOpacity: opacityB,
+        seriesType: seriesTypeB,
+        showValue: showValueB,
+        stack: stackB,
+        yAxisIndex: yAxisIndexB,
+        filterState,
+      },
+      rawSeriesA,
+    );
     if (transformedSeries) series.push(transformedSeries);
   });
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -165,19 +165,25 @@ export default function transformProps(
   );
 
   rawSeriesA.forEach(entry => {
-    const transformedSeries = transformSeries(entry, colorScale, {
-      area,
-      markerEnabled,
-      markerSize,
-      areaOpacity: opacity,
-      seriesType,
-      showValue,
-      stack,
-      yAxisIndex,
-      filterState,
-    });
+    const transformedSeries = transformSeries(
+      entry,
+      colorScale,
+      {
+        area,
+        markerEnabled,
+        markerSize,
+        areaOpacity: opacity,
+        seriesType,
+        showValue,
+        stack,
+        yAxisIndex,
+        filterState,
+      },
+      rawSeriesB,
+    );
     if (transformedSeries) series.push(transformedSeries);
   });
+
   rawSeriesB.forEach(entry => {
     const transformedSeries = transformSeries(entry, colorScale, {
       area: areaB,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -84,6 +84,7 @@ export function transformSeries(
     thresholdValues?: number[];
     richTooltip?: boolean;
   },
+  rawSeriesB?: SeriesOption[],
 ): SeriesOption | undefined {
   const { name } = series;
   const {
@@ -147,8 +148,14 @@ export function transformSeries(
   } else {
     plotType = seriesType === 'bar' ? 'bar' : 'line';
   }
+  const rawSeriesBHasMetric = !!(rawSeriesB || []).find(
+    (serie: SeriesOption) => serie.name === forecastSeries.name,
+  );
+  // forcing the colorScale to return a different color for same metrics across different queries
   const itemStyle = {
-    color: colorScale(forecastSeries.name),
+    color: colorScale(
+      rawSeriesBHasMetric ? `${forecastSeries.name}-A` : forecastSeries.name,
+    ),
     opacity,
   };
   let emphasis = {};

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -83,8 +83,8 @@ export function transformSeries(
     showValueIndexes?: number[];
     thresholdValues?: number[];
     richTooltip?: boolean;
+    seriesKey?: OptionName;
   },
-  additionalSeriesGroup?: SeriesOption[],
 ): SeriesOption | undefined {
   const { name } = series;
   const {
@@ -104,6 +104,7 @@ export function transformSeries(
     showValueIndexes = [],
     thresholdValues = [],
     richTooltip,
+    seriesKey,
   } = opts;
   const contexts = seriesContexts[name || ''] || [];
   const hasForecast =
@@ -148,20 +149,9 @@ export function transformSeries(
   } else {
     plotType = seriesType === 'bar' ? 'bar' : 'line';
   }
-  // checking if the same metric name is available in the previous query
-  const metricExists = !!(additionalSeriesGroup || []).find(
-    (serie: SeriesOption) => {
-      const otherForecastedSeries = extractForecastSeriesContext(
-        serie.name || '',
-      );
-      return otherForecastedSeries.name === forecastSeries.name;
-    },
-  );
   // forcing the colorScale to return a different color for same metrics across different queries
   const itemStyle = {
-    color: colorScale(
-      metricExists ? `${forecastSeries.name} (1)` : forecastSeries.name,
-    ),
+    color: colorScale(seriesKey || forecastSeries.name),
     opacity,
   };
   let emphasis = {};

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -84,7 +84,7 @@ export function transformSeries(
     thresholdValues?: number[];
     richTooltip?: boolean;
   },
-  rawSeriesB?: SeriesOption[],
+  additionalSeriesGroup?: SeriesOption[],
 ): SeriesOption | undefined {
   const { name } = series;
   const {
@@ -148,13 +148,19 @@ export function transformSeries(
   } else {
     plotType = seriesType === 'bar' ? 'bar' : 'line';
   }
-  const rawSeriesBHasMetric = !!(rawSeriesB || []).find(
-    (serie: SeriesOption) => serie.name === forecastSeries.name,
+  // checking if the same metric name is available in the previous query
+  const metricExists = !!(additionalSeriesGroup || []).find(
+    (serie: SeriesOption) => {
+      const otherForecastedSeries = extractForecastSeriesContext(
+        serie.name || '',
+      );
+      return otherForecastedSeries.name === forecastSeries.name;
+    },
   );
   // forcing the colorScale to return a different color for same metrics across different queries
   const itemStyle = {
     color: colorScale(
-      rawSeriesBHasMetric ? `${forecastSeries.name}-A` : forecastSeries.name,
+      metricExists ? `${forecastSeries.name} (1)` : forecastSeries.name,
     ),
     opacity,
   };


### PR DESCRIPTION
### SUMMARY
This PR forces the `colorScale` to return a different color when the same metrics are found across the two queries in order to apply contrasting colors. It appends a `(1)` to the name of the metric in series B when found in series A so that the `colorScale` will treat it as a different value and it behaves consistently with how the chart renames these labels.

### BEFORE

https://user-images.githubusercontent.com/60598000/152832268-17552fbb-5bdd-4abc-ae8c-f6b347bb4bce.mp4

### AFTER

https://user-images.githubusercontent.com/60598000/153009181-8161365e-e0cc-4fe2-a477-5db853b2f272.mp4


### TESTING INSTRUCTIONS

1. Choose a mixed time-series chart
2. Date added in Time with a Grain: Month
3. Add the same metrics A and B
4. Customize -> Create 1 metric as a Line and the other as a Bar
5. Make sure different colors applied

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
