### PR TITLE
fix(sql lab): display the 'View Results' button consistently in the history tab on sync mode

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -248,6 +248,10 @@ export default class ResultSet extends React.PureComponent<
       );
     }
 
+    // Only fetch results if the result key change
+    // If we didn't have a result key before, then the results are loaded elsewhere
+    // so we can skip it, unless the query id changed, in that case we should
+    // refetch regardless.
     if (
       (this.props.query.resultsKey &&
         nextProps.query.resultsKey &&

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -247,9 +247,12 @@ export default class ResultSet extends React.PureComponent<
         this.clearQueryResults(nextProps.query),
       );
     }
+
     if (
-      nextProps.query.resultsKey &&
-      nextProps.query.resultsKey !== this.props.query.resultsKey
+      (this.props.query.resultsKey &&
+        nextProps.query.resultsKey &&
+        nextProps.query.resultsKey !== this.props.query.resultsKey) ||
+      (nextProps.query.id !== this.props.query.id && nextProps.query.resultsKey)
     ) {
       this.fetchResults(nextProps.query);
     }

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -328,8 +328,10 @@ export default function sqlLabReducer(state = {}, action) {
       if (action.query.state === 'stopped') {
         return state;
       }
+
       const alts = {
         endDttm: now(),
+        resultsKey: action?.results?.query?.resultsKey,
         progress: 100,
         results: action.results,
         rows: action?.results?.query?.rows || 0,

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -528,6 +528,8 @@ def execute_sql_statements(  # pylint: disable=too-many-arguments, too-many-loca
 
     if store_results and results_backend:
         key = str(uuid.uuid4())
+        payload["query"]["resultsKey"] = key
+
         logger.info(
             "Query %s: Storing results in results backend, key: %s", str(query_id), key
         )


### PR DESCRIPTION
### SUMMARY
In order to display the 'View Results' button in the history tab of the SQL Lab, the query must have a `resultsKey`.
When the query is executed in sync mode, that key was not properly propagated from the API to the FE, thus, the button did not appeared after execution.

The button did appeared once the running polling watching for queries updated, since that fetches fresh results from the api.

This PR forwards that key to make the button show for every successfully executed query.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/17252075/160002524-d03da706-ab0a-4d6f-b404-639fc12d5a73.mov

After:

https://user-images.githubusercontent.com/17252075/160002321-6feacd4d-c5af-4c91-8228-3a1858834d3d.mov

### TESTING INSTRUCTIONS
1. Configure a database for sync mode
2. Run queries in SQL Lab in that database
3. Check query history

Ensure that, if the queries are successful, the 'View Results' button always displays.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
