### PR TITLE
chore(explore): Set Drag&Drop feature flags to True by default

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/AdhocMetrics.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/AdhocMetrics.test.ts
@@ -33,7 +33,7 @@ describe('AdhocMetrics', () => {
       .click();
 
     cy.get('[data-test=metrics]')
-      .find('[data-test="add-metric-button"]')
+      .contains('Drop columns/metrics here or click')
       .click();
 
     // Title edit for saved metrics is disabled - switch to Simple

--- a/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
@@ -255,10 +255,13 @@ describe('Groupby control', () => {
     cy.visitChartByName('Num Births Trend');
     cy.verifySliceSuccess({ waitAlias: '@chartData' });
 
-    cy.get('[data-test=groupby]').within(() => {
-      cy.get('.ant-select').click();
-      cy.get('input[type=search]').type('state{enter}');
-    });
+    cy.get('[data-test=groupby]')
+      .contains('Drop columns here or click')
+      .click();
+    cy.get('[id="adhoc-metric-edit-tabs-tab-simple"]').click();
+    cy.get('input[aria-label="Column"]').click().type('state{enter}');
+    cy.get('[data-test="ColumnEdit#save"]').contains('Save').click();
+
     cy.get('button[data-test="run-query-button"]').click();
     cy.verifySliceSuccess({ waitAlias: '@chartData', chartSelector: 'svg' });
   });

--- a/superset-frontend/cypress-base/cypress/integration/explore/visualizations/line.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/visualizations/line.test.ts
@@ -43,7 +43,7 @@ describe('Visualization > Line', () => {
     cy.get('.text-danger').contains('Metrics');
 
     cy.get('[data-test=metrics]')
-      .find('[data-test="add-metric-button"]')
+      .contains('Drop columns/metrics here or click')
       .click();
 
     // Title edit for saved metrics is disabled - switch to Simple

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -348,6 +348,7 @@ const ColumnSelectPopover = ({
           }
           buttonSize="small"
           onClick={onSave}
+          data-test="ColumnEdit#save"
           cta
         >
           {t('Save')}

--- a/superset/config.py
+++ b/superset/config.py
@@ -416,9 +416,9 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     # Enable experimental feature to search for other dashboards
     "OMNIBAR": False,
     "DASHBOARD_RBAC": False,
-    "ENABLE_EXPLORE_DRAG_AND_DROP": False,
+    "ENABLE_EXPLORE_DRAG_AND_DROP": True,
     "ENABLE_FILTER_BOX_MIGRATION": False,
-    "ENABLE_DND_WITH_CLICK_UX": False,
+    "ENABLE_DND_WITH_CLICK_UX": True,
     # Enabling ALERTS_ATTACH_REPORTS, the system sends email and slack message
     # with screenshot and link
     # Disables ALERTS_ATTACH_REPORTS, the system DOES NOT generate screenshot


### PR DESCRIPTION
### SUMMARY
Flip `ENABLE_EXPLORE_DRAG_AND_DROP` and `ENABLE_DND_WITH_CLICK_UX` feature flags to `True` by default. This will enable the drag and drop controls in the chart control panels in Explore pages.
Related PRs: https://github.com/apache/superset/pulls?q=is%3Apr+is%3Aclosed+drag+and+drop+in%3Atitle%2Cbody+

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: https://github.com/apache/superset/issues/18901
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

https://app.shortcut.com/preset/story/39407/flip-dnd-feature-flags-2-0