### PR TITLE
fix(sql lab): most recently selected table should appear at the top of the list on the left panel

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -1005,8 +1005,8 @@ export function queryEditorSetSelectedText(queryEditor, sql) {
   return { type: QUERY_EDITOR_SET_SELECTED_TEXT, queryEditor, sql };
 }
 
-export function mergeTable(table, query) {
-  return { type: MERGE_TABLE, table, query };
+export function mergeTable(table, query, prepend) {
+  return { type: MERGE_TABLE, table, query, prepend };
 }
 
 function getTableMetadata(table, query, dispatch) {
@@ -1076,12 +1076,16 @@ export function addTable(query, database, tableName, schemaName) {
       name: tableName,
     };
     dispatch(
-      mergeTable({
-        ...table,
-        isMetadataLoading: true,
-        isExtraMetadataLoading: true,
-        expanded: true,
-      }),
+      mergeTable(
+        {
+          ...table,
+          isMetadataLoading: true,
+          isExtraMetadataLoading: true,
+          expanded: true,
+        },
+        null,
+        true,
+      ),
     );
 
     return Promise.all([

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.js
@@ -725,7 +725,7 @@ describe('async actions', () => {
 
     describe('addTable', () => {
       it('updates the table schema state in the backend', () => {
-        expect.assertions(5);
+        expect.assertions(6);
 
         const database = { disable_data_preview: true };
         const tableName = 'table';
@@ -743,6 +743,7 @@ describe('async actions', () => {
             expect(store.getActions().map(a => a.type)).toEqual(
               expectedActionTypes,
             );
+            expect(store.getActions()[0].prepend).toBeTruthy();
             expect(fetchMock.calls(updateTableSchemaEndpoint)).toHaveLength(1);
             expect(fetchMock.calls(getTableMetadataEndpoint)).toHaveLength(1);
             expect(fetchMock.calls(getExtraTableMetadataEndpoint)).toHaveLength(

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -134,7 +134,7 @@ export default function sqlLabReducer(state = {}, action) {
       }
       // for new table, associate Id of query for data preview
       at.dataPreviewQueryId = null;
-      let newState = addToArr(state, 'tables', at);
+      let newState = addToArr(state, 'tables', at, Boolean(action.prepend));
       if (action.query) {
         newState = alterInArr(newState, 'tables', at, {
           dataPreviewQueryId: action.query.id,


### PR DESCRIPTION
### SUMMARY
When adding a new table in the SQL Tab, it should appear at the top, since it's the most recent.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/17252075/159037243-2f85f5cf-5481-42c1-8fec-bc266df03877.mov

After:

https://user-images.githubusercontent.com/17252075/159037009-4b9b27d0-f31f-4021-bb62-87908f786104.mov

### TESTING INSTRUCTIONS
1. Go to SQL Lab
2. Select a DB
3. Select a Schema
4. Select tables

Ensure the tables are added at the top.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
