### PR TITLE
refactor(TimezoneSelector): simplify override logics and tests

### DIFF
--- a/superset-frontend/src/components/TimezoneSelector/index.tsx
+++ b/superset-frontend/src/components/TimezoneSelector/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { useEffect, useRef, useCallback } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import moment from 'moment-timezone';
 import { t } from '@superset-ui/core';
 import { Select } from 'src/components';
@@ -92,43 +92,40 @@ const TIMEZONE_OPTIONS = TIMEZONES.map(zone => ({
   timezoneName: zone.name,
 }));
 
-const TimezoneSelector = ({ onTimezoneChange, timezone }: TimezoneProps) => {
-  const prevTimezone = useRef(timezone);
-  const matchTimezoneToOptions = (timezone: string) =>
-    TIMEZONE_OPTIONS.find(option => option.offsets === getOffsetKey(timezone))
-      ?.value || DEFAULT_TIMEZONE.value;
+const TIMEZONE_OPTIONS_SORT_COMPARATOR = (
+  a: typeof TIMEZONE_OPTIONS[number],
+  b: typeof TIMEZONE_OPTIONS[number],
+) =>
+  moment.tz(currentDate, a.timezoneName).utcOffset() -
+  moment.tz(currentDate, b.timezoneName).utcOffset();
 
-  const updateTimezone = useCallback(
-    (tz: string) => {
-      // update the ref to track changes
-      prevTimezone.current = tz;
-      // the parent component contains the state for the value
-      onTimezoneChange(tz);
-    },
-    [onTimezoneChange],
+TIMEZONE_OPTIONS.sort(TIMEZONE_OPTIONS_SORT_COMPARATOR);
+
+const matchTimezoneToOptions = (timezone: string) =>
+  TIMEZONE_OPTIONS.find(option => option.offsets === getOffsetKey(timezone))
+    ?.value || DEFAULT_TIMEZONE.value;
+
+const TimezoneSelector = ({ onTimezoneChange, timezone }: TimezoneProps) => {
+  const validTimezone = useMemo(
+    () => matchTimezoneToOptions(timezone || moment.tz.guess()),
+    [timezone],
   );
 
+  // force trigger a timezone update if provided `timezone` is not invalid
   useEffect(() => {
-    const updatedTz = matchTimezoneToOptions(timezone || moment.tz.guess());
-    if (prevTimezone.current !== updatedTz) {
-      updateTimezone(updatedTz);
+    if (timezone !== validTimezone) {
+      onTimezoneChange(validTimezone);
     }
-  }, [timezone, updateTimezone]);
+  }, [validTimezone, onTimezoneChange, timezone]);
 
   return (
     <Select
       ariaLabel={t('Timezone selector')}
       css={{ minWidth: MIN_SELECT_WIDTH }} // smallest size for current values
-      onChange={onTimezoneChange}
-      value={timezone || DEFAULT_TIMEZONE.value}
+      onChange={tz => onTimezoneChange(tz as string)}
+      value={validTimezone}
       options={TIMEZONE_OPTIONS}
-      sortComparator={(
-        a: typeof TIMEZONE_OPTIONS[number],
-        b: typeof TIMEZONE_OPTIONS[number],
-      ) =>
-        moment.tz(currentDate, a.timezoneName).utcOffset() -
-        moment.tz(currentDate, b.timezoneName).utcOffset()
-      }
+      sortComparator={TIMEZONE_OPTIONS_SORT_COMPARATOR}
     />
   );
 };


### PR DESCRIPTION
### SUMMARY

Encountered a broken unit test in `TimezoneSelector` after making changes in #19085 , found some room for improvements so I refactored this component a little: simplified the timezone overriding logics and made the unit tests more complete. See comments for details.

As the changes are quite significant and the component itself is small, it may be easier to review the diff in split view.

<img width="324" alt="Xnip2022-03-09_17-32-11" src="https://user-images.githubusercontent.com/335541/157569467-106b9b01-a3d1-4cb3-9759-11e0b1f544d9.png">


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

No visual changes

### TESTING INSTRUCTIONS

Test places where timezone selector is used. The functionality should not change.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: #15880 #17124
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
