### PR TITLE
fix(dashboard): fix default filter bar visibility + add docs

### DIFF
--- a/docs/docs/creating-charts-dashboards/creating-your-first-dashboard.mdx
+++ b/docs/docs/creating-charts-dashboards/creating-your-first-dashboard.mdx
@@ -197,15 +197,15 @@ The following URL parameters can be used to modify how the dashboard is rendered
   - `0` (default): dashboard is displayed normally
   - `1`: Top Navigation is hidden
   - `2`: Top Navigation + title is hidden
-  - `3`: Top Navigation + title + top level tab is hidden
+  - `3`: Top Navigation + title + top level tabs are hidden
 - `show_filters`:
-  - `0`: render dashboard without Filter Tab
-  - `1` (default): render dashboard with Filter Tab if native filters are enabled
+  - `0`: render dashboard without Filter Bar
+  - `1` (default): render dashboard with Filter Bar if native filters are enabled
 - `expand_filters`:
-  - (default): render dashboard with Filter Tab expanded if there are native filters
-  - `0`: render dashboard with Filter Tab collapsed
-  - `1`: render dashboard with Filter Tab expanded
+  - (default): render dashboard with Filter Bar expanded if there are native filters
+  - `0`: render dashboard with Filter Bar collapsed
+  - `1`: render dashboard with Filter Bar expanded
 
 For example, when running the local development build, the following will disable the
-Top Nav and remove the Filter Tab:
+Top Nav and remove the Filter Bar:
 `http://localhost:8088/superset/dashboard/my-dashboard/?standalone=1&show_filters=0`

--- a/docs/docs/creating-charts-dashboards/creating-your-first-dashboard.mdx
+++ b/docs/docs/creating-charts-dashboards/creating-your-first-dashboard.mdx
@@ -189,3 +189,23 @@ all charts will load their data even if feature flag is turned on and no roles a
 to roles the access will fallback to **Dataset permissions**
 
 <img src={useBaseUrl("/img/tutorial/tutorial_dashboard_access.png" )} />
+
+### Customizing dashboard
+
+The following URL parameters can be used to modify how the dashboard is rendered:
+- `standalone`:
+  - `0` (default): dashboard is displayed normally
+  - `1`: Top Navigation is hidden
+  - `2`: Top Navigation + title is hidden
+  - `3`: Top Navigation + title + top level tab is hidden
+- `show_filters`:
+  - `0`: render dashboard without Filter Tab
+  - `1` (default): render dashboard with Filter Tab if native filters are enabled
+- `expand_filters`:
+  - (default): render dashboard with Filter Tab expanded if there are native filters
+  - `0`: render dashboard with Filter Tab collapsed
+  - `1`: render dashboard with Filter Tab expanded
+
+For example, when running the local development build, the following will disable the
+Top Nav and remove the Filter Tab:
+`http://localhost:8088/superset/dashboard/my-dashboard/?standalone=1&show_filters=0`

--- a/superset-frontend/src/components/UiConfigContext/index.tsx
+++ b/superset-frontend/src/components/UiConfigContext/index.tsx
@@ -41,7 +41,7 @@ export const useUiConfig = () => useContext(UiConfigContext);
 
 export const EmbeddedUiConfigProvider: React.FC<EmbeddedUiConfigProviderProps> =
   ({ children }) => {
-    const config = getUrlParam(URL_PARAMS.uiConfig);
+    const config = getUrlParam(URL_PARAMS.uiConfig) || 0;
     const [embeddedConfig] = useState({
       hideTitle: (config & 1) !== 0,
       hideTab: (config & 2) !== 0,

--- a/superset-frontend/src/constants.ts
+++ b/superset-frontend/src/constants.ts
@@ -55,6 +55,10 @@ export const URL_PARAMS = {
     name: 'show_filters',
     type: 'boolean',
   },
+  expandFilters: {
+    name: 'expand_filters',
+    type: 'boolean',
+  },
   formDataKey: {
     name: 'form_data_key',
     type: 'string',

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -350,7 +350,7 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
           <StickyPanel ref={containerRef} width={filterBarWidth}>
             <ErrorBoundary>
               <FilterBar
-                filtersOpen={dashboardFiltersOpen}
+                filtersOpen={!!dashboardFiltersOpen}
                 toggleFiltersBar={toggleDashboardFiltersOpen}
                 directPathToChild={directPathToChild}
                 width={filterBarWidth}
@@ -407,7 +407,7 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
         >
           <StyledDashboardContent
             className="dashboard-content"
-            dashboardFiltersOpen={dashboardFiltersOpen}
+            dashboardFiltersOpen={!!dashboardFiltersOpen}
             editMode={editMode}
             nativeFiltersEnabled={nativeFiltersEnabled}
           >

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -350,7 +350,7 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
           <StickyPanel ref={containerRef} width={filterBarWidth}>
             <ErrorBoundary>
               <FilterBar
-                filtersOpen={!!dashboardFiltersOpen}
+                filtersOpen={dashboardFiltersOpen}
                 toggleFiltersBar={toggleDashboardFiltersOpen}
                 directPathToChild={directPathToChild}
                 width={filterBarWidth}
@@ -407,7 +407,7 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
         >
           <StyledDashboardContent
             className="dashboard-content"
-            dashboardFiltersOpen={!!dashboardFiltersOpen}
+            dashboardFiltersOpen={dashboardFiltersOpen}
             editMode={editMode}
             nativeFiltersEnabled={nativeFiltersEnabled}
           >

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/state.ts
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/state.ts
@@ -32,11 +32,10 @@ import {
 export const useNativeFilters = () => {
   const filterboxMigrationState = useContext(MigrationContext);
   const [isInitialized, setIsInitialized] = useState(false);
-  const [dashboardFiltersOpen, setDashboardFiltersOpen] = useState(
-    getUrlParam(URL_PARAMS.showFilters) ?? true,
-  );
   const showNativeFilters = useSelector<RootState, boolean>(
-    state => state.dashboardInfo.metadata?.show_native_filters,
+    state =>
+      (getUrlParam(URL_PARAMS.showFilters) ?? true) &&
+      state.dashboardInfo.metadata?.show_native_filters,
   );
   const canEdit = useSelector<RootState, boolean>(
     ({ dashboardInfo }) => dashboardInfo.dash_edit_perm,
@@ -44,6 +43,10 @@ export const useNativeFilters = () => {
 
   const filters = useFilters();
   const filterValues = Object.values(filters);
+  const expandFilters = getUrlParam(URL_PARAMS.expandFilters);
+  const [dashboardFiltersOpen, setDashboardFiltersOpen] = useState(
+    expandFilters ?? filterValues.length,
+  );
 
   const nativeFiltersEnabled =
     showNativeFilters &&
@@ -74,9 +77,10 @@ export const useNativeFilters = () => {
 
   useEffect(() => {
     if (
-      filterValues.length === 0 &&
-      nativeFiltersEnabled &&
-      ['CONVERTED', 'REVIEWING', 'NOOP'].includes(filterboxMigrationState)
+      expandFilters === false ||
+      (filterValues.length === 0 &&
+        nativeFiltersEnabled &&
+        ['CONVERTED', 'REVIEWING', 'NOOP'].includes(filterboxMigrationState))
     ) {
       toggleDashboardFiltersOpen(false);
     } else {

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/state.ts
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/state.ts
@@ -45,7 +45,7 @@ export const useNativeFilters = () => {
   const filterValues = Object.values(filters);
   const expandFilters = getUrlParam(URL_PARAMS.expandFilters);
   const [dashboardFiltersOpen, setDashboardFiltersOpen] = useState(
-    expandFilters ?? filterValues.length,
+    expandFilters ?? !!filterValues.length,
   );
 
   const nativeFiltersEnabled =

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/keyValue.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/keyValue.tsx
@@ -21,7 +21,7 @@ import { DashboardPermalinkValue } from 'src/dashboard/types';
 
 const assembleEndpoint = (
   dashId: string | number,
-  key?: string,
+  key?: string | null,
   tabId?: string,
 ) => {
   let endpoint = `api/v1/dashboard/${dashId}/filter_state`;
@@ -65,7 +65,7 @@ export const createFilterKey = (
       return null;
     });
 
-export const getFilterValue = (dashId: string | number, key: string) =>
+export const getFilterValue = (dashId: string | number, key?: string | null) =>
   SupersetClient.get({
     endpoint: assembleEndpoint(dashId, key),
   })

--- a/superset-frontend/src/utils/urlUtils.ts
+++ b/superset-frontend/src/utils/urlUtils.ts
@@ -30,14 +30,22 @@ import serializeActiveFilterValues from '../dashboard/util/serializeActiveFilter
 
 export type UrlParamType = 'string' | 'number' | 'boolean' | 'object' | 'rison';
 export type UrlParam = typeof URL_PARAMS[keyof typeof URL_PARAMS];
-export function getUrlParam(param: UrlParam & { type: 'string' }): string;
-export function getUrlParam(param: UrlParam & { type: 'number' }): number;
-export function getUrlParam(param: UrlParam & { type: 'boolean' }): boolean;
-export function getUrlParam(param: UrlParam & { type: 'object' }): object;
-export function getUrlParam(param: UrlParam & { type: 'rison' }): object;
+export function getUrlParam(
+  param: UrlParam & { type: 'string' },
+): string | null;
+export function getUrlParam(
+  param: UrlParam & { type: 'number' },
+): number | null;
+export function getUrlParam(
+  param: UrlParam & { type: 'boolean' },
+): boolean | null;
+export function getUrlParam(
+  param: UrlParam & { type: 'object' },
+): object | null;
+export function getUrlParam(param: UrlParam & { type: 'rison' }): object | null;
 export function getUrlParam(
   param: UrlParam & { type: 'rison | string' },
-): string | object;
+): string | object | null;
 export function getUrlParam({ name, type }: UrlParam): unknown {
   const urlParam = new URLSearchParams(window.location.search).get(name);
   switch (type) {


### PR DESCRIPTION
### SUMMARY
This adds docs for reserved/supported URL parameters in the dashboard view. While writing docs for the Dashboard URL params, I noticed some inconsistencies in how they work:
- The return type for `getUrlParam` was missing `null` which it defaults to when the param is missing
- There was no way to disable native filters via URL params the same way that the dashboard metadata flag `show_native_filters` does. Here we recycle the `show_filters` URL param to mimic the behavior of `show_native_filters`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Go to a dashboard with no native filters and set `expand_filters=1` on the URL to forcefully expand the Filter Bar: http://35.86.100.235:8080/superset/dashboard/10/?expand_filters=1
2. Go to a dashboard with at least 1 native filter and set `expand_filters=0` on the URL to forcefully collapse the Filter Bar: http://35.86.100.235:8080/superset/dashboard/10/?expand_filters=0
3. Go to a dashboard and set `show_filters=0` to forcefully disable native filters (handy for standalone mode): http://35.86.100.235:8080/superset/dashboard/10/?show_filters=0
4. Go to the "Video Game Sales" dashboard and set `standalone=0` to verify that it looks like the default configuration: http://35.86.100.235:8080/superset/dashboard/5/?standalone=0
5. Set `standalone=1` to see that the top nav is removed: http://35.86.100.235:8080/superset/dashboard/5/?standalone=1
6. Set `standalone=2` to see that the top nav + title is removed: http://35.86.100.235:8080/superset/dashboard/5/?standalone=2
7. Set `standalone=3` to see that the top nav + title + top tabs are removed: http://35.86.100.235:8080/superset/dashboard/5/?standalone=3
8. Set `standalone=3&show_filters=0` to make sure filter bar, nav, title and top tabs are removed: http://35.86.100.235:8080/superset/dashboard/5/?standalone=3&show_filters=0

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
