### PR TITLE
fix: Fix NoAuthorizationError in /me endpoint

### DIFF
--- a/superset/views/users/api.py
+++ b/superset/views/users/api.py
@@ -16,6 +16,7 @@
 # under the License.
 from flask import g, Response
 from flask_appbuilder.api import BaseApi, expose, safe
+from flask_jwt_extended.exceptions import NoAuthorizationError
 
 from .schemas import UserResponseSchema
 
@@ -51,6 +52,10 @@ class CurrentUserRestApi(BaseApi):
             401:
               $ref: '#/components/responses/401'
         """
-        if g.user is None or g.user.is_anonymous:
+        try:
+            if g.user is None or g.user.is_anonymous:
+                return self.response_401()
+        except NoAuthorizationError:
             return self.response_401()
+
         return self.response(200, result=user_response_schema.dump(g.user))


### PR DESCRIPTION
### SUMMARY
Fixes an error for which the /me endpoint was returning 500 instead of 401 when a NoAuthorizationError exception was thrown.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
