### PR TITLE
fix: allow to select <NULL> in a native filter single mode

### DIFF
--- a/superset-frontend/src/components/Select/utils.ts
+++ b/superset-frontend/src/components/Select/utils.ts
@@ -60,7 +60,7 @@ export function findValue<OptionType extends OptionTypeBase>(
   return (Array.isArray(value) ? value : [value]).map(find);
 }
 
-export function getValue(option: string | number | { value: string | number }) {
+export function getValue(option: string | number | { value: string | number | null }) {
   return option && typeof option === 'object' ? option.value : option;
 }
 

--- a/superset-frontend/src/components/Select/utils.ts
+++ b/superset-frontend/src/components/Select/utils.ts
@@ -61,7 +61,7 @@ export function findValue<OptionType extends OptionTypeBase>(
 }
 
 export function getValue(option: string | number | { value: string | number }) {
-  return typeof option === 'object' ? option.value : option;
+  return option && typeof option === 'object' ? option.value : option;
 }
 
 type LabeledValue<V> = { label?: ReactNode; value?: V };

--- a/superset-frontend/src/components/Select/utils.ts
+++ b/superset-frontend/src/components/Select/utils.ts
@@ -60,7 +60,9 @@ export function findValue<OptionType extends OptionTypeBase>(
   return (Array.isArray(value) ? value : [value]).map(find);
 }
 
-export function getValue(option: string | number | { value: string | number | null }) {
+export function getValue(
+  option: string | number | { value: string | number | null } | null,
+) {
   return option && typeof option === 'object' ? option.value : option;
 }
 

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -22,6 +22,7 @@ import React from 'react';
 import { render, screen } from 'spec/helpers/testing-library';
 import SelectFilterPlugin from './SelectFilterPlugin';
 import transformProps from './transformProps';
+import { NULL_STRING } from 'src/utils/common';
 
 const selectMultipleProps = {
   formData: {
@@ -55,7 +56,7 @@ const selectMultipleProps = {
       rowcount: 2,
       colnames: ['gender'],
       coltypes: [1],
-      data: [{ gender: 'boy' }, { gender: 'girl' }],
+      data: [{ gender: 'boy' }, { gender: 'girl' }, { gender: null }],
       applied_filters: [{ column: 'gender' }],
       rejected_filters: [],
     },
@@ -191,6 +192,30 @@ describe('SelectFilterPlugin', () => {
       filterState: {
         label: 'girl (excluded)',
         value: ['girl'],
+      },
+    });
+  });
+
+  it('Select single null (empty) value', () => {
+    getWrapper();
+    userEvent.click(screen.getByRole('combobox'));
+    userEvent.click(screen.getByTitle(NULL_STRING));
+    expect(setDataMask).toHaveBeenLastCalledWith({
+      __cache: {
+        value: ['boy'],
+      },
+      extraFormData: {
+        filters: [
+          {
+            col: 'gender',
+            op: 'IN',
+            val: ['boy', null],
+          },
+        ],
+      },
+      filterState: {
+        label: `boy, ${NULL_STRING}`,
+        value: ['boy', null],
       },
     });
   });

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -20,9 +20,9 @@ import userEvent from '@testing-library/user-event';
 import { AppSection } from '@superset-ui/core';
 import React from 'react';
 import { render, screen } from 'spec/helpers/testing-library';
+import { NULL_STRING } from 'src/utils/common';
 import SelectFilterPlugin from './SelectFilterPlugin';
 import transformProps from './transformProps';
-import { NULL_STRING } from 'src/utils/common';
 
 const selectMultipleProps = {
   formData: {

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -209,7 +209,8 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
 
   const handleChange = useCallback(
     (value?: SelectValue | number | string) => {
-      const values = ensureIsArray(value);
+      const values = value === null ? [null] : ensureIsArray(value);
+
       if (values.length === 0) {
         updateDataMask(null);
       } else {

--- a/superset-frontend/src/filters/components/Select/types.ts
+++ b/superset-frontend/src/filters/components/Select/types.ts
@@ -29,7 +29,7 @@ import {
 import { RefObject } from 'react';
 import { PluginFilterHooks, PluginFilterStylesProps } from '../types';
 
-export type SelectValue = (number | string)[] | null | undefined;
+export type SelectValue = (number | string | null)[] | null | undefined;
 
 export interface PluginFilterSelectCustomizeProps {
   defaultValue?: SelectValue;


### PR DESCRIPTION
### SUMMARY
The native filter used in the Dashboard filters <NULL> values in single mode, which is a valid state.
The filter needs to be made only on `undefined` specifically.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Fix demo:

https://user-images.githubusercontent.com/17252075/157457995-84d8242e-d3ef-4515-ba4b-4ff85e5daca7.mov

### TESTING INSTRUCTIONS
1. go to FCC survey dashboard
2. create value filter for bootcamp name
3. unselect ' Can select multiple values'
4. Select <'NULL'> in the bootcamp name

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
