### PR TITLE
fix(dashboard): Empty states overflowing small chart containers

### DIFF
--- a/superset-frontend/src/components/Chart/Chart.jsx
+++ b/superset-frontend/src/components/Chart/Chart.jsx
@@ -298,7 +298,11 @@ class Chart extends React.PureComponent {
             className={`slice_container ${isFaded ? ' faded' : ''}`}
             data-test="slice-container"
           >
-            <ChartRenderer {...this.props} data-test={this.props.vizType} />
+            <ChartRenderer
+              {...this.props}
+              source={this.props.dashboardId ? 'dashboard' : 'explore'}
+              data-test={this.props.vizType}
+            />
           </div>
 
           {!isLoading && !chartAlert && isFaded && (

--- a/superset-frontend/src/components/Chart/ChartRenderer.jsx
+++ b/superset-frontend/src/components/Chart/ChartRenderer.jsx
@@ -21,7 +21,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { SuperChart, logging, Behavior, t } from '@superset-ui/core';
 import { Logger, LOG_ACTIONS_RENDER_CHART } from 'src/logger/LogUtils';
-import { EmptyStateBig } from 'src/components/EmptyState';
+import { EmptyStateBig, EmptyStateSmall } from 'src/components/EmptyState';
 
 const propTypes = {
   annotationData: PropTypes.object,
@@ -48,9 +48,13 @@ const propTypes = {
   onFilterMenuOpen: PropTypes.func,
   onFilterMenuClose: PropTypes.func,
   ownState: PropTypes.object,
+  source: PropTypes.oneOf(['dashboard', 'explore']),
 };
 
 const BLANK = {};
+
+const BIG_NO_RESULT_MIN_WIDTH = 300;
+const BIG_NO_RESULT_MIN_HEIGHT = 220;
 
 const defaultProps = {
   addFilter: () => BLANK,
@@ -212,6 +216,29 @@ class ChartRenderer extends React.Component {
           }`
         : '';
 
+    let noResultsComponent;
+    const noResultTitle = t('No results were returned for this query');
+    const noResultDescription =
+      this.props.source === 'explore'
+        ? t(
+            'Make sure that the controls are configured properly and the datasource contains data for the selected time range',
+          )
+        : undefined;
+    const noResultImage = 'chart.svg';
+    if (width > BIG_NO_RESULT_MIN_WIDTH && height > BIG_NO_RESULT_MIN_HEIGHT) {
+      noResultsComponent = (
+        <EmptyStateBig
+          title={noResultTitle}
+          description={noResultDescription}
+          image={noResultImage}
+        />
+      );
+    } else {
+      noResultsComponent = (
+        <EmptyStateSmall title={noResultTitle} image={noResultImage} />
+      );
+    }
+
     return (
       <SuperChart
         disableErrorBoundary
@@ -232,15 +259,7 @@ class ChartRenderer extends React.Component {
         queriesData={queriesResponse}
         onRenderSuccess={this.handleRenderSuccess}
         onRenderFailure={this.handleRenderFailure}
-        noResults={
-          <EmptyStateBig
-            title={t('No results were returned for this query')}
-            description={t(
-              'Make sure that the controls are configured properly and the datasource contains data for the selected time range',
-            )}
-            image="chart.svg"
-          />
-        }
+        noResults={noResultsComponent}
       />
     );
   }

--- a/superset-frontend/src/dashboard/components/gridComponents/ChartHolder.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/ChartHolder.test.tsx
@@ -86,10 +86,10 @@ describe('ChartHolder', () => {
       screen.getByText('No results were returned for this query'),
     ).toBeVisible();
     expect(
-      screen.getByText(
+      screen.queryByText(
         'Make sure that the controls are configured properly and the datasource contains data for the selected time range',
       ),
-    ).toBeVisible();
+    ).not.toBeInTheDocument(); // description should display only in Explore view
     expect(screen.getByAltText('empty')).toBeVisible();
   });
 });


### PR DESCRIPTION
### SUMMARY
When query returned no results, we were showing a large empty state component in chart container on the dashboard, regardless of container's size. If the container was small, the empty state was overflowing. This PR fixes that behaviour by replacing large empty state with a small one if chart's width is smaller than 300px or if chart's height is smaller than 220px.
Also, I removed chart empty state's description if it's displayed on the dashboard - the description will be displayed only on Explore page.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/15073128/157640833-1807023c-d423-4a4d-90cc-247c17f5036e.png">

After:

<img width="1791" alt="image" src="https://user-images.githubusercontent.com/15073128/157640724-dafda228-4379-4e05-ad3b-9e14d11135be.png">


### TESTING INSTRUCTIONS
1. Create a dashboard with large and small charts
2. Add a filter that filters out all results
3. Verify that the empty state is not overflowing in any chart
4. Verify that the empty state has only image and title
5. Click "View chart in Explore"
6. Verify that empty state has an image, title and description

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @kasiazjc