### PR TITLE
fix: Metadata browser in SQL not render nicely in Safari

### DIFF
--- a/superset-frontend/src/SqlLab/components/ColumnElement/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ColumnElement/index.tsx
@@ -75,6 +75,10 @@ interface ColumnElementProps {
   };
 }
 
+const NowrapDiv = styled.div`
+  white-space: nowrap;
+`;
+
 const ColumnElement = ({ column }: ColumnElementProps) => {
   let columnName: React.ReactNode = column.name;
   let icons;
@@ -105,9 +109,9 @@ const ColumnElement = ({ column }: ColumnElementProps) => {
         {columnName}
         {icons}
       </div>
-      <div className="pull-right text-muted">
+      <NowrapDiv className="pull-right text-muted">
         <small> {column.type}</small>
-      </div>
+      </NowrapDiv>
     </div>
   );
 };


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Metadata in SQL Lab doesn't render nicely in safari browser. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
> After
<img width="496" alt="image" src="https://user-images.githubusercontent.com/39701522/155222077-7389ff83-51f2-4be9-baaa-e67d519ac168.png">

