### PR TITLE
fix(plugin-chart-echarts): Apply temporary filters to Query B in explore

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx
@@ -80,7 +80,7 @@ export const dndEntity: typeof dndGroupByControl = {
 export const dnd_adhoc_filters: SharedControlConfig<'DndFilterSelect'> = {
   type: 'DndFilterSelect',
   label: t('Filters'),
-  default: null,
+  default: [],
   description: '',
   mapStateToProps: ({ datasource, form_data }) => ({
     columns: datasource?.columns.filter(c => c.filterable) || [],

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -458,7 +458,7 @@ const x_axis_time_format: SharedControlConfig<'SelectControl'> = {
 const adhoc_filters: SharedControlConfig<'AdhocFilterControl'> = {
   type: 'AdhocFilterControl',
   label: t('Filters'),
-  default: null,
+  default: [],
   description: '',
   mapStateToProps: ({ datasource, form_data }) => ({
     columns: datasource?.columns.filter(c => c.filterable) || [],

--- a/superset/migrations/versions/7293b0ca7944_change_adhoc_filter_b_from_none_to_.py
+++ b/superset/migrations/versions/7293b0ca7944_change_adhoc_filter_b_from_none_to_.py
@@ -24,7 +24,7 @@ Create Date: 2022-03-02 16:41:36.350540
 
 # revision identifiers, used by Alembic.
 revision = "7293b0ca7944"
-down_revision = "b8d3a24d9131"
+down_revision = "b5a422d8e252"
 
 
 import json

--- a/superset/migrations/versions/7293b0ca7944_change_adhoc_filter_b_from_none_to_.py
+++ b/superset/migrations/versions/7293b0ca7944_change_adhoc_filter_b_from_none_to_.py
@@ -24,7 +24,7 @@ Create Date: 2022-03-02 16:41:36.350540
 
 # revision identifiers, used by Alembic.
 revision = "7293b0ca7944"
-down_revision = "b5a422d8e252"
+down_revision = "ab9a9d86e695"
 
 
 import json

--- a/superset/migrations/versions/7293b0ca7944_change_adhoc_filter_b_from_none_to_.py
+++ b/superset/migrations/versions/7293b0ca7944_change_adhoc_filter_b_from_none_to_.py
@@ -1,0 +1,84 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""change_adhoc_filter_b_from_none_to_empty_array
+
+Revision ID: 7293b0ca7944
+Revises: b8d3a24d9131
+Create Date: 2022-03-02 16:41:36.350540
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "7293b0ca7944"
+down_revision = "b8d3a24d9131"
+
+
+import json
+
+from alembic import op
+from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
+
+Base = declarative_base()
+
+
+class Slice(Base):
+    __tablename__ = "slices"
+
+    id = Column(Integer, primary_key=True)
+    params = Column(Text)
+    viz_type = Column(String(250))
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for slc in session.query(Slice).filter(Slice.viz_type == "mixed_timeseries").all():
+        try:
+            params = json.loads(slc.params)
+
+            adhoc_filters_b = params.get("adhoc_filters_b", None)
+            if not adhoc_filters_b:
+                params["adhoc_filters_b"] = []
+                slc.params = json.dumps(params, sort_keys=True)
+        except Exception:
+            pass
+
+    session.commit()
+    session.close()
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for slc in session.query(Slice).filter(Slice.viz_type == "mixed_timeseries").all():
+        try:
+            params = json.loads(slc.params)
+
+            adhoc_filters_b = params.get("adhoc_filters_b", [])
+            if not adhoc_filters_b:
+                del params["adhoc_filters_b"]
+                slc.params = json.dumps(params, sort_keys=True)
+        except Exception:
+            pass
+
+    session.commit()
+    session.close()

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1040,6 +1040,16 @@ def form_data_to_adhoc(form_data: Dict[str, Any], clause: str) -> AdhocFilterCla
     return result
 
 
+def append_filters_to_adhoc_filters(
+    adhoc_filters: List[AdhocFilterClause], filters: List[QueryObjectFilterClause]
+):
+    adhoc_filters.extend(
+        simple_filter_to_adhoc({"isExtra": True, **fltr})  # type: ignore
+        for fltr in filters
+        if fltr
+    )
+
+
 def merge_extra_form_data(form_data: Dict[str, Any]) -> None:
     """
     Merge extra form data (appends and overrides) into the main payload
@@ -1081,11 +1091,9 @@ def merge_extra_form_data(form_data: Dict[str, Any]) -> None:
         {"isExtra": True, **fltr} for fltr in append_adhoc_filters  # type: ignore
     )
     if append_filters:
-        adhoc_filters.extend(
-            simple_filter_to_adhoc({"isExtra": True, **fltr})  # type: ignore
-            for fltr in append_filters
-            if fltr
-        )
+        for key, value in form_data.items():
+            if re.match("adhoc_filter.*", key):
+                append_filters_to_adhoc_filters(value, append_filters)
 
 
 def merge_extra_filters(form_data: Dict[str, Any]) -> None:

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1042,7 +1042,7 @@ def form_data_to_adhoc(form_data: Dict[str, Any], clause: str) -> AdhocFilterCla
 
 def append_filters_to_adhoc_filters(
     adhoc_filters: List[AdhocFilterClause], filters: List[QueryObjectFilterClause]
-):
+) -> None:
     adhoc_filters.extend(
         simple_filter_to_adhoc({"isExtra": True, **fltr})  # type: ignore
         for fltr in filters

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1040,16 +1040,6 @@ def form_data_to_adhoc(form_data: Dict[str, Any], clause: str) -> AdhocFilterCla
     return result
 
 
-def append_filters_to_adhoc_filters(
-    adhoc_filters: List[AdhocFilterClause], filters: List[QueryObjectFilterClause]
-) -> None:
-    adhoc_filters.extend(
-        simple_filter_to_adhoc({"isExtra": True, **fltr})  # type: ignore
-        for fltr in filters
-        if fltr
-    )
-
-
 def merge_extra_form_data(form_data: Dict[str, Any]) -> None:
     """
     Merge extra form data (appends and overrides) into the main payload
@@ -1093,7 +1083,11 @@ def merge_extra_form_data(form_data: Dict[str, Any]) -> None:
     if append_filters:
         for key, value in form_data.items():
             if re.match("adhoc_filter.*", key):
-                append_filters_to_adhoc_filters(value, append_filters)
+                value.extend(
+                    simple_filter_to_adhoc({"isExtra": True, **fltr})  # type: ignore
+                    for fltr in append_filters
+                    if fltr
+                )
 
 
 def merge_extra_filters(form_data: Dict[str, Any]) -> None:


### PR DESCRIPTION
### SUMMARY
When going from the dashboard to Explore view with extra filters (native filters or filter box), the filters are only appended to the first query. This PR iterates through form data and adds extra filters to every field that matches pattern `adhoc_filters.*`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1789" alt="image" src="https://user-images.githubusercontent.com/15073128/156404079-ddf01b2d-6b4e-41e7-9616-42f0aae9a068.png">

After:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/15073128/156403586-b0fac9cf-1dbe-4b8c-91e6-c108801f0ef8.png">

### TESTING INSTRUCTIONS
1. Create a mixed timeseries chart and add it to a dashboard
2. Go to that dashboard and apply some native filters
3. Click View chart in explore on mixed timeseries chart
4. Verify that native filter is applied in both Query A and Query B adhoc filter control

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes #15858
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

DB migration stats:
```
Current: 0.42 s
10+: 0.44 s
100+: 0.26 s
1000+: 0.25 s
```

This PR replaces #18740 

https://app.shortcut.com/preset/story/37242/explore-mixed-time-series-chart-native-filter-only-apply-to-query-a-but-not-query-b-when-open-mixed-time-series-chart-from