### PR TITLE
chore: Add theme color to ParallelCoordinates

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/src/ReactParallelCoordinates.jsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/src/ReactParallelCoordinates.jsx
@@ -39,7 +39,7 @@ export default styled(ParallelCoordianes)`
       overflow: auto;
       div.row {
         &:hover {
-          background-color: #ccc;
+          background-color: ${({ theme }) => theme.colors.grayscale.light2};
         }
       }
     }


### PR DESCRIPTION
### SUMMARY
Removes a hex color from the style and adds a theme color instead

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No visual changes

### TESTING INSTRUCTIONS
1. Open a Parallel Coordinates chart
2. Make sure there are no observable visual changes. Colors might be slightly adjusted to use the theme available ones.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
