### PR TITLE
fix(embedded): guest token expiration should be in seconds not milliseconds

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1319,7 +1319,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         audience = self._get_guest_token_jwt_audience()
         # calculate expiration time
         now = self._get_current_epoch_time()
-        exp = now + (exp_seconds * 1000)
+        exp = now + exp_seconds
         claims = {
             "user": user,
             "resources": resources,

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -1192,7 +1192,7 @@ class TestGuestTokens(SupersetTestCase):
         self.assertEqual(aud, decoded_token["aud"])
         self.assertEqual("guest", decoded_token["type"])
         self.assertEqual(
-            now + (self.app.config["GUEST_TOKEN_JWT_EXP_SECONDS"] * 1000),
+            now + self.app.config["GUEST_TOKEN_JWT_EXP_SECONDS"],
             decoded_token["exp"],
         )
 
@@ -1210,7 +1210,7 @@ class TestGuestTokens(SupersetTestCase):
     def test_get_guest_user_expired_token(self, get_time_mock):
         # make a just-expired token
         get_time_mock.return_value = (
-            time.time() - (self.app.config["GUEST_TOKEN_JWT_EXP_SECONDS"] * 1000) - 1
+            time.time() - self.app.config["GUEST_TOKEN_JWT_EXP_SECONDS"] - 1
         )
         token = self.create_guest_token()
         fake_request = FakeRequest()

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -1192,8 +1192,7 @@ class TestGuestTokens(SupersetTestCase):
         self.assertEqual(aud, decoded_token["aud"])
         self.assertEqual("guest", decoded_token["type"])
         self.assertEqual(
-            now + self.app.config["GUEST_TOKEN_JWT_EXP_SECONDS"],
-            decoded_token["exp"],
+            now + self.app.config["GUEST_TOKEN_JWT_EXP_SECONDS"], decoded_token["exp"],
         )
 
     def test_get_guest_user(self):


### PR DESCRIPTION



### SUMMARY
`GUEST_TOKEN_JWT_EXP_SECONDS` is expected to be in seconds, but results in much longer expiration due to being multiplied by 1000, making the jwt valid for an unexpectedly long time

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
confirmed `time.time()` returns seconds, confirmed pyjwt exp expects unixtime seconds.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
