### PR TITLE
fix(sql lab): increase the size of the action icons in the history tab

### DIFF
--- a/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
@@ -283,21 +283,21 @@ const QueryTable = ({
               )}
               placement="top"
             >
-              <Icons.Edit iconSize="s" />
+              <Icons.Edit iconSize="xl" />
             </StyledTooltip>
             <StyledTooltip
               onClick={() => openQueryInNewTab(query)}
               tooltip={t('Run query in a new tab')}
               placement="top"
             >
-              <Icons.PlusCircleOutlined iconSize="xs" css={verticalAlign} />
+              <Icons.PlusCircleOutlined iconSize="xl" css={verticalAlign} />
             </StyledTooltip>
             {q.id !== latestQueryId && (
               <StyledTooltip
                 tooltip={t('Remove query from log')}
                 onClick={() => removeQuery(query)}
               >
-                <Icons.Trash iconSize="xs" />
+                <Icons.Trash iconSize="xl" />
               </StyledTooltip>
             )}
           </div>


### PR DESCRIPTION
### SUMMARY
This PR increases the size of the action icons in the SQL Lab history tab to match the rest of the application.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1287" alt="Screen Shot 2022-03-22 at 14 45 03" src="https://user-images.githubusercontent.com/17252075/159543061-f4416c53-3124-42f1-b7fe-eecefc44c9cf.png">

After:
<img width="1283" alt="Screen Shot 2022-03-22 at 14 44 15" src="https://user-images.githubusercontent.com/17252075/159542934-fcaa2b5b-e63d-4bc2-970e-8b3941805c4a.png">

### TESTING INSTRUCTIONS

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
