### PR TITLE
fix(hive): stop query on the processing engine when user clicks STOP on SQL Lab

### DIFF
--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -335,6 +335,10 @@ class HiveEngineSpec(PrestoEngineSpec):
         job_id = None
         query_id = query.id
         while polled.operationState in unfinished_states:
+            # Queries don't terminate when user clicks the STOP button on SQL LAB.
+            # Refresh session so that the `query.status` modified in stop_query in
+            # views/core.py is reflected here.
+            session.refresh(query)
             query = session.query(type(query)).filter_by(id=query_id).one()
             if query.status == QueryStatus.STOPPED:
                 cursor.cancel()


### PR DESCRIPTION
This addressed [18787](https://github.com/apache/superset/issues/18787)
The issue concerns hive/spark-thriftserver as the processing engine.
When a user runs a query on SQL Lab and later for any reason wants to stop it, it doesn't stop it on the hive/spark query engine.

### SUMMARY
While debugging we figured that the state updated at [core.py](https://github.com/saurabh3091/superset/blob/f03b4dbedb29087c6958804aa803b5fb3200c7bb/superset/views/core.py#L2417) is not reflected at the [logic](https://github.com/saurabh3091/superset/blob/5805fb3cfbce632b8cda38e8bfa5650f19517ca1/superset/db_engine_specs/hive.py#L343) for canceling the job.

So we have added a small fix to update the session before it checks for the STOPPED status.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After
![image](https://user-images.githubusercontent.com/17564120/154525559-fcf390db-1435-40da-a1b3-d8b2d97fab2f.png)


### TESTING INSTRUCTIONS
1. Run any query in SQL Lab with hive/spark-thriftserver as backend processing engine.
2. Press STOP button on the UI.
3. Check the query engine, the query will be stopped both on the frontend and backend.


### ADDITIONAL INFORMATION
Fixes #18787 
- [x] Has associated issue: [18787](https://github.com/apache/superset/issues/18787)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
