### PR TITLE
fix: native filter dropdown not attached to parent node

### DIFF
--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -306,7 +306,9 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
           value={filterState.value || []}
           disabled={isDisabled}
           getPopupContainer={
-            showOverflow ? () => parentRef?.current : undefined
+            showOverflow
+              ? () => parentRef?.current
+              : (trigger: HTMLElement) => trigger?.parentNode
           }
           showSearch={showSearch}
           mode={multiSelect ? 'multiple' : 'single'}


### PR DESCRIPTION
### SUMMARY
This PR addresses the issue mentioned in https://github.com/apache/superset/pull/18102
By attaching the select popover to the parent node, we ensure it's tied to the left side content and thus scroll with it.
We can also leverage the Select's own calculations for top/bottom placement.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/17252075/160455163-dfcd1b43-4678-49a1-8a4d-6c064cf3ad21.mov

After:

https://user-images.githubusercontent.com/17252075/160455012-13471e18-62ac-4b9e-b54f-c12741841bd6.mov

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
