### PR TITLE
fix: ensure validation for db modal for googlesheets

### DIFF
--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -649,7 +649,7 @@ export function useDatabaseValidation() {
     null,
   );
   const getValidation = useCallback(
-    (database: Partial<DatabaseObject> | null, onCreate = false) => {
+    (database: Partial<DatabaseObject> | null, onCreate = false) =>
       SupersetClient.post({
         endpoint: '/api/v1/database/validate_parameters',
         body: JSON.stringify(database),
@@ -658,10 +658,10 @@ export function useDatabaseValidation() {
         .then(() => {
           setValidationErrors(null);
         })
+        // eslint-disable-next-line consistent-return
         .catch(e => {
-          setValidationErrors(null);
           if (typeof e.json === 'function') {
-            e.json().then(({ errors = [] }: JsonObject) => {
+            return e.json().then(({ errors = [] }: JsonObject) => {
               const parsedErrors = errors
                 .filter((error: { error_type: string }) => {
                   const skipValidationError = ![
@@ -749,12 +749,10 @@ export function useDatabaseValidation() {
                 );
               setValidationErrors(parsedErrors);
             });
-          } else {
-            // eslint-disable-next-line no-console
-            console.error(e);
           }
-        });
-    },
+          // eslint-disable-next-line no-console
+          console.error(e);
+        }),
     [setValidationErrors],
   );
 

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -659,6 +659,7 @@ export function useDatabaseValidation() {
           setValidationErrors(null);
         })
         .catch(e => {
+          setValidationErrors(null);
           if (typeof e.json === 'function') {
             e.json().then(({ errors = [] }: JsonObject) => {
               const parsedErrors = errors


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This pr fixes possibly fixes an issue where the validation for name or googlesheet api could be negated as truthy when trying to connect a gsheet. This is because the two of the same set state methods not separated by async method creating a race condition being returned from the hook. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
after

https://user-images.githubusercontent.com/17326228/156671557-29be21a1-7324-4bbd-a766-6eb086b44892.mov



### TESTING INSTRUCTIONS
Go to gsheets database modal and try to connect a gsheet without name or url. It should not proceed to the next step without both being valid.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
