### PR TITLE
chore(plugin-chart-echarts): upgrade echarts 5.3.2

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/package.json
+++ b/superset-frontend/plugins/plugin-chart-echarts/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "d3-array": "^1.2.0",
-    "echarts": "^5.3.1",
+    "echarts": "^5.3.2",
     "lodash": "^4.17.15",
     "moment": "^2.26.0"
   },


### PR DESCRIPTION
### SUMMARY
Upgrade ECharts to the latest 5.3.2 version. See changelog here (mostly unrelated to current Superset features): https://echarts.apache.org/en/changelog.html#v5-3-2

### TESTING INSTRUCTIONS
Local testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
