### PR TITLE
fix: improve alerts & reports modal on small devices

### DIFF
--- a/superset-frontend/src/components/TimezoneSelector/index.tsx
+++ b/superset-frontend/src/components/TimezoneSelector/index.tsx
@@ -104,11 +104,13 @@ const matchTimezoneToOptions = (timezone: string) =>
 export type TimezoneSelectorProps = {
   onTimezoneChange: (value: string) => void;
   timezone?: string | null;
+  minWidth?: string;
 };
 
 export default function TimezoneSelector({
   onTimezoneChange,
   timezone,
+  minWidth = MIN_SELECT_WIDTH, // smallest size for current values
 }: TimezoneSelectorProps) {
   const validTimezone = useMemo(
     () => matchTimezoneToOptions(timezone || moment.tz.guess()),
@@ -125,7 +127,7 @@ export default function TimezoneSelector({
   return (
     <Select
       ariaLabel={t('Timezone selector')}
-      css={{ minWidth: MIN_SELECT_WIDTH }} // smallest size for current values
+      css={{ minWidth }}
       onChange={tz => onTimezoneChange(tz as string)}
       value={validTimezone}
       options={TIMEZONE_OPTIONS}

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -153,6 +153,9 @@ const DEFAULT_ALERT = {
 };
 
 const StyledModal = styled(Modal)`
+  max-width: 1200px;
+  width: 100%;
+
   .ant-modal-body {
     overflow: initial;
   }
@@ -165,7 +168,6 @@ const StyledIcon = (theme: SupersetTheme) => css`
 
 const StyledSectionContainer = styled.div`
   display: flex;
-  min-width: 1000px;
   flex-direction: column;
 
   .header-section {
@@ -1242,6 +1244,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
               <TimezoneSelector
                 onTimezoneChange={onTimezoneChange}
                 timezone={currentAlert?.timezone}
+                minWidth="100%"
               />
             </div>
             <StyledSectionTitle>


### PR DESCRIPTION
### SUMMARY
The alerts & report modal content is divided into columns, but the content is neither responsive nor fluid, so it doesn't play well on small screen sizes.

This PR introduces small tweaks to ensure the content from one column does not overflow to the next.
The timezone selector is reduced when needed & the text inside it is truncated (on small screens).

A better way to approach this would require using media queries, but the viewport meta tag is not defined and thus the media queries based on width do not work.
It's a larger discussion to be had the path to introduce responsive design.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![Clipboard 2021-06-10 at 2 38 32 PM](https://user-images.githubusercontent.com/17252075/159379878-38085e36-c39f-474f-bc27-fffbb515c7d7.png)

After:
<img width="517" alt="Screen Shot 2022-03-21 at 20 34 35" src="https://user-images.githubusercontent.com/17252075/159379919-3674037f-191b-43d1-b94f-d97c8be3c2e9.png">

### TESTING INSTRUCTIONS
1. Open alerts & reports menu item
2. Create an alert or report
3. With the modal up, make your browser narrow

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
