### PR TITLE
fix(allow-db-explore): make that the set the allow-db-explore option

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -214,7 +214,7 @@ function dbReducer(
   };
   let query = {};
   let query_input = '';
-  let deserializeExtraJSON = {};
+  let deserializeExtraJSON = { allows_virtual_table_explore: true };
   let extra_json: DatabaseObject['extra_json'];
 
   switch (action.type) {


### PR DESCRIPTION
### SUMMARY
The "Allow this database to be explored" setting should be checked by default in the Database Connection UI

**How to reproduce the bug**

1. Create a new Database connection. (Google sheets is a quick one to create)
2. Expand the SQL Lab section under the ADVANCED tab, and make sure that Allow this database to be explored is disabled.
3. Save the connection.
4. However, the functionality is working as if the box was checked:
5. Navigate to SQL Lab > SQL Editor on the top navigation bar.
6. Execute a query on this newly connected database.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
AFTER:

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
