### PR TITLE
fix(sqllab/charts): casting from timestamp[us] to timestamp[ns] would result in out of bounds timestamp

### DIFF
--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -177,10 +177,7 @@ class SupersetResultSet:
         try:
             return table.to_pandas(integer_object_nulls=True)
         except pa.lib.ArrowInvalid:
-            return table.to_pandas(
-                integer_object_nulls=True,
-                timestamp_as_object=True
-            )
+            return table.to_pandas(integer_object_nulls=True, timestamp_as_object=True)
 
     @staticmethod
     def first_nonempty(items: List[Any]) -> Any:

--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -174,7 +174,13 @@ class SupersetResultSet:
 
     @staticmethod
     def convert_table_to_df(table: pa.Table) -> pd.DataFrame:
-        return table.to_pandas(integer_object_nulls=True)
+        try:
+            return table.to_pandas(integer_object_nulls=True)
+        except pa.lib.ArrowInvalid:
+            return table.to_pandas(
+                integer_object_nulls=True,
+                timestamp_as_object=True
+            )
 
     @staticmethod
     def first_nonempty(items: List[Any]) -> Any:

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1748,14 +1748,14 @@ def normalize_dttm_col(
             # Column is formatted as a numeric value
             unit = timestamp_format.replace("epoch_", "")
             df[DTTM_ALIAS] = pd.to_datetime(
-                dttm_col, utc=False, unit=unit, origin="unix", errors='coerce'
+                dttm_col, utc=False, unit=unit, origin="unix", errors="coerce"
             )
         else:
             # Column has already been formatted as a timestamp.
             df[DTTM_ALIAS] = dttm_col.apply(pd.Timestamp)
     else:
         df[DTTM_ALIAS] = pd.to_datetime(
-            df[DTTM_ALIAS], utc=False, format=timestamp_format, errors='coerce'
+            df[DTTM_ALIAS], utc=False, format=timestamp_format, errors="coerce"
         )
     if offset:
         df[DTTM_ALIAS] += timedelta(hours=offset)

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1748,14 +1748,14 @@ def normalize_dttm_col(
             # Column is formatted as a numeric value
             unit = timestamp_format.replace("epoch_", "")
             df[DTTM_ALIAS] = pd.to_datetime(
-                dttm_col, utc=False, unit=unit, origin="unix"
+                dttm_col, utc=False, unit=unit, origin="unix", errors='coerce'
             )
         else:
             # Column has already been formatted as a timestamp.
             df[DTTM_ALIAS] = dttm_col.apply(pd.Timestamp)
     else:
         df[DTTM_ALIAS] = pd.to_datetime(
-            df[DTTM_ALIAS], utc=False, format=timestamp_format
+            df[DTTM_ALIAS], utc=False, format=timestamp_format, errors='coerce'
         )
     if offset:
         df[DTTM_ALIAS] += timedelta(hours=offset)

--- a/tests/integration_tests/utils_tests.py
+++ b/tests/integration_tests/utils_tests.py
@@ -1195,3 +1195,8 @@ class TestUtils(SupersetTestCase):
         # test numeric epoch_ms format
         df = pd.DataFrame([{"__timestamp": ts.timestamp() * 1000, "a": 1}])
         assert normalize_col(df, "epoch_ms", 0, None)[DTTM_ALIAS][0] == ts
+
+        # test that out of bounds timestamps are coerced to None instead of
+        # erroring out
+        df = pd.DataFrame([{"__timestamp": "1677-09-21 00:00:00", "a": 1}])
+        assert pd.isnull(normalize_col(df, None, 0, None)[DTTM_ALIAS][0])

--- a/tests/unit_tests/dataframe_test.py
+++ b/tests/unit_tests/dataframe_test.py
@@ -15,6 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=unused-argument, import-outside-toplevel
+from datetime import datetime
+
+import pytest
+from pandas import Timestamp
+
 from superset.dataframe import df_to_records
 from superset.typing import DbapiDescription
 
@@ -53,3 +58,44 @@ def test_js_max_int(app_context: None) -> None:
         {"a": 1, "b": "1239162456494753670", "c": "c1"},
         {"a": 2, "b": 100, "c": "c2"},
     ]
+
+
+@pytest.mark.parametrize(
+    "inpt, expected",
+    [
+        pytest.param(
+            [
+                (datetime.strptime("1677-09-22 00:12:43", "%Y-%m-%d %H:%M:%S"), 1),
+                (datetime.strptime("2262-04-11 23:47:17", "%Y-%m-%d %H:%M:%S"), 2),
+            ],
+            [
+                {"a": datetime.strptime("1677-09-22 00:12:43", "%Y-%m-%d %H:%M:%S"), "b": 1},
+                {"a": datetime.strptime("2262-04-11 23:47:17", "%Y-%m-%d %H:%M:%S"), "b": 2},
+            ],
+            id="timestamp conversion fail"
+        ),
+        pytest.param(
+            [
+                (datetime.strptime("1677-09-22 00:12:44", "%Y-%m-%d %H:%M:%S"), 1),
+                (datetime.strptime("2262-04-11 23:47:16", "%Y-%m-%d %H:%M:%S"), 2)
+            ],
+            [
+                {"a": Timestamp("1677-09-22 00:12:44"), "b": 1},
+                {"a": Timestamp("2262-04-11 23:47:16"), "b": 2}
+            ],
+            id="timestamp conversion success"
+        )
+    ]
+)
+def test_max_pandas_timestamp(inpt, expected) -> None:
+    from superset.db_engine_specs import BaseEngineSpec
+    from superset.result_set import SupersetResultSet
+
+    cursor_descr: DbapiDescription = [
+        ("a", "datetime", None, None, None, None, False),
+        ("b", "int", None, None, None, None, False),
+    ]
+    results = SupersetResultSet(inpt, cursor_descr, BaseEngineSpec)
+    df = results.to_pandas_df()
+
+    assert df_to_records(df) == expected

--- a/tests/unit_tests/dataframe_test.py
+++ b/tests/unit_tests/dataframe_test.py
@@ -61,7 +61,7 @@ def test_js_max_int(app_context: None) -> None:
 
 
 @pytest.mark.parametrize(
-    "inpt, expected",
+    "input_, expected",
     [
         pytest.param(
             [
@@ -69,25 +69,31 @@ def test_js_max_int(app_context: None) -> None:
                 (datetime.strptime("2262-04-11 23:47:17", "%Y-%m-%d %H:%M:%S"), 2),
             ],
             [
-                {"a": datetime.strptime("1677-09-22 00:12:43", "%Y-%m-%d %H:%M:%S"), "b": 1},
-                {"a": datetime.strptime("2262-04-11 23:47:17", "%Y-%m-%d %H:%M:%S"), "b": 2},
+                {
+                    "a": datetime.strptime("1677-09-22 00:12:43", "%Y-%m-%d %H:%M:%S"),
+                    "b": 1,
+                },
+                {
+                    "a": datetime.strptime("2262-04-11 23:47:17", "%Y-%m-%d %H:%M:%S"),
+                    "b": 2,
+                },
             ],
-            id="timestamp conversion fail"
+            id="timestamp conversion fail",
         ),
         pytest.param(
             [
                 (datetime.strptime("1677-09-22 00:12:44", "%Y-%m-%d %H:%M:%S"), 1),
-                (datetime.strptime("2262-04-11 23:47:16", "%Y-%m-%d %H:%M:%S"), 2)
+                (datetime.strptime("2262-04-11 23:47:16", "%Y-%m-%d %H:%M:%S"), 2),
             ],
             [
                 {"a": Timestamp("1677-09-22 00:12:44"), "b": 1},
-                {"a": Timestamp("2262-04-11 23:47:16"), "b": 2}
+                {"a": Timestamp("2262-04-11 23:47:16"), "b": 2},
             ],
-            id="timestamp conversion success"
-        )
-    ]
+            id="timestamp conversion success",
+        ),
+    ],
 )
-def test_max_pandas_timestamp(inpt, expected) -> None:
+def test_max_pandas_timestamp(input_, expected) -> None:
     from superset.db_engine_specs import BaseEngineSpec
     from superset.result_set import SupersetResultSet
 
@@ -95,7 +101,7 @@ def test_max_pandas_timestamp(inpt, expected) -> None:
         ("a", "datetime", None, None, None, None, False),
         ("b", "int", None, None, None, None, False),
     ]
-    results = SupersetResultSet(inpt, cursor_descr, BaseEngineSpec)
+    results = SupersetResultSet(input_, cursor_descr, BaseEngineSpec)
     df = results.to_pandas_df()
 
     assert df_to_records(df) == expected


### PR DESCRIPTION
### SUMMARY
Addresses #18871, #18596, #16487, #13661. This allows users to query date columns outside the maximum ranges of pandas timestamps: `1677-09-22 00:12:43.145225` and `2262-04-11 23:47:16.854775807`.

The same fix as #14006, with a small additional fix for charts to hide the timestamps it cannot convert.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Sql Lab before:
![image](https://user-images.githubusercontent.com/30076090/155315294-63df3e8a-c03b-4c06-bbca-b15f1bbfc3c9.png)

Sql Lab after can query past the date ranges mentioned above:
![image](https://user-images.githubusercontent.com/30076090/155314512-2450154e-9b73-498b-9d4c-42123a4ee4d9.png)

Charts before:
![image](https://user-images.githubusercontent.com/30076090/155315241-23c32087-479a-44a5-80ca-740133b38e5e.png)

Charts after now show data, excluding the dates that reside outside this period:
![image](https://user-images.githubusercontent.com/30076090/155313496-917fb149-eab0-4fca-b788-5ef87e1656fb.png)

### TESTING INSTRUCTIONS
1. In Sql lab, try running `select TIMESTAMP any_timestamp_outside_ranges_mentioned_above`
2. In charts, select a timeseries chart, and add a column with date ranges outside what's supported in pandas in the `TIME COLUMN`, it should still return a chart successfully and omit showing the date ranges that are unsupported.

### ADDITIONAL INFORMATION

- [X] Has associated issue: fixes #18871, fixes #18596, fixes #16487
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
