### PR TITLE
feat(bigquery): add support for query cost estimate

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1430,6 +1430,22 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     def parse_sql(cls, sql: str) -> List[str]:
         return [str(s).strip(" ;") for s in sqlparse.parse(sql)]
 
+    @classmethod
+    def _humanize(cls, value: Any, suffix: str) -> str:
+        try:
+            value = int(value)
+        except ValueError:
+            return str(value)
+
+        prefixes = ["K", "M", "G", "T", "P", "E", "Z", "Y"]
+        prefix = ""
+        to_next_prefix = 1000
+        while value > to_next_prefix and prefixes:
+            prefix = prefixes.pop(0)
+            value //= to_next_prefix
+
+        return f"{value} {prefix}{suffix}"
+
 
 # schema for adding a database by providing parameters instead of the
 # full SQLAlchemy URI

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1025,12 +1025,13 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         return sql
 
     @classmethod
-    def estimate_statement_cost(cls, statement: str, cursor: Any) -> Dict[str, Any]:
+    def estimate_statement_cost(cls, statement: str, cursor: Any, engine: Engine) -> Dict[str, Any]:
         """
         Generate a SQL query that estimates the cost of a given statement.
 
         :param statement: A single SQL statement
         :param cursor: Cursor instance
+        :param engine: Engine instance
         :return: Dictionary with different costs
         """
         raise Exception("Database does not support cost estimation")
@@ -1095,7 +1096,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
                 processed_statement = cls.process_statement(
                     statement, database, user_name
                 )
-                costs.append(cls.estimate_statement_cost(processed_statement, cursor))
+                costs.append(cls.estimate_statement_cost(processed_statement, cursor, engine))
         return costs
 
     @classmethod

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1025,7 +1025,9 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         return sql
 
     @classmethod
-    def estimate_statement_cost(cls, statement: str, cursor: Any, engine: Engine) -> Dict[str, Any]:
+    def estimate_statement_cost(
+        cls, statement: str, cursor: Any, engine: Engine
+    ) -> Dict[str, Any]:
         """
         Generate a SQL query that estimates the cost of a given statement.
 
@@ -1096,7 +1098,9 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
                 processed_statement = cls.process_statement(
                     statement, database, user_name
                 )
-                costs.append(cls.estimate_statement_cost(processed_statement, cursor, engine))
+                costs.append(
+                    cls.estimate_statement_cost(processed_statement, cursor, engine)
+                )
         return costs
 
     @classmethod

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -224,12 +224,12 @@ class BigQueryEngineSpec(BaseEngineSpec):
                 return str(raw_bytes)
             units = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"]
             index = 0
-            bytes = float(raw_bytes)
-            while bytes >= 1024 and index < len(units) - 1:
-                bytes /= 1024
+            bytes_float = float(raw_bytes)
+            while bytes_float >= 1024 and index < len(units) - 1:
+                bytes_float /= 1024
                 index += 1
 
-            return "{:.1f}".format(bytes) + f" {units[index]}"
+            return "{:.1f}".format(bytes_float) + f" {units[index]}"
 
         return [
             {

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -24,8 +24,6 @@ import pandas as pd
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
 from flask_babel import gettext as __
-from google.cloud import bigquery
-from google.oauth2 import service_account
 from marshmallow import fields, Schema
 from marshmallow.exceptions import ValidationError
 from sqlalchemy import column
@@ -195,6 +193,17 @@ class BigQueryEngineSpec(BaseEngineSpec):
     def estimate_statement_cost(
         cls, statement: str, cursor: Any, engine: Engine
     ) -> Dict[str, Any]:
+        try:
+            # pylint: disable=import-outside-toplevel
+            from google.cloud import bigquery
+            from google.oauth2 import service_account
+        except ImportError as ex:
+            raise Exception(
+                "Could not import libraries `google.cloud` or `google.oauth2`, "
+                "which are required to be installed in your environment in order "
+                "to estimate cost"
+            ) from ex
+
         creds = engine.dialect.credentials_info
         credentials = service_account.Credentials.from_service_account_info(creds)
         client = bigquery.Client(credentials=credentials)

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -193,16 +193,9 @@ class BigQueryEngineSpec(BaseEngineSpec):
     def estimate_statement_cost(
         cls, statement: str, cursor: Any, engine: Engine
     ) -> Dict[str, Any]:
-        try:
-            # pylint: disable=import-outside-toplevel
-            from google.cloud import bigquery
-            from google.oauth2 import service_account
-        except ImportError as ex:
-            raise Exception(
-                "Could not import libraries `google.cloud` or `google.oauth2`, "
-                "which are required to be installed in your environment in order "
-                "to estimate cost"
-            ) from ex
+        # pylint: disable=import-outside-toplevel
+        from google.cloud import bigquery
+        from google.oauth2 import service_account
 
         creds = engine.dialect.credentials_info
         credentials = service_account.Credentials.from_service_account_info(creds)
@@ -370,16 +363,9 @@ class BigQueryEngineSpec(BaseEngineSpec):
         :param to_sql_kwargs: The kwargs to be passed to pandas.DataFrame.to_sql` method
         """
 
-        try:
-            # pylint: disable=import-outside-toplevel
-            import pandas_gbq
-            from google.oauth2 import service_account
-        except ImportError as ex:
-            raise Exception(
-                "Could not import libraries `pandas_gbq` or `google.oauth2`, which are "
-                "required to be installed in your environment in order "
-                "to upload data to BigQuery"
-            ) from ex
+        # pylint: disable=import-outside-toplevel
+        import pandas_gbq
+        from google.oauth2 import service_account
 
         if not table.schema:
             raise Exception("The table schema must be defined")

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -198,7 +198,9 @@ class PostgresEngineSpec(PostgresBaseEngineSpec, BasicParametersMixin):
         return True
 
     @classmethod
-    def estimate_statement_cost(cls, statement: str, cursor: Any, engine: Engine) -> Dict[str, Any]:
+    def estimate_statement_cost(
+        cls, statement: str, cursor: Any, engine: Engine
+    ) -> Dict[str, Any]:
         sql = f"EXPLAIN {statement}"
         cursor.execute(sql)
 

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -23,6 +23,7 @@ from typing import Any, Dict, List, Optional, Pattern, Tuple, TYPE_CHECKING
 from flask_babel import gettext as __
 from sqlalchemy.dialects.postgresql import ARRAY, DOUBLE_PRECISION, ENUM, JSON
 from sqlalchemy.dialects.postgresql.base import PGInspector
+from sqlalchemy.engine.base import Engine
 from sqlalchemy.types import String
 
 from superset.db_engine_specs.base import (
@@ -197,7 +198,7 @@ class PostgresEngineSpec(PostgresBaseEngineSpec, BasicParametersMixin):
         return True
 
     @classmethod
-    def estimate_statement_cost(cls, statement: str, cursor: Any) -> Dict[str, Any]:
+    def estimate_statement_cost(cls, statement: str, cursor: Any, engine: Engine) -> Dict[str, Any]:
         sql = f"EXPLAIN {statement}"
         cursor.execute(sql)
 

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -637,7 +637,7 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
         )
 
     @classmethod
-    def estimate_statement_cost(cls, statement: str, cursor: Any) -> Dict[str, Any]:
+    def estimate_statement_cost(cls, statement: str, cursor: Any, engine: Engine) -> Dict[str, Any]:
         """
         Run a SQL query that estimates the cost of a given statement.
 

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -679,18 +679,20 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
 
         cost = []
         columns = [
-            ("outputRowCount", "Output count", " rows"),
-            ("outputSizeInBytes", "Output size", "B"),
-            ("cpuCost", "CPU cost", ""),
-            ("maxMemory", "Max memory", "B"),
-            ("networkCost", "Network cost", ""),
+            ("outputRowCount", "Output count", " rows", None),
+            ("outputSizeInBytes", "Output size", "", "bytes"),
+            ("cpuCost", "CPU cost", "", None),
+            ("maxMemory", "Max memory", "", "bytes"),
+            ("networkCost", "Network cost", "", None),
         ]
         for row in raw_cost:
             estimate: Dict[str, float] = row.get("estimate", {})
             statement_cost = {}
-            for key, label, suffix in columns:
+            for key, label, suffix, category in columns:
                 if key in estimate:
-                    statement_cost[label] = cls._humanize(estimate[key], suffix).strip()
+                    statement_cost[label] = cls._humanize(
+                        estimate[key], suffix, category
+                    ).strip()
             cost.append(statement_cost)
 
         return cost

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -677,21 +677,6 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
         :return: Human readable cost estimate
         """
 
-        def humanize(value: Any, suffix: str) -> str:
-            try:
-                value = int(value)
-            except ValueError:
-                return str(value)
-
-            prefixes = ["K", "M", "G", "T", "P", "E", "Z", "Y"]
-            prefix = ""
-            to_next_prefix = 1000
-            while value > to_next_prefix and prefixes:
-                prefix = prefixes.pop(0)
-                value //= to_next_prefix
-
-            return f"{value} {prefix}{suffix}"
-
         cost = []
         columns = [
             ("outputRowCount", "Output count", " rows"),
@@ -705,7 +690,7 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
             statement_cost = {}
             for key, label, suffix in columns:
                 if key in estimate:
-                    statement_cost[label] = humanize(estimate[key], suffix).strip()
+                    statement_cost[label] = cls._humanize(estimate[key], suffix).strip()
             cost.append(statement_cost)
 
         return cost

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -637,7 +637,9 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
         )
 
     @classmethod
-    def estimate_statement_cost(cls, statement: str, cursor: Any, engine: Engine) -> Dict[str, Any]:
+    def estimate_statement_cost(
+        cls, statement: str, cursor: Any, engine: Engine
+    ) -> Dict[str, Any]:
         """
         Run a SQL query that estimates the cost of a given statement.
 

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -119,7 +119,9 @@ class TrinoEngineSpec(BaseEngineSpec):
         return True
 
     @classmethod
-    def estimate_statement_cost(cls, statement: str, cursor: Any, engine: Engine) -> Dict[str, Any]:
+    def estimate_statement_cost(
+        cls, statement: str, cursor: Any, engine: Engine
+    ) -> Dict[str, Any]:
         """
         Run a SQL query that estimates the cost of a given statement.
 

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -21,6 +21,7 @@ from urllib import parse
 
 import simplejson as json
 from flask import current_app
+from sqlalchemy.engine.base import Engine
 from sqlalchemy.engine.url import make_url, URL
 
 from superset.db_engine_specs.base import BaseEngineSpec
@@ -118,7 +119,7 @@ class TrinoEngineSpec(BaseEngineSpec):
         return True
 
     @classmethod
-    def estimate_statement_cost(cls, statement: str, cursor: Any) -> Dict[str, Any]:
+    def estimate_statement_cost(cls, statement: str, cursor: Any, engine: Engine) -> Dict[str, Any]:
         """
         Run a SQL query that estimates the cost of a given statement.
 

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -161,18 +161,20 @@ class TrinoEngineSpec(BaseEngineSpec):
 
         cost = []
         columns = [
-            ("outputRowCount", "Output count", " rows"),
-            ("outputSizeInBytes", "Output size", "B"),
-            ("cpuCost", "CPU cost", ""),
-            ("maxMemory", "Max memory", "B"),
-            ("networkCost", "Network cost", ""),
+            ("outputRowCount", "Output count", " rows", None),
+            ("outputSizeInBytes", "Output size", "", "bytes"),
+            ("cpuCost", "CPU cost", "", None),
+            ("maxMemory", "Max memory", "", "bytes"),
+            ("networkCost", "Network cost", "", None),
         ]
         for row in raw_cost:
             estimate: Dict[str, float] = row.get("estimate", {})
             statement_cost = {}
-            for key, label, suffix in columns:
+            for key, label, suffix, category in columns:
                 if key in estimate:
-                    statement_cost[label] = cls._humanize(estimate[key], suffix).strip()
+                    statement_cost[label] = cls._humanize(
+                        estimate[key], suffix, category
+                    ).strip()
             cost.append(statement_cost)
 
         return cost

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -159,21 +159,6 @@ class TrinoEngineSpec(BaseEngineSpec):
         :return: Human readable cost estimate
         """
 
-        def humanize(value: Any, suffix: str) -> str:
-            try:
-                value = int(value)
-            except ValueError:
-                return str(value)
-
-            prefixes = ["K", "M", "G", "T", "P", "E", "Z", "Y"]
-            prefix = ""
-            to_next_prefix = 1000
-            while value > to_next_prefix and prefixes:
-                prefix = prefixes.pop(0)
-                value //= to_next_prefix
-
-            return f"{value} {prefix}{suffix}"
-
         cost = []
         columns = [
             ("outputRowCount", "Output count", " rows"),
@@ -187,7 +172,7 @@ class TrinoEngineSpec(BaseEngineSpec):
             statement_cost = {}
             for key, label, suffix in columns:
                 if key in estimate:
-                    statement_cost[label] = humanize(estimate[key], suffix).strip()
+                    statement_cost[label] = cls._humanize(estimate[key], suffix).strip()
             cost.append(statement_cost)
 
         return cost

--- a/tests/integration_tests/db_engine_specs/bigquery_tests.py
+++ b/tests/integration_tests/db_engine_specs/bigquery_tests.py
@@ -420,25 +420,20 @@ class TestBigQueryDbEngineSpec(TestDbEngineSpec):
 
     def test_query_cost_formatter_example_costs(self):
         raw_cost = [
-            {"Total bytes processed": 123, "Some other column": 123,},
-            {"Total bytes processed": 1024, "Some other column": "abcde",},
-            {"Total bytes processed": 1024 * 1024 + 1024 * 512,},
-            {"Total bytes processed": 1024 ** 3,},
-            {"Total bytes processed": 1024 ** 4,},
-            {"Total bytes processed": 1024 ** 5,},
-            {"Total bytes processed": 1024 ** 6,},
+            {"Total bytes processed": 123},
+            {"Total bytes processed": 1024},
+            {"Total bytes processed": 1024 ** 2 + 1024 * 512,},
+            {"Total bytes processed": 1024 ** 3 * 100,},
+            {"Total bytes processed": 1024 ** 4 * 1000,},
         ]
         result = BigQueryEngineSpec.query_cost_formatter(raw_cost)
         self.assertEqual(
             result,
             [
-                {"Total bytes processed": "123.0 B", "Some other column": "123",},
-                {"Total bytes processed": "1.0 KiB", "Some other column": "abcde",},
-                {"Total bytes processed": "1.5 MiB",},
-                {"Total bytes processed": "1.0 GiB",},
-                {"Total bytes processed": "1.0 TiB",},
-                {"Total bytes processed": "1.0 PiB",},
-                # Petabyte is the largest unit, but larger values can be handled
-                {"Total bytes processed": "1024.0 PiB",},
+                {"Total bytes processed": "123 B"},
+                {"Total bytes processed": "1 KiB"},
+                {"Total bytes processed": "1 MiB",},
+                {"Total bytes processed": "100 GiB",},
+                {"Total bytes processed": "1000 TiB",},
             ],
         )

--- a/tests/integration_tests/db_engine_specs/postgres_tests.py
+++ b/tests/integration_tests/db_engine_specs/postgres_tests.py
@@ -176,8 +176,9 @@ class TestPostgresDbEngineSpec(TestDbEngineSpec):
         cursor.fetchone.return_value = (
             "Seq Scan on birth_names  (cost=0.00..1537.91 rows=75691 width=46)",
         )
+        engine = mock.Mock()
         sql = "SELECT * FROM birth_names"
-        results = PostgresEngineSpec.estimate_statement_cost(sql, cursor)
+        results = PostgresEngineSpec.estimate_statement_cost(sql, cursor, engine)
         self.assertEqual(
             results, {"Start-up cost": 0.00, "Total cost": 1537.91,},
         )
@@ -196,9 +197,10 @@ class TestPostgresDbEngineSpec(TestDbEngineSpec):
                             ^
             """
         )
+        engine = mock.Mock()
         sql = "DROP TABLE birth_names"
         with self.assertRaises(errors.SyntaxError):
-            PostgresEngineSpec.estimate_statement_cost(sql, cursor)
+            PostgresEngineSpec.estimate_statement_cost(sql, cursor, engine)
 
     def test_query_cost_formatter_example_costs(self):
         """

--- a/tests/integration_tests/db_engine_specs/presto_tests.py
+++ b/tests/integration_tests/db_engine_specs/presto_tests.py
@@ -795,17 +795,19 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
         mock_cursor.fetchone.return_value = [
             '{"a": "b"}',
         ]
+        mock_engine = mock.Mock()
         result = PrestoEngineSpec.estimate_statement_cost(
-            "SELECT * FROM brth_names", mock_cursor
+            "SELECT * FROM brth_names", mock_cursor, mock_engine
         )
         assert result == estimate_json
 
     def test_estimate_statement_cost_invalid_syntax(self):
         mock_cursor = mock.MagicMock()
         mock_cursor.execute.side_effect = Exception()
+        mock_engine = mock.Mock()
         with self.assertRaises(Exception):
             PrestoEngineSpec.estimate_statement_cost(
-                "DROP TABLE brth_names", mock_cursor
+                "DROP TABLE brth_names", mock_cursor, mock_engine
             )
 
     def test_get_all_datasource_names(self):

--- a/tests/integration_tests/db_engine_specs/presto_tests.py
+++ b/tests/integration_tests/db_engine_specs/presto_tests.py
@@ -524,7 +524,7 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
         expected = [
             {
                 "Output count": "904 M rows",
-                "Output size": "354 GB",
+                "Output size": "329 GiB",
                 "CPU cost": "354 G",
                 "Max memory": "0 B",
                 "Network cost": "354 G",


### PR DESCRIPTION
### SUMMARY
The ability to know in advance how many bytes a query will process is important when using BigQuery.
This PR adds the ability to estimate query cost to BigQuery integration as well as other DB systems such as postgres and presto.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before:
![before](https://user-images.githubusercontent.com/1046476/153748421-d17675de-2812-461e-acbd-96e6ad5e4e36.png)

after:
![after 1](https://user-images.githubusercontent.com/1046476/153748423-dad2e2f2-3eda-478a-bbcc-2741fc9f3110.png)

![after 2](https://user-images.githubusercontent.com/1046476/153748429-c4a8eedf-9b83-40ef-b2e5-0a1de8ec334e.png)


### TESTING INSTRUCTIONS
- Enable feature flag `ESTIMATE_QUERY_COST`
- Check `ADVANCED` > `SQL Lab` > `Enable query cost estimation` in the edit dialog in the BigQuery database connection


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
