### PR TITLE
feat(sip-68)(wip): Add owners to Dataset Model

### DIFF
--- a/superset/datasets/models.py
+++ b/superset/datasets/models.py
@@ -30,6 +30,7 @@ import sqlalchemy as sa
 from flask_appbuilder import Model
 from sqlalchemy.orm import relationship
 
+from superset import security_manager
 from superset.columns.models import Column
 from superset.models.helpers import (
     AuditMixinNullable,
@@ -50,6 +51,13 @@ table_association_table = sa.Table(
     Model.metadata,  # pylint: disable=no-member
     sa.Column("dataset_id", sa.ForeignKey("sl_datasets.id")),
     sa.Column("table_id", sa.ForeignKey("sl_tables.id")),
+)
+
+dataset_user = sa.Table(
+    "sl_dataset_users",
+    Model.metadata,
+    sa.Column("user_id", sa.ForeignKey("ab_user.id")),
+    sa.Column("dataset_id", sa.ForeignKey("sl_datasets.id")),
 )
 
 
@@ -90,3 +98,7 @@ class Dataset(Model, AuditMixinNullable, ExtraJSONMixin, ImportExportMixin):
     # Column is managed externally and should be read-only inside Superset
     is_managed_externally = sa.Column(sa.Boolean, nullable=False, default=False)
     external_url = sa.Column(sa.Text, nullable=True)
+
+    owners = relationship(
+        security_manager.user_model, secondary=dataset_user, backref="sl_datasets"
+    )

--- a/superset/datasets/models.py
+++ b/superset/datasets/models.py
@@ -55,7 +55,7 @@ table_association_table = sa.Table(
 
 dataset_user = sa.Table(
     "sl_dataset_users",
-    Model.metadata,
+    Model.metadata,  # pylint: disable=no-member
     sa.Column("user_id", sa.ForeignKey("ab_user.id")),
     sa.Column("dataset_id", sa.ForeignKey("sl_datasets.id")),
 )

--- a/superset/migrations/versions/89f17d951737_add_owners_dataset_model.py
+++ b/superset/migrations/versions/89f17d951737_add_owners_dataset_model.py
@@ -98,12 +98,7 @@ def upgrade():
         ),
     )
 
-    total_count = session.query(sa.func.count(SqlaTable.id))
-    per_page = 1000
-    page = 1
-    # breakpoint()
-
-    limit = 5
+    limit = 1000
     offset = 0
     idx = 0
     while True:

--- a/superset/migrations/versions/89f17d951737_add_owners_dataset_model.py
+++ b/superset/migrations/versions/89f17d951737_add_owners_dataset_model.py
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add_owners_dataset_model
+
+Revision ID: 89f17d951737
+Revises: 2ed890b36b94
+Create Date: 2022-03-31 22:22:43.831122
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "89f17d951737"
+down_revision = "2ed890b36b94"
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+def upgrade():
+    op.create_table(
+        "sl_dataset_users",
+        sa.Column("user_id", sa.Integer(), nullable=True),
+        sa.Column("dataset_id", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["dataset_id"],
+            ["sl_datasets.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["ab_user.id"],
+        ),
+    )
+
+
+def downgrade():
+    op.drop_table("sl_dataset_users")

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -574,7 +574,6 @@ def get_rls_for_table(
         return None
 
     template_processor = dataset.get_template_processor()
-    # pylint: disable=protected-access
     predicate = " AND ".join(
         str(filter_)
         for filter_ in dataset.get_sqla_row_level_filters(template_processor)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding a new column/relationship for Dataset to have owners. This mapping will be directly tied to how the current `SqlaTable.owners` is being leveraged.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


Benchmark:
```
Results:
Current: 0.44 s
10+: 0.48 s
100+: 0.37 s
1000+: 0.94 s
```