### PR TITLE
perf: speed up db migration for deprecating time_range_endpoints

### DIFF
--- a/superset/migrations/versions/ab9a9d86e695_deprecate_time_range_endpoints.py
+++ b/superset/migrations/versions/ab9a9d86e695_deprecate_time_range_endpoints.py
@@ -46,8 +46,8 @@ def upgrade():
     bind = op.get_bind()
     session = db.Session(bind=bind)
 
-    for slc in session.query(Slice):
-        params = json.loads(slc.params or "{}")
+    for slc in session.query(Slice).filter(Slice.params.like("%time_range_endpoints%")):
+        params = json.loads(slc.params)
         params.pop("time_range_endpoints", None)
         slc.params = json.dumps(params)
 

--- a/superset/migrations/versions/c53bae8f08dd_add_saved_query_foreign_key_to_tab_state.py
+++ b/superset/migrations/versions/c53bae8f08dd_add_saved_query_foreign_key_to_tab_state.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """add_saved_query_foreign_key_to_tab_state
+
 Revision ID: c53bae8f08dd
 Revises: bb38f40aa3ff
 Create Date: 2021-12-15 15:05:21.845777

--- a/superset/migrations/versions/e866bd2d4976_smaller_grid.py
+++ b/superset/migrations/versions/e866bd2d4976_smaller_grid.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """smaller_grid
+
 Revision ID: e866bd2d4976
 Revises: 21e88bc06c02
 Create Date: 2018-02-13 08:07:40.766277


### PR DESCRIPTION
### SUMMARY

This speeds up db migrations for deprecating `time_range_endpoints` by pre-filtering to the subset of slices with potential changes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #19423 #18936 
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
