### PR TITLE
feat: pin version of superset in helm chart

### DIFF
--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
   - name: craig-rueda
     email: craig@craigrueda.com
     url: https://github.com/craig-rueda
-version: 0.5.9
+version: 0.5.10
 dependencies:
 - name: postgresql
   version: 10.2.0

--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
   - name: craig-rueda
     email: craig@craigrueda.com
     url: https://github.com/craig-rueda
-version: 0.5.8
+version: 0.5.9
 dependencies:
 - name: postgresql
   version: 10.2.0

--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 apiVersion: v2
-appVersion: "1.0"
+appVersion: "1.4.1"
 description: Apache Superset is a modern, enterprise-ready business intelligence web application
 name: superset
 maintainers:

--- a/helm/superset/templates/deployment-beat.yaml
+++ b/helm/superset/templates/deployment-beat.yaml
@@ -67,7 +67,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion ) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: {{  tpl (toJson .Values.supersetCeleryBeat.command) . }}
           env:

--- a/helm/superset/templates/deployment-worker.yaml
+++ b/helm/superset/templates/deployment-worker.yaml
@@ -68,7 +68,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion ) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: {{  tpl (toJson .Values.supersetWorker.command) . }}
           env:

--- a/helm/superset/templates/deployment.yaml
+++ b/helm/superset/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion ) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: {{  tpl (toJson .Values.supersetNode.command) . }}
           env:

--- a/helm/superset/templates/init-job.yaml
+++ b/helm/superset/templates/init-job.yaml
@@ -42,7 +42,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "superset.name" . }}-init-db
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion ) }}"
         {{- if or .Values.extraEnv .Values.extraEnvRaw }}
         env:
           {{- range $key, $value := .Values.extraEnv }}

--- a/helm/superset/values.schema.json
+++ b/helm/superset/values.schema.json
@@ -96,7 +96,8 @@
                     "type": "string"
                 },
                 "tag": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Defaults to version match to Chart.appVersion"
                 },
                 "pullPolicy": {
                     "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.23.0/_definitions.json##/definitions/io.k8s.api.core.v1.Container/properties/imagePullPolicy"
@@ -104,7 +105,6 @@
             },
             "required": [
                 "repository",
-                "tag",
                 "pullPolicy"
             ]
         },
@@ -168,9 +168,6 @@
                 },
                 "pathType": {
                     "type": "string"
-                },
-                "ingressClassName": {
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.23.0/_definitions.json##/definitions/io.k8s.api.networking.v1.IngressSpec/properties/ingressClassName"
                 },
                 "hosts": {
                     "type": "array",

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -160,7 +160,7 @@ extraConfigMountPath: "/app/configs"
 
 image:
   repository: apache/superset
-  tag: latest
+  # tag: "v{{ $.Chart.AppVersion }}"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
### SUMMARY

I propose to pin version of Superset in Chart. 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

There are several reasons for this:
- during the restart of the pod, no automatic update is performed, which may potentially damage the user's data (backup must be performed before the update, etc.) or affect the availability of the application,
- new versions of the Superset may require an adaptation of the Superset,
- old versions of Helm Chart will be known to correctly run old versions of Superset,

The downside is that we need to update the Chart and release it in order for users to use the new versions. Currently, however, releases are automated, and verification of the new Superset release that it is compatible with the Chart is even advisable.

In the future, we can think of an automatic version update when the Superset version is changed. For this, the e2e Superset tests could be useful, perhaps taking into account the update process as well.

### TESTING INSTRUCTIONS

I deployed an updated Chart and verified if pods started and inspected created manifests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: #17540
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

@CarpathianUA ,@quenchua, @alexander-onesoil as affected by #17540, could you take a look and provide feedback?
@craig-rueda as maintainer of Helm Chart, could you take a look?