### PR TITLE
fix(Explore): Annotation cache should be ignore when adding new / updated annotation

### DIFF
--- a/superset-frontend/src/chart/chartAction.js
+++ b/superset-frontend/src/chart/chartAction.js
@@ -244,14 +244,14 @@ export async function getChartDataRequest({
   );
 }
 
-export function runAnnotationQuery(
+export function runAnnotationQuery({
   annotation,
   timeout = 60,
   formData = null,
   key,
   isDashboardRequest = false,
   force = false,
-) {
+}) {
   return function (dispatch, getState) {
     const sliceKey = key || Object.keys(getState().charts)[0];
     // make a copy of formData, not modifying original formData
@@ -482,16 +482,16 @@ export function exploreJSON(
       chartDataRequestCaught,
       dispatch(triggerQuery(false, key)),
       dispatch(updateQueryFormData(formData, key)),
-      ...annotationLayers.map(x =>
+      ...annotationLayers.map(annotation =>
         dispatch(
-          runAnnotationQuery(
-            x,
+          runAnnotationQuery({
+            annotation,
             timeout,
             formData,
             key,
             isDashboardRequest,
             force,
-          ),
+          }),
         ),
       ),
     ]);

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/index.jsx
@@ -98,7 +98,11 @@ class AnnotationLayerControl extends React.PureComponent {
       this.setState({ addedAnnotationIndex: annotations.length - 1 });
     }
 
-    this.props.refreshAnnotationData(newAnnotation);
+    this.props.refreshAnnotationData({
+      annotation: newAnnotation,
+      force: true,
+    });
+
     this.props.onChange(annotations);
   }
 
@@ -239,8 +243,8 @@ function mapStateToProps({ charts, explore }) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    refreshAnnotationData: annotationLayer =>
-      dispatch(runAnnotationQuery(annotationLayer)),
+    refreshAnnotationData: annotationObj =>
+      dispatch(runAnnotationQuery(annotationObj)),
   };
 }
 


### PR DESCRIPTION
### SUMMARY
This PR fixes an issue for which the annotations were using the cached data when adding or updating them. The problem happened because the `refreshAnnotationData` wasn't using the `force` cache parameter.

### BEFORE

https://user-images.githubusercontent.com/60598000/154524022-5282cfe3-b5d8-483e-badf-5a521550e464.mp4


### AFTER

https://user-images.githubusercontent.com/60598000/154522846-2719557a-271e-4b28-af2e-9dd0207dc485.mp4

### TESTING INSTRUCTIONS
1. Open a Chart
2. Add annotations
3. Make sure the annotations are the most updated
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
