### PR TITLE
fix(sql lab): when editing a saved query, the status is lost when switching tabs

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -1279,6 +1279,7 @@ export function popSavedQuery(saveQueryId) {
       .then(({ json }) => {
         const queryEditorProps = {
           ...convertQueryToClient(json.result),
+          loaded: true,
           autorun: false,
         };
         return dispatch(addQueryEditor(queryEditorProps));


### PR DESCRIPTION
### SUMMARY
When opening a saved query, the SQL Lab does not retain the "saved" status after switching to another query and switching back.
So, the edited query cannot be updated, nor can it's perma link be retrieved.

This PR ensures that, when opening any saved query, the tab retains the save status even when switching to another tab.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://user-images.githubusercontent.com/17252075/160923426-cd21e3e5-a15b-4d78-900b-afc769653a7e.mov

After:

https://user-images.githubusercontent.com/17252075/160923411-8db13f31-c163-4c80-850d-c70480e3cd02.mov

### TESTING INSTRUCTIONS
1. Go to Saved Queries
2. Click on a saved query, open it in sql lab
3. Create a new tab, then go back to the original tab.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
