### PR TITLE
fix: time filter should be [start, end)

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -308,7 +308,7 @@ class TableColumn(Model, BaseColumn, CertificationMixin):
         if start_dttm:
             l.append(col >= self.table.text(self.dttm_sql_literal(start_dttm)))
         if end_dttm:
-            l.append(col <= self.table.text(self.dttm_sql_literal(end_dttm)))
+            l.append(col < self.table.text(self.dttm_sql_literal(end_dttm)))
         return and_(*l)
 
     def get_timestamp_expression(

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -614,8 +614,11 @@ def test_should_generate_closed_and_open_time_filter_range():
         table = SqlaTable(
             table_name="temporal_column_table",
             sql=(
-                "SELECT '2022-01-01'::timestamp as datetime_col"
-                " UNION SELECT '2023-01-01'::timestamp"
+                "SELECT '2021-12-31'::timestamp as datetime_col "
+                "UNION SELECT '2022-01-01'::timestamp "
+                "UNION SELECT '2022-03-10'::timestamp "
+                "UNION SELECT '2023-01-01'::timestamp "
+                "UNION SELECT '2023-03-10'::timestamp "
             ),
             database=get_example_database(),
         )
@@ -636,12 +639,15 @@ def test_should_generate_closed_and_open_time_filter_range():
         """ >>> result_object.query
                 SELECT count(*) AS count
                 FROM
-                  (SELECT '2022-01-01'::timestamp as datetime_col
-                   UNION SELECT '2023-01-01'::timestamp) AS virtual_table
+                  (SELECT '2021-12-31'::timestamp as datetime_col
+                   UNION SELECT '2022-01-01'::timestamp
+                   UNION SELECT '2022-03-10'::timestamp
+                   UNION SELECT '2023-01-01'::timestamp
+                   UNION SELECT '2023-03-10'::timestamp) AS virtual_table
                 WHERE datetime_col >= TO_TIMESTAMP('2022-01-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
                   AND datetime_col < TO_TIMESTAMP('2023-01-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
         """
-        assert result_object.df.iloc[0]["count"] == 1
+        assert result_object.df.iloc[0]["count"] == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -631,13 +631,13 @@ def test_should_generate_closed_and_open_time_filter_range():
             }
         )
         """ >>> result_object.query
-            SELECT datetime_col AS __timestamp,
-                   count(*) AS count
-            FROM
-              (SELECT '2022-03-10' as datetime_col) AS virtual_table
-            WHERE datetime_col >= '2022-01-01 00:00:00.000000'
-              AND datetime_col < '2023-01-01 00:00:00.000000'
-            GROUP BY datetime_col
+                SELECT datetime_col AS __timestamp,
+                       count(*) AS count
+                FROM
+                  (SELECT '2022-03-10'::timestamp as datetime_col) AS virtual_table
+                WHERE datetime_col >= TO_TIMESTAMP('2022-01-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
+                  AND datetime_col < TO_TIMESTAMP('2023-01-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
+                GROUP BY datetime_col
         """
         unformat_sql = result_object.query.replace("\n", " ")
         unformat_sql = re.sub(r"(\s){2,}", " ", unformat_sql)

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -608,7 +608,7 @@ def test_filter_on_text_column(text_column_table):
 
 def test_should_generate_closed_and_open_time_filter_range():
     with app.app_context():
-        if backend() in ["sqlite", "mysql"]:
+        if backend() != "postgresql":
             pytest.skip(f"{backend()} has different dialect for datetime column")
 
         table = SqlaTable(

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -647,7 +647,8 @@ def test_should_generate_closed_and_open_time_filter_range():
             ">= "
             "TO_TIMESTAMP('2022-01-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US') "
             "AND "
-            "datetime_col < "
+            "datetime_col "
+            "< "
             "TO_TIMESTAMP('2023-01-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')"
             in unformat_sql
         )


### PR DESCRIPTION
### SUMMARY
This PR fixes a regression issue from [the remove legacy SIP-15 interim logic/flags](https://github.com/apache/superset/pull/18936). 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before
<img width="966" alt="image" src="https://user-images.githubusercontent.com/2016594/158506149-47c2382a-9998-4bde-900d-444c25eb549b.png">


#### After
<img width="894" alt="image" src="https://user-images.githubusercontent.com/2016594/158506096-616e5bbb-5e2e-401e-99a0-3db0cfe0ba58.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: https://github.com/apache/superset/issues/18906
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
