### PR TITLE
fix(dashboard): import handle missing excluded charts

### DIFF
--- a/superset/dashboards/commands/importers/v1/utils.py
+++ b/superset/dashboards/commands/importers/v1/utils.py
@@ -137,7 +137,7 @@ def update_id_refs(  # pylint: disable=too-many-locals
         scope_excluded = native_filter.get("scope", {}).get("excluded", [])
         if scope_excluded:
             native_filter["scope"]["excluded"] = [
-                id_map[old_id] for old_id in scope_excluded
+                id_map[old_id] for old_id in scope_excluded if old_id in id_map
             ]
 
     return fixed

--- a/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
@@ -93,7 +93,7 @@ def test_update_native_filter_config_scope_excluded(app_context: None):
             },
         },
         "metadata": {
-            "native_filter_configuration": [{"scope": {"excluded": [101, 102]}}],
+            "native_filter_configuration": [{"scope": {"excluded": [101, 102, 103]}}],
         },
     }
     chart_ids = {"uuid1": 1, "uuid2": 2}


### PR DESCRIPTION
### SUMMARY

This PR extends the awesome work in #18562 by removing excluded charts from native filter configurations during importing. This can happen if a chart that was present when a native filter scope was defined is later removed from the dashboard.

### TESTING INSTRUCTIONS
1. Import the exported dashboard from this PR: #19064
2. See the `KeyError` that's raised (with this change the import is successful)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
