### PR TITLE
fix: number format should editable in time comparison

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -44,6 +44,7 @@ import {
   legacyValidateInteger,
   validateNonEmpty,
   JsonArray,
+  ComparisionType,
 } from '@superset-ui/core';
 
 import {
@@ -455,16 +456,12 @@ const y_axis_format: SharedControlConfig<'SelectControl', SelectDefaultOption> =
     filterOption: ({ data: option }, search) =>
       option.label.includes(search) || option.value.includes(search),
     mapStateToProps: state => {
-      const showWarning =
-        state.controls?.comparison_type?.value === 'percentage';
+      const isPercentage =
+        state.controls?.comparison_type?.value === ComparisionType.Percentage;
       return {
-        warning: showWarning
-          ? t(
-              'When `Calculation type` is set to "Percentage change", the Y ' +
-                'Axis Format is forced to `.1%`',
-            )
-          : null,
-        disabled: showWarning,
+        choices: isPercentage
+          ? D3_FORMAT_OPTIONS.filter(option => option[0].includes('%'))
+          : D3_FORMAT_OPTIONS,
       };
     },
   };


### PR DESCRIPTION
### SUMMARY
Currently, users are unable to edit `Y axis format` when they use `time compare` and set `compare type` to `percentage`. This PR unlock the `y axis format` selection and filtered percentage fomatter.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
#### After
![image](https://user-images.githubusercontent.com/2016594/159900818-d209ad71-25b3-4155-8105-75a3215e71ea.png)

#### Before
![image](https://user-images.githubusercontent.com/2016594/159901477-be798c7b-5114-4f75-b47d-469e87e2d14b.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Charting a echart version timeseries chart
2. add a `metric` in metics control
3. Select `Time shift` duration in time comparison panel
4. Select `pecentage change`
5. Run query
6. Switch to customize panel
7. Verify the `Y axis format` can be switching and corresponding formatting applies to the chart.
8. `Y axis format` control is able to input user defined formatter as well.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
