### PR TITLE
fix(sqllab): Removed the tooltip from CopyToClipboard button in sqllab

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -550,6 +550,7 @@ export default class ResultSet extends React.PureComponent<
                   <i className="fa fa-clipboard" /> {t('Copy to Clipboard')}
                 </Button>
               }
+              hasTooltip={false}
             />
           </ResultSetButtons>
           {this.props.search && (

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -550,7 +550,7 @@ export default class ResultSet extends React.PureComponent<
                   <i className="fa fa-clipboard" /> {t('Copy to Clipboard')}
                 </Button>
               }
-              hasTooltip={false}
+              hideTooltip
             />
           </ResultSetButtons>
           {this.props.search && (

--- a/superset-frontend/src/components/CopyToClipboard/CopyToClipboard.stories.tsx
+++ b/superset-frontend/src/components/CopyToClipboard/CopyToClipboard.stories.tsx
@@ -49,6 +49,7 @@ InteractiveCopyToClipboard.args = {
   text: 'http://superset.apache.org/',
   wrapped: true,
   tooltipText: 'Copy to clipboard',
+  hideTooltip: false,
 };
 
 InteractiveCopyToClipboard.argTypes = {

--- a/superset-frontend/src/components/CopyToClipboard/CopyToClipboard.test.tsx
+++ b/superset-frontend/src/components/CopyToClipboard/CopyToClipboard.test.tsx
@@ -58,6 +58,16 @@ test('renders tooltip on hover', async () => {
   expect(tooltip).toHaveTextContent(tooltipText);
 });
 
+test('not renders tooltip on hover with hideTooltip props', async () => {
+  const tooltipText = 'Tooltip';
+  render(<CopyToClipboard tooltipText={tooltipText} hideTooltip />, {
+    useRedux: true,
+  });
+  userEvent.hover(screen.getByText('Copy'));
+  const tooltip = screen.queryByRole('tooltip');
+  expect(tooltip).toBe(null);
+});
+
 test('triggers onCopyEnd', async () => {
   const onCopyEnd = jest.fn();
   render(<CopyToClipboard onCopyEnd={onCopyEnd} />, {

--- a/superset-frontend/src/components/CopyToClipboard/index.jsx
+++ b/superset-frontend/src/components/CopyToClipboard/index.jsx
@@ -88,15 +88,7 @@ class CopyToClipboard extends React.Component {
 
   renderNotWrapped() {
     return (
-      <Tooltip
-        id="copy-to-clipboard-tooltip"
-        placement="top"
-        style={{ cursor: 'pointer' }}
-        title={this.props.tooltipText}
-        trigger={['hover']}
-      >
-        {this.getDecoratedCopyNode()}
-      </Tooltip>
+      this.getDecoratedCopyNode()
     );
   }
 
@@ -108,14 +100,7 @@ class CopyToClipboard extends React.Component {
             {this.props.text}
           </span>
         )}
-        <Tooltip
-          id="copy-to-clipboard-tooltip"
-          placement="top"
-          title={this.props.tooltipText}
-          trigger={['hover']}
-        >
-          {this.getDecoratedCopyNode()}
-        </Tooltip>
+        {this.getDecoratedCopyNode()}
       </span>
     );
   }

--- a/superset-frontend/src/components/CopyToClipboard/index.jsx
+++ b/superset-frontend/src/components/CopyToClipboard/index.jsx
@@ -33,6 +33,7 @@ const propTypes = {
   tooltipText: PropTypes.string,
   addDangerToast: PropTypes.func.isRequired,
   addSuccessToast: PropTypes.func.isRequired,
+  hasTooltip: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -41,6 +42,7 @@ const defaultProps = {
   shouldShowText: true,
   wrapped: true,
   tooltipText: t('Copy to clipboard'),
+  hasTooltip: true,
 };
 
 class CopyToClipboard extends React.Component {
@@ -88,7 +90,21 @@ class CopyToClipboard extends React.Component {
 
   renderNotWrapped() {
     return (
-      this.getDecoratedCopyNode()
+      <>
+        {this.props.hasTooltip ? (
+          <Tooltip
+            id="copy-to-clipboard-tooltip"
+            placement="top"
+            style={{ cursor: 'pointer' }}
+            title={this.props.tooltipText}
+            trigger={['hover']}
+          >
+            {this.getDecoratedCopyNode()}
+          </Tooltip>
+        ) : (
+          this.getDecoratedCopyNode()
+        )}
+      </>
     );
   }
 
@@ -100,7 +116,18 @@ class CopyToClipboard extends React.Component {
             {this.props.text}
           </span>
         )}
-        {this.getDecoratedCopyNode()}
+        {this.props.hasTooltip ? (
+          <Tooltip
+            id="copy-to-clipboard-tooltip"
+            placement="top"
+            title={this.props.tooltipText}
+            trigger={['hover']}
+          >
+            {this.getDecoratedCopyNode()}
+          </Tooltip>
+        ) : (
+          this.getDecoratedCopyNode()
+        )}
       </span>
     );
   }

--- a/superset-frontend/src/components/CopyToClipboard/index.jsx
+++ b/superset-frontend/src/components/CopyToClipboard/index.jsx
@@ -33,7 +33,7 @@ const propTypes = {
   tooltipText: PropTypes.string,
   addDangerToast: PropTypes.func.isRequired,
   addSuccessToast: PropTypes.func.isRequired,
-  hasTooltip: PropTypes.bool,
+  hideTooltip: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -42,7 +42,7 @@ const defaultProps = {
   shouldShowText: true,
   wrapped: true,
   tooltipText: t('Copy to clipboard'),
-  hasTooltip: true,
+  hideTooltip: false,
 };
 
 class CopyToClipboard extends React.Component {
@@ -88,14 +88,14 @@ class CopyToClipboard extends React.Component {
       });
   }
 
-  renderNotWrapped() {
+  renderTooltip(cursor) {
     return (
       <>
-        {this.props.hasTooltip ? (
+        {!this.props.hideTooltip ? (
           <Tooltip
             id="copy-to-clipboard-tooltip"
             placement="top"
-            style={{ cursor: 'pointer' }}
+            style={{ cursor }}
             title={this.props.tooltipText}
             trigger={['hover']}
           >
@@ -108,6 +108,10 @@ class CopyToClipboard extends React.Component {
     );
   }
 
+  renderNotWrapped() {
+    return this.renderTooltip('pointer');
+  }
+
   renderLink() {
     return (
       <span css={{ display: 'inline-flex', alignItems: 'center' }}>
@@ -116,18 +120,7 @@ class CopyToClipboard extends React.Component {
             {this.props.text}
           </span>
         )}
-        {this.props.hasTooltip ? (
-          <Tooltip
-            id="copy-to-clipboard-tooltip"
-            placement="top"
-            title={this.props.tooltipText}
-            trigger={['hover']}
-          >
-            {this.getDecoratedCopyNode()}
-          </Tooltip>
-        ) : (
-          this.getDecoratedCopyNode()
-        )}
+        {this.renderTooltip()}
       </span>
     );
   }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Removed the tooltip from CopyToClipboard button in sqllab

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://user-images.githubusercontent.com/47900232/154514993-dcc58b3f-76c6-4f0f-b012-e811c3075579.png)
After:
![image](https://user-images.githubusercontent.com/47900232/154515106-58d6ded6-2b95-4d21-a6a6-087d0813539c.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
