### PR TITLE
(update) installing-superset-from-scratch.mdx

### DIFF
--- a/docs/docs/installation/installing-superset-from-scratch.mdx
+++ b/docs/docs/installation/installing-superset-from-scratch.mdx
@@ -119,6 +119,13 @@ First, start by installing `apache-superset`:
 pip install apache-superset
 ```
 
+### (The following is required to address a backward-compatibility issue with the `markupsafe` dependency)
+
+```
+pip uninstall -y markupsafe
+pip install markupsafe==2.0.1
+```
+
 Then, you need to initialize the database:
 
 ```


### PR DESCRIPTION
fix(installing-superset-from-scratch): Fix to address a backward-compatibility issue with the `markupsafe` dependency when installing with pip.

### SUMMARY
Without this superset setup fails when running "superset load_examples"

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
Follow install with the fix steps as included.
