### PR TITLE
fix(drill): specify an SA URL parm of `impersonation_target` for drill+sadrill

### DIFF
--- a/superset/db_engine_specs/drill.py
+++ b/superset/db_engine_specs/drill.py
@@ -14,17 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import logging
 from datetime import datetime
 from typing import Any, Dict, Optional
 from urllib import parse
 
 from sqlalchemy.engine.url import URL
 
+from superset.db_engine_specs.exceptions import SupersetDBAPIProgrammingError
 from superset.db_engine_specs.base import BaseEngineSpec
 from superset.utils import core as utils
-
-logger = logging.getLogger(__name__)
 
 
 class DrillEngineSpec(BaseEngineSpec):
@@ -90,4 +88,6 @@ class DrillEngineSpec(BaseEngineSpec):
             elif url.drivername in ["drill+sadrill", "drill+jdbc"]:
                 url.query["impersonation_target"] = username
             else:
-                logger.warning("impersonation is not supported for %s", url.drivername)
+                raise SupersetDBAPIProgrammingError(
+                    f"impersonation is not supported for {url.drivername}"
+                )

--- a/superset/db_engine_specs/drill.py
+++ b/superset/db_engine_specs/drill.py
@@ -20,8 +20,8 @@ from urllib import parse
 
 from sqlalchemy.engine.url import URL
 
-from superset.db_engine_specs.exceptions import SupersetDBAPIProgrammingError
 from superset.db_engine_specs.base import BaseEngineSpec
+from superset.db_engine_specs.exceptions import SupersetDBAPIProgrammingError
 from superset.utils import core as utils
 
 

--- a/superset/db_engine_specs/drill.py
+++ b/superset/db_engine_specs/drill.py
@@ -90,4 +90,4 @@ class DrillEngineSpec(BaseEngineSpec):
             elif url.drivername in ["drill+sadrill", "drill+jdbc"]:
                 url.query["impersonation_target"] = username
             else:
-                logger.warn(f"impersonation is not supported for {url.drivername}.")
+                logger.warning("impersonation is not supported for %s", url.drivername)

--- a/superset/db_engine_specs/drill.py
+++ b/superset/db_engine_specs/drill.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import logging
 from datetime import datetime
 from typing import Any, Dict, Optional
 from urllib import parse
@@ -22,6 +23,8 @@ from sqlalchemy.engine.url import URL
 
 from superset.db_engine_specs.base import BaseEngineSpec
 from superset.utils import core as utils
+
+logger = logging.getLogger(__name__)
 
 
 class DrillEngineSpec(BaseEngineSpec):
@@ -84,7 +87,7 @@ class DrillEngineSpec(BaseEngineSpec):
         if impersonate_user and username is not None:
             if url.drivername == "drill+odbc":
                 url.query["DelegationUID"] = username
-            elif url.drivername == "drill+jdbc":
+            elif url.drivername in ["drill+sadrill", "drill+jdbc"]:
                 url.query["impersonation_target"] = username
             else:
-                url.username = username
+                logger.warn(f"impersonation is not supported for {url.drivername}.")

--- a/tests/unit_tests/db_engine_specs/test_drill.py
+++ b/tests/unit_tests/db_engine_specs/test_drill.py
@@ -17,7 +17,7 @@
 # pylint: disable=unused-argument, import-outside-toplevel, protected-access
 
 from flask.ctx import AppContext
-from superset.db_engine_specs.exceptions import SupersetDBAPIProgrammingError
+from pytest import raises
 
 
 def test_odbc_impersonation(app_context: AppContext) -> None:
@@ -78,14 +78,10 @@ def test_invalid_impersonation(app_context: AppContext) -> None:
     from sqlalchemy.engine.url import URL
 
     from superset.db_engine_specs.drill import DrillEngineSpec
+    from superset.db_engine_specs.exceptions import SupersetDBAPIProgrammingError
 
     url = URL("drill+foobar")
     username = "DoAsUser"
-    exception_type = None
 
-    try:
+    with raises(SupersetDBAPIProgrammingError):
         DrillEngineSpec.modify_url_for_impersonation(url, True, username)
-    except Exception as e:
-        exception_type = type(e)
-
-    assert exception_type == SupersetDBAPIProgrammingError

--- a/tests/unit_tests/db_engine_specs/test_drill.py
+++ b/tests/unit_tests/db_engine_specs/test_drill.py
@@ -55,7 +55,7 @@ def test_sadrill_impersonation(app_context: AppContext) -> None:
     """
     Test ``modify_url_for_impersonation`` method when driver == sadrill.
 
-    The method changes the username of URL Object.
+    The method adds the parameter ``impersonation_target`` to the query string.
     """
     from sqlalchemy.engine.url import URL
 
@@ -64,4 +64,4 @@ def test_sadrill_impersonation(app_context: AppContext) -> None:
     url = URL("drill+sadrill")
     username = "DoAsUser"
     DrillEngineSpec.modify_url_for_impersonation(url, True, username)
-    assert url.username == username
+    assert url.query["impersonation_target"] == username


### PR DESCRIPTION
### SUMMARY
[Sqlalchemy-drill has been updated](https://github.com/JohnOmernik/sqlalchemy-drill/pull/74) to support impersonation with the
drill+sadrill driver, where previously it did not.  The way that callers
should specify impersonation matches that for the drill+jdbc driver in that
a SA URL parameter of impersonation_target should be set to the username
of the user to be impersonated, while the standard SA username and password
should be those of the proxy user.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
Configure a new Apache Drill connection using the drill+sadrill driver from
sqlalchemy-drill.  Enable impersonation and trigger the execution of a Drill
query.  In the Drill query profile history, confirm that the query was executed
as the impersonated user.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
