### PR TITLE
fix: missing home label on welcome page

### DIFF
--- a/superset-frontend/src/assets/stylesheets/superset.less
+++ b/superset-frontend/src/assets/stylesheets/superset.less
@@ -545,7 +545,6 @@ td.filtered {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  display: none;
 }
 
 // Making native radio buttons use brand color


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fixes the following bug where the "Home" text wasn't displayed on the welcome page:
![image](https://user-images.githubusercontent.com/7409244/162082115-acb4eb1f-bc73-4a4c-b649-e6644910b3df.png)


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After:
![image](https://user-images.githubusercontent.com/7409244/162082173-ba1e3df2-b374-4d81-ad82-6de3434643ed.png)


### TESTING INSTRUCTIONS
test env soon

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @ktmud @michael-s-molina @rusackas 