### PR TITLE
feat(explore): SQL popover in datasource panel

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -111,6 +111,7 @@
     "@superset-ui/switchboard": "file:./packages/superset-ui-switchboard",
     "@vx/responsive": "^0.0.195",
     "abortcontroller-polyfill": "^1.1.9",
+    "ace-builds": "^1.4.14",
     "antd": "^4.9.4",
     "array-move": "^2.2.1",
     "babel-plugin-typescript-to-proptypes": "^2.0.0",

--- a/superset-frontend/packages/superset-ui-chart-controls/package.json
+++ b/superset-frontend/packages/superset-ui-chart-controls/package.json
@@ -39,7 +39,9 @@
     "@types/enzyme": "^3.10.5",
     "@types/react": "*",
     "antd": "^4.9.4",
+    "brace": "^0.11.1",
     "react": "^16.13.1",
+    "react-ace": "^9.4.4",
     "react-dom": "^16.13.1"
   },
   "publishConfig": {

--- a/superset-frontend/packages/superset-ui-chart-controls/package.json
+++ b/superset-frontend/packages/superset-ui-chart-controls/package.json
@@ -24,6 +24,8 @@
   ],
   "dependencies": {
     "@react-icons/all-files": "^4.1.0",
+    "@types/enzyme": "^3.10.5",
+    "@types/react": "*",
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2"
   },
@@ -36,8 +38,6 @@
     "@testing-library/react": "^11.2.0",
     "@testing-library/react-hooks": "^5.0.3",
     "@testing-library/user-event": "^12.7.0",
-    "@types/enzyme": "^3.10.5",
-    "@types/react": "*",
     "antd": "^4.9.4",
     "brace": "^0.11.1",
     "react": "^16.13.1",

--- a/superset-frontend/packages/superset-ui-chart-controls/package.json
+++ b/superset-frontend/packages/superset-ui-chart-controls/package.json
@@ -38,6 +38,7 @@
     "@testing-library/react": "^11.2.0",
     "@testing-library/react-hooks": "^5.0.3",
     "@testing-library/user-event": "^12.7.0",
+    "ace-builds": "^1.4.14",
     "antd": "^4.9.4",
     "brace": "^0.11.1",
     "react": "^16.13.1",

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useState, ReactNode, useLayoutEffect } from 'react';
-import { css, styled, SupersetTheme, t } from '@superset-ui/core';
+import { css, styled, SupersetTheme } from '@superset-ui/core';
 import { Tooltip } from './Tooltip';
 import { ColumnTypeLabel } from './ColumnTypeLabel/ColumnTypeLabel';
 import CertifiedIconWithTooltip from './CertifiedIconWithTooltip';
@@ -69,11 +69,7 @@ export function ColumnOption({
           {getColumnLabelText(column)}
         </span>
       </Tooltip>
-
-      {hasExpression && (
-        <SQLPopover title={t('SQL Expression')} sqlExpression={expression} />
-      )}
-
+      {hasExpression && <SQLPopover sqlExpression={expression} />}
       {column.is_certified && (
         <CertifiedIconWithTooltip
           metricName={column.metric_name}

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
@@ -17,13 +17,13 @@
  * under the License.
  */
 import React, { useState, ReactNode, useLayoutEffect } from 'react';
-import { css, styled, SupersetTheme } from '@superset-ui/core';
+import { css, styled, SupersetTheme, t } from '@superset-ui/core';
 import { Tooltip } from './Tooltip';
 import { ColumnTypeLabel } from './ColumnTypeLabel/ColumnTypeLabel';
-import InfoTooltipWithTrigger from './InfoTooltipWithTrigger';
 import CertifiedIconWithTooltip from './CertifiedIconWithTooltip';
 import { ColumnMeta } from '../types';
 import { getColumnLabelText, getColumnTooltipNode } from './labelUtils';
+import { SQLPopover } from './SQLPopover';
 
 export type ColumnOptionProps = {
   column: ColumnMeta;
@@ -71,13 +71,7 @@ export function ColumnOption({
       </Tooltip>
 
       {hasExpression && (
-        <InfoTooltipWithTrigger
-          className="m-r-5 text-muted"
-          icon="question-circle-o"
-          tooltip={column.expression}
-          label={`expr-${column.column_name}`}
-          placement="top"
-        />
+        <SQLPopover title={t('SQL Expression')} sqlExpression={expression} />
       )}
 
       {column.is_certified && (

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
@@ -23,7 +23,6 @@ import {
   Metric,
   SafeMarkdown,
   SupersetTheme,
-  t,
 } from '@superset-ui/core';
 import InfoTooltipWithTrigger from './InfoTooltipWithTrigger';
 import { ColumnTypeLabel } from './ColumnTypeLabel/ColumnTypeLabel';
@@ -92,10 +91,7 @@ export function MetricOption({
         </span>
       </Tooltip>
       {showFormula && metric.expression && (
-        <SQLPopover
-          title={t('SQL Expression')}
-          sqlExpression={metric.expression}
-        />
+        <SQLPopover sqlExpression={metric.expression} />
       )}
       {metric.is_certified && (
         <CertifiedIconWithTooltip

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
@@ -23,12 +23,14 @@ import {
   Metric,
   SafeMarkdown,
   SupersetTheme,
+  t,
 } from '@superset-ui/core';
 import InfoTooltipWithTrigger from './InfoTooltipWithTrigger';
 import { ColumnTypeLabel } from './ColumnTypeLabel/ColumnTypeLabel';
 import CertifiedIconWithTooltip from './CertifiedIconWithTooltip';
 import Tooltip from './Tooltip';
 import { getMetricTooltipNode } from './labelUtils';
+import { SQLPopover } from './SQLPopover';
 
 const FlexRowContainer = styled.div`
   align-items: center;
@@ -89,12 +91,10 @@ export function MetricOption({
           {link}
         </span>
       </Tooltip>
-      {showFormula && (
-        <InfoTooltipWithTrigger
-          className="text-muted m-r-5"
-          icon="question-circle-o"
-          tooltip={metric.expression}
-          label={`expr-${metric.metric_name}`}
+      {showFormula && metric.expression && (
+        <SQLPopover
+          title={t('SQL Expression')}
+          sqlExpression={metric.expression}
         />
       )}
       {metric.is_certified && (

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/SQLPopover.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/SQLPopover.tsx
@@ -44,7 +44,10 @@ export const SQLPopover = (props: PopoverProps & { sqlExpression: string }) => {
           mode="sql"
           value={props.sqlExpression}
           editorProps={{ $blockScrolling: true }}
-          setOptions={{ highlightActiveLine: false }}
+          setOptions={{
+            highlightActiveLine: false,
+            highlightGutterLine: false,
+          }}
           minLines={2}
           maxLines={6}
           readOnly

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/SQLPopover.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/SQLPopover.tsx
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { Popover } from 'antd';
+import type { PopoverProps } from 'antd/lib/popover';
+import AceEditor from 'react-ace';
+import 'brace/mode/sql';
+import { CalculatorOutlined } from '@ant-design/icons';
+import { css, styled, useTheme } from '@superset-ui/core';
+
+const StyledCalculatorIcon = styled(CalculatorOutlined)`
+  ${({ theme }) => css`
+    color: ${theme.colors.grayscale.base};
+    font-size: ${theme.typography.sizes.s}px;
+    & svg {
+      margin-left: ${theme.gridUnit}px;
+      margin-right: ${theme.gridUnit}px;
+    }
+  `}
+`;
+
+export const SQLPopover = (props: PopoverProps & { sqlExpression: string }) => {
+  const theme = useTheme();
+  return (
+    <Popover
+      content={
+        <AceEditor
+          mode="sql"
+          value={props.sqlExpression}
+          editorProps={{ $blockScrolling: true }}
+          setOptions={{ highlightActiveLine: false }}
+          minLines={2}
+          maxLines={6}
+          readOnly
+          wrapEnabled
+          style={{
+            border: `1px solid ${theme.colors.grayscale.light2}`,
+            background: theme.colors.secondary.light5,
+            maxWidth: theme.gridUnit * 100,
+          }}
+        />
+      }
+      placement="bottomLeft"
+      arrowPointAtCenter
+      {...props}
+    >
+      <StyledCalculatorIcon />
+    </Popover>
+  );
+};

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/SQLPopover.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/SQLPopover.tsx
@@ -22,7 +22,7 @@ import type { PopoverProps } from 'antd/lib/popover';
 import AceEditor from 'react-ace';
 import 'brace/mode/sql';
 import { CalculatorOutlined } from '@ant-design/icons';
-import { css, styled, useTheme } from '@superset-ui/core';
+import { css, styled, useTheme, t } from '@superset-ui/core';
 
 const StyledCalculatorIcon = styled(CalculatorOutlined)`
   ${({ theme }) => css`
@@ -58,6 +58,7 @@ export const SQLPopover = (props: PopoverProps & { sqlExpression: string }) => {
       }
       placement="bottomLeft"
       arrowPointAtCenter
+      title={t('SQL expression')}
       {...props}
     >
       <StyledCalculatorIcon />

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/SQLPopover.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/SQLPopover.tsx
@@ -20,9 +20,9 @@ import React from 'react';
 import { Popover } from 'antd';
 import type { PopoverProps } from 'antd/lib/popover';
 import AceEditor from 'react-ace';
-import 'brace/mode/sql';
 import { CalculatorOutlined } from '@ant-design/icons';
 import { css, styled, useTheme, t } from '@superset-ui/core';
+import 'ace-builds/src-noconflict/mode-sql';
 
 const StyledCalculatorIcon = styled(CalculatorOutlined)`
   ${({ theme }) => css`

--- a/superset-frontend/packages/superset-ui-chart-controls/test/components/ColumnOption.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/components/ColumnOption.test.tsx
@@ -20,12 +20,8 @@ import React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import { GenericDataType } from '@superset-ui/core';
 
-import {
-  ColumnOption,
-  ColumnOptionProps,
-  ColumnTypeLabel,
-  InfoTooltipWithTrigger,
-} from '../../src';
+import { ColumnOption, ColumnOptionProps, ColumnTypeLabel } from '../../src';
+import { SQLPopover } from '../../src/components/SQLPopover';
 
 describe('ColumnOption', () => {
   const defaultProps: ColumnOptionProps = {
@@ -53,8 +49,8 @@ describe('ColumnOption', () => {
     expect(lbl).toHaveLength(1);
     expect(lbl.first().text()).toBe('Foo');
   });
-  it('shows 1 InfoTooltipWithTrigger', () => {
-    expect(wrapper.find(InfoTooltipWithTrigger)).toHaveLength(1);
+  it('shows SQL Popover trigger', () => {
+    expect(wrapper.find(SQLPopover)).toHaveLength(1);
   });
   it('shows a label with column_name when no verbose_name', () => {
     delete props.column.verbose_name;

--- a/superset-frontend/packages/superset-ui-chart-controls/test/components/MetricOption.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/components/MetricOption.test.tsx
@@ -51,18 +51,21 @@ describe('MetricOption', () => {
     expect(lbl).toHaveLength(1);
     expect(lbl.first().text()).toBe('Foo');
   });
-  it('shows 2 InfoTooltipWithTrigger', () => {
-    expect(wrapper.find('InfoTooltipWithTrigger')).toHaveLength(2);
+  it('shows a InfoTooltipWithTrigger', () => {
+    expect(wrapper.find('InfoTooltipWithTrigger')).toHaveLength(1);
+  });
+  it('shows SQL Popover trigger', () => {
+    expect(wrapper.find('SQLPopover')).toHaveLength(1);
   });
   it('shows a label with metric_name when no verbose_name', () => {
     props.metric.verbose_name = '';
     wrapper = shallow(factory(props));
     expect(wrapper.find('.option-label').first().text()).toBe('foo');
   });
-  it('shows only 1 InfoTooltipWithTrigger when no warning', () => {
+  it('doesnt show InfoTooltipWithTrigger when no warning', () => {
     props.metric.warning_text = '';
     wrapper = shallow(factory(props));
-    expect(wrapper.find('InfoTooltipWithTrigger')).toHaveLength(1);
+    expect(wrapper.find('InfoTooltipWithTrigger')).toHaveLength(0);
   });
   it('sets target="_blank" when openInNewWindow is true', () => {
     props.url = 'https://github.com/apache/incubator-superset';

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor/TemplateParamsEditor.test.tsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor/TemplateParamsEditor.test.tsx
@@ -24,7 +24,6 @@ import {
   getByText,
   waitFor,
 } from 'spec/helpers/testing-library';
-import brace from 'brace';
 import { ThemeProvider, supersetTheme } from '@superset-ui/core';
 
 import TemplateParamsEditor from 'src/SqlLab/components/TemplateParamsEditor';
@@ -48,8 +47,6 @@ describe('TemplateParamsEditor', () => {
       { wrapper: ThemeWrapper },
     );
     fireEvent.click(getByText(container, 'Parameters'));
-    const spy = jest.spyOn(brace, 'require');
-    spy.mockReturnValue({ setCompleters: () => 'foo' });
     await waitFor(() => {
       expect(baseElement.querySelector('#ace-editor')).toBeInTheDocument();
     });

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor/TemplateParamsEditor.test.tsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor/TemplateParamsEditor.test.tsx
@@ -48,7 +48,7 @@ describe('TemplateParamsEditor', () => {
       { wrapper: ThemeWrapper },
     );
     fireEvent.click(getByText(container, 'Parameters'));
-    const spy = jest.spyOn(brace, 'acequire');
+    const spy = jest.spyOn(brace, 'require');
     spy.mockReturnValue({ setCompleters: () => 'foo' });
     await waitFor(() => {
       expect(baseElement.querySelector('#ace-editor')).toBeInTheDocument();

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor/index.tsx
@@ -74,7 +74,6 @@ function TemplateParamsEditor({
         syntax.
       </p>
       <StyledConfigEditor
-        keywords={[]}
         mode={language}
         minLines={25}
         maxLines={50}

--- a/superset-frontend/src/components/AsyncAceEditor/index.tsx
+++ b/superset-frontend/src/components/AsyncAceEditor/index.tsx
@@ -24,6 +24,7 @@ import {
   TextMode as OrigTextMode,
 } from 'brace';
 import AceEditor, { IAceEditorProps } from 'react-ace';
+import { acequire } from 'ace-builds/src-noconflict/ace';
 import AsyncEsmComponent, {
   PlaceholderProps,
 } from 'src/components/AsyncEsmComponent';
@@ -101,7 +102,6 @@ export default function AsyncAceEditor(
   }: AsyncAceEditorOptions = {},
 ) {
   return AsyncEsmComponent(async () => {
-    const { default: ace } = await import('brace');
     const { default: ReactAceEditor } = await import('react-ace');
 
     await Promise.all(aceModules.map(x => aceModuleLoaders[x]()));
@@ -126,9 +126,6 @@ export default function AsyncAceEditor(
         ref,
       ) {
         if (keywords) {
-          // ace doesn't have property acequire if there are multiple ace editors on a page
-          // @ts-ignore
-          const acequire = ace.acequire ?? ace.require;
           const langTools = acequire('ace/ext/language_tools');
           const completer = {
             getCompletions: (

--- a/superset-frontend/src/components/AsyncAceEditor/index.tsx
+++ b/superset-frontend/src/components/AsyncAceEditor/index.tsx
@@ -55,7 +55,7 @@ export interface AceCompleterKeyword extends AceCompleterKeywordData {
 
 /**
  * Async loaders to import brace modules. Must manually create call `import(...)`
- * promises because webpack can only analyze asycn imports statically.
+ * promises because webpack can only analyze async imports statically.
  */
 const aceModuleLoaders = {
   'mode/sql': () => import('brace/mode/sql'),
@@ -126,7 +126,9 @@ export default function AsyncAceEditor(
         ref,
       ) {
         if (keywords) {
-          const langTools = ace.acequire('ace/ext/language_tools');
+          console.log({ ace });
+          const langTools = ace.require('ace/ext/language_tools');
+          console.log({ langTools });
           const completer = {
             getCompletions: (
               editor: AceEditor,

--- a/superset-frontend/src/components/AsyncAceEditor/index.tsx
+++ b/superset-frontend/src/components/AsyncAceEditor/index.tsx
@@ -126,9 +126,10 @@ export default function AsyncAceEditor(
         ref,
       ) {
         if (keywords) {
-          console.log({ ace });
-          const langTools = ace.require('ace/ext/language_tools');
-          console.log({ langTools });
+          // ace doesn't have property acequire if there are multiple ace editors on a page
+          // @ts-ignore
+          const acequire = ace.acequire ?? ace.require;
+          const langTools = acequire('ace/ext/language_tools');
           const completer = {
             getCompletions: (
               editor: AceEditor,


### PR DESCRIPTION
### SUMMARY
Previously, we displayed metric's or calculateed column's SQL expression in a tooltip. This PR refactors that component to use a popover and present the SQL in ace editor - thanks to that the code is nicely formatted and easier to read. Also, the icon has been change from a question mark to a calculator.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="517" alt="image" src="https://user-images.githubusercontent.com/15073128/159517560-280b0fea-d010-456b-8ca0-c22fc5a772cd.png">
<img width="376" alt="image" src="https://user-images.githubusercontent.com/15073128/159517491-6b9e3823-b329-42b8-9a93-f68ba093a5de.png">

After:
<img width="679" alt="image" src="https://user-images.githubusercontent.com/15073128/159516915-6b12e551-303f-4557-abfc-af337ba42a60.png">
<img width="740" alt="image" src="https://user-images.githubusercontent.com/15073128/159516953-5652740f-ca8d-442f-a682-0ee847c99c5f.png">

### TESTING INSTRUCTIONS
1. Create a chart using a dataset with saved metrics and calculated columns
2. Verify that the SQL popovers in dataset panel display correctly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @kasiazjc