### PR TITLE
perf(alembic): paginize db migration for new dataset models

### DIFF
--- a/superset/migrations/versions/b8d3a24d9131_new_dataset_models.py
+++ b/superset/migrations/versions/b8d3a24d9131_new_dataset_models.py
@@ -370,7 +370,9 @@ new_tables = [
             "uuid", UUIDType(binary=True), primary_key=False, default=uuid4, unique=True
         ),
         # Column
-        sa.Column("id", sa.INTEGER(), autoincrement=True, nullable=False),
+        sa.Column(
+            "id", sa.INTEGER(), primary_key=True, autoincrement=True, nullable=False
+        ),
         sa.Column("name", sa.TEXT(), nullable=False),
         sa.Column("type", sa.TEXT(), nullable=False),
         sa.Column("expression", sa.TEXT(), nullable=False),
@@ -391,7 +393,6 @@ new_tables = [
             server_default=sa.false(),
         ),
         sa.Column("external_url", sa.Text(), nullable=True),
-        sa.PrimaryKeyConstraint("id"),
     ),
     (
         "sl_tables",
@@ -407,8 +408,16 @@ new_tables = [
             "uuid", UUIDType(binary=True), primary_key=False, default=uuid4, unique=True
         ),
         # Table
-        sa.Column("id", sa.INTEGER(), autoincrement=True, nullable=False),
-        sa.Column("database_id", sa.INTEGER(), autoincrement=False, nullable=False),
+        sa.Column(
+            "id", sa.INTEGER(), primary_key=True, autoincrement=True, nullable=False
+        ),
+        sa.Column(
+            "database_id",
+            sa.INTEGER(),
+            sa.ForeignKey("dbs.id"),
+            autoincrement=False,
+            nullable=False,
+        ),
         sa.Column("catalog", sa.TEXT(), nullable=True),
         sa.Column("schema", sa.TEXT(), nullable=True),
         sa.Column("name", sa.TEXT(), nullable=False),
@@ -419,8 +428,6 @@ new_tables = [
             server_default=sa.false(),
         ),
         sa.Column("external_url", sa.Text(), nullable=True),
-        sa.ForeignKeyConstraint(["database_id"], ["dbs.id"], name="sl_tables_ibfk_1"),
-        sa.PrimaryKeyConstraint("id"),
     ),
     (
         "sl_datasets",
@@ -436,8 +443,16 @@ new_tables = [
             "uuid", UUIDType(binary=True), primary_key=False, default=uuid4, unique=True
         ),
         # Dataset
-        sa.Column("id", sa.INTEGER(), autoincrement=True, nullable=False),
-        sa.Column("sqlatable_id", sa.INTEGER(), unique=True, nullable=True),
+        sa.Column(
+            "id", sa.INTEGER(), primary_key=True, autoincrement=True, nullable=False
+        ),
+        sa.Column(
+            "sqlatable_id",
+            sa.INTEGER(),
+            sa.ForeignKey("tables.id"),
+            unique=True,
+            nullable=True,
+        ),
         sa.Column("name", sa.TEXT(), nullable=False),
         sa.Column("expression", sa.TEXT(), nullable=False),
         sa.Column("is_physical", sa.BOOLEAN(), nullable=False, default=False),
@@ -448,40 +463,57 @@ new_tables = [
             server_default=sa.false(),
         ),
         sa.Column("external_url", sa.Text(), nullable=True),
-        sa.PrimaryKeyConstraint("id"),
     ),
     # Relationships...
     (
         "sl_table_columns",
-        sa.Column("table_id", sa.INTEGER(), autoincrement=False, nullable=False),
-        sa.Column("column_id", sa.INTEGER(), autoincrement=False, nullable=False),
-        sa.ForeignKeyConstraint(
-            ["column_id"], ["sl_columns.id"], name="sl_table_columns_ibfk_2"
+        sa.Column(
+            "table_id",
+            sa.INTEGER(),
+            sa.ForeignKey("sl_tables.id"),
+            autoincrement=False,
+            nullable=False,
         ),
-        sa.ForeignKeyConstraint(
-            ["table_id"], ["sl_tables.id"], name="sl_table_columns_ibfk_1"
+        sa.Column(
+            "column_id",
+            sa.INTEGER(),
+            sa.ForeignKey("sl_columns.id"),
+            autoincrement=False,
+            nullable=False,
         ),
     ),
     (
         "sl_dataset_columns",
-        sa.Column("dataset_id", sa.INTEGER(), autoincrement=False, nullable=False),
-        sa.Column("column_id", sa.INTEGER(), autoincrement=False, nullable=False),
-        sa.ForeignKeyConstraint(
-            ["column_id"], ["sl_columns.id"], name="sl_dataset_columns_ibfk_2"
+        sa.Column(
+            "dataset_id",
+            sa.INTEGER(),
+            sa.ForeignKey("sl_datasets.id"),
+            autoincrement=False,
+            nullable=False,
         ),
-        sa.ForeignKeyConstraint(
-            ["dataset_id"], ["sl_datasets.id"], name="sl_dataset_columns_ibfk_1"
+        sa.Column(
+            "column_id",
+            sa.INTEGER(),
+            sa.ForeignKey("sl_columns.id"),
+            autoincrement=False,
+            nullable=False,
         ),
     ),
     (
         "sl_dataset_tables",
-        sa.Column("dataset_id", sa.INTEGER(), autoincrement=False, nullable=False),
-        sa.Column("table_id", sa.INTEGER(), autoincrement=False, nullable=False),
-        sa.ForeignKeyConstraint(
-            ["dataset_id"], ["sl_datasets.id"], name="sl_dataset_tables_ibfk_1"
+        sa.Column(
+            "dataset_id",
+            sa.INTEGER(),
+            sa.ForeignKey("sl_datasets.id"),
+            autoincrement=False,
+            nullable=False,
         ),
-        sa.ForeignKeyConstraint(
-            ["table_id"], ["sl_tables.id"], name="sl_dataset_tables_ibfk_2"
+        sa.Column(
+            "table_id",
+            sa.INTEGER(),
+            sa.ForeignKey("sl_tables.id"),
+            autoincrement=False,
+            nullable=False,
         ),
     ),
 ]


### PR DESCRIPTION
### SUMMARY

We run into some scalability issues with the db migration script for [SIP-68](https://github.com/apache/superset/issues/14909) (PR #17543). For context, we have more than 165k datasets, 1.9 million columns and 345k metrics. Loading all of them in memory and convert them to the new tables in one giant commit, like current implementation does, is impractical. It'd kill the Python process if not the db connection.

This PR tries to optimize this migration script by:
1. **Adding pagination:** instead of migrate all datasets & columns in one commit, I added a manual pagination to fetch datasets 100 at a time.  SQLA streaming with [yield_per](https://docs.sqlalchemy.org/en/14/orm/query.html#sqlalchemy.orm.Query.yield_per) may also be an option but it's more complicated when read and write are interlaced with each other---SQLA will complain `iter_next` is impossible because entities have changed.
2. **Committing changes in small batches:** use [autocommit_block()](https://alembic.sqlalchemy.org/en/latest/api/runtime.html#alembic.runtime.migration.MigrationContext.autocommit_block) to move write operations for each dataset out of the [per-migration transaction](https://github.com/apache/superset/blob/b3db6140c88106fedebe91db0ca817eca4234dc8/superset/migrations/env.py#L117) so new entities are written to the database faster. This avoids keeping all loaded and created entities in memory, either on the Python side or in db buffer. I'm placing the autocommit block around each dataset instead of each page---i.e., writing the dataset and all related columns for each SqlTable in one transaction instead of writing all datasets and all columns from one page of SqlTables in one transaction, as this is tested to be the fastest configuration. Also tested different page sizes and 20 seemed to be working the best. 2,000 datasets can be converted in under 3 minutes. The average memory usage is less than 350MB while writing is in progress.
3. **Use eager loading:** added `lazy="selectin"` to enable [`SELECT IN`](https://docs.sqlalchemy.org/en/14/tutorial/orm_related_objects.html?highlight=selectin#selectin-load) eager loading that pulls related data in one SQL statement instead of three.

After this optimization, the migration for our 165k datasets took about **7 hours** to finish. Still slow, but better than not able to finish at all. Ideally, in the future, for large full-table migrations like this, the script should be written with raw SQL as much as possible for each dialect we support. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<img width="818" alt="image" src="https://user-images.githubusercontent.com/335541/160579397-4bbabd92-382d-4759-b61b-7fec83b67d1b.png">

### TESTING INSTRUCTIONS

- Tested locally with our large internal database.
- Added following filters [here](https://github.com/apache/superset/blob/b8e1999b943b121259f56f53e3906e59721159ea/superset/migrations/versions/b8d3a24d9131_new_dataset_models.py#L513) to test db records generated for specific data tables:
  ```python
            .filter(
                or_(
                    SqlaTable.table_name == "my_table_name",
                    SqlaTable.sql.like("%my_table_name%"),
                )
            )
  ```
- Verified values of created entities in MySQL shell via selected SELECT queries:
   ```SQL
    SELECT `schema`, `name`, `is_physical` from sl_datasets limit 10;
    SELECT count(*) from sl_columns;
   ```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
