### PR TITLE
fix: filter indicator pointing issue on popover

### DIFF
--- a/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel/index.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel/index.tsx
@@ -279,7 +279,7 @@ const DetailsPanelPopover = ({
       content={content}
       visible={visible}
       onVisibleChange={handlePopoverStatus}
-      placement="bottom"
+      placement="bottomRight"
       trigger="click"
     >
       {children}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Original report:
When chart is at max length, pointer of the filter indicator is not pointing correctly. 

Grooming report:
1. This issue is related to the placement of popover. We could use `bottomRight` as the placement of popover because all of filter badge icons are placed on top right corner of its section. 
2. Popover is being triggered for filter badge icons only for now. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
> BEFORE
![image](https://user-images.githubusercontent.com/39701522/155219387-46baacc8-1452-4fef-b695-3689eda95671.png)


> AFTER
![image](https://user-images.githubusercontent.com/39701522/155219140-05dbef4d-6c0d-46bb-ac1f-16a909da247e.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Go to dashboard
2. Click filter badge icon on the right side chart component.
3. See if the popover is placed on bottom-right.
