### PR TITLE
fix: View Results Doesn't Match Chart After Refreshing Cache

### DIFF
--- a/superset-frontend/src/components/Chart/chartAction.js
+++ b/superset-frontend/src/components/Chart/chartAction.js
@@ -55,8 +55,17 @@ export function chartUpdateStarted(queryController, latestQueryFormData, key) {
 }
 
 export const CHART_UPDATE_SUCCEEDED = 'CHART_UPDATE_SUCCEEDED';
-export function chartUpdateSucceeded(queriesResponse, key) {
-  return { type: CHART_UPDATE_SUCCEEDED, queriesResponse, key };
+export function chartUpdateSucceeded(
+  queriesResponse,
+  key,
+  cacheInvalidated = false,
+) {
+  return {
+    type: CHART_UPDATE_SUCCEEDED,
+    queriesResponse,
+    key,
+    cacheInvalidated,
+  };
 }
 
 export const CHART_UPDATE_STOPPED = 'CHART_UPDATE_STOPPED';
@@ -65,8 +74,18 @@ export function chartUpdateStopped(key) {
 }
 
 export const CHART_UPDATE_FAILED = 'CHART_UPDATE_FAILED';
-export function chartUpdateFailed(queriesResponse, key) {
-  return { type: CHART_UPDATE_FAILED, queriesResponse, key };
+export function chartUpdateFailed(
+  queriesResponse,
+  key,
+  cacheInvalidated = false,
+) {
+  return { type: CHART_UPDATE_FAILED, queriesResponse, key, cacheInvalidated };
+}
+
+export const CHART_UPDATE_CACHE_INVALIDATION_STATUS =
+  'CHART_UPDATE_CACHE_INVALIDATION_STATUS';
+export function chartUpdateCacheInvalidationStatus(status) {
+  return { type: CHART_UPDATE_CACHE_INVALIDATION_STATUS, status };
 }
 
 export const CHART_RENDERING_FAILED = 'CHART_RENDERING_FAILED';
@@ -437,11 +456,11 @@ export function exploreJSON(
             }),
           ),
         );
-        return dispatch(chartUpdateSucceeded(queriesResponse, key));
+        return dispatch(chartUpdateSucceeded(queriesResponse, key, force));
       })
       .catch(response => {
         if (isFeatureEnabled(FeatureFlag.GLOBAL_ASYNC_QUERIES)) {
-          return dispatch(chartUpdateFailed([response], key));
+          return dispatch(chartUpdateFailed([response], key, force));
         }
 
         const appendErrorLog = (errorDetails, isCached) => {
@@ -468,7 +487,7 @@ export function exploreJSON(
           } else {
             appendErrorLog(parsedResponse.error, parsedResponse.is_cached);
           }
-          return dispatch(chartUpdateFailed([parsedResponse], key));
+          return dispatch(chartUpdateFailed([parsedResponse], key, force));
         });
       });
 

--- a/superset-frontend/src/components/Chart/chartReducer.ts
+++ b/superset-frontend/src/components/Chart/chartReducer.ts
@@ -33,6 +33,7 @@ export const chart: ChartState = {
   chartUpdateEndTime: null,
   chartUpdateStartTime: 0,
   latestQueryFormData: {},
+  latestQueryCacheInvalidated: false,
   sliceFormData: null,
   queryController: null,
   queriesResponse: null,
@@ -61,6 +62,7 @@ export default function chartReducer(
         chartStatus: 'success',
         chartAlert: null,
         queriesResponse: action.queriesResponse,
+        latestQueryCacheInvalidated: !!action.cacheInvalidated,
         chartUpdateEndTime: now(),
       };
     },
@@ -106,6 +108,7 @@ export default function chartReducer(
           : t('Network error.'),
         chartUpdateEndTime: now(),
         queriesResponse: action.queriesResponse,
+        latestQueryCacheInvalidated: !!action.cacheInvalidated,
         chartStackTrace: action.queriesResponse
           ? action.queriesResponse?.[0]?.stacktrace
           : null,

--- a/superset-frontend/src/dashboard/util/getFormDataWithExtraFilters.test.ts
+++ b/superset-frontend/src/dashboard/util/getFormDataWithExtraFilters.test.ts
@@ -31,6 +31,7 @@ describe('getFormDataWithExtraFilters', () => {
     chartUpdateStartTime: 1,
     lastRendered: 1,
     latestQueryFormData: {},
+    latestQueryCacheInvalidated: false,
     sliceFormData: null,
     queryController: null,
     queriesResponse: null,

--- a/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.test.tsx
@@ -56,6 +56,8 @@ const createProps = () => ({
   },
   chartStatus: 'rendered',
   onCollapseChange: jest.fn(),
+  chartUpdateCacheInvalidationStatus: jest.fn(),
+  latestQueryCacheInvalidated: false,
   queriesResponse: [
     {
       colnames: [],

--- a/superset-frontend/src/explore/components/DataTablesPane/index.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/index.tsx
@@ -22,6 +22,7 @@ import React, {
   useMemo,
   useState,
   MouseEvent,
+  useRef,
 } from 'react';
 import {
   css,
@@ -238,6 +239,8 @@ export const DataTablesPane = ({
   ownState,
   errorMessage,
   queriesResponse,
+  chartUpdateCacheInvalidationStatus,
+  latestQueryCacheInvalidated,
 }: {
   queryFormData: Record<string, any>;
   chartStatus: string;
@@ -245,6 +248,8 @@ export const DataTablesPane = ({
   onCollapseChange: (isOpen: boolean) => void;
   errorMessage?: JSX.Element;
   queriesResponse: Record<string, any>;
+  chartUpdateCacheInvalidationStatus: (status: boolean) => void;
+  latestQueryCacheInvalidated: boolean;
 }) => {
   const theme = useTheme();
   const [data, setData] = useState(getDefaultDataTablesState(undefined));
@@ -263,15 +268,22 @@ export const DataTablesPane = ({
     getItem(LocalStorageKeys.is_datapanel_open, false),
   );
 
+  const latestQueryCacheInvalidatedRef = useRef(latestQueryCacheInvalidated);
+  latestQueryCacheInvalidatedRef.current = latestQueryCacheInvalidated;
+
   const getData = useCallback(
     (resultType: 'samples' | 'results') => {
       setIsLoading(prevIsLoading => ({
         ...prevIsLoading,
         [resultType]: true,
       }));
+
+      chartUpdateCacheInvalidationStatus(false);
+
       return getChartDataRequest({
         formData: queryFormData,
         resultFormat: 'json',
+        force: !!latestQueryCacheInvalidatedRef.current,
         resultType,
         ownState,
       })
@@ -331,7 +343,7 @@ export const DataTablesPane = ({
           });
         });
     },
-    [queryFormData, columnNames],
+    [chartUpdateCacheInvalidationStatus, queryFormData, columnNames],
   );
 
   useEffect(() => {

--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -391,6 +391,12 @@ const ExploreChartPanel = ({
             chartStatus={chart.chartStatus}
             errorMessage={errorMessage}
             queriesResponse={chart.queriesResponse}
+            chartUpdateCacheInvalidationStatus={
+              props.actions.chartUpdateCacheInvalidationStatus
+            }
+            latestQueryCacheInvalidated={
+              props.chart.latestQueryCacheInvalidated
+            }
           />
         </Split>
       )}

--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -392,11 +392,9 @@ const ExploreChartPanel = ({
             errorMessage={errorMessage}
             queriesResponse={chart.queriesResponse}
             chartUpdateCacheInvalidationStatus={
-              props.actions.chartUpdateCacheInvalidationStatus
+              actions.chartUpdateCacheInvalidationStatus
             }
-            latestQueryCacheInvalidated={
-              props.chart.latestQueryCacheInvalidated
-            }
+            latestQueryCacheInvalidated={chart.latestQueryCacheInvalidated}
           />
         </Split>
       )}

--- a/superset-frontend/src/explore/reducers/getInitialState.ts
+++ b/superset-frontend/src/explore/reducers/getInitialState.ts
@@ -107,6 +107,7 @@ export default function getInitialState(
     chartUpdateEndTime: null,
     chartUpdateStartTime: 0,
     latestQueryFormData: getFormDataFromControls(exploreState.controls),
+    latestQueryCacheInvalidated: false,
     sliceFormData,
     queryController: null,
     queriesResponse: null,

--- a/superset-frontend/src/explore/types.ts
+++ b/superset-frontend/src/explore/types.ts
@@ -46,6 +46,7 @@ export interface ChartState {
   chartUpdateStartTime: number;
   lastRendered: number;
   latestQueryFormData: Partial<QueryFormData>;
+  latestQueryCacheInvalidated: boolean;
   sliceFormData: QueryFormData | null;
   queryController: AbortController | null;
   queriesResponse: QueryData | null;


### PR DESCRIPTION
### SUMMARY
When the data cache is configured, after a cache invalidation in the explore, the results view is not impacted.
So, if we modify the underlying dataset while using the explore, and we try to invalidate the cache, then the chart correctly displays the new data, but the view results doesn't.

This PR ensures that, after a cache invalidation, both the chart and results reflect the latest data.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://user-images.githubusercontent.com/17252075/161868686-e21df3d3-715b-4dab-8ab4-56bb0c8f928c.mov

After:

https://user-images.githubusercontent.com/17252075/161868702-d739e8b9-4687-4d9c-9bed-b10360554a9b.mov


### TESTING INSTRUCTIONS
1. Create a table chart with raw records, pointing to a dataset that is easy to update (Gsheets for example)
2. Add or remove some rows from your dataset
3. Refresh the cache on the chart

Ensure that, after cache invalidation, both the chart and data results view reflect the latest data.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
