### PR TITLE
chore: Fix deprecated unittest aliases.

### DIFF
--- a/tests/integration_tests/security/row_level_security_tests.py
+++ b/tests/integration_tests/security/row_level_security_tests.py
@@ -256,7 +256,7 @@ class GuestTokenRowLevelSecurityTests(SupersetTestCase):
         tbl = self.get_table(name="birth_names")
         sql = tbl.get_query_str(self.query_obj)
 
-        self.assertRegexpMatches(sql, RLS_ALICE_REGEX)
+        self.assertRegex(sql, RLS_ALICE_REGEX)
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_rls_filter_does_not_alter_unrelated_query(self):
@@ -271,7 +271,7 @@ class GuestTokenRowLevelSecurityTests(SupersetTestCase):
         tbl = self.get_table(name="birth_names")
         sql = tbl.get_query_str(self.query_obj)
 
-        self.assertNotRegexpMatches(sql, RLS_ALICE_REGEX)
+        self.assertNotRegex(sql, RLS_ALICE_REGEX)
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_multiple_rls_filters_are_unionized(self):
@@ -287,8 +287,8 @@ class GuestTokenRowLevelSecurityTests(SupersetTestCase):
         tbl = self.get_table(name="birth_names")
         sql = tbl.get_query_str(self.query_obj)
 
-        self.assertRegexpMatches(sql, RLS_ALICE_REGEX)
-        self.assertRegexpMatches(sql, RLS_GENDER_REGEX)
+        self.assertRegex(sql, RLS_ALICE_REGEX)
+        self.assertRegex(sql, RLS_GENDER_REGEX)
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     @pytest.mark.usefixtures("load_energy_table_with_slice")
@@ -301,8 +301,8 @@ class GuestTokenRowLevelSecurityTests(SupersetTestCase):
         births_sql = births.get_query_str(self.query_obj)
         energy_sql = energy.get_query_str(self.query_obj)
 
-        self.assertRegexpMatches(births_sql, RLS_ALICE_REGEX)
-        self.assertRegexpMatches(energy_sql, RLS_ALICE_REGEX)
+        self.assertRegex(births_sql, RLS_ALICE_REGEX)
+        self.assertRegex(energy_sql, RLS_ALICE_REGEX)
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_dataset_id_can_be_string(self):
@@ -313,4 +313,4 @@ class GuestTokenRowLevelSecurityTests(SupersetTestCase):
         )
         sql = dataset.get_query_str(self.query_obj)
 
-        self.assertRegexpMatches(sql, RLS_ALICE_REGEX)
+        self.assertRegex(sql, RLS_ALICE_REGEX)


### PR DESCRIPTION
### SUMMARY

Fix deprecated unittest aliases. The deprecated aliases were removed in Python 3.11 and the change was reverted later to keep warnings only. Similar to https://github.com/apache/superset/pull/17562

Command to check for deprecated aliases

```
rg -t py 'assertEquals|assertNotEquals|assertAlmostEquals|assertNotAlmostEquals|assertRegexpMatches|assertNotRegexpMatches|assertRaisesRegexp|failUnlessEqual|failIfEqual|failUnlessAlmostEqual|failUnless|failUnlessRaises|failIf|assertDictContainsSubset|_TextTestResult'
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
