### PR TITLE
fix: adhoc column in legacy chart

### DIFF
--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -339,11 +339,14 @@ class BaseDatasource(
                     or []
                 )
             else:
-                column_names.update(
-                    column
+                _columns = [
+                    utils.get_column_name(column)
+                    if utils.is_adhoc_column(column)
+                    else column
                     for column_param in COLUMN_FORM_DATA_PARAMS
                     for column in utils.get_iterable(form_data.get(column_param) or [])
-                )
+                ]
+                column_names.update(_columns)
 
         filtered_metrics = [
             metric

--- a/tests/integration_tests/model_tests.py
+++ b/tests/integration_tests/model_tests.py
@@ -609,6 +609,9 @@ class TestSqlaTableModel(SupersetTestCase):
         datasource_info = slc.datasource.data_for_slices([slc])
         assert "database" in datasource_info
 
+        # clean up and auto commit
+        metadata_db.session.delete(slc)
+
 
 def test_literal_dttm_type_factory():
     orig_type = DateTime()

--- a/tests/integration_tests/model_tests.py
+++ b/tests/integration_tests/model_tests.py
@@ -583,6 +583,8 @@ class TestSqlaTableModel(SupersetTestCase):
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_data_for_slices_with_adhoc_column(self):
+        # should perform sqla.model.BaseDatasource.data_for_slices() with adhoc
+        # column and legacy chart
         tbl = self.get_table(name="birth_names")
         slc = (
             metadata_db.session.query(Slice)

--- a/tests/integration_tests/model_tests.py
+++ b/tests/integration_tests/model_tests.py
@@ -18,7 +18,6 @@
 import json
 import textwrap
 import unittest
-from pprint import pprint
 from unittest import mock
 
 from superset.connectors.sqla.models import SqlaTable


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, If a chart applied Adhoc Column and it was a legacy chart without QueryContext in slice metadata, user will see an error on Dashboard: `TypeError: unhashable type: 'dict'`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### Before

https://user-images.githubusercontent.com/2016594/158774241-880b3a7b-6326-422e-97a5-aa6d145342c2.mov

### After

https://user-images.githubusercontent.com/2016594/158774666-38e0c383-cd47-4c14-9085-04ea59fada75.mov


### TESTING INSTRUCTIONS
a) use following step to reproduce this issue
1. open `USA Births Names` in examples dashboard.
2. open `Boy` chart
3. add or change a Adhoc Column on the chart, then save and overwrite.
4. manually remove `QueryContext` for `Boy` chart from Superset metadata
    i) connect to Superset metadata by any database client or SQLLab
    ii) run SQL `UPDATE slices set query_context=NULL WHERE slices.slice_name='Boys'` in DB
5. open `USA Births Names`, reproduced
6. after this PR, will not see errors anymore

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
