### PR TITLE
fix(select): fix typing for customLabel

### DIFF
--- a/superset-frontend/src/addSlice/AddSliceContainer.tsx
+++ b/superset-frontend/src/addSlice/AddSliceContainer.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { ReactNode } from 'react';
+import React from 'react';
 import rison from 'rison';
 import { styled, t, SupersetClient, JsonResponse } from '@superset-ui/core';
 import { Steps } from 'src/common/components';
@@ -24,6 +24,7 @@ import Button from 'src/components/Button';
 import { Select } from 'src/components';
 import { FormLabel } from 'src/components/Form';
 import { Tooltip } from 'src/components/Tooltip';
+import { LabeledValues } from 'src/components/Select/Select';
 
 import VizTypeGallery, {
   MAX_ADVISABLE_VIZ_GALLERY_WIDTH,
@@ -252,11 +253,7 @@ export default class AddSliceContainer extends React.PureComponent<
     return SupersetClient.get({
       endpoint: `/api/v1/dataset/?q=${query}`,
     }).then((response: JsonResponse) => {
-      const list: {
-        customLabel: ReactNode;
-        label: string;
-        value: string;
-      }[] = response.json.result.map((item: Dataset) => ({
+      const list: LabeledValues = response.json.result.map((item: Dataset) => ({
         value: `${item.id}__${item.datasource_type}`,
         customLabel: this.newLabel(item),
         label: item.table_name,

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -54,9 +54,9 @@ export interface LabeledValue {
 
 export type RawValues = RawValue[];
 export type LabeledValues = LabeledValue[];
-export type SelectValue = RawValue | LabeledValue | RawValues | LabeledValues;
 export type OptionsType = LabeledValues;
 
+type SelectValue = RawValue | LabeledValue | RawValues | LabeledValues;
 type AntdSelectAllProps = AntdSelectProps<SelectValue>;
 
 type PickedSelectProps = Pick<

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -216,7 +216,7 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
           setLoadingTables(false);
           if (forceRefresh) addSuccessToast('List updated');
         })
-        .catch(e => {
+        .catch(() => {
           setLoadingTables(false);
           handleError(t('There was an error loading the tables'));
         });

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
@@ -387,7 +387,7 @@ const AdhocFilterEditPopoverSimpleTabContent: React.FC<Props> = props => {
             ('column_name' in column && column.column_name) ||
             ('label' in column && column.label),
           key:
-            ('id' in column && column.id) ||
+            ('id' in column && String(column.id)) ||
             ('optionName' in column && column.optionName) ||
             undefined,
           customLabel: renderSubjectOptionLabel(column),


### PR DESCRIPTION
### SUMMARY

Typing for `option.customLabel` in the Select component is not correctly applied because it extended the wrong source type. This should fix it. No changes to code functionalities whatsoever.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

`.customLabel` is `any` where it was referenced:

<img width="663" alt="Xnip2022-02-25_11-28-36" src="https://user-images.githubusercontent.com/335541/155780133-0b3ebec6-d8c3-4ac2-98bb-6f3d624dea5a.png">

#### After

`.customLabel` is ReactNode

<img width="746" alt="Xnip2022-02-25_11-06-30" src="https://user-images.githubusercontent.com/335541/155780483-149a59a4-b11e-4dde-8121-10b97d5515ca.png">


### TESTING INSTRUCTIONS

CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: this issue was caught while I was working on #18799 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
