### PR TITLE
feat(native-filters): Re-arrange controls in FilterBar

### DIFF
--- a/superset-frontend/cypress-base/cypress/support/directories.ts
+++ b/superset-frontend/cypress-base/cypress/support/directories.ts
@@ -343,7 +343,7 @@ export const nativeFilters = {
     collapse: dataTestLocator('filter-bar__collapse-button'),
     filterName: dataTestLocator('filter-control-name'),
     filterContent: '.ant-select-selection-item',
-    createFilterButton: dataTestLocator('create-filter'),
+    createFilterButton: dataTestLocator('filter-bar__create-filter'),
     timeRangeFilterContent: dataTestLocator('time-range-trigger'),
   },
   createFilterButton: dataTestLocator('filter-bar__create-filter'),

--- a/superset-frontend/src/components/Button/index.tsx
+++ b/superset-frontend/src/components/Button/index.tsx
@@ -200,14 +200,16 @@ export default function Button(props: ButtonProps) {
         },
         '&[disabled], &[disabled]:hover': {
           color: grayscale.base,
-          backgroundColor: backgroundColorDisabled,
-          borderColor: borderColorDisabled,
+          backgroundColor:
+            buttonStyle === 'link' ? 'transparent' : backgroundColorDisabled,
+          borderColor:
+            buttonStyle === 'link' ? 'transparent' : borderColorDisabled,
         },
         marginLeft: 0,
         '& + .superset-button': {
           marginLeft: theme.gridUnit * 2,
         },
-        '& :first-of-type': {
+        '& > :first-of-type': {
           marginRight: firstChildMargin,
         },
       }}

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -51,18 +51,19 @@ import FilterBar from 'src/dashboard/components/nativeFilters/FilterBar';
 import Loading from 'src/components/Loading';
 import { EmptyStateBig } from 'src/components/EmptyState';
 import { useUiConfig } from 'src/components/UiConfigContext';
+import {
+  BUILDER_SIDEPANEL_WIDTH,
+  CLOSED_FILTER_BAR_WIDTH,
+  FILTER_BAR_HEADER_HEIGHT,
+  FILTER_BAR_TABS_HEIGHT,
+  HEADER_HEIGHT,
+  MAIN_HEADER_HEIGHT,
+  OPEN_FILTER_BAR_WIDTH,
+  TABS_HEIGHT,
+} from 'src/dashboard/constants';
 import { shouldFocusTabs, getRootLevelTabsComponent } from './utils';
 import DashboardContainer from './DashboardContainer';
 import { useNativeFilters } from './state';
-
-const MAIN_HEADER_HEIGHT = 53;
-const TABS_HEIGHT = 50;
-const HEADER_HEIGHT = 72;
-const CLOSED_FILTER_BAR_WIDTH = 32;
-const OPEN_FILTER_BAR_WIDTH = 260;
-const FILTER_BAR_HEADER_HEIGHT = 80;
-const FILTER_BAR_TABS_HEIGHT = 46;
-const BUILDER_SIDEPANEL_WIDTH = 374;
 
 type DashboardBuilderProps = {};
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/ActionButtons.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/ActionButtons.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from 'spec/helpers/testing-library';
+import { ActionButtons } from './index';
+
+const createProps = () => ({
+  onApply: jest.fn(),
+  onClearAll: jest.fn(),
+  dataMaskSelected: {
+    DefaultsID: {
+      filterState: {
+        value: null,
+      },
+    },
+  },
+  dataMaskApplied: {
+    DefaultsID: {
+      id: 'DefaultsID',
+      filterState: {
+        value: null,
+      },
+    },
+  },
+  isApplyDisabled: false,
+});
+
+test('should render the "Clear all" option', () => {
+  const mockedProps = createProps();
+  render(<ActionButtons {...mockedProps} />, { useRedux: true });
+  expect(screen.getByText('Clear all')).toBeInTheDocument();
+});
+
+test('should render the "Apply" button', () => {
+  const mockedProps = createProps();
+  render(<ActionButtons {...mockedProps} />, { useRedux: true });
+  expect(screen.getByText('Apply filters')).toBeInTheDocument();
+  expect(screen.getByText('Apply filters').parentElement).toBeEnabled();
+});
+
+test('should render the "Clear all" button as disabled', () => {
+  const mockedProps = createProps();
+  render(<ActionButtons {...mockedProps} />, { useRedux: true });
+  const clearBtn = screen.getByText('Clear all');
+  expect(clearBtn.parentElement).toBeDisabled();
+});
+
+test('should render the "Apply" button as disabled', () => {
+  const mockedProps = createProps();
+  const applyDisabledProps = {
+    ...mockedProps,
+    isApplyDisabled: true,
+  };
+  render(<ActionButtons {...applyDisabledProps} />, { useRedux: true });
+  const applyBtn = screen.getByText('Apply filters');
+  expect(applyBtn.parentElement).toBeDisabled();
+  userEvent.click(applyBtn);
+  expect(mockedProps.onApply).not.toHaveBeenCalled();
+});
+
+test('should apply', () => {
+  const mockedProps = createProps();
+  render(<ActionButtons {...mockedProps} />, { useRedux: true });
+  const applyBtn = screen.getByText('Apply filters');
+  expect(mockedProps.onApply).not.toHaveBeenCalled();
+  userEvent.click(applyBtn);
+  expect(mockedProps.onApply).toHaveBeenCalled();
+});

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/ActionButtons.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/ActionButtons.test.tsx
@@ -42,12 +42,6 @@ const createProps = () => ({
   isApplyDisabled: false,
 });
 
-test('should render the "Clear all" option', () => {
-  const mockedProps = createProps();
-  render(<ActionButtons {...mockedProps} />, { useRedux: true });
-  expect(screen.getByText('Clear all')).toBeInTheDocument();
-});
-
 test('should render the "Apply" button', () => {
   const mockedProps = createProps();
   render(<ActionButtons {...mockedProps} />, { useRedux: true });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
@@ -55,6 +55,12 @@ const ActionButtonsContainer = styled.div`
 
     background: linear-gradient(transparent, white 25%);
 
+    pointer-events: none;
+
+    & > button {
+      pointer-events: auto;
+    }
+
     & > .filter-apply-button {
       margin-bottom: ${theme.gridUnit * 3}px;
     }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
@@ -48,7 +48,9 @@ const ActionButtonsContainer = styled.div`
     right: 0;
 
     padding: ${theme.gridUnit * 4}px;
-    background: linear-gradient(transparent, white 50%);
+    padding-top: ${theme.gridUnit * 6}px;
+
+    background: linear-gradient(transparent, white 25%);
 
     & > .filter-apply-button {
       margin-bottom: ${theme.gridUnit * 3}px;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { useMemo } from 'react';
+import {
+  css,
+  DataMaskState,
+  DataMaskStateWithId,
+  styled,
+  t,
+} from '@superset-ui/core';
+import Button from 'src/components/Button';
+import { getFilterBarTestId } from '../index';
+
+interface ActionButtonsProps {
+  onApply: () => void;
+  onClearAll: () => void;
+  dataMaskSelected: DataMaskState;
+  dataMaskApplied: DataMaskStateWithId;
+  isApplyDisabled: boolean;
+}
+
+const ActionButtonsContainer = styled.div`
+  ${({ theme }) => css`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+
+    padding: ${theme.gridUnit * 4}px;
+    background: linear-gradient(transparent, white 50%);
+
+    & > .filter-apply-button {
+      margin-bottom: ${theme.gridUnit * 3}px;
+    }
+
+    && > .filter-clear-all-button {
+      color: ${theme.colors.grayscale.light1};
+      margin-left: 0;
+
+      &[disabled],
+      &[disabled]:hover {
+        color: ${theme.colors.grayscale.light1};
+      }
+    }
+  `};
+`;
+
+export const ActionButtons = ({
+  onApply,
+  onClearAll,
+  dataMaskApplied,
+  dataMaskSelected,
+  isApplyDisabled,
+}: ActionButtonsProps) => {
+  const isClearAllDisabled = useMemo(
+    () =>
+      Object.values(dataMaskApplied).every(
+        filter =>
+          dataMaskSelected[filter.id]?.filterState?.value === null ||
+          (!dataMaskSelected[filter.id] && filter.filterState?.value === null),
+      ),
+    [dataMaskApplied, dataMaskSelected],
+  );
+
+  return (
+    <ActionButtonsContainer>
+      <Button
+        disabled={isApplyDisabled}
+        buttonStyle="primary"
+        htmlType="submit"
+        className="filter-apply-button"
+        onClick={onApply}
+        {...getFilterBarTestId('apply-button')}
+      >
+        {t('Apply filters')}
+      </Button>
+      <Button
+        disabled={isClearAllDisabled}
+        buttonStyle="link"
+        buttonSize="small"
+        className="filter-clear-all-button"
+        onClick={onClearAll}
+        {...getFilterBarTestId('clear-button')}
+      >
+        {t('Clear all')}
+      </Button>
+    </ActionButtonsContainer>
+  );
+};

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
@@ -44,6 +44,7 @@ const ActionButtonsContainer = styled.div`
     align-items: center;
 
     position: fixed;
+    z-index: 100;
 
     // filter bar width minus 1px for border
     width: ${OPEN_FILTER_BAR_WIDTH - 1}px;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
@@ -26,6 +26,7 @@ import {
 } from '@superset-ui/core';
 import Button from 'src/components/Button';
 import { isNullish } from 'src/utils/common';
+import { OPEN_FILTER_BAR_WIDTH } from 'src/dashboard/constants';
 import { getFilterBarTestId } from '../index';
 
 interface ActionButtonsProps {
@@ -42,10 +43,11 @@ const ActionButtonsContainer = styled.div`
     flex-direction: column;
     align-items: center;
 
-    position: absolute;
+    position: fixed;
+
+    // filter bar width minus 1px for border
+    width: ${OPEN_FILTER_BAR_WIDTH - 1}px;
     bottom: 0;
-    left: 0;
-    right: 0;
 
     padding: ${theme.gridUnit * 4}px;
     padding-top: ${theme.gridUnit * 6}px;
@@ -57,8 +59,11 @@ const ActionButtonsContainer = styled.div`
     }
 
     && > .filter-clear-all-button {
-      color: ${theme.colors.grayscale.light1};
+      color: ${theme.colors.grayscale.base};
       margin-left: 0;
+      &:hover {
+        color: ${theme.colors.primary.dark1};
+      }
 
       &[disabled],
       &[disabled]:hover {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
@@ -25,6 +25,7 @@ import {
   t,
 } from '@superset-ui/core';
 import Button from 'src/components/Button';
+import { isNullish } from 'src/utils/common';
 import { getFilterBarTestId } from '../index';
 
 interface ActionButtonsProps {
@@ -76,9 +77,9 @@ export const ActionButtons = ({
     () =>
       Object.values(dataMaskApplied).some(
         filter =>
-          dataMaskSelected[filter.id]?.filterState?.value !== undefined ||
+          !isNullish(dataMaskSelected[filter.id]?.filterState?.value) ||
           (!dataMaskSelected[filter.id] &&
-            filter.filterState?.value !== undefined),
+            !isNullish(filter.filterState?.value)),
       ),
     [dataMaskApplied, dataMaskSelected],
   );

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
@@ -72,12 +72,13 @@ export const ActionButtons = ({
   dataMaskSelected,
   isApplyDisabled,
 }: ActionButtonsProps) => {
-  const isClearAllDisabled = useMemo(
+  const isClearAllEnabled = useMemo(
     () =>
-      Object.values(dataMaskApplied).every(
+      Object.values(dataMaskApplied).some(
         filter =>
-          dataMaskSelected[filter.id]?.filterState?.value === null ||
-          (!dataMaskSelected[filter.id] && filter.filterState?.value === null),
+          dataMaskSelected[filter.id]?.filterState?.value !== undefined ||
+          (!dataMaskSelected[filter.id] &&
+            filter.filterState?.value !== undefined),
       ),
     [dataMaskApplied, dataMaskSelected],
   );
@@ -95,7 +96,7 @@ export const ActionButtons = ({
         {t('Apply filters')}
       </Button>
       <Button
-        disabled={isClearAllDisabled}
+        disabled={!isClearAllEnabled}
         buttonStyle="link"
         buttonSize="small"
         className="filter-clear-all-button"

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
@@ -241,9 +241,9 @@ describe('FilterBar', () => {
     expect(screen.getByText('Clear all')).toBeInTheDocument();
   });
 
-  it('should render the "Apply" option', () => {
+  it('should render the "Apply filters" option', () => {
     renderWrapper();
-    expect(screen.getByText('Apply')).toBeInTheDocument();
+    expect(screen.getByText('Apply filters')).toBeInTheDocument();
   });
 
   it('should render the collapse icon', () => {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -42,6 +42,9 @@ import { buildCascadeFiltersTree } from './utils';
 
 const Wrapper = styled.div`
   padding: ${({ theme }) => theme.gridUnit * 4}px;
+  // 108px padding to make room for buttons with position: absolute
+  padding-bottom: ${({ theme }) => theme.gridUnit * 27}px;
+
   &:hover {
     cursor: pointer;
   }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/index.tsx
@@ -48,6 +48,8 @@ const FilterSetsWrapper = styled.div`
   align-items: center;
   justify-content: center;
   grid-template-columns: 1fr;
+  // 108px padding to make room for buttons with position: absolute
+  padding-bottom: ${({ theme }) => theme.gridUnit * 27}px;
 
   & button.superset-button {
     margin-left: 0;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/Header.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/Header.test.tsx
@@ -23,24 +23,6 @@ import Header from './index';
 
 const createProps = () => ({
   toggleFiltersBar: jest.fn(),
-  onApply: jest.fn(),
-  onClearAll: jest.fn(),
-  dataMaskSelected: {
-    DefaultsID: {
-      filterState: {
-        value: null,
-      },
-    },
-  },
-  dataMaskApplied: {
-    DefaultsID: {
-      id: 'DefaultsID',
-      filterState: {
-        value: null,
-      },
-    },
-  },
-  isApplyDisabled: false,
 });
 
 test('should render', () => {
@@ -53,48 +35,6 @@ test('should render the "Filters" heading', () => {
   const mockedProps = createProps();
   render(<Header {...mockedProps} />, { useRedux: true });
   expect(screen.getByText('Filters')).toBeInTheDocument();
-});
-
-test('should render the "Clear all" option', () => {
-  const mockedProps = createProps();
-  render(<Header {...mockedProps} />, { useRedux: true });
-  expect(screen.getByText('Clear all')).toBeInTheDocument();
-});
-
-test('should render the "Apply" button', () => {
-  const mockedProps = createProps();
-  render(<Header {...mockedProps} />, { useRedux: true });
-  expect(screen.getByText('Apply')).toBeInTheDocument();
-  expect(screen.getByText('Apply').parentElement).toBeEnabled();
-});
-
-test('should render the "Clear all" button as disabled', () => {
-  const mockedProps = createProps();
-  render(<Header {...mockedProps} />, { useRedux: true });
-  const clearBtn = screen.getByText('Clear all');
-  expect(clearBtn.parentElement).toBeDisabled();
-});
-
-test('should render the "Apply" button as disabled', () => {
-  const mockedProps = createProps();
-  const applyDisabledProps = {
-    ...mockedProps,
-    isApplyDisabled: true,
-  };
-  render(<Header {...applyDisabledProps} />, { useRedux: true });
-  const applyBtn = screen.getByText('Apply');
-  expect(applyBtn.parentElement).toBeDisabled();
-  userEvent.click(applyBtn);
-  expect(mockedProps.onApply).not.toHaveBeenCalled();
-});
-
-test('should apply', () => {
-  const mockedProps = createProps();
-  render(<Header {...mockedProps} />, { useRedux: true });
-  const applyBtn = screen.getByText('Apply');
-  expect(mockedProps.onApply).not.toHaveBeenCalled();
-  userEvent.click(applyBtn);
-  expect(mockedProps.onApply).toHaveBeenCalled();
 });
 
 test('should render the expand button', () => {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx
@@ -48,10 +48,6 @@ const Wrapper = styled.div`
     ${({ theme }) => theme.gridUnit * 2}px;
 `;
 
-const PlusIcon = styled(Icons.PlusSmall)`
-  padding-bottom: 1px;
-`;
-
 type HeaderProps = {
   toggleFiltersBar: (arg0: boolean) => void;
 };
@@ -63,6 +59,10 @@ const AddFiltersButtonContainer = styled.div`
     & button > [role='img']:first-of-type {
       margin-right: ${theme.gridUnit}px;
       line-height: 0;
+    }
+
+    span[role='img'] {
+      padding-bottom: 1px;
     }
 
     .ant-btn > .anticon + span {
@@ -101,7 +101,7 @@ const Header: FC<HeaderProps> = ({ toggleFiltersBar }) => {
             dashboardId={dashboardId}
             createNewOnOpen={filterValues.length === 0}
           >
-            <PlusIcon /> {t('Add/Edit Filters')}
+            <Icons.PlusSmall /> {t('Add/Edit Filters')}
           </FilterConfigurationLink>
         </AddFiltersButtonContainer>
       )}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx
@@ -60,6 +60,10 @@ const AddFiltersButtonContainer = styled.div`
       margin-right: ${theme.gridUnit}px;
       line-height: 0;
     }
+
+    .ant-btn > .anticon + span {
+      margin-left: 0;
+    }
   `}
 `;
 
@@ -93,9 +97,7 @@ const Header: FC<HeaderProps> = ({ toggleFiltersBar }) => {
             dashboardId={dashboardId}
             createNewOnOpen={filterValues.length === 0}
           >
-            <>
-              <Icons.PlusSmall /> Add/Edit Filters
-            </>
+            <Icons.PlusSmall /> {t('Add/Edit Filters')}
           </FilterConfigurationLink>
         </AddFiltersButtonContainer>
       )}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx
@@ -17,22 +17,15 @@
  * under the License.
  */
 /* eslint-disable no-param-reassign */
-import {
-  DataMaskState,
-  DataMaskStateWithId,
-  Filter,
-  styled,
-  t,
-  useTheme,
-} from '@superset-ui/core';
+import { css, Filter, styled, t, useTheme } from '@superset-ui/core';
 import React, { FC } from 'react';
 import Icons from 'src/components/Icons';
 import Button from 'src/components/Button';
 import { useSelector } from 'react-redux';
 import FilterConfigurationLink from 'src/dashboard/components/nativeFilters/FilterBar/FilterConfigurationLink';
 import { useFilters } from 'src/dashboard/components/nativeFilters/FilterBar/state';
+import { RootState } from 'src/dashboard/types';
 import { getFilterBarTestId } from '..';
-import { RootState } from '../../../../types';
 
 const TitleArea = styled.h4`
   display: flex;
@@ -43,20 +36,6 @@ const TitleArea = styled.h4`
 
   & > span {
     flex-grow: 1;
-  }
-`;
-
-const ActionButtons = styled.div`
-  display: grid;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  grid-gap: 10px;
-  grid-template-columns: 1fr 1fr;
-  ${({ theme }) => `padding: 0 ${theme.gridUnit * 2}px`};
-
-  .btn {
-    flex: 1;
   }
 `;
 
@@ -71,21 +50,20 @@ const Wrapper = styled.div`
 
 type HeaderProps = {
   toggleFiltersBar: (arg0: boolean) => void;
-  onApply: () => void;
-  onClearAll: () => void;
-  dataMaskSelected: DataMaskState;
-  dataMaskApplied: DataMaskStateWithId;
-  isApplyDisabled: boolean;
 };
 
-const Header: FC<HeaderProps> = ({
-  onApply,
-  onClearAll,
-  isApplyDisabled,
-  dataMaskSelected,
-  dataMaskApplied,
-  toggleFiltersBar,
-}) => {
+const AddFiltersButtonContainer = styled.div`
+  ${({ theme }) => css`
+    margin-top: ${theme.gridUnit * 2}px;
+
+    & button > [role='img']:first-of-type {
+      margin-right: ${theme.gridUnit}px;
+      line-height: 0;
+    }
+  `}
+`;
+
+const Header: FC<HeaderProps> = ({ toggleFiltersBar }) => {
   const theme = useTheme();
   const filters = useFilters();
   const filterValues = Object.values<Filter>(filters);
@@ -96,27 +74,10 @@ const Header: FC<HeaderProps> = ({
     ({ dashboardInfo }) => dashboardInfo.id,
   );
 
-  const isClearAllDisabled = Object.values(dataMaskApplied).every(
-    filter =>
-      dataMaskSelected[filter.id]?.filterState?.value === null ||
-      (!dataMaskSelected[filter.id] && filter.filterState?.value === null),
-  );
-
   return (
     <Wrapper>
       <TitleArea>
         <span>{t('Filters')}</span>
-        {canEdit && (
-          <FilterConfigurationLink
-            dashboardId={dashboardId}
-            createNewOnOpen={filterValues.length === 0}
-          >
-            <Icons.Edit
-              data-test="create-filter"
-              iconColor={theme.colors.grayscale.base}
-            />
-          </FilterConfigurationLink>
-        )}
         <HeaderButton
           {...getFilterBarTestId('collapse-button')}
           buttonStyle="link"
@@ -126,29 +87,18 @@ const Header: FC<HeaderProps> = ({
           <Icons.Expand iconColor={theme.colors.grayscale.base} />
         </HeaderButton>
       </TitleArea>
-      <ActionButtons className="filter-action-buttons">
-        <Button
-          disabled={isClearAllDisabled}
-          buttonStyle="tertiary"
-          buttonSize="small"
-          className="filter-clear-all-button"
-          onClick={onClearAll}
-          {...getFilterBarTestId('clear-button')}
-        >
-          {t('Clear all')}
-        </Button>
-        <Button
-          disabled={isApplyDisabled}
-          buttonStyle="primary"
-          htmlType="submit"
-          buttonSize="small"
-          className="filter-apply-button"
-          onClick={onApply}
-          {...getFilterBarTestId('apply-button')}
-        >
-          {t('Apply')}
-        </Button>
-      </ActionButtons>
+      {canEdit && (
+        <AddFiltersButtonContainer>
+          <FilterConfigurationLink
+            dashboardId={dashboardId}
+            createNewOnOpen={filterValues.length === 0}
+          >
+            <>
+              <Icons.PlusSmall /> Add/Edit Filters
+            </>
+          </FilterConfigurationLink>
+        </AddFiltersButtonContainer>
+      )}
     </Wrapper>
   );
 };

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx
@@ -48,6 +48,10 @@ const Wrapper = styled.div`
     ${({ theme }) => theme.gridUnit * 2}px;
 `;
 
+const PlusIcon = styled(Icons.PlusSmall)`
+  padding-bottom: 1px;
+`;
+
 type HeaderProps = {
   toggleFiltersBar: (arg0: boolean) => void;
 };
@@ -97,7 +101,7 @@ const Header: FC<HeaderProps> = ({ toggleFiltersBar }) => {
             dashboardId={dashboardId}
             createNewOnOpen={filterValues.length === 0}
           >
-            <Icons.PlusSmall /> {t('Add/Edit Filters')}
+            <PlusIcon /> {t('Add/Edit Filters')}
           </FilterConfigurationLink>
         </AddFiltersButtonContainer>
       )}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -328,7 +328,6 @@ const FilterBar: React.FC<FiltersBarProps> = ({
     filterValue => filterValue.type === NativeFilterType.NATIVE_FILTER,
   ).length;
 
-  console.log({ height, width, offset });
   return (
     <BarWrapper
       {...getFilterBarTestId()}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -382,7 +382,9 @@ const FilterBar: React.FC<FiltersBarProps> = ({
                     image="filter.svg"
                     description={
                       canEdit &&
-                      t('Click button above to add a filter to the dashboard')
+                      t(
+                        'Click the button above to add a filter to the dashboard',
+                      )
                     }
                   />
                 </FilterBarEmptyStateContainer>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -165,7 +165,7 @@ const publishDataMask = debounce(
     const { search } = location;
     const previousParams = new URLSearchParams(search);
     const newParams = new URLSearchParams();
-    let dataMaskKey = '';
+    let dataMaskKey: string;
     previousParams.forEach((value, key) => {
       if (key !== URL_PARAMS.nativeFilters.name) {
         newParams.append(key, value);
@@ -251,7 +251,7 @@ const FilterBar: React.FC<FiltersBarProps> = ({
         };
       });
     },
-    [dataMaskSelected, dispatch, setDataMaskSelected, tab],
+    [dataMaskSelected, dispatch, setDataMaskSelected],
   );
 
   useEffect(() => {
@@ -280,10 +280,6 @@ const FilterBar: React.FC<FiltersBarProps> = ({
       }
     }
   }, [JSON.stringify(filters), JSON.stringify(previousFilters)]);
-
-  useEffect(() => {
-    setDataMaskSelected(() => dataMaskApplied);
-  }, [JSON.stringify(dataMaskApplied), setDataMaskSelected]);
 
   const dataMaskAppliedText = JSON.stringify(dataMaskApplied);
   useEffect(() => {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -61,6 +61,7 @@ import EditSection from './FilterSets/EditSection';
 import Header from './Header';
 import FilterControls from './FilterControls/FilterControls';
 import { RootState } from '../../../types';
+import { ActionButtons } from './ActionButtons';
 
 export const FILTER_BAR_TEST_ID = 'filter-bar';
 export const getFilterBarTestId = testWithId(FILTER_BAR_TEST_ID);
@@ -327,6 +328,7 @@ const FilterBar: React.FC<FiltersBarProps> = ({
     filterValue => filterValue.type === NativeFilterType.NATIVE_FILTER,
   ).length;
 
+  console.log({ height, width, offset });
   return (
     <BarWrapper
       {...getFilterBarTestId()}
@@ -346,14 +348,7 @@ const FilterBar: React.FC<FiltersBarProps> = ({
         <StyledFilterIcon {...getFilterBarTestId('filter-icon')} iconSize="l" />
       </CollapsedBar>
       <Bar className={cx({ open: filtersOpen })} width={width}>
-        <Header
-          toggleFiltersBar={toggleFiltersBar}
-          onApply={handleApply}
-          onClearAll={handleClearAll}
-          isApplyDisabled={isApplyDisabled}
-          dataMaskSelected={dataMaskSelected}
-          dataMaskApplied={dataMaskApplied}
-        />
+        <Header toggleFiltersBar={toggleFiltersBar} />
         {!isInitialized ? (
           <div css={{ height }}>
             <Loading />
@@ -380,11 +375,24 @@ const FilterBar: React.FC<FiltersBarProps> = ({
                   filterSetId={editFilterSetId}
                 />
               )}
-              <FilterControls
-                dataMaskSelected={dataMaskSelected}
-                directPathToChild={directPathToChild}
-                onFilterSelectionChange={handleFilterSelectionChange}
-              />
+              {filterValues.length === 0 ? (
+                <FilterBarEmptyStateContainer>
+                  <EmptyStateSmall
+                    title={t('No filters are currently added')}
+                    image="filter.svg"
+                    description={
+                      canEdit &&
+                      t('Click button above to add a filter to the dashboard')
+                    }
+                  />
+                </FilterBarEmptyStateContainer>
+              ) : (
+                <FilterControls
+                  dataMaskSelected={dataMaskSelected}
+                  directPathToChild={directPathToChild}
+                  onFilterSelectionChange={handleFilterSelectionChange}
+                />
+              )}
             </Tabs.TabPane>
             <Tabs.TabPane
               disabled={!!editFilterSetId}
@@ -412,9 +420,7 @@ const FilterBar: React.FC<FiltersBarProps> = ({
                   image="filter.svg"
                   description={
                     canEdit &&
-                    t(
-                      'Click the pencil icon above to add a filter to the dashboard',
-                    )
+                    t('Click the button above to add a filter to the dashboard')
                   }
                 />
               </FilterBarEmptyStateContainer>
@@ -427,6 +433,13 @@ const FilterBar: React.FC<FiltersBarProps> = ({
             )}
           </div>
         )}
+        <ActionButtons
+          onApply={handleApply}
+          onClearAll={handleClearAll}
+          dataMaskSelected={dataMaskSelected}
+          dataMaskApplied={dataMaskApplied}
+          isApplyDisabled={isApplyDisabled}
+        />
       </Bar>
     </BarWrapper>
   );

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -306,9 +306,14 @@ const FilterBar: React.FC<FiltersBarProps> = ({
     filterIds.forEach(filterId => {
       if (dataMaskSelected[filterId]) {
         dispatch(clearDataMask(filterId));
+        setDataMaskSelected(draft => {
+          if (draft[filterId].filterState?.value !== undefined) {
+            draft[filterId].filterState!.value = undefined;
+          }
+        });
       }
     });
-  }, [dataMaskSelected, dispatch]);
+  }, [dataMaskSelected, dispatch, setDataMaskSelected]);
 
   const openFiltersBar = useCallback(
     () => toggleFiltersBar(true),

--- a/superset-frontend/src/dashboard/constants.ts
+++ b/superset-frontend/src/dashboard/constants.ts
@@ -33,3 +33,12 @@ export const PLACEHOLDER_DATASOURCE: Datasource = {
   main_dttm_col: '',
   description: '',
 };
+
+export const MAIN_HEADER_HEIGHT = 53;
+export const TABS_HEIGHT = 50;
+export const HEADER_HEIGHT = 72;
+export const CLOSED_FILTER_BAR_WIDTH = 32;
+export const OPEN_FILTER_BAR_WIDTH = 260;
+export const FILTER_BAR_HEADER_HEIGHT = 80;
+export const FILTER_BAR_TABS_HEIGHT = 46;
+export const BUILDER_SIDEPANEL_WIDTH = 374;

--- a/superset-frontend/src/utils/common.js
+++ b/superset-frontend/src/utils/common.js
@@ -144,3 +144,5 @@ export const detectOS = () => {
 
   return 'Unknown OS';
 };
+
+export const isNullish = value => value === null || value === undefined;


### PR DESCRIPTION
### SUMMARY
This PR implements a part of Stage 1 of native filters rework.
Changes included:
- Replace a pencil icon with text button - "+ Add/Edit Filters"
- Move "apply filters" and "clear all" buttons to the bottom of filter bar and make them sticky. The background of the buttons container is semi-transparent (with a gradient) so that scrolling filters looks smoother
- Adjust the text in empty state

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF


https://user-images.githubusercontent.com/15073128/154497849-c549f8d2-8138-4c60-a4c8-f128f9362f23.mov

<img width="263" alt="image" src="https://user-images.githubusercontent.com/15073128/154497953-552ab0f6-4363-47ae-8cc3-03a8c0a2edf6.png">

### TESTING INSTRUCTIONS
Make sure that every button in Filters Bar works exactly like in the old version

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
