### PR TITLE
chore: unify usages of nvd3 library

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-rose/package.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-rose/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "d3": "^3.5.17",
-    "nvd3": "1.8.6",
+    "nvd3-fork": "^2.0.5",
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {

--- a/superset-frontend/plugins/legacy-plugin-chart-rose/src/Rose.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-rose/src/Rose.js
@@ -21,7 +21,7 @@
 /* eslint-disable react/sort-prop-types */
 import d3 from 'd3';
 import PropTypes from 'prop-types';
-import nv from 'nvd3';
+import nv from 'nvd3-fork';
 import {
   getTimeFormatter,
   getNumberFormatter,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Background: According to bundle analysis, we use both `nvd3` and `nvd3-fork`. We should probably just use `nvd3-fork` to unify this.
Currently only `Nightingale Rose Chart` is using `nvd3`, we remove it here.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
