### PR TITLE
feat: add a `where_in` filter for Jinja2

### DIFF
--- a/docs/docs/installation/sql-templating.mdx
+++ b/docs/docs/installation/sql-templating.mdx
@@ -206,9 +206,11 @@ Here's a concrete example:
 SELECT action, count(*) as times
 FROM logs
 WHERE
-    action in ({{ "'" + "','".join(filter_values('action_type')) + "'" }})
+    action in {{ filter_values('action_type')|where_in }}
 GROUP BY action
 ```
+
+There `where_in` filter converts the list of values from `filter_values('action_type')` into a string suitable for an `IN` expression.
 
 **Filters for a Specific Column**
 
@@ -243,7 +245,7 @@ Here's a concrete example:
 
     {%- if filter.get('op') == 'IN' -%}
         AND
-        full_name IN ( {{ "'" + "', '".join(filter.get('val')) + "'" }} )
+        full_name IN {{ filter.get('val')|where_in }}
     {%- endif -%}
 
     {%- if filter.get('op') == 'LIKE' -%}

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -401,6 +401,25 @@ def validate_template_context(
     return validate_context_types(context)
 
 
+def where_in(values: List[Any], mark: str = "'") -> str:
+    """
+    Given a list of values, build a parenthesis list suitable for an IN expression.
+
+        >>> where_in([1, "b", 3])
+        (1, 'b', 3)
+
+    """
+
+    def quote(value: Any) -> str:
+        if isinstance(value, str):
+            value = value.replace(mark, mark * 2)
+            return f"{mark}{value}{mark}"
+        return str(value)
+
+    joined_values = ", ".join(quote(value) for value in values)
+    return f"({joined_values})"
+
+
 class BaseTemplateProcessor:
     """
     Base class for database-specific jinja context
@@ -432,6 +451,9 @@ class BaseTemplateProcessor:
         self._context: Dict[str, Any] = {}
         self._env = SandboxedEnvironment(undefined=DebugUndefined)
         self.set_context(**kwargs)
+
+        # custom filters
+        self._env.filters["where_in"] = where_in
 
     def set_context(self, **kwargs: Any) -> None:
         self._context.update(kwargs)

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from superset.jinja_context import where_in
+
+
+def test_where_in() -> None:
+    """
+    Test the ``where_in`` Jinja2 filter.
+    """
+    assert where_in([1, "b", 3]) == "(1, 'b', 3)"
+    assert where_in([1, "b", 3], '"') == '(1, "b", 3)'
+    assert where_in(["O'Malley's"]) == "('O''Malley''s')"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Using the Jinja2 function `filter_values` in WHERE clauses today is very cumbersome, requiring the user to quote and join elements from the list:

```sql
SELECT * FROM some_table
WHERE
    action in ({{ "'" + "','".join(filter_values('action_type')) + "'" }})
```

I created a simple `where_in` filter that does the same logic, since this is a common pattern for users. With the filter users only need to write:

```sql
SELECT * FROM some_table
WHERE
    action IN {{ filter_values('action_type')|where_in }}
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
