### PR TITLE
fix(sqllab): fix query results sorting

### DIFF
--- a/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
@@ -116,10 +116,10 @@ describe('FilterableTable sorting - RTL', () => {
     expect(gridCells[1]).toHaveTextContent('Bravo');
     expect(gridCells[2]).toHaveTextContent('Alpha');
 
-    // Third click to sort ascending again
+    // Third click to clear sorting
     userEvent.click(stringColumn);
-    expect(gridCells[0]).toHaveTextContent('Alpha');
-    expect(gridCells[1]).toHaveTextContent('Bravo');
+    expect(gridCells[0]).toHaveTextContent('Bravo');
+    expect(gridCells[1]).toHaveTextContent('Alpha');
     expect(gridCells[2]).toHaveTextContent('Charlie');
   });
 
@@ -151,10 +151,10 @@ describe('FilterableTable sorting - RTL', () => {
     expect(gridCells[1]).toHaveTextContent('10');
     expect(gridCells[2]).toHaveTextContent('0');
 
-    // Third click to sort ascending again
+    // Third click to clear sorting
     userEvent.click(integerColumn);
-    expect(gridCells[0]).toHaveTextContent('0');
-    expect(gridCells[1]).toHaveTextContent('10');
+    expect(gridCells[0]).toHaveTextContent('10');
+    expect(gridCells[1]).toHaveTextContent('0');
     expect(gridCells[2]).toHaveTextContent('100');
   });
 
@@ -186,10 +186,10 @@ describe('FilterableTable sorting - RTL', () => {
     expect(gridCells[1]).toHaveTextContent('45.67');
     expect(gridCells[2]).toHaveTextContent('1.23');
 
-    // Third click to sort ascending again
+    // Third click to clear sorting
     userEvent.click(floatColumn);
-    expect(gridCells[0]).toHaveTextContent('1.23');
-    expect(gridCells[1]).toHaveTextContent('45.67');
+    expect(gridCells[0]).toHaveTextContent('45.67');
+    expect(gridCells[1]).toHaveTextContent('1.23');
     expect(gridCells[2]).toHaveTextContent('89.0000001');
   });
 
@@ -257,17 +257,17 @@ describe('FilterableTable sorting - RTL', () => {
     expect(gridCells[9]).toHaveTextContent('26260.210000000003');
     expect(gridCells[10]).toHaveTextContent('24078.610000000004');
 
-    // Third click to sort ascending again
+    // Third click to clear sorting
     userEvent.click(mixedFloatColumn);
-    expect(gridCells[0]).toHaveTextContent('24078.610000000004');
-    expect(gridCells[1]).toHaveTextContent('26260.210000000003');
-    expect(gridCells[2]).toHaveTextContent('28550.59');
-    expect(gridCells[3]).toHaveTextContent('48710.92');
-    expect(gridCells[4]).toHaveTextContent('72212.86');
-    expect(gridCells[5]).toHaveTextContent('98089.08000000002');
-    expect(gridCells[6]).toHaveTextContent('144729.96000000002');
-    expect(gridCells[7]).toHaveTextContent('145776.56');
-    expect(gridCells[8]).toHaveTextContent('152718.97999999998');
+    expect(gridCells[0]).toHaveTextContent('48710.92');
+    expect(gridCells[1]).toHaveTextContent('145776.56');
+    expect(gridCells[2]).toHaveTextContent('72212.86');
+    expect(gridCells[3]).toHaveTextContent('144729.96000000002');
+    expect(gridCells[4]).toHaveTextContent('26260.210000000003');
+    expect(gridCells[5]).toHaveTextContent('152718.97999999998');
+    expect(gridCells[6]).toHaveTextContent('28550.59');
+    expect(gridCells[7]).toHaveTextContent('24078.610000000004');
+    expect(gridCells[8]).toHaveTextContent('98089.08000000002');
     expect(gridCells[9]).toHaveTextContent('3439718.0300000007');
     expect(gridCells[10]).toHaveTextContent('4528047.219999993');
   });
@@ -320,14 +320,14 @@ describe('FilterableTable sorting - RTL', () => {
     expect(gridCells[5]).toHaveTextContent('2021-01-02');
     expect(gridCells[6]).toHaveTextContent('2021-01-01');
 
-    // Third click to sort ascending again
+    // Third click to clear sorting
     userEvent.click(dsColumn);
     expect(gridCells[0]).toHaveTextContent('2021-01-01');
-    expect(gridCells[1]).toHaveTextContent('2021-01-02');
-    expect(gridCells[2]).toHaveTextContent('2021-01-03');
-    expect(gridCells[3]).toHaveTextContent('2021-10-01');
+    expect(gridCells[1]).toHaveTextContent('2022-01-01');
+    expect(gridCells[2]).toHaveTextContent('2021-01-02');
+    expect(gridCells[3]).toHaveTextContent('2021-01-03');
     expect(gridCells[4]).toHaveTextContent('2021-12-01');
-    expect(gridCells[5]).toHaveTextContent('2022-01-01');
+    expect(gridCells[5]).toHaveTextContent('2021-10-01');
     expect(gridCells[6]).toHaveTextContent('2022-01-02');
   });
 });

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -296,30 +296,31 @@ export default class FilterableTable extends PureComponent<
     sortBy: string;
     sortDirection: SortDirectionType;
   }) {
-    this.setState(
-      ({
-        sortBy: prevSortBy,
-        sortDirection: prevSortDirection,
-        displayedList: prevDisplayedList,
-      }) => {
-        const shouldClearSort =
-          prevSortDirection === SortDirection.DESC && prevSortBy === sortBy;
-        if (shouldClearSort)
-          return {
-            sortBy: undefined,
-            sortDirection: undefined,
-            displayedList: [...this.list],
-          };
+    let updatedState: FilterableTableState;
 
-        return {
-          sortBy,
-          sortDirection,
-          displayedList: prevDisplayedList.sort(
-            this.sortResults(sortBy, sortDirection === SortDirection.DESC),
-          ),
-        };
-      },
-    );
+    const shouldClearSort =
+      this.state.sortDirection === SortDirection.DESC &&
+      this.state.sortBy === sortBy;
+
+    if (shouldClearSort) {
+      updatedState = {
+        ...this.state,
+        sortBy: undefined,
+        sortDirection: undefined,
+        displayedList: [...this.list],
+      };
+    } else {
+      updatedState = {
+        ...this.state,
+        sortBy,
+        sortDirection,
+        displayedList: [...this.list].sort(
+          this.sortResults(sortBy, sortDirection === SortDirection.DESC),
+        ),
+      };
+    }
+
+    this.setState(updatedState);
   }
 
   fitTableToWidthIfNeeded() {

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -114,8 +114,9 @@ interface FilterableTableProps {
 
 interface FilterableTableState {
   sortBy?: string;
-  sortDirection: SortDirectionType;
+  sortDirection?: SortDirectionType;
   fitted: boolean;
+  displayedList: Datum[];
 }
 
 export default class FilterableTable extends PureComponent<
@@ -175,8 +176,8 @@ export default class FilterableTable extends PureComponent<
     this.totalTableHeight = props.height;
 
     this.state = {
-      sortDirection: SortDirection.ASC,
       fitted: false,
+      displayedList: [...this.list],
     };
 
     this.container = React.createRef();
@@ -191,7 +192,7 @@ export default class FilterableTable extends PureComponent<
   }
 
   getWidthsForColumns() {
-    const PADDING = 40; // accounts for cell padding and width of sorting icon
+    const PADDING = 50; // accounts for cell padding and width of sorting icon
     const widthsByColumnKey = {};
     const cellContent = ([] as string[]).concat(
       ...this.props.orderedColumnKeys.map(key => {
@@ -295,7 +296,30 @@ export default class FilterableTable extends PureComponent<
     sortBy: string;
     sortDirection: SortDirectionType;
   }) {
-    this.setState({ sortBy, sortDirection });
+    this.setState(
+      ({
+        sortBy: prevSortBy,
+        sortDirection: prevSortDirection,
+        displayedList: prevDisplayedList,
+      }) => {
+        const shouldClearSort =
+          prevSortDirection === SortDirection.DESC && prevSortBy === sortBy;
+        if (shouldClearSort)
+          return {
+            sortBy: undefined,
+            sortDirection: undefined,
+            displayedList: [...this.list],
+          };
+
+        return {
+          sortBy,
+          sortDirection,
+          displayedList: prevDisplayedList.sort(
+            this.sortResults(sortBy, sortDirection === SortDirection.DESC),
+          ),
+        };
+      },
+    );
   }
 
   fitTableToWidthIfNeeded() {
@@ -362,6 +386,17 @@ export default class FilterableTable extends PureComponent<
     };
   }
 
+  sortGrid = (label: string) => {
+    this.sort({
+      sortBy: label,
+      sortDirection:
+        this.state.sortDirection === SortDirection.DESC ||
+        this.state.sortBy !== label
+          ? SortDirection.ASC
+          : SortDirection.DESC,
+    });
+  };
+
   renderTableHeader({
     dataKey,
     label,
@@ -425,8 +460,14 @@ export default class FilterableTable extends PureComponent<
                 : style.top,
           }}
           className={`${className} grid-cell grid-header-cell`}
+          role="columnheader"
+          tabIndex={columnIndex}
+          onClick={() => this.sortGrid(label)}
         >
-          <div>{label}</div>
+          {label}
+          {this.state.sortBy === label && (
+            <SortIndicator sortDirection={this.state.sortDirection} />
+          )}
         </div>
       </Tooltip>
     );
@@ -444,7 +485,7 @@ export default class FilterableTable extends PureComponent<
     style: React.CSSProperties;
   }) {
     const columnKey = this.props.orderedColumnKeys[columnIndex];
-    const cellData = this.list[rowIndex][columnKey];
+    const cellData = this.state.displayedList[rowIndex][columnKey];
     const cellText = this.getCellContent({ cellData, columnKey });
     const content =
       cellData === null ? <i className="text-muted">{cellText}</i> : cellText;
@@ -563,17 +604,11 @@ export default class FilterableTable extends PureComponent<
       rowHeight,
     } = this.props;
 
-    let sortedAndFilteredList = this.list;
+    let sortedAndFilteredList = this.state.displayedList;
     // filter list
     if (filterText) {
-      sortedAndFilteredList = this.list.filter((row: Datum) =>
+      sortedAndFilteredList = sortedAndFilteredList.filter((row: Datum) =>
         this.hasMatch(filterText, row),
-      );
-    }
-    // sort list
-    if (sortBy) {
-      sortedAndFilteredList = sortedAndFilteredList.sort(
-        this.sortResults(sortBy, sortDirection === SortDirection.DESC),
       );
     }
 

--- a/superset-frontend/src/components/FilterableTable/FilterableTableStyles.less
+++ b/superset-frontend/src/components/FilterableTable/FilterableTableStyles.less
@@ -57,6 +57,7 @@
 
 .grid-header-cell {
   font-weight: @font-weight-bold;
+  cursor: pointer;
 }
 
 .ReactVirtualized__Table__headerColumn:last-of-type,


### PR DESCRIPTION
### SUMMARY

- Adds/fixes sorting for results with more than 50 columns
- Adds third sort state that clears the sort and returns list to its initial order
- Adds a little more padding for the sorting icons because they were being truncated on some headers

---

### Sorting

In SQL Lab there is currently no sorting for data with more than 50 columns because `FilterableTable` switches from using the react-virtualized `Table` to the react-virtualized `Grid`. [Grid](https://github.com/bvaughn/react-virtualized/blob/master/docs/Grid.md) isn't set up to have sorting the way that [Table](https://github.com/bvaughn/react-virtualized/blob/master/docs/Table.md) is.

The UI is the same as far as the user can tell so the sorting appears to stop working when there are too many columns.

I added listeners to the grid headers and added a `displayedList` state that gets sorted and used by the grid cells when rendering. I used the `SortIndicator` icon component and used the same `sortBy` and `sortDirection` state that the `Table` uses. They are never rendered at the same time so it didn't feel necessary to give the Grid its own separate states.

For the same reason I slightly changed the `renderTable` method to use the new `displayedList` state as well. 

This allows the initial list to remain intact because it is now doing "out of place" sorting instead of "in place" sorting. This allowed me to add a third cleared sort state that reverts the sorting back to before it was sorted.

---

### Third Sort State (Cleared Sort State)

Added a third sorting state to FilterableTable that will return the results to its original order. As far as I know, this was not requested anywhere but I added it because I was in the area.

This is done by having an initial list and a displayed list and only mutating the displayed list when sorting. Then we just set the list back to its initial state when we have already sorted by descending and ascending. 

The logic and flow is simple enough

The current sorting flow is:
- Original list order
- Click -> Ascending list order
- Click -> Descending list order
- Click -> Ascending list order

This PR will change it to:
- Original list order
- Click -> Ascending list order
- Click -> Descending list order
- Click -> Original list order

**Logic:**

```javascript
sort({
    sortBy,
    sortDirection,
  }: {
    sortBy: string;
    sortDirection: SortDirectionType;
  }) {
    this.setState(
      ({
        sortBy: prevSortBy,
        sortDirection: prevSortDirection,
        displayedList: prevDisplayedList,
      }) => {
        const shouldClearSort =
          prevSortDirection === SortDirection.DESC && prevSortBy === sortBy;
        if (shouldClearSort)
          return {
            sortBy: undefined,
            sortDirection: undefined,
            displayedList: [...this.list],
          };

        return {
          sortBy,
          sortDirection,
          displayedList: prevDisplayedList.sort(
            this.sortResults(sortBy, sortDirection === SortDirection.DESC),
          ),
        };
      },
    );
  }
```

---

### Extra Padding

Increases the constant for the default padding on cells from `40` to `50`

The sorting icon was being truncated on some cells so I added a little more padded to fix it. 

### Screenshots

### BEFORE

**Example of clicking on headers in table with >50 columns**

![Screen Recording BEFORE 1](https://user-images.githubusercontent.com/31329271/153471540-01261bbd-d648-410c-8b90-c3c24bfecf33.gif)

**Example of sorting on tables <50 columns**

![Screen Recording BEFORE 2](https://user-images.githubusercontent.com/31329271/153471546-56908c68-2169-475d-a9bc-26f0cc1843b1.gif)

**Examples of headers being truncated after triggering sorting**

![Screen Shot 2022-02-10 at 11 17 08 AM](https://user-images.githubusercontent.com/31329271/153471580-14637c33-97fc-4e65-8f0e-fe90baed9bfc.png)

![Screen Shot 2022-02-10 at 11 17 19 AM](https://user-images.githubusercontent.com/31329271/153471590-b67b5efd-a167-4830-9db6-b51789cc36ff.png)

### AFTER

**Example of clicking on headers in table with >50 columns**

![Screen Recording AFTER](https://user-images.githubusercontent.com/31329271/153470023-09ff67a6-b78b-4a78-8ad5-0b9eacd9ccf2.gif)

**Examples of headers not being truncated after triggering sorting**

![Screen Shot 2022-02-10 at 11 18 43 AM](https://user-images.githubusercontent.com/31329271/153471598-2a53a3ab-bb5f-4b35-894e-64a4661445c6.png)

![Screen Shot 2022-02-10 at 11 19 12 AM](https://user-images.githubusercontent.com/31329271/153471611-ebdc1351-b6a4-4ce1-9639-565abfbc3c45.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #16261
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
