### PR TITLE
test(Native Filter): User can create parent filters using "Filter is hierarchical

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
@@ -22,7 +22,11 @@ import {
   nativeFilters,
   exploreView,
 } from 'cypress/support/directories';
-import { testItems } from './dashboard.helper';
+import {
+  testItems,
+  WORLD_HEALTH_CHARTS,
+  waitForChartLoad,
+} from './dashboard.helper';
 import { DASHBOARD_LIST } from '../dashboard_list/dashboard_list.helper';
 import { CHART_LIST } from '../chart_list/chart_list.helper';
 import { FORM_DATA_DEFAULTS } from '../explore/visualizations/shared.helper';
@@ -541,6 +545,107 @@ describe('Nativefilters Sanity test', () => {
     cy.get(nativeFilters.filterFromDashboardView.filterContent)
       .contains('year')
       .should('be.visible');
+  });
+  it('User can create parent filters using "Filter is hierarchical"', () => {
+    cy.get(nativeFilters.filterFromDashboardView.expand).click({ force: true });
+    cy.get(nativeFilters.filterFromDashboardView.createFilterButton)
+      .should('be.visible')
+      .click();
+    cy.get(nativeFilters.filtersPanel.filterTypeInput)
+      .find(nativeFilters.filtersPanel.filterTypeItem)
+      .click({ force: true });
+    cy.get('[label="Value"]').click();
+    cy.get(nativeFilters.modal.container)
+      .find(nativeFilters.filtersPanel.datasetName)
+      .click({ force: true })
+      .within(() =>
+        cy
+          .get('input')
+          .type('wb_health_population{enter}', { delay: 50, force: true }),
+      );
+    cy.get(nativeFilters.modal.container)
+      .find(nativeFilters.filtersPanel.filterName)
+      .click({ force: true })
+      .clear()
+      .type('region', { scrollBehavior: false, force: true });
+    cy.wait(3000);
+    cy.get(nativeFilters.silentLoading).should('not.exist');
+    cy.get(nativeFilters.filtersPanel.filterInfoInput)
+      .last()
+      .should('be.visible')
+      .click({ force: true });
+    cy.get(nativeFilters.filtersPanel.filterInfoInput).last().type('region');
+    cy.get(nativeFilters.filtersPanel.inputDropdown)
+      .last()
+      .should('be.visible', { timeout: 20000 })
+      .click({ force: true });
+    cy.get(nativeFilters.addFilterButton.button)
+      .first()
+      .click({ force: true })
+      .then(() => {
+        cy.get(nativeFilters.addFilterButton.dropdownItem)
+          .contains('Filter')
+          .click({ force: true });
+      });
+    cy.get(nativeFilters.filtersPanel.filterTypeInput)
+      .find(nativeFilters.filtersPanel.filterTypeItem)
+      .last()
+      .click({ force: true });
+    cy.get('[label="Value"]').last().click({ force: true });
+    cy.get(nativeFilters.modal.container)
+      .find(nativeFilters.filtersPanel.datasetName)
+      .last()
+      .click({ scrollBehavior: false })
+      .within(() =>
+        cy
+          .get('input')
+          .clear({ force: true })
+          .type('wb_health_population{enter}', {
+            delay: 50,
+            force: true,
+            scrollBehavior: false,
+          }),
+      );
+    cy.get(nativeFilters.filtersPanel.filterInfoInput)
+      .last()
+      .should('be.visible')
+      .click({ force: true });
+    cy.get(nativeFilters.filtersPanel.inputDropdown)
+      .should('be.visible', { timeout: 20000 })
+      .last()
+      .click();
+    cy.get(nativeFilters.modal.container)
+      .find(nativeFilters.filtersPanel.filterName)
+      .last()
+      .click({ force: true })
+      .type('country', { scrollBehavior: false, force: true });
+    cy.get(nativeFilters.silentLoading).should('not.exist');
+    cy.get(nativeFilters.filtersPanel.filterInfoInput)
+      .last()
+      .click({ force: true });
+    cy.get(nativeFilters.filtersPanel.filterInfoInput)
+      .last()
+      .type('country_name', { delay: 50, scrollBehavior: false, force: true });
+    cy.get(nativeFilters.filtersPanel.inputDropdown)
+      .last()
+      .should('be.visible', { timeout: 20000 })
+      .click({ force: true });
+    cy.get(nativeFilters.filterConfigurationSections.displayedSection).within(
+      () => {
+        cy.contains('Filter is hierarchical').should('be.visible').click();
+        cy.wait(1000);
+        cy.get(nativeFilters.filterConfigurationSections.parentFilterInput)
+          .click()
+          .type('region{enter}', { delay: 30 });
+      },
+    );
+    cy.get(nativeFilters.modal.footer)
+      .contains('Save')
+      .should('be.visible')
+      .click();
+    WORLD_HEALTH_CHARTS.forEach(waitForChartLoad);
+    cy.get(nativeFilters.filterIcon).click({ force: true });
+    cy.contains('Select parent filters (2)').should('be.visible');
   });
 });
 

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
@@ -632,7 +632,7 @@ describe('Nativefilters Sanity test', () => {
       .last()
       .should('be.visible', { timeout: 20000 })
       .click({ force: true });
-    // Setup parent filter 
+    // Setup parent filter
     cy.get(nativeFilters.filterConfigurationSections.displayedSection).within(
       () => {
         cy.contains('Filter is hierarchical').should('be.visible').click();

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
@@ -548,6 +548,7 @@ describe('Nativefilters Sanity test', () => {
   });
   it('User can create parent filters using "Filter is hierarchical"', () => {
     cy.get(nativeFilters.filterFromDashboardView.expand).click({ force: true });
+    // Create region filter
     cy.get(nativeFilters.filterFromDashboardView.createFilterButton)
       .should('be.visible')
       .click();
@@ -579,6 +580,7 @@ describe('Nativefilters Sanity test', () => {
       .last()
       .should('be.visible', { timeout: 20000 })
       .click({ force: true });
+    // Create country filter
     cy.get(nativeFilters.addFilterButton.button)
       .first()
       .click({ force: true })
@@ -630,6 +632,7 @@ describe('Nativefilters Sanity test', () => {
       .last()
       .should('be.visible', { timeout: 20000 })
       .click({ force: true });
+    // Setup parent filter 
     cy.get(nativeFilters.filterConfigurationSections.displayedSection).within(
       () => {
         cy.contains('Filter is hierarchical').should('be.visible').click();
@@ -644,7 +647,11 @@ describe('Nativefilters Sanity test', () => {
       .should('be.visible')
       .click();
     WORLD_HEALTH_CHARTS.forEach(waitForChartLoad);
-    cy.get(nativeFilters.filterIcon).click({ force: true });
+    // assert that native filter is created
+    cy.get(nativeFilters.filterFromDashboardView.filterName)
+      .should('be.visible')
+      .contains('region');
+    cy.get(nativeFilters.filterIcon).click();
     cy.contains('Select parent filters (2)').should('be.visible');
   });
 });

--- a/superset-frontend/cypress-base/cypress/support/directories.ts
+++ b/superset-frontend/cypress-base/cypress/support/directories.ts
@@ -327,6 +327,10 @@ export const nativeFilters = {
     addFilter: dataTestLocator('add-filter-button'),
     defaultValueCheck: '.ant-checkbox-checked',
   },
+  addFilterButton: {
+    button: `.ant-modal-content [data-test="new-dropdown-icon"]`,
+    dropdownItem: '.ant-dropdown-menu-item',
+  },
   filtersPanel: {
     filterName: dataTestLocator('filters-config-modal__name-input'),
     datasetName: dataTestLocator('filters-config-modal__datasource-input'),
@@ -350,6 +354,7 @@ export const nativeFilters = {
   removeFilter: '[aria-label="remove"]',
   silentLoading: '.loading inline-centered css-101mkpk',
   filterConfigurationSections: {
+    displayedSection: 'div[style="height: 100%; overflow-y: auto;"]',
     collapseExpandButton: '.ant-collapse-arrow',
     checkedCheckbox: '.ant-checkbox-wrapper-checked',
     infoTooltip: '[aria-label="Show info tooltip"]',


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
add new native filter test: User can create parent filters using "Filter is hierarchical
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
