### PR TITLE
fix(sql lab): add quotes when autocompleting table names with spaces in the editor

### DIFF
--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/index.tsx
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/index.tsx
@@ -221,11 +221,15 @@ class AceEditorWrapper extends React.PureComponent<Props, State> {
             this.props.queryEditor.schema,
           );
         }
+
+        let { caption } = data;
+        if (data.meta === 'table' && caption.includes(' ')) {
+          caption = `"${caption}"`;
+        }
+
         // executing https://github.com/thlorenz/brace/blob/3a00c5d59777f9d826841178e1eb36694177f5e6/ext/language_tools.js#L1448
         editor.completer.insertMatch(
-          `${data.caption}${
-            ['function', 'schema'].includes(data.meta) ? '' : ' '
-          }`,
+          `${caption}${['function', 'schema'].includes(data.meta) ? '' : ' '}`,
         );
       },
     };


### PR DESCRIPTION
### SUMMARY
The SQL autocomplete in the SQL Lab editor work with the tables loaded from the schema.
The autocomplete works, but if the table has spaces, the query won't work as it's not properly escaped.

This PR adds quotes around the table name if it has spaces in it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/17252075/159539920-b16e82fa-d327-4c4d-8820-ec3ebca5074c.mov

After:

https://user-images.githubusercontent.com/17252075/159539935-6d209442-1f5d-4171-b343-f55b3c2268d4.mov

### TESTING INSTRUCTIONS
1. Open SQL lab
2. Select a database & schema that contain table with spaces
3. Attempt to add that table with autocomplete

Ensure the autocompleted table has quotes if the name has spaces in it.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
