### PR TITLE
fix(dbs-dropdown): make to allow the search in supported db dropdown

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -688,6 +688,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
         className="available-select"
         onChange={setDatabaseModel}
         placeholder={t('Choose a database...')}
+        showSearch
       >
         {[...(availableDbs?.databases || [])]
           ?.sort((a: DatabaseForm, b: DatabaseForm) =>


### PR DESCRIPTION
### SUMMARY
Update Supported Databases Dropdown to Allow Typeahead

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
![image](https://user-images.githubusercontent.com/47900232/157892583-f71a675c-0090-463d-95c6-453cf29c0c83.png)

AFTER:
![image](https://user-images.githubusercontent.com/47900232/157892353-a2a4c583-eb4a-47af-ba4f-30ed4b79f2c4.png)

### TESTING INSTRUCTIONS
**How to reproduce bug**

1. Click to the Databases page
2. Open the + Databases button
3. Click to type in the dropdown search bar

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
