### PR TITLE
fix(database): make to allow the expose db as default in sqlalchemy form db

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -348,6 +348,7 @@ function dbReducer(
         } as DatabaseObject['extra_json'];
 
         deserializeExtraJSON = {
+          ...deserializeExtraJSON,
           ...JSON.parse(action.payload.extra || ''),
           metadata_params: JSON.stringify(extra_json?.metadata_params),
           engine_params: JSON.stringify(extra_json?.engine_params),


### PR DESCRIPTION
### SUMMARY
SQL lab advanced will show expose database in sql lab even though it was not selected in the URI database connection form

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:

By default, The option of Allow this database to be explored is not checked when the db is created with sqlalchemy form.
![image](https://user-images.githubusercontent.com/47900232/159746084-27c90073-c63d-4ba4-a2ec-052634d6ae43.png)

AFTER:
By default, he option of Allow this database to be explored is checked when the db is created with sqlalchemy form.
![image](https://user-images.githubusercontent.com/47900232/159746343-de63970d-d4c8-4956-8a13-a6b699da7a8a.png)

### TESTING INSTRUCTIONS
How to reproduce the issue?

1. Go through the onboard flow
2. On the db connection screen, select something that uses the sql alchemy uri connection form like Athena or Elastic Search
3. Go to the advanced tab (before the database is connected)
4. Notice in the sql tab that expose database in sql lab is not checked
5. connect to the database
6. log into your workspace
7. go to databases
8. edit your connection
9. Go to the advanced tab
10. The expose database in sql lab is not checked by default

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
