### PR TITLE
fix: adaptive formatting typo in explore dropdowns

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts
@@ -25,7 +25,7 @@ export const D3_FORMAT_DOCS = t(
 
 // input choices & options
 export const D3_FORMAT_OPTIONS: [string, string][] = [
-  [NumberFormats.SMART_NUMBER, t('Adaptative formating')],
+  [NumberFormats.SMART_NUMBER, t('Adaptive formatting')],
   ['~g', t('Original value')],
   [',d', ',d (12345.432 => 12,345)'],
   ['.1s', '.1s (12345.432 => 10k)'],
@@ -48,7 +48,7 @@ export const D3_TIME_FORMAT_DOCS = t(
 );
 
 export const D3_TIME_FORMAT_OPTIONS: [string, string][] = [
-  [smartDateFormatter.id, t('Adaptative formating')],
+  [smartDateFormatter.id, t('Adaptive formatting')],
   ['%d/%m/%Y', '%d/%m/%Y | 14/01/2019'],
   ['%m/%d/%Y', '%m/%d/%Y | 01/14/2019'],
   ['%Y-%m-%d', '%Y-%m-%d | 2019-01-14'],

--- a/superset-frontend/src/explore/controls.jsx
+++ b/superset-frontend/src/explore/controls.jsx
@@ -75,7 +75,7 @@ export const PRIMARY_COLOR = { r: 0, g: 122, b: 135, a: 1 };
 
 // input choices & options
 export const D3_FORMAT_OPTIONS = [
-  ['SMART_NUMBER', 'Adaptative formating'],
+  ['SMART_NUMBER', 'Adaptive formatting'],
   ['~g', 'Original value'],
   [',d', ',d (12345.432 => 12,345)'],
   ['.1s', '.1s (12345.432 => 10k)'],
@@ -98,7 +98,7 @@ export const D3_FORMAT_DOCS =
   'D3 format syntax: https://github.com/d3/d3-format';
 
 export const D3_TIME_FORMAT_OPTIONS = [
-  ['smart_date', 'Adaptative formating'],
+  ['smart_date', 'Adaptive formatting'],
   ['%d/%m/%Y', '%d/%m/%Y | 14/01/2019'],
   ['%m/%d/%Y', '%m/%d/%Y | 01/14/2019'],
   ['%Y-%m-%d', '%Y-%m-%d | 2019-01-14'],

--- a/superset/translations/de/LC_MESSAGES/messages.json
+++ b/superset/translations/de/LC_MESSAGES/messages.json
@@ -199,7 +199,7 @@
       "Actions": ["Aktion"],
       "Active": ["Aktiv"],
       "Actual time range": ["Tatsächlicher Zeitbereich"],
-      "Adaptative formating": ["Adaptative Formatierung"],
+      "Adaptive formatting": ["Adaptative Formatierung"],
       "Add": ["Hinzufügen"],
       "Add Alert": ["Alarm hinzufügen"],
       "Add Annotation": ["Anmerkungen hinzufügen"],

--- a/superset/translations/de/LC_MESSAGES/messages.po
+++ b/superset/translations/de/LC_MESSAGES/messages.po
@@ -703,7 +703,7 @@ msgstr "Tatsächlicher Zeitbereich"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:28
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:49
-msgid "Adaptative formating"
+msgid "Adaptive formatting"
 msgstr "Adaptative Formatierung"
 
 #: superset-frontend/src/components/ReportModal/index.tsx:267

--- a/superset/translations/en/LC_MESSAGES/messages.po
+++ b/superset/translations/en/LC_MESSAGES/messages.po
@@ -600,7 +600,7 @@ msgstr ""
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:28
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:49
-msgid "Adaptative formating"
+msgid "Adaptive formatting"
 msgstr ""
 
 #: superset-frontend/src/components/ReportModal/index.tsx:267

--- a/superset/translations/es/LC_MESSAGES/messages.po
+++ b/superset/translations/es/LC_MESSAGES/messages.po
@@ -631,7 +631,7 @@ msgstr "Rango de tiempo actual"
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:28
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:49
 #, fuzzy
-msgid "Adaptative formating"
+msgid "Adaptive formatting"
 msgstr "Formato Fecha/Hora"
 
 #: superset-frontend/src/components/ReportModal/index.tsx:267

--- a/superset/translations/fr/LC_MESSAGES/messages.po
+++ b/superset/translations/fr/LC_MESSAGES/messages.po
@@ -675,7 +675,7 @@ msgstr "Intervalle de temps courant"
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:28
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:49
 #, fuzzy
-msgid "Adaptative formating"
+msgid "Adaptive formatting"
 msgstr "Format Datetime"
 
 #: superset-frontend/src/components/ReportModal/index.tsx:267

--- a/superset/translations/it/LC_MESSAGES/messages.po
+++ b/superset/translations/it/LC_MESSAGES/messages.po
@@ -613,7 +613,7 @@ msgstr ""
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:28
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:49
 #, fuzzy
-msgid "Adaptative formating"
+msgid "Adaptive formatting"
 msgstr "Formato Datetime"
 
 #: superset-frontend/src/components/ReportModal/index.tsx:267

--- a/superset/translations/ja/LC_MESSAGES/messages.po
+++ b/superset/translations/ja/LC_MESSAGES/messages.po
@@ -608,7 +608,7 @@ msgstr "実際の期間"
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:28
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:49
 #, fuzzy
-msgid "Adaptative formating"
+msgid "Adaptive formatting"
 msgstr "日時フォーマット"
 
 #: superset-frontend/src/components/ReportModal/index.tsx:267

--- a/superset/translations/ko/LC_MESSAGES/messages.po
+++ b/superset/translations/ko/LC_MESSAGES/messages.po
@@ -609,7 +609,7 @@ msgstr ""
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:28
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:49
-msgid "Adaptative formating"
+msgid "Adaptive formatting"
 msgstr ""
 
 #: superset-frontend/src/components/ReportModal/index.tsx:267

--- a/superset/translations/messages.pot
+++ b/superset/translations/messages.pot
@@ -606,7 +606,7 @@ msgstr ""
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:28
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:49
-msgid "Adaptative formating"
+msgid "Adaptive formatting"
 msgstr ""
 
 #: superset-frontend/src/components/ReportModal/index.tsx:267

--- a/superset/translations/nl/LC_MESSAGES/messages.json
+++ b/superset/translations/nl/LC_MESSAGES/messages.json
@@ -1777,7 +1777,7 @@
         ""
       ],
       "D3 format syntax: https://github.com/d3/d3-format": [""],
-      "Adaptative formating": [""],
+      "Adaptive formatting": [""],
       "Duration in ms (66000 => 1m 6s)": [""],
       "Duration in ms (1.40008 => 1ms 400µs 80ns)": [""],
       "D3 time format syntax: https://github.com/d3/d3-time-format": [""],

--- a/superset/translations/nl/LC_MESSAGES/messages.po
+++ b/superset/translations/nl/LC_MESSAGES/messages.po
@@ -5036,7 +5036,7 @@ msgstr ""
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:28
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:49
-msgid "Adaptative formating"
+msgid "Adaptive formatting"
 msgstr ""
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:40

--- a/superset/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/superset/translations/pt_BR/LC_MESSAGES/messages.po
@@ -671,7 +671,7 @@ msgstr "Intervalo de tempo real"
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:28
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:49
 #, fuzzy
-msgid "Adaptative formating"
+msgid "Adaptive formatting"
 msgstr "Formato de data e hora"
 
 #: superset-frontend/src/components/ReportModal/index.tsx:267

--- a/superset/translations/ru/LC_MESSAGES/messages.po
+++ b/superset/translations/ru/LC_MESSAGES/messages.po
@@ -648,7 +648,7 @@ msgstr ""
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:28
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:49
 #, fuzzy
-msgid "Adaptative formating"
+msgid "Adaptive formatting"
 msgstr "Формат Datetime"
 
 #: superset-frontend/src/components/ReportModal/index.tsx:267

--- a/superset/translations/sk/LC_MESSAGES/messages.po
+++ b/superset/translations/sk/LC_MESSAGES/messages.po
@@ -600,7 +600,7 @@ msgstr ""
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:28
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:49
-msgid "Adaptative formating"
+msgid "Adaptive formatting"
 msgstr ""
 
 #: superset-frontend/src/components/ReportModal/index.tsx:267

--- a/superset/translations/sl/LC_MESSAGES/messages.json
+++ b/superset/translations/sl/LC_MESSAGES/messages.json
@@ -3816,7 +3816,7 @@
       "D3 format syntax: https://github.com/d3/d3-format": [
         "Sintaksa D3 formata: https://github.com/d3/d3-format"
       ],
-      "Adaptative formating": ["Adaptivno oblikovanje"],
+      "Adaptive formatting": ["Adaptivno oblikovanje"],
       "Duration in ms (66000 => 1m 6s)": ["Trajanje v ms (66000 => 1m 6s)"],
       "Duration in ms (1.40008 => 1ms 400µs 80ns)": [
         "Trajanje v ms (1.40008 => 1ms 400µs 80ns)"

--- a/superset/translations/sl/LC_MESSAGES/messages.po
+++ b/superset/translations/sl/LC_MESSAGES/messages.po
@@ -678,7 +678,7 @@ msgstr "Dejansko časovno obdobje"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:28
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:49
-msgid "Adaptative formating"
+msgid "Adaptive formatting"
 msgstr "Adaptivno oblikovanje"
 
 #: superset-frontend/src/components/ReportModal/index.tsx:267

--- a/superset/translations/zh/LC_MESSAGES/messages.json
+++ b/superset/translations/zh/LC_MESSAGES/messages.json
@@ -2617,7 +2617,7 @@
       "Whether to apply filter to dashboards when table cells are clicked": [
         "单击表单元格时是否对看板应用过滤条件"
       ],
-      "Adaptative formating": ["自动匹配格式化"],
+      "Adaptive formatting": ["自动匹配格式化"],
       "Aggregate": ["聚合"],
       "Raw Records": ["原始记录"],
       "Query Mode": ["查询模式"],

--- a/superset/translations/zh/LC_MESSAGES/messages.po
+++ b/superset/translations/zh/LC_MESSAGES/messages.po
@@ -637,7 +637,7 @@ msgstr "实际时间范围"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:28
 #: superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts:49
-msgid "Adaptative formating"
+msgid "Adaptive formatting"
 msgstr "自动匹配格式化"
 
 #: superset-frontend/src/components/ReportModal/index.tsx:267


### PR DESCRIPTION
### SUMMARY
In time-series type charts in customize section we have fields that are related to numbers - y axis format, time format, tooltip time format (and maybe more?). The default setting is "adaptive formatting" and it's spelled wrong.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TESTING INSTRUCTIONS

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
