### PR TITLE
fix: report list search by created_by

### DIFF
--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -211,7 +211,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
         "dashboard": "dashboard_title",
         "chart": "slice_name",
         "database": "database_name",
-        "owners": RelatedFieldFilter("first_name", FilterRelatedOwners),
+        "created_by": RelatedFieldFilter("first_name", FilterRelatedOwners),
     }
 
     apispec_parameter_schemas = {

--- a/tests/integration_tests/reports/api_tests.py
+++ b/tests/integration_tests/reports/api_tests.py
@@ -432,7 +432,7 @@ class TestReportSchedulesApi(SupersetTestCase):
         ReportSchedule Api: Test get releated report schedule
         """
         self.login(username="admin")
-        related_columns = ["owners", "chart", "dashboard", "database"]
+        related_columns = ["created_by", "chart", "dashboard", "database"]
         for related_column in related_columns:
             uri = f"api/v1/report/related/{related_column}"
             rv = self.client.get(uri)


### PR DESCRIPTION
### SUMMARY
This PR is to fix the issue when search by created_by in report/alert list. 
Steps to reproduce (see issue##17162)
1. open alert/report list
2. In CREATED BY, search for a username, for example "Grace".
<img width="1440" alt="Screen Shot 2022-02-14 at 5 05 57 PM" src="https://user-images.githubusercontent.com/27990562/153973110-fff2fde4-0e19-4dc3-a3aa-38da2ae7d99c.png">

3. It will generate a request to `/related/` endpoint: `Request URL: https://superset.d.musta.ch/api/v1/report/related/created_by?q=(filter:grace,page:0,page_size:100)`
4.  But for report schedule, it has `owners` in `related_field_filters`, not `created_by`. This mis-match cause filter didn't take any effect. 

The proposed fix is to use `created_by` in the `related_field_filters`.

### TESTING INSTRUCTIONS
CI and manual test


