### PR TITLE
chore: Disables no-literal-colors for the theme configuration

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -194,6 +194,7 @@ module.exports = {
         'fixtures.*',
         'cypress-base/cypress/**/*',
         'Stories.tsx',
+        'packages/superset-ui-core/src/style/index.tsx',
       ],
       rules: {
         'theme-colors/no-literal-colors': 0,


### PR DESCRIPTION
### SUMMARY
Disables `no-literal-colors` lint rule for the theme configuration.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1109" alt="Screen Shot 2022-03-30 at 11 02 20 AM" src="https://user-images.githubusercontent.com/70410625/160853620-e1833831-3d80-4a79-9fa2-f35fc33991b0.png">
<img width="1315" alt="Screen Shot 2022-03-30 at 11 06 53 AM" src="https://user-images.githubusercontent.com/70410625/160854231-dc977e93-d5e7-491d-8b5d-140740613129.png">

### TESTING INSTRUCTIONS
Make sure literal colors are allowed for the theme configuration.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
