### PR TITLE
fix(dashboard): incorrect chart error with slow dataset api request

### DIFF
--- a/superset-frontend/src/chart/Chart.jsx
+++ b/superset-frontend/src/chart/Chart.jsx
@@ -220,6 +220,7 @@ class Chart extends React.PureComponent {
 
     return (
       <ChartErrorMessage
+        key={chartId}
         chartId={chartId}
         error={error}
         subtitle={message}

--- a/superset-frontend/src/chart/Chart.jsx
+++ b/superset-frontend/src/chart/Chart.jsx
@@ -208,6 +208,7 @@ class Chart extends React.PureComponent {
     ) {
       return (
         <Styles
+          key={chartId}
           data-ui-anchor="chart"
           className="chart-container"
           data-test="chart-container"

--- a/superset-frontend/src/chart/chartReducer.ts
+++ b/superset-frontend/src/chart/chartReducer.ts
@@ -201,9 +201,10 @@ export default function chartReducer(
     return Object.fromEntries(
       Object.entries(charts).map(([chartId, chart]) => [
         chartId,
-        // if render has failed, clear error message,
-        // which will trigger a re-render
-        chart.chartStatus === 'failed'
+        // some charts may not have properly handled missing datasource,
+        // so we reset error message and try to re-render the chart
+        // once datasource is fully loaded
+        chart.chartStatus === 'failed' && chart.chartStackTrace
           ? {
               ...chart,
               chartStatus: '',

--- a/superset-frontend/src/chart/chartReducer.ts
+++ b/superset-frontend/src/chart/chartReducer.ts
@@ -202,8 +202,8 @@ export default function chartReducer(
       Object.entries(charts).map(([chartId, chart]) => [
         chartId,
         // some charts may not have properly handled missing datasource,
-        // so we reset error message and try to re-render the chart
-        // once datasource is fully loaded
+        // causing a JS error, so we reset error message and try to re-render
+        // the chart once the datasource is fully loaded
         chart.chartStatus === 'failed' && chart.chartStackTrace
           ? {
               ...chart,


### PR DESCRIPTION
### SUMMARY

Fix a bug where sever side chart data query errors were displayed as "No results" when the `/dashboard/[id]/datasets` API is slow. 

#### Background

#15699 made loading full datasource info for Dashboard charts async, however, some chart types didn't handle incomplete datasource info properly, causing JS errors. #15993 fixed that by re-rendering the charts after the datasources are fully loaded. Then a “No results" state for dashboard chart container is introduced in 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

Charts with server side errors may show as "no results":

<img width="729" alt="Xnip2022-02-22_11-17-46" src="https://user-images.githubusercontent.com/335541/155210656-f6a1e392-4579-4878-962a-bb9ba33b2840.png">

#### After

Server side errors correctly rendered as unexpected errors:

<img width="736" alt="Xnip2022-02-22_11-16-44" src="https://user-images.githubusercontent.com/335541/155210705-3f3b1e7f-585b-433f-a183-5c8b50146f69.png">


### TESTING INSTRUCTIONS

Here's how to reproduce the bug:

1. Go to a dashboard where the dashboard/datasets API may be slow---e.g. dashboard that used a large dataset with a lot of columns
2. Make sure users have access control error (or any other server side errors) when accessing one of the charts
2. Refresh the page until you see the datasets API returns later than the chart data api:
    <img width="430" alt="Xnip2022-02-22_12-05-00" src="https://user-images.githubusercontent.com/335541/155210621-56c474c2-fd91-486c-bbdf-28d3ada20a6f.png">


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
