### PR TITLE
chore: Removes hard-coded colors from legacy-plugin-chart-sankey

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-sankey/src/ReactSankey.jsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-sankey/src/ReactSankey.jsx
@@ -34,40 +34,42 @@ SankeyComponent.propTypes = {
 };
 
 export default styled(SankeyComponent)`
-  .superset-legacy-chart-sankey {
-    .node {
-      rect {
-        cursor: move;
-        fill-opacity: 0.9;
-        shape-rendering: crispEdges;
+  ${({ theme }) => `
+    .superset-legacy-chart-sankey {
+      .node {
+        rect {
+          cursor: move;
+          fill-opacity: 0.9;
+          shape-rendering: crispEdges;
+        }
+        text {
+          pointer-events: none;
+          text-shadow: 0 1px 0 ${theme.colors.grayscale.light5};
+          font-size: ${theme.typography.sizes.s}px;
+        }
       }
-      text {
-        pointer-events: none;
-        text-shadow: 0 1px 0 #fff;
-        font-size: ${({ fontSize }) => fontSize}em;
+      .link {
+        fill: none;
+        stroke: ${theme.colors.grayscale.dark2};
+        stroke-opacity: 0.2;
+        &:hover {
+          stroke-opacity: 0.5;
+        }
+      }
+      .opacity-0 {
+        opacity: 0;
       }
     }
-    .link {
-      fill: none;
-      stroke: #000;
-      stroke-opacity: 0.2;
-      &:hover {
-        stroke-opacity: 0.5;
-      }
+    .sankey-tooltip {
+      position: absolute;
+      width: auto;
+      background: ${theme.colors.grayscale.light2};
+      padding: ${theme.gridUnit * 3}px;
+      font-size: ${theme.typography.sizes.s}px;
+      color: ${theme.colors.grayscale.dark2};
+      border: 1px solid ${theme.colors.grayscale.light5};
+      text-align: center;
+      pointer-events: none;
     }
-    .opacity-0 {
-      opacity: 0;
-    }
-  }
-  .sankey-tooltip {
-    position: absolute;
-    width: auto;
-    background: #ddd;
-    padding: 10px;
-    font-size: ${({ fontSize }) => fontSize}em;
-    color: #000;
-    border: 1px solid #fff;
-    text-align: center;
-    pointer-events: none;
-  }
+  `}
 `;

--- a/superset-frontend/plugins/legacy-plugin-chart-sankey/src/ReactSankey.jsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-sankey/src/ReactSankey.jsx
@@ -39,7 +39,7 @@ export default styled(SankeyComponent)`
       .node {
         rect {
           cursor: move;
-          fill-opacity: 0.9;
+          fill-opacity: ${theme.opacity.heavy};
           shape-rendering: crispEdges;
         }
         text {
@@ -51,9 +51,9 @@ export default styled(SankeyComponent)`
       .link {
         fill: none;
         stroke: ${theme.colors.grayscale.dark2};
-        stroke-opacity: 0.2;
+        stroke-opacity: ${theme.opacity.light};
         &:hover {
-          stroke-opacity: 0.5;
+          stroke-opacity: ${theme.opacity.mediumLight};
         }
       }
       .opacity-0 {


### PR DESCRIPTION
### SUMMARY
Removes hard-coded colors from `legacy-plugin-chart-sankey`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1153" alt="Screen Shot 2022-04-01 at 2 47 05 PM" src="https://user-images.githubusercontent.com/70410625/161316591-551b4ebe-8ceb-4dba-b2ff-cdbaee43f992.png">
<img width="1150" alt="Screen Shot 2022-04-01 at 2 51 41 PM" src="https://user-images.githubusercontent.com/70410625/161316598-a3340611-b6ae-45f4-8f00-619160604730.png">

### TESTING INSTRUCTIONS
Check that the plugin is very similar to the previous version. We may have color, font, and opacity differences due to theme adjustments.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
