### PR TITLE
docs: fix: Use three backticks for code blocks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -412,7 +412,7 @@ You also need to install MySQL or [MariaDB](https://mariadb.com/downloads).
 
 Ensure that you are using Python version 3.7 or 3.8, then proceed with:
 
-````bash
+```bash
 # Create a virtual environment and activate it (recommended)
 python3 -m venv venv # setup a python3 virtualenv
 source venv/bin/activate
@@ -457,7 +457,7 @@ $ make superset
 
 # Setup pre-commit only
 $ make pre-commit
-````
+```
 
 **Note: the FLASK_APP env var should not need to be set, as it's currently controlled
 via `.flaskenv`, however if needed, it should be set to `superset.app:create_app()`**


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Fixes a tiny issue in **CONTRIBUTING.md**: A code block was opened with four backticks, attempted to be closed with three backticks, and then a second code block was opened with three backticks and closed with four. The result was that the three backticks appeared inside the code block as code, along with a line of plain text.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**BEFORE**
![image](https://user-images.githubusercontent.com/708421/159698640-6c2b6b77-3984-45c8-89c1-4935b6f56053.png)

**AFTER**
![image](https://user-images.githubusercontent.com/708421/159698472-a18f6591-71d2-45f2-8e3f-7364048cf587.png)


### TESTING INSTRUCTIONS

Rendered Markdown locally.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes https://github.com/apache/superset/issues/19330

- [x] Has associated issue: #19330 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
