### PR TITLE
fix: Remove`time_range_endpoints` from query context object

### DIFF
--- a/superset/migrations/versions/2ed890b36b94_rm_time_range_endpoints_from_qc.py
+++ b/superset/migrations/versions/2ed890b36b94_rm_time_range_endpoints_from_qc.py
@@ -48,11 +48,15 @@ def upgrade():
     bind = op.get_bind()
     session = db.Session(bind=bind)
     for slc in session.query(Slice):
-        query_context = json.loads(slc.query_context)
-        queries = query_context.get("queries")
-        for query in queries:
-            query.get("extras", {}).pop("time_range_endpoints", None)
-        slc.queries = json.dumps(queries)
+        if slc.query_context:
+            try:
+                query_context = json.loads(slc.query_context)
+                queries = query_context.get("queries")
+                for query in queries:
+                    query.get("extras", {}).pop("time_range_endpoints", None)
+                slc.queries = json.dumps(queries)
+            except json.decoder.JSONDecodeError:
+                pass
 
     session.commit()
     session.close()

--- a/superset/migrations/versions/2ed890b36b94_rm_time_range_endpoints_from_qc.py
+++ b/superset/migrations/versions/2ed890b36b94_rm_time_range_endpoints_from_qc.py
@@ -47,14 +47,11 @@ class Slice(Base):
 def upgrade():
     bind = op.get_bind()
     session = db.Session(bind=bind)
-
-    for m in session.query(MyModel):
-        queries = json.loads(m.queries)
-        for q in queries:
-            extras = q.get("extras")
-            if extras:
-                extras.pop("time_range_endpoints", None)
-        m.queries = json.dumps(queries)
+    for slc in session.query(Slice):
+        queries = json.loads(slc.queries)
+        for query in queries:
+            query.get("extras", {}).pop("time_range_endpoints", None)
+        slc.queries = json.dumps(queries)
 
     session.commit()
     session.close()

--- a/superset/migrations/versions/2ed890b36b94_rm_time_range_endpoints_from_qc.py
+++ b/superset/migrations/versions/2ed890b36b94_rm_time_range_endpoints_from_qc.py
@@ -51,12 +51,12 @@ def upgrade():
         if slc.query_context:
             try:
                 query_context = json.loads(slc.query_context)
-                queries = query_context.get("queries")
-                for query in queries:
-                    query.get("extras", {}).pop("time_range_endpoints", None)
-                slc.queries = json.dumps(queries)
             except json.decoder.JSONDecodeError:
-                pass
+                continue
+            queries = query_context.get("queries")
+            for query in queries:
+                query.get("extras", {}).pop("time_range_endpoints", None)
+            slc.queries = json.dumps(queries)
 
     session.commit()
     session.close()

--- a/superset/migrations/versions/2ed890b36b94_rm_time_range_endpoints_from_qc.py
+++ b/superset/migrations/versions/2ed890b36b94_rm_time_range_endpoints_from_qc.py
@@ -48,7 +48,8 @@ def upgrade():
     bind = op.get_bind()
     session = db.Session(bind=bind)
     for slc in session.query(Slice):
-        queries = json.loads(slc.queries)
+        query_context = json.loads(slc.query_context)
+        queries = query_context.get("queries")
         for query in queries:
             query.get("extras", {}).pop("time_range_endpoints", None)
         slc.queries = json.dumps(queries)

--- a/superset/migrations/versions/2ed890b36b94_rm_time_range_endpoints_from_qc.py
+++ b/superset/migrations/versions/2ed890b36b94_rm_time_range_endpoints_from_qc.py
@@ -41,7 +41,7 @@ Base = declarative_base()
 class Slice(Base):
     __tablename__ = "slices"
     id = sa.Column(sa.Integer, primary_key=True)
-    queries = sa.Column(sa.Text)
+    query_context = sa.Column(sa.Text)
 
 
 def upgrade():

--- a/superset/migrations/versions/2ed890b36b94_rm_time_range_endpoints_from_qc.py
+++ b/superset/migrations/versions/2ed890b36b94_rm_time_range_endpoints_from_qc.py
@@ -38,8 +38,8 @@ from superset import db
 Base = declarative_base()
 
 
-class MyModel(Base):
-    __tablename__ = "MyModel"
+class Slice(Base):
+    __tablename__ = "slices"
     id = sa.Column(sa.Integer, primary_key=True)
     queries = sa.Column(sa.Text)
 

--- a/superset/migrations/versions/2ed890b36b94_rm_time_range_endpoints_from_qc.py
+++ b/superset/migrations/versions/2ed890b36b94_rm_time_range_endpoints_from_qc.py
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""rm_time_range_endpoints_from_qc
+
+Revision ID: 2ed890b36b94
+Revises: 58df9d617f14
+Create Date: 2022-03-29 18:03:48.977741
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "2ed890b36b94"
+down_revision = "58df9d617f14"
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
+
+Base = declarative_base()
+
+
+class MyModel(Base):
+    __tablename__ = "MyModel"
+    id = sa.Column(sa.Integer, primary_key=True)
+    queries = sa.Column(sa.Text)
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for m in session.query(MyModel):
+        queries = json.loads(m.queries)
+        for q in queries:
+            extras = q.get("extras")
+            if extras:
+                extras.pop("time_range_endpoints", None)
+        m.queries = json.dumps(queries)
+
+    session.commit()
+    session.close()
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When running reports/alerts charts are getting the following 400 error, due deprecating time_range_endpoints field.
```
{"message":"Request is incorrect: {'queries': {0: {'extras': {'time_range_endpoints': ['Unknown field.']}}}}"}
```

To fix this we'll be running a migration to remove all the `time_range_endpoints` keys from the `slice.query_context`. We are only updating the query_context that are valid json

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [X] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [X] Confirm DB migration upgrade and downgrade tested
  - [X] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

```
Benchmark Results:
Current: 0.42 s
10+: 0.45 s
100+: 0.34 s
1000+: 0.33 s
Cleaning up DB
```

Downgrade:
```
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade 2ed890b36b94 -> 58df9d617f14, rm_time_range_endpoints_from_qc
```

Upgrade:
```
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 58df9d617f14 -> 2ed890b36b94, rm_time_range_endpoints_from_qc
```