### PR TITLE
fix(dashboard list): do not show favorite star for anonymous users  #18210

### DIFF
--- a/superset-frontend/src/components/ListViewCard/index.tsx
+++ b/superset-frontend/src/components/ListViewCard/index.tsx
@@ -26,7 +26,7 @@ import CertifiedBadge from '../CertifiedBadge';
 const ActionsWrapper = styled.div`
   width: 64px;
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
 `;
 
 const StyledCard = styled(AntdCard)`

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardCard.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardCard.tsx
@@ -44,7 +44,7 @@ interface DashboardCardProps {
   saveFavoriteStatus: (id: number, isStarred: boolean) => void;
   favoriteStatus: boolean;
   dashboardFilter?: string;
-  userId?: number;
+  userId?: string | number;
   showThumbnails?: boolean;
   handleBulkDashboardExport: (dashboardsToExport: Dashboard[]) => void;
 }
@@ -171,11 +171,13 @@ function DashboardCard({
               e.preventDefault();
             }}
           >
-            <FaveStar
-              itemId={dashboard.id}
-              saveFaveStar={saveFavoriteStatus}
-              isStarred={favoriteStatus}
-            />
+            {userId && (
+              <FaveStar
+                itemId={dashboard.id}
+                saveFaveStar={saveFavoriteStatus}
+                isStarred={favoriteStatus}
+              />
+            )}
             <AntdDropdown overlay={menu}>
               <Icons.MoreVert iconColor={theme.colors.grayscale.base} />
             </AntdDropdown>

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardList.test.jsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardList.test.jsx
@@ -36,6 +36,9 @@ import DashboardList from 'src/views/CRUD/dashboard/DashboardList';
 import ListView from 'src/components/ListView';
 import ListViewCard from 'src/components/ListViewCard';
 import PropertiesModal from 'src/dashboard/components/PropertiesModal';
+import FaveStar from 'src/components/FaveStar';
+import TableCollection from 'src/components/TableCollection';
+import CardCollection from 'src/components/ListView/CardCollection';
 
 // store needed for withToasts(DashboardTable)
 const mockStore = configureStore([thunk]);
@@ -104,15 +107,18 @@ describe('DashboardList', () => {
   });
 
   const mockedProps = {};
-  const wrapper = mount(
-    <MemoryRouter>
-      <Provider store={store}>
-        <DashboardList {...mockedProps} user={mockUser} />
-      </Provider>
-    </MemoryRouter>,
-  );
+  let wrapper;
 
   beforeAll(async () => {
+    fetchMock.resetHistory();
+    wrapper = mount(
+      <MemoryRouter>
+        <Provider store={store}>
+          <DashboardList {...mockedProps} user={mockUser} />
+        </Provider>
+      </MemoryRouter>,
+    );
+
     await waitForComponentToPaint(wrapper);
   });
 
@@ -178,6 +184,18 @@ describe('DashboardList', () => {
     await waitForComponentToPaint(wrapper);
     expect(wrapper.find(ConfirmStatusChange)).toExist();
   });
+
+  it('renders the Favorite Star column in list view for logged in user', async () => {
+    wrapper.find('[aria-label="list-view"]').first().simulate('click');
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find(TableCollection).find(FaveStar)).toExist();
+  });
+
+  it('renders the Favorite Star in card view for logged in user', async () => {
+    wrapper.find('[aria-label="card-view"]').first().simulate('click');
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find(CardCollection).find(FaveStar)).toExist();
+  });
 });
 
 describe('RTL', () => {
@@ -220,5 +238,41 @@ describe('RTL', () => {
     });
 
     expect(importTooltip).toBeInTheDocument();
+  });
+});
+
+describe('DashboardList - anonymous view', () => {
+  const mockedProps = {};
+  const mockUserLoggedOut = {};
+  let wrapper;
+
+  beforeAll(async () => {
+    fetchMock.resetHistory();
+    wrapper = mount(
+      <MemoryRouter>
+        <Provider store={store}>
+          <DashboardList {...mockedProps} user={mockUserLoggedOut} />
+        </Provider>
+      </MemoryRouter>,
+    );
+
+    await waitForComponentToPaint(wrapper);
+  });
+
+  afterAll(() => {
+    cleanup();
+    fetch.resetMocks();
+  });
+
+  it('does not render the Favorite Star column in list view for anonymous user', async () => {
+    wrapper.find('[aria-label="list-view"]').first().simulate('click');
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find(TableCollection).find(FaveStar)).not.toExist();
+  });
+
+  it('does not render the Favorite Star in card view for anonymous user', async () => {
+    wrapper.find('[aria-label="card-view"]').first().simulate('click');
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find(CardCollection).find(FaveStar)).not.toExist();
   });
 });

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { styled, SupersetClient, t } from '@superset-ui/core';
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import rison from 'rison';
 import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
@@ -95,7 +95,11 @@ const Actions = styled.div`
 `;
 
 function DashboardList(props: DashboardListProps) {
-  const { addDangerToast, addSuccessToast } = props;
+  const {
+    addDangerToast,
+    addSuccessToast,
+    user: { userId },
+  } = props;
 
   const {
     state: {
@@ -143,7 +147,6 @@ function DashboardList(props: DashboardListProps) {
     addSuccessToast(t('Dashboard imported'));
   };
 
-  const { userId } = props.user;
   // TODO: Fix usage of localStorage keying on the user id
   const userKey = dangerouslyGetItemDoNotUse(userId?.toString(), null);
 
@@ -232,27 +235,25 @@ function DashboardList(props: DashboardListProps) {
 
   const columns = useMemo(
     () => [
-      ...(props.user.userId
-        ? [
-            {
-              Cell: ({
-                row: {
-                  original: { id },
-                },
-              }: any) => (
-                <FaveStar
-                  itemId={id}
-                  saveFaveStar={saveFavoriteStatus}
-                  isStarred={favoriteStatus[id]}
-                />
-              ),
-              Header: '',
-              id: 'id',
-              disableSortBy: true,
-              size: 'xs',
-            },
-          ]
-        : []),
+      {
+        Cell: ({
+          row: {
+            original: { id },
+          },
+        }: any) =>
+          userId ? (
+            <FaveStar
+              itemId={id}
+              saveFaveStar={saveFavoriteStatus}
+              isStarred={favoriteStatus[id]}
+            />
+          ) : null,
+        Header: '',
+        id: 'id',
+        disableSortBy: true,
+        size: 'xs',
+        hidden: !userId,
+      },
       {
         Cell: ({
           row: {
@@ -422,10 +423,15 @@ function DashboardList(props: DashboardListProps) {
       },
     ],
     [
+      userId,
       canEdit,
       canDelete,
       canExport,
-      ...(props.user.userId ? [favoriteStatus] : []),
+      saveFavoriteStatus,
+      favoriteStatus,
+      refreshData,
+      addSuccessToast,
+      addDangerToast,
     ],
   );
 
@@ -500,7 +506,7 @@ function DashboardList(props: DashboardListProps) {
           { label: t('Draft'), value: false },
         ],
       },
-      ...(props.user.userId ? [favoritesFilter] : []),
+      ...(userId ? [favoritesFilter] : []),
       {
         Header: t('Certified'),
         id: 'id',
@@ -544,8 +550,8 @@ function DashboardList(props: DashboardListProps) {
     },
   ];
 
-  function renderCard(dashboard: Dashboard) {
-    return (
+  const renderCard = useCallback(
+    (dashboard: Dashboard) => (
       <DashboardCard
         dashboard={dashboard}
         hasPerm={hasPerm}
@@ -556,6 +562,7 @@ function DashboardList(props: DashboardListProps) {
             ? userKey.thumbnails
             : isFeatureEnabled(FeatureFlag.THUMBNAILS)
         }
+        userId={userId}
         loading={loading}
         addDangerToast={addDangerToast}
         addSuccessToast={addSuccessToast}
@@ -564,8 +571,20 @@ function DashboardList(props: DashboardListProps) {
         favoriteStatus={favoriteStatus[dashboard.id]}
         handleBulkDashboardExport={handleBulkDashboardExport}
       />
-    );
-  }
+    ),
+    [
+      addDangerToast,
+      addSuccessToast,
+      bulkSelectEnabled,
+      favoriteStatus,
+      hasPerm,
+      loading,
+      userId,
+      refreshData,
+      saveFavoriteStatus,
+      userKey,
+    ],
+  );
 
   const subMenuButtons: SubMenuProps['buttons'] = [];
   if (canDelete || canExport) {

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
@@ -241,13 +241,13 @@ function DashboardList(props: DashboardListProps) {
             original: { id },
           },
         }: any) =>
-          userId ? (
+          userId && (
             <FaveStar
               itemId={id}
               saveFaveStar={saveFavoriteStatus}
               isStarred={favoriteStatus[id]}
             />
-          ) : null,
+          ),
         Header: '',
         id: 'id',
         disableSortBy: true,

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -64,57 +64,60 @@ import { Dashboard, Filters } from './types';
   risonRef.next_id = new RegExp(idrx, 'g');
 })();
 
-const createFetchResourceMethod = (method: string) => (
-  resource: string,
-  relation: string,
-  handleError: (error: Response) => void,
-  user?: { userId: string | number; firstName: string; lastName: string },
-) => async (filterValue = '', page: number, pageSize: number) => {
-  const resourceEndpoint = `/api/v1/${resource}/${method}/${relation}`;
-  const queryParams = rison.encode_uri({
-    filter: filterValue,
-    page,
-    page_size: pageSize,
-  });
-  const { json = {} } = await SupersetClient.get({
-    endpoint: `${resourceEndpoint}?q=${queryParams}`,
-  });
+const createFetchResourceMethod =
+  (method: string) =>
+  (
+    resource: string,
+    relation: string,
+    handleError: (error: Response) => void,
+    user?: { userId: string | number; firstName: string; lastName: string },
+  ) =>
+  async (filterValue = '', page: number, pageSize: number) => {
+    const resourceEndpoint = `/api/v1/${resource}/${method}/${relation}`;
+    const queryParams = rison.encode_uri({
+      filter: filterValue,
+      page,
+      page_size: pageSize,
+    });
+    const { json = {} } = await SupersetClient.get({
+      endpoint: `${resourceEndpoint}?q=${queryParams}`,
+    });
 
-  let fetchedLoggedUser = false;
-  const loggedUser = user
-    ? {
-        label: `${user.firstName} ${user.lastName}`,
-        value: user.userId,
-      }
-    : undefined;
+    let fetchedLoggedUser = false;
+    const loggedUser = user
+      ? {
+          label: `${user.firstName} ${user.lastName}`,
+          value: user.userId,
+        }
+      : undefined;
 
-  const data: { label: string; value: string | number }[] = [];
-  json?.result?.forEach(
-    ({ text, value }: { text: string; value: string | number }) => {
-      if (
-        loggedUser &&
-        value === loggedUser.value &&
-        text === loggedUser.label
-      ) {
-        fetchedLoggedUser = true;
-      } else {
-        data.push({
-          label: text,
-          value,
-        });
-      }
-    },
-  );
+    const data: { label: string; value: string | number }[] = [];
+    json?.result?.forEach(
+      ({ text, value }: { text: string; value: string | number }) => {
+        if (
+          loggedUser &&
+          value === loggedUser.value &&
+          text === loggedUser.label
+        ) {
+          fetchedLoggedUser = true;
+        } else {
+          data.push({
+            label: text,
+            value,
+          });
+        }
+      },
+    );
 
-  if (loggedUser && (!filterValue || fetchedLoggedUser)) {
-    data.unshift(loggedUser);
-  }
+    if (loggedUser && (!filterValue || fetchedLoggedUser)) {
+      data.unshift(loggedUser);
+    }
 
-  return {
-    data,
-    totalCount: json?.count,
+    return {
+      data,
+      totalCount: json?.count,
+    };
   };
-};
 
 export const PAGE_SIZE = 5;
 const getParams = (filters?: Array<Filters>) => {

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -64,60 +64,57 @@ import { Dashboard, Filters } from './types';
   risonRef.next_id = new RegExp(idrx, 'g');
 })();
 
-const createFetchResourceMethod =
-  (method: string) =>
-  (
-    resource: string,
-    relation: string,
-    handleError: (error: Response) => void,
-    user?: { userId: string | number; firstName: string; lastName: string },
-  ) =>
-  async (filterValue = '', page: number, pageSize: number) => {
-    const resourceEndpoint = `/api/v1/${resource}/${method}/${relation}`;
-    const queryParams = rison.encode_uri({
-      filter: filterValue,
-      page,
-      page_size: pageSize,
-    });
-    const { json = {} } = await SupersetClient.get({
-      endpoint: `${resourceEndpoint}?q=${queryParams}`,
-    });
+const createFetchResourceMethod = (method: string) => (
+  resource: string,
+  relation: string,
+  handleError: (error: Response) => void,
+  user?: { userId: string | number; firstName: string; lastName: string },
+) => async (filterValue = '', page: number, pageSize: number) => {
+  const resourceEndpoint = `/api/v1/${resource}/${method}/${relation}`;
+  const queryParams = rison.encode_uri({
+    filter: filterValue,
+    page,
+    page_size: pageSize,
+  });
+  const { json = {} } = await SupersetClient.get({
+    endpoint: `${resourceEndpoint}?q=${queryParams}`,
+  });
 
-    let fetchedLoggedUser = false;
-    const loggedUser = user
-      ? {
-          label: `${user.firstName} ${user.lastName}`,
-          value: user.userId,
-        }
-      : undefined;
+  let fetchedLoggedUser = false;
+  const loggedUser = user
+    ? {
+        label: `${user.firstName} ${user.lastName}`,
+        value: user.userId,
+      }
+    : undefined;
 
-    const data: { label: string; value: string | number }[] = [];
-    json?.result?.forEach(
-      ({ text, value }: { text: string; value: string | number }) => {
-        if (
-          loggedUser &&
-          value === loggedUser.value &&
-          text === loggedUser.label
-        ) {
-          fetchedLoggedUser = true;
-        } else {
-          data.push({
-            label: text,
-            value,
-          });
-        }
-      },
-    );
+  const data: { label: string; value: string | number }[] = [];
+  json?.result?.forEach(
+    ({ text, value }: { text: string; value: string | number }) => {
+      if (
+        loggedUser &&
+        value === loggedUser.value &&
+        text === loggedUser.label
+      ) {
+        fetchedLoggedUser = true;
+      } else {
+        data.push({
+          label: text,
+          value,
+        });
+      }
+    },
+  );
 
-    if (loggedUser && (!filterValue || fetchedLoggedUser)) {
-      data.unshift(loggedUser);
-    }
+  if (loggedUser && (!filterValue || fetchedLoggedUser)) {
+    data.unshift(loggedUser);
+  }
 
-    return {
-      data,
-      totalCount: json?.count,
-    };
+  return {
+    data,
+    totalCount: json?.count,
   };
+};
 
 export const PAGE_SIZE = 5;
 const getParams = (filters?: Array<Filters>) => {
@@ -285,7 +282,7 @@ export function handleDashboardDelete(
   addSuccessToast: (arg0: string) => void,
   addDangerToast: (arg0: string) => void,
   dashboardFilter?: string,
-  userId?: number,
+  userId?: string | number,
 ) {
   return SupersetClient.delete({
     endpoint: `/api/v1/dashboard/${id}`,


### PR DESCRIPTION
### SUMMARY
A previous commit removed the `FaveStar` component and the `id` column with it from the dashboards list view for anonymous users. This broke the `CERTIFIED` filter because it also depends on the `id` column.
This PR re-adds the id column, but removes the favorite star and hides the column if the user is not logged in. Also removing the stars from the `DashboardCard` component if not applicable.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
#### Before ####
Anonymous user, list/card view:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/6893357/160627257-1486fe28-63d5-4b43-93d7-7e925d16cbb2.png">

Logged in user, dashboard (*for reference, not supposed to change*):
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/6893357/160627067-9e791ee9-ec05-43ba-9fcd-6c8ad43212de.png">

Logged in user, list view (*for reference, not supposed to change*):
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/6893357/160627128-0f1e0547-d5b6-4cf8-9250-78dc4e351141.png">

Logged in user, card view (*for reference, not supposed to change*):
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/6893357/160627181-d33b4712-9445-44a6-a0e9-fe819f1e1279.png">

#### After ####
Anonymous user, list view:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/6893357/160624102-95c050ae-b702-43b7-8981-c9250ef0786b.png">

Anonymous user, card view:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/6893357/160624177-51f2904e-57d8-462f-85b4-e432fdbd7e1a.png">

Logged in user, dashboard (*not supposed to change visually, but screenshot is included because some components are modified*):
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/6893357/160624411-a1af82b0-cbb7-41ec-82e1-7a53ff85dcd2.png">

Logged in user, list view (*not supposed to change visually, but screenshot is included because some components are modified*):
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/6893357/160624579-d6e3713e-d565-45c3-8cdf-2ee9441fb8b7.png">

Logged in user, card view (*not supposed to change visually, but screenshot is included because some components are modified*):
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/6893357/160624819-4b42afbc-5c24-4dea-8f84-24a7dd9acd6e.png">


### TESTING INSTRUCTIONS
Automated tests added for both logged in/anonymous cases for table and card view.

For manual testing add 
```python
PUBLIC_ROLE_LIKE = "Gamma"
```
to `docker/pythonpath_dev/superset_config.py` and run `docker compose up`.

Log in as admin and add the `all datasource access on all_datasource_access` and `all database access on all_database_access` permissions to the public role.

After logging out, navigate to [http://localhost:3000/superset/dashboards/list](http://localhost:3000/superset/dashboards/list) and the dashboard list should open without an error and the CERTIFIED filter should work and the favorite star should not be present on the list view nor the table view. When logging in, the favorite star should be there.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #18210
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
