### PR TITLE
fix: revert handle null values in time-series table

### DIFF
--- a/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
+++ b/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
@@ -192,17 +192,14 @@ const TimeTable = ({
         } else {
           v = reversedEntries[timeLag][valueField];
         }
-        if (typeof v === 'number' || typeof recent === 'number') {
-          if (column.comparisonType === 'diff') {
-            v = recent - v;
-          } else if (column.comparisonType === 'perc') {
-            v = recent / v;
-          } else if (column.comparisonType === 'perc_change') {
-            v = recent / v - 1;
-          }
-        } else {
-          v = 'N/A';
+        if (column.comparisonType === 'diff') {
+          v = recent - v;
+        } else if (column.comparisonType === 'perc') {
+          v = recent / v;
+        } else if (column.comparisonType === 'perc_change') {
+          v = recent / v - 1;
         }
+        v = v || 0;
       } else if (column.colType === 'contrib') {
         // contribution to column total
         v =


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
#18039 caused an issue that table values are not corrected sorted in front-end. Revert it by now.


### TESTING INSTRUCTIONS
CI 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: #18039
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
