### PR TITLE
fix: CSV upload with overprescribed table/schema

### DIFF
--- a/superset/views/database/forms.py
+++ b/superset/views/database/forms.py
@@ -29,7 +29,7 @@ from wtforms import (
     StringField,
 )
 from wtforms.ext.sqlalchemy.fields import QuerySelectField
-from wtforms.validators import DataRequired, Length, NumberRange, Optional
+from wtforms.validators import DataRequired, Length, NumberRange, Optional, Regexp
 
 from superset import app, db, security_manager
 from superset.forms import (
@@ -94,7 +94,10 @@ class CsvToDatabaseForm(UploadToDatabaseForm):
     name = StringField(
         _("Table Name"),
         description=_("Name of table to be created from csv data."),
-        validators=[DataRequired()],
+        validators=[
+            DataRequired(),
+            Regexp(r"^[^\.]+$", message=_("Table name cannot contain a schema")),
+        ],
         widget=BS3TextFieldWidget(),
     )
     csv_file = FileField(
@@ -245,7 +248,10 @@ class ExcelToDatabaseForm(UploadToDatabaseForm):
     name = StringField(
         _("Table Name"),
         description=_("Name of table to be created from excel data."),
-        validators=[DataRequired()],
+        validators=[
+            DataRequired(),
+            Regexp(r"^[^\.]+$", message=_("Table name cannot contain a schema")),
+        ],
         widget=BS3TextFieldWidget(),
     )
     excel_file = FileField(
@@ -378,7 +384,10 @@ class ColumnarToDatabaseForm(UploadToDatabaseForm):
     name = StringField(
         _("Table Name"),
         description=_("Name of table to be created from columnar data."),
-        validators=[DataRequired()],
+        validators=[
+            DataRequired(),
+            Regexp(r"^[^\.]+$", message=_("Table name cannot contain a schema")),
+        ],
         widget=BS3TextFieldWidget(),
     )
     columnar_file = MultipleFileField(

--- a/superset/views/database/views.py
+++ b/superset/views/database/views.py
@@ -142,17 +142,6 @@ class CsvToDatabaseView(SimpleFormView):
             flash(message, "danger")
             return redirect("/csvtodatabaseview/form")
 
-        if "." in csv_table.table and csv_table.schema:
-            message = _(
-                "You cannot specify a namespace both in the name of the table: "
-                '"%(csv_table.table)s" and in the schema field: '
-                '"%(csv_table.schema)s". Please remove one',
-                table=csv_table.table,
-                schema=csv_table.schema,
-            )
-            flash(message, "danger")
-            return redirect("/csvtodatabaseview/form")
-
         try:
             df = pd.concat(
                 pd.read_csv(
@@ -285,17 +274,6 @@ class ExcelToDatabaseView(SimpleFormView):
                 "is not allowed for excel uploads. Please contact your Superset Admin.",
                 database_name=database.database_name,
                 schema_name=excel_table.schema,
-            )
-            flash(message, "danger")
-            return redirect("/exceltodatabaseview/form")
-
-        if "." in excel_table.table and excel_table.schema:
-            message = _(
-                "You cannot specify a namespace both in the name of the table: "
-                '"%(excel_table.table)s" and in the schema field: '
-                '"%(excel_table.schema)s". Please remove one',
-                table=excel_table.table,
-                schema=excel_table.schema,
             )
             flash(message, "danger")
             return redirect("/exceltodatabaseview/form")
@@ -455,17 +433,6 @@ class ColumnarToDatabaseView(SimpleFormView):
                 "Please contact your Superset Admin.",
                 database_name=database.database_name,
                 schema_name=columnar_table.schema,
-            )
-            flash(message, "danger")
-            return redirect("/columnartodatabaseview/form")
-
-        if "." in columnar_table.table and columnar_table.schema:
-            message = _(
-                "You cannot specify a namespace both in the name of the table: "
-                '"%(columnar_table.table)s" and in the schema field: '
-                '"%(columnar_table.schema)s". Please remove one',
-                table=columnar_table.table,
-                schema=columnar_table.schema,
             )
             flash(message, "danger")
             return redirect("/columnartodatabaseview/form")

--- a/tests/integration_tests/csv_upload_tests.py
+++ b/tests/integration_tests/csv_upload_tests.py
@@ -219,6 +219,10 @@ def test_import_csv_enforced_schema(mock_event_logger):
 
     full_table_name = f"admin_database.{CSV_UPLOAD_TABLE_W_SCHEMA}"
 
+    # Invalid table name
+    resp = upload_csv(CSV_FILENAME1, full_table_name)
+    assert "Table name cannot contain a schema" in resp
+
     # no schema specified, fail upload
     resp = upload_csv(CSV_FILENAME1, CSV_UPLOAD_TABLE_W_SCHEMA, extra={"schema": None})
     assert (


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR fixes a couple of issues related to CSV upload:

1. If the schema was overprescribed (both explicitly and in the table name) the flashed message would fail (resulting in a 500 error) due to invalid field names passed to the message generator. This code path was not covered by unit tests.
2. The schema was not correctly extracted when specified in the table name.

I debated how best to tackle this and initially went down the route of redefining the server-side form post logic (with unit tests), but opted for hopefully an easier/cleaner route by adding form validators.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<img width="921" alt="Screen Shot 2022-02-18 at 6 42 17 PM" src="https://user-images.githubusercontent.com/4567245/154625362-a17147fb-3dda-40c3-bdeb-27ed36d19fbc.png">

### TESTING INSTRUCTIONS

Tested locally.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
