### PR TITLE
feat: SupersetClient config to override 401 behavior

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/connection/SupersetClientClass.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/SupersetClientClass.ts
@@ -33,6 +33,12 @@ import {
 } from './types';
 import { DEFAULT_FETCH_RETRY_OPTIONS, DEFAULT_BASE_URL } from './constants';
 
+const defaultUnauthorizedHandler = () => {
+  window.location.href = `/login?next=${
+    window.location.pathname + window.location.search
+  }`;
+};
+
 export default class SupersetClientClass {
   credentials: Credentials;
 
@@ -58,6 +64,8 @@ export default class SupersetClientClass {
 
   timeout: ClientTimeout;
 
+  handleUnauthorized: () => void;
+
   constructor({
     baseUrl = DEFAULT_BASE_URL,
     host,
@@ -70,6 +78,7 @@ export default class SupersetClientClass {
     csrfToken = undefined,
     guestToken = undefined,
     guestTokenHeaderName = 'X-GuestToken',
+    unauthorizedHandler = defaultUnauthorizedHandler,
   }: ClientConfig = {}) {
     const url = new URL(
       host || protocol
@@ -100,6 +109,7 @@ export default class SupersetClientClass {
     if (guestToken) {
       this.headers[guestTokenHeaderName] = guestToken;
     }
+    this.handleUnauthorized = unauthorizedHandler;
   }
 
   async init(force = false): CsrfPromise {
@@ -151,6 +161,7 @@ export default class SupersetClientClass {
     headers,
     timeout,
     fetchRetryOptions,
+    ignoreUnauthorized,
     ...rest
   }: RequestConfig & { parseMethod?: T }) {
     await this.ensureAuth();
@@ -164,7 +175,7 @@ export default class SupersetClientClass {
       fetchRetryOptions: fetchRetryOptions ?? this.fetchRetryOptions,
     }).catch(res => {
       if (res?.status === 401) {
-        this.redirectUnauthorized();
+        this.handleUnauthorized();
       }
       return Promise.reject(res);
     });
@@ -228,12 +239,6 @@ export default class SupersetClientClass {
 
     return `${this.protocol}//${cleanHost}/${
       endpoint[0] === '/' ? endpoint.slice(1) : endpoint
-    }`;
-  }
-
-  redirectUnauthorized() {
-    window.location.href = `/login?next=${
-      window.location.pathname + window.location.search
     }`;
   }
 }

--- a/superset-frontend/packages/superset-ui-core/src/connection/SupersetClientClass.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/SupersetClientClass.ts
@@ -174,7 +174,7 @@ export default class SupersetClientClass {
       timeout: timeout ?? this.timeout,
       fetchRetryOptions: fetchRetryOptions ?? this.fetchRetryOptions,
     }).catch(res => {
-      if (res?.status === 401) {
+      if (res?.status === 401 && !ignoreUnauthorized) {
         this.handleUnauthorized();
       }
       return Promise.reject(res);

--- a/superset-frontend/packages/superset-ui-core/src/connection/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/types.ts
@@ -81,6 +81,7 @@ export interface RequestBase {
   fetchRetryOptions?: FetchRetryOptions;
   headers?: Headers;
   host?: Host;
+  ignoreUnauthorized?: boolean;
   mode?: Mode;
   method?: Method;
   jsonPayload?: Payload;
@@ -89,7 +90,6 @@ export interface RequestBase {
   signal?: Signal;
   stringify?: Stringify;
   timeout?: ClientTimeout;
-  ignoreUnauthorized?: boolean;
 }
 
 export interface CallApi extends RequestBase {

--- a/superset-frontend/packages/superset-ui-core/src/connection/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/types.ts
@@ -89,6 +89,7 @@ export interface RequestBase {
   signal?: Signal;
   stringify?: Stringify;
   timeout?: ClientTimeout;
+  ignoreUnauthorized?: boolean;
 }
 
 export interface CallApi extends RequestBase {
@@ -136,6 +137,7 @@ export interface ClientConfig {
   headers?: Headers;
   mode?: Mode;
   timeout?: ClientTimeout;
+  unauthorizedHandler?: () => void;
 }
 
 export interface SupersetClientInterface

--- a/superset-frontend/packages/superset-ui-core/test/connection/SupersetClientClass.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/connection/SupersetClientClass.test.ts
@@ -499,42 +499,92 @@ describe('SupersetClientClass', () => {
     });
   });
 
-  it('should redirect Unauthorized', async () => {
+  describe('when unauthorized', () => {
+    let originalLocation: any;
+    let authSpy: jest.SpyInstance;
     const mockRequestUrl = 'https://host/get/url';
     const mockRequestPath = '/get/url';
     const mockRequestSearch = '?param=1&param=2';
-    const { location } = window;
-    // @ts-ignore
-    delete window.location;
-    // @ts-ignore
-    window.location = {
-      pathname: mockRequestPath,
-      search: mockRequestSearch,
-    };
-    const authSpy = jest
-      .spyOn(SupersetClientClass.prototype, 'ensureAuth')
-      .mockImplementation();
-    const rejectValue = { status: 401 };
-    fetchMock.get(mockRequestUrl, () => Promise.reject(rejectValue), {
-      overwriteRoutes: true,
+
+    beforeEach(() => {
+      originalLocation = window.location;
+      // @ts-ignore
+      delete window.location;
+      // @ts-ignore
+      window.location = {
+        pathname: mockRequestPath,
+        search: mockRequestSearch,
+        href: mockRequestPath + mockRequestSearch,
+      };
+      authSpy = jest
+        .spyOn(SupersetClientClass.prototype, 'ensureAuth')
+        .mockImplementation();
+      const rejectValue = { status: 401 };
+      fetchMock.get(mockRequestUrl, () => Promise.reject(rejectValue), {
+        overwriteRoutes: true,
+      });
     });
 
-    const client = new SupersetClientClass({});
+    afterEach(() => {
+      authSpy.mockReset();
+      window.location = originalLocation;
+    });
 
-    let error;
-    try {
-      await client.request({ url: mockRequestUrl, method: 'GET' });
-    } catch (err) {
-      error = err;
-    } finally {
-      const redirectURL = window.location.href;
-      expect(redirectURL).toBe(
-        `/login?next=${mockRequestPath + mockRequestSearch}`,
-      );
-      expect(error.status).toBe(401);
-    }
+    it('should redirect', async () => {
+      const client = new SupersetClientClass({});
 
-    authSpy.mockReset();
-    window.location = location;
+      let error;
+      try {
+        await client.request({ url: mockRequestUrl, method: 'GET' });
+      } catch (err) {
+        error = err;
+      } finally {
+        const redirectURL = window.location.href;
+        expect(redirectURL).toBe(
+          `/login?next=${mockRequestPath + mockRequestSearch}`,
+        );
+        expect(error.status).toBe(401);
+      }
+    });
+
+    it('does nothing if instructed to ignoreUnauthorized', async () => {
+      const client = new SupersetClientClass({});
+
+      let error;
+      try {
+        await client.request({
+          url: mockRequestUrl,
+          method: 'GET',
+          ignoreUnauthorized: true,
+        });
+      } catch (err) {
+        error = err;
+      } finally {
+        // unchanged href, no redirect
+        expect(window.location.href).toBe(mockRequestPath + mockRequestSearch);
+        expect(error.status).toBe(401);
+      }
+    });
+
+    it('accepts an unauthorizedHandler to override redirect behavior', async () => {
+      const unauthorizedHandler = jest.fn();
+      const client = new SupersetClientClass({ unauthorizedHandler });
+
+      let error;
+      try {
+        await client.request({
+          url: mockRequestUrl,
+          method: 'GET',
+          ignoreUnauthorized: true,
+        });
+      } catch (err) {
+        error = err;
+      } finally {
+        // unchanged href, no redirect
+        expect(window.location.href).toBe(mockRequestPath + mockRequestSearch);
+        expect(error.status).toBe(401);
+        expect(unauthorizedHandler).toHaveBeenCalledTimes(1);
+      }
+    });
   });
 });

--- a/superset-frontend/packages/superset-ui-core/test/connection/SupersetClientClass.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/connection/SupersetClientClass.test.ts
@@ -505,6 +505,7 @@ describe('SupersetClientClass', () => {
     const mockRequestUrl = 'https://host/get/url';
     const mockRequestPath = '/get/url';
     const mockRequestSearch = '?param=1&param=2';
+    const mockHref = 'http://localhost' + mockRequestPath + mockRequestSearch;
 
     beforeEach(() => {
       originalLocation = window.location;
@@ -514,7 +515,7 @@ describe('SupersetClientClass', () => {
       window.location = {
         pathname: mockRequestPath,
         search: mockRequestSearch,
-        href: mockRequestPath + mockRequestSearch,
+        href: mockHref,
       };
       authSpy = jest
         .spyOn(SupersetClientClass.prototype, 'ensureAuth')
@@ -561,7 +562,7 @@ describe('SupersetClientClass', () => {
         error = err;
       } finally {
         // unchanged href, no redirect
-        expect(window.location.href).toBe(mockRequestPath + mockRequestSearch);
+        expect(window.location.href).toBe(mockHref);
         expect(error.status).toBe(401);
       }
     });
@@ -575,13 +576,12 @@ describe('SupersetClientClass', () => {
         await client.request({
           url: mockRequestUrl,
           method: 'GET',
-          ignoreUnauthorized: true,
         });
       } catch (err) {
         error = err;
       } finally {
         // unchanged href, no redirect
-        expect(window.location.href).toBe(mockRequestPath + mockRequestSearch);
+        expect(window.location.href).toBe(mockHref);
         expect(error.status).toBe(401);
         expect(unauthorizedHandler).toHaveBeenCalledTimes(1);
       }

--- a/superset-frontend/packages/superset-ui-core/test/connection/SupersetClientClass.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/connection/SupersetClientClass.test.ts
@@ -505,7 +505,7 @@ describe('SupersetClientClass', () => {
     const mockRequestUrl = 'https://host/get/url';
     const mockRequestPath = '/get/url';
     const mockRequestSearch = '?param=1&param=2';
-    const mockHref = 'http://localhost' + mockRequestPath + mockRequestSearch;
+    const mockHref = `http://localhost${mockRequestPath + mockRequestSearch}`;
 
     beforeEach(() => {
       originalLocation = window.location;

--- a/superset-frontend/src/components/MessageToasts/ToastContainer.tsx
+++ b/superset-frontend/src/components/MessageToasts/ToastContainer.tsx
@@ -17,12 +17,14 @@
  * under the License.
  */
 import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
+import { connect, ConnectedProps } from 'react-redux';
 import ToastPresenter from './ToastPresenter';
 
 import { removeToast } from './actions';
 
-export default connect(
-  ({ messageToasts: toasts }) => ({ toasts }),
+const ToastContainer = connect(
+  ({ messageToasts: toasts }: any) => ({ toasts }),
   dispatch => bindActionCreators({ removeToast }, dispatch),
 )(ToastPresenter);
+
+export default ToastContainer;

--- a/superset-frontend/src/components/MessageToasts/ToastContainer.tsx
+++ b/superset-frontend/src/components/MessageToasts/ToastContainer.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { bindActionCreators } from 'redux';
-import { connect, ConnectedProps } from 'react-redux';
+import { connect } from 'react-redux';
 import ToastPresenter from './ToastPresenter';
 
 import { removeToast } from './actions';

--- a/superset-frontend/src/components/MessageToasts/ToastPresenter.tsx
+++ b/superset-frontend/src/components/MessageToasts/ToastPresenter.tsx
@@ -73,7 +73,7 @@ const StyledToastPresenter = styled.div<VisualProps>`
   }
 `;
 
-type ToastPresenterProps = VisualProps & {
+type ToastPresenterProps = Partial<VisualProps> & {
   toasts: Array<ToastMeta>;
   removeToast: () => any;
 };

--- a/superset-frontend/src/components/MessageToasts/ToastPresenter.tsx
+++ b/superset-frontend/src/components/MessageToasts/ToastPresenter.tsx
@@ -21,10 +21,14 @@ import { styled } from '@superset-ui/core';
 import { ToastMeta } from 'src/components/MessageToasts/types';
 import Toast from './Toast';
 
-const StyledToastPresenter = styled.div`
+export interface VisualProps {
+  position: 'bottom' | 'top';
+}
+
+const StyledToastPresenter = styled.div<VisualProps>`
   max-width: 600px;
   position: fixed;
-  bottom: 0px;
+  ${({ position }) => (position === 'bottom' ? 'bottom' : 'top')}: 0px;
   right: 0px;
   margin-right: 50px;
   margin-bottom: 50px;
@@ -69,22 +73,25 @@ const StyledToastPresenter = styled.div`
   }
 `;
 
-type ToastPresenterProps = {
+type ToastPresenterProps = VisualProps & {
   toasts: Array<ToastMeta>;
-  removeToast: () => void;
+  removeToast: () => any;
 };
 
 export default function ToastPresenter({
   toasts,
   removeToast,
+  position = 'top',
 }: ToastPresenterProps) {
   return (
-    toasts.length > 0 && (
-      <StyledToastPresenter id="toast-presenter">
-        {toasts.map(toast => (
-          <Toast key={toast.id} toast={toast} onCloseToast={removeToast} />
-        ))}
-      </StyledToastPresenter>
-    )
+    <>
+      {toasts.length > 0 && (
+        <StyledToastPresenter id="toast-presenter" position={position}>
+          {toasts.map(toast => (
+            <Toast key={toast.id} toast={toast} onCloseToast={removeToast} />
+          ))}
+        </StyledToastPresenter>
+      )}
+    </>
   );
 }

--- a/superset-frontend/src/components/MessageToasts/withToasts.tsx
+++ b/superset-frontend/src/components/MessageToasts/withToasts.tsx
@@ -35,7 +35,8 @@ export interface ToastProps {
   addWarningToast: typeof addWarningToast;
 }
 
-const toasters = {
+/** just action creators, these do not dispatch */
+export const toasters = {
   addInfoToast,
   addSuccessToast,
   addWarningToast,

--- a/superset-frontend/src/embedded/index.tsx
+++ b/superset-frontend/src/embedded/index.tsx
@@ -28,6 +28,7 @@ import { store } from 'src/views/store';
 import ErrorBoundary from 'src/components/ErrorBoundary';
 import Loading from 'src/components/Loading';
 import { addDangerToast } from 'src/components/MessageToasts/actions';
+import ToastContainer from 'src/components/MessageToasts/ToastContainer';
 
 const debugMode = process.env.WEBPACK_MODE === 'development';
 
@@ -52,6 +53,7 @@ const EmbeddedApp = () => (
           <ErrorBoundary>
             <LazyDashboardPage />
           </ErrorBoundary>
+          <ToastContainer />
         </RootContextProviders>
       </Suspense>
     </Route>

--- a/superset-frontend/src/embedded/index.tsx
+++ b/superset-frontend/src/embedded/index.tsx
@@ -98,7 +98,7 @@ function guestUnauthorizedHandler() {
         'This session has encountered an interruption, and some controls may not work as intended. If you are the developer of this app, please check that the guest token is being generated correctly.',
       ),
       {
-        duration: -1, // stay open until closed
+        duration: -1, // stay open until manually closed
         noDuplicate: true,
       },
     ),

--- a/superset-frontend/src/embedded/index.tsx
+++ b/superset-frontend/src/embedded/index.tsx
@@ -117,14 +117,6 @@ function setupGuestClient(guestToken: string) {
 }
 
 function validateMessageEvent(event: MessageEvent) {
-  if (
-    event.data?.type === 'webpackClose' ||
-    event.data?.source === '@devtools-page'
-  ) {
-    // sometimes devtools use the messaging api and we want to ignore those
-    throw new Error("Sir, this is a Wendy's");
-  }
-
   // if (!ALLOW_ORIGINS.includes(event.origin)) {
   //   throw new Error('Message origin is not in the allowed list');
   // }
@@ -138,7 +130,7 @@ window.addEventListener('message', function embeddedPageInitializer(event) {
   try {
     validateMessageEvent(event);
   } catch (err) {
-    log('ignoring message', err, event);
+    log('ignoring message unrelated to embedded comms', err, event);
     return;
   }
 

--- a/superset-frontend/src/embedded/index.tsx
+++ b/superset-frontend/src/embedded/index.tsx
@@ -53,7 +53,7 @@ const EmbeddedApp = () => (
           <ErrorBoundary>
             <LazyDashboardPage />
           </ErrorBoundary>
-          <ToastContainer />
+          <ToastContainer position="top" />
         </RootContextProviders>
       </Suspense>
     </Route>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Requests should be able to be made without triggering the usual redirect-to-login if a 401 is returned.

Additionally, we need to have a default action other than a redirect if we get a 401 in the embedded page. This PR also adds code for Embedded so that 401s result in a toast warning instead of a redirect. We may want to change this to something other than a toast in the future, but for now it gets the job done.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before, a 401 resulted in a redirect to our login screen, which since you were already logged in to Preset, redirected to an app-in-app experience, which is pretty confusing. Now you get error messages and this explanation. Less brain-bending.

<img width="1212" alt="Screen Shot 2022-03-18 at 7 12 07 PM" src="https://user-images.githubusercontent.com/1858430/159103163-81e9caaa-4ef6-4441-a320-2e0aa224a4f9.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
