### PR TITLE
feat(native-filters): Implement filter cards

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CascadeFilters/CascadePopover/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CascadeFilters/CascadePopover/index.tsx
@@ -38,7 +38,6 @@ import { Pill } from 'src/dashboard/components/FiltersBadge/Styles';
 import FilterControl from 'src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl';
 import CascadeFilterControl from 'src/dashboard/components/nativeFilters/FilterBar/CascadeFilters/CascadeFilterControl';
 import { CascadeFilter } from 'src/dashboard/components/nativeFilters/FilterBar/CascadeFilters/types';
-import { FilterCard } from '../../../FilterCard';
 
 interface CascadePopoverProps {
   dataMaskSelected: DataMaskStateWithId;
@@ -164,15 +163,13 @@ const CascadePopover: React.FC<CascadePopoverProps> = ({
 
   if (!filter.cascadeChildren?.length) {
     return (
-      <FilterCard filter={filter}>
-        <FilterControl
-          dataMaskSelected={dataMaskSelected}
-          filter={filter}
-          directPathToChild={directPathToChild}
-          onFilterSelectionChange={onFilterSelectionChange}
-          inView={inView}
-        />
-      </FilterCard>
+      <FilterControl
+        dataMaskSelected={dataMaskSelected}
+        filter={filter}
+        directPathToChild={directPathToChild}
+        onFilterSelectionChange={onFilterSelectionChange}
+        inView={inView}
+      />
     );
   }
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CascadeFilters/CascadePopover/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CascadeFilters/CascadePopover/index.tsx
@@ -38,6 +38,7 @@ import { Pill } from 'src/dashboard/components/FiltersBadge/Styles';
 import FilterControl from 'src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl';
 import CascadeFilterControl from 'src/dashboard/components/nativeFilters/FilterBar/CascadeFilters/CascadeFilterControl';
 import { CascadeFilter } from 'src/dashboard/components/nativeFilters/FilterBar/CascadeFilters/types';
+import { FilterCard } from '../../../FilterCard';
 
 interface CascadePopoverProps {
   dataMaskSelected: DataMaskStateWithId;
@@ -163,13 +164,15 @@ const CascadePopover: React.FC<CascadePopoverProps> = ({
 
   if (!filter.cascadeChildren?.length) {
     return (
-      <FilterControl
-        dataMaskSelected={dataMaskSelected}
-        filter={filter}
-        directPathToChild={directPathToChild}
-        onFilterSelectionChange={onFilterSelectionChange}
-        inView={inView}
-      />
+      <FilterCard filter={filter}>
+        <FilterControl
+          dataMaskSelected={dataMaskSelected}
+          filter={filter}
+          directPathToChild={directPathToChild}
+          onFilterSelectionChange={onFilterSelectionChange}
+          inView={inView}
+        />
+      </FilterCard>
     );
   }
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -44,10 +44,6 @@ const Wrapper = styled.div`
   padding: ${({ theme }) => theme.gridUnit * 4}px;
   // 108px padding to make room for buttons with position: absolute
   padding-bottom: ${({ theme }) => theme.gridUnit * 27}px;
-
-  &:hover {
-    cursor: pointer;
-  }
 `;
 
 type FilterControlsProps = {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/DependenciesRow.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/DependenciesRow.tsx
@@ -29,6 +29,7 @@ import {
   RowTruncationCount,
   RowValue,
   TooltipList,
+  TooltipTrigger,
 } from './Styles';
 import { useFilterDependencies } from './useFilterDependencies';
 import { useTruncation } from './useTruncation';
@@ -48,7 +49,7 @@ const DependencyValue = ({ dependency, label }: DependencyValueProps) => {
 
 export const DependenciesRow = React.memo(({ filter }: FilterCardRowProps) => {
   const dependencies = useFilterDependencies(filter);
-  const dependenciesRef = useRef<HTMLElement>(null);
+  const dependenciesRef = useRef<HTMLDivElement>(null);
   const [elementsTruncated, hasHiddenElements] = useTruncation(dependenciesRef);
   const theme = useTheme();
 
@@ -99,25 +100,27 @@ export const DependenciesRow = React.memo(({ filter }: FilterCardRowProps) => {
         title={tooltipText}
         placement="bottom"
       >
-        <RowValue ref={dependenciesRef}>
-          {dependencies.map((dependency, index) =>
-            index === 0 ? (
-              <DependencyValue
-                dependency={dependency}
-                label={dependency.name}
-              />
-            ) : (
-              <DependencyValue
-                dependency={dependency}
-                label={`, ${dependency.name}`}
-              />
-            ),
+        <TooltipTrigger>
+          <RowValue ref={dependenciesRef}>
+            {dependencies.map((dependency, index) =>
+              index === 0 ? (
+                <DependencyValue
+                  dependency={dependency}
+                  label={dependency.name}
+                />
+              ) : (
+                <DependencyValue
+                  dependency={dependency}
+                  label={`, ${dependency.name}`}
+                />
+              ),
+            )}
+          </RowValue>
+          {hasHiddenElements && (
+            <RowTruncationCount>+{elementsTruncated}</RowTruncationCount>
           )}
-        </RowValue>
+        </TooltipTrigger>
       </Tooltip>
-      {hasHiddenElements && (
-        <RowTruncationCount>+{elementsTruncated}</RowTruncationCount>
-      )}
     </Row>
   ) : null;
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/DependenciesRow.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/DependenciesRow.tsx
@@ -1,0 +1,123 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { useCallback, useMemo, useRef } from 'react';
+import { useDispatch } from 'react-redux';
+import { css, t, useTheme } from '@superset-ui/core';
+import { setDirectPathToChild } from 'src/dashboard/actions/dashboardState';
+import Icons from 'src/components/Icons';
+import { Tooltip } from 'src/components/Tooltip';
+import {
+  DependencyItem,
+  Row,
+  RowLabel,
+  RowTruncationCount,
+  RowValue,
+  TooltipList,
+} from './Styles';
+import { useFilterDependencies } from './useFilterDependencies';
+import { useTruncation } from './useTruncation';
+import { DependencyValueProps, FilterCardRowProps } from './types';
+
+const DependencyValue = ({ dependency, label }: DependencyValueProps) => {
+  const dispatch = useDispatch();
+  const handleClick = useCallback(() => {
+    dispatch(setDirectPathToChild([dependency.id]));
+  }, [dependency.id, dispatch]);
+  return (
+    <DependencyItem role="button" onClick={handleClick} tabIndex={0}>
+      {label}
+    </DependencyItem>
+  );
+};
+
+export const DependenciesRow = React.memo(({ filter }: FilterCardRowProps) => {
+  const dependencies = useFilterDependencies(filter);
+  const dependenciesRef = useRef<HTMLElement>(null);
+  const [elementsTruncated, hasHiddenElements] = useTruncation(dependenciesRef);
+  const theme = useTheme();
+
+  const tooltipText = useMemo(
+    () =>
+      elementsTruncated > 0 && dependencies ? (
+        <TooltipList>
+          {dependencies.map(dependency => (
+            <li>
+              <DependencyValue
+                dependency={dependency}
+                label={dependency.name}
+              />
+            </li>
+          ))}
+        </TooltipList>
+      ) : null,
+    [elementsTruncated, dependencies],
+  );
+
+  return Array.isArray(dependencies) && dependencies.length > 0 ? (
+    <Row>
+      <RowLabel
+        css={css`
+          display: inline-flex;
+          align-items: center;
+        `}
+      >
+        Dependent on{' '}
+        <Tooltip
+          title={t(
+            'Filter only displays values relevant to selections made in other filters.',
+          )}
+          placement="bottom"
+          overlayClassName="filter-card-tooltip"
+        >
+          <Icons.Info
+            iconSize="s"
+            iconColor={theme.colors.grayscale.light1}
+            css={css`
+              margin-left: ${theme.gridUnit}px;
+            `}
+          />
+        </Tooltip>
+      </RowLabel>
+      <Tooltip
+        overlayClassName="filter-card-tooltip"
+        title={tooltipText}
+        placement="bottom"
+      >
+        <RowValue ref={dependenciesRef}>
+          {dependencies.map((dependency, index) =>
+            index === 0 ? (
+              <DependencyValue
+                dependency={dependency}
+                label={dependency.name}
+              />
+            ) : (
+              <DependencyValue
+                dependency={dependency}
+                label={`, ${dependency.name}`}
+              />
+            ),
+          )}
+        </RowValue>
+      </Tooltip>
+      {hasHiddenElements && (
+        <RowTruncationCount>+{elementsTruncated}</RowTruncationCount>
+      )}
+    </Row>
+  ) : null;
+});

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/DependenciesRow.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/DependenciesRow.tsx
@@ -70,7 +70,10 @@ export const DependenciesRow = React.memo(({ filter }: FilterCardRowProps) => {
     [elementsTruncated, dependencies],
   );
 
-  return Array.isArray(dependencies) && dependencies.length > 0 ? (
+  if (!Array.isArray(dependencies) || dependencies.length === 0) {
+    return null;
+  }
+  return (
     <Row>
       <RowLabel
         css={css`
@@ -78,7 +81,7 @@ export const DependenciesRow = React.memo(({ filter }: FilterCardRowProps) => {
           align-items: center;
         `}
       >
-        Dependent on{' '}
+        {t('Dependent on')}{' '}
         <Tooltip
           title={t(
             'Filter only displays values relevant to selections made in other filters.',
@@ -102,19 +105,12 @@ export const DependenciesRow = React.memo(({ filter }: FilterCardRowProps) => {
       >
         <TooltipTrigger>
           <RowValue ref={dependenciesRef}>
-            {dependencies.map((dependency, index) =>
-              index === 0 ? (
-                <DependencyValue
-                  dependency={dependency}
-                  label={dependency.name}
-                />
-              ) : (
-                <DependencyValue
-                  dependency={dependency}
-                  label={`, ${dependency.name}`}
-                />
-              ),
-            )}
+            {dependencies.map((dependency, index) => (
+              <DependencyValue
+                dependency={dependency}
+                label={index === 0 ? dependency.name : `, ${dependency.name}`}
+              />
+            ))}
           </RowValue>
           {hasHiddenElements && (
             <RowTruncationCount>+{elementsTruncated}</RowTruncationCount>
@@ -122,5 +118,5 @@ export const DependenciesRow = React.memo(({ filter }: FilterCardRowProps) => {
         </TooltipTrigger>
       </Tooltip>
     </Row>
-  ) : null;
+  );
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/DependenciesRow.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/DependenciesRow.tsx
@@ -21,7 +21,6 @@ import { useDispatch } from 'react-redux';
 import { css, t, useTheme } from '@superset-ui/core';
 import { setDirectPathToChild } from 'src/dashboard/actions/dashboardState';
 import Icons from 'src/components/Icons';
-import { Tooltip } from 'src/components/Tooltip';
 import {
   DependencyItem,
   Row,
@@ -29,11 +28,11 @@ import {
   RowTruncationCount,
   RowValue,
   TooltipList,
-  TooltipTrigger,
 } from './Styles';
 import { useFilterDependencies } from './useFilterDependencies';
 import { useTruncation } from './useTruncation';
 import { DependencyValueProps, FilterCardRowProps } from './types';
+import { TooltipWithTruncation } from './TooltipWithTruncation';
 
 const DependencyValue = ({ dependency, label }: DependencyValueProps) => {
   const dispatch = useDispatch();
@@ -82,12 +81,10 @@ export const DependenciesRow = React.memo(({ filter }: FilterCardRowProps) => {
         `}
       >
         {t('Dependent on')}{' '}
-        <Tooltip
+        <TooltipWithTruncation
           title={t(
             'Filter only displays values relevant to selections made in other filters.',
           )}
-          placement="bottom"
-          overlayClassName="filter-card-tooltip"
         >
           <Icons.Info
             iconSize="s"
@@ -96,27 +93,21 @@ export const DependenciesRow = React.memo(({ filter }: FilterCardRowProps) => {
               margin-left: ${theme.gridUnit}px;
             `}
           />
-        </Tooltip>
+        </TooltipWithTruncation>
       </RowLabel>
-      <Tooltip
-        overlayClassName="filter-card-tooltip"
-        title={tooltipText}
-        placement="bottom"
-      >
-        <TooltipTrigger>
-          <RowValue ref={dependenciesRef}>
-            {dependencies.map((dependency, index) => (
-              <DependencyValue
-                dependency={dependency}
-                label={index === 0 ? dependency.name : `, ${dependency.name}`}
-              />
-            ))}
-          </RowValue>
-          {hasHiddenElements && (
-            <RowTruncationCount>+{elementsTruncated}</RowTruncationCount>
-          )}
-        </TooltipTrigger>
-      </Tooltip>
+      <TooltipWithTruncation title={tooltipText}>
+        <RowValue ref={dependenciesRef}>
+          {dependencies.map((dependency, index) => (
+            <DependencyValue
+              dependency={dependency}
+              label={index === 0 ? dependency.name : `, ${dependency.name}`}
+            />
+          ))}
+        </RowValue>
+        {hasHiddenElements && (
+          <RowTruncationCount>+{elementsTruncated}</RowTruncationCount>
+        )}
+      </TooltipWithTruncation>
     </Row>
   );
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/FilterCardContent.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/FilterCardContent.tsx
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useMemo } from 'react';
+import {
+  css,
+  Filter,
+  getChartMetadataRegistry,
+  SupersetTheme,
+  t,
+} from '@superset-ui/core';
+import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
+import Icons from 'src/components/Icons';
+import { useFilterDependencies } from './useFilterDependencies';
+import { Row, RowLabel, RowValue } from './Styles';
+import { ScopeRow } from './ScopeRow';
+
+export const FilterCardContent = ({ filter }: { filter: Filter }) => {
+  const metadata = useMemo(
+    () => getChartMetadataRegistry().get(filter.filterType),
+    [filter.filterType],
+  );
+  const dependencies = useFilterDependencies(filter);
+  return (
+    <div>
+      <Row
+        css={(theme: SupersetTheme) =>
+          css`
+            margin-bottom: ${theme.gridUnit * 3}px;
+          `
+        }
+      >
+        <Icons.FilterSmall
+          css={(theme: SupersetTheme) =>
+            css`
+              margin-right: ${theme.gridUnit}px;
+            `
+          }
+        />
+        <span>{filter.name}</span>
+      </Row>
+      <Row>
+        <RowLabel>{t('Filter type')}</RowLabel>
+        <RowValue>{metadata?.name}</RowValue>
+      </Row>
+      <ScopeRow filter={filter} />
+      {dependencies.length > 0 && (
+        <Row>
+          <RowLabel>
+            Dependent on{' '}
+            <span>
+              <InfoTooltipWithTrigger
+                tooltip={t(
+                  'Filter only displays values relevant to selections made in other filters.',
+                )}
+                label={t('dependent on')}
+              />
+            </span>
+          </RowLabel>
+          <RowValue>
+            {dependencies.map(dependency => dependency.name).join(', ')}
+          </RowValue>
+        </Row>
+      )}
+    </div>
+  );
+};

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/NameRow.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/NameRow.tsx
@@ -16,19 +16,27 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 import React from 'react';
-import { Filter } from '@superset-ui/core';
-import { ScopeRow } from './ScopeRow';
-import { DependenciesRow } from './DependenciesRow';
-import { NameRow } from './NameRow';
-import { TypeRow } from './TypeRow';
+import { css, SupersetTheme } from '@superset-ui/core';
+import Icons from 'src/components/Icons';
+import { Row } from './Styles';
+import { FilterCardRowProps } from './types';
 
-export const FilterCardContent = ({ filter }: { filter: Filter }) => (
-  <div>
-    <NameRow filter={filter} />
-    <TypeRow filter={filter} />
-    <ScopeRow filter={filter} />
-    <DependenciesRow filter={filter} />
-  </div>
+export const NameRow = ({ filter }: FilterCardRowProps) => (
+  <Row
+    css={(theme: SupersetTheme) =>
+      css`
+        margin-bottom: ${theme.gridUnit * 3}px;
+      `
+    }
+  >
+    <Icons.FilterSmall
+      css={(theme: SupersetTheme) =>
+        css`
+          margin-right: ${theme.gridUnit}px;
+        `
+      }
+    />
+    <span>{filter.name}</span>
+  </Row>
 );

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/NameRow.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/NameRow.tsx
@@ -16,27 +16,35 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
+import React, { useRef } from 'react';
 import { css, SupersetTheme } from '@superset-ui/core';
 import Icons from 'src/components/Icons';
-import { Row } from './Styles';
+import { Row, FilterName } from './Styles';
 import { FilterCardRowProps } from './types';
+import { useTruncation } from './useTruncation';
+import { TooltipWithTruncation } from './TooltipWithTruncation';
 
-export const NameRow = ({ filter }: FilterCardRowProps) => (
-  <Row
-    css={(theme: SupersetTheme) =>
-      css`
-        margin-bottom: ${theme.gridUnit * 3}px;
-      `
-    }
-  >
-    <Icons.FilterSmall
+export const NameRow = ({ filter }: FilterCardRowProps) => {
+  const filterNameRef = useRef<HTMLElement>(null);
+  const [elementsTruncated] = useTruncation(filterNameRef);
+  return (
+    <Row
       css={(theme: SupersetTheme) =>
         css`
-          margin-right: ${theme.gridUnit}px;
+          margin-bottom: ${theme.gridUnit * 3}px;
         `
       }
-    />
-    <span>{filter.name}</span>
-  </Row>
-);
+    >
+      <Icons.FilterSmall
+        css={(theme: SupersetTheme) =>
+          css`
+            margin-right: ${theme.gridUnit}px;
+          `
+        }
+      />
+      <TooltipWithTruncation title={elementsTruncated ? filter.name : null}>
+        <FilterName ref={filterNameRef}>{filter.name}</FilterName>
+      </TooltipWithTruncation>
+    </Row>
+  );
+};

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/ScopeRow.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/ScopeRow.tsx
@@ -48,7 +48,10 @@ export const ScopeRow = React.memo(({ filter }: FilterCardRowProps) => {
     [elementsTruncated, scope],
   );
 
-  return Array.isArray(scope) && scope.length > 0 ? (
+  if (!Array.isArray(scope) || scope.length === 0) {
+    return null;
+  }
+  return (
     <Row>
       <RowLabel>{t('Scope')}</RowLabel>
       <Tooltip
@@ -58,9 +61,9 @@ export const ScopeRow = React.memo(({ filter }: FilterCardRowProps) => {
       >
         <TooltipTrigger>
           <RowValue ref={scopeRef}>
-            {scope.map((element, index) =>
-              index === 0 ? <span>{element}</span> : <span>, {element}</span>,
-            )}
+            {scope.map((element, index) => (
+              <span>{index === 0 ? element : `, {element}`}</span>
+            ))}
           </RowValue>
           {hasHiddenElements > 0 && (
             <RowTruncationCount>+{elementsTruncated}</RowTruncationCount>
@@ -68,5 +71,5 @@ export const ScopeRow = React.memo(({ filter }: FilterCardRowProps) => {
         </TooltipTrigger>
       </Tooltip>
     </Row>
-  ) : null;
+  );
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/ScopeRow.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/ScopeRow.tsx
@@ -26,13 +26,14 @@ import {
   RowTruncationCount,
   RowValue,
   TooltipList,
+  TooltipTrigger,
 } from './Styles';
 import { useTruncation } from './useTruncation';
 import { FilterCardRowProps } from './types';
 
 export const ScopeRow = React.memo(({ filter }: FilterCardRowProps) => {
   const scope = useFilterScope(filter);
-  const scopeRef = useRef<HTMLElement>(null);
+  const scopeRef = useRef<HTMLDivElement>(null);
 
   const [elementsTruncated, hasHiddenElements] = useTruncation(scopeRef);
   const tooltipText = useMemo(
@@ -55,15 +56,17 @@ export const ScopeRow = React.memo(({ filter }: FilterCardRowProps) => {
         placement="bottom"
         overlayClassName="filter-card-tooltip"
       >
-        <RowValue ref={scopeRef}>
-          {scope.map((element, index) =>
-            index === 0 ? <span>{element}</span> : <span>, {element}</span>,
+        <TooltipTrigger>
+          <RowValue ref={scopeRef}>
+            {scope.map((element, index) =>
+              index === 0 ? <span>{element}</span> : <span>, {element}</span>,
+            )}
+          </RowValue>
+          {hasHiddenElements > 0 && (
+            <RowTruncationCount>+{elementsTruncated}</RowTruncationCount>
           )}
-        </RowValue>
+        </TooltipTrigger>
       </Tooltip>
-      {hasHiddenElements > 0 && (
-        <RowTruncationCount>+{elementsTruncated}</RowTruncationCount>
-      )}
     </Row>
   ) : null;
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/ScopeRow.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/ScopeRow.tsx
@@ -18,7 +18,6 @@
  */
 import React, { useMemo, useRef } from 'react';
 import { t } from '@superset-ui/core';
-import { Tooltip } from 'src/components/Tooltip';
 import { useFilterScope } from './useFilterScope';
 import {
   Row,
@@ -26,10 +25,10 @@ import {
   RowTruncationCount,
   RowValue,
   TooltipList,
-  TooltipTrigger,
 } from './Styles';
 import { useTruncation } from './useTruncation';
 import { FilterCardRowProps } from './types';
+import { TooltipWithTruncation } from './TooltipWithTruncation';
 
 export const ScopeRow = React.memo(({ filter }: FilterCardRowProps) => {
   const scope = useFilterScope(filter);
@@ -54,22 +53,16 @@ export const ScopeRow = React.memo(({ filter }: FilterCardRowProps) => {
   return (
     <Row>
       <RowLabel>{t('Scope')}</RowLabel>
-      <Tooltip
-        title={tooltipText}
-        placement="bottom"
-        overlayClassName="filter-card-tooltip"
-      >
-        <TooltipTrigger>
-          <RowValue ref={scopeRef}>
-            {scope.map((element, index) => (
-              <span>{index === 0 ? element : `, {element}`}</span>
-            ))}
-          </RowValue>
-          {hasHiddenElements > 0 && (
-            <RowTruncationCount>+{elementsTruncated}</RowTruncationCount>
-          )}
-        </TooltipTrigger>
-      </Tooltip>
+      <TooltipWithTruncation title={tooltipText}>
+        <RowValue ref={scopeRef}>
+          {scope.map((element, index) => (
+            <span>{index === 0 ? element : `, ${element}`}</span>
+          ))}
+        </RowValue>
+        {hasHiddenElements > 0 && (
+          <RowTruncationCount>+{elementsTruncated}</RowTruncationCount>
+        )}
+      </TooltipWithTruncation>
     </Row>
   );
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/ScopeRow.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/ScopeRow.tsx
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { ReactNode, useLayoutEffect, useRef, useState } from 'react';
+import { Filter, t } from '@superset-ui/core';
+import { Tooltip } from 'src/components/Tooltip';
+import { useFilterScope } from './useFilterScope';
+import { Row, RowLabel, RowTruncationCount, RowValue } from './Styles';
+
+export const isLabelTruncated = (labelRef?: React.RefObject<any>) =>
+  !!(
+    labelRef &&
+    labelRef.current &&
+    labelRef.current.scrollWidth > labelRef.current.clientWidth
+  );
+
+export const ScopeRow = ({ filter }: { filter: Filter }) => {
+  const scope = useFilterScope(filter);
+  const scopeRef = useRef(null);
+  const [elementsTruncated] = useState(5);
+  const [tooltipText, setTooltipText] = useState<ReactNode | string | null>(
+    null,
+  );
+
+  useLayoutEffect(() => {
+    if (isLabelTruncated(scopeRef)) {
+      setTooltipText(scope?.map(val => <div>{val}</div>));
+    }
+  }, [scope]);
+
+  console.log({ tooltipText });
+  return Array.isArray(scope) && scope.length > 0 ? (
+    <Row>
+      <RowLabel>{t('Scope')}</RowLabel>
+
+      <RowValue ref={scopeRef}>
+        <Tooltip title={tooltipText}>{scope.join(', ')}</Tooltip>
+      </RowValue>
+      {elementsTruncated && (
+        <RowTruncationCount>+{elementsTruncated}</RowTruncationCount>
+      )}
+    </Row>
+  ) : null;
+};

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/Styles.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/Styles.ts
@@ -51,7 +51,7 @@ export const Row = styled.div`
     font-size: ${theme.typography.sizes.s}px;
 
     & .ant-tooltip-open {
-      display: inline;
+      display: inline-flex;
     }
   `};
 `;
@@ -66,13 +66,14 @@ export const RowLabel = styled.span`
   `};
 `;
 
-export const RowValue = styled.span`
+export const RowValue = styled.div`
   ${({ theme }) => css`
     color: ${theme.colors.grayscale.dark1};
     font-size: ${theme.typography.sizes.s}px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    display: inline;
   `};
 `;
 
@@ -92,4 +93,10 @@ export const TooltipList = styled.ul`
     padding-left: ${theme.gridUnit * 3}px;
     margin-bottom: 0;
   `};
+`;
+
+export const TooltipTrigger = styled.div`
+  min-width: 0;
+  display: inline-flex;
+  white-space: nowrap;
 `;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/Styles.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/Styles.ts
@@ -52,12 +52,17 @@ export const RowLabel = styled.span`
 export const RowValue = styled.div`
   ${({ theme }) => css`
     color: ${theme.colors.grayscale.dark1};
-    font-size: ${theme.typography.sizes.s}px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
     display: inline;
   `};
+`;
+
+export const FilterName = styled.span`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 export const DependencyItem = styled.span`

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/Styles.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/Styles.ts
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { css, styled } from '@superset-ui/core';
+
+export const Styles = styled.div`
+  ${({ theme }) => css`
+    .filter-card-popover {
+      width: 240px;
+      padding: 0;
+      border-radius: 4px;
+
+      .ant-popover-inner-content {
+        padding: ${theme.gridUnit * 4}px;
+      }
+
+      .ant-popover-arrow {
+        display: none;
+      }
+    }
+  `}
+`;
+
+export const Row = styled.div`
+  ${({ theme }) => css`
+    display: flex;
+    align-items: center;
+    margin: ${theme.gridUnit}px 0;
+    font-size: ${theme.typography.sizes.s}px;
+  `};
+`;
+
+export const RowLabel = styled.span`
+  ${({ theme }) => css`
+    color: ${theme.colors.grayscale.base};
+    padding-right: ${theme.gridUnit * 4}px;
+    margin-right: auto;
+    text-transform: uppercase;
+  `};
+`;
+
+export const RowValue = styled.span`
+  ${({ theme }) => css`
+    color: ${theme.colors.grayscale.dark1};
+    font-size: ${theme.typography.sizes.s}px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `};
+`;
+
+export const RowTruncationCount = styled.span`
+  ${({ theme }) => css`
+    color: ${theme.colors.primary.base};
+  `}
+`;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/Styles.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/Styles.ts
@@ -16,24 +16,31 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { css, styled } from '@superset-ui/core';
+import { css, styled, SupersetTheme } from '@superset-ui/core';
 
-export const Styles = styled.div`
-  ${({ theme }) => css`
-    .filter-card-popover {
-      width: 240px;
-      padding: 0;
-      border-radius: 4px;
+export const popoverStyle = (theme: SupersetTheme) => css`
+  .filter-card-popover {
+    width: 240px;
+    padding: 0;
+    border-radius: 4px;
 
-      .ant-popover-inner-content {
-        padding: ${theme.gridUnit * 4}px;
-      }
+    .ant-popover-inner-content {
+      padding: ${theme.gridUnit * 4}px;
+    }
 
-      .ant-popover-arrow {
-        display: none;
+    .ant-popover-arrow {
+      display: none;
+    }
+  }
+
+  .filter-card-tooltip {
+    &.ant-tooltip-placement-bottom {
+      padding-top: 0;
+      & .ant-tooltip-arrow {
+        top: -13px;
       }
     }
-  `}
+  }
 `;
 
 export const Row = styled.div`
@@ -42,6 +49,10 @@ export const Row = styled.div`
     align-items: center;
     margin: ${theme.gridUnit}px 0;
     font-size: ${theme.typography.sizes.s}px;
+
+    & .ant-tooltip-open {
+      display: inline;
+    }
   `};
 `;
 
@@ -51,6 +62,7 @@ export const RowLabel = styled.span`
     padding-right: ${theme.gridUnit * 4}px;
     margin-right: auto;
     text-transform: uppercase;
+    white-space: nowrap;
   `};
 `;
 
@@ -64,8 +76,20 @@ export const RowValue = styled.span`
   `};
 `;
 
+export const DependencyItem = styled.span`
+  text-decoration: underline;
+  cursor: pointer;
+`;
+
 export const RowTruncationCount = styled.span`
   ${({ theme }) => css`
     color: ${theme.colors.primary.base};
   `}
+`;
+
+export const TooltipList = styled.ul`
+  ${({ theme }) => css`
+    padding-left: ${theme.gridUnit * 3}px;
+    margin-bottom: 0;
+  `};
 `;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/Styles.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/Styles.ts
@@ -16,32 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { css, styled, SupersetTheme } from '@superset-ui/core';
-
-export const popoverStyle = (theme: SupersetTheme) => css`
-  .filter-card-popover {
-    width: 240px;
-    padding: 0;
-    border-radius: 4px;
-
-    .ant-popover-inner-content {
-      padding: ${theme.gridUnit * 4}px;
-    }
-
-    .ant-popover-arrow {
-      display: none;
-    }
-  }
-
-  .filter-card-tooltip {
-    &.ant-tooltip-placement-bottom {
-      padding-top: 0;
-      & .ant-tooltip-arrow {
-        top: -13px;
-      }
-    }
-  }
-`;
+import { css, styled } from '@superset-ui/core';
 
 export const Row = styled.div`
   ${({ theme }) => css`

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/Styles.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/Styles.ts
@@ -50,6 +50,14 @@ export const Row = styled.div`
     margin: ${theme.gridUnit}px 0;
     font-size: ${theme.typography.sizes.s}px;
 
+    &:first-of-type {
+      margin-top: 0;
+    }
+
+    &:last-of-type {
+      margin-bottom: 0;
+    }
+
     & .ant-tooltip-open {
       display: inline-flex;
     }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/TooltipWithTruncation.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/TooltipWithTruncation.tsx
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { TooltipProps } from 'antd/lib/tooltip';
+import { Tooltip } from 'src/components/Tooltip';
+import { TooltipTrigger } from './Styles';
+
+export const TooltipWithTruncation = ({
+  title,
+  children,
+  ...props
+}: TooltipProps) => (
+  <Tooltip
+    title={title}
+    placement="bottom"
+    overlayClassName="filter-card-tooltip"
+    {...props}
+  >
+    <TooltipTrigger>{children}</TooltipTrigger>
+  </Tooltip>
+);

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/TypeRow.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/TypeRow.tsx
@@ -16,19 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import React, { useMemo } from 'react';
+import { getChartMetadataRegistry, t } from '@superset-ui/core';
+import { Row, RowLabel, RowValue } from './Styles';
+import { FilterCardRowProps } from './types';
 
-import React from 'react';
-import { Filter } from '@superset-ui/core';
-import { ScopeRow } from './ScopeRow';
-import { DependenciesRow } from './DependenciesRow';
-import { NameRow } from './NameRow';
-import { TypeRow } from './TypeRow';
-
-export const FilterCardContent = ({ filter }: { filter: Filter }) => (
-  <div>
-    <NameRow filter={filter} />
-    <TypeRow filter={filter} />
-    <ScopeRow filter={filter} />
-    <DependenciesRow filter={filter} />
-  </div>
-);
+export const TypeRow = ({ filter }: FilterCardRowProps) => {
+  const metadata = useMemo(
+    () => getChartMetadataRegistry().get(filter.filterType),
+    [filter.filterType],
+  );
+  return (
+    <Row>
+      <RowLabel>{t('Filter type')}</RowLabel>
+      <RowValue>{metadata?.name}</RowValue>
+    </Row>
+  );
+};

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/index.tsx
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { ReactNode } from 'react';
+import { Filter } from '@superset-ui/core';
+import Popover from 'src/components/Popover';
+import { FilterCardContent } from './FilterCardContent';
+import { Styles } from './Styles';
+
+export interface FilterCardProps {
+  children: ReactNode;
+  filter: Filter;
+  triggerNode?: (node: HTMLElement) => HTMLElement;
+}
+
+export const FilterCard = ({
+  children,
+  filter,
+  triggerNode,
+}: FilterCardProps) => {
+  return (
+    <Styles>
+      <Popover
+        placement="bottomLeft"
+        overlayClassName="filter-card-popover"
+        mouseEnterDelay={0.2}
+        mouseLeaveDelay={0.2}
+        content={<FilterCardContent filter={filter} />}
+        visible
+        getPopupContainer={node =>
+          triggerNode?.(node) ??
+          (node.parentNode as HTMLElement) ??
+          document.body
+        }
+      >
+        {children}
+      </Popover>
+    </Styles>
+  );
+};

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/index.tsx
@@ -18,12 +18,9 @@
  */
 
 import React, { useState } from 'react';
-import { Global } from '@emotion/react';
-import { useTheme } from '@superset-ui/core';
 import Popover from 'src/components/Popover';
 import { FilterCardContent } from './FilterCardContent';
 import { FilterCardProps } from './types';
-import { popoverStyle } from './Styles';
 
 export const FilterCard = ({
   children,
@@ -31,27 +28,23 @@ export const FilterCard = ({
   getPopupContainer,
   isVisible: externalIsVisible = true,
 }: FilterCardProps) => {
-  const theme = useTheme();
   const [internalIsVisible, setInternalIsVisible] = useState(false);
 
   return (
-    <>
-      <Global styles={popoverStyle(theme)} />
-      <Popover
-        placement="right"
-        overlayClassName="filter-card-popover"
-        mouseEnterDelay={0.2}
-        mouseLeaveDelay={0.2}
-        onVisibleChange={visible => {
-          setInternalIsVisible(visible);
-        }}
-        visible={externalIsVisible && internalIsVisible}
-        content={<FilterCardContent filter={filter} />}
-        getPopupContainer={getPopupContainer ?? (() => document.body)}
-        destroyTooltipOnHide
-      >
-        {children}
-      </Popover>
-    </>
+    <Popover
+      placement="right"
+      overlayClassName="filter-card-popover"
+      mouseEnterDelay={0.2}
+      mouseLeaveDelay={0.2}
+      onVisibleChange={visible => {
+        setInternalIsVisible(visible);
+      }}
+      visible={externalIsVisible && internalIsVisible}
+      content={<FilterCardContent filter={filter} />}
+      getPopupContainer={getPopupContainer ?? (() => document.body)}
+      destroyTooltipOnHide
+    >
+      {children}
+    </Popover>
   );
 };

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/index.tsx
@@ -17,40 +17,41 @@
  * under the License.
  */
 
-import React, { ReactNode } from 'react';
-import { Filter } from '@superset-ui/core';
+import React, { useState } from 'react';
+import { Global } from '@emotion/react';
+import { useTheme } from '@superset-ui/core';
 import Popover from 'src/components/Popover';
 import { FilterCardContent } from './FilterCardContent';
-import { Styles } from './Styles';
-
-export interface FilterCardProps {
-  children: ReactNode;
-  filter: Filter;
-  triggerNode?: (node: HTMLElement) => HTMLElement;
-}
+import { FilterCardProps } from './types';
+import { popoverStyle } from './Styles';
 
 export const FilterCard = ({
   children,
   filter,
-  triggerNode,
+  getPopupContainer,
+  isVisible: externalIsVisible = true,
 }: FilterCardProps) => {
+  const theme = useTheme();
+  const [internalIsVisible, setInternalIsVisible] = useState(false);
+
   return (
-    <Styles>
+    <>
+      <Global styles={popoverStyle(theme)} />
       <Popover
-        placement="bottomLeft"
+        placement="right"
         overlayClassName="filter-card-popover"
         mouseEnterDelay={0.2}
         mouseLeaveDelay={0.2}
+        onVisibleChange={visible => {
+          setInternalIsVisible(visible);
+        }}
+        visible={externalIsVisible && internalIsVisible}
         content={<FilterCardContent filter={filter} />}
-        visible
-        getPopupContainer={node =>
-          triggerNode?.(node) ??
-          (node.parentNode as HTMLElement) ??
-          document.body
-        }
+        getPopupContainer={getPopupContainer ?? (() => document.body)}
+        destroyTooltipOnHide
       >
         {children}
       </Popover>
-    </Styles>
+    </>
   );
 };

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/types.ts
@@ -16,19 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-import React from 'react';
+import { ReactNode } from 'react';
 import { Filter } from '@superset-ui/core';
-import { ScopeRow } from './ScopeRow';
-import { DependenciesRow } from './DependenciesRow';
-import { NameRow } from './NameRow';
-import { TypeRow } from './TypeRow';
 
-export const FilterCardContent = ({ filter }: { filter: Filter }) => (
-  <div>
-    <NameRow filter={filter} />
-    <TypeRow filter={filter} />
-    <ScopeRow filter={filter} />
-    <DependenciesRow filter={filter} />
-  </div>
-);
+export interface FilterCardProps {
+  children: ReactNode;
+  filter: Filter;
+  getPopupContainer?: (node: HTMLElement) => HTMLElement;
+  isVisible?: boolean;
+}
+
+export interface FilterCardRowProps {
+  filter: Filter;
+}
+
+export interface DependencyValueProps {
+  dependency: Filter;
+  label: string;
+}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/useFilterDependencies.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/useFilterDependencies.ts
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { ensureIsArray, Filter } from '@superset-ui/core';
+import { useSelector } from 'react-redux';
+import { RootState } from 'src/dashboard/types';
+
+export const useFilterDependencies = (filter: Filter) => {
+  const filterDependencyIds = ensureIsArray(filter.cascadeParentIds);
+  return useSelector<RootState, Filter[]>(state => {
+    if (filterDependencyIds.length === 0) {
+      return [];
+    }
+    return filterDependencyIds.reduce((acc: Filter[], filterDependencyId) => {
+      acc.push(state.nativeFilters.filters[filterDependencyId]);
+      return acc;
+    }, []);
+  });
+};

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/useFilterScope.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/useFilterScope.ts
@@ -28,9 +28,9 @@ import { DASHBOARD_ROOT_ID } from 'src/dashboard/util/constants';
 import { CHART_TYPE } from 'src/dashboard/util/componentTypes';
 import { useMemo } from 'react';
 
-const extractTabLabel = (tab: LayoutItem) =>
+const extractTabLabel = (tab?: LayoutItem) =>
   tab?.meta?.text || tab?.meta?.defaultText;
-const extractChartLabel = (chart: LayoutItem) =>
+const extractChartLabel = (chart?: LayoutItem) =>
   chart?.meta?.sliceNameOverride || chart?.meta?.sliceName || chart?.id;
 
 const useCharts = () => {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/useFilterScope.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/useFilterScope.ts
@@ -134,7 +134,7 @@ export const useFilterScope = (filter: Filter) => {
         }, []);
       // Join tab names and chart names
       return topLevelTabsInFullScope
-        .map(tabId => extractChartLabel(layout[tabId]))
+        .map(tabId => extractTabLabel(layout[tabId]))
         .concat(chartsInExcludedTabs.map(extractChartLabel));
     }
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/useTruncation.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/useTruncation.ts
@@ -22,18 +22,20 @@ export const useTruncation = (elementRef: RefObject<HTMLElement>) => {
   const [elementsTruncated, setElementsTruncated] = useState(0);
   const [hasHiddenElements, setHasHiddenElements] = useState(false);
 
+  const currentElement = elementRef.current;
   useLayoutEffect(() => {
-    if (!elementRef.current) {
+    if (!currentElement) {
       return;
     }
-    if (elementRef.current.scrollWidth > elementRef.current.clientWidth) {
-      // "..." is around 6x wide
-      const maxWidth = elementRef.current.clientWidth - 6;
-      const elementsCount = elementRef.current.childNodes.length;
+    const { scrollWidth, clientWidth, childNodes } = currentElement;
+    if (scrollWidth > clientWidth) {
+      // "..." is around 6px wide
+      const maxWidth = clientWidth - 6;
+      const elementsCount = childNodes.length;
       let width = 0;
       let i = 0;
       while (width < maxWidth) {
-        width += (elementRef.current.childNodes[i] as HTMLElement).offsetWidth;
+        width += (childNodes[i] as HTMLElement).offsetWidth;
         i += 1;
       }
       if (i === elementsCount) {
@@ -47,9 +49,9 @@ export const useTruncation = (elementRef: RefObject<HTMLElement>) => {
       setElementsTruncated(0);
     }
   }, [
-    elementRef.current?.offsetWidth,
-    elementRef.current?.clientWidth,
-    elementRef,
+    currentElement?.offsetWidth,
+    currentElement?.clientWidth,
+    currentElement,
   ]);
 
   return [elementsTruncated, hasHiddenElements];

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/useTruncation.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/useTruncation.ts
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { RefObject, useLayoutEffect, useState } from 'react';
+
+export const useTruncation = (elementRef: RefObject<HTMLElement>) => {
+  const [elementsTruncated, setElementsTruncated] = useState(0);
+  const [hasHiddenElements, setHasHiddenElements] = useState(false);
+
+  useLayoutEffect(() => {
+    if (!elementRef.current) {
+      return;
+    }
+    if (elementRef.current.scrollWidth > elementRef.current.clientWidth) {
+      // "..." is around 6x wide
+      const maxWidth = elementRef.current.clientWidth - 6;
+      const elementsCount = elementRef.current.childNodes.length;
+      let width = 0;
+      let i = 0;
+      while (width < maxWidth) {
+        width += (elementRef.current.childNodes[i] as HTMLElement).offsetWidth;
+        i += 1;
+      }
+      if (i === elementsCount) {
+        setElementsTruncated(1);
+        setHasHiddenElements(false);
+      } else {
+        setElementsTruncated(elementsCount - i);
+        setHasHiddenElements(true);
+      }
+    } else {
+      setElementsTruncated(0);
+    }
+  }, [
+    elementRef.current?.offsetWidth,
+    elementRef.current?.clientWidth,
+    elementRef,
+  ]);
+
+  return [elementsTruncated, hasHiddenElements];
+};

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/useTruncation.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/useTruncation.ts
@@ -22,8 +22,8 @@ export const useTruncation = (elementRef: RefObject<HTMLElement>) => {
   const [elementsTruncated, setElementsTruncated] = useState(0);
   const [hasHiddenElements, setHasHiddenElements] = useState(false);
 
-  const currentElement = elementRef.current;
   useLayoutEffect(() => {
+    const currentElement = elementRef.current;
     if (!currentElement) {
       return;
     }
@@ -49,9 +49,9 @@ export const useTruncation = (elementRef: RefObject<HTMLElement>) => {
       setElementsTruncated(0);
     }
   }, [
-    currentElement?.offsetWidth,
-    currentElement?.clientWidth,
-    currentElement,
+    elementRef.current?.offsetWidth,
+    elementRef.current?.clientWidth,
+    elementRef,
   ]);
 
   return [elementsTruncated, hasHiddenElements];

--- a/superset-frontend/src/dashboard/containers/DashboardPage.tsx
+++ b/superset-frontend/src/dashboard/containers/DashboardPage.tsx
@@ -17,8 +17,9 @@
  * under the License.
  */
 import React, { FC, useRef, useEffect, useState } from 'react';
-import { FeatureFlag, isFeatureEnabled, t } from '@superset-ui/core';
+import { FeatureFlag, isFeatureEnabled, t, useTheme } from '@superset-ui/core';
 import { useDispatch, useSelector } from 'react-redux';
+import { Global } from '@emotion/react';
 import { useParams } from 'react-router-dom';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
 import Loading from 'src/components/Loading';
@@ -49,6 +50,7 @@ import { getUrlParam } from 'src/utils/urlUtils';
 import { canUserEditDashboard } from 'src/dashboard/util/findPermission';
 import { getFilterSets } from '../actions/nativeFilters';
 import { getFilterValue } from '../components/nativeFilters/FilterBar/keyValue';
+import { filterCardPopoverStyle } from '../styles';
 
 export const MigrationContext = React.createContext(
   FILTER_BOX_MIGRATION_STATES.NOOP,
@@ -68,6 +70,7 @@ const originalDocumentTitle = document.title;
 
 const DashboardPage: FC = () => {
   const dispatch = useDispatch();
+  const theme = useTheme();
   const user = useSelector<any, UserWithPermissionsAndRoles>(
     state => state.user,
   );
@@ -226,6 +229,7 @@ const DashboardPage: FC = () => {
 
   return (
     <>
+      <Global styles={filterCardPopoverStyle(theme)} />
       <FilterBoxMigrationModal
         show={filterboxMigrationState === FILTER_BOX_MIGRATION_STATES.UNDECIDED}
         hideFooter={!isMigrationEnabled}

--- a/superset-frontend/src/dashboard/styles.ts
+++ b/superset-frontend/src/dashboard/styles.ts
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { css, SupersetTheme } from '@superset-ui/core';
+
+export const filterCardPopoverStyle = (theme: SupersetTheme) => css`
+  .filter-card-popover {
+    width: 240px;
+    padding: 0;
+    border-radius: 4px;
+
+    .ant-popover-inner-content {
+      padding: ${theme.gridUnit * 4}px;
+    }
+
+    .ant-popover-arrow {
+      display: none;
+    }
+  }
+
+  .filter-card-tooltip {
+    &.ant-tooltip-placement-bottom {
+      padding-top: 0;
+      & .ant-tooltip-arrow {
+        top: -13px;
+      }
+    }
+  }
+`;


### PR DESCRIPTION
### SUMMARY
This PR implements the Filter Card component. Please note that as of now this component is not used anywhere - usages will be added in upcoming PRs.

Filter card is a component that displays native filter's metadata in user-friendly, readable way.
Information displayed:
- filter's name
- filter's type
- filter's scope
- filter's dependencies

Filter scope values:
- "All charts" if every chart in the dashboard is in scope
- "Tab name 1, Tab name 2" if "Tab name 1" and "Tab name 2" are filter scope's rootpath and every chart in those tabs is in scope
- "Tab name 1, Chart1" if every chart in top level tab "Tab name 1" is in scope + "Chart1" from another tab is in scope
- "Chart1, Chart2" if only those 2 charts are in scope and previous conditions are not fulfilled

Filter dependencies:
- list of native filters that current native filter is dependent on
- clicking a name of dependency highlights the filter

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="244" alt="image" src="https://user-images.githubusercontent.com/15073128/155317999-0b4e5a70-2300-45b1-925e-7c8f9a673655.png">

<img width="249" alt="image" src="https://user-images.githubusercontent.com/15073128/155318282-2ab74b7a-0a87-4859-b953-1142007a129d.png">

<img width="250" alt="image" src="https://user-images.githubusercontent.com/15073128/155318311-265a718c-e7a4-4736-86ed-08d35d7fe19f.png">


### TESTING INSTRUCTIONS
TODO: add unit tests
Manual tests will be performed when filter cards are added to filters

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @kasiazjc

https://app.shortcut.com/preset/story/36388/filter-cards