### PR TITLE
fix(docs): add missing static files to build

### DIFF
--- a/.github/workflows/superset-docs.yml
+++ b/.github/workflows/superset-docs.yml
@@ -27,6 +27,7 @@ jobs:
       - name: yarn build
         run: |
           yarn build
+          yarn copy-www-site-files
       - name: deploy docs
         if: github.ref == 'refs/heads/master'
         uses: ./.github/actions/github-action-push-to-another-repository

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
+    "copy-www-site-files": "cp static/resources/.asf.yaml static/resources/.htaccess build/",
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",

--- a/docs/static/resources/.asf.yaml
+++ b/docs/static/resources/.asf.yaml
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+publish:
+  whoami: asf-site
+
+staging:
+  whoami: asf-site

--- a/docs/static/resources/.htaccess
+++ b/docs/static/resources/.htaccess
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+RewriteEngine On
+RewriteCond %{SERVER_PORT} 80
+RewriteRule ^(.*)$ https://superset.apache.org/$1 [R,L]
+
+RewriteCond %{HTTP_HOST} ^superset.incubator.apache.org$ [NC]
+RewriteRule ^(.*)$ https://superset.apache.org/$1 [R=301,L]


### PR DESCRIPTION
### SUMMARY
Currently the built docs assets are missing two critical files required for deploying the Superset www site. This adds an additional script `copy-www-site-files` to the docs `package.json` that is executed before the build is deployed to the `apache/superset-site` repo.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
