### PR TITLE
fix(sqllab): null database with backend persistence

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -1393,10 +1393,21 @@ export function queryEditorSetFunctionNames(queryEditor, dbId) {
           functionNames: json.function_names,
         }),
       )
-      .catch(() =>
-        dispatch(
-          addDangerToast(t('An error occurred while fetching function names.')),
-        ),
-      );
+      .catch(err => {
+        if (err.status === 404) {
+          // for databases that have been deleted, just reset the function names
+          dispatch({
+            type: QUERY_EDITOR_SET_FUNCTION_NAMES,
+            queryEditor,
+            functionNames: [],
+          });
+        } else {
+          dispatch(
+            addDangerToast(
+              t('An error occurred while fetching function names.'),
+            ),
+          );
+        }
+      });
   };
 }

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -118,7 +118,7 @@ class Query(Model, ExtraJSONMixin):
             "changedOn": self.changed_on,
             "changed_on": self.changed_on.isoformat(),
             "dbId": self.database_id,
-            "db": self.database.database_name,
+            "db": self.database.database_name if self.database else None,
             "endDttm": self.end_time,
             "errorMessage": self.error_message,
             "executedSql": self.executed_sql,


### PR DESCRIPTION
### SUMMARY
This PR fixes two problems in SQL Lab if the `SQLLAB_BACKEND_PERSISTENCE` feature flag is enabled (default as of 2.0):
- When opening SQL Lab and a persisted tab is referencing a database that has been deleted, SQL Lab will fail with a 500 (see error below). This is due to `self.database` being `None`
- when the above has been resolved, and the user switches to a tab referencing a missing database, a 404 is returned from the function names request, which in turn triggers an error toast. As this is an expected case, we avoid dispatching an error toast for 404s.

### SCRENSHOTS
When accessing SQL Lab with `SQLLAB_BACKEND_PERSISTENCE` turned on and a referenced database being missing, the following happens:
```json
{
   "errors":[
      {
         "message":"'NoneType' object has no attribute 'database_name'",
         "error_type":"GENERIC_BACKEND_ERROR",
         "level":"error",
         "extra":{
            "issue_codes":[
               {
                  "code":1011,
                  "message":"Issue 1011 - Superset encountered an unexpected error."
               }
            ]
         }
      }
   ]
}
```
After the above has been fixed and switching tabs into a tab where the database is missing, the following error toast is brought up:
<img width="1313" alt="image" src="https://user-images.githubusercontent.com/33317356/161932512-4f66e6d3-e1ca-442e-b184-d5f9cd7aeebb.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
