### PR TITLE
chore: Add craig-rueda as codeowner of Helm Chart

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,3 +9,6 @@
 
 # Notify some committers of changes in the Select component
 /superset-frontend/src/components/Select/ @michael-s-molina @geido
+
+# Notify Helm Chart maintainers about changes in it
+/helm/superset/ @craig-rueda


### PR DESCRIPTION

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

I feel that @craig-rueda should be mentioned as codeowner of Helm Chart as maintainer of Helm Chart: 

https://github.com/apache/superset/blob/1fbdabd2cf88ce4da0b99897ce00afd03ae47d27/helm/superset/Chart.yaml#L21-L24

It also documents responsibility in project.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

N/A

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
