### PR TITLE
feat: add drag and drop column rearrangement for table viz

### DIFF
--- a/superset-frontend/packages/superset-ui-demo/storybook/stories/plugins/plugin-chart-table/TableStories.tsx
+++ b/superset-frontend/packages/superset-ui-demo/storybook/stories/plugins/plugin-chart-table/TableStories.tsx
@@ -66,6 +66,7 @@ function loadData(
     alignPn = false,
     showCellBars = true,
     includeSearch = true,
+    rearrangeColumns = false,
   },
 ): TableChartProps {
   if (!props.queriesData || !props.queriesData[0]) return props;
@@ -86,6 +87,7 @@ function loadData(
       page_length: pageLength,
       show_cell_bars: showCellBars,
       include_search: includeSearch,
+      rearrange_columns: rearrangeColumns,
     },
     height: window.innerHeight - 130,
   };
@@ -117,8 +119,9 @@ export const BigTable = ({ width, height }) => {
   const cols = number('Columns', 8, { range: true, min: 1, max: 20 });
   const pageLength = number('Page size', 50, { range: true, min: 0, max: 100 });
   const includeSearch = boolean('Include search', true);
-  const alignPn = boolean('Algin PosNeg', false);
+  const alignPn = boolean('Align PosNeg', false);
   const showCellBars = boolean('Show Cell Bars', true);
+  const rearrangeColumns = boolean('Allow user to rearrange columns', false);
   const chartProps = loadData(birthNames, {
     pageLength,
     rows,
@@ -126,6 +129,7 @@ export const BigTable = ({ width, height }) => {
     alignPn,
     showCellBars,
     includeSearch,
+    rearrangeColumns,
   });
   return (
     <SuperChart

--- a/superset-frontend/packages/superset-ui-demo/storybook/stories/plugins/plugin-chart-table/TableStories.tsx
+++ b/superset-frontend/packages/superset-ui-demo/storybook/stories/plugins/plugin-chart-table/TableStories.tsx
@@ -66,7 +66,7 @@ function loadData(
     alignPn = false,
     showCellBars = true,
     includeSearch = true,
-    rearrangeColumns = false,
+    allowRearrangeColumns = false,
   },
 ): TableChartProps {
   if (!props.queriesData || !props.queriesData[0]) return props;
@@ -87,7 +87,7 @@ function loadData(
       page_length: pageLength,
       show_cell_bars: showCellBars,
       include_search: includeSearch,
-      rearrange_columns: rearrangeColumns,
+      allow_rearrange_columns: allowRearrangeColumns,
     },
     height: window.innerHeight - 130,
   };
@@ -121,7 +121,10 @@ export const BigTable = ({ width, height }) => {
   const includeSearch = boolean('Include search', true);
   const alignPn = boolean('Align PosNeg', false);
   const showCellBars = boolean('Show Cell Bars', true);
-  const rearrangeColumns = boolean('Allow user to rearrange columns', false);
+  const allowRearrangeColumns = boolean(
+    'Allow end user to drag-and-drop column headers to rearrange them.',
+    false,
+  );
   const chartProps = loadData(birthNames, {
     pageLength,
     rows,
@@ -129,7 +132,7 @@ export const BigTable = ({ width, height }) => {
     alignPn,
     showCellBars,
     includeSearch,
-    rearrangeColumns,
+    allowRearrangeColumns,
   });
   return (
     <SuperChart

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
@@ -65,7 +65,6 @@ export interface DataTableProps<D extends object> extends TableOptions<D> {
   rowCount: number;
   wrapperRef?: MutableRefObject<HTMLDivElement>;
   onColumnOrderChange: () => void;
-  rearrangeColumns: boolean;
 }
 
 export interface RenderHTMLCellProps extends HTMLProps<HTMLTableCellElement> {
@@ -97,7 +96,6 @@ export default function DataTable<D extends object>({
   hooks,
   serverPagination,
   wrapperRef: userWrapperRef,
-  rearrangeColumns,
   onColumnOrderChange,
   ...moreUseTableOptions
 }: DataTableProps<D>): JSX.Element {

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
@@ -46,6 +46,7 @@ import SimplePagination from './components/Pagination';
 import useSticky from './hooks/useSticky';
 import { PAGE_SIZE_OPTIONS } from '../consts';
 import { sortAlphanumericCaseInsensitive } from './utils/sortAlphanumericCaseInsensitive';
+import { REACT_TABLE_ROW_NUMBER_COLUMN_ID } from '../types';
 
 export interface DataTableProps<D extends object> extends TableOptions<D> {
   tableClassName?: string;

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
@@ -46,7 +46,6 @@ import SimplePagination from './components/Pagination';
 import useSticky from './hooks/useSticky';
 import { PAGE_SIZE_OPTIONS } from '../consts';
 import { sortAlphanumericCaseInsensitive } from './utils/sortAlphanumericCaseInsensitive';
-import { REACT_TABLE_ROW_NUMBER_COLUMN_ID } from '../types';
 
 export interface DataTableProps<D extends object> extends TableOptions<D> {
   tableClassName?: string;

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/hooks/useSticky.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/hooks/useSticky.tsx
@@ -348,6 +348,7 @@ function useInstance<D extends object>(instance: TableInstance<D>) {
     data,
     page,
     rows,
+    allColumns,
     getTableSize = () => undefined,
   } = instance;
 
@@ -368,7 +369,7 @@ function useInstance<D extends object>(instance: TableInstance<D>) {
       useMountedMemo(getTableSize, [getTableSize]) || sticky;
     // only change of data should trigger re-render
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    const table = useMemo(renderer, [page, rows]);
+    const table = useMemo(renderer, [page, rows, allColumns]);
 
     useLayoutEffect(() => {
       if (!width || !height) {

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/types/react-table.d.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/types/react-table.d.ts
@@ -36,6 +36,8 @@ import {
   UseSortByState,
   UseTableHooks,
   UseSortByHooks,
+  UseColumnOrderState,
+  UseColumnOrderInstanceProps,
   Renderer,
   HeaderProps,
   TableFooterProps,
@@ -64,6 +66,7 @@ declare module 'react-table' {
       UseRowSelectInstanceProps<D>,
       UseRowStateInstanceProps<D>,
       UseSortByInstanceProps<D>,
+      UseColumnOrderInstanceProps<D>,
       UseStickyInstanceProps {}
 
   export interface TableState<D extends object>
@@ -73,6 +76,7 @@ declare module 'react-table' {
       UsePaginationState<D>,
       UseRowSelectState<D>,
       UseSortByState<D>,
+      UseColumnOrderState<D>,
       UseStickyState {}
 
   // Typing from @types/react-table is incomplete
@@ -82,12 +86,19 @@ declare module 'react-table' {
     onClick?: React.MouseEventHandler;
   }
 
+  interface TableRearrangeColumnsProps {
+    onDragStart: (e: React.DragEvent) => void;
+    onDrop: (e: React.DragEvent) => void;
+  }
+
   export interface ColumnInterface<D extends object>
     extends UseGlobalFiltersColumnOptions<D>,
       UseSortByColumnOptions<D> {
     // must define as a new property because it's not possible to override
     // the existing `Header` renderer option
-    Header?: Renderer<TableSortByToggleProps & HeaderProps<D>>;
+    Header?: Renderer<
+      TableSortByToggleProps & HeaderProps<D> & TableRearrangeColumnsProps
+    >;
     Footer?: Renderer<TableFooterProps<D>>;
   }
 

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { CSSProperties, useCallback, useMemo } from 'react';
+import React, { CSSProperties, useCallback, useMemo, useState } from 'react';
 import {
   ColumnInstance,
   ColumnWithLooseAccessor,
@@ -188,11 +188,15 @@ export default function TableChart<D extends DataRecord = DataRecord>(
     filters,
     sticky = true, // whether to use sticky header
     columnColorFormatters,
+    rearrangeColumns = false,
   } = props;
   const timestampFormatter = useCallback(
     value => getTimeFormatterForGranularity(timeGrain)(value),
     [timeGrain],
   );
+
+  // keep track of whether column order changed, so that column widths can too
+  const [columnOrderToggle, setColumnOrderToggle] = useState(false);
 
   const handleChange = useCallback(
     (filters: { [x: string]: DataRecordValue[] }) => {
@@ -410,7 +414,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
           // render `Cell`. This saves some time for large tables.
           return <td {...cellProps}>{text}</td>;
         },
-        Header: ({ column: col, onClick, style }) => (
+        Header: ({ column: col, onClick, style, onDragStart, onDrop }) => (
           <th
             title="Shift + Click to sort by multiple columns"
             className={[className, col.isSorted ? 'is-sorted' : ''].join(' ')}
@@ -419,6 +423,14 @@ export default function TableChart<D extends DataRecord = DataRecord>(
               ...style,
             }}
             onClick={onClick}
+            data-column-name={col.id}
+            {...(rearrangeColumns && {
+              draggable: 'true',
+              onDragStart,
+              onDragOver: e => e.preventDefault(),
+              onDragEnter: e => e.preventDefault(),
+              onDrop,
+            })}
           >
             {/* can't use `columnWidth &&` because it may also be zero */}
             {config.columnWidth ? (
@@ -466,6 +478,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
       toggleFilter,
       totals,
       columnColorFormatters,
+      columnOrderToggle,
     ],
   );
 
@@ -495,6 +508,8 @@ export default function TableChart<D extends DataRecord = DataRecord>(
         height={height}
         serverPagination={serverPagination}
         onServerPaginationChange={handleServerPaginationChange}
+        onColumnOrderChange={() => setColumnOrderToggle(!columnOrderToggle)}
+        rearrangeColumns={rearrangeColumns}
         // 9 page items in > 340px works well even for 100+ pages
         maxPageItemCount={width > 340 ? 9 : 7}
         noResults={(filter: string) =>

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -188,7 +188,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
     filters,
     sticky = true, // whether to use sticky header
     columnColorFormatters,
-    rearrangeColumns = false,
+    allowRearrangeColumns = false,
   } = props;
   const timestampFormatter = useCallback(
     value => getTimeFormatterForGranularity(timeGrain)(value),
@@ -424,7 +424,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
             }}
             onClick={onClick}
             data-column-name={col.id}
-            {...(rearrangeColumns && {
+            {...(allowRearrangeColumns && {
               draggable: 'true',
               onDragStart,
               onDragOver: e => e.preventDefault(),
@@ -510,7 +510,6 @@ export default function TableChart<D extends DataRecord = DataRecord>(
         serverPagination={serverPagination}
         onServerPaginationChange={handleServerPaginationChange}
         onColumnOrderChange={() => setColumnOrderToggle(!columnOrderToggle)}
-        rearrangeColumns={rearrangeColumns}
         // 9 page items in > 340px works well even for 100+ pages
         maxPageItemCount={width > 340 ? 9 : 7}
         noResults={(filter: string) =>

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -443,12 +443,13 @@ export default function TableChart<D extends DataRecord = DataRecord>(
               />
             ) : null}
             <div
+              data-column-name={col.id}
               css={{
                 display: 'inline-flex',
                 alignItems: 'center',
               }}
             >
-              <span>{label}</span>
+              <span data-column-name={col.id}>{label}</span>
               <SortIcon column={col} />
             </div>
           </th>

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -447,6 +447,20 @@ const config: ControlPanelConfig = {
         ],
         [
           {
+            name: 'rearrange_columns',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Allow columns to be rearranged'),
+              renderTrigger: true,
+              default: false,
+              description: t(
+                'Allow the end user to drag-and-drop the column headers to rearrange them.',
+              ),
+            },
+          },
+        ],
+        [
+          {
             name: 'column_config',
             config: {
               type: 'ColumnConfigControl',

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -447,14 +447,14 @@ const config: ControlPanelConfig = {
         ],
         [
           {
-            name: 'rearrange_columns',
+            name: 'allow_rearrange_columns',
             config: {
               type: 'CheckboxControl',
               label: t('Allow columns to be rearranged'),
               renderTrigger: true,
               default: false,
               description: t(
-                'Allow the end user to drag-and-drop the column headers to rearrange them.',
+                "Allow end user to drag-and-drop column headers to rearrange them. Note their changes won't persist for the next time they open the chart.",
               ),
             },
           },

--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -215,6 +215,7 @@ const transformProps = (
     query_mode: queryMode,
     show_totals: showTotals,
     conditional_formatting: conditionalFormatting,
+    rearrange_columns: rearrangeColumns,
   } = formData;
   const timeGrain = extractTimegrain(formData);
 
@@ -265,6 +266,7 @@ const transformProps = (
     onChangeFilter,
     columnColorFormatters,
     timeGrain,
+    rearrangeColumns,
   };
 };
 

--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -215,7 +215,7 @@ const transformProps = (
     query_mode: queryMode,
     show_totals: showTotals,
     conditional_formatting: conditionalFormatting,
-    rearrange_columns: rearrangeColumns,
+    allow_rearrange_columns: allowRearrangeColumns,
   } = formData;
   const timeGrain = extractTimegrain(formData);
 
@@ -266,7 +266,7 @@ const transformProps = (
     onChangeFilter,
     columnColorFormatters,
     timeGrain,
-    rearrangeColumns,
+    allowRearrangeColumns,
   };
 };
 

--- a/superset-frontend/plugins/plugin-chart-table/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/types.ts
@@ -71,6 +71,7 @@ export type TableChartFormData = QueryFormData & {
   emit_filter?: boolean;
   time_grain_sqla?: TimeGranularity;
   column_config?: Record<string, ColumnConfig>;
+  rearrange_columns?: boolean;
 };
 
 export interface TableChartProps extends ChartProps {
@@ -109,6 +110,7 @@ export interface TableChartTransformedProps<D extends DataRecord = DataRecord> {
   emitFilter?: boolean;
   onChangeFilter?: ChartProps['hooks']['onAddFilter'];
   columnColorFormatters?: ColorFormatters;
+  rearrangeColumns?: boolean;
 }
 
 export default {};

--- a/superset-frontend/plugins/plugin-chart-table/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/types.ts
@@ -71,7 +71,7 @@ export type TableChartFormData = QueryFormData & {
   emit_filter?: boolean;
   time_grain_sqla?: TimeGranularity;
   column_config?: Record<string, ColumnConfig>;
-  rearrange_columns?: boolean;
+  allow_rearrange_columns?: boolean;
 };
 
 export interface TableChartProps extends ChartProps {
@@ -110,7 +110,7 @@ export interface TableChartTransformedProps<D extends DataRecord = DataRecord> {
   emitFilter?: boolean;
   onChangeFilter?: ChartProps['hooks']['onAddFilter'];
   columnColorFormatters?: ColorFormatters;
-  rearrangeColumns?: boolean;
+  allowRearrangeColumns?: boolean;
 }
 
 export default {};


### PR DESCRIPTION
Bringing this over from superset-ui (some discussion was on the old PR)
https://github.com/apache-superset/superset-ui/pull/1423

### SUMMARY
Add the ability for the end user to drag and drop columns for a table visualization

Table designer can enable column rearrangement in the config options when building the table. Then, user can drag columns around

These are **volatile changes**, so when the browser is refreshed, the column order goes back to default. Demo is in the chart edit page, which is just for simple demonstration purposes. This is intended for the end user to be allowed to rearrange the columns.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**OFF**
![dnd_off](https://user-images.githubusercontent.com/70416691/160242444-fae73b3d-315c-4efd-b225-21f80031e064.gif)

**ON**
![dnd_on](https://user-images.githubusercontent.com/70416691/160242449-3666a274-bf06-455c-8908-751d7510f5fb.gif)


### ADDITIONAL INFORMATION
- [x] Has associated issue: #19380 
- [x] Fixes #19380 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
