### PR TITLE
fix(external-link): change the external link in creating chart dashboard

### DIFF
--- a/superset-frontend/src/addSlice/AddSliceContainer.tsx
+++ b/superset-frontend/src/addSlice/AddSliceContainer.tsx
@@ -294,7 +294,7 @@ export default class AddSliceContainer extends React.PureComponent<
                     'Instructions to add a dataset are available in the Superset tutorial.',
                   )}{' '}
                   <a
-                    href="https://superset.apache.org/docs/creating-charts-dashboards/first-dashboard#adding-a-new-table"
+                    href="https://superset.apache.org/docs/creating-charts-dashboards/creating-your-first-dashboard/#registering-a-new-table"
                     rel="noopener noreferrer"
                     target="_blank"
                   >


### PR DESCRIPTION
### SUMMARY
The external link available on the Create Chart dialog is broken

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE
Old Link: https://superset.apache.org/docs/creating-charts-dashboards/first-dashboard#adding-a-new-table
AFTER
New Link: https://superset.apache.org/docs/creating-charts-dashboards/creating-your-first-dashboard/#registering-a-new-table
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
