### PR TITLE
fix: big number with trendline can't calculate cumsum

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/buildQuery.ts
@@ -18,63 +18,33 @@
  */
 import {
   buildQueryContext,
-  PostProcessingResample,
+  DTTM_ALIAS,
   QueryFormData,
 } from '@superset-ui/core';
 import {
   flattenOperator,
+  pivotOperator,
+  resampleOperator,
   rollingWindowOperator,
-  sortOperator,
 } from '@superset-ui/chart-controls';
-
-const TIME_GRAIN_MAP: Record<string, string> = {
-  PT1S: 'S',
-  PT1M: 'min',
-  PT5M: '5min',
-  PT10M: '10min',
-  PT15M: '15min',
-  PT30M: '30min',
-  PT1H: 'H',
-  P1D: 'D',
-  P1M: 'MS',
-  P3M: 'QS',
-  P1Y: 'AS',
-  // TODO: these need to be mapped carefully, as the first day of week
-  //  can vary from engine to engine
-  // P1W: 'W',
-  // '1969-12-28T00:00:00Z/P1W': 'W',
-  // '1969-12-29T00:00:00Z/P1W': 'W',
-  // 'P1W/1970-01-03T00:00:00Z': 'W',
-  // 'P1W/1970-01-04T00:00:00Z': 'W',
-};
 
 export default function buildQuery(formData: QueryFormData) {
   return buildQueryContext(formData, baseQueryObject => {
-    // todo: move into full advanced analysis section here
-    const rollingProc = rollingWindowOperator(formData, baseQueryObject);
-    const { time_grain_sqla } = formData;
-    let resampleProc: PostProcessingResample;
-    if (rollingProc && time_grain_sqla) {
-      const rule = TIME_GRAIN_MAP[time_grain_sqla];
-      if (rule) {
-        resampleProc = {
-          operation: 'resample',
-          options: {
-            method: 'asfreq',
-            rule,
-            fill_value: null,
-          },
-        };
-      }
-    }
+    const { x_axis } = formData;
+    const is_timeseries = x_axis === DTTM_ALIAS || !x_axis;
+
     return [
       {
         ...baseQueryObject,
         is_timeseries: true,
         post_processing: [
-          sortOperator(formData, baseQueryObject),
-          resampleProc,
-          rollingProc,
+          pivotOperator(formData, {
+            ...baseQueryObject,
+            index: x_axis,
+            is_timeseries,
+          }),
+          rollingWindowOperator(formData, baseQueryObject),
+          resampleOperator(formData, baseQueryObject),
           flattenOperator(formData, baseQueryObject),
         ],
       },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/controlPanel.tsx
@@ -217,6 +217,52 @@ const config: ControlPanelConfig = {
             },
           },
         ],
+        // eslint-disable-next-line react/jsx-key
+        [<h1 className="section-header">{t('Resample')}</h1>],
+        [
+          {
+            name: 'resample_rule',
+            config: {
+              type: 'SelectControl',
+              freeForm: true,
+              label: t('Rule'),
+              default: null,
+              choices: [
+                ['1T', '1 minutely frequency'],
+                ['1H', '1 hourly frequency'],
+                ['1D', '1 calendar day frequency'],
+                ['7D', '7 calendar day frequency'],
+                ['1MS', '1 month start frequency'],
+                ['1M', '1 month end frequency'],
+                ['1AS', '1 year start frequency'],
+                ['1A', '1 year end frequency'],
+              ],
+              description: t('Pandas resample rule'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'resample_method',
+            config: {
+              type: 'SelectControl',
+              freeForm: true,
+              label: t('Fill method'),
+              default: null,
+              choices: [
+                ['asfreq', 'Null imputation'],
+                ['zerofill', 'Zero imputation'],
+                ['linear', 'Linear interpolation'],
+                ['ffill', 'Forward values'],
+                ['bfill', 'Backward values'],
+                ['median', 'Median values'],
+                ['mean', 'Mean values'],
+                ['sum', 'Sum values'],
+              ],
+              description: t('Pandas resample method'),
+            },
+          },
+        ],
       ],
     },
   ],


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixed that the Big Number with Trendline can't calculate with `cumsum`. In addition, I moved the Resample panel into the chart.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### Before
<img width="1404" alt="image" src="https://user-images.githubusercontent.com/2016594/161904257-e87d4c32-b527-4d7c-a943-9e225bd0d06e.png">




#### After
<img width="1411" alt="image" src="https://user-images.githubusercontent.com/2016594/161904120-6afb4007-7ea8-498d-9219-dc4b17b924ea.png">



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Select the `cleaned_sales_data` dataset and the `Big Number with Trendline` Chart
2. Set:
  a. `order date` as the TIME COLUMN.
  b. `Month` as the TIME GRAIN.
  c. `COUNT(*)` as the METRIC.
  d. `cumsum` as the ROLLING FUNCTION.
3. Click on RUN.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
