### PR TITLE
fix: Don't allow duplicated tag values in the Select

### DIFF
--- a/superset-frontend/src/components/Select/Select.test.tsx
+++ b/superset-frontend/src/components/Select/Select.test.tsx
@@ -314,6 +314,17 @@ test('searches for custom fields', async () => {
   expect(screen.getByText(NO_DATA)).toBeInTheDocument();
 });
 
+test('removes duplicated values', async () => {
+  render(<Select {...defaultProps} mode="multiple" allowNewOptions />);
+  await type('a,b,b,b,c,d,d');
+  const values = await findAllSelectValues();
+  expect(values.length).toBe(4);
+  expect(values[0]).toHaveTextContent('a');
+  expect(values[1]).toHaveTextContent('b');
+  expect(values[2]).toHaveTextContent('c');
+  expect(values[3]).toHaveTextContent('d');
+});
+
 test('renders a custom label', async () => {
   const options = [
     { label: 'John', value: 1, customLabel: <h1>John</h1> },

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -385,34 +385,20 @@ const Select = (
 
   const hasCustomLabels = fullSelectOptions.some(opt => !!opt?.customLabel);
 
-  const valueAsArray = <T,>(value: any): T[] => {
-    const array = value ? (Array.isArray(value) ? value : [value]) : [];
-    return array as T[];
-  };
-
-  const handleOnSelect = (
-    selectedValue: string | number | AntdLabeledValue,
-  ) => {
+  const handleOnSelect = (selectedItem: string | number | AntdLabeledValue) => {
     if (isSingleMode) {
-      setSelectValue(selectedValue);
-    } else if (
-      typeof selectedValue === 'number' ||
-      typeof selectedValue === 'string'
-    ) {
-      setSelectValue(previousState => {
-        const primitiveArray = valueAsArray<string | number>(previousState);
-        // Tokenized values can contain duplicated values
-        if (!primitiveArray.some(value => value === selectedValue)) {
-          return [...primitiveArray, selectedValue as string | number];
-        }
-        return previousState;
-      });
+      setSelectValue(selectedItem);
     } else {
       setSelectValue(previousState => {
-        const objectArray = valueAsArray<AntdLabeledValue>(previousState);
+        const array = ensureIsArray(previousState);
+        const isObject = typeof selectedItem === 'object';
+        const value = isObject ? selectedItem.value : selectedItem;
         // Tokenized values can contain duplicated values
-        if (!objectArray.some(object => object.value === selectedValue.label)) {
-          return [...objectArray, selectedValue as AntdLabeledValue];
+        if (!hasOption(value, array)) {
+          const result = [...array, selectedItem];
+          return isObject
+            ? (result as AntdLabeledValue[])
+            : (result as (string | number)[]);
         }
         return previousState;
       });

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -385,31 +385,37 @@ const Select = (
 
   const hasCustomLabels = fullSelectOptions.some(opt => !!opt?.customLabel);
 
+  const valueAsArray = <T,>(value: any): T[] => {
+    const array = value ? (Array.isArray(value) ? value : [value]) : [];
+    return array as T[];
+  };
+
   const handleOnSelect = (
     selectedValue: string | number | AntdLabeledValue,
   ) => {
     if (isSingleMode) {
       setSelectValue(selectedValue);
+    } else if (
+      typeof selectedValue === 'number' ||
+      typeof selectedValue === 'string'
+    ) {
+      setSelectValue(previousState => {
+        const primitiveArray = valueAsArray<string | number>(previousState);
+        // Tokenized values can contain duplicated values
+        if (!primitiveArray.some(value => value === selectedValue)) {
+          return [...primitiveArray, selectedValue as string | number];
+        }
+        return previousState;
+      });
     } else {
-      const currentSelected = selectValue
-        ? Array.isArray(selectValue)
-          ? selectValue
-          : [selectValue]
-        : [];
-      if (
-        typeof selectedValue === 'number' ||
-        typeof selectedValue === 'string'
-      ) {
-        setSelectValue([
-          ...(currentSelected as (string | number)[]),
-          selectedValue as string | number,
-        ]);
-      } else {
-        setSelectValue([
-          ...(currentSelected as AntdLabeledValue[]),
-          selectedValue as AntdLabeledValue,
-        ]);
-      }
+      setSelectValue(previousState => {
+        const objectArray = valueAsArray<AntdLabeledValue>(previousState);
+        // Tokenized values can contain duplicated values
+        if (!objectArray.some(object => object.value === selectedValue.label)) {
+          return [...objectArray, selectedValue as AntdLabeledValue];
+        }
+        return previousState;
+      });
     }
     setInputValue('');
   };


### PR DESCRIPTION
### SUMMARY
This PR fixes two bugs in the Select component:
- Duplicated tags were allowed
- When pasting multiple values, only the last value was being added

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/159281594-e5774b41-f70a-493e-b211-254ba7753307.mov

https://user-images.githubusercontent.com/70410625/159281684-ae031fc3-7539-4069-860b-3a3f705c2588.mov

### TESTING INSTRUCTIONS
Check the videos for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
