### PR TITLE
fix(explore-sqllab): make that Timestamp column keep the Is temporal …

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -278,7 +278,10 @@ export default class ResultSet extends React.PureComponent<
       dbId,
       datasetToOverwrite.datasetId,
       sql,
-      results.selected_columns.map(d => ({ column_name: d.name })),
+      results.selected_columns.map(d => ({
+        column_name: d.name,
+        is_dttm: d.is_date,
+      })),
       datasetToOverwrite.owners.map((o: DatasetOwner) => o.id),
       true,
     );

--- a/superset-frontend/src/SqlLab/types.ts
+++ b/superset-frontend/src/SqlLab/types.ts
@@ -23,6 +23,7 @@ import { ToastType } from 'src/components/MessageToasts/types';
 
 export type Column = {
   name: string;
+  is_date?: boolean;
 };
 
 export type QueryState =


### PR DESCRIPTION
### SUMMARY
Overwriting an existing virtual dataset removes the Is temporal flag from columns

**How to reproduce the bug**
1. Navigate to the SQL Lab.
2. Run a SELECT statement including a timestamp column.
3. Click on EXPLORE.
4. Create a new dataset.
5. Note that the timestamp column is available to be selected on the time column drop-down.
6. Navigate back to the SQL Lab.
7. Run the same query again.
8. Click on EXPLORE.
9. Choose to overwrite the dataset you have just created.
10. Note that the timestamp column is not available to be used on the time column drop-down.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
![image](https://user-images.githubusercontent.com/47900232/156579628-c14f22a6-3ed5-4780-b688-a56a6d3864dd.png)

AFTER:
![image](https://user-images.githubusercontent.com/47900232/156579508-cf548868-8326-4bf9-a48f-99f33db820bf.png)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
