### PR TITLE
chore: Removes hard-coded colors from legacy-plugin-chart-world-map

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/ReactWorldMap.jsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/ReactWorldMap.jsx
@@ -37,7 +37,7 @@ export default styled(WorldMapComponent)`
   .superset-legacy-chart-world-map {
     position: relative;
     svg {
-      background-color: #feffff;
+      background-color: ${({ theme }) => theme.colors.grayscale.light5};
     }
   }
 `;


### PR DESCRIPTION
### SUMMARY
Removes hard-coded colors from `legacy-plugin-chart-world-map`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1151" alt="Screen Shot 2022-03-31 at 11 29 21 AM" src="https://user-images.githubusercontent.com/70410625/161080310-6dceecac-e7b5-426c-827e-6520e68bc355.png">
<img width="1152" alt="Screen Shot 2022-03-31 at 11 31 20 AM" src="https://user-images.githubusercontent.com/70410625/161080326-2fc966c4-e7b8-4574-bc30-f3a7109548e2.png">

### TESTING INSTRUCTIONS
Check that the plugin is very similar to the previous version. We may have color, font, and opacity differences due to theme adjustments.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
