### PR TITLE
feat: log decorator util - adding automatic logs out of the box

### DIFF
--- a/tests/common/logger_utils.py
+++ b/tests/common/logger_utils.py
@@ -1,0 +1,162 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+from __future__ import annotations
+
+import logging
+from functools import wraps
+from inspect import (
+    getcallargs,
+    getmembers,
+    getmodule,
+    isclass,
+    isfunction,
+    ismethod,
+    signature,
+    Signature,
+)
+from logging import Logger
+from typing import Any, Callable, cast, Optional, Type, Union
+
+_DEFAULT_ENTER_MSG_PREFIX = "enter to "
+_DEFAULT_ENTER_MSG_SUFFIX = ""
+_DEFAULT_WITH_ARGUMENTS_MSG_PART = " with: "
+_DEFAULT_EXIT_MSG_PREFIX = "exit from "
+_DEFAULT_EXIT_MSG_SUFFIX = ""
+_DEFAULT_RETURN_VALUE_MSG_PART = " with return value: "
+
+_CLS_PARAM = "cls"
+_SELF_PARAM = "self"
+_PRIVATE_PREFIX_SYMBOL = "_"
+_FIXTURE_ATTRIBUTE = "_pytestfixturefunction"
+_LOGGER_VAR_NAME = "logger"
+
+empty_and_none = {Signature.empty, "None"}
+
+
+Function = Callable[..., Any]
+Decorated = Union[Type[Any], Function]
+
+
+def log(
+    decorated: Optional[Decorated] = None,
+    *,
+    prefix_enter_msg: str = _DEFAULT_ENTER_MSG_PREFIX,
+    suffix_enter_msg: str = _DEFAULT_ENTER_MSG_SUFFIX,
+    with_arguments_msg_part=_DEFAULT_WITH_ARGUMENTS_MSG_PART,
+    prefix_exit_msg: str = _DEFAULT_EXIT_MSG_PREFIX,
+    suffix_exit_msg: str = _DEFAULT_EXIT_MSG_SUFFIX,
+    return_value_msg_part=_DEFAULT_RETURN_VALUE_MSG_PART,
+) -> Decorated:
+
+    decorator: Decorated = _make_decorator(
+        prefix_enter_msg,
+        suffix_enter_msg,
+        with_arguments_msg_part,
+        prefix_exit_msg,
+        suffix_exit_msg,
+        return_value_msg_part,
+    )
+    if decorated is None:
+        return decorator
+    return decorator(decorated)
+
+
+def _make_decorator(
+    prefix_enter_msg: str,
+    suffix_enter_msg: str,
+    with_arguments_msg_part,
+    prefix_out_msg: str,
+    suffix_out_msg: str,
+    return_value_msg_part,
+) -> Decorated:
+    def decorator(decorated: Decorated):
+        decorated_logger = _get_logger(decorated)
+        is_debug_enable = decorated_logger.isEnabledFor(logging.DEBUG)
+        is_under_info = decorated_logger.level < logging.INFO
+
+        def decorator_class(clazz: Type[Any]) -> Type[Any]:
+            _decorate_class_members_with_logs(clazz)
+            return clazz
+
+        def _decorate_class_members_with_logs(clazz: Type[Any]) -> None:
+            members = getmembers(
+                clazz, predicate=lambda val: ismethod(val) or isfunction(val)
+            )
+            for member_name, member in members:
+                setattr(clazz, member_name, decorator_func(member, f"{clazz.__name__}"))
+
+        def decorator_func(func: Function, prefix_name: str = "") -> Function:
+            func_name = func.__name__
+            func_signature: Signature = signature(func)
+            is_fixture = hasattr(func, _FIXTURE_ATTRIBUTE)
+            has_return_value = func_signature.return_annotation not in empty_and_none
+            is_private = func_name.startswith(_PRIVATE_PREFIX_SYMBOL)
+            full_func_name = f"{prefix_name}.{func_name}"
+
+            @wraps(func)
+            def _wrapper_func(*args, **kwargs) -> Any:
+                _log_enter_to_function(*args, **kwargs)
+                val = func(*args, **kwargs)
+                _log_exit_of_function(val)
+                return val
+
+            def _log_enter_to_function(*args, **kwargs) -> None:
+                if _is_log_info():
+                    decorated_logger.info(
+                        f"{prefix_enter_msg}'{full_func_name}'{suffix_enter_msg}"
+                    )
+                elif is_debug_enable:
+                    _log_debug(*args, **kwargs)
+
+            def _is_log_info() -> bool:
+                return not (is_under_info or is_private or is_fixture)
+
+            def _log_debug(*args, **kwargs) -> None:
+                used_parameters = getcallargs(func, *args, **kwargs)
+                _SELF_PARAM in used_parameters and used_parameters.pop(_SELF_PARAM)
+                _CLS_PARAM in used_parameters and used_parameters.pop(_CLS_PARAM)
+                if used_parameters:
+                    decorated_logger.debug(
+                        f"{prefix_enter_msg}'{full_func_name}'{with_arguments_msg_part}"
+                        f"{used_parameters}{suffix_enter_msg}"
+                    )
+                else:
+                    decorated_logger.debug(
+                        f"{prefix_enter_msg}'{full_func_name}'{suffix_enter_msg}"
+                    )
+
+            def _log_exit_of_function(return_value: Any) -> None:
+                if is_debug_enable and has_return_value:
+                    decorated_logger.debug(
+                        f"{prefix_out_msg}'{full_func_name}'{return_value_msg_part}"
+                        f"'{return_value}'{suffix_out_msg}"
+                    )
+
+            return _wrapper_func
+
+        if isclass(decorated):
+            return decorator_class(cast(Type[Any], decorated))
+        return decorator_func(cast(Function, decorated))
+
+    return decorator
+
+
+def _get_logger(decorated: Decorated) -> Logger:
+    module = getmodule(decorated)
+    return module.__dict__.get(
+        _LOGGER_VAR_NAME, logging.getLogger(module.__name__)  # type: ignore
+    )

--- a/tests/common/logger_utils.py
+++ b/tests/common/logger_utils.py
@@ -137,7 +137,6 @@ def _make_decorator(
                     debug_enable = decorated_logger.isEnabledFor(logging.DEBUG)
                 return debug_enable
 
-
             def _log_debug(*args, **kwargs) -> None:
                 used_parameters = getcallargs(func, *args, **kwargs)
                 _SELF_PARAM in used_parameters and used_parameters.pop(_SELF_PARAM)

--- a/tests/example_data/data_loading/pandas/pandas_data_loader.py
+++ b/tests/example_data/data_loading/pandas/pandas_data_loader.py
@@ -14,15 +14,6 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#
-#  http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing,
-#  software distributed under the License is distributed on an
-#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-#  KIND, either express or implied.  See the License for the
-#  specific language governing permissions and limitations
-#  under the License.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
@@ -31,6 +22,7 @@ from typing import Dict, Optional, TYPE_CHECKING
 from pandas import DataFrame
 from sqlalchemy.inspection import inspect
 
+from tests.common.logger_utils import log
 from tests.example_data.data_loading.base_data_loader import DataLoader
 
 if TYPE_CHECKING:
@@ -42,6 +34,7 @@ if TYPE_CHECKING:
     )
 
 
+@log
 class PandasDataLoader(DataLoader):
     _db_engine: Engine
     _configurations: PandasLoaderConfigurations

--- a/tests/example_data/data_loading/pandas/table_df_convertor.py
+++ b/tests/example_data/data_loading/pandas/table_df_convertor.py
@@ -20,12 +20,14 @@ from typing import Optional, TYPE_CHECKING
 
 from pandas import DataFrame
 
+from tests.common.logger_utils import log
 from tests.example_data.data_loading.pandas.pandas_data_loader import TableToDfConvertor
 
 if TYPE_CHECKING:
     from tests.example_data.data_loading.data_definitions.types import Table
 
 
+@log
 class TableToDfConvertorImpl(TableToDfConvertor):
     convert_datetime_to_str: bool
     _time_format: Optional[str]


### PR DESCRIPTION
### SUMMARY
When functions are implemented, they have a specific reason and responsible for change (SRP)
Writing logs is a different concern that is not related to the reason of the functions that logging statements were added to them. 
In addition, writing logs imply code duplication (imagine writing the logs in the example)
and remember, logging is a cross-cutting concern so adding logging behavior is best used as AOP 

That PR adds a log decorator ability so you can decorate a function or class and you'll get logging out of the box.

Right now as of POC I added and use it under tests. 
After adding the decorator, for each public method that is called, new log records will be added.
In case the logger is configured as DEBUG, for each method call (whether is private or public) a new log will be added with the passed arguments and return value.

#### Example 
```python

from tests.common.logger_utils import log

@log
class PandasDataLoader(DataLoader):
    ...

@log
class TableToDfConvertorImpl(TableToDfConvertorI)
   ...
```
```
INFO     tests.example_data.data_loading.pandas.pandas_data_loader:logger_utils.py:119 enter to 'PandasDataLoader.load_table'
INFO     tests.example_data.data_loading.pandas.table_df_convertor:logger_utils.py:119 enter to 'TableToDfConvertorImpl.convert'
```
or
```
DEBUG    tests.example_data.data_loading.pandas.table_df_convertor:logger_utils.py:145 enter to 'TableToDfConvertorImpl.__init__' with: {'convert_ds_to_datetime': False, 'time_format': '%Y-%m-%d %H:%M:%S'}
DEBUG    tests.example_data.data_loading.pandas.pandas_data_loader:logger_utils.py:145 enter to 'PandasDataLoader.__init__' with: {'db_engine': Engine(mysql+mysqldb://superset:***@127.0.0.1:13306/superset?binary_prefix=true&charset=utf8mb4), 'config': <tests.example_data.data_loading.pandas.pands_data_loading_conf.PandasLoaderConfigurations object at 0x12785e670>, 'table_to_df_convertor': <tests.example_data.data_loading.pandas.table_df_convertor.TableToDfConvertorImpl object at 0x12785e3a0>}
DEBUG    tests.example_data.data_loading.pandas.pandas_data_loader:logger_utils.py:145 enter to 'PandasDataLoader.load_table' with: {'table': Table(table_name='birth_names', table_metadata=TableMetaData(table_name='birth_names', types={'ds': <class 'sqlalchemy.sql.sqltypes.DateTime'>, 'gender': String(length=16), 'name': String(length=255), 'num': <class 'sqlalchemy.sql.sqltypes.Integer'>, 'state': String(length=10), 'num_boys': <class 'sqlalchemy.sql.sqltypes.Integer'>, 'num_girls': <class 'sqlalchemy.sql.sqltypes.Integer'>}), data=<generator object BirthNamesGenerator.generate at 0x127a7ea50>)}
DEBUG    tests.example_data.data_loading.pandas.table_df_convertor:logger_utils.py:145 enter to 'TableToDfConvertorImpl.convert' with: {'table': Table(table_name='birth_names', table_metadata=TableMetaData(table_name='birth_names', types={'ds': <class 'sqlalchemy.sql.sqltypes.DateTime'>, 'gender': String(length=16), 'name': String(length=255), 'num': <class 'sqlalchemy.sql.sqltypes.Integer'>, 'state': String(length=10), 'num_boys': <class 'sqlalchemy.sql.sqltypes.Integer'>, 'num_girls': <class 'sqlalchemy.sql.sqltypes.Integer'>}), data=<generator object BirthNamesGenerator.generate at 0x127a7ea50>)}
DEBUG    tests.example_data.data_loading.pandas.table_df_convertor:logger_utils.py:150 enter to 'TableToDfConvertorImpl._should_convert_datetime_to_str'
DEBUG    tests.example_data.data_loading.pandas.table_df_convertor:logger_utils.py:156 exit from 'TableToDfConvertorImpl._should_convert_datetime_to_str' with return value: 'False'
DEBUG    tests.example_data.data_loading.pandas.table_df_convertor:logger_utils.py:156 exit from 'TableToDfConvertorImpl.convert' with return value: '             ds gender        name    num state  num_boys  num_girls
0    1960-01-01    boy        asoq  86721    KY     86721          0
1    1960-01-01    boy     bdycsfn  31088    TX     31088          0
2    1960-01-01    boy      xbojgx  65611    MA     65611          0
3    1960-01-01    boy    awaahduh  26394    CA     26394          0
4    1960-01-01   girl       hgvei  11012    MT         0      11012
...         ...    ...         ...    ...   ...       ...        ...
1195 2019-01-01   girl        bwty  78079    VT         0      78079
1196 2019-01-01   girl   irwcwcsol  20513    CO         0      20513
1197 2019-01-01   girl  hjpuvonlmv   1093    FL         0       1093
1198 2019-01-01   girl     cjikohg  27274    KY         0      27274
1199 2019-01-01   girl    fpuvnstv  91479    MO         0      91479
[1200 rows x 7 columns]'
DEBUG    tests.example_data.data_loading.pandas.pandas_data_loader:logger_utils.py:145 enter to 'PandasDataLoader._take_data_types' with: {'table': Table(table_name='birth_names', table_metadata=TableMetaData(table_name='birth_names', types={'ds': <class 'sqlalchemy.sql.sqltypes.DateTime'>, 'gender': String(length=16), 'name': String(length=255), 'num': <class 'sqlalchemy.sql.sqltypes.Integer'>, 'state': String(length=10), 'num_boys': <class 'sqlalchemy.sql.sqltypes.Integer'>, 'num_girls': <class 'sqlalchemy.sql.sqltypes.Integer'>}), data=<generator object BirthNamesGenerator.generate at 0x127a7ea50>)}
DEBUG    tests.example_data.data_loading.pandas.pandas_data_loader:logger_utils.py:156 exit from 'PandasDataLoader._take_data_types' with return value: '{'ds': <class 'sqlalchemy.sql.sqltypes.DateTime'>, 'gender': String(length=16), 'name': String(length=255), 'num': <class 'sqlalchemy.sql.sqltypes.Integer'>, 'state': String(length=10), 'num_boys': <class 'sqlalchemy.sql.sqltypes.Integer'>, 'num_girls': <class 'sqlalchemy.sql.sqltypes.Integer'>}'
DEBUG    tests.example_data.data_loading.pandas.pandas_data_loader:logger_utils.py:150 enter to 'PandasDataLoader._detect_schema_name'
DEBUG    tests.example_data.data_loading.pandas.pandas_data_loader:logger_utils.py:156 exit from 'PandasDataLoader._detect_schema_name' with return value: 'superset'
```
### Implemntation details 
To understand the code I recommend reading the post [decorators-and-closures-in-python
](https://towardsdatascience.com/decorators-and-closures-by-example-in-python-382758321164)

When the decorator is created, it takes the decorated class or function, extracts the logger defined inside the module containing the decorated (in case a logger was not defined, a new one will be created).

with the help of the builtin inspect library the decorator will decorate all the class functions members, then for each function, the inspect will parse the function signature and wrap the function with logs statements 


### Important notes
- Right now Pytest captures all the logs, so you won't see them unless a test will be failed or configure pytest not to capture the logs. 
- You can configure different format messages parts by passing prefixes to the decorator. 
- When logging a class methods of function, the "self" and "cls" parameter are omitted 

### Follow up tasks:
- Make the logic more configurable (when logging private and public methods, when adding the arguments and etc..)
- Logging setup (setup tests logger more explicitly and set the level loggers )
- Add exclude decorator in case I decorate a class but I don't want the specific function to be decorated)
