### PR TITLE
fix: Select clear and loading icons overlap

### DIFF
--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -283,6 +283,7 @@ const getQueryCacheKey = (value: string, page: number, pageSize: number) =>
  */
 const Select = (
   {
+    allowClear,
     allowNewOptions = false,
     ariaLabel,
     fetchOnlyOnSearch,
@@ -668,6 +669,7 @@ const Select = (
     <StyledContainer>
       {header}
       <StyledSelect
+        allowClear={!isLoading && allowClear}
         aria-label={ariaLabel || name}
         dropdownRender={dropdownRender}
         filterOption={handleFilterOption}


### PR DESCRIPTION
### SUMMARY
Fixes https://github.com/apache/superset/issues/19063

### AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/70410625/157313255-bf73d946-566a-4743-9409-6801f55fa56b.mov

### TESTING INSTRUCTIONS
Check the original issue for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
