### PR TITLE
fix: apply url_params in global async query

### DIFF
--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -287,6 +287,8 @@ class ChartDataRestApi(ChartRestApi):
         """
         try:
             cached_data = self._load_query_context_form_from_cache(cache_key)
+            # In order to get `url_params` in form_data(used for async queries)
+            setattr(g, "form_data", cached_data)
             query_context = self._create_query_context_from_form(cached_data)
             command = ChartDataCommand(query_context)
             command.validate()


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix Jinja template is not working when the global async query is enabled.

Currently, Superset uses [serialized query_obj](https://github.com/apache/superset/blob/16380906d1ba0f98b486cfec4b4b16ebed5b8a14/superset/common/query_context_processor.py#L156) and [form_data](https://github.com/apache/superset/blob/16380906d1ba0f98b486cfec4b4b16ebed5b8a14/superset/jinja_context.py#L189-L199) to generate [query_cache_key](https://github.com/apache/superset/blob/16380906d1ba0f98b486cfec4b4b16ebed5b8a14/superset/common/query_context_processor.py#L158). But in the global async query, we didn't pass form_data. We have to get cached data from the data cache and put the cache data to `g.form_data` to fix it.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### Before

https://user-images.githubusercontent.com/2016594/155511464-b0f99a24-cb90-467e-ad2a-7e862d6fd769.mov

### After



https://user-images.githubusercontent.com/2016594/155512121-c2feea8f-e880-483f-b5c4-e4860cd5c88d.mov



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fix: https://github.com/apache/superset/issues/16650
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
