### PR TITLE
fix(nested-tab-available): make the another tabs into one tabs available

### DIFF
--- a/superset-frontend/src/dashboard/util/getDropPosition.js
+++ b/superset-frontend/src/dashboard/util/getDropPosition.js
@@ -54,15 +54,6 @@ export default function getDropPosition(monitor, Component) {
     return null;
   }
 
-  // TODO need a better solution to prevent nested tabs
-  // if (
-  //   draggingItem.type === TABS_TYPE &&
-  //   component.type === TAB_TYPE &&
-  //   componentDepth === 2
-  // ) {
-  //   return null;
-  // }
-
   const validChild = isValidChild({
     parentType: component.type,
     parentDepth: componentDepth,

--- a/superset-frontend/src/dashboard/util/getDropPosition.js
+++ b/superset-frontend/src/dashboard/util/getDropPosition.js
@@ -55,13 +55,13 @@ export default function getDropPosition(monitor, Component) {
   }
 
   // TODO need a better solution to prevent nested tabs
-  if (
-    draggingItem.type === TABS_TYPE &&
-    component.type === TAB_TYPE &&
-    componentDepth === 2
-  ) {
-    return null;
-  }
+  // if (
+  //   draggingItem.type === TABS_TYPE &&
+  //   component.type === TAB_TYPE &&
+  //   componentDepth === 2
+  // ) {
+  //   return null;
+  // }
 
   const validChild = isValidChild({
     parentType: component.type,


### PR DESCRIPTION
### SUMMARY
Unable to add Tabs inside a Tab unless the Tab already has other elements (Dashboard Layout)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![Screen Shot 2022-02-23 at 8 21 22 AM](https://user-images.githubusercontent.com/47900232/155327551-f854e303-4cd5-4f77-a416-21daf7a7d1db.png)

After:
![Screen Shot 2022-02-23 at 8 21 08 AM](https://user-images.githubusercontent.com/47900232/155327526-c1b669ee-cad1-4cfd-b9cd-995bc7105114.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
