### PR TITLE
feat(native-filters): Don't scroll main window when scrolling filter bar

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -327,7 +327,10 @@ const FilterBar: React.FC<FiltersBarProps> = ({
     filterValues,
   );
   const isInitialized = useInitialization();
-  const tabPaneStyle = useMemo(() => ({ overflow: 'auto', height }), [height]);
+  const tabPaneStyle = useMemo(
+    () => ({ overflow: 'auto', height, overscrollBehavior: 'contain' }),
+    [height],
+  );
 
   const numberOfFilters = filterValues.filter(
     filterValue => filterValue.type === NativeFilterType.NATIVE_FILTER,


### PR DESCRIPTION
### SUMMARY
When user scrolls to the bottom of filter bar and keeps scrolling, the whole dashboard starts scrolling. Filter bar should be independent from dashboard, so this PR detaches filter bar scroll from main window scroll.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/15073128/155324238-ad979a10-7884-4599-96dc-a1cb50ff4039.mov

After:

https://user-images.githubusercontent.com/15073128/155324018-184b0dd8-5646-4770-86d7-08936bad8e9c.mov


### TESTING INSTRUCTIONS
1. Open a dashboard with native filters
2. Add multiple native filters and multiple charts, so that filters bar and dashboard are both scrollable
3. Verify that scrolling while hovering over filters bar doesn't trigger scrolling of main window

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @rusackas @kasiazjc