### PR TITLE
fix(csv-export): pivot v2 with verbose names

### DIFF
--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -241,7 +241,9 @@ class ChartDataRestApi(ChartRestApi):
             return self._run_async(json_body, command)
 
         form_data = json_body.get("form_data")
-        return self._get_data_response(command, form_data=form_data)
+        return self._get_data_response(
+            command, form_data=form_data, datasource=query_context.datasource
+        )
 
     @expose("/data/<cache_key>", methods=["GET"])
     @protect()

--- a/superset/charts/post_processing.py
+++ b/superset/charts/post_processing.py
@@ -271,7 +271,7 @@ def pivot_table(
         df,
         rows=get_column_names(form_data.get("groupby"), verbose_map),
         columns=get_column_names(form_data.get("columns"), verbose_map),
-        metrics=get_metric_names(form_data["metrics"]),
+        metrics=get_metric_names(form_data["metrics"], verbose_map),
         aggfunc=func_map.get(form_data.get("pandas_aggfunc", "sum"), "Sum"),
         transpose_pivot=bool(form_data.get("transpose_pivot")),
         combine_metrics=bool(form_data.get("combine_metric")),

--- a/superset/charts/post_processing.py
+++ b/superset/charts/post_processing.py
@@ -32,7 +32,12 @@ from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 import pandas as pd
 
 from superset.common.chart_data import ChartDataResultFormat
-from superset.utils.core import DTTM_ALIAS, extract_dataframe_dtypes, get_metric_name
+from superset.utils.core import (
+    DTTM_ALIAS,
+    extract_dataframe_dtypes,
+    get_column_names,
+    get_metric_names,
+)
 
 if TYPE_CHECKING:
     from superset.connectors.base.models import BaseDatasource
@@ -214,18 +219,23 @@ pivot_v2_aggfunc_map = {
 }
 
 
-def pivot_table_v2(df: pd.DataFrame, form_data: Dict[str, Any]) -> pd.DataFrame:
+def pivot_table_v2(
+    df: pd.DataFrame,
+    form_data: Dict[str, Any],
+    datasource: Optional["BaseDatasource"] = None,
+) -> pd.DataFrame:
     """
     Pivot table v2.
     """
+    verbose_map = datasource.data["verbose_map"] if datasource else None
     if form_data.get("granularity_sqla") == "all" and DTTM_ALIAS in df:
         del df[DTTM_ALIAS]
 
     return pivot_df(
         df,
-        rows=form_data.get("groupbyRows") or [],
-        columns=form_data.get("groupbyColumns") or [],
-        metrics=[get_metric_name(m) for m in form_data["metrics"]],
+        rows=get_column_names(form_data.get("groupbyRows"), verbose_map),
+        columns=get_column_names(form_data.get("groupbyColumns"), verbose_map),
+        metrics=get_metric_names(form_data["metrics"], verbose_map),
         aggfunc=form_data.get("aggregateFunction", "Sum"),
         transpose_pivot=bool(form_data.get("transposePivot")),
         combine_metrics=bool(form_data.get("combineMetric")),
@@ -235,10 +245,15 @@ def pivot_table_v2(df: pd.DataFrame, form_data: Dict[str, Any]) -> pd.DataFrame:
     )
 
 
-def pivot_table(df: pd.DataFrame, form_data: Dict[str, Any]) -> pd.DataFrame:
+def pivot_table(
+    df: pd.DataFrame,
+    form_data: Dict[str, Any],
+    datasource: Optional["BaseDatasource"] = None,
+) -> pd.DataFrame:
     """
     Pivot table (v1).
     """
+    verbose_map = datasource.data["verbose_map"] if datasource else None
     if form_data.get("granularity") == "all" and DTTM_ALIAS in df:
         del df[DTTM_ALIAS]
 
@@ -254,9 +269,9 @@ def pivot_table(df: pd.DataFrame, form_data: Dict[str, Any]) -> pd.DataFrame:
 
     return pivot_df(
         df,
-        rows=form_data.get("groupby") or [],
-        columns=form_data.get("columns") or [],
-        metrics=[get_metric_name(m) for m in form_data["metrics"]],
+        rows=get_column_names(form_data.get("groupby"), verbose_map),
+        columns=get_column_names(form_data.get("columns"), verbose_map),
+        metrics=get_metric_names(form_data["metrics"]),
         aggfunc=func_map.get(form_data.get("pandas_aggfunc", "sum"), "Sum"),
         transpose_pivot=bool(form_data.get("transpose_pivot")),
         combine_metrics=bool(form_data.get("combine_metric")),
@@ -266,7 +281,11 @@ def pivot_table(df: pd.DataFrame, form_data: Dict[str, Any]) -> pd.DataFrame:
     )
 
 
-def table(df: pd.DataFrame, form_data: Dict[str, Any]) -> pd.DataFrame:
+def table(
+    df: pd.DataFrame,
+    form_data: Dict[str, Any],
+    datasource: Optional["BaseDatasource"] = None,  # pylint: disable=unused-argument
+) -> pd.DataFrame:
     """
     Table.
     """
@@ -312,7 +331,7 @@ def apply_post_process(
         else:
             raise Exception(f"Result format {query['result_format']} not supported")
 
-        processed_df = post_processor(df, form_data)
+        processed_df = post_processor(df, form_data, datasource)
 
         query["colnames"] = list(processed_df.columns)
         query["indexnames"] = list(processed_df.index)

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1240,7 +1240,6 @@ def get_column_name(
     :return: String representation of column
     :raises ValueError: if metric object is invalid
     """
-    verbose_map = verbose_map or {}
     if isinstance(column, dict):
         label = column.get("label")
         if label:
@@ -1249,6 +1248,7 @@ def get_column_name(
         if expr:
             return expr
         raise ValueError("Missing label")
+    verbose_map = verbose_map or {}
     return verbose_map.get(column, column)
 
 
@@ -1264,7 +1264,6 @@ def get_metric_name(
     :return: String representation of metric
     :raises ValueError: if metric object is invalid
     """
-    verbose_map = verbose_map or {}
     if is_adhoc_metric(metric):
         label = metric.get("label")
         if label:
@@ -1281,9 +1280,10 @@ def get_metric_name(
             if column and aggregate:
                 return f"{aggregate}({column_name})"
             if column_name:
-                return verbose_map.get(column_name, column_name)
+                return column_name
         raise ValueError(__("Invalid metric object"))
 
+    verbose_map = verbose_map or {}
     return verbose_map.get(metric, metric)  # type: ignore
 
 

--- a/tests/unit_tests/core_tests.py
+++ b/tests/unit_tests/core_tests.py
@@ -19,10 +19,13 @@ from copy import deepcopy
 import pytest
 
 from superset.utils.core import (
+    AdhocColumn,
     AdhocMetric,
     ExtraFiltersReasonType,
     ExtraFiltersTimeColumnType,
     GenericDataType,
+    get_column_name,
+    get_column_names,
     get_metric_name,
     get_metric_names,
     get_time_filter_status,
@@ -47,15 +50,23 @@ SQL_ADHOC_METRIC: AdhocMetric = {
     "label": "my_sql",
     "sqlExpression": "SUM(my_col)",
 }
+STR_COLUMN = "my_column"
+SQL_ADHOC_COLUMN: AdhocColumn = {
+    "hasCustomLabel": True,
+    "label": "My Adhoc Column",
+    "sqlExpression": "case when foo = 1 then 'foo' else 'bar' end",
+}
 
 
 def test_get_metric_name_saved_metric():
     assert get_metric_name(STR_METRIC) == "my_metric"
+    assert get_metric_name(STR_METRIC, {STR_METRIC: "My Metric"}) == "My Metric"
 
 
 def test_get_metric_name_adhoc():
     metric = deepcopy(SIMPLE_SUM_ADHOC_METRIC)
     assert get_metric_name(metric) == "my SUM"
+    assert get_metric_name(metric, {"my SUM": "My Irrelevant Mapping"}) == "my SUM"
     del metric["label"]
     assert get_metric_name(metric) == "SUM(my_col)"
     metric["label"] = ""
@@ -97,6 +108,46 @@ def test_get_metric_names():
     assert get_metric_names(
         [STR_METRIC, SIMPLE_SUM_ADHOC_METRIC, SQL_ADHOC_METRIC]
     ) == ["my_metric", "my SUM", "my_sql"]
+    assert get_metric_names(
+        [STR_METRIC, SIMPLE_SUM_ADHOC_METRIC, SQL_ADHOC_METRIC],
+        {STR_METRIC: "My Metric"},
+    ) == ["My Metric", "my SUM", "my_sql"]
+
+
+def test_get_column_name_physical_column():
+    assert get_column_name(STR_COLUMN) == "my_column"
+    assert get_metric_name(STR_COLUMN, {STR_COLUMN: "My Column"}) == "My Column"
+
+
+def test_get_column_name_adhoc():
+    column = deepcopy(SQL_ADHOC_COLUMN)
+    assert get_column_name(column) == "My Adhoc Column"
+    assert (
+        get_column_name(column, {"My Adhoc Column": "My Irrelevant Mapping"})
+        == "My Adhoc Column"
+    )
+    del column["label"]
+    assert get_column_name(column) == "case when foo = 1 then 'foo' else 'bar' end"
+    column["label"] = ""
+    assert get_column_name(column) == "case when foo = 1 then 'foo' else 'bar' end"
+
+
+def test_get_column_names():
+    assert get_column_names([STR_COLUMN, SQL_ADHOC_COLUMN]) == [
+        "my_column",
+        "My Adhoc Column",
+    ]
+    assert get_column_names(
+        [STR_COLUMN, SQL_ADHOC_COLUMN], {"my_column": "My Column"},
+    ) == ["My Column", "My Adhoc Column"]
+
+
+def test_get_column_name_invalid_metric():
+    column = deepcopy(SQL_ADHOC_COLUMN)
+    del column["label"]
+    del column["sqlExpression"]
+    with pytest.raises(ValueError):
+        get_column_name(column)
 
 
 def test_is_adhoc_metric():

--- a/tests/unit_tests/core_tests.py
+++ b/tests/unit_tests/core_tests.py
@@ -75,9 +75,11 @@ def test_get_metric_name_adhoc():
     assert get_metric_name(metric) == "my_col"
     metric["aggregate"] = ""
     assert get_metric_name(metric) == "my_col"
+    assert get_metric_name(metric, {"my_col": "My Irrelevant Mapping"}) == "my_col"
 
     metric = deepcopy(SQL_ADHOC_METRIC)
     assert get_metric_name(metric) == "my_sql"
+    assert get_metric_name(metric, {"my_sql": "My Irrelevant Mapping"}) == "my_sql"
     del metric["label"]
     assert get_metric_name(metric) == "SUM(my_col)"
     metric["label"] = ""


### PR DESCRIPTION
### SUMMARY
When exporting a pivoted CSV for the Pivot v2 chart with columns or metrics that have a verbose name, the export fails. This adds the option of passing the `verbose_map` from the datasource to the `get_column_name` and `get_metric_name` util functions + adds some missing tests. Note that remapping the column names is usually not needed, hence mapping is optional.

### TESTING INSTRUCTIONS
1. Create a Pivot v2 using the FCC 2018 Survey example dataset
2. Set the metric as the saved metric "COUNT(*)"
3. Set the columns as "Job location preference"
4. Set the rows as "Willing to relocate"
5. Export a Pivoted CSV and observe a 500

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
