### PR TITLE
fix: FilterBox date endpoints to use [inclusive, exclusive)

### DIFF
--- a/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
@@ -277,6 +277,7 @@ class FilterBox extends React.PureComponent {
               onOpenDateFilterControl={this.onOpenDateFilterControl}
               onCloseDateFilterControl={this.onCloseDateFilterControl}
               value={this.state.selectedValues[TIME_RANGE] || 'No filter'}
+              endpoints={['inclusive', 'exclusive']}
             />
           </div>
         </div>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
The date filter display for filterboxes was not displaying the proper [inclusive, exclusive) operators. I assume this was missed at some point since all other implementations of date filters set the endpoints to `["inclusive", "exclusive"]` This resolves the issue.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![Screen Shot 2022-02-22 at 2 11 03 PM](https://user-images.githubusercontent.com/7409244/155228312-cd914776-45f4-42f4-a123-8071463d42dd.png)
![Screen Shot 2022-02-22 at 2 12 38 PM](https://user-images.githubusercontent.com/7409244/155228370-a11226f2-2ef3-4844-887f-97a44299db25.png)


After:
![Screen Shot 2022-02-22 at 2 05 12 PM](https://user-images.githubusercontent.com/7409244/155228334-dee097b0-5d0f-4fc9-97ff-d1b2bb171d47.png)
![Screen Shot 2022-02-22 at 2 05 17 PM](https://user-images.githubusercontent.com/7409244/155228335-b4da14d8-4717-4f0e-9f1d-56a33a240fd7.png)


### TESTING INSTRUCTIONS
Test in dev with the filter box

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @ktmud @michael-s-molina @graceguo-supercat