### PR TITLE
fix(big-number): Big Number with Trendline Chart is not working if Time Grain is set to Month

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/buildQuery.ts
@@ -34,8 +34,8 @@ const TIME_GRAIN_MAP: Record<string, string> = {
   PT1H: 'H',
   P1D: 'D',
   P1M: 'MS',
-  P3M: 'Q',
-  P1Y: 'A',
+  P3M: 'QS',
+  P1Y: 'AS',
   // TODO: these need to be mapped carefully, as the first day of week
   //  can vary from engine to engine
   // P1W: 'W',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/buildQuery.ts
@@ -33,7 +33,7 @@ const TIME_GRAIN_MAP: Record<string, string> = {
   PT30M: '30min',
   PT1H: 'H',
   P1D: 'D',
-  P1M: 'M',
+  P1M: 'MS',
   P3M: 'Q',
   P1Y: 'A',
   // TODO: these need to be mapped carefully, as the first day of week


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes the issue that Big Number with Trendline Chart is not working if Time Grain is set to Month and  Rolling Function is set to `cumsum`.
refer https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### before

https://user-images.githubusercontent.com/11830681/156992870-160c3c1c-8a67-4c05-ab85-5db03ac1031e.mov


### after

https://user-images.githubusercontent.com/11830681/156992746-33b13989-346b-4898-92b6-58f2c8b65095.mov



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
