### PR TITLE
fix(deck.gl): make Deck.gl Javascript tooltip generator works correctly

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -323,6 +323,7 @@
     "transform-loader": "^0.2.4",
     "ts-loader": "^9.2.5",
     "typescript": "^4.5.4",
+    "vm-browserify": "^1.1.2",
     "webpack": "^5.52.1",
     "webpack-bundle-analyzer": "^4.4.2",
     "webpack-cli": "^4.8.0",

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -294,7 +294,7 @@ const config = {
     extensions: ['.ts', '.tsx', '.js', '.jsx', '.yml'],
     fallback: {
       fs: false,
-      vm: false,
+      vm: require.resolve('vm-browserify'),
       path: false,
     },
   },


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR fixed the problem that JAVASCRIPT TOOLTIP GENERATOR of Deck.gl is not working.

I installed `vm-browserify` and specified it in `webpack.config.js`.
Because Webpack 5 no longer polyfills and `vm` module is used at `sandboxedEval` function defined `superset/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utils/sandbox.js`.

> Webpack 5 no longer polyfills Node.js core modules automatically which means if you use them in your code running in browsers or alike, you will have to install compatible modules from npm and include them yourself.
> https://webpack.js.org/configuration/resolve/


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

https://user-images.githubusercontent.com/12185831/157202321-d74d61db-db1d-4bf5-8d6b-861a585f1a15.mp4

#### After

https://user-images.githubusercontent.com/12185831/157202370-eb17145c-bb43-476e-ba65-2f18fc0e24ef.mp4

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/18696
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
