### PR TITLE
fix(deck.gl): multiple layers map size is shrunk

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/Multi/Multi.jsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/Multi/Multi.jsx
@@ -120,7 +120,7 @@ class DeckMulti extends React.PureComponent {
   };
 
   render() {
-    const { payload, formData, setControlValue } = this.props;
+    const { payload, formData, setControlValue, height, width } = this.props;
     const { subSlicesLayers } = this.state;
 
     const layers = Object.values(subSlicesLayers);
@@ -134,6 +134,8 @@ class DeckMulti extends React.PureComponent {
         mapStyle={formData.mapbox_style}
         setControlValue={setControlValue}
         onViewportChange={this.onViewportChange}
+        height={height}
+        width={width}
       />
     );
   }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixed the problem that map will be shrunk when using deck.gl multiple layer chart.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### before
https://user-images.githubusercontent.com/81597121/148283229-79586301-9b2a-4d55-a68f-307cab164f7f.mov

### after

https://user-images.githubusercontent.com/11830681/155688415-1acb344f-bea1-4710-a49e-36fc1959323a.mov



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/17940
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
