### PR TITLE
feat(CI): clean up Python tests output

### DIFF
--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Python unit tests
         if: steps.check.outcome == 'failure'
         run: |
-          pytest --durations=0 ./tests/common ./tests/unit_tests --cache-clear
+          pytest --durations-min=0.5 --cov-report= --cov=superset ./tests/common ./tests/unit_tests --cache-clear
       - name: Upload code coverage
         if: steps.check.outcome == 'failure'
         run: |

--- a/scripts/python_tests.sh
+++ b/scripts/python_tests.sh
@@ -32,4 +32,4 @@ superset init
 
 echo "Running tests"
 
-pytest --durations=0 --maxfail=1 --cov=superset "$@"
+pytest --durations-min=2 --maxfail=1 --cov-report= --cov=superset "$@"


### PR DESCRIPTION
### SUMMARY

Currently the CI logs output a lot of useless information. Making it harder to glance through test errors. This PR changes that by:
1. Limiting test duration report to only those are actually slow
2. Remove codecov report in the terminal---users can check code coverage on codecov.io.

Also, the Python unittest workflow seems didn't getting codecov reported. So I added it, too.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
