### PR TITLE
chore(Explore): Change text when saving a chart in a new dashboard

### DIFF
--- a/superset-frontend/src/explore/components/SaveModal.test.jsx
+++ b/superset-frontend/src/explore/components/SaveModal.test.jsx
@@ -95,7 +95,34 @@ describe('SaveModal', () => {
     expect(wrapper.find(Radio)).toHaveLength(2);
 
     const footerWrapper = shallow(wrapper.find(StyledModal).props().footer);
+
     expect(footerWrapper.find(Button)).toHaveLength(3);
+  });
+
+  it('renders the right footer buttons when an existing dashboard', () => {
+    const wrapper = getWrapper();
+    const footerWrapper = shallow(wrapper.find(StyledModal).props().footer);
+    const saveAndGoDash = footerWrapper
+      .find('#btn_modal_save_goto_dash')
+      .getElement();
+    const save = footerWrapper.find('#btn_modal_save').getElement();
+    expect(save.props.children).toBe('Save');
+    expect(saveAndGoDash.props.children).toBe('Save & go to dashboard');
+  });
+
+  it('renders the right footer buttons when a new dashboard', () => {
+    const wrapper = getWrapper();
+    wrapper.setState({
+      saveToDashboardId: null,
+      newDashboardName: 'Test new dashboard',
+    });
+    const footerWrapper = shallow(wrapper.find(StyledModal).props().footer);
+    const saveAndGoDash = footerWrapper
+      .find('#btn_modal_save_goto_dash')
+      .getElement();
+    const save = footerWrapper.find('#btn_modal_save').getElement();
+    expect(save.props.children).toBe('Save to new dashboard');
+    expect(saveAndGoDash.props.children).toBe('Save & go to new dashboard');
   });
 
   it('overwrite radio button is disabled for new slice', () => {

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -76,6 +76,11 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
     this.onSliceNameChange = this.onSliceNameChange.bind(this);
     this.changeAction = this.changeAction.bind(this);
     this.saveOrOverwrite = this.saveOrOverwrite.bind(this);
+    this.isNewDashboard = this.isNewDashboard.bind(this);
+  }
+
+  isNewDashboard(): boolean {
+    return !!(!this.state.saveToDashboardId && this.state.newDashboardName);
   }
 
   canOverwriteSlice(): boolean {
@@ -195,7 +200,9 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
               }
               onClick={() => this.saveOrOverwrite(true)}
             >
-              {t('Save & go to dashboard')}
+              {this.isNewDashboard()
+                ? t('Save & go to new dashboard')
+                : t('Save & go to dashboard')}
             </Button>
             <Button
               id="btn_modal_save"
@@ -207,6 +214,8 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
             >
               {!this.canOverwriteSlice() && this.props.slice
                 ? t('Save as new chart')
+                : this.isNewDashboard()
+                ? t('Save to new dashboard')
                 : t('Save')}
             </Button>
           </div>


### PR DESCRIPTION
### SUMMARY
It adds the new keywork to save actions when saving to a new dashboard.

### BEFORE

https://user-images.githubusercontent.com/60598000/161080069-96ba4da9-2482-4763-9a5f-47d54963f8f2.mov

### AFTER

https://user-images.githubusercontent.com/60598000/161081295-1fc34936-aecf-401e-9c94-80d1ca7c91fe.mp4

### TESTING INSTRUCTIONS
1. Open a chart
2. Open the save chart modal
3. Enter a new dashboard
4. Observe the behavior

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
