### PR TITLE
fix: Dynamic form to connect to Snowflake DB is not displaying authentication errors

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -89,6 +89,9 @@ const engineSpecificAlertMapping = {
 };
 
 const errorAlertMapping = {
+  GENERIC_DB_ENGINE_ERROR: {
+    message: t('Generic database engine error'),
+  },
   CONNECTION_MISSING_PARAMETERS_ERROR: {
     message: t('Missing Required Fields'),
     description: t('Please complete all required fields.'),
@@ -929,6 +932,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
           }
           description={
             errorAlertMapping[validationErrors?.error_type]?.description ||
+            validationErrors?.description ||
             JSON.stringify(validationErrors)
           }
           showIcon

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -689,6 +689,10 @@ export function useDatabaseValidation() {
                           url: string;
                           idx: number;
                         };
+                        issue_codes?: {
+                          code?: number;
+                          message?: string;
+                        }[];
                       };
                       message: string;
                     },
@@ -744,6 +748,15 @@ export function useDatabaseValidation() {
                         ),
                       };
                     }
+                    if (extra.issue_codes?.length) {
+                      return {
+                        ...obj,
+                        error_type,
+                        description:
+                          message || extra?.issue_codes?.[0]?.message,
+                      };
+                    }
+
                     return obj;
                   },
                   {},

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -752,8 +752,7 @@ export function useDatabaseValidation() {
                       return {
                         ...obj,
                         error_type,
-                        description:
-                          message || extra?.issue_codes?.[0]?.message,
+                        description: message || extra.issue_codes[0]?.message,
                       };
                     }
 


### PR DESCRIPTION
### SUMMARY
There are two ways to create a connection with a Snowflake DB:

Using the dynamic form.
Using a SQLAlchemy URI string.
However, the dynamic form is not displaying authentication errors to the user, in case the authentication fails.

This PR adds additional code to trap that error and display it to the user.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://user-images.githubusercontent.com/17252075/161301153-772e3b64-5ff2-4ce0-a41b-372821481fe5.mov

After:

https://user-images.githubusercontent.com/17252075/161300579-d02d006d-999d-43bd-bae7-e6acf3cbd32d.mov

### TESTING INSTRUCTIONS
1. Access your Workspace.
2. Navigate to Data > Databases on the top navigation bar.
3. Click on +DATABASE.
4. Select Snowflake.
5. Fill the form with below information:
 * Database name: testdb
 * Username: test
 * Password: test
 * Account: tfa63492
 * Warehouse: compute_wh
 * Role: public.
6. Click on CONNECT.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
