### PR TITLE
fix(sql lab): replace the output column in the query history table

### DIFF
--- a/superset-frontend/src/SqlLab/components/QueryHistory/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryHistory/index.tsx
@@ -61,7 +61,7 @@ const QueryHistory = ({
         'progress',
         'rows',
         'sql',
-        'output',
+        'results',
         'actions',
       ]}
       queries={queries}

--- a/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
@@ -36,7 +36,7 @@ import HighlightedSql from '../HighlightedSql';
 import { StaticPosition, verticalAlign, StyledTooltip } from './styles';
 
 interface QueryTableQuery
-  extends Omit<Query, 'state' | 'sql' | 'progress' | 'output' | 'results'> {
+  extends Omit<Query, 'state' | 'sql' | 'progress' | 'results'> {
   state?: Record<string, any>;
   sql?: Record<string, any>;
   progress?: Record<string, any>;

--- a/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
@@ -35,10 +35,12 @@ import ResultSet from '../ResultSet';
 import HighlightedSql from '../HighlightedSql';
 import { StaticPosition, verticalAlign, StyledTooltip } from './styles';
 
-interface QueryTableQuery extends Omit<Query, 'state' | 'sql' | 'progress'> {
+interface QueryTableQuery
+  extends Omit<Query, 'state' | 'sql' | 'progress' | 'output' | 'results'> {
   state?: Record<string, any>;
   sql?: Record<string, any>;
   progress?: Record<string, any>;
+  results?: Record<string, any>;
 }
 
 interface QueryTableProps {
@@ -227,12 +229,12 @@ const QueryTable = ({
           </Card>
         );
         if (q.resultsKey) {
-          q.output = (
+          q.results = (
             <ModalTrigger
               className="ResultsModal"
               triggerNode={
                 <Label type="info" className="pointer">
-                  {t('View results')}
+                  {t('View')}
                 </Label>
               }
               modalTitle={t('Data preview')}
@@ -252,13 +254,8 @@ const QueryTable = ({
               responsive
             />
           );
-        } else {
-          // if query was run using ctas and force_ctas_schema was set
-          // tempTable will have the schema
-          const schemaUsed =
-            q.ctas && q.tempTable && q.tempTable.includes('.') ? '' : q.schema;
-          q.output = [schemaUsed, q.tempTable].filter(v => v).join('.');
         }
+
         q.progress =
           state === 'success' ? (
             <ProgressBar


### PR DESCRIPTION
### SUMMARY
The current output column in the Query History table in the SQL Lab currently displays the schema if the query failed.
The resulting UI is a column with "View results" button for successful queries and some seemingly random text if the query failed that lacks the appropriate context.

This PR makes some cosmetic changes that include:
* Removing the schema for failed queries and leaving the field blank
* Renaming the column from "output" to "results"
* Renaming the button for successful queries from "View results" to "View"

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1289" alt="Screen Shot 2022-03-25 at 09 30 29" src="https://user-images.githubusercontent.com/17252075/160128737-0c957259-b7fe-49df-a61d-42ec335591ac.png">

After:
<img width="1284" alt="Screen Shot 2022-03-25 at 09 48 22" src="https://user-images.githubusercontent.com/17252075/160128766-7acf76f2-2004-433b-b826-4f045fa20722.png">

### TESTING INSTRUCTIONS
1. Open the SQL Lab
2. Execute valid and invalid queries

Ensure the results column show the View button for successful queries & nothing for failed ones.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
