### PR TITLE
fix(explore): make to convert null to N/A in view results

### DIFF
--- a/superset-frontend/src/constants.ts
+++ b/superset-frontend/src/constants.ts
@@ -98,3 +98,8 @@ export const FAST_DEBOUNCE = 250;
  * Slower debounce delay for inputs with expensive API calls.
  */
 export const SLOW_DEBOUNCE = 500;
+
+/**
+ * Display null as `N/A`
+ */
+export const NULL_DISPLAY = 'N/A';

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -308,11 +308,11 @@ export const useTableColumns = (
                   if (value === false) {
                     return BOOL_FALSE_DISPLAY;
                   }
-                  if (timeFormattedColumnIndex > -1) {
-                    return timeFormatter(value);
-                  }
                   if (value === null) {
                     return <CellNull>{NULL_DISPLAY}</CellNull>;
+                  }
+                  if (timeFormattedColumnIndex > -1) {
+                    return timeFormatter(value);
                   }
                   return String(value);
                 },

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -36,6 +36,7 @@ import {
   BOOL_FALSE_DISPLAY,
   BOOL_TRUE_DISPLAY,
   SLOW_DEBOUNCE,
+  NULL_DISPLAY,
 } from 'src/constants';
 import { Radio } from 'src/components/Radio';
 import Icons from 'src/components/Icons';
@@ -48,6 +49,10 @@ import {
   setTimeFormattedColumn,
   unsetTimeFormattedColumn,
 } from 'src/explore/actions/exploreActions';
+
+export const CellNull = styled('span')`
+  color: ${({ theme }) => theme.colors.grayscale.light1};
+`;
 
 export const CopyButton = styled(Button)`
   font-size: ${({ theme }) => theme.typography.sizes.s}px;
@@ -305,6 +310,9 @@ export const useTableColumns = (
                   }
                   if (timeFormattedColumnIndex > -1) {
                     return timeFormatter(value);
+                  }
+                  if (value === null) {
+                    return <CellNull>{NULL_DISPLAY}</CellNull>;
                   }
                   return String(value);
                 },


### PR DESCRIPTION
### SUMMARY
NULL values not showing up in View Results in Explore

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
BEFORE:
![image](https://user-images.githubusercontent.com/47900232/159550566-80e6a11d-6056-458b-889c-ffdbc84501b2.png)

AFTER:
![image](https://user-images.githubusercontent.com/47900232/159550460-5b3120f1-44ec-4eb8-8b2b-e95950699e91.png)

### TESTING INSTRUCTIONS
How to reproduce the issue
1. Go to Chart Table. (can try with cleaned_sales_data datasets)
2. Set the Group BY as territorry field
3. Set the Metrics as SUM(price_each)
4. Run the chart
5. Table has the null value, this is displayed as N/A
6. But in View results, Table don't show null value as N/A like viz chart table.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
