### PR TITLE
fix: cannot delete a database if team member has SQL editor tab that uses that db

### DIFF
--- a/superset/migrations/versions/58df9d617f14_add_on_saved_query_delete_tab_state_.py
+++ b/superset/migrations/versions/58df9d617f14_add_on_saved_query_delete_tab_state_.py
@@ -17,14 +17,14 @@
 """add_on_saved_query_delete_tab_state_null_constraint"
 
 Revision ID: 58df9d617f14
-Revises: 8b841273bec3
+Revises: 6766938c6065
 Create Date: 2022-03-16 23:24:40.278937
 
 """
 
 # revision identifiers, used by Alembic.
 revision = "58df9d617f14"
-down_revision = "8b841273bec3"
+down_revision = "6766938c6065"
 
 import sqlalchemy as sa
 from alembic import op

--- a/superset/migrations/versions/58df9d617f14_add_on_saved_query_delete_tab_state_.py
+++ b/superset/migrations/versions/58df9d617f14_add_on_saved_query_delete_tab_state_.py
@@ -17,14 +17,14 @@
 """add_on_saved_query_delete_tab_state_null_constraint"
 
 Revision ID: 58df9d617f14
-Revises: 6766938c6065
+Revises: 8b841273bec3
 Create Date: 2022-03-16 23:24:40.278937
 
 """
 
 # revision identifiers, used by Alembic.
 revision = "58df9d617f14"
-down_revision = "6766938c6065"
+down_revision = "8b841273bec3"
 
 import sqlalchemy as sa
 from alembic import op

--- a/superset/migrations/versions/8b841273bec3_sql_lab_models_database_constraint_updates.py
+++ b/superset/migrations/versions/8b841273bec3_sql_lab_models_database_constraint_updates.py
@@ -1,0 +1,111 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""sql_lab_models_database_constraint_updates
+
+Revision ID: 8b841273bec3
+Revises: 6766938c6065
+Create Date: 2022-03-16 21:07:48.768425
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "8b841273bec3"
+down_revision = "6766938c6065"
+
+import sqlalchemy as sa
+from alembic import op
+
+from superset.utils.core import generic_find_fk_constraint_name
+
+
+def upgrade():
+    bind = op.get_bind()
+    insp = sa.engine.reflection.Inspector.from_engine(bind)
+
+    with op.batch_alter_table("tab_state") as batch_op:
+        batch_op.drop_constraint(
+            generic_find_fk_constraint_name("tab_state", {"id"}, "dbs", insp),
+            type_="foreignkey",
+        )
+
+        batch_op.drop_constraint(
+            generic_find_fk_constraint_name("tab_state", {"client_id"}, "query", insp),
+            type_="foreignkey",
+        )
+
+        batch_op.create_foreign_key(
+            "tab_state_database_id_fkey",
+            "dbs",
+            ["database_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+
+        batch_op.create_foreign_key(
+            "tab_state_latest_query_id_fkey",
+            "query",
+            ["latest_query_id"],
+            ["client_id"],
+            ondelete="SET NULL",
+        )
+
+    with op.batch_alter_table("table_schema") as batch_op:
+        batch_op.drop_constraint(
+            generic_find_fk_constraint_name("table_schema", {"id"}, "dbs", insp),
+            type_="foreignkey",
+        )
+        batch_op.create_foreign_key(
+            "table_schema_database_id_fkey",
+            "dbs",
+            ["database_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+
+
+def downgrade():
+    bind = op.get_bind()
+    insp = sa.engine.reflection.Inspector.from_engine(bind)
+
+    with op.batch_alter_table("tab_state") as batch_op:
+        batch_op.drop_constraint(
+            generic_find_fk_constraint_name("tab_state", {"id"}, "dbs", insp),
+            type_="foreignkey",
+        )
+        batch_op.drop_constraint(
+            generic_find_fk_constraint_name("tab_state", {"client_id"}, "query", insp),
+            type_="foreignkey",
+        )
+
+        batch_op.create_foreign_key(
+            "tab_state_database_id_fkey", "dbs", ["database_id"], ["id"]
+        )
+        batch_op.create_foreign_key(
+            "tab_state_latest_query_id_fkey",
+            "query",
+            ["latest_query_id"],
+            ["client_id"],
+        )
+
+    with op.batch_alter_table("table_schema") as batch_op:
+        batch_op.drop_constraint(
+            generic_find_fk_constraint_name("table_schema", {"id"}, "dbs", insp),
+            type_="foreignkey",
+        )
+        batch_op.create_foreign_key(
+            "table_schema_database_id_fkey", "dbs", ["database_id"], ["id"]
+        )

--- a/superset/migrations/versions/8b841273bec3_sql_lab_models_database_constraint_updates.py
+++ b/superset/migrations/versions/8b841273bec3_sql_lab_models_database_constraint_updates.py
@@ -17,14 +17,14 @@
 """sql_lab_models_database_constraint_updates
 
 Revision ID: 8b841273bec3
-Revises: 6766938c6065
+Revises: 2ed890b36b94
 Create Date: 2022-03-16 21:07:48.768425
 
 """
 
 # revision identifiers, used by Alembic.
 revision = "8b841273bec3"
-down_revision = "6766938c6065"
+down_revision = "2ed890b36b94"
 
 import sqlalchemy as sa
 from alembic import op

--- a/superset/migrations/versions/8b841273bec3_sql_lab_models_database_constraint_updates.py
+++ b/superset/migrations/versions/8b841273bec3_sql_lab_models_database_constraint_updates.py
@@ -37,15 +37,23 @@ def upgrade():
     insp = sa.engine.reflection.Inspector.from_engine(bind)
 
     with op.batch_alter_table("tab_state") as batch_op:
-        batch_op.drop_constraint(
-            generic_find_fk_constraint_name("tab_state", {"id"}, "dbs", insp),
-            type_="foreignkey",
+        table_schema_id_constraint = generic_find_fk_constraint_name(
+            "tab_state", {"id"}, "dbs", insp
         )
+        if table_schema_id_constraint:
+            batch_op.drop_constraint(
+                table_schema_id_constraint,
+                type_="foreignkey",
+            )
 
-        batch_op.drop_constraint(
-            generic_find_fk_constraint_name("tab_state", {"client_id"}, "query", insp),
-            type_="foreignkey",
+        table_schema_id_constraint = generic_find_fk_constraint_name(
+            "tab_state", {"client_id"}, "query", insp
         )
+        if table_schema_id_constraint:
+            batch_op.drop_constraint(
+                table_schema_id_constraint,
+                type_="foreignkey",
+            )
 
         batch_op.create_foreign_key(
             "tab_state_database_id_fkey",
@@ -64,10 +72,15 @@ def upgrade():
         )
 
     with op.batch_alter_table("table_schema") as batch_op:
-        batch_op.drop_constraint(
-            generic_find_fk_constraint_name("table_schema", {"id"}, "dbs", insp),
-            type_="foreignkey",
+        table_schema_id_constraint = generic_find_fk_constraint_name(
+            "table_schema", {"id"}, "dbs", insp
         )
+        if table_schema_id_constraint:
+            batch_op.drop_constraint(
+                table_schema_id_constraint,
+                type_="foreignkey",
+            )
+
         batch_op.create_foreign_key(
             "table_schema_database_id_fkey",
             "dbs",
@@ -82,14 +95,23 @@ def downgrade():
     insp = sa.engine.reflection.Inspector.from_engine(bind)
 
     with op.batch_alter_table("tab_state") as batch_op:
-        batch_op.drop_constraint(
-            generic_find_fk_constraint_name("tab_state", {"id"}, "dbs", insp),
-            type_="foreignkey",
+        table_schema_id_constraint = generic_find_fk_constraint_name(
+            "tab_state", {"id"}, "dbs", insp
         )
-        batch_op.drop_constraint(
-            generic_find_fk_constraint_name("tab_state", {"client_id"}, "query", insp),
-            type_="foreignkey",
+        if table_schema_id_constraint:
+            batch_op.drop_constraint(
+                table_schema_id_constraint,
+                type_="foreignkey",
+            )
+
+        table_schema_id_constraint = generic_find_fk_constraint_name(
+            "tab_state", {"client_id"}, "query", insp
         )
+        if table_schema_id_constraint:
+            batch_op.drop_constraint(
+                table_schema_id_constraint,
+                type_="foreignkey",
+            )
 
         batch_op.create_foreign_key(
             "tab_state_database_id_fkey", "dbs", ["database_id"], ["id"]
@@ -102,10 +124,15 @@ def downgrade():
         )
 
     with op.batch_alter_table("table_schema") as batch_op:
-        batch_op.drop_constraint(
-            generic_find_fk_constraint_name("table_schema", {"id"}, "dbs", insp),
-            type_="foreignkey",
+        table_schema_id_constraint = generic_find_fk_constraint_name(
+            "table_schema", {"id"}, "dbs", insp
         )
+        if table_schema_id_constraint:
+            batch_op.drop_constraint(
+                table_schema_id_constraint,
+                type_="foreignkey",
+            )
+
         batch_op.create_foreign_key(
             "table_schema_database_id_fkey", "dbs", ["database_id"], ["id"]
         )

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -265,7 +265,7 @@ class TabState(Model, AuditMixinNullable, ExtraJSONMixin):
     active = Column(Boolean, default=False)
 
     # selected DB and schema
-    database_id = Column(Integer, ForeignKey("dbs.id"))
+    database_id = Column(Integer, ForeignKey("dbs.id", ondelete="CASCADE"))
     database = relationship("Database", foreign_keys=[database_id])
     schema = Column(String(256))
 
@@ -282,7 +282,9 @@ class TabState(Model, AuditMixinNullable, ExtraJSONMixin):
     query_limit = Column(Integer)
 
     # latest query that was run
-    latest_query_id = Column(Integer, ForeignKey("query.client_id"))
+    latest_query_id = Column(
+        Integer, ForeignKey("query.client_id", ondelete="SET NULL")
+    )
     latest_query = relationship("Query")
 
     # other properties
@@ -322,7 +324,9 @@ class TableSchema(Model, AuditMixinNullable, ExtraJSONMixin):
     id = Column(Integer, primary_key=True, autoincrement=True)
     tab_state_id = Column(Integer, ForeignKey("tab_state.id", ondelete="CASCADE"))
 
-    database_id = Column(Integer, ForeignKey("dbs.id"), nullable=False)
+    database_id = Column(
+        Integer, ForeignKey("dbs.id", ondelete="CASCADE"), nullable=False
+    )
     database = relationship("Database", foreign_keys=[database_id])
     schema = Column(String(256))
     table = Column(String(256))


### PR DESCRIPTION
### SUMMARY
The `TabState` model has foreign key constraints on it that are not properly handled when the referred rows are deleted.
This causes, for instance, that a database fails to be deleted if the user has an SQL Lab editor opened with a query referencing that database.

This PR adds a database migration with `ondelete` instructions to properly handle cascading deletes when needed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TESTING INSTRUCTIONS
1. Team member A previously has a SQL editor tab with DB1
2. Team member B (or same user might work as well) try to delete DB1
3. When prompted, confirm the deletion

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### Runtime estimates results (benchmark_migration.py)

```
Migration for 1000+ entities took: 2.53 seconds

Results:

Current: 2.51 s
10+: 2.27 s
100+: 2.24 s
1000+: 2.53 s
```
