### PR TITLE
fix(key-value): lost url_params after long-url feature

### DIFF
--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -175,6 +175,13 @@ const updateHistory = debounce(
       additionalParam[URL_PARAMS.datasetId.name] = datasetId;
     }
 
+    const urlParams = payload?.url_params || {};
+    Object.entries(urlParams).forEach(([key, value]) => {
+      if (!['slice_id', 'form_data_key', 'dataset_id'].includes(key)) {
+        additionalParam[key] = value;
+      }
+    });
+
     try {
       let key;
       let stateModifier;

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -177,7 +177,13 @@ const updateHistory = debounce(
 
     const urlParams = payload?.url_params || {};
     Object.entries(urlParams).forEach(([key, value]) => {
-      if (!['slice_id', 'form_data_key', 'dataset_id'].includes(key)) {
+      if (
+        ![
+          URL_PARAMS.sliceId.name,
+          URL_PARAMS.formDataKey.name,
+          URL_PARAMS.datasetId.name,
+        ].includes(key)
+      ) {
         additionalParam[key] = value;
       }
     });

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -744,8 +744,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         if form_data_key:
             parameters = CommandParameters(actor=g.user, key=form_data_key,)
             value = GetFormDataCommand(parameters).run()
-            if value:
-                initial_form_data = json.loads(value)
+            initial_form_data = json.loads(value) if value else {}
 
         if not initial_form_data:
             slice_id = request.args.get("slice_id")


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, the parameters in the browser can't show in URL. This PR resolved it.

partial fix https://github.com/apache/superset/issues/16650


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### After

![image](https://user-images.githubusercontent.com/2016594/155121386-93a75af1-2901-4f6e-9e11-d9c58d9ff71a.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
