### PR TITLE
fix(native-filters): Error when selecting filter value "null"

### DIFF
--- a/superset-frontend/src/components/Select/utils.ts
+++ b/superset-frontend/src/components/Select/utils.ts
@@ -60,8 +60,10 @@ export function findValue<OptionType extends OptionTypeBase>(
   return (Array.isArray(value) ? value : [value]).map(find);
 }
 
-export function getValue(option: string | number | { value: string | number }) {
-  return typeof option === 'object' ? option.value : option;
+export function getValue(
+  option: string | number | { value: string | number } | null,
+) {
+  return typeof option === 'object' && option !== null ? option.value : option;
 }
 
 type LabeledValue<V> = { label?: ReactNode; value?: V };


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes an error `Cannot read properties of null` when 1 of native filter's options was `null`.
The problem was that in `src/components/Select/utils.ts::getValue` function we tried to access `option.value` if option was an object. However, `typeof null === "object"`, so that resulted in an error if 1 of the options was null.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/15073128/157644122-2d90612e-c484-4d36-ad2e-64653c0b18a7.png">

After:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/15073128/157644001-6f677efe-8a4c-4482-8832-a1fad13f1a41.png">


### TESTING INSTRUCTIONS
1. Create a dashboard with a value native filter, which has "null" as 1 of its options
2. Verify that the filter works as expected

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
