### PR TITLE
fix: remove unnecessary divider

### DIFF
--- a/superset-frontend/src/views/components/Menu.tsx
+++ b/superset-frontend/src/views/components/Menu.tsx
@@ -287,7 +287,6 @@ export function Menu({
             className="main-nav"
           >
             {menu.map(item => {
-              console.log('item', item)
               const props = {
                 ...item,
                 isFrontendRoute: isFrontendRoute(item.url),

--- a/superset-frontend/src/views/components/Menu.tsx
+++ b/superset-frontend/src/views/components/Menu.tsx
@@ -242,7 +242,7 @@ export function Menu({
         icon={showMenu === 'inline' ? <></> : <Icons.TriangleDown />}
       >
         {childs?.map((child: MenuObjectChildProps | string, index1: number) => {
-          if (typeof child === 'string' && child === '-') {
+          if (typeof child === 'string' && child === '-' && label !== 'Data') {
             return <DropdownMenu.Divider key={`$${index1}`} />;
           }
           if (typeof child !== 'string') {
@@ -287,6 +287,7 @@ export function Menu({
             className="main-nav"
           >
             {menu.map(item => {
+              console.log('item', item)
               const props = {
                 ...item,
                 isFrontendRoute: isFrontendRoute(item.url),


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This pr removes the divider that is no longer need in the data dropdown menu.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

before 
<img width="318" alt="Screen Shot 2022-03-07 at 1 39 59 PM" src="https://user-images.githubusercontent.com/17326228/157122271-5c3bbfc4-c666-4457-949b-c0f6243f20ff.png">

after
<img width="308" alt="Screen Shot 2022-03-07 at 1 37 35 PM" src="https://user-images.githubusercontent.com/17326228/157122026-23551eb1-8ff8-4144-a5c4-963dc070e228.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
