### PR TITLE
fix: alert/report created by filter inconsistency with table display

### DIFF
--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -264,22 +264,23 @@ function AlertList({
       {
         Cell: ({
           row: {
-            original: { owners = [] },
+            original: { created_by },
           },
-        }: any) => <FacePile users={owners} />,
-        Header: t('Owners'),
-        id: 'owners',
+        }: any) =>
+          created_by ? `${created_by.first_name} ${created_by.last_name}` : '',
+        Header: t('Created by'),
+        id: 'created_by',
         disableSortBy: true,
         size: 'xl',
       },
       {
         Cell: ({
           row: {
-            original: { created_by },
+            original: { owners = [] },
           },
-        }: any) => <FacePile users={[created_by]} />,
-        Header: t('Created by'),
-        id: 'created_by',
+        }: any) => <FacePile users={owners} />,
+        Header: t('Owners'),
+        id: 'owners',
         disableSortBy: true,
         size: 'xl',
       },

--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -90,7 +90,7 @@ function AlertList({
   const title = isReportEnabled ? t('report') : t('alert');
   const titlePlural = isReportEnabled ? t('reports') : t('alerts');
   const pathName = isReportEnabled ? 'Reports' : 'Alerts';
-  const initalFilters = useMemo(
+  const initialFilters = useMemo(
     () => [
       {
         id: 'type',
@@ -118,7 +118,7 @@ function AlertList({
     addDangerToast,
     true,
     undefined,
-    initalFilters,
+    initialFilters,
   );
 
   const { updateResource } = useSingleViewResource<Partial<AlertObject>>(
@@ -262,12 +262,6 @@ function AlertList({
         size: 'xl',
       },
       {
-        accessor: 'created_by',
-        disableSortBy: true,
-        hidden: true,
-        size: 'xl',
-      },
-      {
         Cell: ({
           row: {
             original: { owners = [] },
@@ -275,6 +269,17 @@ function AlertList({
         }: any) => <FacePile users={owners} />,
         Header: t('Owners'),
         id: 'owners',
+        disableSortBy: true,
+        size: 'xl',
+      },
+      {
+        Cell: ({
+          row: {
+            original: { created_by },
+          },
+        }: any) => <FacePile users={[created_by]} />,
+        Header: t('Created by'),
+        id: 'created_by',
         disableSortBy: true,
         size: 'xl',
       },
@@ -379,6 +384,22 @@ function AlertList({
 
   const filters: Filters = useMemo(
     () => [
+      {
+        Header: t('Owner'),
+        id: 'owners',
+        input: 'select',
+        operator: FilterOperator.relationManyMany,
+        unfilteredLabel: 'All',
+        fetchSelects: createFetchRelated(
+          'report',
+          'owners',
+          createErrorHandler(errMsg =>
+            t('An error occurred while fetching owners values: %s', errMsg),
+          ),
+          user,
+        ),
+        paginate: true,
+      },
       {
         Header: t('Created by'),
         id: 'created_by',

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -189,6 +189,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
         "name",
         "active",
         "created_by",
+        "owners",
         "type",
         "last_state",
         "creation_method",
@@ -212,6 +213,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
         "chart": "slice_name",
         "database": "database_name",
         "created_by": RelatedFieldFilter("first_name", FilterRelatedOwners),
+        "owners": RelatedFieldFilter("first_name", FilterRelatedOwners),
     }
 
     apispec_parameter_schemas = {


### PR DESCRIPTION
### SUMMARY
The Alert/Report list doesn't have a creator column, yet there's a "created by" filter for it.
This creates an inconsistency for the user, that has a filter that is not visually represented in the table.
Furthermore, the table has some inconsistencies in the display with other tables in the system around these fields, like the dashboard ones.

This PR solves both, by adding the created by field to the table & allow the user to sort by both created by and owners.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://user-images.githubusercontent.com/17252075/161585875-cfb61ba4-a7be-4026-8875-377dd23674b6.mov

After:

https://user-images.githubusercontent.com/17252075/161585174-13b47f16-4bfb-4b21-862d-49b828389bee.mov

### TESTING INSTRUCTIONS
1. Go to the reports view
2. Add one report with user A (current user) as owner
3. Add one report with user A & user B as owners

Ensure that the owner & created by fields display correctly.
Ensure that the owner & created by filters work by filtering by their respective fields accordingly.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
