### PR TITLE
fix(build): update webpack jsx paths

### DIFF
--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -340,6 +340,9 @@ const config = {
         exclude: [/superset-ui.*\/node_modules\//, /\.test.jsx?$/],
         include: [
           new RegExp(`${APP_DIR}/(src|.storybook|plugins|packages)`),
+          ...['./src', './.storybook', './plugins', './packages'].map(p =>
+            path.resolve(__dirname, p),
+          ), // redundant but required for windows
           /@encodable/,
         ],
         use: [babelLoader],


### PR DESCRIPTION
### SUMMARY
Update webpack jsx paths to support windows builds/dev server

closes https://github.com/apache/superset/issues/10997

Adapted from : https://github.com/apache/superset/pull/13744


### TESTING INSTRUCTIONS
`npm run dev-server` in windows


