### PR TITLE
feat(select): sort exact and startsWith match to first

### DIFF
--- a/superset-frontend/src/components/Select/Select.stories.tsx
+++ b/superset-frontend/src/components/Select/Select.stories.tsx
@@ -80,12 +80,6 @@ const ARG_TYPES = {
       The options can also be async, a promise that returns an array of options.
     `,
   },
-  optionsCount: {
-    defaultValue: options.length,
-    control: {
-      type: 'number',
-    },
-  },
   ariaLabel: {
     description: `It adds the aria-label tag for accessibility standards.
       Must be plain English and localized.
@@ -205,6 +199,12 @@ InteractiveSelect.args = {
 
 InteractiveSelect.argTypes = {
   ...ARG_TYPES,
+  optionsCount: {
+    defaultValue: options.length,
+    control: {
+      type: 'number',
+    },
+  },
   header: {
     defaultValue: 'none',
     description: `It adds a header on top of the Select. Can be any ReactNode.`,

--- a/superset-frontend/src/components/Select/Select.stories.tsx
+++ b/superset-frontend/src/components/Select/Select.stories.tsx
@@ -18,7 +18,7 @@
  */
 import React, { ReactNode, useState, useCallback } from 'react';
 import ControlHeader from 'src/explore/components/ControlHeader';
-import Select, { SelectProps, OptionsTypePage } from './Select';
+import Select, { SelectProps, OptionsTypePage, OptionsType } from './Select';
 
 export default {
   title: 'Select',
@@ -27,7 +27,7 @@ export default {
 
 const DEFAULT_WIDTH = 200;
 
-const options = [
+const options: OptionsType = [
   {
     label: 'Such an incredibly awesome long long label',
     value: 'Such an incredibly awesome long long label',
@@ -79,6 +79,12 @@ const ARG_TYPES = {
       The options can be static, an array of options.
       The options can also be async, a promise that returns an array of options.
     `,
+  },
+  optionsCount: {
+    defaultValue: options.length,
+    control: {
+      type: 'number',
+    },
   },
   ariaLabel: {
     description: `It adds the aria-label tag for accessibility standards.
@@ -147,13 +153,42 @@ const mountHeader = (type: String) => {
   return header;
 };
 
-export const InteractiveSelect = (args: SelectProps & { header: string }) => (
+const generateOptions = (opts: OptionsType, count: number) => {
+  let generated = opts.slice();
+  let iteration = 0;
+  while (generated.length < count) {
+    iteration += 1;
+    generated = generated.concat(
+      // eslint-disable-next-line no-loop-func
+      generated.map(({ label, value }) => ({
+        label: `${label} ${iteration}`,
+        value: `${value} ${iteration}`,
+      })),
+    );
+  }
+  return generated.slice(0, count);
+};
+
+export const InteractiveSelect = ({
+  header,
+  options,
+  optionsCount,
+  ...args
+}: SelectProps & { header: string; optionsCount: number }) => (
   <div
     style={{
       width: DEFAULT_WIDTH,
     }}
   >
-    <Select {...args} header={mountHeader(args.header)} />
+    <Select
+      {...args}
+      options={
+        Array.isArray(options)
+          ? generateOptions(options, optionsCount)
+          : options
+      }
+      header={mountHeader(header)}
+    />
   </div>
 );
 

--- a/superset-frontend/src/components/Select/Select.test.tsx
+++ b/superset-frontend/src/components/Select/Select.test.tsx
@@ -46,6 +46,9 @@ const OPTIONS = [
   { label: 'Irfan', value: 18, gender: 'Male' },
   { label: 'George', value: 19, gender: 'Male' },
   { label: 'Ashfaq', value: 20, gender: 'Male' },
+  { label: 'Herme', value: 21, gender: 'Male' },
+  { label: 'Cher', value: 22, gender: 'Female' },
+  { label: 'Her', value: 23, gender: 'Male' },
 ].sort((option1, option2) => option1.label.localeCompare(option2.label));
 
 const loadOptions = async (search: string, page: number, pageSize: number) => {
@@ -111,9 +114,21 @@ test('displays a header', async () => {
 });
 
 test('adds a new option if the value is not in the options', async () => {
-  render(<Select {...defaultProps} options={[]} value={OPTIONS[0]} />);
+  const { rerender } = render(
+    <Select {...defaultProps} options={[]} value={OPTIONS[0]} />,
+  );
   await open();
   expect(await findSelectOption(OPTIONS[0].label)).toBeInTheDocument();
+
+  rerender(
+    <Select {...defaultProps} options={[OPTIONS[1]]} value={OPTIONS[0]} />,
+  );
+  await open();
+  const options = await findAllSelectOptions();
+  expect(options).toHaveLength(2);
+  options.forEach((option, i) =>
+    expect(option).toHaveTextContent(OPTIONS[i].label),
+  );
 });
 
 test('inverts the selection', async () => {
@@ -149,9 +164,9 @@ test('sort the options using a custom sort comparator', async () => {
   const options = await findAllSelectOptions();
   const optionsPage = OPTIONS.slice(0, defaultProps.pageSize);
   const sortedOptions = optionsPage.sort(sortComparator);
-  options.forEach((option, key) =>
-    expect(option).toHaveTextContent(sortedOptions[key].label),
-  );
+  options.forEach((option, key) => {
+    expect(option).toHaveTextContent(sortedOptions[key].label);
+  });
 });
 
 test('displays the selected values first', async () => {
@@ -194,10 +209,36 @@ test('searches for label or value', async () => {
   expect(options[0]).toHaveTextContent(option.label);
 });
 
+test('search order exact and startWith match first', async () => {
+  render(<Select {...defaultProps} />);
+  await type('Her');
+  const options = await findAllSelectOptions();
+  expect(options.length).toBe(4);
+  expect(options[0]?.textContent).toEqual('Her');
+  expect(options[1]?.textContent).toEqual('Herme');
+  expect(options[2]?.textContent).toEqual('Cher');
+  expect(options[3]?.textContent).toEqual('Guilherme');
+});
+
 test('ignores case when searching', async () => {
   render(<Select {...defaultProps} />);
   await type('george');
   expect(await findSelectOption('George')).toBeInTheDocument();
+});
+
+test('same case should be ranked to the top', async () => {
+  render(
+    <Select
+      {...defaultProps}
+      options={[{ value: 'Ca' }, { value: 'ab' }, { value: 'Ac' }]}
+    />,
+  );
+  await type('A');
+  const options = await findAllSelectOptions();
+  expect(options.length).toBe(3);
+  expect(options[0]?.textContent).toEqual('Ac');
+  expect(options[1]?.textContent).toEqual('ab');
+  expect(options[2]?.textContent).toEqual('Ca');
 });
 
 test('ignores special keys when searching', async () => {
@@ -214,12 +255,13 @@ test('searches for custom fields', async () => {
   expect(options[0]).toHaveTextContent('Liam');
   await type('Female');
   options = await findAllSelectOptions();
-  expect(options.length).toBe(5);
+  expect(options.length).toBe(6);
   expect(options[0]).toHaveTextContent('Ava');
   expect(options[1]).toHaveTextContent('Charlotte');
-  expect(options[2]).toHaveTextContent('Emma');
-  expect(options[3]).toHaveTextContent('Nikole');
-  expect(options[4]).toHaveTextContent('Olivia');
+  expect(options[2]).toHaveTextContent('Cher');
+  expect(options[3]).toHaveTextContent('Emma');
+  expect(options[4]).toHaveTextContent('Nikole');
+  expect(options[5]).toHaveTextContent('Olivia');
   await type('1');
   expect(screen.getByText(NO_DATA)).toBeInTheDocument();
 });

--- a/superset-frontend/src/components/Select/Select.test.tsx
+++ b/superset-frontend/src/components/Select/Select.test.tsx
@@ -230,15 +230,21 @@ test('same case should be ranked to the top', async () => {
   render(
     <Select
       {...defaultProps}
-      options={[{ value: 'Ca' }, { value: 'ab' }, { value: 'Ac' }]}
+      options={[
+        { value: 'Cac' },
+        { value: 'abac' },
+        { value: 'acbc' },
+        { value: 'CAc' },
+      ]}
     />,
   );
-  await type('A');
+  await type('Ac');
   const options = await findAllSelectOptions();
-  expect(options.length).toBe(3);
-  expect(options[0]?.textContent).toEqual('Ac');
-  expect(options[1]?.textContent).toEqual('ab');
-  expect(options[2]?.textContent).toEqual('Ca');
+  expect(options.length).toBe(4);
+  expect(options[0]?.textContent).toEqual('acbc');
+  expect(options[1]?.textContent).toEqual('CAc');
+  expect(options[2]?.textContent).toEqual('abac');
+  expect(options[3]?.textContent).toEqual('Cac');
 });
 
 test('ignores special keys when searching', async () => {

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -355,9 +355,7 @@ const Select = (
   // add selected values to options list if they are not in it
   const fullSelectOptions = useMemo(() => {
     const missingValues: OptionsType = ensureIsArray(selectValue)
-      .filter(
-        opt => !hasOption(getValue(opt), selectOptions as AntdLabeledValue[]),
-      )
+      .filter(opt => !hasOption(getValue(opt), selectOptions))
       .map(opt =>
         typeof opt === 'object' ? opt : { value: opt, label: String(opt) },
       );
@@ -497,7 +495,7 @@ const Select = (
     const searchValue = search.trim();
     if (allowNewOptions && isSingleMode) {
       const newOption = searchValue &&
-        !hasOption(searchValue, fullSelectOptions as AntdLabeledValue[]) && {
+        !hasOption(searchValue, fullSelectOptions, true) && {
           label: searchValue,
           value: searchValue,
           isNewOption: true,

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -28,7 +28,7 @@ import React, {
   useRef,
   useCallback,
 } from 'react';
-import { styled, t } from '@superset-ui/core';
+import { ensureIsArray, styled, t } from '@superset-ui/core';
 import AntdSelect, {
   SelectProps as AntdSelectProps,
   SelectValue as AntdSelectValue,
@@ -41,7 +41,8 @@ import { Spin } from 'antd';
 import Icons from 'src/components/Icons';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 import { SLOW_DEBOUNCE } from 'src/constants';
-import { hasOption, hasOptionIgnoreCase } from './utils';
+import { rankedSearchCompare } from 'src/utils/rankedSearchCompare';
+import { getValue, hasOption, hasOptionIgnoreCase } from './utils';
 
 const { Option } = AntdSelect;
 
@@ -155,7 +156,7 @@ export interface SelectProps extends PickedSelectProps {
    * Works in async mode only (See the options property).
    */
   onError?: (error: string) => void;
-  sortComparator?: (a: AntdLabeledValue, b: AntdLabeledValue) => number;
+  sortComparator?: typeof DEFAULT_SORT_COMPARATOR;
 }
 
 const StyledContainer = styled.div`
@@ -227,12 +228,26 @@ const Error = ({ error }: { error: string }) => (
   </StyledError>
 );
 
-const defaultSortComparator = (a: AntdLabeledValue, b: AntdLabeledValue) => {
+export const DEFAULT_SORT_COMPARATOR = (
+  a: AntdLabeledValue,
+  b: AntdLabeledValue,
+  search?: string,
+) => {
+  let aText: string | undefined;
+  let bText: string | undefined;
   if (typeof a.label === 'string' && typeof b.label === 'string') {
-    return a.label.localeCompare(b.label);
+    aText = a.label;
+    bText = b.label;
+  } else if (typeof a.value === 'string' && typeof b.value === 'string') {
+    aText = a.value;
+    bText = b.value;
   }
-  if (typeof a.value === 'string' && typeof b.value === 'string') {
-    return a.value.localeCompare(b.value);
+  // sort selected options first
+  if (typeof aText === 'string' && typeof bText === 'string') {
+    if (search) {
+      return rankedSearchCompare(aText, bText, search);
+    }
+    return aText.localeCompare(bText);
   }
   return (a.value as number) - (b.value as number);
 };
@@ -289,7 +304,7 @@ const Select = (
     pageSize = DEFAULT_PAGE_SIZE,
     placeholder = t('Select ...'),
     showSearch = true,
-    sortComparator = defaultSortComparator,
+    sortComparator = DEFAULT_SORT_COMPARATOR,
     value,
     ...props
   }: SelectProps,
@@ -299,15 +314,9 @@ const Select = (
   const isSingleMode = mode === 'single';
   const shouldShowSearch = isAsync || allowNewOptions ? true : showSearch;
   const initialOptions =
-    options && Array.isArray(options) ? options : EMPTY_OPTIONS;
-  const [selectOptions, setSelectOptions] = useState<OptionsType>(
-    initialOptions.sort(sortComparator),
-  );
-  const shouldUseChildrenOptions = !!selectOptions.find(
-    opt => opt?.customLabel,
-  );
+    options && Array.isArray(options) ? options.slice() : EMPTY_OPTIONS;
   const [selectValue, setSelectValue] = useState(value);
-  const [searchedValue, setSearchedValue] = useState('');
+  const [inputValue, setInputValue] = useState('');
   const [isLoading, setIsLoading] = useState(loading);
   const [error, setError] = useState('');
   const [isDropdownVisible, setIsDropdownVisible] = useState(false);
@@ -321,81 +330,44 @@ const Select = (
     : allowNewOptions
     ? 'tags'
     : 'multiple';
-  const allowFetch = !fetchOnlyOnSearch || searchedValue;
+  const allowFetch = !fetchOnlyOnSearch || inputValue;
 
-  // TODO: Don't assume that isAsync is always labelInValue
-  const handleTopOptions = useCallback(
-    (selectedValue: AntdSelectValue | undefined) => {
-      // bringing selected options to the top of the list
-      if (selectedValue !== undefined && selectedValue !== null) {
-        const isLabeledValue = isAsync || labelInValue;
-        const topOptions: OptionsType = [];
-        const otherOptions: OptionsType = [];
-
-        selectOptions.forEach(opt => {
-          let found = false;
-          if (Array.isArray(selectedValue)) {
-            if (isLabeledValue) {
-              found =
-                (selectedValue as AntdLabeledValue[]).find(
-                  element => element.value === opt.value,
-                ) !== undefined;
-            } else {
-              found = selectedValue.includes(opt.value);
-            }
-          } else {
-            found = isLabeledValue
-              ? (selectedValue as AntdLabeledValue).value === opt.value
-              : selectedValue === opt.value;
-          }
-
-          if (found) {
-            topOptions.push(opt);
-          } else {
-            otherOptions.push(opt);
-          }
-        });
-
-        // fallback for custom options in tags mode as they
-        // do not appear in the selectOptions state
-        if (!isSingleMode && Array.isArray(selectedValue)) {
-          selectedValue.forEach((val: string | number | AntdLabeledValue) => {
-            if (
-              !topOptions.find(
-                tOpt =>
-                  tOpt.value ===
-                  (isLabeledValue ? (val as AntdLabeledValue)?.value : val),
-              )
-            ) {
-              if (isLabeledValue) {
-                const labelValue = val as AntdLabeledValue;
-                topOptions.push({
-                  label: labelValue.label,
-                  value: labelValue.value,
-                });
-              } else {
-                const value = val as string | number;
-                topOptions.push({ label: String(value), value });
-              }
-            }
-          });
-        }
-        const sortedOptions = [
-          ...topOptions.sort(sortComparator),
-          ...otherOptions.sort(sortComparator),
-        ];
-        if (!isEqual(sortedOptions, selectOptions)) {
-          setSelectOptions(sortedOptions);
-        }
-      } else {
-        const sortedOptions = [...selectOptions].sort(sortComparator);
-        if (!isEqual(sortedOptions, selectOptions)) {
-          setSelectOptions(sortedOptions);
-        }
-      }
-    },
-    [isAsync, isSingleMode, labelInValue, selectOptions, sortComparator],
+  const sortSelectedFirst = useCallback(
+    (a: AntdLabeledValue, b: AntdLabeledValue) =>
+      selectValue && a.value !== undefined && b.value !== undefined
+        ? Number(hasOption(b.value, selectValue)) -
+          Number(hasOption(a.value, selectValue))
+        : 0,
+    [selectValue],
   );
+  const sortComparatorWithSearch = useCallback(
+    (a: AntdLabeledValue, b: AntdLabeledValue) =>
+      sortSelectedFirst(a, b) || sortComparator(a, b, inputValue),
+    [inputValue, sortComparator, sortSelectedFirst],
+  );
+  const sortComparatorWithoutSearch = useCallback(
+    (a: AntdLabeledValue, b: AntdLabeledValue) =>
+      sortSelectedFirst(a, b) || sortComparator(a, b, ''),
+    [sortComparator, sortSelectedFirst],
+  );
+  const [selectOptions_, setSelectOptions] =
+    useState<OptionsType>(initialOptions);
+  // add selected values to options list if they are not in it
+  const selectOptions = useMemo(() => {
+    const missingValues: OptionsType = ensureIsArray(selectValue)
+      .filter(
+        opt => !hasOption(getValue(opt), selectOptions_ as AntdLabeledValue[]),
+      )
+      .map(opt =>
+        typeof opt === 'object' ? opt : { value: opt, label: String(opt) },
+      );
+    if (missingValues.length > 0) {
+      return missingValues.concat(selectOptions_);
+    }
+    return selectOptions_;
+  }, [selectOptions_, selectValue]);
+
+  const hasCustomLabels = selectOptions.some(opt => !!opt?.customLabel);
 
   const handleOnSelect = (
     selectedValue: string | number | AntdLabeledValue,
@@ -423,7 +395,7 @@ const Select = (
         ]);
       }
     }
-    setSearchedValue('');
+    setInputValue('');
   };
 
   const handleOnDeselect = (value: string | number | AntdLabeledValue) => {
@@ -436,7 +408,7 @@ const Select = (
         setSelectValue(array.filter(element => element.value !== value.value));
       }
     }
-    setSearchedValue('');
+    setInputValue('');
   };
 
   const internalOnError = useCallback(
@@ -452,42 +424,34 @@ const Select = (
     [onError],
   );
 
-  const handleData = useCallback(
+  const mergeData = useCallback(
     (data: OptionsType) => {
       let mergedData: OptionsType = [];
       if (data && Array.isArray(data) && data.length) {
-        const dataValues = new Set();
-        data.forEach(option =>
-          dataValues.add(String(option.value).toLocaleLowerCase()),
-        );
-
+        // unique option values should always be case sensitive so don't lowercase
+        const dataValues = new Set(data.map(opt => opt.value));
         // merges with existing and creates unique options
         setSelectOptions(prevOptions => {
-          mergedData = [
-            ...prevOptions.filter(
-              previousOption =>
-                !dataValues.has(
-                  String(previousOption.value).toLocaleLowerCase(),
-                ),
-            ),
-            ...data,
-          ];
-          mergedData.sort(sortComparator);
+          mergedData = prevOptions
+            .filter(previousOption => !dataValues.has(previousOption.value))
+            .concat(data)
+            .sort(sortComparatorWithoutSearch);
           return mergedData;
         });
       }
       return mergedData;
     },
-    [sortComparator],
+    [sortComparatorWithoutSearch],
   );
 
-  const handlePaginatedFetch = useMemo(
-    () => (value: string, page: number) => {
+  const fetchPage = useMemo(
+    () => (search: string, page: number) => {
+      setPage(page);
       if (allValuesLoaded) {
         setIsLoading(false);
         return;
       }
-      const key = getQueryCacheKey(value, page, pageSize);
+      const key = getQueryCacheKey(search, page, pageSize);
       const cachedCount = fetchedQueries.current.get(key);
       if (cachedCount !== undefined) {
         setTotalCount(cachedCount);
@@ -496,9 +460,9 @@ const Select = (
       }
       setIsLoading(true);
       const fetchOptions = options as OptionsPagePromise;
-      fetchOptions(value, page, pageSize)
+      fetchOptions(search, page, pageSize)
         .then(({ data, totalCount }: OptionsTypePage) => {
-          const mergedData = handleData(data);
+          const mergedData = mergeData(data);
           fetchedQueries.current.set(key, totalCount);
           setTotalCount(totalCount);
           if (
@@ -517,20 +481,17 @@ const Select = (
     [
       allValuesLoaded,
       fetchOnlyOnSearch,
-      handleData,
+      mergeData,
       internalOnError,
       options,
       pageSize,
+      value,
     ],
   );
 
-  const debouncedHandleSearch = useMemo(
-    () =>
-      debounce((search: string) => {
-        // async search will be triggered in handlePaginatedFetch
-        setSearchedValue(search);
-      }, SLOW_DEBOUNCE),
-    [],
+  const debouncedFetchPage = useMemo(
+    () => debounce(fetchPage, SLOW_DEBOUNCE),
+    [fetchPage],
   );
 
   const handleOnSearch = (search: string) => {
@@ -560,7 +521,7 @@ const Select = (
       // in loading state
       setIsLoading(!(fetchOnlyOnSearch && !searchValue));
     }
-    return debouncedHandleSearch(search);
+    setInputValue(search);
   };
 
   const handlePagination = (e: UIEvent<HTMLElement>) => {
@@ -571,8 +532,7 @@ const Select = (
 
     if (!isLoading && isAsync && hasMoreData && thresholdReached) {
       const newPage = page + 1;
-      handlePaginatedFetch(searchedValue, newPage);
-      setPage(newPage);
+      fetchPage(inputValue, newPage);
     }
   };
 
@@ -583,7 +543,6 @@ const Select = (
 
     if (filterOption) {
       const searchValue = search.trim().toLowerCase();
-
       if (optionFilterProps && optionFilterProps.length) {
         return optionFilterProps.some(prop => {
           const optionProp = option?.[prop]
@@ -616,11 +575,13 @@ const Select = (
         }, 250);
       }
     }
-
-    // multiple or tags mode keep the dropdown visible while selecting options
-    // this waits for the dropdown to be opened before sorting the top options
-    if (!isSingleMode && isDropdownVisible) {
-      handleTopOptions(selectValue);
+    // if no search input value, force sort options because it won't be sorted by
+    // `filterSort`.
+    if (isDropdownVisible && !inputValue && selectOptions.length > 0) {
+      const sortedOptions = [...selectOptions].sort(sortComparatorWithSearch);
+      if (!isEqual(sortedOptions, selectOptions)) {
+        setSelectOptions(sortedOptions);
+      }
     }
 
     if (onDropdownVisibleChange) {
@@ -660,75 +621,43 @@ const Select = (
   };
 
   useEffect(() => {
+    // when `options` list is updated from component prop, reset states
     fetchedQueries.current.clear();
+    setAllValuesLoaded(false);
     setSelectOptions(
       options && Array.isArray(options) ? options : EMPTY_OPTIONS,
     );
-    setAllValuesLoaded(false);
   }, [options]);
 
   useEffect(() => {
     setSelectValue(value);
   }, [value]);
 
-  useEffect(() => {
-    if (selectValue) {
-      setSelectOptions(selectOptions => {
-        const array = Array.isArray(selectValue)
-          ? (selectValue as AntdLabeledValue[])
-          : [selectValue as AntdLabeledValue | string | number];
-        const options: AntdLabeledValue[] = [];
-        const isLabeledValue = isAsync || labelInValue;
-        array.forEach(element => {
-          const found = selectOptions.find(
-            (option: { value: string | number }) =>
-              isLabeledValue
-                ? option.value === (element as AntdLabeledValue).value
-                : option.value === element,
-          );
-          if (!found) {
-            options.push(
-              isLabeledValue
-                ? (element as AntdLabeledValue)
-                : ({ value: element, label: element } as AntdLabeledValue),
-            );
-          }
-        });
-        if (options.length > 0) {
-          return [...options, ...selectOptions];
-        }
-        // return same options won't trigger a re-render
-        return selectOptions;
-      });
-    }
-  }, [labelInValue, isAsync, selectValue]);
-
   // Stop the invocation of the debounced function after unmounting
   useEffect(
     () => () => {
-      debouncedHandleSearch.cancel();
+      debouncedFetchPage.cancel();
     },
-    [debouncedHandleSearch],
+    [debouncedFetchPage],
   );
 
   useEffect(() => {
     if (isAsync && loadingEnabled && allowFetch) {
-      handlePaginatedFetch(searchedValue, 0);
-      setPage(0);
+      // trigger fetch every time inputValue changes
+      if (inputValue) {
+        debouncedFetchPage(inputValue, 0);
+      } else {
+        fetchPage('', 0);
+      }
     }
   }, [
     isAsync,
-    searchedValue,
-    handlePaginatedFetch,
     loadingEnabled,
+    fetchPage,
     allowFetch,
+    inputValue,
+    debouncedFetchPage,
   ]);
-
-  useEffect(() => {
-    if (isSingleMode) {
-      handleTopOptions(selectValue);
-    }
-  }, [handleTopOptions, isSingleMode, selectValue]);
 
   useEffect(() => {
     if (loading !== undefined && loading !== isLoading) {
@@ -743,6 +672,7 @@ const Select = (
         aria-label={ariaLabel || name}
         dropdownRender={dropdownRender}
         filterOption={handleFilterOption}
+        filterSort={sortComparatorWithSearch}
         getPopupContainer={triggerNode => triggerNode.parentNode}
         labelInValue={isAsync || labelInValue}
         maxTagCount={MAX_TAG_COUNT}
@@ -755,7 +685,7 @@ const Select = (
         onSelect={handleOnSelect}
         onClear={handleClear}
         onChange={onChange}
-        options={shouldUseChildrenOptions ? undefined : selectOptions}
+        options={hasCustomLabels ? undefined : selectOptions}
         placeholder={placeholder}
         showSearch={shouldShowSearch}
         showArrow
@@ -772,13 +702,12 @@ const Select = (
         ref={ref}
         {...props}
       >
-        {shouldUseChildrenOptions &&
+        {hasCustomLabels &&
           selectOptions.map(opt => {
             const isOptObject = typeof opt === 'object';
             const label = isOptObject ? opt?.label || opt.value : opt;
             const value = isOptObject ? opt.value : opt;
             const { customLabel, ...optProps } = opt;
-
             return (
               <Option {...optProps} key={value} label={label} value={value}>
                 {isOptObject && customLabel ? customLabel : label}

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -42,7 +42,7 @@ import Icons from 'src/components/Icons';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 import { SLOW_DEBOUNCE } from 'src/constants';
 import { rankedSearchCompare } from 'src/utils/rankedSearchCompare';
-import { getValue, hasOption, hasOptionIgnoreCase } from './utils';
+import { getValue, hasOption } from './utils';
 
 const { Option } = AntdSelect;
 

--- a/superset-frontend/src/components/Select/utils.ts
+++ b/superset-frontend/src/components/Select/utils.ts
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { ReactNode } from 'react';
 import { ensureIsArray } from '@superset-ui/core';
 import {
   OptionTypeBase,
@@ -63,14 +64,21 @@ export function getValue(option: string | number | { value: string | number }) {
   return typeof option === 'object' ? option.value : option;
 }
 
-export function hasOption<VT extends string | number>(
-  value: VT,
-  options?: VT | VT[] | { value?: VT } | { value?: VT }[],
-) {
+type LabeledValue<V> = { label?: ReactNode; value?: V };
+
+export function hasOption<V>(
+  value: V,
+  options?: V | LabeledValue<V> | (V | LabeledValue<V>)[],
+  checkLabel = false,
+): boolean {
   const optionsArray = ensureIsArray(options);
   return (
-    optionsArray.find(x =>
-      typeof x === 'object' ? x.value === value : x === value,
+    optionsArray.find(
+      x =>
+        x === value ||
+        (typeof x === 'object' &&
+          (('value' in x && x.value === value) ||
+            (checkLabel && 'label' in x && x.label === value))),
     ) !== undefined
   );
 }

--- a/superset-frontend/src/components/Select/utils.ts
+++ b/superset-frontend/src/components/Select/utils.ts
@@ -1,4 +1,3 @@
-import { ensureIsArray } from '@superset-ui/core';
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -17,6 +16,7 @@ import { ensureIsArray } from '@superset-ui/core';
  * specific language governing permissions and limitations
  * under the License.
  */
+import { ensureIsArray } from '@superset-ui/core';
 import {
   OptionTypeBase,
   ValueType,
@@ -61,9 +61,13 @@ export function findValue<OptionType extends OptionTypeBase>(
   return (Array.isArray(value) ? value : [value]).map(find);
 }
 
+export function getValue(option: string | number | { value: string | number }) {
+  return typeof option === 'object' ? option.value : option;
+}
+
 export function hasOption<VT extends string | number>(
   value: VT,
-  options?: VT | VT[] | { value: VT } | { value: VT }[],
+  options?: VT | VT[] | { value?: VT } | { value?: VT }[],
 ) {
   const optionsArray = ensureIsArray(options);
   return (

--- a/superset-frontend/src/components/Select/utils.ts
+++ b/superset-frontend/src/components/Select/utils.ts
@@ -24,8 +24,6 @@ import {
   GroupedOptionsType,
 } from 'react-select';
 
-import { OptionsType as AntdOptionsType } from './Select';
-
 /**
  * Find Option value that matches a possibly string value.
  *
@@ -75,17 +73,4 @@ export function hasOption<VT extends string | number>(
       typeof x === 'object' ? x.value === value : x === value,
     ) !== undefined
   );
-}
-
-export function hasOptionIgnoreCase(search: string, options: AntdOptionsType) {
-  const searchOption = search.trim().toLowerCase();
-  return options.find(opt => {
-    const { label, value } = opt;
-    const labelText = String(label);
-    const valueText = String(value);
-    return (
-      valueText.toLowerCase() === searchOption ||
-      labelText.toLowerCase() === searchOption
-    );
-  });
 }

--- a/superset-frontend/src/explore/components/controls/SelectControl.test.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.test.jsx
@@ -153,11 +153,12 @@ describe('SelectControl', () => {
     });
 
     describe('when select has a sortComparator prop', () => {
-      it('does not add add order key and sorts by sortComparator', () => {
+      it('does not add add order key', () => {
         const sortComparator = (a, b) => a.label.localeCompare(b.label);
-        const optionsSortedByLabel = options
-          .map(opt => ({ label: opt.label, value: opt.value }))
-          .sort(sortComparator);
+        const optionsSortedByLabel = options.map(opt => ({
+          label: opt.label,
+          value: opt.value,
+        }));
         wrapper = mount(
           <SelectControl
             {...defaultProps}
@@ -167,19 +168,6 @@ describe('SelectControl', () => {
           />,
         );
         expect(wrapper.state().options).toEqual(optionsSortedByLabel);
-      });
-    });
-
-    describe('when select does not have a sortComparator prop', () => {
-      it('adds an order key and maintains its intial order', () => {
-        wrapper = mount(
-          <SelectControl
-            {...defaultProps}
-            value={50}
-            placeholder="add something"
-          />,
-        );
-        expect(wrapper.state().options).toEqual(options);
       });
     });
   });

--- a/superset-frontend/src/utils/rankedSearchCompare.test.ts
+++ b/superset-frontend/src/utils/rankedSearchCompare.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { rankedSearchCompare } from './rankedSearchCompare';
+
+const searchSort = (search: string) => (a: string, b: string) =>
+  rankedSearchCompare(a, b, search);
+
+test('Sort exact match first', async () => {
+  expect(['abc', 'bc', 'bcd', 'cbc'].sort(searchSort('bc'))).toEqual([
+    'bc',
+    'bcd',
+    'abc',
+    'cbc',
+  ]);
+});
+
+test('Sort starts with first', async () => {
+  expect(['her', 'Cher', 'Her', 'Hermon'].sort(searchSort('Her'))).toEqual([
+    'Her',
+    'Hermon',
+    'her',
+    'Cher',
+  ]);
+  expect(
+    ['abc', 'ab', 'aaabc', 'bbabc', 'BBabc'].sort(searchSort('abc')),
+  ).toEqual(['abc', 'aaabc', 'bbabc', 'BBabc', 'ab']);
+});
+
+test('Sort same case first', async () => {
+  expect(['%f %B', '%F %b'].sort(searchSort('%F'))).toEqual(['%F %b', '%f %B']);
+});

--- a/superset-frontend/src/utils/rankedSearchCompare.ts
+++ b/superset-frontend/src/utils/rankedSearchCompare.ts
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Sort comparator with basic rankings.
+ */
+export function rankedSearchCompare(a: string, b: string, search: string) {
+  const aLower = a.toLowerCase() || '';
+  const bLower = b.toLowerCase() || '';
+  const searchLower = search.toLowerCase() || '';
+  if (!search) return a.localeCompare(b);
+  return (
+    Number(b === search) - Number(a === search) ||
+    Number(b.startsWith(search)) - Number(a.startsWith(search)) ||
+    Number(bLower === searchLower) - Number(aLower === searchLower) ||
+    Number(bLower.startsWith(searchLower)) -
+      Number(aLower.startsWith(searchLower)) ||
+    Number(b.includes(search)) - Number(a.includes(search)) ||
+    Number(bLower.includes(searchLower)) - Number(a.includes(searchLower)) ||
+    a.localeCompare(b)
+  );
+}


### PR DESCRIPTION
### SUMMARY

Sort exact match and startsWith matches in the Select component to top of the list. This improves the user experience when searching a very large list where a partial match may be sorted to the top even when an extract match exists only because the former ranks higher in lexicographic order.

https://github.com/apache/superset/pull/16414 tried to tackle this but the work was put on hold as the Select component was undergoing a significant migration and feature-enrichment. Now that it's more stable,  it's worth giving this problem another go.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

Partial match may be sorted to the top if it ranks higher alphabetically:

<img width="372" alt="Xnip2022-02-22_13-26-49" src="https://user-images.githubusercontent.com/335541/155222372-6b43f547-c234-4f47-ad7f-c68095e89219.png">


#### After

"Starts with" and exact matches always ranks higher, making it easier to search for and select things the users actually want:

<img width="381" alt="Xnip2022-02-22_13-27-09" src="https://user-images.githubusercontent.com/335541/155222384-1b25d068-5451-4065-a2ca-50c59a4c139d.png">



### TESTING INSTRUCTIONS

Go to any Select component and search for things

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
