### PR TITLE
chore: remove redundant adodbapi warning

### DIFF
--- a/superset/db_engine_specs/__init__.py
+++ b/superset/db_engine_specs/__init__.py
@@ -116,6 +116,9 @@ def get_available_engine_specs() -> Dict[Type[BaseEngineSpec], Set[str]]:
                 hasattr(attribute, "dialect")
                 and inspect.isclass(attribute.dialect)
                 and issubclass(attribute.dialect, DefaultDialect)
+                # adodbapi dialect is removed in SQLA 1.4 and doesn't implement the
+                # `dbapi` method, hence needs to be ignored to avoid logging a warning
+                and attribute.dialect.driver != "adodbapi"
             ):
                 try:
                     attribute.dialect.dbapi()


### PR DESCRIPTION
### SUMMARY
The `adodbapi` dialect appears to be the only dialect included in `SQLAlchemy` 1.3 that doesn't implement the `dbapi()` method, and is fully removed in 1.4. To avoid logging a confusing warning, we should avoid trying to use the driver until we bump to 1.4.

### BEFORE
Previous to this check, the following would regularly pop up on logs:
```
2022-04-06 13:31:24,380:WARNING:superset.db_engine_specs:Unable to load dialect <class 'sqlalchemy.dialects.mssql.adodbapi.MSDialect_adodbapi'>: type object 'MSDialect_adodbapi' has no attribute 'dbapi'
```

### TESTING INSTRUCTIONS
Call `http://host/api/v1/database/available/` and make sure the you get the same available drivers as before, but no warning on the logs.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
