### PR TITLE
fix: TimezoneSelector is not reliably testable

### DIFF
--- a/superset-frontend/src/components/TimezoneSelector/TimezoneSelector.test.tsx
+++ b/superset-frontend/src/components/TimezoneSelector/TimezoneSelector.test.tsx
@@ -27,91 +27,104 @@ jest.spyOn(moment.tz, 'guess').mockReturnValue('America/New_York');
 const getSelectOptions = () =>
   waitFor(() => document.querySelectorAll('.ant-select-item-option-content'));
 
-it('use the timezone from `moment` if no timezone provided', () => {
-  const onTimezoneChange = jest.fn();
-  render(<TimezoneSelector onTimezoneChange={onTimezoneChange} />);
-  expect(onTimezoneChange).toHaveBeenCalledTimes(1);
-  expect(onTimezoneChange).toHaveBeenCalledWith('America/Nassau');
-});
-
-it('update to closest deduped timezone when timezone is provided', async () => {
-  const onTimezoneChange = jest.fn();
-  render(
-    <TimezoneSelector
-      onTimezoneChange={onTimezoneChange}
-      timezone="America/Los_Angeles"
-    />,
-  );
-  expect(onTimezoneChange).toHaveBeenCalledTimes(1);
-  expect(onTimezoneChange).toHaveBeenLastCalledWith('America/Vancouver');
-});
-
-it('use the default timezone when an invalid timezone is provided', async () => {
-  const onTimezoneChange = jest.fn();
-  render(
-    <TimezoneSelector onTimezoneChange={onTimezoneChange} timezone="UTC" />,
-  );
-  expect(onTimezoneChange).toHaveBeenCalledTimes(1);
-  expect(onTimezoneChange).toHaveBeenLastCalledWith('Africa/Abidjan');
-});
-
-it('can select a timezone values and returns canonical value', async () => {
-  const onTimezoneChange = jest.fn();
-  render(
-    <TimezoneSelector
-      onTimezoneChange={onTimezoneChange}
-      timezone="America/Nassau"
-    />,
-  );
-
-  const searchInput = screen.getByRole('combobox', {
-    name: 'Timezone selector',
+describe('TimezoneSelector', () => {
+  beforeAll(() => {
+    jest.useFakeTimers('modern');
+    jest.setSystemTime(new Date('January 10 2022'));
   });
-  expect(searchInput).toBeInTheDocument();
-  userEvent.click(searchInput);
-  const isDaylight = moment(moment.now()).isDST();
 
-  const selectedTimezone = isDaylight
-    ? 'GMT -04:00 (Eastern Daylight Time)'
-    : 'GMT -05:00 (Eastern Standard Time)';
+  afterAll(() => {
+    jest.useRealTimers();
+  });
 
-  // selected option ranks first
-  const options = await getSelectOptions();
-  expect(options[0]).toHaveTextContent(selectedTimezone);
+  it('use the timezone from `moment` if no timezone provided', () => {
+    const onTimezoneChange = jest.fn();
+    render(<TimezoneSelector onTimezoneChange={onTimezoneChange} />);
+    expect(onTimezoneChange).toHaveBeenCalledTimes(1);
+    expect(onTimezoneChange).toHaveBeenCalledWith('America/Nassau');
+  });
 
-  // others are ranked by offset
-  expect(options[1]).toHaveTextContent('GMT -11:00 (Pacific/Pago_Pago)');
-  expect(options[2]).toHaveTextContent('GMT -10:00 (Hawaii Standard Time)');
-  expect(options[3]).toHaveTextContent('GMT -10:00 (America/Adak)');
+  it('update to closest deduped timezone when timezone is provided', async () => {
+    const onTimezoneChange = jest.fn();
+    render(
+      <TimezoneSelector
+        onTimezoneChange={onTimezoneChange}
+        timezone="America/Los_Angeles"
+      />,
+    );
+    expect(onTimezoneChange).toHaveBeenCalledTimes(1);
+    expect(onTimezoneChange).toHaveBeenLastCalledWith('America/Vancouver');
+  });
 
-  // search for mountain time
-  await userEvent.type(searchInput, 'mou', { delay: 10 });
+  it('use the default timezone when an invalid timezone is provided', async () => {
+    const onTimezoneChange = jest.fn();
+    render(
+      <TimezoneSelector onTimezoneChange={onTimezoneChange} timezone="UTC" />,
+    );
+    expect(onTimezoneChange).toHaveBeenCalledTimes(1);
+    expect(onTimezoneChange).toHaveBeenLastCalledWith('Africa/Abidjan');
+  });
 
-  const findTitle = isDaylight
-    ? 'GMT -06:00 (Mountain Daylight Time)'
-    : 'GMT -07:00 (Mountain Standard Time)';
-  const selectOption = await screen.findByTitle(findTitle);
-  expect(selectOption).toBeInTheDocument();
-  userEvent.click(selectOption);
-  expect(onTimezoneChange).toHaveBeenCalledTimes(1);
-  expect(onTimezoneChange).toHaveBeenLastCalledWith('America/Cambridge_Bay');
-});
+  it('can select a timezone values and returns canonical value', async () => {
+    const onTimezoneChange = jest.fn();
+    render(
+      <TimezoneSelector
+        onTimezoneChange={onTimezoneChange}
+        timezone="America/Nassau"
+      />,
+    );
 
-it('can update props and rerender with different values', async () => {
-  const onTimezoneChange = jest.fn();
-  const { rerender } = render(
-    <TimezoneSelector
-      onTimezoneChange={onTimezoneChange}
-      timezone="Asia/Dubai"
-    />,
-  );
-  expect(screen.getByTitle('GMT +04:00 (Asia/Dubai)')).toBeInTheDocument();
-  rerender(
-    <TimezoneSelector
-      onTimezoneChange={onTimezoneChange}
-      timezone="Australia/Perth"
-    />,
-  );
-  expect(screen.getByTitle('GMT +08:00 (Australia/Perth)')).toBeInTheDocument();
-  expect(onTimezoneChange).toHaveBeenCalledTimes(0);
+    const searchInput = screen.getByRole('combobox', {
+      name: 'Timezone selector',
+    });
+    expect(searchInput).toBeInTheDocument();
+    userEvent.click(searchInput);
+    const isDaylight = moment().isDST();
+
+    const selectedTimezone = isDaylight
+      ? 'GMT -04:00 (Eastern Daylight Time)'
+      : 'GMT -05:00 (Eastern Standard Time)';
+
+    // selected option ranks first
+    const options = await getSelectOptions();
+    expect(options[0]).toHaveTextContent(selectedTimezone);
+
+    // others are ranked by offset
+    expect(options[1]).toHaveTextContent('GMT -11:00 (Pacific/Pago_Pago)');
+    expect(options[2]).toHaveTextContent('GMT -10:00 (Hawaii Standard Time)');
+    expect(options[3]).toHaveTextContent('GMT -10:00 (America/Adak)');
+
+    // search for mountain time
+    await userEvent.type(searchInput, 'mou', { delay: 10 });
+
+    const findTitle = isDaylight
+      ? 'GMT -06:00 (Mountain Daylight Time)'
+      : 'GMT -07:00 (Mountain Standard Time)';
+    const selectOption = await screen.findByTitle(findTitle);
+    expect(selectOption).toBeInTheDocument();
+    userEvent.click(selectOption);
+    expect(onTimezoneChange).toHaveBeenCalledTimes(1);
+    expect(onTimezoneChange).toHaveBeenLastCalledWith('America/Cambridge_Bay');
+  });
+
+  it('can update props and rerender with different values', async () => {
+    const onTimezoneChange = jest.fn();
+    const { rerender } = render(
+      <TimezoneSelector
+        onTimezoneChange={onTimezoneChange}
+        timezone="Asia/Dubai"
+      />,
+    );
+    expect(screen.getByTitle('GMT +04:00 (Asia/Dubai)')).toBeInTheDocument();
+    rerender(
+      <TimezoneSelector
+        onTimezoneChange={onTimezoneChange}
+        timezone="Australia/Perth"
+      />,
+    );
+    expect(
+      screen.getByTitle('GMT +08:00 (Australia/Perth)'),
+    ).toBeInTheDocument();
+    expect(onTimezoneChange).toHaveBeenCalledTimes(0);
+  });
 });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When DST switched, this test suite broke. This new version of the component and its tests should be functionally equivalent to the original, but with system time properly mocked and frozen for the duration of the test.

The test has some odd failures that I haven't yet figured out. All I know about them so far is that when I remove the line `await userEvent.type(searchInput, 'mou', { delay: 10 });` they pass. That line seems important. Since the test passes when the line is removed, I would presume that the test is also not adequately asserting that something actually changed after the user input.

Help getting the tests passing would be appreciated.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
