### PR TITLE
fix: add previous line hotkey to SQL Lab for macOS

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -306,7 +306,8 @@ class SqlEditor extends React.PureComponent {
   getHotkeyConfig() {
     // Get the user's OS
     const userOS = detectOS();
-    return [
+
+    const base = [
       {
         name: 'runQuery1',
         key: 'ctrl+r',
@@ -346,6 +347,19 @@ class SqlEditor extends React.PureComponent {
         func: this.stopQuery,
       },
     ];
+
+    if (userOS === 'MacOS') {
+      base.push({
+        name: 'previousLine',
+        key: 'ctrl+p',
+        descr: t('Previous Line'),
+        func: editor => {
+          editor.navigateUp(1);
+        },
+      });
+    }
+
+    return base;
   }
 
   setQueryEditorSql(sql) {


### PR DESCRIPTION
### SUMMARY

Adds an extra ctrl+p hotkey for macOS only that navigates to the previous line in SQL Lab editor.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TESTING INSTRUCTIONS

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
