### PR TITLE
perf(dashboard): Improve performance of complex dashboards

### DIFF
--- a/superset-frontend/spec/fixtures/mockNativeFilters.ts
+++ b/superset-frontend/spec/fixtures/mockNativeFilters.ts
@@ -55,6 +55,7 @@ export const nativeFilters: NativeFiltersState = {
       },
       type: NativeFilterType.NATIVE_FILTER,
       description: '',
+      chartsInScope: [18],
     },
     'NATIVE_FILTER-x9QPw0so1': {
       id: 'NATIVE_FILTER-x9QPw0so1',
@@ -85,6 +86,7 @@ export const nativeFilters: NativeFiltersState = {
       },
       type: NativeFilterType.NATIVE_FILTER,
       description: '2 letter code',
+      chartsInScope: [18],
     },
   },
 };

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
@@ -20,12 +20,7 @@
 // when its container size changes, due to e.g., builder side panel opening
 import React, { FC, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import {
-  FeatureFlag,
-  Filter,
-  Filters,
-  isFeatureEnabled,
-} from '@superset-ui/core';
+import { FeatureFlag, Filters, isFeatureEnabled } from '@superset-ui/core';
 import { ParentSize } from '@vx/responsive';
 import Tabs from 'src/components/Tabs';
 import DashboardGrid from 'src/dashboard/containers/DashboardGrid';
@@ -41,7 +36,7 @@ import {
   DASHBOARD_ROOT_DEPTH,
 } from 'src/dashboard/util/constants';
 import { getRootLevelTabIndex, getRootLevelTabsComponent } from './utils';
-import { getChartIdsInFilterScope2 } from '../../util/activeDashboardFilters';
+import { getChartIdsInFilterScope } from '../../util/activeDashboardFilters';
 import findTabIndexByComponentId from '../../util/findTabIndexByComponentId';
 import { findTabsWithChartsInScope } from '../nativeFilters/utils';
 import { setInScopeStatusOfFilters } from '../../actions/nativeFilters';
@@ -106,9 +101,8 @@ const DashboardContainer: FC<DashboardContainerProps> = ({ topLevelTabs }) => {
           chartsInScope: [],
         };
       }
-      const { scope } = filterScope;
-      const chartsInScope: number[] = getChartIdsInFilterScope2(
-        scope,
+      const chartsInScope: number[] = getChartIdsInFilterScope(
+        filterScope.scope,
         charts,
         dashboardLayout,
       );

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
@@ -51,7 +51,7 @@ type DashboardContainerProps = {
   topLevelTabs?: LayoutItem;
 };
 
-const useFilterScopes = () => {
+const useNativeFilterScopes = () => {
   const nativeFilters = useSelector<RootState, Filters>(
     state => state.nativeFilters?.filters,
   );
@@ -70,7 +70,7 @@ const DashboardContainer: FC<DashboardContainerProps> = ({ topLevelTabs }) => {
   const dashboardLayout = useSelector<RootState, DashboardLayout>(
     state => state.dashboardLayout.present,
   );
-  const filtersScopes = useFilterScopes();
+  const nativeFiltersScopes = useNativeFilterScopes();
   const directPathToChild = useSelector<RootState, string[]>(
     state => state.dashboardState.directPathToChild,
   );
@@ -94,11 +94,11 @@ const DashboardContainer: FC<DashboardContainerProps> = ({ topLevelTabs }) => {
   useEffect(() => {
     if (
       !isFeatureEnabled(FeatureFlag.DASHBOARD_NATIVE_FILTERS) ||
-      filtersScopes.length === 0
+      nativeFiltersScopes.length === 0
     ) {
       return;
     }
-    const scopes = filtersScopes.map(filterScope => {
+    const scopes = nativeFiltersScopes.map(filterScope => {
       if (filterScope.id.startsWith(NATIVE_FILTER_DIVIDER_PREFIX)) {
         return {
           filterId: filterScope.id,
@@ -123,7 +123,7 @@ const DashboardContainer: FC<DashboardContainerProps> = ({ topLevelTabs }) => {
       };
     });
     dispatch(setInScopeStatusOfFilters(scopes));
-  }, [filtersScopes, dashboardLayout, dispatch]);
+  }, [nativeFiltersScopes, dashboardLayout, dispatch]);
 
   const childIds: string[] = topLevelTabs
     ? topLevelTabs.children

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
@@ -27,24 +27,25 @@ import {
   isFeatureEnabled,
 } from '@superset-ui/core';
 import { ParentSize } from '@vx/responsive';
+import pick from 'lodash/pick';
 import Tabs from 'src/components/Tabs';
 import DashboardGrid from 'src/dashboard/containers/DashboardGrid';
-import getLeafComponentIdFromPath from 'src/dashboard/util/getLeafComponentIdFromPath';
 import {
   ChartsState,
   DashboardLayout,
   LayoutItem,
   RootState,
 } from 'src/dashboard/types';
+import getLeafComponentIdFromPath from 'src/dashboard/util/getLeafComponentIdFromPath';
 import {
   DASHBOARD_GRID_ID,
   DASHBOARD_ROOT_DEPTH,
 } from 'src/dashboard/util/constants';
+import { getChartIdsInFilterScope } from 'src/dashboard/util/getChartIdsInFilterScope';
+import findTabIndexByComponentId from 'src/dashboard/util/findTabIndexByComponentId';
+import { setInScopeStatusOfFilters } from 'src/dashboard/actions/nativeFilters';
 import { getRootLevelTabIndex, getRootLevelTabsComponent } from './utils';
-import { getChartIdsInFilterScope } from '../../util/getChartIdsInFilterScope';
-import findTabIndexByComponentId from '../../util/findTabIndexByComponentId';
 import { findTabsWithChartsInScope } from '../nativeFilters/utils';
-import { setInScopeStatusOfFilters } from '../../actions/nativeFilters';
 import { NATIVE_FILTER_DIVIDER_PREFIX } from '../nativeFilters/FiltersConfigModal/utils';
 
 type DashboardContainerProps = {
@@ -58,11 +59,9 @@ const useNativeFilterScopes = () => {
   return useMemo(
     () =>
       nativeFilters
-        ? Object.values(nativeFilters).map((filter: Filter) => ({
-            id: filter.id,
-            scope: filter.scope,
-            type: filter.type,
-          }))
+        ? Object.values(nativeFilters).map((filter: Filter) =>
+            pick(filter, ['id', 'scope', 'type']),
+          )
         : [],
     [JSON.stringify(nativeFilters)],
   );

--- a/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
@@ -28,10 +28,10 @@ import {
 } from '@superset-ui/core';
 import { NO_TIME_RANGE, TIME_FILTER_MAP } from 'src/explore/constants';
 import { getChartIdsInFilterBoxScope } from 'src/dashboard/util/activeDashboardFilters';
+import { CHART_TYPE } from 'src/dashboard/util/componentTypes';
 import { ChartConfiguration } from 'src/dashboard/reducers/types';
+import { Layout } from 'src/dashboard/types';
 import { areObjectsEqual } from 'src/reduxUtils';
-import { Layout } from '../../types';
-import { CHART_TYPE } from '../../util/componentTypes';
 
 export enum IndicatorStatus {
   Unset = 'UNSET',

--- a/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
@@ -291,16 +291,17 @@ export const selectNativeIndicatorsForChart = (
 
   let crossFilterIndicators: any = [];
   if (isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS)) {
+    const dashboardLayoutValues = Object.values(dashboardLayout);
+    const chartLayoutItem = dashboardLayoutValues.find(
+      layoutItem => layoutItem?.meta?.chartId === chartId,
+    );
     crossFilterIndicators = Object.values(chartConfiguration)
-      .filter(chartConfig =>
-        getChartIdsInFilterScope({
-          filterScope: {
-            scope: chartConfig?.crossFilters?.scope.rootPath,
-            immune: chartConfig?.crossFilters?.scope.excluded,
-          },
-        }).some(
-          layoutItem => dashboardLayout[layoutItem]?.meta?.chartId === chartId,
-        ),
+      .filter(
+        chartConfig =>
+          !chartConfig.crossFilters.scope.excluded.includes(chartId) &&
+          chartConfig.crossFilters.scope.rootPath.some(elementId =>
+            chartLayoutItem?.parents.includes(elementId),
+          ),
       )
       .map(chartConfig => {
         const filterState = dataMask[chartConfig.id]?.filterState;
@@ -308,7 +309,7 @@ export const selectNativeIndicatorsForChart = (
         const filtersState = filterState?.filters;
         const column = filtersState && Object.keys(filtersState)[0];
 
-        const dashboardLayoutItem = Object.values(dashboardLayout).find(
+        const dashboardLayoutItem = dashboardLayoutValues.find(
           layoutItem => layoutItem?.meta?.chartId === chartConfig.id,
         );
         return {

--- a/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
@@ -27,7 +27,7 @@ import {
   NativeFilterType,
 } from '@superset-ui/core';
 import { NO_TIME_RANGE, TIME_FILTER_MAP } from 'src/explore/constants';
-import { getChartIdsInFilterScope } from 'src/dashboard/util/activeDashboardFilters';
+import { getChartIdsInFilterBoxScope } from 'src/dashboard/util/activeDashboardFilters';
 import { ChartConfiguration } from 'src/dashboard/reducers/types';
 import { areObjectsEqual } from 'src/reduxUtils';
 import { Layout } from '../../types';
@@ -122,7 +122,7 @@ const selectIndicatorsForChartFromFilter = (
 
   return Object.keys(filter.columns)
     .filter(column =>
-      getChartIdsInFilterScope({
+      getChartIdsInFilterBoxScope({
         filterScope: filter.scopes[column],
       }).includes(chartId),
     )

--- a/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
@@ -302,7 +302,7 @@ export const selectNativeIndicatorsForChart = (
           !chartConfig.crossFilters.scope.excluded.includes(chartId) &&
           chartConfig.crossFilters.scope.rootPath.some(
             elementId =>
-              chartLayoutItem.type === CHART_TYPE &&
+              chartLayoutItem?.type === CHART_TYPE &&
               chartLayoutItem?.parents?.includes(elementId),
           ),
       )

--- a/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
@@ -31,7 +31,6 @@ import { getChartIdsInFilterScope } from 'src/dashboard/util/activeDashboardFilt
 import { ChartConfiguration } from 'src/dashboard/reducers/types';
 import { areObjectsEqual } from 'src/reduxUtils';
 import { Layout } from '../../types';
-import { getTreeCheckedItems } from '../nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils';
 
 export enum IndicatorStatus {
   Unset = 'UNSET',
@@ -274,10 +273,7 @@ export const selectNativeIndicatorsForChart = (
         .filter(
           nativeFilter =>
             nativeFilter.type === NativeFilterType.NATIVE_FILTER &&
-            getTreeCheckedItems(nativeFilter.scope, dashboardLayout).some(
-              layoutItem =>
-                dashboardLayout[layoutItem]?.meta?.chartId === chartId,
-            ),
+            nativeFilter.chartsInScope?.includes(chartId),
         )
         .map(nativeFilter => {
           const column = nativeFilter.targets?.[0]?.column?.name;
@@ -297,10 +293,12 @@ export const selectNativeIndicatorsForChart = (
   if (isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS)) {
     crossFilterIndicators = Object.values(chartConfiguration)
       .filter(chartConfig =>
-        getTreeCheckedItems(
-          chartConfig?.crossFilters?.scope,
-          dashboardLayout,
-        ).some(
+        getChartIdsInFilterScope({
+          filterScope: {
+            scope: chartConfig?.crossFilters?.scope.rootPath,
+            immune: chartConfig?.crossFilters?.scope.excluded,
+          },
+        }).some(
           layoutItem => dashboardLayout[layoutItem]?.meta?.chartId === chartId,
         ),
       )

--- a/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
@@ -31,6 +31,7 @@ import { getChartIdsInFilterBoxScope } from 'src/dashboard/util/activeDashboardF
 import { ChartConfiguration } from 'src/dashboard/reducers/types';
 import { areObjectsEqual } from 'src/reduxUtils';
 import { Layout } from '../../types';
+import { CHART_TYPE } from '../../util/componentTypes';
 
 export enum IndicatorStatus {
   Unset = 'UNSET',
@@ -299,8 +300,10 @@ export const selectNativeIndicatorsForChart = (
       .filter(
         chartConfig =>
           !chartConfig.crossFilters.scope.excluded.includes(chartId) &&
-          chartConfig.crossFilters.scope.rootPath.some(elementId =>
-            chartLayoutItem?.parents.includes(elementId),
+          chartConfig.crossFilters.scope.rootPath.some(
+            elementId =>
+              chartLayoutItem.type === CHART_TYPE &&
+              chartLayoutItem?.parents?.includes(elementId),
           ),
       )
       .map(chartConfig => {

--- a/superset-frontend/src/dashboard/components/filterscope/FilterScopeSelector.jsx
+++ b/superset-frontend/src/dashboard/components/filterscope/FilterScopeSelector.jsx
@@ -30,7 +30,7 @@ import getKeyForFilterScopeTree from 'src/dashboard/util/getKeyForFilterScopeTre
 import getSelectedChartIdForFilterScopeTree from 'src/dashboard/util/getSelectedChartIdForFilterScopeTree';
 import getFilterScopeFromNodesTree from 'src/dashboard/util/getFilterScopeFromNodesTree';
 import getRevertedFilterScope from 'src/dashboard/util/getRevertedFilterScope';
-import { getChartIdsInFilterScope } from 'src/dashboard/util/activeDashboardFilters';
+import { getChartIdsInFilterBoxScope } from 'src/dashboard/util/activeDashboardFilters';
 import {
   getChartIdAndColumnFromFilterKey,
   getDashboardFilterKey,
@@ -106,7 +106,7 @@ export default class FilterScopeSelector extends React.PureComponent {
               const expanded = getFilterScopeParentNodes(nodes, 1);
               // force display filter_box chart as unchecked, but show checkbox as disabled
               const chartIdsInFilterScope = (
-                getChartIdsInFilterScope({
+                getChartIdsInFilterBoxScope({
                   filterScope: dashboardFilters[filterId].scopes[columnName],
                 }) || []
               ).filter(id => id !== filterId);

--- a/superset-frontend/src/dashboard/components/gridComponents/ChartHolder.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/ChartHolder.jsx
@@ -22,7 +22,7 @@ import cx from 'classnames';
 import { useTheme } from '@superset-ui/core';
 import { useSelector, connect } from 'react-redux';
 
-import { getChartIdsInFilterScope } from 'src/dashboard/util/activeDashboardFilters';
+import { getChartIdsInFilterBoxScope } from 'src/dashboard/util/activeDashboardFilters';
 import Chart from '../../containers/Chart';
 import AnchorLink from '../../../components/AnchorLink';
 import DeleteComponentButton from '../DeleteComponentButton';
@@ -142,7 +142,7 @@ const FilterFocusHighlight = React.forwardRef(
       }
     } else if (
       chartId === focusedFilterScope.chartId ||
-      getChartIdsInFilterScope({
+      getChartIdsInFilterBoxScope({
         filterScope: focusedFilterScope.scope,
       }).includes(chartId)
     ) {

--- a/superset-frontend/src/dashboard/reducers/types.ts
+++ b/superset-frontend/src/dashboard/reducers/types.ts
@@ -30,6 +30,7 @@ export type ChartConfiguration = {
     id: number;
     crossFilters: {
       scope: NativeFilterScope;
+      chartsInScope?: number[];
     };
   };
 };

--- a/superset-frontend/src/dashboard/reducers/types.ts
+++ b/superset-frontend/src/dashboard/reducers/types.ts
@@ -30,7 +30,6 @@ export type ChartConfiguration = {
     id: number;
     crossFilters: {
       scope: NativeFilterScope;
-      chartsInScope?: number[];
     };
   };
 };

--- a/superset-frontend/src/dashboard/util/activeDashboardFilters.js
+++ b/superset-frontend/src/dashboard/util/activeDashboardFilters.js
@@ -60,7 +60,7 @@ export function getAppliedFilterValues(chartId) {
   }
   return appliedFilterValuesByChart[chartId];
 }
-export function getChartIdsInFilterScope2(filterScope, charts, layout) {
+export function getChartIdsInFilterScope(filterScope, charts, layout) {
   const layoutItems = Object.values(layout);
   return Object.values(charts)
     .filter(
@@ -77,7 +77,7 @@ export function getChartIdsInFilterScope2(filterScope, charts, layout) {
     .map(chart => chart.id);
 }
 
-export function getChartIdsInFilterScope({ filterScope }) {
+export function getChartIdsInFilterBoxScope({ filterScope }) {
   function traverse(chartIds = [], component = {}, immuneChartIds = []) {
     if (!component) {
       return;
@@ -132,7 +132,7 @@ export function buildActiveFilters({ dashboardFilters = {}, components = {} }) {
           : columns[column] !== undefined
       ) {
         // remove filter itself
-        const scope = getChartIdsInFilterScope({
+        const scope = getChartIdsInFilterBoxScope({
           filterScope: scopes[column],
         }).filter(id => chartId !== id);
 

--- a/superset-frontend/src/dashboard/util/activeDashboardFilters.js
+++ b/superset-frontend/src/dashboard/util/activeDashboardFilters.js
@@ -18,7 +18,6 @@
  */
 import { isEmpty } from 'lodash';
 import { mapValues, flow, keyBy } from 'lodash/fp';
-
 import {
   getChartIdAndColumnFromFilterKey,
   getDashboardFilterKey,
@@ -60,6 +59,22 @@ export function getAppliedFilterValues(chartId) {
     )(applicableFilters);
   }
   return appliedFilterValuesByChart[chartId];
+}
+export function getChartIdsInFilterScope2(filterScope, charts, layout) {
+  const layoutItems = Object.values(layout);
+  return Object.values(charts)
+    .filter(
+      chart =>
+        !filterScope.excluded.includes(chart.id) &&
+        layoutItems
+          .find(
+            layoutItem =>
+              layoutItem.type === CHART_TYPE &&
+              layoutItem.meta.chartId === chart.id,
+          )
+          ?.parents.some(elementId => filterScope.rootPath.includes(elementId)),
+    )
+    .map(chart => chart.id);
 }
 
 export function getChartIdsInFilterScope({ filterScope }) {

--- a/superset-frontend/src/dashboard/util/activeDashboardFilters.js
+++ b/superset-frontend/src/dashboard/util/activeDashboardFilters.js
@@ -69,10 +69,12 @@ export function getChartIdsInFilterScope(filterScope, charts, layout) {
         layoutItems
           .find(
             layoutItem =>
-              layoutItem.type === CHART_TYPE &&
-              layoutItem.meta.chartId === chart.id,
+              layoutItem?.type === CHART_TYPE &&
+              layoutItem.meta?.chartId === chart.id,
           )
-          ?.parents.some(elementId => filterScope.rootPath.includes(elementId)),
+          ?.parents?.some(elementId =>
+            filterScope.rootPath.includes(elementId),
+          ),
     )
     .map(chart => chart.id);
 }

--- a/superset-frontend/src/dashboard/util/activeDashboardFilters.js
+++ b/superset-frontend/src/dashboard/util/activeDashboardFilters.js
@@ -60,25 +60,10 @@ export function getAppliedFilterValues(chartId) {
   }
   return appliedFilterValuesByChart[chartId];
 }
-export function getChartIdsInFilterScope(filterScope, charts, layout) {
-  const layoutItems = Object.values(layout);
-  return Object.values(charts)
-    .filter(
-      chart =>
-        !filterScope.excluded.includes(chart.id) &&
-        layoutItems
-          .find(
-            layoutItem =>
-              layoutItem?.type === CHART_TYPE &&
-              layoutItem.meta?.chartId === chart.id,
-          )
-          ?.parents?.some(elementId =>
-            filterScope.rootPath.includes(elementId),
-          ),
-    )
-    .map(chart => chart.id);
-}
 
+// Legacy - getChartIdsInFilterBoxScope is used only by
+// components and functions related to filter box
+// Please use src/dashboard/util/getChartIdsInFilterScope instead
 export function getChartIdsInFilterBoxScope({ filterScope }) {
   function traverse(chartIds = [], component = {}, immuneChartIds = []) {
     if (!component) {

--- a/superset-frontend/src/dashboard/util/filterboxMigrationHelper.ts
+++ b/superset-frontend/src/dashboard/util/filterboxMigrationHelper.ts
@@ -26,7 +26,7 @@ import {
 } from 'src/explore/constants';
 import { DASHBOARD_FILTER_SCOPE_GLOBAL } from 'src/dashboard/reducers/dashboardFilters';
 import { Filter, NativeFilterType, TimeGranularity } from '@superset-ui/core';
-import { getChartIdsInFilterScope } from './activeDashboardFilters';
+import { getChartIdsInFilterBoxScope } from './activeDashboardFilters';
 import getFilterConfigsFromFormdata from './getFilterConfigsFromFormdata';
 
 interface FilterConfig {
@@ -147,7 +147,7 @@ const getFilterboxDependencies = (filterScopes: FilterScopesMetadata) => {
   Object.entries(filterScopes).forEach(([key, filterFields]) => {
     filterFieldsDependencies[key] = {};
     Object.entries(filterFields).forEach(([filterField, filterScope]) => {
-      filterFieldsDependencies[key][filterField] = getChartIdsInFilterScope({
+      filterFieldsDependencies[key][filterField] = getChartIdsInFilterBoxScope({
         filterScope,
       }).filter(
         chartId => filterChartIds.includes(chartId) && String(chartId) !== key,

--- a/superset-frontend/src/dashboard/util/getChartIdsInFilterScope.ts
+++ b/superset-frontend/src/dashboard/util/getChartIdsInFilterScope.ts
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { NativeFilterScope } from '@superset-ui/core';
+import { CHART_TYPE } from './componentTypes';
+import { ChartsState, Layout } from '../types';
+
+export function getChartIdsInFilterScope(
+  filterScope: NativeFilterScope,
+  charts: ChartsState,
+  layout: Layout,
+) {
+  const layoutItems = Object.values(layout);
+  return Object.values(charts)
+    .filter(
+      chart =>
+        !filterScope.excluded.includes(chart.id) &&
+        layoutItems
+          .find(
+            layoutItem =>
+              layoutItem?.type === CHART_TYPE &&
+              layoutItem.meta?.chartId === chart.id,
+          )
+          ?.parents?.some(elementId =>
+            filterScope.rootPath.includes(elementId),
+          ),
+    )
+    .map(chart => chart.id);
+}


### PR DESCRIPTION
### SUMMARY
This PR improves the performance of dashboards with complex structure (multiple tabs, many levels of nesting, many charts, native filters).
The main culprit of poor performance was a function used for finding charts in filter's scope. `getChartIdsInFilterScope` was written in a very suboptimal way, which drastically slowed down loading charts - which was especially noticeable when opening a dashboard or switching tabs.
I've rewritten that function and made a few other improvements, which resulted in a much smoother experience.
The scope of the changes in this PR is related only to native filters and cross filters. Performance issues related to filter box were not addressed, as the filter box will soon be deprecated in favor of native filters.

The tests were performed on a dashboard with 100+ charts, 70+ tabs, up to 4 levels of nested tabs, up to 10 charts in a single tab, 9 native filters.

Dashboard used for testing: [dashboard_export_20220309T112451.zip](https://github.com/apache/superset/files/8213872/dashboard_export_20220309T112451.zip)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/15073128/157247412-84be2244-b26c-48b4-9eb4-4005ffc4ebcd.mov

After:

https://user-images.githubusercontent.com/15073128/157247602-359b5bab-e857-466f-a6d4-dfc8422fcd48.mov

### TESTING INSTRUCTIONS
1. Verify that building dashboards works like before
2. Verify that applying native filters works like before
3. Verify that applying cross filters works like before
4. Verify that applying filters from filter box works like before

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

https://app.shortcut.com/preset/story/38683/performance-issues-to-navigate-between-tabs-depending-on-the-amount-of-charts-nested-tabs-on-a-dashboard