### PR TITLE
fix(cache): only warn about fallback cache for non-debug mode

### DIFF
--- a/superset/utils/cache_manager.py
+++ b/superset/utils/cache_manager.py
@@ -41,7 +41,7 @@ class CacheManager:
         cache_config = app.config[cache_config_key]
         cache_type = cache_config.get("CACHE_TYPE")
         if required and cache_type in (None, "SupersetMetastoreCache"):
-            if cache_type is None:
+            if cache_type is None and not app.debug:
                 logger.warning(
                     "Falling back to the built-in cache, that stores data in the "
                     "metadata database, for the followinng cache: `%s`. "


### PR DESCRIPTION
### SUMMARY
#19232 introduced a new default cache based on the key value table in the metadata database. To avoid triggering the warning when running in development/debug mode, this PR adds a check to skip the warning if the application is running in debug mode.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
