### PR TITLE
fix: Dataset search when creating a chart

### DIFF
--- a/superset-frontend/src/addSlice/AddSliceContainer.tsx
+++ b/superset-frontend/src/addSlice/AddSliceContainer.tsx
@@ -253,9 +253,11 @@ export default class AddSliceContainer extends React.PureComponent<
     }).then((response: JsonResponse) => {
       const list: {
         customLabel: ReactNode;
+        id: number;
         label: string;
         value: string;
       }[] = response.json.result.map((item: Dataset) => ({
+        id: item.id,
         value: `${item.id}__${item.datasource_type}`,
         customLabel: this.newLabel(item),
         label: item.table_name,
@@ -284,6 +286,7 @@ export default class AddSliceContainer extends React.PureComponent<
                   name="select-datasource"
                   onChange={this.changeDatasource}
                   options={this.loadDatasources}
+                  optionFilterProps={['id', 'label']}
                   placeholder={t('Choose a dataset')}
                   showSearch
                   value={this.state.datasource}


### PR DESCRIPTION
### SUMMARY
Fixes dataset search when creating a chart. Previously, when we typed "b" for example, the option "channels" was appearing in the results. That happened because the value for the dataset is in the form "table_<id>" and since the default `optionFilterProps` is `['label', 'value']`, the "b" was being matched with the "b" in "table". This PR fixes this by introducing an `id` prop and configuring `optionFilterProps`. Now the search is correct and we preserve the ability to search by id.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/157252888-69db5982-7f5f-4a70-beb5-f620eed203dd.mov

https://user-images.githubusercontent.com/70410625/157253191-7df6c389-526a-4bc3-b54b-abed6beadd71.mov

### TESTING INSTRUCTIONS
Check the videos for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
