### PR TITLE
fix: Add perm for showing DBC-UI in Global Nav

### DIFF
--- a/superset-frontend/src/views/components/MenuRight.tsx
+++ b/superset-frontend/src/views/components/MenuRight.tsx
@@ -87,17 +87,23 @@ const RightMenu = ({
   const canChart = findPermission('can_write', 'Chart', roles);
   const canDatabase = findPermission('can_write', 'Database', roles);
 
-  const canUploadCSV = findPermission('can_this_form_get', 'CsvToDatabaseView');
+  const canUploadCSV = findPermission(
+    'can_this_form_get',
+    'CsvToDatabaseView',
+    roles,
+  );
   const canUploadColumnar = findPermission(
     'can_this_form_get',
     'ColumnarToDatabaseView',
+    roles,
   );
   const canUploadExcel = findPermission(
     'can_this_form_get',
     'ExcelToDatabaseView',
+    roles,
   );
-  const canUpload = canUploadCSV || canUploadColumnar || canUploadExcel;
 
+  const canUpload = canUploadCSV || canUploadColumnar || canUploadExcel;
   const showActionDropdown = canSql || canChart || canDashboard;
   const dropdownItems: MenuObjectProps[] = [
     {

--- a/superset-frontend/src/views/components/MenuRight.tsx
+++ b/superset-frontend/src/views/components/MenuRight.tsx
@@ -85,6 +85,7 @@ const RightMenu = ({
   const canSql = findPermission('can_sqllab', 'Superset', roles);
   const canDashboard = findPermission('can_write', 'Dashboard', roles);
   const canChart = findPermission('can_write', 'Chart', roles);
+  const canDatabase = findPermission('can_write', 'Database', roles);
   const showActionDropdown = canSql || canChart || canDashboard;
   const dropdownItems: MenuObjectProps[] = [
     {
@@ -94,12 +95,12 @@ const RightMenu = ({
         {
           label: t('Connect Database'),
           name: GlobalMenuDataOptions.DB_CONNECTION,
-          perm: true,
+          perm: canDatabase,
         },
         {
           label: t('Connect Google Sheet'),
           name: GlobalMenuDataOptions.GOOGLE_SHEETS,
-          perm: HAS_GSHEETS_INSTALLED,
+          perm: canDatabase && HAS_GSHEETS_INSTALLED,
         },
         {
           label: t('Upload a CSV'),
@@ -183,7 +184,7 @@ const RightMenu = ({
           >
             {dropdownItems.map(menu => {
               if (menu.childs) {
-                return (
+                return canDatabase ? (
                   <SubMenu
                     key="sub2"
                     className="data-menu"
@@ -206,7 +207,7 @@ const RightMenu = ({
                       ) : null,
                     )}
                   </SubMenu>
-                );
+                ) : null;
               }
               return (
                 findPermission(

--- a/superset-frontend/src/views/components/MenuRight.tsx
+++ b/superset-frontend/src/views/components/MenuRight.tsx
@@ -86,6 +86,18 @@ const RightMenu = ({
   const canDashboard = findPermission('can_write', 'Dashboard', roles);
   const canChart = findPermission('can_write', 'Chart', roles);
   const canDatabase = findPermission('can_write', 'Database', roles);
+
+  const canUploadCSV = findPermission('can_this_form_get', 'CsvToDatabaseView');
+  const canUploadColumnar = findPermission(
+    'can_this_form_get',
+    'ColumnarToDatabaseView',
+  );
+  const canUploadExcel = findPermission(
+    'can_this_form_get',
+    'ExcelToDatabaseView',
+  );
+  const canUpload = canUploadCSV || canUploadColumnar || canUploadExcel;
+
   const showActionDropdown = canSql || canChart || canDashboard;
   const dropdownItems: MenuObjectProps[] = [
     {
@@ -106,19 +118,19 @@ const RightMenu = ({
           label: t('Upload a CSV'),
           name: 'Upload a CSV',
           url: '/csvtodatabaseview/form',
-          perm: CSV_EXTENSIONS,
+          perm: CSV_EXTENSIONS && canUploadCSV,
         },
         {
           label: t('Upload a Columnar File'),
           name: 'Upload a Columnar file',
           url: '/columnartodatabaseview/form',
-          perm: COLUMNAR_EXTENSIONS,
+          perm: COLUMNAR_EXTENSIONS && canUploadColumnar,
         },
         {
           label: t('Upload Excel'),
           name: 'Upload Excel',
           url: '/exceltodatabaseview/form',
-          perm: EXCEL_EXTENSIONS,
+          perm: EXCEL_EXTENSIONS && canUploadExcel,
         },
       ],
     },
@@ -184,7 +196,7 @@ const RightMenu = ({
           >
             {dropdownItems.map(menu => {
               if (menu.childs) {
-                return canDatabase ? (
+                return canDatabase || canUpload ? (
                   <SubMenu
                     key="sub2"
                     className="data-menu"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add perm check for showing DBC-UI inside the global nav create nav button, users must have `can_write -> Database` to be able to see the links

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
