### PR TITLE
fix: Null schema issue in the list of saved queries.

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
@@ -39,7 +39,7 @@ interface actionsTypes {
   addTable: (queryEditor: any, value: any, schema: any) => void;
   setDatabases: (arg0: any) => {};
   addDangerToast: (msg: string) => void;
-  queryEditorSetSchema: (schema?: string) => void;
+  queryEditorSetSchema: (queryEditor: QueryEditor, schema?: string) => void;
   queryEditorSetSchemaOptions: () => void;
   queryEditorSetTableOptions: (options: Array<any>) => void;
   resetState: () => void;
@@ -132,6 +132,10 @@ export default function SqlEditorLeftBar({
   const shouldShowReset = window.location.search === '?reset=1';
   const tableMetaDataHeight = height - 130; // 130 is the height of the selects above
 
+  const onSchemaChange = (schema: string) => {
+    actions.queryEditorSetSchema(queryEditor, schema);
+  };
+
   return (
     <div className="SqlEditorLeftBar">
       <TableSelector
@@ -139,7 +143,7 @@ export default function SqlEditorLeftBar({
         getDbList={actions.setDatabases}
         handleError={actions.addDangerToast}
         onDbChange={onDbChange}
-        onSchemaChange={actions.queryEditorSetSchema}
+        onSchemaChange={onSchemaChange}
         onSchemasLoad={actions.queryEditorSetSchemaOptions}
         onTableChange={onTableChange}
         onTablesLoad={actions.queryEditorSetTableOptions}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Database schema is displayed as null in the list of saved queries.
It should be displayed according to the schema selected in sql editor.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

> BEFORE & AFTER updates:
![image](https://user-images.githubusercontent.com/39701522/155187456-ce996bdc-5dde-45df-b5f3-a047c91ccc3e.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Go to SQL Editor
2. Run any query and save it
3. Go to the `Saved Queries` page
4. Check the database schema of newly saved query.