### PR TITLE
feat(sql lab): enable ACE editor search in SQL editors

### DIFF
--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/index.tsx
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/index.tsx
@@ -127,8 +127,6 @@ class AceEditorWrapper extends React.PureComponent<Props, State> {
   }
 
   onEditorLoad(editor: any) {
-    editor.commands.removeCommand('find');
-
     editor.commands.addCommand({
       name: 'runQuery',
       bindKey: { win: 'Alt-enter', mac: 'Alt-enter' },

--- a/superset-frontend/src/components/AsyncAceEditor/index.tsx
+++ b/superset-frontend/src/components/AsyncAceEditor/index.tsx
@@ -68,6 +68,7 @@ const aceModuleLoaders = {
   'theme/textmate': () => import('brace/theme/textmate'),
   'theme/github': () => import('brace/theme/github'),
   'ext/language_tools': () => import('brace/ext/language_tools'),
+  'ext/searchbox': () => import('brace/ext/searchbox'),
 };
 
 export type AceModule = keyof typeof aceModuleLoaders;
@@ -164,10 +165,11 @@ export const SQLEditor = AsyncAceEditor([
   'mode/sql',
   'theme/github',
   'ext/language_tools',
+  'ext/searchbox',
 ]);
 
 export const FullSQLEditor = AsyncAceEditor(
-  ['mode/sql', 'theme/github', 'ext/language_tools'],
+  ['mode/sql', 'theme/github', 'ext/language_tools', 'ext/searchbox'],
   {
     // a custom placeholder in SQL lab for less jumpy re-renders
     placeholder: () => {

--- a/superset-frontend/src/types/brace.d.ts
+++ b/superset-frontend/src/types/brace.d.ts
@@ -26,3 +26,4 @@ declare module 'brace/mode/javascript';
 declare module 'brace/theme/textmate';
 declare module 'brace/theme/github';
 declare module 'brace/ext/language_tools';
+declare module 'brace/ext/searchbox';


### PR DESCRIPTION
### SUMMARY
Currently, in the SQL editor inside the Lab, the search available is the native one provided by the browser.

For performance reasons, the editor only renders a subset of the entire content. So, the native search cannot find content in the editor that's not currently rendered.

This PR changes the search mechanism to use the ACE plugin one, which will enable full search inside the editor.
The search is only enabled if the editor is focused, otherwise the normal native search is used.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/17252075/159695557-532bbeb1-494f-4fd0-926e-08f586241427.mov

After:

https://user-images.githubusercontent.com/17252075/159695513-2614f01a-b462-4ac4-95c4-65a47da9473a.mov

### TESTING INSTRUCTIONS
1. Open the SQL Lab
2. Write (or copy paste) a large text inside the editor.

Ensure the search inside the editor can find anything inside it, including text that's not currently visible.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
