### PR TITLE
fix(docs): update dependencies for Clickhouse

### DIFF
--- a/docs/docs/databases/clickhouse.mdx
+++ b/docs/docs/databases/clickhouse.mdx
@@ -18,7 +18,7 @@ If running Superset using Docker Compose, add the following to your `./docker/re
 
 ```
 clickhouse-driver>=0.2.0
-clickhouse-sqlalchemy>=0.1.6
+clickhouse-sqlalchemy>=0.1.6,<0.2
 ```
 
 The recommended connector library for Clickhouse is


### PR DESCRIPTION
### SUMMARY
`clickhouse-sqlalchemy` 0.2 pulls SQLAlchemy 1.4 which is not supported by Superset.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
