### PR TITLE
fix(sqllab): make to hide the delete button of most recent query history

### DIFF
--- a/superset-frontend/src/SqlLab/components/QueryHistory/QueryHistory.test.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryHistory/QueryHistory.test.tsx
@@ -31,6 +31,7 @@ const mockedProps = {
     removeQuery: NOOP,
   },
   displayLimit: 1000,
+  latestQueryId: 'yhMUZCGb',
 };
 
 const setup = (overrides = {}) => (

--- a/superset-frontend/src/SqlLab/components/QueryHistory/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryHistory/index.tsx
@@ -32,6 +32,7 @@ interface QueryHistoryProps {
     removeQuery: Function;
   };
   displayLimit: number;
+  latestQueryId: string | undefined;
 }
 
 const StyledEmptyStateWrapper = styled.div`
@@ -45,7 +46,12 @@ const StyledEmptyStateWrapper = styled.div`
   }
 `;
 
-const QueryHistory = ({ queries, actions, displayLimit }: QueryHistoryProps) =>
+const QueryHistory = ({
+  queries,
+  actions,
+  displayLimit,
+  latestQueryId,
+}: QueryHistoryProps) =>
   queries.length > 0 ? (
     <QueryTable
       columns={[
@@ -61,6 +67,7 @@ const QueryHistory = ({ queries, actions, displayLimit }: QueryHistoryProps) =>
       queries={queries}
       actions={actions}
       displayLimit={displayLimit}
+      latestQueryId={latestQueryId}
     />
   ) : (
     <StyledEmptyStateWrapper>

--- a/superset-frontend/src/SqlLab/components/QueryTable/QueryTable.test.jsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/QueryTable.test.jsx
@@ -32,6 +32,7 @@ describe('QueryTable', () => {
     queries,
     displayLimit: 100,
     actions,
+    latestQueryId: 'ryhMUZCGb',
   };
   it('is valid', () => {
     expect(React.isValidElement(<QueryTable displayLimit={100} />)).toBe(true);

--- a/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
@@ -54,6 +54,7 @@ interface QueryTableProps {
   onUserClicked?: Function;
   onDbClicked?: Function;
   displayLimit: number;
+  latestQueryId?: string | undefined;
 }
 
 const openQuery = (id: number) => {
@@ -68,6 +69,7 @@ const QueryTable = ({
   onUserClicked = () => undefined,
   onDbClicked = () => undefined,
   displayLimit,
+  latestQueryId,
 }: QueryTableProps) => {
   const theme = useTheme();
 
@@ -290,12 +292,14 @@ const QueryTable = ({
             >
               <Icons.PlusCircleOutlined iconSize="xs" css={verticalAlign} />
             </StyledTooltip>
-            <StyledTooltip
-              tooltip={t('Remove query from log')}
-              onClick={() => removeQuery(query)}
-            >
-              <Icons.Trash iconSize="xs" />
-            </StyledTooltip>
+            {q.id !== latestQueryId && (
+              <StyledTooltip
+                tooltip={t('Remove query from log')}
+                onClick={() => removeQuery(query)}
+              >
+                <Icons.Trash iconSize="xs" />
+              </StyledTooltip>
+            )}
           </div>
         );
         return q;

--- a/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
@@ -223,6 +223,7 @@ export default function SouthPane({
             queries={editorQueries}
             actions={actions}
             displayLimit={displayLimit}
+            latestQueryId={latestQueryId}
           />
         </Tabs.TabPane>
         {renderDataPreviewTabs()}


### PR DESCRIPTION
### SUMMARY
Hide Delete Action on Most Recently Run Query

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
After deleting the most recently query, clear the result tab.
![image](https://user-images.githubusercontent.com/47900232/159974482-01fb95e4-35b9-4afd-95b7-c92b9d29e115.png)
![image](https://user-images.githubusercontent.com/47900232/159974378-88c79636-e5e3-4ed8-a9de-be1922755f06.png)

AFTER:
The result tab is not cleared by hiding the delete action on Most recent run query
![image](https://user-images.githubusercontent.com/47900232/159974180-dcc3f1f2-5438-4cf7-b062-bd4ae38b37d0.png)

### TESTING INSTRUCTIONS
**How to reproduce the issue**

1. In SQL Lab, run 2 queries
2. In the query history tab of SQL Lab, delete the most recent query
3. Deleting the most recent query also clears your query results tab
4. Should not clear query results tab.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
