### PR TITLE
fix: string aggregation is incorrect in PivotTableV2

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/utilities.js
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/utilities.js
@@ -257,8 +257,8 @@ const baseAggregatorTemplates = {
           push(record) {
             let x = record[attr];
             if (['min', 'max'].includes(mode)) {
-              x = isNaN(x) ? x : parseFloat(parsed);
-              if (isNaN(x)) {
+              const coercedValue = parseFloat(x);
+              if (Number.isNaN(coercedValue)) {
                 this.val =
                   !this.val ||
                   (mode === 'min' && x < this.val) ||
@@ -266,7 +266,7 @@ const baseAggregatorTemplates = {
                     ? x
                     : this.val;
               } else {
-                this.val = Math[mode](x, this.val !== null ? this.val : x);
+                this.val = Math[mode](coercedValue, this.val !== null ? this.val : coercedValue);
               }
             } else if (
               mode === 'first' &&
@@ -284,10 +284,10 @@ const baseAggregatorTemplates = {
             return this.val;
           },
           format(x) {
-            if (isNaN(x)) {
-              return x;
+            if (typeof x === 'number') {
+              return formatter(x);
             }
-            return formatter(x);
+            return x;
           },
           numInputs: typeof attr !== 'undefined' ? 0 : 1,
         };

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/utilities.js
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/utilities.js
@@ -255,7 +255,7 @@ const baseAggregatorTemplates = {
             attr,
           ),
           push(record) {
-            let x = record[attr];
+            const x = record[attr];
             if (['min', 'max'].includes(mode)) {
               const coercedValue = parseFloat(x);
               if (Number.isNaN(coercedValue)) {
@@ -266,7 +266,10 @@ const baseAggregatorTemplates = {
                     ? x
                     : this.val;
               } else {
-                this.val = Math[mode](coercedValue, this.val !== null ? this.val : coercedValue);
+                this.val = Math[mode](
+                  coercedValue,
+                  this.val !== null ? this.val : coercedValue,
+                );
               }
             } else if (
               mode === 'first' &&


### PR DESCRIPTION
### SUMMARY
The aggregation functions for PivotTableV2 only take into account numeric values.
This PR adds support for strings, only for the aggregation functions that were supported on PivotTable originally.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/17252075/157701090-70ad6668-b319-485a-82cb-7edabcc042c6.mov

### TESTING INSTRUCTIONS
Follow the example described in the issue

### ADDITIONAL INFORMATION
Fixes #18572 
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
