### PR TITLE
fix: Null values on Explore filter

### DIFF
--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -42,7 +42,7 @@ import Icons from 'src/components/Icons';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 import { SLOW_DEBOUNCE } from 'src/constants';
 import { rankedSearchCompare } from 'src/utils/rankedSearchCompare';
-import { getValue, hasOption } from './utils';
+import { getValue, hasOption, isObject } from './utils';
 
 const { Option } = AntdSelect;
 
@@ -385,18 +385,20 @@ const Select = (
 
   const hasCustomLabels = fullSelectOptions.some(opt => !!opt?.customLabel);
 
-  const handleOnSelect = (selectedItem: string | number | AntdLabeledValue) => {
+  const handleOnSelect = (
+    selectedItem: string | number | AntdLabeledValue | undefined,
+  ) => {
     if (isSingleMode) {
       setSelectValue(selectedItem);
     } else {
       setSelectValue(previousState => {
         const array = ensureIsArray(previousState);
-        const isObject = typeof selectedItem === 'object';
-        const value = isObject ? selectedItem.value : selectedItem;
+        const isLabeledValue = isObject(selectedItem);
+        const value = isLabeledValue ? selectedItem.value : selectedItem;
         // Tokenized values can contain duplicated values
         if (!hasOption(value, array)) {
           const result = [...array, selectedItem];
-          return isObject
+          return isLabeledValue
             ? (result as AntdLabeledValue[])
             : (result as (string | number)[]);
         }
@@ -406,9 +408,11 @@ const Select = (
     setInputValue('');
   };
 
-  const handleOnDeselect = (value: string | number | AntdLabeledValue) => {
+  const handleOnDeselect = (
+    value: string | number | AntdLabeledValue | undefined,
+  ) => {
     if (Array.isArray(selectValue)) {
-      if (typeof value === 'number' || typeof value === 'string') {
+      if (typeof value === 'number' || typeof value === 'string' || !value) {
         const array = selectValue as (string | number)[];
         setSelectValue(array.filter(element => element !== value));
       } else {

--- a/superset-frontend/src/components/Select/utils.ts
+++ b/superset-frontend/src/components/Select/utils.ts
@@ -25,7 +25,7 @@ import {
   GroupedOptionsType,
 } from 'react-select';
 
-function isObject(value: unknown): value is Record<string, unknown> {
+export function isObject(value: unknown): value is Record<string, unknown> {
   return (
     value !== null &&
     typeof value === 'object' &&

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
@@ -406,11 +406,15 @@ const AdhocFilterEditPopoverSimpleTabContent: React.FC<Props> = props => {
         {...operatorSelectProps}
       />
       {MULTI_OPERATORS.has(operatorId) || suggestions.length > 0 ? (
-        <SelectWithLabel
-          labelText={labelText}
-          options={suggestions}
-          {...comparatorSelectProps}
-        />
+        // We need to delay rendering the select because we can't pass a primitive value without options
+        // We can't pass value = [null] and options=[]
+        comparatorSelectProps.value && suggestions.length === 0 ? null : (
+          <SelectWithLabel
+            labelText={labelText}
+            options={suggestions}
+            {...comparatorSelectProps}
+          />
+        )
       ) : (
         <StyledInput
           data-test="adhoc-filter-simple-value"


### PR DESCRIPTION
### SUMMARY
Fixes `NULL` values on Explore filter control.

Fixes https://github.com/apache/superset/issues/19264

### BEFORE/AFTER SCREENSHOTS

https://user-images.githubusercontent.com/70410625/159783385-494dc7e1-603e-469a-bf5d-b97bcf8b00cb.mov

https://user-images.githubusercontent.com/70410625/159784037-39dad8e9-1ef8-422f-8bbd-91b413155711.mov

### TESTING INSTRUCTIONS
Check the video for instructions.

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
