### PR TITLE
fix(sql lab): table selector should display all the selected tables

### DIFF
--- a/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
@@ -1024,7 +1024,7 @@ class DatasourceEditor extends React.PureComponent {
                                 )
                             : undefined
                         }
-                        onTableChange={
+                        onTableSelectChange={
                           this.state.isEditMode
                             ? table =>
                                 this.onDatasourcePropChange('table_name', table)

--- a/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
@@ -1008,7 +1008,7 @@ class DatasourceEditor extends React.PureComponent {
                         handleError={this.props.addDangerToast}
                         schema={datasource.schema}
                         sqlLabMode={false}
-                        tableName={datasource.table_name}
+                        tableValue={datasource.table_name}
                         onSchemaChange={
                           this.state.isEditMode
                             ? schema =>

--- a/superset-frontend/src/components/TableSelector/TableSelector.test.tsx
+++ b/superset-frontend/src/components/TableSelector/TableSelector.test.tsx
@@ -159,7 +159,7 @@ test('table select retain value if not in SQL Lab mode', async () => {
 
   const callback = jest.fn();
   const props = createProps({
-    onTableChange: callback,
+    onTableSelectChange: callback,
     sqlLabMode: false,
   });
 
@@ -200,7 +200,7 @@ test('table select does not retain value in SQL Lab mode', async () => {
 
   const callback = jest.fn();
   const props = createProps({
-    onTableChange: callback,
+    onTableSelectChange: callback,
     sqlLabMode: true,
   });
 

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -165,6 +165,16 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
   );
   const [currentTable, setCurrentTable] = useState<TableOption | undefined>();
   const [refresh, setRefresh] = useState(0);
+  /**
+   * When a table is selected in SQL Lab, the select should not retain
+   * the value, rather update other component.
+   * Setting it to `undefined` is not enough, because that changes
+   * the component to an uncontrolled mode an the value is still
+   * displayed.
+   * By using a key and updating it, this component can capture
+   * the selected value without the select retaining it.
+   */
+  const [currentTableKey, setCurrentTableKey] = useState(0);
   const [previousRefresh, setPreviousRefresh] = useState(0);
   const [loadingTables, setLoadingTables] = useState(false);
   const [tableOptions, setTableOptions] = useState<TableOption[]>([]);
@@ -235,7 +245,12 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
   }
 
   const internalTableChange = (table?: TableOption) => {
-    setCurrentTable(table);
+    if (sqlLabMode) {
+      setCurrentTableKey(key => key + 1);
+    } else {
+      setCurrentTable(table);
+    }
+
     if (onTableChange && currentSchema) {
       onTableChange(table?.value, currentSchema);
     }
@@ -297,6 +312,7 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
 
     const select = (
       <Select
+        key={currentTableKey}
         ariaLabel={t('Select table or type table name')}
         disabled={disabled}
         filterOption={handleFilterOption}

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -23,6 +23,7 @@ import React, {
   useMemo,
   useEffect,
   useCallback,
+  useRef,
 } from 'react';
 import { SelectValue } from 'antd/lib/select';
 
@@ -94,7 +95,7 @@ interface TableSelectorProps {
   readOnly?: boolean;
   schema?: string;
   sqlLabMode?: boolean;
-  tableValue: string | string[];
+  tableValue?: string | string[];
   onTableSelectChange?: (value?: SelectValue, schema?: string) => void;
   tableSelectMode?: 'single' | 'multiple';
   emptyTableSelectValue?: SelectValue;
@@ -161,9 +162,11 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
   sqlLabMode = true,
   tableSelectMode = 'single',
   emptyTableSelectValue = undefined,
-  tableValue,
+  tableValue = undefined,
   onTableSelectChange,
 }) => {
+  const selectRef = useRef<HTMLInputElement>(null);
+
   const [currentDatabase, setCurrentDatabase] = useState<
     DatabaseObject | undefined
   >(database);
@@ -254,6 +257,10 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
   }
 
   const internalTableChange = (value: SelectValue | undefined) => {
+    if (tableSelectMode === 'multiple') {
+      selectRef?.current?.blur();
+    }
+
     if (currentSchema) {
       onTableSelectChange?.(value, currentSchema);
     } else {
@@ -318,6 +325,7 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
 
     const select = (
       <Select
+        ref={selectRef}
         ariaLabel={t('Select table or type table name')}
         disabled={disabled}
         filterOption={handleFilterOption}

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -22,7 +22,6 @@ import React, {
   ReactNode,
   useMemo,
   useEffect,
-  useRef,
 } from 'react';
 import { SelectValue } from 'antd/lib/select';
 
@@ -162,8 +161,6 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
   tableValue = undefined,
   onTableSelectChange,
 }) => {
-  const selectRef = useRef<HTMLInputElement>(null);
-
   const [currentDatabase, setCurrentDatabase] = useState<
     DatabaseObject | undefined
   >(database);
@@ -256,10 +253,6 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
   const internalTableChange = (
     selectedOptions: TableOption | TableOption[] | undefined,
   ) => {
-    if (tableSelectMode === 'multiple') {
-      selectRef?.current?.blur();
-    }
-
     if (currentSchema) {
       onTableSelectChange?.(
         Array.isArray(selectedOptions)
@@ -329,7 +322,6 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
 
     const select = (
       <Select
-        ref={selectRef}
         ariaLabel={t('Select table or type table name')}
         disabled={disabled}
         filterOption={handleFilterOption}
@@ -346,6 +338,7 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
         showSearch
         mode={tableSelectMode}
         value={tableSelectValue}
+        allowClear={tableSelectMode === 'multiple'}
       />
     );
 

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDatasetModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDatasetModal.tsx
@@ -126,10 +126,10 @@ const DatasetModal: FunctionComponent<DatasetModalProps> = ({
           formMode
           database={currentDatabase}
           schema={currentSchema}
-          tableName={currentTableName}
+          tableValue={currentTableName}
           onDbChange={onDbChange}
           onSchemaChange={onSchemaChange}
-          onTableChange={onTableChange}
+          onTableSelectChange={onTableChange}
           handleError={addDangerToast}
         />
       </TableSelectorContainer>


### PR DESCRIPTION
### SUMMARY
On the left panel in the SQL Lab editor, we can select a db, schema & table combination and it will query the schema for us.

**Initial change**
This PR updates the UI interaction so that, once a table is selected, is not persisted in that select. The reason being a user can select multiple tables and the schemas are all shown below.

**After discussions**
This PR updates the UI interaction so that the table select display all the selected tables, as opposed to clearing it.
Now, both the table select & the table list below are linked together bidirectionally and in sync.

The select is closed after each selection, considering that most of the time the user will want to pick a single table to work on (interaction up for debate).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/17252075/159029456-cbef8e12-acdd-411e-9605-a70db46619c1.mov

After:

https://user-images.githubusercontent.com/17252075/160209928-35466d0a-68de-40c7-925d-783b34d50ca0.mov

### TESTING INSTRUCTIONS
1. Go to SQL Lab
2. Select a DB
3. Select a Schema
4. Select tables

Ensure after each table selection, the schema appears below (it appears at the end, so you might need to scroll)
Ensure the select contains all the selected tables, and that both the select. & list have the same tables.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
