### PR TITLE
fix: flaky test for charts changed on

### DIFF
--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -17,11 +17,9 @@
 # isort:skip_file
 """Unit tests for Superset"""
 import json
-from datetime import datetime
 from io import BytesIO
 from zipfile import is_zipfile, ZipFile
 
-import humanize
 import prison
 import pytest
 import yaml
@@ -803,7 +801,6 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         Dashboard API: Test get charts changed on
         """
         admin = self.get_user("admin")
-        start_changed_on = datetime.now()
         chart = self.insert_chart("foo_a", [admin.id], 1, description="ZY_bar")
 
         self.login(username="admin")
@@ -817,9 +814,9 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         rv = self.get_assert_metric(uri, "get_list")
         self.assertEqual(rv.status_code, 200)
         data = json.loads(rv.data.decode("utf-8"))
-        self.assertEqual(
-            data["result"][0]["changed_on_delta_humanized"],
-            humanize.naturaltime(datetime.now() - start_changed_on),
+        assert data["result"][0]["changed_on_delta_humanized"] in (
+            "now",
+            "a second ago",
         )
 
         # rollback changes


### PR DESCRIPTION
### SUMMARY
There is a flaky test for charts changed on the case. This PR changes the assertion to ("now", "a second ago")
<img width="951" alt="image" src="https://user-images.githubusercontent.com/2016594/161212551-811aad1d-20d2-423f-b422-df2db9de30c9.png">


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
