### PR TITLE
fix: unambiguous trino driver

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,10 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    entry_points={"console_scripts": ["superset=superset.cli.main:superset"]},
+    entry_points={
+        "console_scripts": ["superset=superset.cli.main:superset"],
+        "sqlalchemy.dialects": ["trinonative = sqlalchemy_trino.dialect:TrinoDialect"],
+    },
     install_requires=[
         "backoff>=1.8.0",
         "bleach>=3.0.2, <4.0.0",

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 
 class TrinoEngineSpec(BaseEngineSpec):
     engine = "trino"
+    engine_aliases = {"trinonative"}
     engine_name = "Trino"
 
     _time_grain_expressions = {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Both PyHive and `sqlalchemy-trino` declare a `trino://` SQLAlchemy dialect. If you create a database in Superset with the `trino://` SQLAlchemy URI and have both libraries installed the backend will use one the library randomly on every request, making it impossible to connect to a Trino database.

I created a PR upstream renaming the PyHive dialect to `trino+pyhive://` (https://github.com/dropbox/PyHive/pull/428), so that `trino://` resolves unambiguously. In the meantime, this PR adds a `trinonative://` entry pointing directly to the `sqlalchemy-trino` dialect, so that users with both libraries installed can connect to Trino.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Connect to a Trino DB using the `trinonative://` scheme.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
