### PR TITLE
chore: Change Sort by and Sort descending controls for Time-series Bar Chart

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -337,6 +337,15 @@ const row_limit: SharedControlConfig<'SelectControl'> = {
   description: t('Limits the number of rows that get displayed.'),
 };
 
+const order_desc: SharedControlConfig<'CheckboxControl'> = {
+  type: 'CheckboxControl',
+  label: t('Sort Descending'),
+  default: true,
+  description: t('Whether to sort descending or ascending'),
+  visibility: ({ controls }) =>
+    Boolean(controls?.timeseries_limit_metric.value),
+};
+
 const limit: SharedControlConfig<'SelectControl'> = {
   type: 'SelectControl',
   freeForm: true,
@@ -508,6 +517,7 @@ const sharedControls = {
   limit,
   timeseries_limit_metric: enableExploreDnd ? dnd_sort_by : sort_by,
   orderby: enableExploreDnd ? dnd_sort_by : sort_by,
+  order_desc,
   series: enableExploreDnd ? dndSeries : series,
   entity: enableExploreDnd ? dndEntity : entity,
   x: enableExploreDnd ? dnd_x : x,

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bar/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bar/controlPanel.ts
@@ -17,7 +17,11 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
-import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
+import {
+  ControlPanelConfig,
+  sections,
+  sharedControls,
+} from '@superset-ui/chart-controls';
 import {
   lineInterpolation,
   showBrush,
@@ -41,6 +45,38 @@ import {
 } from '../NVD3Controls';
 
 const config: ControlPanelConfig = {
+  controlOverrides: {
+    limit: {
+      rerender: ['timeseries_limit_metric', 'order_desc'],
+    },
+    timeseries_limit_metric: {
+      label: t('Series Limit Sort By'),
+      description: t(
+        'Metric used to order the limit if a series limit is present. ' +
+          'If undefined reverts to the first metric (where appropriate).',
+      ),
+      visibility: ({ controls }) => Boolean(controls?.limit.value),
+      mapStateToProps: (state, controlState) => {
+        const timeserieslimitProps =
+          sharedControls.timeseries_limit_metric.mapStateToProps?.(
+            state,
+            controlState,
+          ) || {};
+        timeserieslimitProps.value = state.controls?.limit?.value
+          ? controlState.value
+          : [];
+        return timeserieslimitProps;
+      },
+    },
+    order_desc: {
+      label: t('Series Limit Sort Descending'),
+      default: false,
+      description: t(
+        'Whether to sort descending or ascending if a series limit is present',
+      ),
+      visibility: ({ controls }) => Boolean(controls?.limit.value),
+    },
+  },
   controlPanelSections: [
     sections.legacyTimeseriesTime,
     timeSeriesSection[0],

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx
@@ -346,19 +346,7 @@ export const timeSeriesSection: ControlPanelSectionConfig[] = [
       ['groupby'],
       ['limit'],
       ['timeseries_limit_metric'],
-      [
-        {
-          name: 'order_desc',
-          config: {
-            type: 'CheckboxControl',
-            label: t('Sort Descending'),
-            default: true,
-            description: t('Whether to sort descending or ascending'),
-            visibility: ({ controls }) =>
-              Boolean(controls?.timeseries_limit_metric.value),
-          },
-        },
-      ],
+      ['order_desc'],
       [
         {
           name: 'contribution',


### PR DESCRIPTION
### SUMMARY
This PR hides the SERIES LIMIT SORT BY and SERIES LIMIT SORT DESCENDING when no SERIES LIMIT is set and viceversa.

There is an issue for which some controls are not properly cleared when hidden. This issue is already affecting master and will be fixed in a separate PR.

### AFTER

https://user-images.githubusercontent.com/60598000/156021827-ca7b40c6-ac7d-436d-8a31-c864e7ec1dbf.mp4

### TESTING INSTRUCTIONS
1. Open a Time-Series Bar Chart
2. Add a SERIES LIMIT
3. Make sure the SERIES LIMIT SORT BY and SERIES LIMIT SORT DESCENDING appear
4. Remove the SERIES LIMIT
5. Make sure the SERIES LIMIT SORT BY and SERIES LIMIT SORT DESCENDING do not appear

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
