### PR TITLE
fix: Monospacing errors in dashboards & charts

### DIFF
--- a/superset-frontend/src/chart/Chart.jsx
+++ b/superset-frontend/src/chart/Chart.jsx
@@ -113,6 +113,14 @@ const RefreshOverlayWrapper = styled.div`
   justify-content: center;
 `;
 
+const MonospaceDiv = styled.div`
+  font-family: ${({ theme }) => theme.typography.families.monospace};
+  white-space: pre;
+  word-break: break-word;
+  overflow-x: auto;
+  white-space: pre-wrap;
+`;
+
 class Chart extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -222,7 +230,7 @@ class Chart extends React.PureComponent {
       <ChartErrorMessage
         chartId={chartId}
         error={error}
-        subtitle={message}
+        subtitle={<MonospaceDiv>{message}</MonospaceDiv>}
         copyText={message}
         link={queryResponse ? queryResponse.link : null}
         source={dashboardId ? 'dashboard' : 'explore'}

--- a/superset-frontend/src/components/Modal/Modal.tsx
+++ b/superset-frontend/src/components/Modal/Modal.tsx
@@ -124,6 +124,14 @@ export const StyledModal = styled(BaseModal)<StyledModalProps>`
     padding: ${({ theme }) => theme.gridUnit * 4}px;
     overflow: auto;
     ${({ resizable, height }) => !resizable && height && `height: ${height};`}
+
+    p:first-child {
+      font-family: ${({ theme }) => theme.typography.families.monospace};
+      white-space: pre;
+      word-break: break-word;
+      overflow-x: auto;
+      white-space: pre-wrap;
+    }
   }
   .ant-modal-footer {
     border-top: ${({ theme }) => theme.gridUnit / 4}px solid

--- a/superset-frontend/src/components/Modal/Modal.tsx
+++ b/superset-frontend/src/components/Modal/Modal.tsx
@@ -124,14 +124,6 @@ export const StyledModal = styled(BaseModal)<StyledModalProps>`
     padding: ${({ theme }) => theme.gridUnit * 4}px;
     overflow: auto;
     ${({ resizable, height }) => !resizable && height && `height: ${height};`}
-
-    p:first-child {
-      font-family: ${({ theme }) => theme.typography.families.monospace};
-      white-space: pre;
-      word-break: break-word;
-      overflow-x: auto;
-      white-space: pre-wrap;
-    }
   }
   .ant-modal-footer {
     border-top: ${({ theme }) => theme.gridUnit / 4}px solid


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
On Charts and Dashboards, if the user has an error, the error message should be displayed in a monospace font so some of the formatting / details is not lost.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
> Before
![image](https://user-images.githubusercontent.com/39701522/154564252-3c761821-4784-404e-a94a-be0c9ad5e4b4.png)

![image](https://user-images.githubusercontent.com/39701522/154564573-9156d69b-5094-4195-b892-a80dd23d865b.png)


> After
![image](https://user-images.githubusercontent.com/39701522/154564368-8a49cc9e-b297-477d-91b6-593a3b4d7500.png)

![image](https://user-images.githubusercontent.com/39701522/154564636-cb219845-1ce4-48a4-83ad-e4f3bc783be7.png)


<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
