### PR TITLE
chore!: turn on Versioned Export in config.py

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -37,7 +37,7 @@ assists people when migrating to a new version.
 - [18970](https://github.com/apache/superset/pull/18970): Changes feature
 flag for the legacy datasource editor (DISABLE_LEGACY_DATASOURCE_EDITOR) in config.py to True, thus disabling the feature from being shown in the client.
 - [19017](https://github.com/apache/superset/pull/19017): Removes Python 3.7 support.
-- [19142](https://github.com/apache/superset/pull/19142): Changes feature flag for versioned export(VERSIONED_EXPORT) to be true, depreciating older api endpoints.
+- [19142](https://github.com/apache/superset/pull/19142): Changes feature flag for versioned export(VERSIONED_EXPORT) to be true.
 
 ### Potential Downtime
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -37,6 +37,7 @@ assists people when migrating to a new version.
 - [18970](https://github.com/apache/superset/pull/18970): Changes feature
 flag for the legacy datasource editor (DISABLE_LEGACY_DATASOURCE_EDITOR) in config.py to True, thus disabling the feature from being shown in the client.
 - [19017](https://github.com/apache/superset/pull/19017): Removes Python 3.7 support.
+- [19142](https://github.com/apache/superset/pull/19142): Changes feature flag for versioned export(VERSIONED_EXPORT) to be true, depreciating older api endpoints.
 
 ### Potential Downtime
 

--- a/superset/cli/importexport.py
+++ b/superset/cli/importexport.py
@@ -23,7 +23,6 @@ from zipfile import is_zipfile, ZipFile
 
 import click
 import yaml
-from deprecation import deprecated
 from flask import g
 from flask.cli import with_appcontext
 
@@ -198,7 +197,6 @@ else:
         default=False,
         help="Print JSON to stdout",
     )
-    @deprecated
     def export_dashboards(
         dashboard_file: Optional[str], print_stdout: bool = False
     ) -> None:
@@ -243,7 +241,6 @@ else:
         default=False,
         help="Include fields containing defaults",
     )
-    @deprecated
     def export_datasources(
         datasource_file: Optional[str],
         print_stdout: bool = False,

--- a/superset/cli/importexport.py
+++ b/superset/cli/importexport.py
@@ -23,6 +23,7 @@ from zipfile import is_zipfile, ZipFile
 
 import click
 import yaml
+from deprecation import deprecated
 from flask import g
 from flask.cli import with_appcontext
 
@@ -197,6 +198,7 @@ else:
         default=False,
         help="Print JSON to stdout",
     )
+    @deprecated
     def export_dashboards(
         dashboard_file: Optional[str], print_stdout: bool = False
     ) -> None:
@@ -241,6 +243,7 @@ else:
         default=False,
         help="Include fields containing defaults",
     )
+    @deprecated
     def export_datasources(
         datasource_file: Optional[str],
         print_stdout: bool = False,

--- a/superset/config.py
+++ b/superset/config.py
@@ -407,7 +407,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     "DASHBOARD_NATIVE_FILTERS_SET": False,
     "DASHBOARD_FILTERS_EXPERIMENTAL": False,
     "GLOBAL_ASYNC_QUERIES": False,
-    "VERSIONED_EXPORT": False,
+    "VERSIONED_EXPORT": True,
     # Note that: RowLevelSecurityFilter is only given by default to the Admin role
     # and the Admin Role does have the all_datasources security permission.
     # But, if users create a specific role with access to RowLevelSecurityFilter MVC

--- a/superset/utils/async_query_manager.py
+++ b/superset/utils/async_query_manager.py
@@ -71,7 +71,7 @@ class AsyncQueryManager:
 
     def __init__(self) -> None:
         super().__init__()
-        self._redis: redis.Redis  # type: ignore
+        self._redis: redis.Redis
         self._stream_prefix: str = ""
         self._stream_limit: Optional[int]
         self._stream_limit_firehose: Optional[int]

--- a/tests/integration_tests/cli_tests.py
+++ b/tests/integration_tests/cli_tests.py
@@ -48,58 +48,6 @@ def assert_cli_fails_properly(response, caplog):
 
 
 @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
-def test_export_dashboards_original(app_context, fs):
-    """
-    Test that a JSON file is exported.
-    """
-    # pylint: disable=reimported, redefined-outer-name
-    import superset.cli.importexport  # noqa: F811
-
-    # reload to define export_dashboards correctly based on the
-    # feature flags
-    importlib.reload(superset.cli.importexport)
-
-    runner = app.test_cli_runner()
-    response = runner.invoke(
-        superset.cli.importexport.export_dashboards, ("-f", "dashboards.json")
-    )
-
-    assert response.exit_code == 0
-    assert Path("dashboards.json").exists()
-
-    # check that file is valid JSON
-    with open("dashboards.json") as fp:
-        contents = fp.read()
-    json.loads(contents)
-
-
-@pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
-def test_export_datasources_original(app_context, fs):
-    """
-    Test that a YAML file is exported.
-    """
-    # pylint: disable=reimported, redefined-outer-name
-    import superset.cli.importexport  # noqa: F811
-
-    # reload to define export_dashboards correctly based on the
-    # feature flags
-    importlib.reload(superset.cli.importexport)
-
-    runner = app.test_cli_runner()
-    response = runner.invoke(
-        superset.cli.importexport.export_datasources, ("-f", "datasources.yaml")
-    )
-
-    assert response.exit_code == 0
-    assert Path("datasources.yaml").exists()
-
-    # check that file is valid JSON
-    with open("datasources.yaml") as fp:
-        contents = fp.read()
-    yaml.safe_load(contents)
-
-
-@pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
 @mock.patch.dict(
     "superset.cli.lib.feature_flags", {"VERSIONED_EXPORT": True}, clear=True
 )
@@ -333,41 +281,6 @@ def test_import_datasets_versioned_export(import_datasets_command, app_context, 
     assert response.exit_code == 0
     expected_contents = {"dataset.yaml": "hello: world"}
     import_datasets_command.assert_called_with(expected_contents, overwrite=True)
-
-
-@mock.patch.dict(
-    "superset.config.DEFAULT_FEATURE_FLAGS", {"VERSIONED_EXPORT": False}, clear=True
-)
-@mock.patch("superset.datasets.commands.importers.v0.ImportDatasetsCommand")
-def test_import_datasets_sync_argument_columns_metrics(
-    import_datasets_command, app_context, fs
-):
-    """
-    Test that the --sync command line argument syncs dataset in superset
-    with YAML file. Using both columns and metrics with the --sync flag
-    """
-    # pylint: disable=reimported, redefined-outer-name
-    import superset.cli.importexport  # noqa: F811
-
-    # reload to define export_datasets correctly based on the
-    # feature flags
-    importlib.reload(superset.cli.importexport)
-
-    # write YAML file
-    with open("dataset.yaml", "w") as fp:
-        fp.write("hello: world")
-
-    runner = app.test_cli_runner()
-    response = runner.invoke(
-        superset.cli.importexport.import_datasources,
-        ["-p", "dataset.yaml", "-s", "metrics,columns"],
-    )
-
-    assert response.exit_code == 0
-    expected_contents = {"dataset.yaml": "hello: world"}
-    import_datasets_command.assert_called_with(
-        expected_contents, sync_columns=True, sync_metrics=True,
-    )
 
 
 @mock.patch.dict(

--- a/tests/integration_tests/cli_tests.py
+++ b/tests/integration_tests/cli_tests.py
@@ -97,7 +97,6 @@ def test_export_datasources_original(app_context, fs):
     )
 
     assert response.exit_code == 0
-    # this api is deprecated, so it shows a response of 1 instead of 0
 
     assert Path("datasources.yaml").exists()
 

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -1346,7 +1346,9 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
         # freeze time to ensure filename is deterministic
         with freeze_time("2020-01-01T00:00:00Z"):
             rv = self.get_assert_metric(uri, "export")
-            headers = generate_download_headers("json")["Content-Disposition"]
+            headers = generate_download_headers(
+                "zip", "dashboard_export_20200101T000000"
+            )["Content-Disposition"]
 
         assert rv.status_code == 200
         assert rv.headers["Content-Disposition"] == headers

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -1331,6 +1331,11 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
         db.session.delete(user_alpha2)
         db.session.commit()
 
+    @patch.dict(
+        "superset.extensions.feature_flag_manager._feature_flags",
+        {"VERSIONED_EXPORT": False},
+        clear=True,
+    )
     @pytest.mark.usefixtures(
         "load_world_bank_dashboard_with_slices",
         "load_birth_names_dashboard_with_slices",
@@ -1346,9 +1351,7 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
         # freeze time to ensure filename is deterministic
         with freeze_time("2020-01-01T00:00:00Z"):
             rv = self.get_assert_metric(uri, "export")
-            headers = generate_download_headers(
-                "zip", "dashboard_export_20200101T000000"
-            )["Content-Disposition"]
+            headers = generate_download_headers("json")["Content-Disposition"]
 
         assert rv.status_code == 200
         assert rv.headers["Content-Disposition"] == headers
@@ -1378,11 +1381,6 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
         db.session.delete(dashboard)
         db.session.commit()
 
-    @patch.dict(
-        "superset.extensions.feature_flag_manager._feature_flags",
-        {"VERSIONED_EXPORT": True},
-        clear=True,
-    )
     def test_export_bundle(self):
         """
         Dashboard API: Test dashboard export
@@ -1398,11 +1396,6 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
         buf = BytesIO(rv.data)
         assert is_zipfile(buf)
 
-    @patch.dict(
-        "superset.extensions.feature_flag_manager._feature_flags",
-        {"VERSIONED_EXPORT": True},
-        clear=True,
-    )
     def test_export_bundle_not_found(self):
         """
         Dashboard API: Test dashboard export not found
@@ -1413,11 +1406,6 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
         rv = self.client.get(uri)
         assert rv.status_code == 404
 
-    @patch.dict(
-        "superset.extensions.feature_flag_manager._feature_flags",
-        {"VERSIONED_EXPORT": True},
-        clear=True,
-    )
     def test_export_bundle_not_allowed(self):
         """
         Dashboard API: Test dashboard export not allowed

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -1455,11 +1455,6 @@ class TestDatasetApi(SupersetTestCase):
         rv = self.client.get(uri)
         assert rv.status_code == 200
 
-    @patch.dict(
-        "superset.extensions.feature_flag_manager._feature_flags",
-        {"VERSIONED_EXPORT": True},
-        clear=True,
-    )
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_export_dataset_bundle(self):
         """
@@ -1482,11 +1477,6 @@ class TestDatasetApi(SupersetTestCase):
         buf = BytesIO(rv.data)
         assert is_zipfile(buf)
 
-    @patch.dict(
-        "superset.extensions.feature_flag_manager._feature_flags",
-        {"VERSIONED_EXPORT": True},
-        clear=True,
-    )
     def test_export_dataset_bundle_not_found(self):
         """
         Dataset API: Test export dataset not found
@@ -1499,11 +1489,6 @@ class TestDatasetApi(SupersetTestCase):
 
         assert rv.status_code == 404
 
-    @patch.dict(
-        "superset.extensions.feature_flag_manager._feature_flags",
-        {"VERSIONED_EXPORT": True},
-        clear=True,
-    )
     @pytest.mark.usefixtures("create_datasets")
     def test_export_dataset_bundle_gamma(self):
         """


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR turns the Versioned Export flag to true, this is a breaking change for superset 2.0

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: https://github.com/apache/superset/issues/18688
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
