### PR TITLE
fix: Saved query without description issue, None showing (Preset-Patch)

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -1273,6 +1273,11 @@ export function popSavedQuery(saveQueryId) {
       endpoint: `/savedqueryviewapi/api/get/${saveQueryId}`,
     })
       .then(({ json }) => {
+        // if description from result is 'None', need to omit this property.
+        if(json.result.description === 'None') {
+          delete json.result.description;
+        }
+
         const queryEditorProps = {
           ...convertQueryToClient(json.result),
           autorun: false,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When we save query without empty description, if we go to savedquery, edit a newly saved one, we would see `None` in description field by clicking `save` button. 

It was because the `savedqueryviewapi/api/get/<pk>` endpoint returns `None` as a description for the saved query without description.

I customized response in frontend so that if we get `None` as a description, we will omit `description` field from the response.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
BEFORE:
[[DEV] Superset - 21 March 2022 - Watch Video](https://www.loom.com/share/587bb5198e424aacb4c6f6141a44d913)
AFTER:
[[DEV] Superset - 21 March 2022 - Watch Video](https://www.loom.com/share/9deb29b710f144629cb44504e64c427d)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

- Save a query in SQL Lab. When saving, leave the description field blank
- Visit the Saved Queries page and open your query in SQL Lab
- Click the "Save" button
- Track the description field.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Small UI bug fix
