### PR TITLE
fix: show the total row count in the SQL Lab Query History tab when limited by DISPLAY_MAX_ROW

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -583,18 +583,20 @@ export default class ResultSet extends React.PureComponent<
     const limitReached = results?.displayLimitReached;
     const limit = queryLimit || results.query.limit;
     const isAdmin = !!this.props.user?.roles?.Admin;
+    const rowsCount = Math.min(rows || 0, results?.data?.length || 0);
+
     const displayMaxRowsReachedMessage = {
       withAdmin: t(
         'The number of results displayed is limited to %(rows)d by the configuration DISPLAY_MAX_ROWS. ' +
           'Please add additional limits/filters or download to csv to see more rows up to ' +
           'the %(limit)d limit.',
-        { rows, limit },
+        { rows: rowsCount, limit },
       ),
       withoutAdmin: t(
         'The number of results displayed is limited to %(rows)d. ' +
           'Please add additional limits/filters, download to csv, or contact an admin ' +
           'to see more rows up to the %(limit)d limit.',
-        { rows, limit },
+        { rows: rowsCount, limit },
       ),
     };
     const shouldUseDefaultDropdownAlert =
@@ -657,7 +659,7 @@ export default class ResultSet extends React.PureComponent<
             <Alert
               type="warning"
               onClose={this.onAlertClose}
-              message={t('%(rows)d rows returned', { rows })}
+              message={t('%(rows)d rows returned', { rows: rowsCount })}
               description={
                 isAdmin
                   ? displayMaxRowsReachedMessage.withAdmin

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -332,7 +332,7 @@ export default function sqlLabReducer(state = {}, action) {
         endDttm: now(),
         progress: 100,
         results: action.results,
-        rows: action?.results?.data?.length,
+        rows: action?.results?.query?.rows || 0,
         state: 'success',
         limitingFactor: action?.results?.query?.limitingFactor,
         tempSchema: action?.results?.query?.tempSchema,


### PR DESCRIPTION
### SUMMARY
When the row count of a query executed in the SQL Lab is greater than the `DISPLAY_MAX_ROW` config, the row count shows incorrectly in the Query History tab.

The expected result is the row count to show the actual number of rows queried, regardless of the `DISPLAY_MAX_ROW` config, since that's only used to limit the result display.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:
<img width="1293" alt="Screen Shot 2022-03-07 at 22 37 46" src="https://user-images.githubusercontent.com/17252075/157148543-c9095973-d9e2-44d4-857a-1a3b2e300704.png">

After:
<img width="1293" alt="Screen Shot 2022-03-07 at 22 36 56" src="https://user-images.githubusercontent.com/17252075/157148468-a9a75c5a-dd18-492c-94f8-0b01e01b0e7c.png">

### TESTING INSTRUCTIONS
* Set the limit dropdown to 100k 
* Run a query (`SELECT country_name from wb_health_population` for example) with more than 10k rows 
* Run another query (a expensive one, like `SELECT * from wb_health_population`)
* Refresh the page while the previous query is executing
* Switch to the query history tab in SQL Lab

It might be needed to try this a couple of times to reproduce the issue

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
