### PR TITLE
fix(embedded): add row level security extra cache keys for guest users

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1769,6 +1769,10 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
             templatable_statements += [
                 f.clause for f in security_manager.get_rls_filters(self)
             ]
+            if is_feature_enabled("EMBEDDED_SUPERSET"):
+                templatable_statements += [
+                    f.clause for f in security_manager.get_guest_rls_filters(self)
+                ]
         for statement in templatable_statements:
             if ExtraCache.regex.search(statement):
                 return True

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1771,7 +1771,7 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
             ]
             if is_feature_enabled("EMBEDDED_SUPERSET"):
                 templatable_statements += [
-                    f.clause for f in security_manager.get_guest_rls_filters(self)
+                    f['clause'] for f in security_manager.get_guest_rls_filters(self)
                 ]
         for statement in templatable_statements:
             if ExtraCache.regex.search(statement):

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1771,7 +1771,7 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
             ]
             if is_feature_enabled("EMBEDDED_SUPERSET"):
                 templatable_statements += [
-                    f['clause'] for f in security_manager.get_guest_rls_filters(self)
+                    f["clause"] for f in security_manager.get_guest_rls_filters(self)
                 ]
         for statement in templatable_statements:
             if ExtraCache.regex.search(statement):


### PR DESCRIPTION


### SUMMARY

Cache keys from guest token row level security clauses were not being evaluated, causing data to leak across sessions via cache. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

In one session, create/use an guest_token without a rls clause, and a session with a rls clause with an additional cache key e.g.:  

 ``` "rls": [
    { "clause": "publisher = '{{cache_key_wrapper('Nintendo')}}'" }
  ]
```

The same dashboard should have independent cache for each session, and the one with the rls clause should be unable to see unfiltered data.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
