### PR TITLE
fix(migrations): reorder skipped 1.4 migrations

### DIFF
--- a/superset/migrations/versions/abe27eaf93db_add_extra_config_column_to_alerts.py
+++ b/superset/migrations/versions/abe27eaf93db_add_extra_config_column_to_alerts.py
@@ -17,14 +17,14 @@
 """add_extra_config_column_to_alerts
 
 Revision ID: abe27eaf93db
-Revises: aea15018d53b
+Revises: 0ca9e5f1dacd
 Create Date: 2021-12-02 12:03:20.691171
 
 """
 
 # revision identifiers, used by Alembic.
 revision = "abe27eaf93db"
-down_revision = "aea15018d53b"
+down_revision = "0ca9e5f1dacd"
 
 import sqlalchemy as sa
 from alembic import op

--- a/superset/migrations/versions/b92d69a6643c_rename_csv_to_file.py
+++ b/superset/migrations/versions/b92d69a6643c_rename_csv_to_file.py
@@ -17,14 +17,14 @@
 """rename_csv_to_file
 
 Revision ID: b92d69a6643c
-Revises: 32646df09c64
+Revises: aea15018d53b
 Create Date: 2021-09-19 14:42:20.130368
 
 """
 
 # revision identifiers, used by Alembic.
 revision = "b92d69a6643c"
-down_revision = "32646df09c64"
+down_revision = "aea15018d53b"
 
 import sqlalchemy as sa
 from alembic import op

--- a/superset/migrations/versions/f9847149153d_add_certifications_columns_to_slice.py
+++ b/superset/migrations/versions/f9847149153d_add_certifications_columns_to_slice.py
@@ -17,7 +17,7 @@
 """add_certifications_columns_to_slice
 
 Revision ID: f9847149153d
-Revises: 0ca9e5f1dacd
+Revises: 32646df09c64
 Create Date: 2021-11-03 14:07:09.905194
 
 """
@@ -27,7 +27,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "f9847149153d"
-down_revision = "0ca9e5f1dacd"
+down_revision = "32646df09c64"
 
 
 def upgrade():


### PR DESCRIPTION
### SUMMARY
Two migrations (`b92d69a6643c` and `0ca9e5f1dacd`) had been skipped in the 1.4 release, causing errors when upgrading from 1.4 to 1.5 or master. See the different down revisions of `f9847149153d` in 1.4 and master:

https://github.com/apache/superset/blob/9fc5e09cb3c5278720d455ddde959ab791713206/superset/migrations/versions/f9847149153d_add_certifications_columns_to_slice.py#L29-L30

https://github.com/apache/superset/blob/156ac7dd79105bca47138d8906b50d01dc4f1cb6/superset/migrations/versions/f9847149153d_add_certifications_columns_to_slice.py#L29-L30

This places the skipped migrations in front of the first migration of 1.5, making sure the migrations are applied to the metadata.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Install version 1.4 of Superset, run db migrations
2. Install 1.5.0rc1 or master branch, run db migrations and run `superset init` and see the error

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #19100
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
