### PR TITLE
fix(dataset): avoid crash if database missing

### DIFF
--- a/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
@@ -1001,10 +1001,10 @@ class DatasourceEditor extends React.PureComponent {
                         database={{
                           ...datasource.database,
                           database_name:
-                            datasource.database.database_name ||
-                            datasource.database.name,
+                            datasource.database?.database_name ||
+                            datasource.database?.name,
                         }}
-                        dbId={datasource.database.id}
+                        dbId={datasource.database?.id}
                         handleError={this.props.addDangerToast}
                         schema={datasource.schema}
                         sqlLabMode={false}


### PR DESCRIPTION
### SUMMARY
When a dataset is referencing a database that is no longer present, trying to edit the dataset fails:

<img width="1037" alt="image" src="https://user-images.githubusercontent.com/33317356/162171684-6eece8d7-0f70-43a5-bfe0-5f7ac2fdf385.png">

After the fix, it's possible to change edit the dataset as expected:
<img width="935" alt="image" src="https://user-images.githubusercontent.com/33317356/162172585-fdd370ff-cb1f-4260-826b-023e52e1a3b7.png">

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
