### PR TITLE
fix: update standalone url for slack reports

### DIFF
--- a/superset/reports/notifications/slack.py
+++ b/superset/reports/notifications/slack.py
@@ -29,6 +29,7 @@ from superset import app
 from superset.models.reports import ReportRecipientType
 from superset.reports.notifications.base import BaseNotification
 from superset.reports.notifications.exceptions import NotificationError
+from superset.utils.urls import modify_url_query
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +48,11 @@ class SlackNotification(BaseNotification):  # pylint: disable=too-few-public-met
         return json.loads(self._recipient.recipient_config_json)["target"]
 
     def _message_template(self, table: str = "") -> str:
+        url = (
+            modify_url_query(self._content.url, standalone="0")
+            if self._content.url is not None
+            else ""
+        )
         return __(
             """*%(name)s*
 
@@ -58,7 +64,7 @@ class SlackNotification(BaseNotification):  # pylint: disable=too-few-public-met
 """,
             name=self._content.name,
             description=self._content.description or "",
-            url=self._content.url,
+            url=url,
             table=table,
         )
 

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -1024,6 +1024,7 @@ def test_slack_chart_report_schedule(
         notification_targets = get_target_from_report_schedule(
             create_report_slack_chart
         )
+
         assert file_upload_mock.call_args[1]["channels"] == notification_targets[0]
         assert file_upload_mock.call_args[1]["file"] == SCREENSHOT_FILE
 
@@ -1118,6 +1119,11 @@ def test_slack_chart_report_schedule_with_text(
 |  0 | c11  | c12  | c13       |
 |  1 | c21  | c22  | c23       |"""
         assert table_markdown in post_message_mock.call_args[1]["text"]
+
+        print(post_message_mock.call_args[1]["text"])
+        assert (
+            f"http://0.0.0.0:8080/superset/explore/?form_data=%7B%22slice_id%22%3A%201%7D&standalone=0&force=false"
+        ) in post_message_mock.call_args[1]["text"]
 
         # Assert logs are correct
         assert_log(ReportState.SUCCESS)

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -1119,11 +1119,10 @@ def test_slack_chart_report_schedule_with_text(
 |  0 | c11  | c12  | c13       |
 |  1 | c21  | c22  | c23       |"""
         assert table_markdown in post_message_mock.call_args[1]["text"]
-
-        print(post_message_mock.call_args[1]["text"])
         assert (
-            f"http://0.0.0.0:8080/superset/explore/?form_data=%7B%22slice_id%22%3A%201%7D&standalone=0&force=false"
-        ) in post_message_mock.call_args[1]["text"]
+            f"<http://0.0.0.0:8080/superset/explore/?form_data=%7B%22slice_id%22%3A%20{create_report_slack_chart_with_text.chart.id}%7D&standalone=0&force=false|Explore in Superset>"
+            in post_message_mock.call_args[1]["text"]
+        )
 
         # Assert logs are correct
         assert_log(ReportState.SUCCESS)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Following https://github.com/apache/superset/pull/18157 we forgot to update the slack url with the new modify url function

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
