### PR TITLE
fix: Add case sensitive option to SelectControl

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -430,6 +430,7 @@ const y_axis_format: SharedControlConfig<'SelectControl'> = {
   label: t('Y Axis Format'),
   renderTrigger: true,
   default: DEFAULT_NUMBER_FORMAT,
+  caseSensitive: true,
   choices: D3_FORMAT_OPTIONS,
   description: D3_FORMAT_DOCS,
   mapStateToProps: state => {
@@ -451,6 +452,7 @@ const x_axis_time_format: SharedControlConfig<'SelectControl'> = {
   freeForm: true,
   label: t('Time format'),
   renderTrigger: true,
+  caseSensitive: true,
   default: DEFAULT_TIME_FORMAT,
   choices: D3_TIME_FORMAT_OPTIONS,
   description: D3_TIME_FORMAT_DOCS,

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts
@@ -23,6 +23,7 @@ import {
   D3_TIME_FORMAT_OPTIONS,
   formatSelectOptions,
   sections,
+  sharedControls,
 } from '@superset-ui/chart-controls';
 
 const config: ControlPanelConfig = {
@@ -136,10 +137,7 @@ const config: ControlPanelConfig = {
           {
             name: 'x_axis_time_format',
             config: {
-              type: 'SelectControl',
-              freeForm: true,
-              label: t('Time Format'),
-              renderTrigger: true,
+              ...sharedControls.x_axis_time_format,
               default: 'smart_date',
               choices: D3_TIME_FORMAT_OPTIONS,
               description: D3_FORMAT_DOCS,

--- a/superset-frontend/src/components/Select/utils.ts
+++ b/superset-frontend/src/components/Select/utils.ts
@@ -60,15 +60,20 @@ export function findValue<OptionType extends OptionTypeBase>(
   return (Array.isArray(value) ? value : [value]).map(find);
 }
 
-export function hasOption(search: string, options: AntdOptionsType) {
+export function hasOption(
+  search: string,
+  options: AntdOptionsType,
+  caseSensitive = false,
+) {
   const searchOption = search.trim().toLowerCase();
   return options.find(opt => {
     const { label, value } = opt;
-    const labelText = String(label);
-    const valueText = String(value);
-    return (
-      valueText.toLowerCase() === searchOption ||
-      labelText.toLowerCase() === searchOption
-    );
+    const labelText = caseSensitive
+      ? String(label)
+      : String(label).toLowerCase();
+    const valueText = caseSensitive
+      ? String(value)
+      : String(value).toLowerCase();
+    return valueText === searchOption || labelText === searchOption;
   });
 }

--- a/superset-frontend/src/explore/components/controls/SelectControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.jsx
@@ -64,6 +64,7 @@ const propTypes = {
   tooltipOnClick: PropTypes.func,
   warning: PropTypes.string,
   danger: PropTypes.string,
+  caseSensitive: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -80,6 +81,7 @@ const defaultProps = {
   onFocus: () => {},
   showHeader: true,
   valueKey: 'value',
+  caseSensitive: false,
 };
 
 export default class SelectControl extends React.PureComponent {
@@ -243,6 +245,7 @@ export default class SelectControl extends React.PureComponent {
       placeholder,
       sortComparator: this.props.sortComparator || propertyComparator('order'),
       value: getValue(),
+      caseSensitive: this.props.caseSensitive
     };
 
     return (


### PR DESCRIPTION
https://github.com/apache/superset/issues/17716
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The d3 time format selection widgets use case insensitive match in filter option, which prevents users from inputing formats which match in a case insensitive manner.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

> After Update
![image](https://user-images.githubusercontent.com/39701522/155008364-a48e89f0-d902-476d-8068-e2027973e516.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Go to `explore`
2. Create a new `Time-series Line Chart`
3. Click on the `CUSTOMIZE` tab.
4. Try entering the `%b %Y` d3 format for the X-Axis time format.
5. See that the UI component uses case-sensitive in filtering options.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
