### PR TITLE
fix(sql-lab): recover from Cannot convert object to primitive value i…

### DIFF
--- a/superset-frontend/src/utils/common.js
+++ b/superset-frontend/src/utils/common.js
@@ -103,7 +103,13 @@ export function prepareCopyToClipboardTabularData(data, columns) {
         row[j] = data[i][parseFloat(key)];
       }
     }
-    result += `${Object.values(row).join('\t')}\n`;
+    try {
+      result += `${Object.values(row).join('\t')}\n`;
+    catch {
+      result += `${Object.values(row)
+        .map(value => JSON.stringify(value))
+        .join('\t')}\n`;
+    }
   }
   return result;
 }

--- a/superset-frontend/src/utils/common.js
+++ b/superset-frontend/src/utils/common.js
@@ -105,7 +105,7 @@ export function prepareCopyToClipboardTabularData(data, columns) {
     }
     try {
       result += `${Object.values(row).join('\t')}\n`;
-    catch {
+    } catch {
       result += `${Object.values(row)
         .map(value => JSON.stringify(value))
         .join('\t')}\n`;


### PR DESCRIPTION
…ssue

A `Cannot convert object to primitive value` error appears in the developer console when trying to format the data coming from Presto. This issue causes the SQL Lab to crash. This can be sorted by stringifying the row data.

### SUMMARY
The SQL Lab crashes when data coming from Presto contains non primitive values. This fix basically catches the exception that occurs and recovers by formatting the row data using `JSON.stringify`. It does the trick in our case.
We also had a look at fixing this on the [presto db engine spec](https://github.com/apache/superset/blob/master/superset/db_engine_specs/presto.py) but couldn't really fix it over there.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<img width="845" alt="Screenshot 2022-03-30 at 12 56 53" src="https://user-images.githubusercontent.com/1241373/160829178-d891e71f-b597-484d-a230-7ca5eed0dce0.png">

### TESTING INSTRUCTIONS
I guess this is hard to test but, in our case, we have a Presto datasource that returns nested data that blows up the SQL Lab when it's getting formatted in a tabulated way.

### ADDITIONAL INFORMATION
- [x] Has associated issue: https://github.com/apache/superset/issues/11295
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
