### PR TITLE
feat(explore): Dataset panel option tooltips

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/package.json
+++ b/superset-frontend/packages/superset-ui-chart-controls/package.json
@@ -2,6 +2,19 @@
   "name": "@superset-ui/chart-controls",
   "version": "0.18.25",
   "description": "Superset UI control-utils",
+  "keywords": [
+    "superset"
+  ],
+  "homepage": "https://github.com/apache-superset/superset-ui#readme",
+  "bugs": {
+    "url": "https://github.com/apache-superset/superset-ui/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/apache-superset/superset-ui.git"
+  },
+  "license": "Apache-2.0",
+  "author": "Superset",
   "sideEffects": false,
   "main": "lib/index.js",
   "module": "esm/index.js",
@@ -9,22 +22,6 @@
     "esm",
     "lib"
   ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/apache-superset/superset-ui.git"
-  },
-  "keywords": [
-    "superset"
-  ],
-  "author": "Superset",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/apache-superset/superset-ui/issues"
-  },
-  "homepage": "https://github.com/apache-superset/superset-ui#readme",
-  "publishConfig": {
-    "access": "public"
-  },
   "dependencies": {
     "@react-icons/all-files": "^4.1.0",
     "lodash": "^4.17.15",
@@ -33,10 +30,18 @@
   "peerDependencies": {
     "@emotion/react": "^11.4.1",
     "@superset-ui/core": "*",
+    "@testing-library/dom": "^7.29.4",
+    "@testing-library/jest-dom": "^5.11.6",
+    "@testing-library/react": "^11.2.0",
+    "@testing-library/react-hooks": "^5.0.3",
+    "@testing-library/user-event": "^12.7.0",
+    "@types/enzyme": "^3.10.5",
     "@types/react": "*",
     "antd": "^4.9.4",
     "react": "^16.13.1",
-    "react-dom": "^16.13.1",
-    "@types/enzyme": "^3.10.5"
+    "react-dom": "^16.13.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useEffect, useState, ReactNode } from 'react';
+import React, { useState, ReactNode, useLayoutEffect } from 'react';
 import { styled } from '@superset-ui/core';
 import { Tooltip } from './Tooltip';
 import { ColumnTypeLabel } from './ColumnTypeLabel';
@@ -47,7 +47,7 @@ export function ColumnOption({
   const type = hasExpression ? 'expression' : type_generic;
   const [tooltipText, setTooltipText] = useState<ReactNode>(column.column_name);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setTooltipText(getColumnTooltipNode(column, labelRef));
   }, [labelRef, column]);
 
@@ -61,26 +61,12 @@ export function ColumnOption({
           details={column.certification_details}
         />
       )}
-      <Tooltip
-        id="metric-name-tooltip"
-        title={tooltipText}
-        trigger={['hover']}
-        placement="top"
-      >
+      <Tooltip id="metric-name-tooltip" title={tooltipText}>
         <span className="m-r-5 option-label column-option-label" ref={labelRef}>
           {getColumnLabelText(column)}
         </span>
       </Tooltip>
 
-      {column.description && (
-        <InfoTooltipWithTrigger
-          className="m-r-5 text-muted"
-          icon="info"
-          tooltip={column.description}
-          label={`descr-${column.column_name}`}
-          placement="top"
-        />
-      )}
       {hasExpression && (
         <InfoTooltipWithTrigger
           className="m-r-5 text-muted"

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useEffect, useState, ReactNode } from 'react';
+import React, { useState, ReactNode, useLayoutEffect } from 'react';
 import { styled, Metric, SafeMarkdown } from '@superset-ui/core';
 import InfoTooltipWithTrigger from './InfoTooltipWithTrigger';
 import { ColumnTypeLabel } from './ColumnTypeLabel';
@@ -63,7 +63,7 @@ export function MetricOption({
 
   const [tooltipText, setTooltipText] = useState<ReactNode>(metric.metric_name);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setTooltipText(getMetricTooltipNode(metric, labelRef));
   }, [labelRef, metric]);
 
@@ -77,24 +77,11 @@ export function MetricOption({
           details={metric.certification_details}
         />
       )}
-      <Tooltip
-        id="metric-name-tooltip"
-        title={tooltipText}
-        trigger={['hover']}
-        placement="top"
-      >
+      <Tooltip id="metric-name-tooltip" title={tooltipText}>
         <span className="option-label metric-option-label" ref={labelRef}>
           {link}
         </span>
       </Tooltip>
-      {metric.description && (
-        <InfoTooltipWithTrigger
-          className="text-muted"
-          icon="info"
-          tooltip={metric.description}
-          label={`descr-${metric.metric_name}`}
-        />
-      )}
       {showFormula && (
         <InfoTooltipWithTrigger
           className="text-muted"

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/Tooltip.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/Tooltip.tsx
@@ -46,15 +46,17 @@ export const Tooltip = ({ overlayStyle, color, ...props }: TooltipProps) => {
         overlayStyle={{
           fontSize: theme.typography.sizes.s,
           lineHeight: '1.6',
-          maxWidth: 250,
-          minWidth: 120,
+          maxWidth: theme.gridUnit * 62,
+          minWidth: theme.gridUnit * 30,
           ...overlayStyle,
         }}
         // make the tooltip display closer to the label
-        align={{ offset: [0, 3] }}
+        align={{ offset: [0, 1] }}
         color={defaultColor || color}
         trigger="hover"
-        placement="top"
+        placement="bottom"
+        // don't allow hovering over the tooltip
+        mouseLeaveDelay={0}
         {...props}
       />
     </>

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/Tooltip.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/Tooltip.tsx
@@ -46,9 +46,15 @@ export const Tooltip = ({ overlayStyle, color, ...props }: TooltipProps) => {
         overlayStyle={{
           fontSize: theme.typography.sizes.s,
           lineHeight: '1.6',
+          maxWidth: 250,
+          minWidth: 120,
           ...overlayStyle,
         }}
+        // make the tooltip display closer to the label
+        align={{ offset: [0, 3] }}
         color={defaultColor || color}
+        trigger="hover"
+        placement="top"
         {...props}
       />
     </>

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.tsx
@@ -67,7 +67,6 @@ export const getColumnTooltipNode = (
   column: ColumnMeta,
   labelRef?: React.RefObject<any>,
 ): ReactNode => {
-  // don't show tooltip if it hasn't verbose_name and hasn't truncated
   if (
     !column.verbose_name &&
     !column.description &&
@@ -95,7 +94,6 @@ export const getMetricTooltipNode = (
   metric: MetricType,
   labelRef?: React.RefObject<any>,
 ): ReactNode => {
-  // don't show tooltip if it hasn't verbose_name, label and hasn't truncated
   if (
     !metric.verbose_name &&
     !metric.description &&

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.tsx
@@ -18,8 +18,40 @@
  */
 import React, { ReactNode } from 'react';
 
-import { t } from '@superset-ui/core';
+import { css, styled, t } from '@superset-ui/core';
 import { ColumnMeta, Metric } from '@superset-ui/chart-controls';
+
+const TooltipSectionWrapper = styled.div`
+  ${({ theme }) => css`
+    display: flex;
+    flex-direction: column;
+    font-size: ${theme.typography.sizes.s}px;
+    line-height: 1.2;
+
+    &:not(:last-of-type) {
+      margin-bottom: ${theme.gridUnit * 2}px;
+    }
+  `}
+`;
+
+const TooltipSectionLabel = styled.span`
+  ${({ theme }) => css`
+    font-weight: ${theme.typography.weights.bold};
+  `}
+`;
+
+const TooltipSection = ({
+  label,
+  text,
+}: {
+  label: ReactNode;
+  text: ReactNode;
+}) => (
+  <TooltipSectionWrapper>
+    <TooltipSectionLabel>{label}</TooltipSectionLabel>
+    <span>{text}</span>
+  </TooltipSectionWrapper>
+);
 
 export const isLabelTruncated = (labelRef?: React.RefObject<any>): boolean =>
   !!(
@@ -36,21 +68,25 @@ export const getColumnTooltipNode = (
   labelRef?: React.RefObject<any>,
 ): ReactNode => {
   // don't show tooltip if it hasn't verbose_name and hasn't truncated
-  if (!column.verbose_name && !isLabelTruncated(labelRef)) {
+  if (
+    !column.verbose_name &&
+    !column.description &&
+    !isLabelTruncated(labelRef)
+  ) {
     return null;
   }
 
-  if (column.verbose_name) {
-    return (
-      <>
-        <div>{t('column name: %s', column.column_name)}</div>
-        <div>{t('verbose name: %s', column.verbose_name)}</div>
-      </>
-    );
-  }
-
-  // show column name in tooltip when column truncated
-  return t('column name: %s', column.column_name);
+  return (
+    <>
+      <TooltipSection label={t('Column name')} text={column.column_name} />
+      {column.verbose_name && (
+        <TooltipSection label={t('Label')} text={column.verbose_name} />
+      )}
+      {column.description && (
+        <TooltipSection label={t('Description')} text={column.description} />
+      )}
+    </>
+  );
 };
 
 type MetricType = Omit<Metric, 'id'> & { label?: string };
@@ -60,22 +96,23 @@ export const getMetricTooltipNode = (
   labelRef?: React.RefObject<any>,
 ): ReactNode => {
   // don't show tooltip if it hasn't verbose_name, label and hasn't truncated
-  if (!metric.verbose_name && !metric.label && !isLabelTruncated(labelRef)) {
+  if (
+    !metric.verbose_name &&
+    !metric.description &&
+    !isLabelTruncated(labelRef)
+  ) {
     return null;
   }
 
-  if (metric.verbose_name) {
-    return (
-      <>
-        <div>{t('metric name: %s', metric.metric_name)}</div>
-        <div>{t('verbose name: %s', metric.verbose_name)}</div>
-      </>
-    );
-  }
-
-  if (isLabelTruncated(labelRef) && metric.label) {
-    return t('label name: %s', metric.label);
-  }
-
-  return t('metric name: %s', metric.metric_name);
+  return (
+    <>
+      <TooltipSection label={t('Metric name')} text={metric.metric_name} />
+      {metric.verbose_name && (
+        <TooltipSection label={t('Label')} text={metric.verbose_name} />
+      )}
+      {metric.description && (
+        <TooltipSection label={t('Description')} text={metric.description} />
+      )}
+    </>
+  );
 };

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.tsx
@@ -99,6 +99,7 @@ export const getMetricTooltipNode = (
   if (
     !metric.verbose_name &&
     !metric.description &&
+    !metric.label &&
     !isLabelTruncated(labelRef)
   ) {
     return null;
@@ -107,8 +108,11 @@ export const getMetricTooltipNode = (
   return (
     <>
       <TooltipSection label={t('Metric name')} text={metric.metric_name} />
-      {metric.verbose_name && (
-        <TooltipSection label={t('Label')} text={metric.verbose_name} />
+      {(metric.label || metric.verbose_name) && (
+        <TooltipSection
+          label={t('Label')}
+          text={metric.label || metric.verbose_name}
+        />
       )}
       {metric.description && (
         <TooltipSection label={t('Description')} text={metric.description} />

--- a/superset-frontend/packages/superset-ui-chart-controls/test/components/ColumnOption.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/components/ColumnOption.test.tsx
@@ -53,12 +53,7 @@ describe('ColumnOption', () => {
     expect(lbl).toHaveLength(1);
     expect(lbl.first().text()).toBe('Foo');
   });
-  it('shows 2 InfoTooltipWithTrigger', () => {
-    expect(wrapper.find(InfoTooltipWithTrigger)).toHaveLength(2);
-  });
-  it('shows only 1 InfoTooltipWithTrigger when no descr', () => {
-    delete props.column.description;
-    wrapper = shallow(factory(props));
+  it('shows 1 InfoTooltipWithTrigger', () => {
     expect(wrapper.find(InfoTooltipWithTrigger)).toHaveLength(1);
   });
   it('shows a label with column_name when no verbose_name', () => {

--- a/superset-frontend/packages/superset-ui-chart-controls/test/components/MetricOption.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/components/MetricOption.test.tsx
@@ -51,12 +51,7 @@ describe('MetricOption', () => {
     expect(lbl).toHaveLength(1);
     expect(lbl.first().text()).toBe('Foo');
   });
-  it('shows 3 InfoTooltipWithTrigger', () => {
-    expect(wrapper.find('InfoTooltipWithTrigger')).toHaveLength(3);
-  });
-  it('shows only 2 InfoTooltipWithTrigger when no descr', () => {
-    props.metric.description = '';
-    wrapper = shallow(factory(props));
+  it('shows 2 InfoTooltipWithTrigger', () => {
     expect(wrapper.find('InfoTooltipWithTrigger')).toHaveLength(2);
   });
   it('shows a label with metric_name when no verbose_name', () => {
@@ -64,7 +59,7 @@ describe('MetricOption', () => {
     wrapper = shallow(factory(props));
     expect(wrapper.find('.option-label').first().text()).toBe('foo');
   });
-  it('shows only 1 InfoTooltipWithTrigger when no descr and no warning', () => {
+  it('shows only 1 InfoTooltipWithTrigger when no warning', () => {
     props.metric.warning_text = '';
     wrapper = shallow(factory(props));
     expect(wrapper.find('InfoTooltipWithTrigger')).toHaveLength(1);

--- a/superset-frontend/packages/superset-ui-chart-controls/test/components/labelUtils.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/components/labelUtils.test.tsx
@@ -16,16 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
-
-// @ts-ignore
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { render, screen } from 'spec/helpers/testing-library';
+import React, { ReactElement } from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ThemeProvider, supersetTheme } from '@superset-ui/core';
 import {
   getColumnLabelText,
   getColumnTooltipNode,
   getMetricTooltipNode,
 } from '../../src/components/labelUtils';
+
+const renderWithTheme = (ui: ReactElement) =>
+  render(<ThemeProvider theme={supersetTheme}>{ui}</ThemeProvider>);
 
 test("should get column name when column doesn't have verbose_name", () => {
   expect(
@@ -64,7 +66,7 @@ test('should get null as tooltip', () => {
 
 test('should get column name, verbose name and description when it has a verbose name', () => {
   const ref = { current: { scrollWidth: 100, clientWidth: 100 } };
-  render(
+  renderWithTheme(
     <>
       {getColumnTooltipNode(
         {
@@ -88,7 +90,7 @@ test('should get column name, verbose name and description when it has a verbose
 
 test('should get column name as tooltip if it overflowed', () => {
   const ref = { current: { scrollWidth: 200, clientWidth: 100 } };
-  render(
+  renderWithTheme(
     <>
       {getColumnTooltipNode(
         {
@@ -109,7 +111,7 @@ test('should get column name as tooltip if it overflowed', () => {
 
 test('should get column name, verbose name and description as tooltip if it overflowed', () => {
   const ref = { current: { scrollWidth: 200, clientWidth: 100 } };
-  render(
+  renderWithTheme(
     <>
       {getColumnTooltipNode(
         {
@@ -148,7 +150,7 @@ test('should get null as tooltip in metric', () => {
 
 test('should get metric name, verbose name and description as tooltip in metric', () => {
   const ref = { current: { scrollWidth: 100, clientWidth: 100 } };
-  render(
+  renderWithTheme(
     <>
       {getMetricTooltipNode(
         {
@@ -171,7 +173,7 @@ test('should get metric name, verbose name and description as tooltip in metric'
 
 test('should get metric name as tooltip if it overflowed', () => {
   const ref = { current: { scrollWidth: 200, clientWidth: 100 } };
-  render(
+  renderWithTheme(
     <>
       {getMetricTooltipNode(
         {
@@ -192,7 +194,7 @@ test('should get metric name as tooltip if it overflowed', () => {
 
 test('should get metric name, verbose name and description in tooltip if it overflowed', () => {
   const ref = { current: { scrollWidth: 200, clientWidth: 100 } };
-  render(
+  renderWithTheme(
     <>
       {getMetricTooltipNode(
         {

--- a/superset-frontend/packages/superset-ui-chart-controls/test/components/labelUtils.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/components/labelUtils.test.tsx
@@ -18,6 +18,9 @@
  */
 import React from 'react';
 
+// @ts-ignore
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { render, screen } from 'spec/helpers/testing-library';
 import {
   getColumnLabelText,
   getColumnTooltipNode,
@@ -52,66 +55,80 @@ test('should get null as tooltip', () => {
         id: 123,
         column_name: 'column name',
         verbose_name: '',
+        description: '',
       },
       ref,
     ),
   ).toBe(null);
 });
 
-test('should get column name and verbose name when it has a verbose name', () => {
-  const rvNode = (
+test('should get column name, verbose name and description when it has a verbose name', () => {
+  const ref = { current: { scrollWidth: 100, clientWidth: 100 } };
+  render(
     <>
-      <div>column name: column name</div>
-      <div>verbose name: verbose name</div>
-    </>
+      {getColumnTooltipNode(
+        {
+          id: 123,
+          column_name: 'column name',
+          verbose_name: 'verbose name',
+          description: 'A very important column',
+        },
+        ref,
+      )}
+    </>,
   );
 
-  const ref = { current: { scrollWidth: 100, clientWidth: 100 } };
-  expect(
-    getColumnTooltipNode(
-      {
-        id: 123,
-        column_name: 'column name',
-        verbose_name: 'verbose name',
-      },
-      ref,
-    ),
-  ).toStrictEqual(rvNode);
+  expect(screen.getByText('Column name')).toBeVisible();
+  expect(screen.getByText('column name')).toBeVisible();
+  expect(screen.getByText('Label')).toBeVisible();
+  expect(screen.getByText('verbose name')).toBeVisible();
+  expect(screen.getByText('Description')).toBeVisible();
+  expect(screen.getByText('A very important column')).toBeVisible();
 });
 
 test('should get column name as tooltip if it overflowed', () => {
   const ref = { current: { scrollWidth: 200, clientWidth: 100 } };
-  expect(
-    getColumnTooltipNode(
-      {
-        id: 123,
-        column_name: 'long long long long column name',
-        verbose_name: '',
-      },
-      ref,
-    ),
-  ).toBe('column name: long long long long column name');
+  render(
+    <>
+      {getColumnTooltipNode(
+        {
+          id: 123,
+          column_name: 'long long long long column name',
+          verbose_name: '',
+          description: '',
+        },
+        ref,
+      )}
+    </>,
+  );
+  expect(screen.getByText('Column name')).toBeVisible();
+  expect(screen.getByText('long long long long column name')).toBeVisible();
+  expect(screen.queryByText('Label')).not.toBeInTheDocument();
+  expect(screen.queryByText('Description')).not.toBeInTheDocument();
 });
 
-test('should get column name and verbose name as tooltip if it overflowed', () => {
-  const rvNode = (
+test('should get column name, verbose name and description as tooltip if it overflowed', () => {
+  const ref = { current: { scrollWidth: 200, clientWidth: 100 } };
+  render(
     <>
-      <div>column name: long long long long column name</div>
-      <div>verbose name: long long long long verbose name</div>
-    </>
+      {getColumnTooltipNode(
+        {
+          id: 123,
+          column_name: 'long long long long column name',
+          verbose_name: 'long long long long verbose name',
+          description: 'A very important column',
+        },
+        ref,
+      )}
+    </>,
   );
 
-  const ref = { current: { scrollWidth: 200, clientWidth: 100 } };
-  expect(
-    getColumnTooltipNode(
-      {
-        id: 123,
-        column_name: 'long long long long column name',
-        verbose_name: 'long long long long verbose name',
-      },
-      ref,
-    ),
-  ).toStrictEqual(rvNode);
+  expect(screen.getByText('Column name')).toBeVisible();
+  expect(screen.getByText('long long long long column name')).toBeVisible();
+  expect(screen.getByText('Label')).toBeVisible();
+  expect(screen.getByText('long long long long verbose name')).toBeVisible();
+  expect(screen.getByText('Description')).toBeVisible();
+  expect(screen.getByText('A very important column')).toBeVisible();
 });
 
 test('should get null as tooltip in metric', () => {
@@ -122,64 +139,76 @@ test('should get null as tooltip in metric', () => {
         metric_name: 'count',
         label: '',
         verbose_name: '',
+        description: '',
       },
       ref,
     ),
   ).toBe(null);
 });
 
-test('should get metric name and verbose name as tooltip in metric', () => {
-  const rvNode = (
-    <>
-      <div>metric name: count</div>
-      <div>verbose name: count(*)</div>
-    </>
-  );
-
+test('should get metric name, verbose name and description as tooltip in metric', () => {
   const ref = { current: { scrollWidth: 100, clientWidth: 100 } };
-  expect(
-    getMetricTooltipNode(
-      {
-        metric_name: 'count',
-        label: 'count(*)',
-        verbose_name: 'count(*)',
-      },
-      ref,
-    ),
-  ).toStrictEqual(rvNode);
-});
-
-test('should get metric name and verbose name in tooltip if it overflowed', () => {
-  const rvNode = (
+  render(
     <>
-      <div>metric name: count</div>
-      <div>verbose name: longlonglonglonglong verbose metric</div>
-    </>
+      {getMetricTooltipNode(
+        {
+          metric_name: 'count',
+          label: 'count(*)',
+          verbose_name: 'count(*)',
+          description: 'Count metric',
+        },
+        ref,
+      )}
+    </>,
   );
-
-  const ref = { current: { scrollWidth: 200, clientWidth: 100 } };
-  expect(
-    getMetricTooltipNode(
-      {
-        metric_name: 'count',
-        label: '',
-        verbose_name: 'longlonglonglonglong verbose metric',
-      },
-      ref,
-    ),
-  ).toStrictEqual(rvNode);
+  expect(screen.getByText('Metric name')).toBeVisible();
+  expect(screen.getByText('count')).toBeVisible();
+  expect(screen.getByText('Label')).toBeVisible();
+  expect(screen.getByText('count(*)')).toBeVisible();
+  expect(screen.getByText('Description')).toBeVisible();
+  expect(screen.getByText('Count metric')).toBeVisible();
 });
 
-test('should get label name as tooltip in metric if it overflowed', () => {
+test('should get metric name as tooltip if it overflowed', () => {
   const ref = { current: { scrollWidth: 200, clientWidth: 100 } };
-  expect(
-    getMetricTooltipNode(
-      {
-        metric_name: 'count',
-        label: 'longlonglonglonglong metric label',
-        verbose_name: '',
-      },
-      ref,
-    ),
-  ).toBe('label name: longlonglonglonglong metric label');
+  render(
+    <>
+      {getMetricTooltipNode(
+        {
+          metric_name: 'long long long long metric name',
+          label: '',
+          verbose_name: '',
+          description: '',
+        },
+        ref,
+      )}
+    </>,
+  );
+  expect(screen.getByText('Metric name')).toBeVisible();
+  expect(screen.getByText('long long long long metric name')).toBeVisible();
+  expect(screen.queryByText('Label')).not.toBeInTheDocument();
+  expect(screen.queryByText('Description')).not.toBeInTheDocument();
+});
+
+test('should get metric name, verbose name and description in tooltip if it overflowed', () => {
+  const ref = { current: { scrollWidth: 200, clientWidth: 100 } };
+  render(
+    <>
+      {getMetricTooltipNode(
+        {
+          metric_name: 'count',
+          label: '',
+          verbose_name: 'longlonglonglonglong verbose metric',
+          description: 'Count metric',
+        },
+        ref,
+      )}
+    </>,
+  );
+  expect(screen.getByText('Metric name')).toBeVisible();
+  expect(screen.getByText('count')).toBeVisible();
+  expect(screen.getByText('Label')).toBeVisible();
+  expect(screen.getByText('longlonglonglonglong verbose metric')).toBeVisible();
+  expect(screen.getByText('Description')).toBeVisible();
+  expect(screen.getByText('Count metric')).toBeVisible();
 });


### PR DESCRIPTION
### SUMMARY
This PR introduces changes to the tooltips that appear when user hovers over metric/column label in dataset panel in Explore.

1. Adds description into the tooltip that appears when user hovers over metric/column name
2. Deletes icon that triggers tooltip with description (since description is now in the main tooltip)
3. Changes formatting of the text in tooltip (see screenshots)
4. Moves the tooltip a bit closer to the label

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="285" alt="image" src="https://user-images.githubusercontent.com/15073128/159057628-a6286355-2f1e-4584-84d9-7eed2f47748e.png">
<img width="289" alt="image" src="https://user-images.githubusercontent.com/15073128/159057667-1d72f488-3962-4f81-a981-70e950ab709a.png">

After:
![image](https://user-images.githubusercontent.com/15073128/159057537-8f2473d8-5d38-4019-a8fa-e9f3fdcd6bd4.png)
![image](https://user-images.githubusercontent.com/15073128/159057545-d7a915b0-9ee0-4ed0-8bcb-c694793fb095.png)
![image](https://user-images.githubusercontent.com/15073128/159057514-413b125c-7443-4cc7-9688-fb3740c30c28.png)

### TESTING INSTRUCTIONS
Add some labels and descriptions to metrics and columns, verify that tooltips display correctly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @kasiazjc