### PR TITLE
fix: [Explore] Adaptive formatting spelling

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts
@@ -25,7 +25,7 @@ export const D3_FORMAT_DOCS = t(
 
 // input choices & options
 export const D3_FORMAT_OPTIONS: [string, string][] = [
-  [NumberFormats.SMART_NUMBER, t('Adaptative formating')],
+  [NumberFormats.SMART_NUMBER, t('Adaptive formatting')],
   ['~g', t('Original value')],
   [',d', ',d (12345.432 => 12,345)'],
   ['.1s', '.1s (12345.432 => 10k)'],
@@ -48,7 +48,7 @@ export const D3_TIME_FORMAT_DOCS = t(
 );
 
 export const D3_TIME_FORMAT_OPTIONS: [string, string][] = [
-  [smartDateFormatter.id, t('Adaptative formating')],
+  [smartDateFormatter.id, t('Adaptive formatting')],
   ['%d/%m/%Y', '%d/%m/%Y | 14/01/2019'],
   ['%m/%d/%Y', '%m/%d/%Y | 01/14/2019'],
   ['%Y-%m-%d', '%Y-%m-%d | 2019-01-14'],

--- a/superset-frontend/src/explore/controls.jsx
+++ b/superset-frontend/src/explore/controls.jsx
@@ -75,7 +75,7 @@ export const PRIMARY_COLOR = { r: 0, g: 122, b: 135, a: 1 };
 
 // input choices & options
 export const D3_FORMAT_OPTIONS = [
-  ['SMART_NUMBER', 'Adaptative formating'],
+  ['SMART_NUMBER', 'Adaptive formatting'],
   ['~g', 'Original value'],
   [',d', ',d (12345.432 => 12,345)'],
   ['.1s', '.1s (12345.432 => 10k)'],
@@ -98,7 +98,7 @@ export const D3_FORMAT_DOCS =
   'D3 format syntax: https://github.com/d3/d3-format';
 
 export const D3_TIME_FORMAT_OPTIONS = [
-  ['smart_date', 'Adaptative formating'],
+  ['smart_date', 'Adaptive formatting'],
   ['%d/%m/%Y', '%d/%m/%Y | 14/01/2019'],
   ['%m/%d/%Y', '%m/%d/%Y | 01/14/2019'],
   ['%Y-%m-%d', '%Y-%m-%d | 2019-01-14'],


### PR DESCRIPTION
### SUMMARY
We noticed that in Explore/Control panel/Customize, sections related to number/time format have incorrect spelling of the default value. 

**Current spelling**
`Adaptative formating`

**Changed to**
`Adaptive formatting`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before**
![image](https://user-images.githubusercontent.com/36897697/159979943-a3d776ca-c8b4-45f5-bb71-1005b2d6a111.png)

**After**
<img width="321" alt="image" src="https://user-images.githubusercontent.com/36897697/159980966-e5e7d56d-3700-4240-af13-aa1cc3144586.png">


### TESTING INSTRUCTIONS
1. Open time series chart in Explore 
2. Open Customize tab 
3. Scroll to chart options section
4. Check fields: time format, time tooltip format, Y axis format 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
