### PR TITLE
fix(Explore): Pivot table V2 sort by failure with D&D enabled

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/buildQueryObject.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/buildQueryObject.ts
@@ -20,7 +20,6 @@
 /* eslint-disable camelcase */
 import {
   AdhocFilter,
-  PhysicalColumn,
   QueryFieldAliases,
   QueryFormColumn,
   QueryFormData,

--- a/superset-frontend/packages/superset-ui-core/src/query/buildQueryObject.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/buildQueryObject.ts
@@ -19,7 +19,6 @@
 
 /* eslint-disable camelcase */
 import {
-  AdhocColumn,
   AdhocFilter,
   PhysicalColumn,
   QueryFieldAliases,
@@ -27,6 +26,8 @@ import {
   QueryFormData,
   QueryObject,
   QueryObjectFilterClause,
+  isPhysicalColumn,
+  isAdhocColumn,
 } from './types';
 import processFilters from './processFilters';
 import extractExtras from './extractExtras';
@@ -92,11 +93,9 @@ export default function buildQueryObject<T extends QueryFormData>(
     ...extras,
     ...filterFormData,
   });
-  const isAdhocColumn = (v?: AdhocColumn | PhysicalColumn) =>
-    (v as AdhocColumn)?.sqlExpression !== undefined;
-  const normalizeSeriesLimitMetric = (v: QueryFormColumn | undefined) => {
-    if (isAdhocColumn(v) || (v as PhysicalColumn)?.length) {
-      return v;
+  const normalizeSeriesLimitMetric = (column: QueryFormColumn | undefined) => {
+    if (isAdhocColumn(column) || isPhysicalColumn(column)) {
+      return column;
     }
     return undefined;
   };

--- a/superset-frontend/packages/superset-ui-core/src/query/buildQueryObject.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/buildQueryObject.ts
@@ -95,7 +95,7 @@ export default function buildQueryObject<T extends QueryFormData>(
   const isAdhocColumn = (v?: AdhocColumn | PhysicalColumn) =>
     (v as AdhocColumn)?.sqlExpression !== undefined;
   const normalizeSeriesLimitMetric = (v: QueryFormColumn | undefined) => {
-    if (isAdhocColumn(v) || (v && (v as PhysicalColumn).length)) {
+    if (isAdhocColumn(v) || (v as PhysicalColumn)?.length) {
       return v;
     }
     return undefined;
@@ -132,10 +132,6 @@ export default function buildQueryObject<T extends QueryFormData>(
     custom_params,
   };
 
-  console.log(
-    'queryObject.series_limit_metric',
-    queryObject.series_limit_metric,
-  );
   // override extra form data used by native and cross filters
   queryObject = overrideExtraFormData(queryObject, overrides);
 

--- a/superset-frontend/packages/superset-ui-core/src/query/buildQueryObject.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/buildQueryObject.ts
@@ -19,8 +19,11 @@
 
 /* eslint-disable camelcase */
 import {
+  AdhocColumn,
   AdhocFilter,
+  PhysicalColumn,
   QueryFieldAliases,
+  QueryFormColumn,
   QueryFormData,
   QueryObject,
   QueryObjectFilterClause,
@@ -89,6 +92,14 @@ export default function buildQueryObject<T extends QueryFormData>(
     ...extras,
     ...filterFormData,
   });
+  const isAdhocColumn = (v?: AdhocColumn | PhysicalColumn) =>
+    (v as AdhocColumn)?.sqlExpression !== undefined;
+  const normalizeSeriesLimitMetric = (v: QueryFormColumn | undefined) => {
+    if (isAdhocColumn(v) || (v && (v as PhysicalColumn).length)) {
+      return v;
+    }
+    return undefined;
+  };
 
   let queryObject: QueryObject = {
     // fallback `null` to `undefined` so they won't be sent to the backend
@@ -113,13 +124,18 @@ export default function buildQueryObject<T extends QueryFormData>(
         : numericRowOffset,
     series_columns,
     series_limit,
-    series_limit_metric,
+    series_limit_metric: normalizeSeriesLimitMetric(series_limit_metric),
     timeseries_limit: limit ? Number(limit) : 0,
     timeseries_limit_metric: timeseries_limit_metric || undefined,
     order_desc: typeof order_desc === 'undefined' ? true : order_desc,
     url_params: url_params || undefined,
     custom_params,
   };
+
+  console.log(
+    'queryObject.series_limit_metric',
+    queryObject.series_limit_metric,
+  );
   // override extra form data used by native and cross filters
   queryObject = overrideExtraFormData(queryObject, overrides);
 

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Column.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Column.ts
@@ -54,7 +54,11 @@ export interface Column {
 export default {};
 
 export function isPhysicalColumn(
-  column: AdhocColumn | PhysicalColumn,
+  column?: AdhocColumn | PhysicalColumn,
 ): column is PhysicalColumn {
   return typeof column === 'string';
+}
+
+export function isAdhocColumn(column?: AdhocColumn | PhysicalColumn) {
+  return (column as AdhocColumn)?.sqlExpression !== undefined;
 }

--- a/superset-frontend/packages/superset-ui-core/test/query/buildQueryObject.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/buildQueryObject.test.ts
@@ -152,6 +152,28 @@ describe('buildQueryObject', () => {
     expect(query.timeseries_limit_metric).toEqual(metric);
   });
 
+  it('should build series_limit_metric', () => {
+    const metric = 'country';
+    query = buildQueryObject({
+      datasource: '5__table',
+      granularity_sqla: 'ds',
+      viz_type: 'pivot_table_v2',
+      series_limit_metric: metric,
+    });
+    expect(query.series_limit_metric).toEqual(metric);
+  });
+
+  it('should build series_limit_metric as undefined when empty array', () => {
+    const metric: any = [];
+    query = buildQueryObject({
+      datasource: '5__table',
+      granularity_sqla: 'ds',
+      viz_type: 'pivot_table_v2',
+      series_limit_metric: metric,
+    });
+    expect(query.series_limit_metric).toEqual(undefined);
+  });
+
   it('should handle null and non-numeric row_limit and row_offset', () => {
     const baseQuery = {
       datasource: '5__table',


### PR DESCRIPTION
### SUMMARY
This PR fixes an issue for which the Pivot Table V2 would fail when the "Sort by" control was cleared with D&D enabled.
The reason for the failure was that when the "Sort by" was cleared, the `series_limit_metric` was passed as an empty array due to the default behavior of the Select control.
With the changes in this PR, the `series_limit_metric` type is strictly checked and converted to `undefined` when the selection is cleared up / an empty array is passed. 

### BEFORE

https://user-images.githubusercontent.com/60598000/154978541-c8961854-77e4-461a-9a47-830bfd337c9a.mp4

### AFTER

https://user-images.githubusercontent.com/60598000/154979004-0e3d2438-f2fb-4cbf-9450-c40900d19432.mp4

### TESTING INSTRUCTIONS
1. Open a Pivot Table V2 with D&D enabled
2. Add a "Sort by" option
3. Clear the "Sort by"
4. Make sure the data is loaded as expected

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags: `ENABLE_EXPLORE_DRAG_AND_DROP` `ENABLE_DND_WITH_CLICK_UX`
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
