### PR TITLE
fix(altered-modal): displayed the metric value in altered modal correctly

### DIFF
--- a/superset-frontend/src/components/AlteredSliceTag/AlteredSliceTag.test.jsx
+++ b/superset-frontend/src/components/AlteredSliceTag/AlteredSliceTag.test.jsx
@@ -219,12 +219,14 @@ describe('AlteredSliceTag', () => {
     });
 
     it('returns Metrics if the field type is metrics', () => {
-      const value = [{
-        label: "SUM(Sales)",
-      }];
-      const expected = "SUM(Sales)";
+      const value = [
+        {
+          label: 'SUM(Sales)',
+        },
+      ];
+      const expected = 'SUM(Sales)';
       expect(
-        wrapper.instance().formatValue(value, "metrics", controlsMap),
+        wrapper.instance().formatValue(value, 'metrics', controlsMap),
       ).toBe(expected);
     });
 

--- a/superset-frontend/src/components/AlteredSliceTag/AlteredSliceTag.test.jsx
+++ b/superset-frontend/src/components/AlteredSliceTag/AlteredSliceTag.test.jsx
@@ -218,6 +218,16 @@ describe('AlteredSliceTag', () => {
       ).toBe(expected);
     });
 
+    it('returns Metrics if the field type is metrics', () => {
+      const value = [{
+        label: "SUM(Sales)",
+      }];
+      const expected = "SUM(Sales)";
+      expect(
+        wrapper.instance().formatValue(value, "metrics", controlsMap),
+      ).toBe(expected);
+    });
+
     it('stringifies objects', () => {
       const value = { 1: 2, alpha: 'bravo' };
       const expected = '{"1":2,"alpha":"bravo"}';

--- a/superset-frontend/src/components/AlteredSliceTag/AlteredSliceTagMocks.js
+++ b/superset-frontend/src/components/AlteredSliceTag/AlteredSliceTagMocks.js
@@ -159,6 +159,14 @@ export const fakePluginControls = {
               default: null,
             },
           },
+          {
+            name: 'metrics',
+            config: {
+              type: "MetricsControl",
+              label: 'Fake Metrics',
+              default: null,
+            },
+          },
         ],
       ],
     },

--- a/superset-frontend/src/components/AlteredSliceTag/AlteredSliceTagMocks.js
+++ b/superset-frontend/src/components/AlteredSliceTag/AlteredSliceTagMocks.js
@@ -162,7 +162,7 @@ export const fakePluginControls = {
           {
             name: 'metrics',
             config: {
-              type: "MetricsControl",
+              type: 'MetricsControl',
               label: 'Fake Metrics',
               default: null,
             },

--- a/superset-frontend/src/components/AlteredSliceTag/index.jsx
+++ b/superset-frontend/src/components/AlteredSliceTag/index.jsx
@@ -135,7 +135,7 @@ export default class AlteredSliceTag extends React.Component {
       return value.map(v => safeStringify(v)).join(', ');
     }
     if (controlsMap[key]?.type === 'MetricsControl' && Array.isArray(value)) {
-      const formattedValue = value.map(v => v.label ? v.label : v);
+      const formattedValue = value.map(v => (v.label ? v.label : v));
       return formattedValue.length ? formattedValue.join(', ') : '[]';
     }
     if (typeof value === 'boolean') {

--- a/superset-frontend/src/components/AlteredSliceTag/index.jsx
+++ b/superset-frontend/src/components/AlteredSliceTag/index.jsx
@@ -134,6 +134,10 @@ export default class AlteredSliceTag extends React.Component {
     if (controlsMap[key]?.type === 'CollectionControl') {
       return value.map(v => safeStringify(v)).join(', ');
     }
+    if (controlsMap[key]?.type === 'MetricsControl' && Array.isArray(value)) {
+      const formattedValue = value.map((v) => v.label ? v.label : v);
+      return formattedValue.length ? formattedValue.join(', ') : '[]';
+    }
     if (typeof value === 'boolean') {
       return value ? 'true' : 'false';
     }

--- a/superset-frontend/src/components/AlteredSliceTag/index.jsx
+++ b/superset-frontend/src/components/AlteredSliceTag/index.jsx
@@ -135,7 +135,7 @@ export default class AlteredSliceTag extends React.Component {
       return value.map(v => safeStringify(v)).join(', ');
     }
     if (controlsMap[key]?.type === 'MetricsControl' && Array.isArray(value)) {
-      const formattedValue = value.map((v) => v.label ? v.label : v);
+      const formattedValue = value.map(v => v.label ? v.label : v);
       return formattedValue.length ? formattedValue.join(', ') : '[]';
     }
     if (typeof value === 'boolean') {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Altered Modal Doesn't Show Metrics Properly

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://user-images.githubusercontent.com/47900232/154682224-f80997a3-da39-4221-bc5e-08b65ba84b1d.png)

After:
![image](https://user-images.githubusercontent.com/47900232/154682307-2ff9fca6-5101-4e60-9097-ff28fbd92894.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
