### PR TITLE
fix(sqllab): Un-render deselected tabs

### DIFF
--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx
@@ -403,6 +403,7 @@ class TabbedSqlEditors extends React.PureComponent {
 
     return (
       <EditableTabs
+        destroyInactiveTabPane
         activeKey={this.props.tabHistory[this.props.tabHistory.length - 1]}
         id="a11y-query-editor-tabs"
         className="SqlEditorTabs"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
When you switch tabs in sql lab, we were keeping them all rendered in the dom, but hidden. This meant that everytime the sql lab redux state changed, we'd re-render all tabs that were viewed since the last page load. This prop is defined on antd tabs (https://ant.design/components/tabs/#API), and un-renders tabs that aren't currently selected, improving the perf of both switching tabs and updating the sql query being run.

### TESTING INSTRUCTIONS
go to SQL Lab, change tabs and see the old tabs un-rendered from the DOM. Ensure all SQL Lab functionality still works

to: @kgabryje @ktmud @rusackas @john-bodley 