### PR TITLE
fix: Update time grain expressions for Spark >= 3.x

### DIFF
--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -21,26 +21,32 @@ from typing import Any, Dict, Optional
 from superset.db_engine_specs.base import BaseEngineSpec
 from superset.db_engine_specs.hive import HiveEngineSpec
 
+time_grain_expressions = {
+    None: "{col}",
+    "PT1S": "date_trunc('second', {col})",
+    "PT1M": "date_trunc('minute', {col})",
+    "PT1H": "date_trunc('hour', {col})",
+    "P1D": "date_trunc('day', {col})",
+    "P1W": "date_trunc('week', {col})",
+    "P1M": "date_trunc('month', {col})",
+    "P3M": "date_trunc('quarter', {col})",
+    "P1Y": "date_trunc('year', {col})",
+    "P1W/1970-01-03T00:00:00Z": (
+        "date_trunc('week', {col} + interval '1 day') + interval '5 days'"
+    ),
+    "1969-12-28T00:00:00Z/P1W": (
+        "date_trunc('week', {col} + interval '1 day') - interval '1 day'"
+    ),
+}
+
 
 class DatabricksHiveEngineSpec(HiveEngineSpec):
     engine = "databricks"
     engine_name = "Databricks Interactive Cluster"
     driver = "pyhive"
     _show_functions_column = "function"
-    
-    _time_grain_expressions = {
-        None: "{col}",
-        "PT1S": "date_trunc('second', {col})",
-        "PT1M": "date_trunc('minute', {col})",
-        "PT1H": "date_trunc('hour', {col})",
-        "P1D": "date_trunc('day', {col})",
-        "P1W": "date_trunc('week', {col})",
-        "P1M": "date_trunc('month', {col})",
-        "P3M": "date_trunc('quarter', {col})",
-        "P1Y": "date_trunc('year', {col})",
-        "P1W/1970-01-03T00:00:00Z": "date_trunc('week', {col} + interval '1 day') + interval '5 days'",
-        "1969-12-28T00:00:00Z/P1W": "date_trunc('week', {col} + interval '1 day') - interval '1 day'",
-    }
+
+    _time_grain_expressions = time_grain_expressions
 
 
 class DatabricksODBCEngineSpec(BaseEngineSpec):
@@ -48,10 +54,7 @@ class DatabricksODBCEngineSpec(BaseEngineSpec):
     engine_name = "Databricks SQL Endpoint"
     driver = "pyodbc"
 
-    # the syntax for the ODBC engine is identical to the Hive one, so
-    # we can reuse the expressions from `HiveEngineSpec`
-    # pylint: disable=protected-access
-    _time_grain_expressions = DatabricksHiveEngineSpec._time_grain_expressions
+    _time_grain_expressions = time_grain_expressions
 
     @classmethod
     def convert_dttm(

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -27,6 +27,20 @@ class DatabricksHiveEngineSpec(HiveEngineSpec):
     engine_name = "Databricks Interactive Cluster"
     driver = "pyhive"
     _show_functions_column = "function"
+    
+    _time_grain_expressions = {
+        None: "{col}",
+        "PT1S": "date_trunc('second', {col})",
+        "PT1M": "date_trunc('minute', {col})",
+        "PT1H": "date_trunc('hour', {col})",
+        "P1D": "date_trunc('day', {col})",
+        "P1W": "date_trunc('week', {col})",
+        "P1M": "date_trunc('month', {col})",
+        "P3M": "date_trunc('quarter', {col})",
+        "P1Y": "date_trunc('year', {col})",
+        "P1W/1970-01-03T00:00:00Z": "date_trunc('week', {col} + interval '1 day') + interval '5 days'",
+        "1969-12-28T00:00:00Z/P1W": "date_trunc('week', {col} + interval '1 day') - interval '1 day'",
+    }
 
 
 class DatabricksODBCEngineSpec(BaseEngineSpec):
@@ -37,7 +51,7 @@ class DatabricksODBCEngineSpec(BaseEngineSpec):
     # the syntax for the ODBC engine is identical to the Hive one, so
     # we can reuse the expressions from `HiveEngineSpec`
     # pylint: disable=protected-access
-    _time_grain_expressions = HiveEngineSpec._time_grain_expressions
+    _time_grain_expressions = DatabricksHiveEngineSpec._time_grain_expressions
 
     @classmethod
     def convert_dttm(


### PR DESCRIPTION
### SUMMARY
Spark removed date format string 'u' in Spark 3.0 [[0]] so the grain expressions need to be updated because ones that depend on that format string are failing 😢. I switched the behavior to use  `date_trunc` which has been around since 2.3 [[1]] based on how the Athena db engine spec handles this [[2]].

I think its probably fine to raise the minimum supported version to 2.3 because this is a "Databricks" db_engine_spec and Databricks hasn't publicly supported something that old since ~Jan 2020 [[3]].

[0]: https://issues.apache.org/jira/browse/SPARK-31892 (is the best reference I can find)
[1]: https://spark.apache.org/docs/latest/api/sql/index.html#date_trunc
[2]: https://github.com/apache/superset/blob/master/superset/db_engine_specs/athena.py#L38-L50
[3]: https://docs.databricks.com/release-notes/runtime/releases.html

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
I can't reproduce the old behavior (I don't have that old a spark cluster xD) but here's a table of timestamps from a current version of spark run through these same expressions:


| **_timestamp** | 2021-02-08T23:58:02 | 2021-02-08T23:58:41 | 2021-02-08T23:59:31 |
| - | - | - | - |
| **PT1S** | 2021-02-08T23:58:02 | 2021-02-08T23:58:41 | 2021-02-08T23:59:31 |
| **PT1M** | 2021-02-08T23:58:00 | 2021-02-08T23:58:00 | 2021-02-08T23:59:00 |
| **PT1H** | 2021-02-08T23:00:00 | 2021-02-08T23:00:00 | 2021-02-08T23:00:00 |
| **P1D** | 2021-02-08T00:00:00 | 2021-02-08T00:00:00 | 2021-02-08T00:00:00 |
| **P1W** | 2021-02-08T00:00:00 | 2021-02-08T00:00:00 | 2021-02-08T00:00:00 |
| **P1M** | 2021-02-01T00:00:00 | 2021-02-01T00:00:00 | 2021-02-01T00:00:00 |
| **P3M** | 2021-01-01T00:00:00 | 2021-01-01T00:00:00 | 2021-01-01T00:00:00 |
| **P1Y** | 2021-01-01T00:00:00 | 2021-01-01T00:00:00 | 2021-01-01T00:00:00 |
| **P1W/1970-01-03T00:00:00Z** | 2021-02-13T00:00:00 | 2021-02-13T00:00:00 | 2021-02-13T00:00:00 |
| **1969-12-28T00:00:00Z/P1W** | 2021-02-07T00:00:00 | 2021-02-07T00:00:00 | 2021-02-07T00:00:00 |


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
