### PR TITLE
fix: contribution operator meets nan value

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
@@ -72,10 +72,10 @@ const config: ControlPanelConfig = {
               default: contributionMode,
               choices: [
                 [null, 'None'],
-                [EchartsTimeseriesContributionType.Row, 'Total'],
+                [EchartsTimeseriesContributionType.Row, 'Row'],
                 [EchartsTimeseriesContributionType.Column, 'Series'],
               ],
-              description: t('Calculate contribution per series or total'),
+              description: t('Calculate contribution per series or row'),
             },
           },
         ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -69,10 +69,10 @@ const config: ControlPanelConfig = {
               default: contributionMode,
               choices: [
                 [null, 'None'],
-                [EchartsTimeseriesContributionType.Row, 'Total'],
+                [EchartsTimeseriesContributionType.Row, 'Row'],
                 [EchartsTimeseriesContributionType.Column, 'Series'],
               ],
-              description: t('Calculate contribution per series or total'),
+              description: t('Calculate contribution per series or row'),
             },
           },
         ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/controlPanel.tsx
@@ -66,10 +66,10 @@ const config: ControlPanelConfig = {
               default: contributionMode,
               choices: [
                 [null, 'None'],
-                [EchartsTimeseriesContributionType.Row, 'Total'],
+                [EchartsTimeseriesContributionType.Row, 'Row'],
                 [EchartsTimeseriesContributionType.Column, 'Series'],
               ],
-              description: t('Calculate contribution per series or total'),
+              description: t('Calculate contribution per series or row'),
             },
           },
         ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
@@ -72,10 +72,10 @@ const config: ControlPanelConfig = {
               default: contributionMode,
               choices: [
                 [null, 'None'],
-                [EchartsTimeseriesContributionType.Row, 'Total'],
+                [EchartsTimeseriesContributionType.Row, 'Row'],
                 [EchartsTimeseriesContributionType.Column, 'Series'],
               ],
-              description: t('Calculate contribution per series or total'),
+              description: t('Calculate contribution per series or row'),
             },
           },
         ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
@@ -73,10 +73,10 @@ const config: ControlPanelConfig = {
               default: contributionMode,
               choices: [
                 [null, 'None'],
-                [EchartsTimeseriesContributionType.Row, 'Total'],
+                [EchartsTimeseriesContributionType.Row, 'Row'],
                 [EchartsTimeseriesContributionType.Column, 'Series'],
               ],
-              description: t('Calculate contribution per series or total'),
+              description: t('Calculate contribution per series or row'),
             },
           },
         ],

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta
+from pprint import pformat
 from typing import Any, Dict, List, NamedTuple, Optional, TYPE_CHECKING
 
 from flask_babel import gettext as _
@@ -395,6 +396,7 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
         :raises QueryObjectValidationError: If the post processing operation
                  is incorrect
         """
+        logger.debug("post_processing: %s", pformat(self.post_processing))
         for post_process in self.post_processing:
             operation = post_process.get("operation")
             if not operation:

--- a/superset/utils/pandas_postprocessing/contribution.py
+++ b/superset/utils/pandas_postprocessing/contribution.py
@@ -17,6 +17,7 @@
 from decimal import Decimal
 from typing import List, Optional
 
+import numpy as np
 from flask_babel import gettext as _
 from pandas import DataFrame
 
@@ -49,6 +50,7 @@ def contribution(
     """
     contribution_df = df.copy()
     numeric_df = contribution_df.select_dtypes(include=["number", Decimal])
+    numeric_df.fillna(0, inplace=True)
     # verify column selections
     if columns:
         numeric_columns = numeric_df.columns.tolist()
@@ -71,5 +73,7 @@ def contribution(
     numeric_df = numeric_df[columns]
     axis = 0 if orientation == PostProcessingContributionOrientation.COLUMN else 1
     numeric_df = numeric_df / numeric_df.values.sum(axis=axis, keepdims=True)
+    # replace infinity and nan with 0 in dataframe
+    numeric_df.replace(to_replace=[np.Inf, -np.Inf, np.nan], value=0, inplace=True)
     contribution_df[rename_columns] = numeric_df
     return contribution_df

--- a/superset/utils/pandas_postprocessing/contribution.py
+++ b/superset/utils/pandas_postprocessing/contribution.py
@@ -17,7 +17,6 @@
 from decimal import Decimal
 from typing import List, Optional
 
-import numpy as np
 from flask_babel import gettext as _
 from pandas import DataFrame
 
@@ -73,7 +72,5 @@ def contribution(
     numeric_df = numeric_df[columns]
     axis = 0 if orientation == PostProcessingContributionOrientation.COLUMN else 1
     numeric_df = numeric_df / numeric_df.values.sum(axis=axis, keepdims=True)
-    # replace infinity and nan with 0 in dataframe
-    numeric_df.replace(to_replace=[np.Inf, -np.Inf, np.nan], value=0, inplace=True)
     contribution_df[rename_columns] = numeric_df
     return contribution_df

--- a/tests/unit_tests/pandas_postprocessing/test_contribution.py
+++ b/tests/unit_tests/pandas_postprocessing/test_contribution.py
@@ -18,6 +18,8 @@
 from datetime import datetime
 
 import pytest
+from numpy import nan
+from numpy.testing import assert_array_equal
 from pandas import DataFrame
 
 from superset.exceptions import QueryObjectValidationError
@@ -28,9 +30,14 @@ from superset.utils.pandas_postprocessing import contribution
 def test_contribution():
     df = DataFrame(
         {
-            DTTM_ALIAS: [datetime(2020, 7, 16, 14, 49), datetime(2020, 7, 16, 14, 50),],
-            "a": [1, 3],
-            "b": [1, 9],
+            DTTM_ALIAS: [
+                datetime(2020, 7, 16, 14, 49),
+                datetime(2020, 7, 16, 14, 50),
+                datetime(2020, 7, 16, 14, 51),
+            ],
+            "a": [1, 3, nan],
+            "b": [1, 9, nan],
+            "c": [nan, nan, nan],
         }
     )
     with pytest.raises(QueryObjectValidationError, match="not numeric"):
@@ -43,18 +50,20 @@ def test_contribution():
     processed_df = contribution(
         df, orientation=PostProcessingContributionOrientation.ROW,
     )
-    assert processed_df.columns.tolist() == [DTTM_ALIAS, "a", "b"]
-    assert processed_df["a"].tolist() == [0.5, 0.25]
-    assert processed_df["b"].tolist() == [0.5, 0.75]
+    assert processed_df.columns.tolist() == [DTTM_ALIAS, "a", "b", "c"]
+    assert processed_df["a"].tolist() == [0.5, 0.25, 0]
+    assert processed_df["b"].tolist() == [0.5, 0.75, 0]
+    assert processed_df["c"].tolist() == [0, 0, 0]
 
     # cell contribution across column without temporal column
     df.pop(DTTM_ALIAS)
     processed_df = contribution(
         df, orientation=PostProcessingContributionOrientation.COLUMN
     )
-    assert processed_df.columns.tolist() == ["a", "b"]
-    assert processed_df["a"].tolist() == [0.25, 0.75]
-    assert processed_df["b"].tolist() == [0.1, 0.9]
+    assert processed_df.columns.tolist() == ["a", "b", "c"]
+    assert processed_df["a"].tolist() == [0.25, 0.75, 0]
+    assert processed_df["b"].tolist() == [0.1, 0.9, 0]
+    assert processed_df["c"].tolist() == [0, 0, 0]
 
     # contribution only on selected columns
     processed_df = contribution(
@@ -63,7 +72,8 @@ def test_contribution():
         columns=["a"],
         rename_columns=["pct_a"],
     )
-    assert processed_df.columns.tolist() == ["a", "b", "pct_a"]
-    assert processed_df["a"].tolist() == [1, 3]
-    assert processed_df["b"].tolist() == [1, 9]
-    assert processed_df["pct_a"].tolist() == [0.25, 0.75]
+    assert processed_df.columns.tolist() == ["a", "b", "c", "pct_a"]
+    assert_array_equal(processed_df["a"].tolist(), [1, 3, nan])
+    assert_array_equal(processed_df["b"].tolist(), [1, 9, nan])
+    assert_array_equal(processed_df["c"].tolist(), [nan, nan, nan])
+    assert processed_df["pct_a"].tolist() == [0.25, 0.75, 0]

--- a/tests/unit_tests/pandas_postprocessing/test_contribution.py
+++ b/tests/unit_tests/pandas_postprocessing/test_contribution.py
@@ -51,9 +51,9 @@ def test_contribution():
         df, orientation=PostProcessingContributionOrientation.ROW,
     )
     assert processed_df.columns.tolist() == [DTTM_ALIAS, "a", "b", "c"]
-    assert processed_df["a"].tolist() == [0.5, 0.25, 0]
-    assert processed_df["b"].tolist() == [0.5, 0.75, 0]
-    assert processed_df["c"].tolist() == [0, 0, 0]
+    assert_array_equal(processed_df["a"].tolist(), [0.5, 0.25, nan])
+    assert_array_equal(processed_df["b"].tolist(), [0.5, 0.75, nan])
+    assert_array_equal(processed_df["c"].tolist(), [0, 0, nan])
 
     # cell contribution across column without temporal column
     df.pop(DTTM_ALIAS)
@@ -61,9 +61,9 @@ def test_contribution():
         df, orientation=PostProcessingContributionOrientation.COLUMN
     )
     assert processed_df.columns.tolist() == ["a", "b", "c"]
-    assert processed_df["a"].tolist() == [0.25, 0.75, 0]
-    assert processed_df["b"].tolist() == [0.1, 0.9, 0]
-    assert processed_df["c"].tolist() == [0, 0, 0]
+    assert_array_equal(processed_df["a"].tolist(), [0.25, 0.75, 0])
+    assert_array_equal(processed_df["b"].tolist(), [0.1, 0.9, 0])
+    assert_array_equal(processed_df["c"].tolist(), [nan, nan, nan])
 
     # contribution only on selected columns
     processed_df = contribution(


### PR DESCRIPTION
### SUMMARY
1. fix: when `NaN` value in contribution operator can't calculate.
2. add unit test to guarantee `nan` value in contribution.

closes: https://github.com/apache/superset/issues/18774

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### After
<img width="1445" alt="image" src="https://user-images.githubusercontent.com/2016594/154427809-1e454ab1-2970-4152-a2db-744559bd23c2.png">

### Before
<img width="1442" alt="image" src="https://user-images.githubusercontent.com/2016594/154428018-51ff5a3c-e143-4a0d-b039-4ec490d7cd5c.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Select **birth_name** as datasource
2. Select **Line Chart** on explore page. notice that, use **echart** version of Line Chart
3. Drag `ds` in **x-axis**
4. Select `sum(num_boys)` in **metrics**
5. Drag `name` in **group by**
6. Select `total` in **contribution mode**
7. You can look at a line chart as before screenshort.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/18774
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
