### PR TITLE
fix(altered-modal): make specified text fields wrap in table

### DIFF
--- a/superset-frontend/src/components/AlteredSliceTag/index.jsx
+++ b/superset-frontend/src/components/AlteredSliceTag/index.jsx
@@ -161,6 +161,8 @@ export default class AlteredSliceTag extends React.Component {
         Header: 'After',
       },
     ];
+    // set the wrap text in the specific columns.
+    const columnsForWrapText = ['Control', 'Before', 'After'];
 
     return (
       <TableView
@@ -168,6 +170,7 @@ export default class AlteredSliceTag extends React.Component {
         data={this.state.rows}
         pageSize={50}
         className="table-condensed"
+        columnsForWrapText={columnsForWrapText}
       />
     );
   }

--- a/superset-frontend/src/components/TableCollection/index.tsx
+++ b/superset-frontend/src/components/TableCollection/index.tsx
@@ -31,7 +31,7 @@ interface TableCollectionProps {
   columns: TableInstance['column'][];
   loading: boolean;
   highlightRowId?: number;
-  columnsForWrapText?: TableInstance['column'][];
+  columnsForWrapText?: string[];
 }
 
 export const Table = styled.table`
@@ -311,8 +311,8 @@ export default React.memo(
                   const columnCellProps = cell.column.cellProps || {};
                   const isWrapText =
                     columnsForWrapText &&
-                    columnsForWrapText.includes(cell.column.Header);
-                  console.log(isWrapText);
+                    columnsForWrapText.includes(cell.column.Header as string);
+
                   return (
                     <td
                       data-test="table-row-cell"

--- a/superset-frontend/src/components/TableCollection/index.tsx
+++ b/superset-frontend/src/components/TableCollection/index.tsx
@@ -192,7 +192,7 @@ export const Table = styled.table`
   .table-cell {
     text-overflow: ellipsis;
     overflow: hidden;
-    white-space: nowrap;
+    white-space: normal;
     max-width: 320px;
     line-height: 1;
     vertical-align: middle;

--- a/superset-frontend/src/components/TableCollection/index.tsx
+++ b/superset-frontend/src/components/TableCollection/index.tsx
@@ -315,7 +315,7 @@ export default React.memo(
                   console.log(isWrapText);
                   return (
                     <td
-                      data-test={`table-row-cell${isWrapText ? '__wrap' : ''}`}
+                      data-test="table-row-cell"
                       className={cx(
                         `table-cell table-cell__${
                           isWrapText ? 'wrap' : 'nowrap'

--- a/superset-frontend/src/components/TableCollection/index.tsx
+++ b/superset-frontend/src/components/TableCollection/index.tsx
@@ -31,7 +31,7 @@ interface TableCollectionProps {
   columns: TableInstance['column'][];
   loading: boolean;
   highlightRowId?: number;
-  columnsForWrapText?: any[];
+  columnsForWrapText?: TableInstance['column'][];
 }
 
 export const Table = styled.table`

--- a/superset-frontend/src/components/TableCollection/index.tsx
+++ b/superset-frontend/src/components/TableCollection/index.tsx
@@ -31,6 +31,7 @@ interface TableCollectionProps {
   columns: TableInstance['column'][];
   loading: boolean;
   highlightRowId?: number;
+  columnsForWrapText?: any[];
 }
 
 export const Table = styled.table`
@@ -192,12 +193,17 @@ export const Table = styled.table`
   .table-cell {
     text-overflow: ellipsis;
     overflow: hidden;
-    white-space: normal;
     max-width: 320px;
     line-height: 1;
     vertical-align: middle;
     &:first-of-type {
       padding-left: ${({ theme }) => theme.gridUnit * 4}px;
+    }
+    &__wrap {
+      white-space: normal;
+    }
+    &__nowrap {
+      white-space: nowrap;
     }
   }
 
@@ -224,6 +230,7 @@ export default React.memo(
     rows,
     loading,
     highlightRowId,
+    columnsForWrapText,
   }: TableCollectionProps) => (
     <Table
       {...getTableProps()}
@@ -301,15 +308,23 @@ export default React.memo(
               >
                 {row.cells.map(cell => {
                   if (cell.column.hidden) return null;
-
                   const columnCellProps = cell.column.cellProps || {};
+                  const isWrapText =
+                    columnsForWrapText &&
+                    columnsForWrapText.includes(cell.column.Header);
+                  console.log(isWrapText);
                   return (
                     <td
-                      data-test="table-row-cell"
-                      className={cx('table-cell', {
-                        'table-cell-loader': loading,
-                        [cell.column.size || '']: cell.column.size,
-                      })}
+                      data-test={`table-row-cell${isWrapText ? '__wrap' : ''}`}
+                      className={cx(
+                        `table-cell table-cell__${
+                          isWrapText ? 'wrap' : 'nowrap'
+                        }`,
+                        {
+                          'table-cell-loader': loading,
+                          [cell.column.size || '']: cell.column.size,
+                        },
+                      )}
                       {...cell.getCellProps()}
                       {...columnCellProps}
                     >

--- a/superset-frontend/src/components/TableView/TableView.stories.tsx
+++ b/superset-frontend/src/components/TableView/TableView.stories.tsx
@@ -43,16 +43,40 @@ InteractiveTableView.args = {
       accessor: 'name',
       Header: 'Name',
     },
+    {
+      accessor: 'summary',
+      Header: 'Summary',
+    },
   ],
   data: [
-    { id: 123, age: 27, name: 'Emily' },
-    { id: 321, age: 10, name: 'Kate' },
+    {
+      id: 123,
+      age: 27,
+      name: 'Emily',
+      summary:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam id porta neque, a vehicula orci. Maecenas rhoncus elit sit amet purus convallis placerat in at nunc. Nulla nec viverra augue.',
+    },
+    {
+      id: 321,
+      age: 10,
+      name: 'Kate',
+      summary:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam id porta neque, a vehicula orci. Maecenas rhoncus elit sit amet purus convallis placerat in at nunc. Nulla nec viverra augue.',
+    },
+    {
+      id: 321,
+      age: 10,
+      name: 'John Smith',
+      summary:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam id porta neque, a vehicula orci. Maecenas rhoncus elit sit amet purus convallis placerat in at nunc. Nulla nec viverra augue.',
+    },
   ],
   initialSortBy: [{ id: 'name', desc: true }],
   noDataText: 'No data here',
   pageSize: 1,
   showRowCount: true,
   withPagination: true,
+  columnsForWrapText: ['Summary'],
 };
 
 InteractiveTableView.argTypes = {

--- a/superset-frontend/src/components/TableView/TableView.test.tsx
+++ b/superset-frontend/src/components/TableView/TableView.test.tsx
@@ -191,3 +191,12 @@ test('should render the right page', () => {
   expect(screen.getByText('Kate')).toBeInTheDocument();
   expect(screen.queryByText('Emily')).not.toBeInTheDocument();
 });
+
+test('should render the right wrap content text by columnsForWrapText', () => {
+  const props = {
+    ...mockedProps,
+    columnsForWrapText: ['Name'],
+  };
+  render(<TableView {...props} />);
+  expect(screen.getByTestId('table-row-cell__wrap')).toBeInTheDocument();
+});

--- a/superset-frontend/src/components/TableView/TableView.test.tsx
+++ b/superset-frontend/src/components/TableView/TableView.test.tsx
@@ -198,5 +198,14 @@ test('should render the right wrap content text by columnsForWrapText', () => {
     columnsForWrapText: ['Name'],
   };
   render(<TableView {...props} />);
-  expect(screen.getByTestId('table-row-cell__wrap')).toBeInTheDocument();
+
+  expect(screen.getAllByTestId('table-row-cell')[0]).toHaveClass(
+    'table-cell__nowrap',
+  );
+  expect(screen.getAllByTestId('table-row-cell')[1]).toHaveClass(
+    'table-cell__nowrap',
+  );
+  expect(screen.getAllByTestId('table-row-cell')[2]).toHaveClass(
+    'table-cell__wrap',
+  );
 });

--- a/superset-frontend/src/components/TableView/TableView.tsx
+++ b/superset-frontend/src/components/TableView/TableView.tsx
@@ -50,6 +50,7 @@ export interface TableViewProps {
   showRowCount?: boolean;
   scrollTable?: boolean;
   small?: boolean;
+  columnsForWrapText?: string[];
 }
 
 const EmptyWrapper = styled.div`
@@ -127,6 +128,7 @@ const TableView = ({
   noDataText,
   showRowCount = true,
   serverPagination = false,
+  columnsForWrapText,
   onServerPagination = () => {},
   ...props
 }: TableViewProps) => {
@@ -204,6 +206,7 @@ const TableView = ({
           rows={content}
           columns={columns}
           loading={loading}
+          columnsForWrapText={columnsForWrapText}
         />
         {isEmpty && (
           <EmptyWrapperComponent>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Altered Modal Doesn't Scroll or Wrap Text

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://user-images.githubusercontent.com/47900232/154821957-e6947d2c-8846-407f-b9b7-dd12d36e90fe.png)

After:
![image](https://user-images.githubusercontent.com/47900232/154821967-c2fa264b-0fb5-4b31-9358-28e387e4e36a.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
