### PR TITLE
fix(dataset): handle missing database in migration

### DIFF
--- a/superset/migrations/versions/b8d3a24d9131_new_dataset_models.py
+++ b/superset/migrations/versions/b8d3a24d9131_new_dataset_models.py
@@ -323,12 +323,10 @@ def after_insert(target: SqlaTable) -> None:  # pylint: disable=too-many-locals
         target.database
         or session.query(Database).filter_by(id=target.database_id).first()
     )
-    engine: Optional[Engine] = None
-    if database:
-        engine = database.get_sqla_engine(schema=target.schema)
-    conditional_quote = (
-        engine.dialect.identifier_preparer.quote if engine else lambda x: x
-    )
+    if not database:
+        return
+    engine = database.get_sqla_engine(schema=target.schema)
+    conditional_quote = engine.dialect.identifier_preparer.quote
 
     # create columns
     columns = []

--- a/superset/migrations/versions/b8d3a24d9131_new_dataset_models.py
+++ b/superset/migrations/versions/b8d3a24d9131_new_dataset_models.py
@@ -321,10 +321,14 @@ def after_insert(target: SqlaTable) -> None:  # pylint: disable=too-many-locals
     # table names
     database = (
         target.database
-        or session.query(Database).filter_by(id=target.database_id).one()
+        or session.query(Database).filter_by(id=target.database_id).first()
     )
-    engine = database.get_sqla_engine(schema=target.schema)
-    conditional_quote = engine.dialect.identifier_preparer.quote
+    engine: Optional[Engine] = None
+    if database:
+        engine = database.get_sqla_engine(schema=target.schema)
+    conditional_quote = (
+        engine.dialect.identifier_preparer.quote if engine else lambda x: x
+    )
 
     # create columns
     columns = []


### PR DESCRIPTION
### SUMMARY
The recent PR #18935 added a migration that fails if a dataset is referencing a database that has been removed. This changes the migration logic to return early if the database is missing.

### BEFORE

When performing a migration on metadata containing datasets that reference a missing database, the following happens:
```
$ superset db upgrade
Loaded your LOCAL configuration at [/Users/ville/superset/superset_config.py]
logging was configured successfully
2022-02-25 17:44:27,115:INFO:superset.utils.logging_configurator:logging was configured successfully
2022-02-25 17:44:27,121:INFO:root:Configured event logger of type <class 'superset.utils.log.DBEventLogger'>
WARNI [alembic.env] SQLite Database support for metadata databases will         be removed in a future version of Superset.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 5afbb1a5849b -> b8d3a24d9131, New dataset models
Traceback (most recent call last):
  File "/Users/ville/src/superset/venv/bin/superset", line 33, in <module>
    sys.exit(load_entry_point('apache-superset', 'console_scripts', 'superset')())
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/flask/cli.py", line 586, in main
    return super(FlaskGroup, self).main(*args, **kwargs)
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/flask/cli.py", line 426, in decorator
    return __ctx.invoke(f, *args, **kwargs)
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/flask_migrate/cli.py", line 149, in upgrade
    _upgrade(directory, revision, sql, tag, x_arg)
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/flask_migrate/__init__.py", line 98, in wrapped
    f(*args, **kwargs)
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/flask_migrate/__init__.py", line 185, in upgrade
    command.upgrade(config, revision, sql=sql, tag=tag)
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/alembic/command.py", line 294, in upgrade
    script.run_env()
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/alembic/script/base.py", line 490, in run_env
    util.load_python_file(self.dir, "env.py")
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/alembic/util/pyfiles.py", line 97, in load_python_file
    module = load_module_py(module_id, path)
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/alembic/util/compat.py", line 184, in load_module_py
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/Users/ville/src/superset/superset/migrations/env.py", line 126, in <module>
    run_migrations_online()
  File "/Users/ville/src/superset/superset/migrations/env.py", line 118, in run_migrations_online
    context.run_migrations()
  File "<string>", line 8, in run_migrations
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/alembic/runtime/environment.py", line 813, in run_migrations
    self.get_context().run_migrations(**kw)
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/alembic/runtime/migration.py", line 561, in run_migrations
    step.migration_fn(**kw)
  File "/Users/ville/src/superset/superset/migrations/versions/b8d3a24d9131_new_dataset_models.py", line 589, in upgrade
    after_insert(target=dataset)
  File "/Users/ville/src/superset/superset/migrations/versions/b8d3a24d9131_new_dataset_models.py", line 324, in after_insert
    or session.query(Database).filter_by(id=target.database_id).one()
  File "/Users/ville/src/superset/venv/lib/python3.8/site-packages/sqlalchemy/orm/query.py", line 3500, in one
    raise orm_exc.NoResultFound("No row was found for one()")
sqlalchemy.orm.exc.NoResultFound: No row was found for one()
$
```

### AFTER
After the change the migration completes successfully:
```
$ superset db upgrade
Loaded your LOCAL configuration at [/Users/ville/superset/superset_config.py]
logging was configured successfully
2022-02-25 17:45:18,798:INFO:superset.utils.logging_configurator:logging was configured successfully
2022-02-25 17:45:18,805:INFO:root:Configured event logger of type <class 'superset.utils.log.DBEventLogger'>
WARNI [alembic.env] SQLite Database support for metadata databases will         be removed in a future version of Superset.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 5afbb1a5849b -> b8d3a24d9131, New dataset models
$
```
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
