### PR TITLE
chore: postpone timerange endpoint removal

### DIFF
--- a/superset/migrations/versions/b0d0249074e4_deprecate_time_range_endpoints_v2.py
+++ b/superset/migrations/versions/b0d0249074e4_deprecate_time_range_endpoints_v2.py
@@ -14,20 +14,45 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""deprecate time_range_endpoints
+"""deprecate time_range_endpoints v2
 
-Revision ID: ab9a9d86e695
-Revises: b5a422d8e252
-Create Date: 2022-02-25 08:06:14.835094
+Revision ID: b0d0249074e4
+Revises: 2ed890b36b94
+Create Date: 2022-04-04 15:04:05.606340
 
 """
+import json
+
+from alembic import op
+from sqlalchemy import Column, Integer, Text
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
+
 # revision identifiers, used by Alembic.
-revision = "ab9a9d86e695"
-down_revision = "b5a422d8e252"
+revision = "b0d0249074e4"
+down_revision = "2ed890b36b94"
+
+Base = declarative_base()
+
+
+class Slice(Base):
+    __tablename__ = "slices"
+    id = Column(Integer, primary_key=True)
+    params = Column(Text)
 
 
 def upgrade():
-    pass
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for slc in session.query(Slice).filter(Slice.params.like("%time_range_endpoints%")):
+        params = json.loads(slc.params)
+        params.pop("time_range_endpoints", None)
+        slc.params = json.dumps(params)
+
+    session.commit()
+    session.close()
 
 
 def downgrade():


### PR DESCRIPTION
### SUMMARY
The PR #18936 that deprecated time range endpoints (breaking change for 2.0) included a migration that had to be changed into a NOOP for 1.5.0 (https://github.com/apache/superset/commit/2001fb5037e10a06e878dbfbcdaa1fd204a8f16a), as there were critical migrations after that PR that needed to go into the LTS v1 branch. This changes the original migration to a NOOP and adds a new migration that performs the same operation. This will ensure that both users that are running master branch, and orgs that run official releases, will have had the same migration logic applied to their metadata.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
