### PR TITLE
fix(dataset): handle missing python_type gracefully

### DIFF
--- a/superset/connectors/sqla/utils.py
+++ b/superset/connectors/sqla/utils.py
@@ -172,6 +172,13 @@ def validate_adhoc_subquery(
     return ";\n".join(str(statement) for statement in statements)
 
 
+def is_column_type_temporal(column_type: TypeEngine) -> bool:
+    try:
+        return column_type.python_type.__name__.upper() in TEMPORAL_TYPES
+    except NotImplementedError:
+        return False
+
+
 def load_or_create_tables(  # pylint: disable=too-many-arguments
     session: Session,
     database_id: int,
@@ -223,8 +230,7 @@ def load_or_create_tables(  # pylint: disable=too-many-arguments
                     name=column["name"],
                     type=str(column["type"]),
                     expression=conditional_quote(column["name"]),
-                    is_temporal=column["type"].python_type.__name__.upper()
-                    in TEMPORAL_TYPES,
+                    is_temporal=is_column_type_temporal(column["type"]),
                     is_aggregation=False,
                     is_physical=True,
                     is_spatial=False,

--- a/superset/connectors/sqla/utils.py
+++ b/superset/connectors/sqla/utils.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from contextlib import closing
+from datetime import date, datetime, time, timedelta
 from typing import Callable, Dict, List, Optional, Set, TYPE_CHECKING
 
 import sqlparse
@@ -41,7 +42,7 @@ if TYPE_CHECKING:
     from superset.connectors.sqla.models import SqlaTable
 
 
-TEMPORAL_TYPES = {"DATETIME", "DATE", "TIME", "TIMEDELTA"}
+TEMPORAL_TYPES = {date, datetime, time, timedelta}
 
 
 def get_physical_table_metadata(
@@ -174,7 +175,7 @@ def validate_adhoc_subquery(
 
 def is_column_type_temporal(column_type: TypeEngine) -> bool:
     try:
-        return column_type.python_type.__name__.upper() in TEMPORAL_TYPES
+        return column_type.python_type in TEMPORAL_TYPES
     except NotImplementedError:
         return False
 

--- a/superset/migrations/versions/b8d3a24d9131_new_dataset_models.py
+++ b/superset/migrations/versions/b8d3a24d9131_new_dataset_models.py
@@ -25,6 +25,7 @@ Create Date: 2021-11-11 16:41:53.266965
 """
 
 import json
+from datetime import date, datetime, time, timedelta
 from typing import Callable, List, Optional, Set
 from uuid import uuid4
 
@@ -231,12 +232,12 @@ class NewDataset(Base):
     external_url = sa.Column(sa.Text, nullable=True)
 
 
-TEMPORAL_TYPES = {"DATETIME", "DATE", "TIME", "TIMEDELTA"}
+TEMPORAL_TYPES = {date, datetime, time, timedelta}
 
 
 def is_column_type_temporal(column_type: TypeEngine) -> bool:
     try:
-        return column_type.python_type.__name__.upper() in TEMPORAL_TYPES
+        return column_type.python_type in TEMPORAL_TYPES
     except NotImplementedError:
         return False
 


### PR DESCRIPTION
### SUMMARY

In the new Dataset model, we check if a column is temporal by checking the `python_type` of all columns. However, the property isn't guaranteed to be implemented: https://github.com/sqlalchemy/sqlalchemy/blob/7935b76d9e5b5fd4e64b2c6c3473737186acf2db/lib/sqlalchemy/sql/type_api.py#L618-L635 . Therefore, if calling it raises `NotImplementedError`, we assume the column is not temporal.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #19546
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
