### PR TITLE
chore: Removes hard-coded colors from plugin-chart-pivot-table

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.js
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.js
@@ -84,7 +84,7 @@ export const Styles = styled.div`
     }
 
     table.pvtTable tr th.active {
-      background-color: #d9dbe4;
+      background-color: ${theme.colors.primary.light3};
     }
 
     table.pvtTable .pvtTotalLabel {
@@ -97,7 +97,7 @@ export const Styles = styled.div`
     }
 
     table.pvtTable tbody tr td {
-      color: #2a3f5f;
+      color: ${theme.colors.primary.dark2};
       padding: ${theme.gridUnit}px;
       background-color: ${theme.colors.grayscale.light5};
       border-top: 1px solid ${theme.colors.grayscale.light2};
@@ -133,7 +133,7 @@ export const Styles = styled.div`
     }
 
     .hoverable:hover {
-      background-color: #eceef2;
+      background-color: ${theme.colors.primary.light4};
       cursor: pointer;
     }
   `}


### PR DESCRIPTION
### SUMMARY
Removes hard-coded colors from `plugin-chart-pivot-table`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="833" alt="Screen Shot 2022-03-30 at 12 08 45 PM" src="https://user-images.githubusercontent.com/70410625/160868765-4abcdf3d-00d0-498d-8284-e9f7356e09c5.png">
<img width="834" alt="Screen Shot 2022-03-30 at 12 00 29 PM" src="https://user-images.githubusercontent.com/70410625/160868831-e8d31e2a-66bf-4605-b197-94d3ab69b5d8.png">

### TESTING INSTRUCTIONS
Check that the plugin is very similar to the previous version. We may have color, font, and opacity differences due to theme adjustments.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
