### PR TITLE
feat: remove loading indicator when typing in select

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
@@ -127,21 +127,10 @@ describe('Nativefilters Sanity test', () => {
       .within(() =>
         cy.get('input').type('wb_health_population{enter}', { force: true }),
       );
-    // Add following step to avoid flaky enter value in line 177
-    cy.get(nativeFilters.filtersPanel.inputDropdown)
-      .should('be.visible', { timeout: 20000 })
-      .last()
-      .click();
 
-    cy.get('.loading inline-centered css-101mkpk').should('not.exist');
-    // hack for unclickable country_name
-    cy.wait(5000);
-    cy.get(nativeFilters.filtersPanel.filterInfoInput)
+    cy.get(`${nativeFilters.filtersPanel.filterInfoInput}:visible:last`)
       .last()
-      .should('be.visible', { timeout: 30000 })
-      .click({ force: true });
-    cy.get(nativeFilters.filtersPanel.filterInfoInput)
-      .last()
+      .focus()
       .type('country_name');
     cy.get(nativeFilters.filtersPanel.inputDropdown)
       .should('be.visible', { timeout: 20000 })

--- a/superset-frontend/src/components/Select/Select.test.tsx
+++ b/superset-frontend/src/components/Select/Select.test.tsx
@@ -17,13 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import {
-  render,
-  screen,
-  waitFor,
-  waitForElementToBeRemoved,
-  within,
-} from 'spec/helpers/testing-library';
+import { render, screen, waitFor, within } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
 import { Select } from 'src/components';
 
@@ -85,9 +79,6 @@ const getElementsByClassName = (className: string) =>
   document.querySelectorAll(className)! as NodeListOf<HTMLElement>;
 
 const getSelect = () => screen.getByRole('combobox', { name: ARIA_LABEL });
-
-const findSpinner = () =>
-  waitFor(() => getElementByClassName('.ant-spin-spinning'));
 
 const findSelectOption = (text: string) =>
   waitFor(() =>
@@ -389,13 +380,6 @@ test('static - does not show "Loading..." when allowNewOptions is false and a ne
   await open();
   await type(NEW_OPTION);
   expect(screen.queryByText(LOADING)).not.toBeInTheDocument();
-});
-
-test('static - shows "Loading..." when allowNewOptions is true and a new option is entered', async () => {
-  render(<Select {...defaultProps} allowNewOptions />);
-  await open();
-  await type(NEW_OPTION);
-  expect(await screen.findByText(LOADING)).toBeInTheDocument();
 });
 
 test('static - does not add a new option if the option already exists', async () => {

--- a/superset-frontend/src/components/Select/Select.test.tsx
+++ b/superset-frontend/src/components/Select/Select.test.tsx
@@ -633,7 +633,7 @@ test('async - does not fire a new request for the same search input', async () =
   expect(loadOptions).toHaveBeenCalledTimes(1);
   clearAll();
   await type('search');
-  expect(await screen.findByText(NO_DATA)).toBeInTheDocument();
+  expect(await screen.findByText(LOADING)).toBeInTheDocument();
   expect(loadOptions).toHaveBeenCalledTimes(1);
 });
 

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -39,6 +39,7 @@ import { isEqual } from 'lodash';
 import { Spin } from 'antd';
 import Icons from 'src/components/Icons';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
+import { SLOW_DEBOUNCE } from 'src/constants';
 import { hasOption } from './utils';
 
 const { Option } = AntdSelect;
@@ -214,7 +215,6 @@ const StyledLoadingText = styled.div`
 
 const MAX_TAG_COUNT = 4;
 const TOKEN_SEPARATORS = [',', '\n', '\t', ';'];
-const DEBOUNCE_TIMEOUT = 500;
 const DEFAULT_PAGE_SIZE = 100;
 const EMPTY_OPTIONS: OptionsType = [];
 
@@ -511,7 +511,7 @@ const Select = ({
     () =>
       debounce((search: string) => {
         setSearchedValue(search);
-      }, DEBOUNCE_TIMEOUT),
+      }, SLOW_DEBOUNCE),
     [],
   );
 

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -673,7 +673,10 @@ const Select = ({
 
   // Stop the invocation of the debounced function after unmounting
   useEffect(
-    () => () => debouncedHandleSearch.cancel(),
+    () => () => {
+      debouncedHandleSearch.cancel();
+      setIsLoading(false);
+    },
     [debouncedHandleSearch],
   );
 
@@ -714,13 +717,7 @@ const Select = ({
         labelInValue={isAsync || labelInValue}
         maxTagCount={MAX_TAG_COUNT}
         mode={mappedMode}
-        notFoundContent={
-          isLoading ? (
-            <StyledLoadingText>{t('Loading...')}</StyledLoadingText>
-          ) : (
-            notFoundContent
-          )
-        }
+        notFoundContent={isLoading ? t('Loading...') : notFoundContent}
         onDeselect={handleOnDeselect}
         onDropdownVisibleChange={handleOnDropdownVisibleChange}
         onPopupScroll={isAsync ? handlePagination : undefined}

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -40,7 +40,7 @@ import { Spin } from 'antd';
 import Icons from 'src/components/Icons';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 import { SLOW_DEBOUNCE } from 'src/constants';
-import { hasOption } from './utils';
+import { hasOption, hasOptionIgnoreCase } from './utils';
 
 const { Option } = AntdSelect;
 
@@ -57,6 +57,8 @@ type PickedSelectProps = Pick<
   | 'notFoundContent'
   | 'onChange'
   | 'onClear'
+  | 'onFocus'
+  | 'onBlur'
   | 'placeholder'
   | 'showSearch'
   | 'value'
@@ -519,7 +521,7 @@ const Select = ({
   const debouncedHandleSearch = useMemo(
     () =>
       debounce((search: string) => {
-        // async search will triggered in handlePaginatedFetch
+        // async search will be triggered in handlePaginatedFetch
         setSearchedValue(search);
       }, SLOW_DEBOUNCE),
     [],
@@ -529,12 +531,14 @@ const Select = ({
     const searchValue = search.trim();
     if (allowNewOptions && isSingleMode) {
       const newOption = searchValue &&
-        !hasOption(searchValue, selectOptions) && {
+        !hasOptionIgnoreCase(searchValue, selectOptions) && {
           label: searchValue,
           value: searchValue,
           isNewOption: true,
         };
-      const cleanSelectOptions = selectOptions.filter(opt => !opt.isNewOption);
+      const cleanSelectOptions = selectOptions.filter(
+        opt => !opt.isNewOption || hasOption(opt.value, selectValue),
+      );
       const newOptions = newOption
         ? [newOption, ...cleanSelectOptions]
         : cleanSelectOptions;

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -63,7 +63,7 @@ type PickedSelectProps = Pick<
   | 'value'
 >;
 
-type OptionsType = Exclude<AntdSelectAllProps['options'], undefined>;
+export type OptionsType = Exclude<AntdSelectAllProps['options'], undefined>;
 
 export type OptionsTypePage = {
   data: OptionsType;

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -305,7 +305,6 @@ const Select = ({
   const [selectValue, setSelectValue] = useState(value);
   const [searchedValue, setSearchedValue] = useState('');
   const [isLoading, setIsLoading] = useState(loading);
-  const [isTyping, setIsTyping] = useState(false);
   const [error, setError] = useState('');
   const [isDropdownVisible, setIsDropdownVisible] = useState(false);
   const [page, setPage] = useState(0);
@@ -481,7 +480,6 @@ const Select = ({
     () => (value: string, page: number, pageSize: number) => {
       if (allValuesLoaded) {
         setIsLoading(false);
-        setIsTyping(false);
         return;
       }
       const key = `${value};${page};${pageSize}`;
@@ -489,7 +487,6 @@ const Select = ({
       if (cachedCount) {
         setTotalCount(cachedCount);
         setIsLoading(false);
-        setIsTyping(false);
         return;
       }
       setIsLoading(true);
@@ -510,7 +507,6 @@ const Select = ({
         .catch(internalOnError)
         .finally(() => {
           setIsLoading(false);
-          setIsTyping(false);
         });
     },
     [allValuesLoaded, fetchOnlyOnSearch, handleData, internalOnError, options],
@@ -536,9 +532,6 @@ const Select = ({
           setSelectOptions(newOptions);
         }
 
-        if (!searchValue || searchValue === searchedValue) {
-          setIsTyping(false);
-        }
         setSearchedValue(searchValue);
       }, DEBOUNCE_TIMEOUT),
     [allowNewOptions, isSingleMode, searchedValue, selectOptions],
@@ -598,16 +591,10 @@ const Select = ({
     if (!isDropdownVisible) {
       originNode.ref?.current?.scrollTo({ top: 0 });
     }
-    if ((isLoading && selectOptions.length === 0) || isTyping) {
+    if (isLoading && selectOptions.length === 0) {
       return <StyledLoadingText>{t('Loading...')}</StyledLoadingText>;
     }
     return error ? <Error error={error} /> : originNode;
-  };
-
-  const onInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key.length === 1 && isAsync && !isTyping) {
-      setIsTyping(true);
-    }
   };
 
   const SuffixIcon = () => {
@@ -722,7 +709,6 @@ const Select = ({
         }
         onDeselect={handleOnDeselect}
         onDropdownVisibleChange={handleOnDropdownVisibleChange}
-        onInputKeyDown={onInputKeyDown}
         onPopupScroll={isAsync ? handlePagination : undefined}
         onSearch={shouldShowSearch ? handleOnSearch : undefined}
         onSelect={handleOnSelect}

--- a/superset-frontend/src/components/Select/utils.ts
+++ b/superset-frontend/src/components/Select/utils.ts
@@ -1,3 +1,4 @@
+import { ensureIsArray } from '@superset-ui/core';
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -60,7 +61,19 @@ export function findValue<OptionType extends OptionTypeBase>(
   return (Array.isArray(value) ? value : [value]).map(find);
 }
 
-export function hasOption(search: string, options: AntdOptionsType) {
+export function hasOption<VT extends string | number>(
+  value: VT,
+  options?: VT | VT[] | { value: VT } | { value: VT }[],
+) {
+  const optionsArray = ensureIsArray(options);
+  return (
+    optionsArray.find(x =>
+      typeof x === 'object' ? x.value === value : x === value,
+    ) !== undefined
+  );
+}
+
+export function hasOptionIgnoreCase(search: string, options: AntdOptionsType) {
   const searchOption = search.trim().toLowerCase();
   return options.find(opt => {
     const { label, value } = opt;


### PR DESCRIPTION
### SUMMARY

Remove the loading indicator in select option menus when users are typing and (some) options are already loaded. The loading indicator showing up as users type was added in #16531, while tackling the issue of the inaccurate "No data" message when data is still loading. But we shouldn't show "Loading..." when there are already filtered options available. Removing this unnecessary loading indicator makes the control feels faster.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

The "Loading..." option shows up as soon as users type, even when all options are loaded:

![before-select](https://user-images.githubusercontent.com/335541/154582570-4288f1c4-1a6a-4df5-bea6-402b12cc6afc.gif)

#### After

No "Loading..." option when users start to type, but there is a loading indicator in the input and all filtered options will show up after actual loading is finished:

![acceptable-select](https://user-images.githubusercontent.com/335541/154582131-c9a925e3-059a-41e4-b65d-9e2b9ea6d696.gif)

When all options are loaded for a specific search string, there is no loading indicator at all and no excessive requests will be fired.

### TESTING INSTRUCTIONS

1. Run `npm run storybook` in `superset-frontend`
2. Test it in the storybook: http://localhost:6006/?path=/story/select--async-select
     1. Try search for something in and not in the first page. E.g. "ale", "sandro"
     2. "No data" should not show up if there is a match in loaded options or the next page is still loading
     3. "Loading..." should not show up if there is already a matched option

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #16531 #16712 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
