### PR TITLE
fix: add missing init on python pkg key_value

### DIFF
--- a/superset/dashboards/permalink/commands/create.py
+++ b/superset/dashboards/permalink/commands/create.py
@@ -53,6 +53,8 @@ class CreateDashboardPermalinkCommand(BaseDashboardPermalinkCommand):
                 resource=self.resource,
                 value=value,
             ).run()
+            if key.id is None:
+                raise DashboardPermalinkCreateFailedError("Unexpected missing key id")
             return encode_permalink_key(key=key.id, salt=self.salt)
         except SQLAlchemyError as ex:
             logger.exception("Error running create command")

--- a/superset/explore/permalink/commands/create.py
+++ b/superset/explore/permalink/commands/create.py
@@ -53,6 +53,8 @@ class CreateExplorePermalinkCommand(BaseExplorePermalinkCommand):
                 value=value,
             )
             key = command.run()
+            if key.id is None:
+                raise ExplorePermalinkCreateFailedError("Unexpected missing key id")
             return encode_permalink_key(key=key.id, salt=self.salt)
         except SQLAlchemyError as ex:
             logger.exception("Error running create command")

--- a/superset/key_value/commands/__init__.py
+++ b/superset/key_value/commands/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/superset/key_value/commands/create.py
+++ b/superset/key_value/commands/create.py
@@ -39,6 +39,7 @@ class CreateKeyValueCommand(BaseCommand):
     key: Optional[Union[int, UUID]]
     expires_on: Optional[datetime]
 
+    # pylint: disable=too-many-arguments
     def __init__(
         self,
         resource: KeyValueResource,

--- a/superset/key_value/commands/update.py
+++ b/superset/key_value/commands/update.py
@@ -41,6 +41,7 @@ class UpdateKeyValueCommand(BaseCommand):
     key: Union[int, UUID]
     expires_on: Optional[datetime]
 
+    # pylint: disable=too-many-argumentsåå
     def __init__(
         self,
         resource: KeyValueResource,

--- a/superset/key_value/commands/upsert.py
+++ b/superset/key_value/commands/upsert.py
@@ -42,6 +42,7 @@ class UpsertKeyValueCommand(BaseCommand):
     key: Union[int, UUID]
     expires_on: Optional[datetime]
 
+    # pylint: disable=too-many-arguments
     def __init__(
         self,
         resource: KeyValueResource,
@@ -96,11 +97,10 @@ class UpsertKeyValueCommand(BaseCommand):
             db.session.merge(entry)
             db.session.commit()
             return Key(entry.id, entry.uuid)
-        else:
-            return CreateKeyValueCommand(
-                resource=self.resource,
-                value=self.value,
-                actor=self.actor,
-                key=self.key,
-                expires_on=self.expires_on,
-            ).run()
+        return CreateKeyValueCommand(
+            resource=self.resource,
+            value=self.value,
+            actor=self.actor,
+            key=self.key,
+            expires_on=self.expires_on,
+        ).run()

--- a/tests/integration_tests/key_value/commands/update_test.py
+++ b/tests/integration_tests/key_value/commands/update_test.py
@@ -53,6 +53,7 @@ def test_update_id_entry(
         key=ID_KEY,
         value=NEW_VALUE,
     ).run()
+    assert key is not None
     assert key.id == ID_KEY
     entry = db.session.query(KeyValueEntry).filter_by(id=ID_KEY).autoflush(False).one()
     assert pickle.loads(entry.value) == NEW_VALUE
@@ -73,6 +74,7 @@ def test_update_uuid_entry(
         key=UUID_KEY,
         value=NEW_VALUE,
     ).run()
+    assert key is not None
     assert key.uuid == UUID_KEY
     entry = (
         db.session.query(KeyValueEntry).filter_by(uuid=UUID_KEY).autoflush(False).one()

--- a/tests/integration_tests/key_value/commands/upsert_test.py
+++ b/tests/integration_tests/key_value/commands/upsert_test.py
@@ -53,6 +53,7 @@ def test_upsert_id_entry(
         key=ID_KEY,
         value=NEW_VALUE,
     ).run()
+    assert key is not None
     assert key.id == ID_KEY
     entry = (
         db.session.query(KeyValueEntry).filter_by(id=int(ID_KEY)).autoflush(False).one()
@@ -75,6 +76,7 @@ def test_upsert_uuid_entry(
         key=UUID_KEY,
         value=NEW_VALUE,
     ).run()
+    assert key is not None
     assert key.uuid == UUID_KEY
     entry = (
         db.session.query(KeyValueEntry).filter_by(uuid=UUID_KEY).autoflush(False).one()
@@ -93,6 +95,7 @@ def test_upsert_missing_entry(app_context: AppContext, admin: User) -> None:
         key=456,
         value=NEW_VALUE,
     ).run()
+    assert key is not None
     assert key.id == 456
     db.session.query(KeyValueEntry).filter_by(id=456).delete()
     db.session.commit()


### PR DESCRIPTION
### SUMMARY

Adds missing `__init__.py` on key_value pkg

Getting:
```
  File "/usr/local/lib/python3.8/site-packages/superset/views/access_requests.py", line 25, in <module>
    from superset.views.core import DAR
  File "/usr/local/lib/python3.8/site-packages/superset/views/core.py", line 74, in <module>
    from superset.dashboards.permalink.commands.get import GetDashboardPermalinkCommand
  File "/usr/local/lib/python3.8/site-packages/superset/dashboards/permalink/commands/get.py", line 28, in <module>
    from superset.key_value.commands.get import GetKeyValueCommand
ModuleNotFoundError: No module named 'superset.key_value.commands'
```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
