### PR TITLE
fix(sqllab): Replace stringified 'null' schema column values with NULL

### DIFF
--- a/superset/migrations/versions/b5a422d8e252_fix_query_and_saved_query_null_schema.py
+++ b/superset/migrations/versions/b5a422d8e252_fix_query_and_saved_query_null_schema.py
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""fix query and saved_query null schema
+
+Revision ID: b5a422d8e252
+Revises: b8d3a24d9131
+Create Date: 2022-03-02 09:20:02.919490
+
+"""
+
+from alembic import op
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
+
+# revision identifiers, used by Alembic.
+revision = "b5a422d8e252"
+down_revision = "b8d3a24d9131"
+
+Base = declarative_base()
+
+
+class Query(Base):
+    __tablename__ = "query"
+
+    id = Column(Integer, primary_key=True)
+    schema = Column(String(256))
+
+
+class SavedQuery(Base):
+    __tablename__ = "saved_query"
+
+    id = Column(Integer, primary_key=True)
+    schema = Column(String(128))
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for model in (Query, SavedQuery):
+        for record in session.query(model).filter(model.schema == "null"):
+            record.schema = None
+
+        session.commit()
+
+    session.close()
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

I'm not sure exactly when this came about, though I _believe_ the issue has been resolved recently (albeit not being able to identify the relevant PR(s)), but it seems at some stage we were stringifying an undefined (`NULL`) schema in SQL Lab as `"null"` in both the `query` and `saved_query` tables resulting in some undesirable user behavior.

This PR includes a migration which simply replaces the `null` string with `NULL`, i.e., undefined.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI and ran the upgrade/downgrade manually.  Also ran the bench-marking  script (thanks @betodealmeida) which produced the following results:

```
Migration for 1000+ entities took: 0.42 seconds

Results:

Current: 0.50 s
10+: 0.35 s
100+: 0.35 s
1000+: 0.42 s
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
