### PR TITLE
[WIP]feat(config_overwrite-import-dashboards): add ability to config which…

### DIFF
--- a/superset-frontend/src/components/ImportModal/index.tsx
+++ b/superset-frontend/src/components/ImportModal/index.tsx
@@ -146,7 +146,7 @@ const ImportModelsModal: FunctionComponent<ImportModelsModalProps> = ({
   };
 
   const {
-    state: { alreadyExists, passwordsNeeded },
+    state: { alreadyExists, passwordsNeeded, alreadyExistsConfigOverwrite },
     importResource,
   } = useImportResource(resourceName, resourceLabel, handleErrorMsg);
 
@@ -158,11 +158,15 @@ const ImportModelsModal: FunctionComponent<ImportModelsModalProps> = ({
   }, [passwordsNeeded, setPasswordFields]);
 
   useEffect(() => {
-    setNeedsOverwriteConfirm(alreadyExists.length > 0);
-    if (alreadyExists.length > 0) {
+    const isNeedConfirmation =
+      alreadyExists.length > 0 || alreadyExistsConfigOverwrite.length > 0;
+    setNeedsOverwriteConfirm(isNeedConfirmation);
+    if (isNeedConfirmation) {
       setImportingModel(false);
     }
-  }, [alreadyExists, setNeedsOverwriteConfirm]);
+  }, [alreadyExists, setNeedsOverwriteConfirm, alreadyExistsConfigOverwrite]);
+
+  console.log(alreadyExistsConfigOverwrite);
 
   // Functions
   const hide = () => {
@@ -176,11 +180,17 @@ const ImportModelsModal: FunctionComponent<ImportModelsModalProps> = ({
       return;
     }
 
+    const configOverwrite = {};
+    if (confirmedOverwrite && alreadyExistsConfigOverwrite.length > 0) {
+      configOverwrite[alreadyExistsConfigOverwrite[0]] = confirmedOverwrite;
+    }
+
     setImportingModel(true);
     importResource(
       fileList[0].originFileObj,
       passwords,
       confirmedOverwrite,
+      configOverwrite,
     ).then(result => {
       if (result) {
         clearModal();

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -377,8 +377,10 @@ const isNeedsPassword = (payload: any) =>
   payload._schema[0] === 'Must provide a password for the database';
 
 export const isAlreadyExists = (payload: any) =>
-  typeof payload === 'string' &&
-  payload.includes('already exists and `overwrite=true` was not passed');
+  typeof payload === 'string' && payload.includes('`overwrite=true`');
+
+export const isAlreadyExistsConfigOverwrite = (payload: any) =>
+  typeof payload === 'string' && payload.includes('`config_overwrite` object');
 
 export const getPasswordsNeeded = (errors: Record<string, any>[]) =>
   errors
@@ -398,6 +400,17 @@ export const getAlreadyExists = (errors: Record<string, any>[]) =>
     )
     .flat();
 
+export const getAlreadyExistsConfigOverwrite = (
+  errors: Record<string, any>[],
+) =>
+  errors
+    .map(error =>
+      Object.entries(error.extra)
+        .filter(([, payload]) => isAlreadyExistsConfigOverwrite(payload))
+        .map(([fileName]) => fileName),
+    )
+    .flat();
+
 export const hasTerminalValidation = (errors: Record<string, any>[]) =>
   errors.some(
     error =>
@@ -405,7 +418,9 @@ export const hasTerminalValidation = (errors: Record<string, any>[]) =>
         .filter(([key, _]) => key !== 'issue_codes')
         .every(
           ([_, payload]) =>
-            isNeedsPassword(payload) || isAlreadyExists(payload),
+            isNeedsPassword(payload) ||
+            isAlreadyExists(payload) ||
+            isAlreadyExistsConfigOverwrite(payload),
         ),
   );
 

--- a/superset/cli/importexport.py
+++ b/superset/cli/importexport.py
@@ -18,7 +18,7 @@ import logging
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional
 from zipfile import is_zipfile, ZipFile
 
 import click
@@ -143,7 +143,9 @@ if feature_flags.get("VERSIONED_EXPORT"):
             with open(path) as file:
                 contents = {path: file.read()}
         try:
-            ImportDashboardsCommand(contents, overwrite=True).run()
+            # TODO configure according to cli input
+            config_overwrite: Dict[str, bool] = {"dashboards": True}
+            ImportDashboardsCommand(contents, config_overwrite=config_overwrite).run()
         except Exception:  # pylint: disable=broad-except
             logger.exception(
                 "There was an error when importing the dashboards(s), please check "

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -19,7 +19,7 @@ import json
 import logging
 from datetime import datetime
 from io import BytesIO
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 from zipfile import is_zipfile, ZipFile
 
 from flask import g, make_response, redirect, request, Response, send_file, url_for
@@ -953,9 +953,10 @@ class DashboardRestApi(BaseSupersetModelRestApi):
                         in the following format:
                         `{"databases/MyDatabase.yaml": "my_password"}`.
                       type: string
-                    overwrite:
-                      description: overwrite existing dashboards?
-                      type: boolean
+                    configOverwrite:
+                      description: determine which models to overwrite
+                      type: object
+                      example: {"dashboards": true, "charts": false ...}
           responses:
             200:
               description: Dashboard import result
@@ -993,10 +994,15 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             if "passwords" in request.form
             else None
         )
-        overwrite = request.form.get("overwrite") == "true"
+
+        config_overwrite: Dict[str, bool] = (
+            json.loads(request.form["configOverwrite"])
+            if "configOverwrite" in request.form
+            else None
+        )
 
         command = ImportDashboardsCommand(
-            contents, passwords=passwords, overwrite=overwrite
+            contents, passwords=passwords, config_overwrite=config_overwrite,
         )
         command.run()
         return self.response(200, message="OK")

--- a/tests/integration_tests/cli_tests.py
+++ b/tests/integration_tests/cli_tests.py
@@ -19,6 +19,7 @@ import importlib
 import json
 import logging
 from pathlib import Path
+from typing import Dict
 from unittest import mock
 from zipfile import is_zipfile, ZipFile
 
@@ -238,8 +239,10 @@ def test_import_dashboards_versioned_export(import_dashboards_command, app_conte
 
     assert response.exit_code == 0
     expected_contents = {"dashboards.json": '{"hello": "world"}'}
-    import_dashboards_command.assert_called_with(expected_contents, overwrite=True)
-
+    config_overwrite: Dict[str, bool] = {"dashboards": True}
+    import_dashboards_command.assert_called_with(
+        expected_contents, config_overwrite=config_overwrite
+    )
     # write ZIP file
     with ZipFile("dashboards.zip", "w") as bundle:
         with bundle.open("dashboards/dashboard.yaml", "w") as fp:
@@ -252,7 +255,9 @@ def test_import_dashboards_versioned_export(import_dashboards_command, app_conte
 
     assert response.exit_code == 0
     expected_contents = {"dashboard.yaml": "hello: world"}
-    import_dashboards_command.assert_called_with(expected_contents, overwrite=True)
+    import_dashboards_command.assert_called_with(
+        expected_contents, config_overwrite=config_overwrite
+    )
 
 
 @mock.patch.dict(

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -1559,7 +1559,7 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
                     "error_type": "GENERIC_COMMAND_ERROR",
                     "level": "warning",
                     "extra": {
-                        "dashboards/imported_dashboard.yaml": "Dashboard already exists and `overwrite=true` was not passed",
+                        "dashboards": "some dashboards already exists and `config_overwrite` object was not passed",
                         "issue_codes": [
                             {
                                 "code": 1010,
@@ -1578,7 +1578,7 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
         buf = self.create_dashboard_import()
         form_data = {
             "formData": (buf, "dashboard_export.zip"),
-            "overwrite": "true",
+            "configOverwrite": json.dumps({"dashboards": True}),
         }
         rv = self.client.post(uri, data=form_data, content_type="multipart/form-data")
         response = json.loads(rv.data.decode("utf-8"))

--- a/tests/integration_tests/dashboards/commands_tests.py
+++ b/tests/integration_tests/dashboards/commands_tests.py
@@ -16,6 +16,7 @@
 # under the License.
 import itertools
 import json
+from typing import Dict
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -592,7 +593,10 @@ class TestImportDashboardsCommand(SupersetTestCase):
             "charts/imported_chart.yaml": yaml.safe_dump(chart_config),
             "dashboards/imported_dashboard.yaml": yaml.safe_dump(dashboard_config),
         }
-        command = v1.ImportDashboardsCommand(contents, overwrite=True)
+        config_overwrite: Dict[str, bool] = {"dashboards": True}
+        command = v1.ImportDashboardsCommand(
+            contents, config_overwrite=config_overwrite
+        )
         command.run()
         command.run()
 


### PR DESCRIPTION
new feat to import dashboards.  
add the ability to config the overwrite.
using the `configOverwrite` object we determine which models to overwrite.  


Throwing a new error when the user folder; is overwriting existing models
small changes at the frontend.   
Need more work at the frontend.
and make the `config_overwrite` available to all others `import api` (charts, datasets...) 
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
