### PR TITLE
fix: improve cypress flakiness

### DIFF
--- a/superset-frontend/cypress-base/cypress.json
+++ b/superset-frontend/cypress-base/cypress.json
@@ -12,7 +12,7 @@
   "viewportHeight": 1024,
   "projectId": "ukwxzo",
   "retries": {
-    "runMode": 1,
+    "runMode": 2,
     "openMode": 0
   }
 }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
We still see a decent number of flaky Cypress tests. Buming from 1 retry to 2 retries on failed tests should significantly reduce the number of cypress failures, while only barely increasing test run time (since the retries will only happen on failure).


### TESTING INSTRUCTIONS
CI

to: @john-bodley @michael-s-molina @graceguo-supercat @ktmud @rusackas 