### PR TITLE
chore: Removes hard-coded opacity and spacing from the BigNumber plugin

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberViz.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberViz.tsx
@@ -277,59 +277,56 @@ class BigNumberVis extends React.PureComponent<BigNumberVisProps> {
 }
 
 export default styled(BigNumberVis)`
-  font-family: ${({ theme }) => theme.typography.families.sansSerif};
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-
-  &.no-trendline .subheader-line {
-    padding-bottom: 0.3em;
-  }
-
-  .text-container {
+  ${({ theme }) => `
+    font-family: ${theme.typography.families.sansSerif};
+    position: relative;
     display: flex;
     flex-direction: column;
     justify-content: center;
-    align-items: flex-start;
-    .alert {
-      font-size: ${({ theme }) => theme.typography.sizes.s};
-      margin: -0.5em 0 0.4em;
-      line-height: 1;
-      padding: 2px 4px 3px;
-      border-radius: 3px;
+
+    &.no-trendline .subheader-line {
+      padding-bottom: 0.3em;
     }
-  }
 
-  .kicker {
-    line-height: 1em;
-    padding-bottom: 2em;
-  }
-
-  .header-line {
-    position: relative;
-    line-height: 1em;
-    span {
-      position: absolute;
-      bottom: 0;
+    .text-container {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: flex-start;
+      .alert {
+        font-size: ${theme.typography.sizes.s};
+        margin: -0.5em 0 0.4em;
+        line-height: 1;
+        padding: ${theme.gridUnit}px;
+        border-radius: ${theme.gridUnit}px;
+      }
     }
-  }
 
-  .subheader-line {
-    line-height: 1em;
-    padding-bottom: 0;
-  }
+    .kicker {
+      line-height: 1em;
+      padding-bottom: 2em;
+    }
 
-  &.is-fallback-value {
-    .kicker,
-    .header-line,
+    .header-line {
+      position: relative;
+      line-height: 1em;
+      span {
+        position: absolute;
+        bottom: 0;
+      }
+    }
+
     .subheader-line {
-      opacity: 0.5;
+      line-height: 1em;
+      padding-bottom: 0;
     }
-  }
 
-  .superset-data-ui-tooltip {
-    z-index: 1000;
-    background: #000;
-  }
+    &.is-fallback-value {
+      .kicker,
+      .header-line,
+      .subheader-line {
+        opacity: ${theme.opacity.mediumHeavy};
+      }
+    }
+  `}
 `;


### PR DESCRIPTION
### SUMMARY
Removes hard-coded opacity and spacing from the `BigNumber` plugin.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1134" alt="Screen Shot 2022-04-05 at 3 09 40 PM" src="https://user-images.githubusercontent.com/70410625/161822512-1707f6e6-4e71-459d-8109-6a7d56ac75ba.png">
<img width="1134" alt="Screen Shot 2022-04-05 at 3 10 56 PM" src="https://user-images.githubusercontent.com/70410625/161822519-25539d9f-decd-4602-b343-9f746095c182.png">

### TESTING INSTRUCTIONS
Check that the plugin is very similar to the previous version. We may have color, font, and opacity differences due to theme adjustments.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
