### PR TITLE
feat(deck.gl): add color range for deck.gl 3D chart

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Grid/Grid.jsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Grid/Grid.jsx
@@ -18,10 +18,11 @@
  */
 import { GridLayer } from 'deck.gl';
 import React from 'react';
-import { t } from '@superset-ui/core';
+import { t, CategoricalColorNamespace } from '@superset-ui/core';
 
 import { commonLayerProps, getAggFunc } from '../common';
 import sandboxedEval from '../../utils/sandbox';
+import { hexToRGB } from '../../utils/colors';
 import { createDeckGLComponent } from '../../factory';
 import TooltipRow from '../../TooltipRow';
 
@@ -42,11 +43,9 @@ function setTooltipContent(o) {
 
 export function getLayer(formData, payload, onAddFilter, setTooltip) {
   const fd = formData;
-  const c = fd.color_picker;
-  let data = payload.data.features.map(d => ({
-    ...d,
-    color: [c.r, c.g, c.b, 255 * c.a],
-  }));
+  const colorScale = CategoricalColorNamespace.getScale(fd.color_scheme);
+  const colorRange = colorScale.range().map(color => hexToRGB(color));
+  let data = payload.data.features;
 
   if (fd.js_data_mutator) {
     // Applying user defined data mutator if defined
@@ -61,9 +60,8 @@ export function getLayer(formData, payload, onAddFilter, setTooltip) {
     data,
     pickable: true,
     cellSize: fd.grid_size,
-    minColor: [0, 0, 0, 0],
     extruded: fd.extruded,
-    maxColor: [c.r, c.g, c.b, 255 * c.a],
+    colorRange,
     outline: false,
     getElevationValue: aggFunc,
     getColorValue: aggFunc,

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Grid/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Grid/controlPanel.ts
@@ -50,8 +50,10 @@ const config: ControlPanelConfig = {
       label: t('Map'),
       controlSetRows: [
         [mapboxStyle, viewport],
-        ['color_picker', autozoom],
-        [gridSize, extruded],
+        ['color_scheme'],
+        [autozoom],
+        [gridSize],
+        [extruded],
       ],
     },
     {

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Hex/Hex.jsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Hex/Hex.jsx
@@ -18,10 +18,11 @@
  */
 import { HexagonLayer } from 'deck.gl';
 import React from 'react';
-import { t } from '@superset-ui/core';
+import { t, CategoricalColorNamespace } from '@superset-ui/core';
 
 import { commonLayerProps, getAggFunc } from '../common';
 import sandboxedEval from '../../utils/sandbox';
+import { hexToRGB } from '../../utils/colors';
 import { createDeckGLComponent } from '../../factory';
 import TooltipRow from '../../TooltipRow';
 
@@ -42,11 +43,9 @@ function setTooltipContent(o) {
 
 export function getLayer(formData, payload, onAddFilter, setTooltip) {
   const fd = formData;
-  const c = fd.color_picker;
-  let data = payload.data.features.map(d => ({
-    ...d,
-    color: [c.r, c.g, c.b, 255 * c.a],
-  }));
+  const colorScale = CategoricalColorNamespace.getScale(fd.color_scheme);
+  const colorRange = colorScale.range().map(color => hexToRGB(color));
+  let data = payload.data.features;
 
   if (fd.js_data_mutator) {
     // Applying user defined data mutator if defined
@@ -60,9 +59,8 @@ export function getLayer(formData, payload, onAddFilter, setTooltip) {
     data,
     pickable: true,
     radius: fd.grid_size,
-    minColor: [0, 0, 0, 0],
     extruded: fd.extruded,
-    maxColor: [c.r, c.g, c.b, 255 * c.a],
+    colorRange,
     outline: false,
     getElevationValue: aggFunc,
     getColorValue: aggFunc,

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Hex/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Hex/controlPanel.ts
@@ -51,7 +51,7 @@ const config: ControlPanelConfig = {
       label: t('Map'),
       controlSetRows: [
         [mapboxStyle, viewport],
-        ['color_picker'],
+        ['color_scheme'],
         [autozoom],
         [gridSize],
         [extruded],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently `deck.gl 3D Hexagon` and `deck.gl Grid` cannot set the color of the extruded bar.  Here we use color scheme control to give these two charts the ability to set colors.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### before

https://user-images.githubusercontent.com/11830681/161592471-149825bc-2ecc-420b-9dda-5a9a82f3cc30.mov


### after

https://user-images.githubusercontent.com/11830681/161592239-3efa6199-f41f-451d-962a-466107be9057.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: 
  - https://github.com/apache/superset/issues/9697
  - https://github.com/apache/superset/issues/8022
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
