### PR TITLE
fix(explore): Chart header icon paddings

### DIFF
--- a/superset-frontend/src/components/AlteredSliceTag/index.jsx
+++ b/superset-frontend/src/components/AlteredSliceTag/index.jsx
@@ -182,10 +182,7 @@ export default class AlteredSliceTag extends React.Component {
   renderTriggerNode() {
     return (
       <Tooltip id="difference-tooltip" title={t('Click to see difference')}>
-        <span
-          className="label label-warning m-l-5"
-          style={{ fontSize: '12px' }}
-        >
+        <span className="label label-warning" style={{ fontSize: '12px' }}>
           {t('Altered')}
         </span>
       </Tooltip>

--- a/superset-frontend/src/components/FaveStar/index.tsx
+++ b/superset-frontend/src/components/FaveStar/index.tsx
@@ -68,11 +68,7 @@ const FaveStar = ({
       data-test="fave-unfave-icon"
       role="button"
     >
-      {isStarred ? (
-        <Icons.FavoriteSelected iconSize="xxl" />
-      ) : (
-        <Icons.FavoriteUnselected iconSize="xxl" />
-      )}
+      {isStarred ? <Icons.FavoriteSelected /> : <Icons.FavoriteUnselected />}
     </StyledLink>
   );
 

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
@@ -96,8 +96,19 @@ const StyledHeader = styled.div`
 `;
 
 const StyledButtons = styled.span`
-  display: flex;
-  align-items: center;
+  ${({ theme }) => css`
+    display: flex;
+    align-items: center;
+    padding-left: ${theme.gridUnit * 2}px;
+
+    & .fave-unfave-icon {
+      padding: 0 ${theme.gridUnit}px;
+
+      &:first-child {
+        padding-left: 0;
+      }
+    }
+  `}
 `;
 
 export class ExploreChartHeader extends React.PureComponent {
@@ -236,16 +247,14 @@ export class ExploreChartHeader extends React.PureComponent {
             onSave={actions.updateChartTitle}
             placeholder={t('Add the name of the chart')}
           />
-          {slice?.certified_by && (
-            <>
-              <CertifiedBadge
-                certifiedBy={slice.certified_by}
-                details={slice.certification_details}
-              />{' '}
-            </>
-          )}
           {slice && (
             <StyledButtons>
+              {slice.certified_by && (
+                <CertifiedBadge
+                  certifiedBy={slice.certified_by}
+                  details={slice.certification_details}
+                />
+              )}
               {user.userId && (
                 <FaveStar
                   itemId={slice.slice_id}


### PR DESCRIPTION
### SUMMARY
Fix uneven paddings of icons in chart header

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/15073128/161820510-34514967-3d07-419b-be08-323dff31dda7.png">

After:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/15073128/161820349-32fc482c-e96e-4e86-a8fc-a27132ff6198.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

@kasiazjc 