### PR TITLE
fix: Only redirect to relative paths when authentication expires

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/connection/SupersetClientClass.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/SupersetClientClass.ts
@@ -232,6 +232,8 @@ export default class SupersetClientClass {
   }
 
   redirectUnauthorized() {
-    window.location.href = `/login?next=${window.location.href}`;
+    window.location.href = `/login?next=${
+      window.location.pathname + window.location.search
+    }`;
   }
 }

--- a/superset-frontend/packages/superset-ui-core/test/connection/SupersetClientClass.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/connection/SupersetClientClass.test.ts
@@ -501,11 +501,16 @@ describe('SupersetClientClass', () => {
 
   it('should redirect Unauthorized', async () => {
     const mockRequestUrl = 'https://host/get/url';
+    const mockRequestPath = '/get/url';
+    const mockRequestSearch = '?param=1&param=2';
     const { location } = window;
     // @ts-ignore
     delete window.location;
     // @ts-ignore
-    window.location = { href: mockRequestUrl };
+    window.location = {
+      pathname: mockRequestPath,
+      search: mockRequestSearch,
+    };
     const authSpy = jest
       .spyOn(SupersetClientClass.prototype, 'ensureAuth')
       .mockImplementation();
@@ -523,7 +528,9 @@ describe('SupersetClientClass', () => {
       error = err;
     } finally {
       const redirectURL = window.location.href;
-      expect(redirectURL).toBe(`/login?next=${mockRequestUrl}`);
+      expect(redirectURL).toBe(
+        `/login?next=${mockRequestPath + mockRequestSearch}`,
+      );
       expect(error.status).toBe(401);
     }
 


### PR DESCRIPTION
### SUMMARY
This PR changes the `next` param used by FAB to redirect the user to the original page after logging back in due to token expiration. The full URL was used before but that should be unnecessary. This PR changes that and passes only the relative path as `next` param.

### TESTING INSTRUCTIONS
1. Do any action on the application after the token has expired
2. Make sure that after login you are redirected to the original page

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
