### PR TITLE
chore: Deprecating /my_queries endpoint

### DIFF
--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import logging
+
 import simplejson as json
 from flask import g, redirect, request, Response
 from flask_appbuilder import expose
@@ -29,6 +31,8 @@ from superset.superset_typing import FlaskResponse
 from superset.utils import core as utils
 
 from .base import BaseSupersetView, DeleteMixin, json_success, SupersetModelView
+
+logger = logging.getLogger(__name__)
 
 
 class SavedQueryView(SupersetModelView, DeleteMixin):
@@ -318,4 +322,7 @@ class SqlLab(BaseSupersetView):
     @has_access
     def my_queries(self) -> FlaskResponse:  # pylint: disable=no-self-use
         """Assigns a list of found users to the given role."""
+        logger.warning(
+            "This endpoint is deprecated and will be removed in the next major release"
+        )
         return redirect("/savedqueryview/list/?_flt_0_user={}".format(g.user.get_id()))


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

We are doing a longer survey of the older api endpoints and migrating them to api/v1

During this we noticed that this particular endpoint is no longer being used in superset, nor is it publicly listed or in the swagger, therefore I think that it is ready to be depreciated, and potentially gotten rid of in the next major release. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
