### PR TITLE
fix: sql lab ctrl t behaved differently from clicking

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -75,6 +75,7 @@ import ShareSqlLabQuery from '../ShareSqlLabQuery';
 import SqlEditorLeftBar from '../SqlEditorLeftBar';
 import AceEditorWrapper from '../AceEditorWrapper';
 import RunQueryActionButton from '../RunQueryActionButton';
+import { newQueryTabName } from '../../utils/newQueryTabName';
 
 const LIMIT_DROPDOWN = [10, 100, 1000, 10000, 100000];
 const SQL_EDITOR_PADDING = 10;
@@ -333,10 +334,10 @@ class SqlEditor extends React.PureComponent {
         key: userOS === 'Windows' ? 'ctrl+q' : 'ctrl+t',
         descr: t('New tab'),
         func: () => {
+          const title = newQueryTabName(this.props.queryEditors || []);
           this.props.addQueryEditor({
             ...this.props.queryEditor,
-            title: t('Untitled query'),
-            sql: '',
+            title,
           });
         },
       },
@@ -804,13 +805,12 @@ class SqlEditor extends React.PureComponent {
 SqlEditor.defaultProps = defaultProps;
 SqlEditor.propTypes = propTypes;
 
-function mapStateToProps(state, props) {
-  const { sqlLab } = state;
+function mapStateToProps({ sqlLab }, props) {
   const queryEditor = sqlLab.queryEditors.find(
     editor => editor.id === props.queryEditorId,
   );
 
-  return { sqlLab, ...props, queryEditor };
+  return { sqlLab, ...props, queryEditor, queryEditors: sqlLab.queryEditors };
 }
 
 function mapDispatchToProps(dispatch) {

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx
@@ -29,9 +29,9 @@ import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 import { areArraysShallowEqual } from 'src/reduxUtils';
 import { Tooltip } from 'src/components/Tooltip';
 import { detectOS } from 'src/utils/common';
-import { newQueryTabName } from '../../utils/newQueryTabName';
 import * as Actions from 'src/SqlLab/actions/sqlLab';
 import { EmptyStateBig } from 'src/components/EmptyState';
+import { newQueryTabName } from '../../utils/newQueryTabName';
 import SqlEditor from '../SqlEditor';
 import TabStatusIcon from '../TabStatusIcon';
 

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx
@@ -418,7 +418,6 @@ class TabbedSqlEditors extends React.PureComponent {
           }
         >
           <i data-test="add-tab-icon" className="fa fa-plus-circle" />
-          Wow!
         </Tooltip>
       </StyledTab>
     );
@@ -461,7 +460,6 @@ class TabbedSqlEditors extends React.PureComponent {
             }
           >
             <i data-test="add-tab-icon" className="fa fa-plus-circle" />
-            Here!
           </Tooltip>
         }
       >

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx
@@ -29,6 +29,7 @@ import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 import { areArraysShallowEqual } from 'src/reduxUtils';
 import { Tooltip } from 'src/components/Tooltip';
 import { detectOS } from 'src/utils/common';
+import { newQueryTabName } from '../../utils/newQueryTabName';
 import * as Actions from 'src/SqlLab/actions/sqlLab';
 import { EmptyStateBig } from 'src/components/EmptyState';
 import SqlEditor from '../SqlEditor';
@@ -262,19 +263,7 @@ class TabbedSqlEditors extends React.PureComponent {
           '-- Note: Unless you save your query, these tabs will NOT persist if you clear your cookies or change browsers.\n\n',
         );
 
-    let newTitle = 'Untitled Query 1';
-
-    if (this.props.queryEditors.length > 0) {
-      const untitledQueryNumbers = this.props.queryEditors
-        .filter(x => x.title.match(/^Untitled Query (\d+)$/))
-        .map(x => x.title.replace('Untitled Query ', ''));
-      if (untitledQueryNumbers.length > 0) {
-        // When there are query tabs open, and at least one is called "Untitled Query #"
-        // Where # is a valid number
-        const largestNumber = Math.max.apply(null, untitledQueryNumbers);
-        newTitle = t('Untitled Query %s', largestNumber + 1);
-      }
-    }
+    const newTitle = newQueryTabName(this.props.queryEditors || []);
 
     const qe = {
       title: newTitle,
@@ -429,6 +418,7 @@ class TabbedSqlEditors extends React.PureComponent {
           }
         >
           <i data-test="add-tab-icon" className="fa fa-plus-circle" />
+          Wow!
         </Tooltip>
       </StyledTab>
     );
@@ -471,6 +461,7 @@ class TabbedSqlEditors extends React.PureComponent {
             }
           >
             <i data-test="add-tab-icon" className="fa fa-plus-circle" />
+            Here!
           </Tooltip>
         }
       >

--- a/superset-frontend/src/SqlLab/utils/newQueryTabName.test.ts
+++ b/superset-frontend/src/SqlLab/utils/newQueryTabName.test.ts
@@ -1,0 +1,27 @@
+import { newQueryTabName } from './newQueryTabName';
+
+const emptyEditor = {
+  title: '',
+  schema: '',
+  autorun: false,
+  sql: '',
+  remoteId: null,
+};
+
+describe('newQueryTabName', () => {
+  it("should return default title if queryEditor's length is 0", () => {
+    const defaultTitle = 'default title';
+    const title = newQueryTabName([], defaultTitle);
+    expect(title).toEqual(defaultTitle);
+  });
+  it('should return next available number if there are unsaved editors', () => {
+    const untitledQueryText = 'Untitled Query';
+    const unsavedEditors = [
+      { ...emptyEditor, title: `${untitledQueryText} 1` },
+      { ...emptyEditor, title: `${untitledQueryText} 2` },
+    ];
+
+    const nextTitle = newQueryTabName(unsavedEditors);
+    expect(nextTitle).toEqual(`${untitledQueryText} 3`);
+  });
+});

--- a/superset-frontend/src/SqlLab/utils/newQueryTabName.test.ts
+++ b/superset-frontend/src/SqlLab/utils/newQueryTabName.test.ts
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import { newQueryTabName } from './newQueryTabName';
 
 const emptyEditor = {

--- a/superset-frontend/src/SqlLab/utils/newQueryTabName.ts
+++ b/superset-frontend/src/SqlLab/utils/newQueryTabName.ts
@@ -8,6 +8,8 @@ export const newQueryTabName = (
   queryEditors: QueryEditor[],
   initialTitle = `${untitledQuery}1`,
 ): string => {
+  const resultTitle = t(initialTitle);
+
   if (queryEditors.length > 0) {
     const mappedUntitled = queryEditors.filter(qe =>
       qe.title.match(untitledQueryRegex),
@@ -21,8 +23,8 @@ export const newQueryTabName = (
       const largestNumber: number = Math.max(...untitledQueryNumbers);
       return t(`${untitledQuery}%s`, largestNumber + 1);
     }
-    return initialTitle;
+    return resultTitle;
   }
 
-  return initialTitle;
+  return resultTitle;
 };

--- a/superset-frontend/src/SqlLab/utils/newQueryTabName.ts
+++ b/superset-frontend/src/SqlLab/utils/newQueryTabName.ts
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import { t } from '@superset-ui/core';
 import { QueryEditor } from '../types';
 

--- a/superset-frontend/src/SqlLab/utils/newQueryTabName.ts
+++ b/superset-frontend/src/SqlLab/utils/newQueryTabName.ts
@@ -1,27 +1,28 @@
-import { QueryEditor } from '../types';
 import { t } from '@superset-ui/core';
+import { QueryEditor } from '../types';
 
-const untitledQueryRegex: RegExp = /^Untitled Query (\d+)$/; // Literal notation isn't recompiled
+const untitledQueryRegex = /^Untitled Query (\d+)$/; // Literal notation isn't recompiled
 const untitledQuery = 'Untitled Query ';
 
 export const newQueryTabName = (
   queryEditors: QueryEditor[],
-  initialTitle = `${untitledQuery} 1`,
+  initialTitle = `${untitledQuery}1`,
 ): string => {
   if (queryEditors.length > 0) {
-    const untitledQueryNumbers: number[] = queryEditors
-      .filter(qe => qe.title.match(untitledQueryRegex))
-      .map(qe => +qe.title.replace(untitledQuery, ''));
-
+    const mappedUntitled = queryEditors.filter(qe =>
+      qe.title.match(untitledQueryRegex),
+    );
+    const untitledQueryNumbers = mappedUntitled.map(
+      qe => +qe.title.replace(untitledQuery, ''),
+    );
     if (untitledQueryNumbers.length > 0) {
       // When there are query tabs open, and at least one is called "Untitled Query #"
       // Where # is a valid number
       const largestNumber: number = Math.max(...untitledQueryNumbers);
       return t(`${untitledQuery}%s`, largestNumber + 1);
-    } else {
-      return initialTitle;
     }
-  } else {
     return initialTitle;
   }
+
+  return initialTitle;
 };

--- a/superset-frontend/src/SqlLab/utils/newQueryTabName.ts
+++ b/superset-frontend/src/SqlLab/utils/newQueryTabName.ts
@@ -1,0 +1,27 @@
+import { QueryEditor } from '../types';
+import { t } from '@superset-ui/core';
+
+const untitledQueryRegex: RegExp = /^Untitled Query (\d+)$/; // Literal notation isn't recompiled
+const untitledQuery = 'Untitled Query ';
+
+export const newQueryTabName = (
+  queryEditors: QueryEditor[],
+  initialTitle = `${untitledQuery} 1`,
+): string => {
+  if (queryEditors.length > 0) {
+    const untitledQueryNumbers: number[] = queryEditors
+      .filter(qe => qe.title.match(untitledQueryRegex))
+      .map(qe => +qe.title.replace(untitledQuery, ''));
+
+    if (untitledQueryNumbers.length > 0) {
+      // When there are query tabs open, and at least one is called "Untitled Query #"
+      // Where # is a valid number
+      const largestNumber: number = Math.max(...untitledQueryNumbers);
+      return t(`${untitledQuery}%s`, largestNumber + 1);
+    } else {
+      return initialTitle;
+    }
+  } else {
+    return initialTitle;
+  }
+};


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

fixes #11589

This changes an inconsistent behaviour when opening tabs in sqlLab with consistent query placeholder and tab sequential naming


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

**After**


https://user-images.githubusercontent.com/22302890/160724036-8761e630-bc92-484c-ae92-bd89aada9629.mov



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
