### PR TITLE
fix: enable find text browser functionality inside SQL Lab editor

### DIFF
--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/index.tsx
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/index.tsx
@@ -121,6 +121,8 @@ class AceEditorWrapper extends React.PureComponent<Props, State> {
   }
 
   onEditorLoad(editor: any) {
+    editor.commands.removeCommand('find');
+
     editor.commands.addCommand({
       name: 'runQuery',
       bindKey: { win: 'Alt-enter', mac: 'Alt-enter' },
@@ -128,6 +130,7 @@ class AceEditorWrapper extends React.PureComponent<Props, State> {
         this.onAltEnter();
       },
     });
+
     this.props.hotkeys.forEach(keyConfig => {
       editor.commands.addCommand({
         name: keyConfig.name,
@@ -135,6 +138,7 @@ class AceEditorWrapper extends React.PureComponent<Props, State> {
         exec: keyConfig.func,
       });
     });
+
     editor.$blockScrolling = Infinity; // eslint-disable-line no-param-reassign
     editor.selection.on('changeSelection', () => {
       const selectedText = editor.getSelectedText();


### PR DESCRIPTION
### SUMMARY
Disable the SQL Lab editor hotkey that prevents the find text browser functionality to work

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TESTING INSTRUCTIONS

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
