### PR TITLE
fix: check type of url before performing string actions

### DIFF
--- a/superset/databases/utils.py
+++ b/superset/databases/utils.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from sqlalchemy.engine.url import make_url, URL
 
@@ -104,7 +104,7 @@ def get_table_metadata(
     }
 
 
-def make_url_safe(raw_url: str) -> URL:
+def make_url_safe(raw_url: Union[str, URL]) -> URL:
     """
     Wrapper for SQLAlchemy's make_url(), which tends to raise too detailed of
     errors, which inevitably find their way into server logs. ArgumentErrors
@@ -113,8 +113,12 @@ def make_url_safe(raw_url: str) -> URL:
     :return:
     """
 
-    url = str(raw_url).strip()
-    try:
-        return make_url(url)  # noqa
-    except Exception:
-        raise DatabaseInvalidError()  # pylint: disable=raise-missing-from
+    if isinstance(raw_url, str):
+        url = raw_url.strip()
+        try:
+            return make_url(url)  # noqa
+        except Exception:
+            raise DatabaseInvalidError()  # pylint: disable=raise-missing-from
+
+    else:
+        return raw_url

--- a/superset/databases/utils.py
+++ b/superset/databases/utils.py
@@ -112,7 +112,9 @@ def make_url_safe(raw_url: str) -> URL:
     :param raw_url:
     :return:
     """
+
+    url = str(raw_url).strip()
     try:
-        return make_url(raw_url.strip())  # noqa
+        return make_url(url)  # noqa
     except Exception:
         raise DatabaseInvalidError()  # pylint: disable=raise-missing-from

--- a/tests/unit_tests/databases/utils_test.py
+++ b/tests/unit_tests/databases/utils_test.py
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from sqlalchemy.engine.url import make_url
+from sqlalchemy.orm.session import Session
+
+from superset.databases.utils import make_url_safe
+
+
+def test_make_url_safe_string(app_context: None, session: Session) -> None:
+    """
+    Test converting a string to a safe uri
+    """
+    uri_string = "postgresql+psycopg2://superset:***@127.0.0.1:5432/superset"
+    uri_safe = make_url_safe(uri_string)
+    assert str(uri_safe) == uri_string
+    assert uri_safe == make_url(uri_string)
+
+
+def test_make_url_safe_url(app_context: None, session: Session) -> None:
+    """
+    Test converting a url to a safe uri
+    """
+    uri = make_url("postgresql+psycopg2://superset:***@127.0.0.1:5432/superset")
+    uri_safe = make_url_safe(uri)
+    assert uri_safe == uri


### PR DESCRIPTION
### SUMMARY
This small change ensures that a uri is a string before performing the `strip` method on it. If the param is a `URL`, like the original function, it will just return the value.

### TESTING INSTRUCTIONS
automated tests to check that the make_url_safe function can take both a string or a `Url`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
