### PR TITLE
feat(explore): Implement data table empty states

### DIFF
--- a/superset-frontend/src/explore/components/DataTablesPane/index.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/index.tsx
@@ -155,12 +155,11 @@ const DataTable = ({
   }
   if (data) {
     if (data.length === 0) {
-      return (
-        <EmptyStateMedium
-          image="document.svg"
-          title={t(`No ${type} were returned for this query`)}
-        />
-      );
+      const title =
+        type === 'samples'
+          ? t('No samples were returned for this query')
+          : t('No results were returned for this query');
+      return <EmptyStateMedium image="document.svg" title={title} />;
     }
     return (
       <TableView
@@ -177,12 +176,11 @@ const DataTable = ({
     );
   }
   if (errorMessage) {
-    return (
-      <EmptyStateMedium
-        image="document.svg"
-        title={t(`Run a query to display ${type}`)}
-      />
-    );
+    const title =
+      type === 'samples'
+        ? t('Run a query to display samples')
+        : t('Run a query to display results');
+    return <EmptyStateMedium image="document.svg" title={title} />;
   }
   return null;
 };

--- a/superset-frontend/src/explore/components/DataTablesPane/index.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/index.tsx
@@ -27,6 +27,7 @@ import {
 import Collapse from 'src/components/Collapse';
 import Tabs from 'src/components/Tabs';
 import Loading from 'src/components/Loading';
+import { EmptyStateMedium } from 'src/components/EmptyState';
 import TableView, { EmptyWrapperType } from 'src/components/TableView';
 import { getChartDataRequest } from 'src/chart/chartAction';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
@@ -120,6 +121,7 @@ interface DataTableProps {
   isLoading: boolean;
   error: string | undefined;
   errorMessage: React.ReactElement | undefined;
+  type: 'results' | 'samples';
 }
 
 const DataTable = ({
@@ -132,6 +134,7 @@ const DataTable = ({
   isLoading,
   error,
   errorMessage,
+  type,
 }: DataTableProps) => {
   // this is to preserve the order of the columns, even if there are integer values,
   // while also only grabbing the first column's keys
@@ -152,14 +155,19 @@ const DataTable = ({
   }
   if (data) {
     if (data.length === 0) {
-      return <span>No data</span>;
+      return (
+        <EmptyStateMedium
+          image="document.svg"
+          title={t(`No ${type} were returned for this query`)}
+        />
+      );
     }
     return (
       <TableView
         columns={columns}
         data={filteredData}
         pageSize={DATA_TABLE_PAGE_SIZE}
-        noDataText={t('No data')}
+        noDataText={t('No results')}
         emptyWrapperType={EmptyWrapperType.Small}
         className="table-condensed"
         isPaginationSticky
@@ -169,7 +177,12 @@ const DataTable = ({
     );
   }
   if (errorMessage) {
-    return <Error>{errorMessage}</Error>;
+    return (
+      <EmptyStateMedium
+        image="document.svg"
+        title={t(`Run a query to display ${type}`)}
+      />
+    );
   }
   return null;
 };
@@ -420,6 +433,7 @@ export const DataTablesPane = ({
                     filterText={filterText}
                     error={error[RESULT_TYPES.results]}
                     errorMessage={errorMessage}
+                    type={RESULT_TYPES.results}
                   />
                 </Tabs.TabPane>
                 <Tabs.TabPane
@@ -436,6 +450,7 @@ export const DataTablesPane = ({
                     filterText={filterText}
                     error={error[RESULT_TYPES.samples]}
                     errorMessage={errorMessage}
+                    type={RESULT_TYPES.samples}
                   />
                 </Tabs.TabPane>
               </Tabs>


### PR DESCRIPTION
### SUMMARY
This PR implements chart empty states for 3 scenarios:

1) Not all required controls have values
2) Query returned no results
3) No samples were retrieved for dataset

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1140" alt="image" src="https://user-images.githubusercontent.com/15073128/153627387-7234b1e8-6f0b-4a3b-a140-f1e80d3e7039.png">

<img width="1143" alt="image" src="https://user-images.githubusercontent.com/15073128/153627652-5eea2bc8-03a1-494c-9380-31884d177580.png">

<img width="1165" alt="image" src="https://user-images.githubusercontent.com/15073128/153627769-e7968676-b384-4a0b-9b9b-3c03bf5c99e6.png">

### TESTING INSTRUCTIONS
1. Create a chart
2. Run a query that returns 0 results (for example set time range for last 5 minutes)
3. Remove required controls

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @kasiazjc

https://app.shortcut.com/preset/story/36403/explore-empty-states