### PR TITLE
feat: linear imputation in Resample

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/sections/advancedAnalytics.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/sections/advancedAnalytics.tsx
@@ -170,7 +170,7 @@ export const advancedAnalyticsControls: ControlPanelSectionConfig = {
           choices: [
             ['asfreq', 'Null imputation'],
             ['zerofill', 'Zero imputation'],
-            ['linear', 'Linear imputation'],
+            ['linear', 'Linear interpolation'],
             ['ffill', 'Forward values'],
             ['bfill', 'Backward values'],
             ['median', 'Median values'],

--- a/superset-frontend/packages/superset-ui-chart-controls/src/sections/advancedAnalytics.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/sections/advancedAnalytics.tsx
@@ -170,6 +170,7 @@ export const advancedAnalyticsControls: ControlPanelSectionConfig = {
           choices: [
             ['asfreq', 'Null imputation'],
             ['zerofill', 'Zero imputation'],
+            ['linear', 'Linear imputation'],
             ['ffill', 'Forward values'],
             ['bfill', 'Backward values'],
             ['median', 'Median values'],

--- a/superset/utils/pandas_postprocessing/resample.py
+++ b/superset/utils/pandas_postprocessing/resample.py
@@ -20,6 +20,7 @@ import pandas as pd
 from flask_babel import gettext as _
 
 from superset.exceptions import InvalidPostProcessingError
+from superset.utils.pandas_postprocessing.utils import RESAMPLE_METHOD
 
 
 def resample(
@@ -40,9 +41,15 @@ def resample(
     """
     if not isinstance(df.index, pd.DatetimeIndex):
         raise InvalidPostProcessingError(_("Resample operation requires DatetimeIndex"))
+    if method not in RESAMPLE_METHOD:
+        raise InvalidPostProcessingError(
+            _("Resample method should in ") + ", ".join(RESAMPLE_METHOD) + "."
+        )
 
     if method == "asfreq" and fill_value is not None:
         _df = df.resample(rule).asfreq(fill_value=fill_value)
+    elif method == "linear":
+        _df = df.resample(rule).interpolate()
     else:
         _df = getattr(df.resample(rule), method)()
     return _df

--- a/superset/utils/pandas_postprocessing/utils.py
+++ b/superset/utils/pandas_postprocessing/utils.py
@@ -92,9 +92,7 @@ PROPHET_TIME_GRAIN_MAP = {
     "P1W/1970-01-04T00:00:00Z": "W",
 }
 
-RESAMPLE_METHOD = tuple(
-    ["asfreq", "bfill", "ffill", "linear", "median", "mean", "sum",]
-)
+RESAMPLE_METHOD = ("asfreq", "bfill", "ffill", "linear", "median", "mean", "sum")
 
 FLAT_COLUMN_SEPARATOR = ", "
 

--- a/superset/utils/pandas_postprocessing/utils.py
+++ b/superset/utils/pandas_postprocessing/utils.py
@@ -92,6 +92,10 @@ PROPHET_TIME_GRAIN_MAP = {
     "P1W/1970-01-04T00:00:00Z": "W",
 }
 
+RESAMPLE_METHOD = tuple(
+    ["asfreq", "bfill", "ffill", "linear", "median", "mean", "sum",]
+)
+
 FLAT_COLUMN_SEPARATOR = ", "
 
 


### PR DESCRIPTION
### SUMMARY
Adding a new `resample method`: linear imputation


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. download [DailyDelhiClimateTrain.csv](https://www.kaggle.com/datasets/sumanthvrao/daily-climate-time-series-data) and create a new dataset in your local. (Use PostgreSQL as current testing)
2. open explore page and select DailyDelhiClimateTrain dataset
3. change viz type to `Bar Chart`, notice that you should pick up echart version
4. drag date in X-Axis
5. set time range from `2014-12-10` to `2014-12-20`
6. set metric to `MAX(meantemp)::INTEGER`
7. set filter to `date not in ('2014-12-11'::TIMESTAMP, '2014-12-12'::TIMESTAMP)`
8. you get a bar chart without data for `12-11 and 12-12`.
![image](https://user-images.githubusercontent.com/2016594/160368557-8e1e330b-5084-4475-bc85-456612bebf6b.png)

9. select `1 calendar day frequency` and `Linear imputation` in Advanced analytics panel, then click `Run`. 
![image](https://user-images.githubusercontent.com/2016594/160368859-b645e423-d424-4226-b3ef-22ac53776c11.png)



### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
