### PR TITLE
fix(frontend react key warnings): add uniq keys to JSX elements

### DIFF
--- a/superset-frontend/src/components/ListView/Filters/index.tsx
+++ b/superset-frontend/src/components/ListView/Filters/index.tsx
@@ -52,7 +52,7 @@ function UIFilters({
                 Header={Header}
                 fetchSelects={fetchSelects}
                 initialValue={initialValue}
-                key={id}
+                key={`${Header} - ${id}`}
                 name={id}
                 onSelect={(option: SelectOption | undefined) =>
                   updateFilterValue(index, option)

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -754,6 +754,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
         ?.filter((db: DatabaseForm) => db.preferred)
         .map((database: DatabaseForm) => (
           <IconButton
+            key={database.name}
             className="preferred-item"
             onClick={() => setDatabaseModel(database.name)}
             buttonText={database.name}

--- a/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
@@ -132,13 +132,25 @@ const WelcomeNav = styled.div`
   }
 `;
 
-export const LoadingCards = ({ cover }: LoadingProps) => (
-  <CardContainer showThumbnails={cover} className="loading-cards">
-    {[...new Array(loadingCardCount)].map(() => (
-      <ListViewCard cover={cover ? false : <></>} description="" loading />
-    ))}
-  </CardContainer>
-);
+export const LoadingCards = ({ cover }: LoadingProps) => {
+  const listViewCards = [];
+  for (let i = 0; i < loadingCardCount; i += 1) {
+    listViewCards.push(
+      <ListViewCard
+        key={i}
+        cover={cover ? false : <></>}
+        description=""
+        loading
+      />,
+    );
+  }
+
+  return (
+    <CardContainer showThumbnails={cover} className="loading-cards">
+      {listViewCards}
+    </CardContainer>
+  );
+};
 
 function Welcome({ user, addDangerToast }: WelcomeProps) {
   const userid = user.userId;

--- a/superset-frontend/src/views/components/Menu.tsx
+++ b/superset-frontend/src/views/components/Menu.tsx
@@ -237,7 +237,7 @@ export function Menu({
     }
     return (
       <SubMenu
-        key={index}
+        key={`${index} - ${label}`}
         title={label}
         icon={showMenu === 'inline' ? <></> : <Icons.TriangleDown />}
       >

--- a/superset-frontend/src/views/components/Menu.tsx
+++ b/superset-frontend/src/views/components/Menu.tsx
@@ -237,7 +237,7 @@ export function Menu({
     }
     return (
       <SubMenu
-        key={`${index} - ${label}`}
+        key={label}
         title={label}
         icon={showMenu === 'inline' ? <></> : <Icons.TriangleDown />}
       >

--- a/superset-frontend/src/views/components/MenuRight.tsx
+++ b/superset-frontend/src/views/components/MenuRight.tsx
@@ -215,7 +215,7 @@ const RightMenu = ({
                   >
                     {menu.childs.map((item, idx) =>
                       typeof item !== 'string' && item.name && item.perm ? (
-                        <>
+                        <div key={item.label}>
                           {idx === 2 && <Menu.Divider />}
                           <Menu.Item key={item.name}>
                             {item.url ? (
@@ -224,7 +224,7 @@ const RightMenu = ({
                               item.label
                             )}
                           </Menu.Item>
-                        </>
+                        </div>
                       ) : null,
                     )}
                   </SubMenu>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add uniq keys to JSX elements,
in order to remove some react warning such as:

<img width="491" alt="image" src="https://user-images.githubusercontent.com/62829859/156232349-b50f9e3b-52c1-4cee-b069-454950ae6463.png">
<img width="502" alt="image" src="https://user-images.githubusercontent.com/62829859/156232504-a6f0f00a-1a5d-490d-80a5-ecb21750b964.png">

That will improve react performance



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
