### PR TITLE
fix: add back view for report reload error

### DIFF
--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -151,7 +151,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         from superset.reports.logs.api import ReportExecutionLogRestApi
         from superset.security.api import SecurityRestApi
         from superset.views.access_requests import AccessRequestsModelView
-        from superset.views.alerts import AlertView
+        from superset.views.alerts import AlertView, ReportView
         from superset.views.annotations import (
             AnnotationLayerModelView,
             AnnotationModelView,
@@ -445,6 +445,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
                 and self.config["DRUID_METADATA_LINKS_ENABLED"]
             ),
         )
+        appbuilder.add_view_no_menu(ReportView)
         appbuilder.add_link(
             "Refresh Druid Metadata",
             label=__("Refresh Druid Metadata"),

--- a/superset/views/alerts.py
+++ b/superset/views/alerts.py
@@ -36,7 +36,6 @@ class BaseAlertReportView(BaseSupersetView):
     @permission_name("read")
     def list(self) -> FlaskResponse:
         if not is_feature_enabled("ALERT_REPORTS"):
-            print('are you hitting here')
             return abort(404)
         return super().render_app_template()
 

--- a/superset/views/alerts.py
+++ b/superset/views/alerts.py
@@ -53,6 +53,7 @@ class AlertView(BaseAlertReportView):
     route_base = "/alert"
     class_permission_name = "ReportSchedule"
 
+
 class ReportView(BaseAlertReportView):
     route_base = "/report"
     class_permission_name = "ReportSchedule"

--- a/superset/views/alerts.py
+++ b/superset/views/alerts.py
@@ -36,6 +36,7 @@ class BaseAlertReportView(BaseSupersetView):
     @permission_name("read")
     def list(self) -> FlaskResponse:
         if not is_feature_enabled("ALERT_REPORTS"):
+            print('are you hitting here')
             return abort(404)
         return super().render_app_template()
 
@@ -51,4 +52,8 @@ class BaseAlertReportView(BaseSupersetView):
 
 class AlertView(BaseAlertReportView):
     route_base = "/alert"
+    class_permission_name = "ReportSchedule"
+
+class ReportView(BaseAlertReportView):
+    route_base = "/report"
     class_permission_name = "ReportSchedule"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This pr fixes an issue when the user reloads the reports page and it returns an 404. Issue was because the reports view was mistakenly removed during the 2.0 code migration.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before

https://user-images.githubusercontent.com/17326228/161628153-cb07023a-7e22-4655-a8e4-f09abe4cbdd0.mov

after 

https://user-images.githubusercontent.com/17326228/161638621-d9b011ed-278e-4215-9161-0cfc9a32decb.mov


### TESTING INSTRUCTIONS
Go to reports list view and reload the page. Page should not error in 404.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
