### PR TITLE
chore: Removes hard-coded colors from legacy-preset-chart-nvd3

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/ReactNVD3.jsx
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/ReactNVD3.jsx
@@ -63,7 +63,7 @@ export default styled(NVD3)`
     }
     .nvtooltip tr.highlight td {
       font-weight: ${({ theme }) => theme.typography.weights.bold};
-      font-size: 15px !important;
+      font-size: ${({ theme }) => theme.typography.sizes.m}px !important;
     }
     text.nv-axislabel {
       font-size: ${({ theme }) => theme.typography.sizes.m} !important;
@@ -160,15 +160,15 @@ export default styled(NVD3)`
   .d3-tip.nv-event-annotation-layer-NATIVE {
     width: 200px;
     border-radius: 2px;
-    background-color: #484848;
+    background-color: ${({ theme }) => theme.colors.grayscale.base};
     fill-opacity: 0.6;
-    margin: 8px;
-    padding: 8px;
-    color: #fff;
+    margin: ${({ theme }) => theme.gridUnit * 2}px;
+    padding: ${({ theme }) => theme.gridUnit * 2}px;
+    color: ${({ theme }) => theme.colors.grayscale.light5};
     &:after {
       content: '\\25BC';
       font-size: ${({ theme }) => theme.typography.sizes.m};
-      color: #484848;
+      color: ${({ theme }) => theme.colors.grayscale.base};
       position: absolute;
       bottom: -14px;
       left: 94px;


### PR DESCRIPTION
### SUMMARY
Removes hard-coded colors from `legacy-preset-chart-nvd3`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1152" alt="Screen Shot 2022-03-30 at 1 48 52 PM" src="https://user-images.githubusercontent.com/70410625/160891400-167a932b-3cd9-47ea-a417-3aa56838a0f5.png">
<img width="1146" alt="Screen Shot 2022-03-30 at 1 54 43 PM" src="https://user-images.githubusercontent.com/70410625/160891421-3ba2d21f-85a6-4036-ae41-529b32f13a4d.png">

### TESTING INSTRUCTIONS
Check that the plugin is very similar to the previous version. We may have color, font, and opacity differences due to theme adjustments.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
