### PR TITLE
fix: Fixed dancing tooltip in database list action buttons

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
@@ -68,6 +68,11 @@ const IconCancelX = styled(Icons.CancelX)`
 
 const Actions = styled.div`
   color: ${({ theme }) => theme.colors.grayscale.base};
+
+  .action-button {
+    display: inline-block;
+    height: 100%;
+  }
 `;
 
 function BooleanDisplay({ value }: { value: Boolean }) {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I stopped the dancing tooltip in the database list's action buttons by setting its button's `display` to `inline-block` and `height` to `100%`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### BEFORE:
![dbDancingTooltip](https://user-images.githubusercontent.com/55605634/153673938-d1cff1bb-2b6a-4b2a-90f3-859866a00516.gif)

#### AFTER:
![dbTooltipInTheCorner](https://user-images.githubusercontent.com/55605634/153673999-531a6a09-ab9c-45b4-a81b-f5563e7400f7.gif)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- In the database list, hover over the action buttons
- Observe that the tooltip does not dance

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
