### PR TITLE
feat(TimeTableViz): sort by first metric

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -854,6 +854,11 @@ class TimeTableViz(BaseViz):
             raise QueryObjectValidationError(
                 _("When using 'Group By' you are limited to use a single metric")
             )
+
+        sort_by = utils.get_first_metric_name(query_obj["metrics"])
+        is_asc = not query_obj.get("order_desc")
+        query_obj["orderby"] = [(sort_by, is_asc)]
+
         return query_obj
 
     def get_data(self, df: pd.DataFrame) -> VizData:

--- a/tests/integration_tests/viz_tests.py
+++ b/tests/integration_tests/viz_tests.py
@@ -1067,6 +1067,13 @@ class TestTimeSeriesTableViz(SupersetTestCase):
         with self.assertRaises(Exception):
             test_viz.query_obj()
 
+    def test_query_obj_order_by(self):
+        test_viz = viz.TimeTableViz(
+            self.get_datasource_mock(), {"metrics": ["sum__A", "count"], "groupby": []}
+        )
+        query_obj = test_viz.query_obj()
+        self.assertEqual(query_obj["orderby"], [("sum__A", False)])
+
 
 class TestBaseDeckGLViz(SupersetTestCase):
     def test_get_metrics(self):


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Sort `TimeTableViz` (time series table) by the first metric descending. Currently, no sorting is applied, so time series tables show the "first" n series, which can be confusing to users and isn't very helpful. Sorting by the first metric descending is more consistent with other chart types.

Note time series tables do not have a sort by control - might be better to add this in the future, but this should still an improvement for now.

### TESTING INSTRUCTIONS
Create time series viz. Confirm that an order by clause exists in the query.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

@john-bodley @ktmud ?