### PR TITLE
fix(dashboard-css): make to stay custom css when reload

### DIFF
--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
@@ -21,6 +21,7 @@ import { render, screen } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import { HeaderDropdownProps } from 'src/dashboard/components/Header/types';
+import injectCustomCss from 'src/dashboard/util/injectCustomCss';
 import HeaderActionsDropdown from '.';
 
 const createProps = () => ({
@@ -180,7 +181,9 @@ test('should NOT render the "Refresh dashboard" menu item as disabled', async ()
 
 test('should render with custom css', () => {
   const mockedProps = createProps();
+  const { customCss } = mockedProps;
   render(setup(mockedProps));
+  injectCustomCss(customCss);
   expect(screen.getByRole('button')).toHaveStyle('margin-left: 100px');
 });
 

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
@@ -117,8 +117,6 @@ class HeaderActionsDropdown extends React.PureComponent {
   }
 
   UNSAFE_componentWillMount() {
-    injectCustomCss(this.state.css);
-
     SupersetClient.get({ endpoint: '/csstemplateasyncmodelview/api/read' })
       .then(({ json }) => {
         const cssTemplates = json.result.map(row => ({


### PR DESCRIPTION
### SUMMARY
Dashboard CSS disappears

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
The dashboard custom css is disappeared when reloaded.
AFTER:
The dashboard custom css stay when reloaded.

### TESTING INSTRUCTIONS

**How to reproduce the bug**
1. create a dashboard
2. Edit CSS and save, for example with: 

```body {   background-color: black; }```

3.The background appears normally but when you reload the page it is not there and the CSS is gone

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
