### PR TITLE
fix(helm): Fix support for ingress.ingressClassName

### DIFF
--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
   - name: craig-rueda
     email: craig@craigrueda.com
     url: https://github.com/craig-rueda
-version: 0.5.6
+version: 0.5.7
 dependencies:
 - name: postgresql
   version: 10.2.0

--- a/helm/superset/values.schema.json
+++ b/helm/superset/values.schema.json
@@ -149,6 +149,9 @@
                 "pathType": {
                     "type": "string"
                 },
+                "ingressClassName": {
+                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.23.0/_definitions.json##/definitions/io.k8s.api.networking.v1.IngressSpec/properties/ingressClassName"
+                },
                 "hosts": {
                     "type": "array",
                     "items": {


### PR DESCRIPTION

### SUMMARY

In #18617 @joatkh reported removed support for `ingress.ingressClassName` in `values.yaml` of our Chart. It is an undocumented parameter but supported by our Chart:
https://github.com/apache/superset/blob/1fbdabd2cf88ce4da0b99897ce00afd03ae47d27/helm/superset/templates/ingress.yaml#L33-L35

That PR re-add that support.
 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Use ingress.ingressClassName eg. via `--set` during installation. It should pass validation.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: #18617
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

@joatkh could you give a shoot to test if it's working for you?
@craig-rueda could you take a look as maintainer of Chart?