### PR TITLE
feat(Helm): Redis with password supported in helm charts and redis chart version updated

### DIFF
--- a/docs/docs/installation/running-on-kubernetes.mdx
+++ b/docs/docs/installation/running-on-kubernetes.mdx
@@ -178,7 +178,7 @@ Data source definitions can be automatically declared by providing key/value yam
 
 ```yaml
 extraConfigs:
-  datasources-init.yaml: |
+  import_datasources.yaml: |
     databases:
     - allow_file_upload: true
       allow_ctas: true

--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -22,13 +22,13 @@ maintainers:
   - name: craig-rueda
     email: craig@craigrueda.com
     url: https://github.com/craig-rueda
-version: 0.5.7
+version: 0.5.8
 dependencies:
 - name: postgresql
   version: 10.2.0
   repository: https://charts.bitnami.com/bitnami
   condition: postgresql.enabled
 - name: redis
-  version: 12.3.3
+  version: 16.3.1
   repository: https://charts.bitnami.com/bitnami
   condition: redis.enabled

--- a/helm/superset/templates/_helpers.tpl
+++ b/helm/superset/templates/_helpers.tpl
@@ -89,34 +89,26 @@ WTF_CSRF_ENABLED = True
 WTF_CSRF_EXEMPT_LIST = []
 # A CSRF token that expires in 1 year
 WTF_CSRF_TIME_LIMIT = 60 * 60 * 24 * 365
+class CeleryConfig(object):
+  CELERY_IMPORTS = ('superset.sql_lab', )
+  CELERY_ANNOTATIONS = {'tasks.add': {'rate_limit': '10/s'}}
 {{- if .Values.supersetNode.connections.redis_password }}
-class CeleryConfig(object):
-  BROKER_URL = f"redis://{env('REDIS_PASSWORD')}@{env('REDIS_HOST')}:{env('REDIS_PORT')}/0"
-  CELERY_IMPORTS = ('superset.sql_lab', )
-  CELERY_RESULT_BACKEND = f"redis://{env('REDIS_PASSWORD')}@{env('REDIS_HOST')}:{env('REDIS_PORT')}/0"
-  CELERY_ANNOTATIONS = {'tasks.add': {'rate_limit': '10/s'}}
-
-CELERY_CONFIG = CeleryConfig
-RESULTS_BACKEND = RedisCache(
-      host=env('REDIS_HOST'),
-      password=env('REDIS_PASSWORD'),
-      port=env('REDIS_PORT'),
-      key_prefix='superset_results'
-)
+  BROKER_URL = f"redis://:{env('REDIS_PASSWORD')}@{env('REDIS_HOST')}:{env('REDIS_PORT')}/0"
+  CELERY_RESULT_BACKEND = f"redis://:{env('REDIS_PASSWORD')}@{env('REDIS_HOST')}:{env('REDIS_PORT')}/0"
 {{- else }}
-class CeleryConfig(object):
   BROKER_URL = f"redis://{env('REDIS_HOST')}:{env('REDIS_PORT')}/0"
-  CELERY_IMPORTS = ('superset.sql_lab', )
   CELERY_RESULT_BACKEND = f"redis://{env('REDIS_HOST')}:{env('REDIS_PORT')}/0"
-  CELERY_ANNOTATIONS = {'tasks.add': {'rate_limit': '10/s'}}
+{{- end }}
 
 CELERY_CONFIG = CeleryConfig
 RESULTS_BACKEND = RedisCache(
       host=env('REDIS_HOST'),
+{{- if .Values.supersetNode.connections.redis_password }}
+      password=env('REDIS_PASSWORD'),
+{{- end }}
       port=env('REDIS_PORT'),
       key_prefix='superset_results'
 )
-{{- end -}}
 
 {{ if .Values.configOverrides }}
 # Overrides

--- a/helm/superset/templates/_helpers.tpl
+++ b/helm/superset/templates/_helpers.tpl
@@ -89,6 +89,21 @@ WTF_CSRF_ENABLED = True
 WTF_CSRF_EXEMPT_LIST = []
 # A CSRF token that expires in 1 year
 WTF_CSRF_TIME_LIMIT = 60 * 60 * 24 * 365
+{{- if .Values.supersetNode.connections.redis_password }}
+class CeleryConfig(object):
+  BROKER_URL = f"redis://{env('REDIS_PASSWORD')}@{env('REDIS_HOST')}:{env('REDIS_PORT')}/0"
+  CELERY_IMPORTS = ('superset.sql_lab', )
+  CELERY_RESULT_BACKEND = f"redis://{env('REDIS_PASSWORD')}@{env('REDIS_HOST')}:{env('REDIS_PORT')}/0"
+  CELERY_ANNOTATIONS = {'tasks.add': {'rate_limit': '10/s'}}
+
+CELERY_CONFIG = CeleryConfig
+RESULTS_BACKEND = RedisCache(
+      host=env('REDIS_HOST'),
+      password=env('REDIS_PASSWORD'),
+      port=env('REDIS_PORT'),
+      key_prefix='superset_results'
+)
+{{- else }}
 class CeleryConfig(object):
   BROKER_URL = f"redis://{env('REDIS_HOST')}:{env('REDIS_PORT')}/0"
   CELERY_IMPORTS = ('superset.sql_lab', )
@@ -101,6 +116,7 @@ RESULTS_BACKEND = RedisCache(
       port=env('REDIS_PORT'),
       key_prefix='superset_results'
 )
+{{- end -}}
 
 {{ if .Values.configOverrides }}
 # Overrides

--- a/helm/superset/templates/secret-env.yaml
+++ b/helm/superset/templates/secret-env.yaml
@@ -26,6 +26,9 @@ metadata:
 type: Opaque
 stringData:
     REDIS_HOST: {{ tpl .Values.supersetNode.connections.redis_host . | quote }}
+    {{- if .Values.supersetNode.connections.redis_password }}
+    REDIS_PASSWORD: {{ .Values.supersetNode.connections.redis_password | quote }}
+    {{- end }}
     REDIS_PORT: {{ .Values.supersetNode.connections.redis_port | quote }}
     DB_HOST: {{ tpl .Values.supersetNode.connections.db_host . | quote }}
     DB_PORT: {{ .Values.supersetNode.connections.db_port | quote }}

--- a/helm/superset/values.schema.json
+++ b/helm/superset/values.schema.json
@@ -206,6 +206,9 @@
                         "redis_host": {
                             "type": "string"
                         },
+                        "redis_password": {
+                            "type": "string"
+                        },
                         "redis_port": {
                             "type": "string"
                         },
@@ -456,23 +459,28 @@
                 "enabled": {
                     "type": "boolean"
                 },
-                "usePassword": {
-                    "type": "boolean"
-                },
-                "existingSecret": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "existingSecretKey": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "password": {
+                "architecture": {
                     "type": "string"
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "existingSecret": {
+                            "type": "string"
+                        },
+                        "existingSecretKey": {
+                            "type": "string"
+                        },
+                        "password": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "enabled"
+                    ]
                 },
                 "master": {
                     "type": "object",
@@ -519,9 +527,8 @@
             },
             "required": [
                 "enabled",
-                "usePassword",
-                "master",
-                "cluster"
+                "architecture",
+                "master"
             ]
         },
         "nodeSelector": {

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -83,7 +83,7 @@ extraSecretEnv: {}
   # GOOGLE_SECRET: ...
 
 extraConfigs: {}
-  # datasources-init.yaml: |
+  # import_datasources.yaml: |
   #     databases:
   #     - allow_file_upload: true
   #       allow_ctas: true

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -220,8 +220,11 @@ supersetNode:
     - "-c"
     - ". {{ .Values.configMountPath }}/superset_bootstrap.sh; /usr/bin/run-server.sh"
   connections:
+    # Change in case of bringing your own redis and then also set redis.enabled:false
     redis_host: '{{ template "superset.fullname" . }}-redis-headless'
+    # redis_password: superset
     redis_port: "6379"
+    # You need to change below configuration incase bringing own PostgresSQL instance and also set postgresql.enabled:false
     db_host: '{{ template "superset.fullname" . }}-postgresql'
     db_port: "5432"
     db_user: superset
@@ -393,27 +396,34 @@ postgresql:
       - ReadWriteOnce
 
 ## Configuration values for the Redis dependency.
-## ref: https://github.com/kubernetes/charts/blob/master/stable/redis/README.md
+## ref: https://github.com/bitnami/charts/blob/master/bitnami/redis
+## More documentation can be found here: https://artifacthub.io/packages/helm/bitnami/redis
 redis:
   ##
   ## Use the redis chart dependency.
+  ##
+  ## If you are bringing your own redis, you can set the host in supersetNode.connections.redis_host
+  ##
   ## Set to false if bringing your own redis.
   enabled: true
-  usePassword: false
   ##
-  ## The name of an existing secret that contains the redis password.
-  existingSecret:
-  ## Name of the key containing the secret.
-  existingSecretKey: redis-password
+  ## Set architecture to standalone/replication
+  architecture: standalone
   ##
-  ## If you are bringing your own redis, you can set the host in redisHost.
-  ## redisHost:
+  ## Auth configuration:
   ##
-  ## Redis password
-  ##
-  password: superset
+  auth:
+    ## Enable password authentication
+    enabled: false
+    ## The name of an existing secret that contains the redis password.
+    existingSecret: ""
+    ## Name of the key containing the secret.
+    existingSecretKey: ""
+    ## Redis password
+    password: superset
   ##
   ## Master configuration
+  ##
   master:
     ##
     ## Image configuration
@@ -434,10 +444,6 @@ redis:
       ## Access mode:
       accessModes:
       - ReadWriteOnce
-  ##
-  ## Disable cluster management by default.
-  cluster:
-    enabled: false
 
 nodeSelector: {}
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Redis with password was not supported out-of-the-box, so I've added this support in celery config in _helpers. When variable: `redis_password` in section: `supersetNode.connections` other version of config script is created during init.

I've also updated quite ancient version of Redis helm chart in dependencies.
Update process was performed according to this doc: https://artifacthub.io/packages/helm/bitnami/redis/16.3.1

I've also added small fix in documentation for helm chart. #18641 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
I've updated values.yaml json schema. `helm lint` command runs successfully. I've also checked helm templates if configs are generated without any missing/additional white space.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
