### PR TITLE
fix(sql lab): deleting the last saved query or the last executed from history

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -1372,7 +1372,7 @@ elif importlib.util.find_spec("superset_config") and not is_test():
     try:
         # pylint: disable=import-error,wildcard-import,unused-wildcard-import
         import superset_config
-        from superset_config import *
+        from superset_config import *  # type:ignore
 
         print(f"Loaded your LOCAL configuration at [{superset_config.__file__}]")
     except Exception:

--- a/superset/config.py
+++ b/superset/config.py
@@ -1372,7 +1372,7 @@ elif importlib.util.find_spec("superset_config") and not is_test():
     try:
         # pylint: disable=import-error,wildcard-import,unused-wildcard-import
         import superset_config
-        from superset_config import *  # type:ignore
+        from superset_config import *
 
         print(f"Loaded your LOCAL configuration at [{superset_config.__file__}]")
     except Exception:

--- a/superset/migrations/versions/58df9d617f14_add_on_saved_query_delete_tab_state_.py
+++ b/superset/migrations/versions/58df9d617f14_add_on_saved_query_delete_tab_state_.py
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add_on_saved_query_delete_tab_state_null_constraint"
+
+Revision ID: 58df9d617f14
+Revises: 7293b0ca7944
+Create Date: 2022-03-16 23:24:40.278937
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "58df9d617f14"
+down_revision = "7293b0ca7944"
+
+import sqlalchemy as sa
+from alembic import op
+
+from superset.utils.core import generic_find_fk_constraint_name
+
+
+def upgrade():
+    bind = op.get_bind()
+    insp = sa.engine.reflection.Inspector.from_engine(bind)
+
+    with op.batch_alter_table("tab_state") as batch_op:
+        batch_op.drop_constraint(
+            generic_find_fk_constraint_name("tab_state", {"id"}, "saved_query", insp),
+            type_="foreignkey",
+        )
+
+        batch_op.create_foreign_key(
+            "saved_query_id",
+            "saved_query",
+            ["saved_query_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+
+def downgrade():
+    bind = op.get_bind()
+    insp = sa.engine.reflection.Inspector.from_engine(bind)
+
+    with op.batch_alter_table("tab_state") as batch_op:
+        batch_op.drop_constraint(
+            generic_find_fk_constraint_name("tab_state", {"id"}, "saved_query", insp),
+            type_="foreignkey",
+        )
+
+        batch_op.create_foreign_key(
+            "saved_query_id", "saved_query", ["saved_query_id"], ["id"],
+        )

--- a/superset/migrations/versions/58df9d617f14_add_on_saved_query_delete_tab_state_.py
+++ b/superset/migrations/versions/58df9d617f14_add_on_saved_query_delete_tab_state_.py
@@ -17,14 +17,14 @@
 """add_on_saved_query_delete_tab_state_null_constraint"
 
 Revision ID: 58df9d617f14
-Revises: 7293b0ca7944
+Revises: 6766938c6065
 Create Date: 2022-03-16 23:24:40.278937
 
 """
 
 # revision identifiers, used by Alembic.
 revision = "58df9d617f14"
-down_revision = "7293b0ca7944"
+down_revision = "6766938c6065"
 
 import sqlalchemy as sa
 from alembic import op

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -291,7 +291,9 @@ class TabState(Model, AuditMixinNullable, ExtraJSONMixin):
     hide_left_bar = Column(Boolean, default=False)
 
     # any saved queries that are associated with the Tab State
-    saved_query_id = Column(Integer, ForeignKey("saved_query.id"), nullable=True)
+    saved_query_id = Column(
+        Integer, ForeignKey("saved_query.id", ondelete="SET NULL"), nullable=True
+    )
     saved_query = relationship("SavedQuery", foreign_keys=[saved_query_id])
 
     def to_dict(self) -> Dict[str, Any]:


### PR DESCRIPTION
### SUMMARY
When the SQL Lab has the persistence enabled on the backend (`SQLLAB_BACKEND_PERSISTENCE`), the queries failed on delete in two cases:

* From the Query History tab, if the query was the last executed.
* From the Saved queries, if the query was the last executed in a tab.

The issue is rooted in the `TabState` table, which has a foreign key to the saved query and to the latest executed one.
So, we need to clear that relation before deleting the query.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Query History

Before:

https://user-images.githubusercontent.com/17252075/158682064-793e824c-f29b-491f-bdf7-6b6d01918e2e.mp4

After:

https://user-images.githubusercontent.com/17252075/158684980-93b09132-d1d4-4029-a6ea-10891d68a0f1.mov

#### Saved Query

Before:

https://user-images.githubusercontent.com/17252075/158681766-eda7dbb2-9ffd-4f35-b703-17c9e2e0e138.mp4

After:

https://user-images.githubusercontent.com/17252075/158685178-409ff966-c6a9-4179-9d77-30e44a79038b.mov

### TESTING INSTRUCTIONS
Saved query:

* Go to SQL editor
* Input a valid sql query using examples or your own db
* Run query and Save as a new query (don't close the saved query tab in SQL editor)
* Go to "Saved queries" page
* Try to delete the saved query
* See the error

Query History:

* In SQL editor, run query
* Navigate to query history
* Click on trash icon

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
