### PR TITLE
fix(welcome): saved queries causing error

### DIFF
--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -161,20 +161,22 @@ export const getEditedObjects = (userId: string | number) => {
     .catch(err => err);
 };
 
-export const getUserOwnedObjects = (
+export const getUserObjects = (
   userId: string | number,
   resource: string,
-  filters: Array<Filters> = [
+  filterBy: 'created_by' | 'owners',
+) => {
+  const filters: Filters[] = [
     {
-      col: 'created_by',
-      opr: 'rel_o_m',
+      col: filterBy,
+      opr: filterBy === 'created_by' ? 'rel_o_m' : 'rel_m_m',
       value: `${userId}`,
     },
-  ],
-) =>
-  SupersetClient.get({
+  ];
+  return SupersetClient.get({
     endpoint: `/api/v1/${resource}/?q=${getParams(filters)}`,
   }).then(res => res.json?.result);
+};
 
 export const getRecentAcitivtyObjs = (
   userId: string | number,

--- a/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
@@ -35,7 +35,7 @@ import {
   getRecentAcitivtyObjs,
   mq,
   CardContainer,
-  getUserOwnedObjects,
+  getUserObjects,
   loadingCardCount,
 } from 'src/views/CRUD/utils';
 import { FeatureFlag, isFeatureEnabled } from 'src/featureFlags';
@@ -202,14 +202,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
       );
 
     // Sets other activity data in parallel with recents api call
-    const ownSavedQueryFilters = [
-      {
-        col: 'owners',
-        opr: 'rel_m_m',
-        value: `${id}`,
-      },
-    ];
-    getUserOwnedObjects(id, 'dashboard')
+    getUserObjects(id, 'dashboard', 'owners')
       .then(r => {
         setDashboardData(r);
         setLoadedCount(loadedCount => loadedCount + 1);
@@ -221,7 +214,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
           t('There was an issue fetching your dashboards: %s', err),
         );
       });
-    getUserOwnedObjects(id, 'chart')
+    getUserObjects(id, 'chart', 'owners')
       .then(r => {
         setChartData(r);
         setLoadedCount(loadedCount => loadedCount + 1);
@@ -231,7 +224,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
         setLoadedCount(loadedCount => loadedCount + 1);
         addDangerToast(t('There was an issue fetching your chart: %s', err));
       });
-    getUserOwnedObjects(id, 'saved_query', ownSavedQueryFilters)
+    getUserObjects(id, 'saved_query', 'created_by')
       .then(r => {
         setQueryData(r);
         setLoadedCount(loadedCount => loadedCount + 1);


### PR DESCRIPTION
### SUMMARY
A recent PR #19223 caused a regression due to trying to query for `saved_query` objects by their owners, despite the model only having a creator (there is no `saved_query_user`, like there is for `dashboard_user` for `dashboards` and `slice_user` for `slices`). This renames the `getUserOwnedObjects` to `getUserObjects` and adds a parameter `filterBy` which makes it possible to define whether or not to query by `owners` or `created_by`.

### AFTER
After the change, the welcome page loads without errors:
<img width="1660" alt="image" src="https://user-images.githubusercontent.com/33317356/161073736-38973eaf-5fa7-45ae-874a-17fa82042986.png">

### BEFORE
Previously there was an error toast caused by a 400:
<img width="1667" alt="image" src="https://user-images.githubusercontent.com/33317356/161073889-44bf0d17-9b21-4890-87f9-f18bec634c3c.png">

### TESTING INSTRUCTIONS
1. Go to welcome page
2. Verify that the error no longer happens

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
