### PR TITLE
ci: add more code owners to helm chart source

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,4 @@
 /superset-frontend/src/components/Select/ @michael-s-molina @geido
 
 # Notify Helm Chart maintainers about changes in it
-/helm/superset/ @craig-rueda
+/helm/superset/ @craig-rueda @dpgaspar @villebro


### PR DESCRIPTION
### SUMMARY

Adding myself and Ville has code owners for helm

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
