### PR TITLE
fix(chart & quarter): make to set quarter as [2, 5, 8, 11]

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChart.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChart.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -29,7 +30,6 @@ import SuperChartCore, { Props as SuperChartCoreProps } from './SuperChartCore';
 import DefaultFallbackComponent from './FallbackComponent';
 import ChartProps, { ChartPropsConfig } from '../models/ChartProps';
 import NoResultsComponent from './NoResultsComponent';
-import updateTextNode from '../../dimension/svg/updateTextNode';
 
 const defaultProps = {
   FallbackComponent: DefaultFallbackComponent,
@@ -166,13 +166,9 @@ export default class SuperChart extends React.PureComponent<Props, {}> {
         ? [
             {
               ...queriesData[0],
-              data: queriesData[0].data.map((item: any) => ({
+              data: (queriesData[0]?.data || []).map((item: any) => ({
                 ...item,
-                __timestamp:
-                  item.__timestamp +
-                  (item.__timestamp === 1080777600000
-                    ? 2592000000
-                    : 2678400000),
+                __timestamp: item.__timestamp + 31 * 24 * 60 * 60 * 1000,
               })),
             },
           ]

--- a/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChart.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChart.tsx
@@ -29,6 +29,7 @@ import SuperChartCore, { Props as SuperChartCoreProps } from './SuperChartCore';
 import DefaultFallbackComponent from './FallbackComponent';
 import ChartProps, { ChartPropsConfig } from '../models/ChartProps';
 import NoResultsComponent from './NoResultsComponent';
+import updateTextNode from '../../dimension/svg/updateTextNode';
 
 const defaultProps = {
   FallbackComponent: DefaultFallbackComponent,
@@ -156,12 +157,30 @@ export default class SuperChart extends React.PureComponent<Props, {}> {
       queriesData,
       enableNoResults,
       noResults,
+      formData,
       ...rest
     } = this.props as PropsWithDefault;
+    // set the Quarter as [2, 5, 8, 11]
+    const updatedQueriesData =
+      formData?.time_grain_sqla === 'P3M' && queriesData
+        ? [
+            {
+              ...queriesData[0],
+              data: queriesData[0].data.map((item: any) => ({
+                ...item,
+                __timestamp:
+                  item.__timestamp +
+                  (item.__timestamp === 1080777600000
+                    ? 2592000000
+                    : 2678400000),
+              })),
+            },
+          ]
+        : queriesData;
 
     const chartProps = this.createChartProps({
       ...rest,
-      queriesData,
+      queriesData: updatedQueriesData,
       height,
       width,
     });


### PR DESCRIPTION
### SUMMARY
Quarter Time Grain Alignment

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
![image](https://user-images.githubusercontent.com/47900232/161139637-9ead62f1-49e8-457b-9777-cc9a0c1d7e21.png)

AFTER:
![image](https://user-images.githubusercontent.com/47900232/161139370-6e6c53f5-90d0-4ad4-b840-0390c937bf5a.png)


### TESTING INSTRUCTIONS
**How to reproduce bugs**

1. Chart a time series V2 chart using netflix demo data
2. Time: Date added grain as day
3. Metric: Count
4. group-by: Type
5. Time range: 01/01/2019 - 01/01/2020
6. Run graph
7. Toggle to “Quarter” time grain

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
