### PR TITLE
fix(Dashboard): Fix blinking native filters on zoom

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -133,6 +133,10 @@ const StyledTabs = styled(Tabs)`
     margin: 0;
     flex: 1;
   }
+
+  & .ant-tabs-nav-operations {
+    display: none;
+  }
 `;
 
 export interface FiltersBarProps {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -134,7 +134,7 @@ const StyledTabs = styled(Tabs)`
     flex: 1;
   }
 
-  & .ant-tabs-nav-operations {
+  & > .ant-tabs-nav .ant-tabs-nav-operations {
     display: none;
   }
 `;


### PR DESCRIPTION
### SUMMARY
Fixes #18213

This PR hides the _more_ icon from the filter bar which is unnecessary and it is causing the filters to blink when the page is zoomed or on larger screens.

### BEFORE

https://user-images.githubusercontent.com/60598000/153887567-f7db1c4e-f189-4148-8760-231a00198cdf.mp4

### AFTER

https://user-images.githubusercontent.com/60598000/153888749-7a7656e8-ef3e-473b-be2e-0eb632bd9a48.mp4


### TESTING INSTRUCTIONS
1. Open a Dashboard with filter sets enabled
2. Zoom in up to 125%
3. Make sure the filter tab is not blinking

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #18213
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
