### PR TITLE
fix: request samples with default row limit

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
@@ -129,7 +129,7 @@ describe('Test datatable', () => {
   it('Datapane loads view samples', () => {
     cy.get('[data-test="data-tab"]').click();
     cy.contains('View samples').click();
-    cy.get('[data-test="row-count-label"]').contains('10k rows retrieved');
+    cy.get('[data-test="row-count-label"]').contains('1k rows retrieved');
     cy.get('.ant-empty-description').should('not.exist');
   });
 });

--- a/superset-frontend/src/explore/exploreUtils/index.js
+++ b/superset-frontend/src/explore/exploreUtils/index.js
@@ -26,6 +26,7 @@ import {
   getChartBuildQueryRegistry,
   getChartMetadataRegistry,
 } from '@superset-ui/core';
+import { omit } from 'lodash';
 import { availableDomains } from 'src/utils/hostNamesConfig';
 import { safeStringify } from 'src/utils/safeStringify';
 import { URL_PARAMS } from 'src/constants';
@@ -231,11 +232,9 @@ export const buildV1ChartDataPayload = ({
   );
   if (resultType === 'samples') {
     // remove row limit and offset to fall back to defaults
-    payload.queries = payload.queries.map(query => ({
-      ...query,
-      row_offset: null,
-      row_limit: null,
-    }));
+    payload.queries = payload.queries.map(query =>
+      omit(query, ['row_limit', 'row_offset']),
+    );
   }
   return payload;
 };

--- a/superset-frontend/src/explore/exploreUtils/index.js
+++ b/superset-frontend/src/explore/exploreUtils/index.js
@@ -215,7 +215,7 @@ export const buildV1ChartDataPayload = ({
           ...baseQueryObject,
         },
       ]));
-  return buildQuery(
+  const payload = buildQuery(
     {
       ...formData,
       force,
@@ -229,6 +229,15 @@ export const buildV1ChartDataPayload = ({
       },
     },
   );
+  if (resultType === 'samples') {
+    // remove row limit and offset to fall back to defaults
+    payload.queries = payload.queries.map(query => ({
+      ...query,
+      row_offset: null,
+      row_limit: null,
+    }));
+  }
+  return payload;
 };
 
 export const getLegacyEndpointType = ({ resultType, resultFormat }) =>

--- a/superset/common/query_actions.py
+++ b/superset/common/query_actions.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
+
 import copy
 from typing import Any, Callable, cast, Dict, List, Optional, TYPE_CHECKING
 
@@ -41,13 +43,13 @@ config = app.config
 
 
 def _get_datasource(
-    query_context: "QueryContext", query_obj: "QueryObject"
+    query_context: QueryContext, query_obj: QueryObject
 ) -> BaseDatasource:
     return query_obj.datasource or query_context.datasource
 
 
 def _get_columns(
-    query_context: "QueryContext", query_obj: "QueryObject", _: bool
+    query_context: QueryContext, query_obj: QueryObject, _: bool
 ) -> Dict[str, Any]:
     datasource = _get_datasource(query_context, query_obj)
     return {
@@ -63,7 +65,7 @@ def _get_columns(
 
 
 def _get_timegrains(
-    query_context: "QueryContext", query_obj: "QueryObject", _: bool
+    query_context: QueryContext, query_obj: QueryObject, _: bool
 ) -> Dict[str, Any]:
     datasource = _get_datasource(query_context, query_obj)
     return {
@@ -79,8 +81,8 @@ def _get_timegrains(
 
 
 def _get_query(
-    query_context: "QueryContext",
-    query_obj: "QueryObject",
+    query_context: QueryContext,
+    query_obj: QueryObject,
     _: bool,
 ) -> Dict[str, Any]:
     datasource = _get_datasource(query_context, query_obj)
@@ -93,8 +95,8 @@ def _get_query(
 
 
 def _get_full(
-    query_context: "QueryContext",
-    query_obj: "QueryObject",
+    query_context: QueryContext,
+    query_obj: QueryObject,
     force_cached: Optional[bool] = False,
 ) -> Dict[str, Any]:
     datasource = _get_datasource(query_context, query_obj)
@@ -140,7 +142,7 @@ def _get_full(
 
 
 def _get_samples(
-    query_context: "QueryContext", query_obj: "QueryObject", force_cached: bool = False
+    query_context: QueryContext, query_obj: QueryObject, force_cached: bool = False
 ) -> Dict[str, Any]:
     datasource = _get_datasource(query_context, query_obj)
     query_obj = copy.copy(query_obj)
@@ -155,14 +157,14 @@ def _get_samples(
 
 
 def _get_results(
-    query_context: "QueryContext", query_obj: "QueryObject", force_cached: bool = False
+    query_context: QueryContext, query_obj: QueryObject, force_cached: bool = False
 ) -> Dict[str, Any]:
     payload = _get_full(query_context, query_obj, force_cached)
     return payload
 
 
 _result_type_functions: Dict[
-    ChartDataResultType, Callable[["QueryContext", "QueryObject", bool], Dict[str, Any]]
+    ChartDataResultType, Callable[[QueryContext, QueryObject, bool], Dict[str, Any]]
 ] = {
     ChartDataResultType.COLUMNS: _get_columns,
     ChartDataResultType.TIMEGRAINS: _get_timegrains,
@@ -179,8 +181,8 @@ _result_type_functions: Dict[
 
 def get_query_results(
     result_type: ChartDataResultType,
-    query_context: "QueryContext",
-    query_obj: "QueryObject",
+    query_context: QueryContext,
+    query_obj: QueryObject,
     force_cached: bool,
 ) -> Dict[str, Any]:
     """

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -100,7 +100,7 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
     orderby: List[OrderBy]
     post_processing: List[Dict[str, Any]]
     result_type: Optional[ChartDataResultType]
-    row_limit: int
+    row_limit: Optional[int]
     row_offset: int
     series_columns: List[Column]
     series_limit: int
@@ -127,7 +127,7 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
         order_desc: bool = True,
         orderby: Optional[List[OrderBy]] = None,
         post_processing: Optional[List[Optional[Dict[str, Any]]]] = None,
-        row_limit: int,
+        row_limit: Optional[int],
         row_offset: Optional[int] = None,
         series_columns: Optional[List[Column]] = None,
         series_limit: int = 0,


### PR DESCRIPTION
### SUMMARY
Currently samples are requested with the original row limit, which tends to be 10k. However, samples should by default return 1k rows. This changes the frontend logic to remove `row_limit` and `row_offset` from the requested query object so the backend can use the appropriate defaults. The reason this is done in the frontend is to ensure that it's still possible to paginate samples requests if needed. Also clean up some incorrect types + add `__future__` annotations for cleaner python sig types.

### AFTER
After the change the samples tab only displays 1k rows
<img width="899" alt="image" src="https://user-images.githubusercontent.com/33317356/161026082-611b5f20-d6a2-4ca5-84b6-6b6b1cb646ab.png">

### BEFORE
Previously it would request 10k rows if the row limit control was set to 10k:
<img width="899" alt="image" src="https://user-images.githubusercontent.com/33317356/161026257-762076f3-f39a-469f-b4a1-b2d73a2ca396.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
