### PR TITLE
feat: helper functions for RLS

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -484,7 +484,7 @@ def has_table_query(statement: Statement) -> bool:
         if isinstance(token, TokenList):
             tokens.extend(token.tokens)
 
-        if token.ttype == Keyword and token.value.lower() in ("from", "join"):
+        if imt(token, m=[(Keyword, "FROM"), (Keyword, "JOIN")]):
             seen_source = True
         elif seen_source and (
             isinstance(token, sqlparse.sql.Identifier) or token.ttype == Keyword

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -1299,6 +1299,22 @@ def test_has_table_query(sql: str, expected: bool) -> None:
             "id=42",
             "SELECT * FROM (SELECT * FROM other_table WHERE other_table.id=42)",
         ),
+        # union
+        (
+            "SELECT * FROM table UNION ALL SELECT * FROM other_table",
+            "table",
+            "id=42",
+            "SELECT * FROM table WHERE table.id=42 UNION ALL SELECT * FROM other_table",
+        ),
+        (
+            "SELECT * FROM table UNION ALL SELECT * FROM other_table",
+            "other_table",
+            "id=42",
+            (
+                "SELECT * FROM table UNION ALL "
+                "SELECT * FROM other_table WHERE other_table.id=42"
+            ),
+        ),
     ],
 )
 def test_insert_rls(sql, table, rls, expected) -> None:

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -1227,7 +1227,7 @@ def test_has_table_query(sql: str, expected: bool) -> None:
             "SELECT * FROM some_table WHERE 1=1",
             "some_table",
             "id=42",
-            "SELECT * FROM some_table WHERE (1=1) AND some_table.id=42",
+            "SELECT * FROM some_table WHERE ( 1=1) AND some_table.id=42",
         ),
         # Any existing predicates MUST to be wrapped in parenthesis because AND has higher
         # precedence than OR. If the RLS it `1=0` and we didn't add parenthesis a user
@@ -1237,7 +1237,7 @@ def test_has_table_query(sql: str, expected: bool) -> None:
             "SELECT * FROM some_table WHERE TRUE OR FALSE",
             "some_table",
             "1=0",
-            "SELECT * FROM some_table WHERE (TRUE OR FALSE) AND 1=0",
+            "SELECT * FROM some_table WHERE ( TRUE OR FALSE) AND 1=0",
         ),
         # Here "table" is a reserved word; since sqlparse is too aggressive when
         # characterizing reserved words we need to support them even when not quoted.
@@ -1245,7 +1245,7 @@ def test_has_table_query(sql: str, expected: bool) -> None:
             "SELECT * FROM table WHERE 1=1",
             "table",
             "id=42",
-            "SELECT * FROM table WHERE (1=1) AND table.id=42",
+            "SELECT * FROM table WHERE ( 1=1) AND table.id=42",
         ),
         # RLS is only applied to queries reading from the associated table.
         (
@@ -1277,25 +1277,25 @@ def test_has_table_query(sql: str, expected: bool) -> None:
             "SELECT * FROM table ORDER BY id",
             "table",
             "id=42",
-            "SELECT * FROM table WHERE table.id=42 ORDER BY id",
+            "SELECT * FROM table  WHERE table.id=42 ORDER BY id",
         ),
         (
             "SELECT * FROM some_table;",
             "some_table",
             "id=42",
-            "SELECT * FROM some_table WHERE some_table.id=42;",
+            "SELECT * FROM some_table WHERE some_table.id=42 ;",
         ),
         (
             "SELECT * FROM some_table       ;",
             "some_table",
             "id=42",
-            "SELECT * FROM some_table       WHERE some_table.id=42;",
+            "SELECT * FROM some_table        WHERE some_table.id=42 ;",
         ),
         (
             "SELECT * FROM some_table       ",
             "some_table",
             "id=42",
-            "SELECT * FROM some_table       WHERE some_table.id=42",
+            "SELECT * FROM some_table        WHERE some_table.id=42",
         ),
         # We add the RLS even if it's already present, to be conservative. It should have
         # no impact on the query, and it's easier than testing if the RLS is already
@@ -1304,7 +1304,7 @@ def test_has_table_query(sql: str, expected: bool) -> None:
             "SELECT * FROM table WHERE 1=1 AND table.id=42",
             "table",
             "id=42",
-            "SELECT * FROM table WHERE (1=1 AND table.id=42) AND table.id=42",
+            "SELECT * FROM table WHERE ( 1=1 AND table.id=42) AND table.id=42",
         ),
         (
             (
@@ -1322,7 +1322,7 @@ def test_has_table_query(sql: str, expected: bool) -> None:
             "SELECT * FROM table WHERE 1=1 AND id=42",
             "table",
             "id=42",
-            "SELECT * FROM table WHERE (1=1 AND id=42) AND table.id=42",
+            "SELECT * FROM table WHERE ( 1=1 AND id=42) AND table.id=42",
         ),
         # For joins we apply the RLS to the ON clause, since it's easier and prevents
         # leaking information about number of rows on OUTER JOINs.
@@ -1352,14 +1352,14 @@ def test_has_table_query(sql: str, expected: bool) -> None:
             "SELECT * FROM (SELECT * FROM other_table)",
             "other_table",
             "id=42",
-            "SELECT * FROM (SELECT * FROM other_table WHERE other_table.id=42)",
+            "SELECT * FROM (SELECT * FROM other_table WHERE other_table.id=42 )",
         ),
         # As well as UNION.
         (
             "SELECT * FROM table UNION ALL SELECT * FROM other_table",
             "table",
             "id=42",
-            "SELECT * FROM table WHERE table.id=42 UNION ALL SELECT * FROM other_table",
+            "SELECT * FROM table  WHERE table.id=42 UNION ALL SELECT * FROM other_table",
         ),
         (
             "SELECT * FROM table UNION ALL SELECT * FROM other_table",

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -25,6 +25,7 @@ import sqlparse
 
 from superset.exceptions import QueryClauseValidationException
 from superset.sql_parse import (
+    add_table_name,
     has_table_query,
     insert_rls,
     ParsedQuery,
@@ -1343,3 +1344,18 @@ def test_insert_rls(sql, table, rls, expected) -> None:
     statement = sqlparse.parse(sql)[0]
     condition = sqlparse.parse(rls)[0]
     assert str(insert_rls(statement, table, condition)).strip() == expected.strip()
+
+
+@pytest.mark.parametrize(
+    "rls,table,expected",
+    [
+        ("id=42", "users", "users.id=42"),
+        ("users.id=42", "users", "users.id=42"),
+        ("schema.users.id=42", "users", "schema.users.id=42"),
+        ("false", "users", "false"),
+    ],
+)
+def test_add_table_name(rls, table, expected) -> None:
+    condition = sqlparse.parse(rls)[0]
+    add_table_name(condition, table)
+    assert str(condition) == expected

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -1315,6 +1315,25 @@ def test_has_table_query(sql: str, expected: bool) -> None:
                 "SELECT * FROM other_table WHERE other_table.id=42"
             ),
         ),
+        # fully qualified table names
+        (
+            "SELECT * FROM schema.table_name",
+            "table_name",
+            "id=42",
+            "SELECT * FROM schema.table_name WHERE table_name.id=42",
+        ),
+        (
+            "SELECT * FROM schema.table_name",
+            "schema.table_name",
+            "id=42",
+            "SELECT * FROM schema.table_name WHERE schema.table_name.id=42",
+        ),
+        (
+            "SELECT * FROM table_name",
+            "schema.table_name",
+            "id=42",
+            "SELECT * FROM table_name WHERE schema.table_name.id=42",
+        ),
     ],
 )
 def test_insert_rls(sql, table, rls, expected) -> None:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR introduces 2 helper functions for RLS:

- `has_table_query(statement: Statement) -> bool:`, which analyzes a SQL statement parsed by`sqlparse` and returns `True` if it queries a table (either in a `FROM` or `JOIN`).
- `insert_rls(token_list: TokenList, table: str, rls: TokenList) -> TokenList:`, which given a parsed statement (or token list), a table name, and a parsed RLS expression, will reformat the query so that the RLS is present in any queries or subqueries referencing the table.

For example, if we have the RLS expression `id=42` on the table `my_table` we could do:

```python
>>> statement = sqlparse.parse('SELECT COUNT(*) FROM my_table')[0]
>>> has_table_query(statement)
True
>>> rls = sqlparse.parse('id=42')[0]
>>> print(insert_rls(statement, 'my_table', rls)
SELECT COUNT(*) FROM my_table WHERE my_table.id=42
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

I added unit tests covering different cases:

- Regular queries
- Nested queries
- Joins
- Union
- Fully qualified table names (eg, `schema.table_name`)
- RLS already in the SQL

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
