### PR TITLE
fix: handle null params in #18936 migration

### DIFF
--- a/superset/migrations/versions/ab9a9d86e695_deprecate_time_range_endpoints.py
+++ b/superset/migrations/versions/ab9a9d86e695_deprecate_time_range_endpoints.py
@@ -47,7 +47,7 @@ def upgrade():
     session = db.Session(bind=bind)
 
     for slc in session.query(Slice):
-        params = json.loads(slc.params)
+        params = json.loads(slc.params or "{}")
         params.pop("time_range_endpoints", None)
         slc.params = json.dumps(params)
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This migration failed in our env because we have a few slices with null params. The UI/API should have prevented this from happening so I don't know how this happened, but as the params column is nullable in the db, we should handle nulls.

### TESTING INSTRUCTIONS
Tested upgrade
