### PR TITLE
[WIP] fix: default area chart to stacking

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
@@ -33,9 +33,9 @@ import {
   EchartsTimeseriesSeriesType,
 } from '../types';
 import {
+  getShowValueSection,
   legendSection,
   richTooltipSection,
-  showValueSection,
   xAxisControl,
 } from '../../controls';
 
@@ -144,7 +144,7 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        ...showValueSection,
+        ...getShowValueSection({ stackDefault: true }),
         [
           {
             name: 'markerEnabled',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -34,7 +34,7 @@ import {
 import {
   legendSection,
   richTooltipSection,
-  showValueSection,
+  getShowValueSection,
   xAxisControl,
 } from '../../../controls';
 
@@ -105,7 +105,7 @@ const config: ControlPanelConfig = {
       expanded: true,
       controlSetRows: [
         ['color_scheme'],
-        ...showValueSection,
+        ...getShowValueSection(),
         [
           {
             name: 'markerEnabled',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
@@ -29,9 +29,9 @@ import {
 
 import { DEFAULT_FORM_DATA } from '../../types';
 import {
+  getShowValueSection,
   legendSection,
   richTooltipSection,
-  showValueSection,
   xAxisControl,
 } from '../../../controls';
 
@@ -85,7 +85,7 @@ const config: ControlPanelConfig = {
       expanded: true,
       controlSetRows: [
         ['color_scheme'],
-        ...showValueSection,
+        ...getShowValueSection(),
         [
           {
             name: 'markerEnabled',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/controlPanel.tsx
@@ -31,7 +31,7 @@ import { DEFAULT_FORM_DATA, EchartsTimeseriesContributionType } from '../types';
 import {
   legendSection,
   richTooltipSection,
-  showValueSectionWithoutStack,
+  getShowValueSection,
   xAxisControl,
 } from '../../controls';
 
@@ -102,7 +102,7 @@ const config: ControlPanelConfig = {
       expanded: true,
       controlSetRows: [
         ['color_scheme'],
-        ...showValueSectionWithoutStack,
+        ...getShowValueSection({ withStack: false }),
         [
           {
             name: 'markerEnabled',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
@@ -33,9 +33,9 @@ import {
   EchartsTimeseriesSeriesType,
 } from '../types';
 import {
+  getShowValueSection,
   legendSection,
   richTooltipSection,
-  showValueSection,
   xAxisControl,
 } from '../../controls';
 
@@ -127,7 +127,7 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        ...showValueSection,
+        ...getShowValueSection(),
         [
           {
             name: 'area',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
@@ -33,9 +33,9 @@ import {
   EchartsTimeseriesSeriesType,
 } from './types';
 import {
+  getShowValueSection,
   legendSection,
   richTooltipSection,
-  showValueSection,
   xAxisControl,
 } from '../controls';
 
@@ -130,7 +130,7 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        ...showValueSection,
+        ...getShowValueSection(),
         [
           {
             name: 'area',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
@@ -112,7 +112,7 @@ const showValueControl: ControlSetItem = {
   },
 };
 
-const stackControl: ControlSetItem = {
+export const getStackControl = (overrides = {}): ControlSetItem => ({
   name: 'stack',
   config: {
     type: 'CheckboxControl',
@@ -120,8 +120,9 @@ const stackControl: ControlSetItem = {
     renderTrigger: true,
     default: false,
     description: t('Stack series on top of each other'),
+    ...overrides,
   },
-};
+});
 
 const onlyTotalControl: ControlSetItem = {
   name: 'only_total',
@@ -168,17 +169,27 @@ const percentageThresholdControl: ControlSetItem = {
   },
 };
 
-export const showValueSection: ControlSetRow[] = [
-  [showValueControl],
-  [stackControl],
-  [onlyTotalControl],
-  [percentageThresholdControl],
-];
-
-export const showValueSectionWithoutStack: ControlSetRow[] = [
-  [showValueControl],
-  [onlyTotalControl],
-];
+export const getShowValueSection = ({
+  withStack,
+  stackDefault,
+}: {
+  withStack?: boolean;
+  stackDefault?: boolean;
+} = {}): ControlSetRow[] => {
+  if (withStack !== false) {
+    return [
+      [showValueControl],
+      [
+        getStackControl(
+          stackDefault === undefined ? {} : { default: stackDefault },
+        ),
+      ],
+      [onlyTotalControl],
+      [percentageThresholdControl],
+    ];
+  }
+  return [[showValueControl], [onlyTotalControl]];
+};
 
 const richTooltipControl: ControlSetItem = {
   name: 'rich_tooltip',

--- a/superset-frontend/plugins/plugin-chart-echarts/test/controls.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/controls.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { getStackControl, getShowValueSection } from '../src/controls';
+
+test('getStackControl defaults to expected values', () => {
+  const control = getStackControl();
+  expect(control.config.default).toEqual(false);
+});
+
+test('getStackControl overrides config', () => {
+  const control = getStackControl({ default: true });
+  expect(control.config.default).toEqual(true);
+});
+
+test('getShowValueSection defaults to expected values', () => {
+  const section = getShowValueSection();
+  expect(section.length).toEqual(4);
+  const control = section[1][0];
+  expect(control.config.default).toEqual(false);
+});
+
+test('getShowValueSection omits stacking controls', () => {
+  const section = getShowValueSection({ withStack: false });
+  expect(section.length).toEqual(2);
+});
+
+test('getShowValueSection overrides stacking default', () => {
+  const section = getShowValueSection({ stackDefault: true });
+  expect(section.length).toEqual(4);
+  const control = section[1][0];
+  expect(control.config.default).toEqual(true);
+});


### PR DESCRIPTION
### SUMMARY

This PR is not meant to be merged just yet - currently only here for discussion.

Right now the ECharts area chart doesn't stack by default, often leading to confusion as many users expect area charts to be stacked. This PR changes the default behavior to set stacking to true when switching to the ECharts area chart. In addition, we currently don't support stacking on the ECharts line chart, which is in line with how Google Sheets does it. Incidentally, "Area Chart" and "Stacked Area Chart" are two separate chart types both ton Google Sheets and Excel. This is also the case for bar charts. See screenshot from Google Sheets:
<img width="284" alt="image" src="https://user-images.githubusercontent.com/33317356/154437570-6876ea38-4d29-498b-a211-0e0f6f4e05aa.png">

So a follow-up question is, would it be more intuitive to have separate stacking charts, or should stacking be a control in the parent chart?

A few options come to mind:

Option 1: Maintain the current status quo:
- Line charts can't be stacked
- Stacking in area and bar charts default to false
- When setting stacking to true and moving from area to bar chart, the bars appear stacked.

Option 2: Introduce separate chart types for the stacking variants:
- Area Chart
- Stacked Area Chart (new)
- Bar Chart
- Stacked Bar Chart (new)
- Line Chart
- Stacked Line Chart (new)
- etc

Unfortunately we now have to rerun the query whenever switching between these charts that have fully compatible query sections. So we should also consider creating a mechanism that rerenders the chart when switching between charts that are known to have compatible query sections (for instance all charts that share the same `buildQuery` callback).

Option 3: Assume that stacking is an inherent viz type option that should be reset to its default when going between chart types:
- Area Chart (stacking = true?)
- Bar Chart (stacking = false?)
- Line Chart (stacking unavailable? or add stacking and default to false?)

### Video
This demonstrates option 2:

https://user-images.githubusercontent.com/33317356/154436935-70448695-3b56-4c15-9cc2-1aa165f33e50.mp4

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
