### PR TITLE
fix: Add 1 month to quaterly time grain

### DIFF
--- a/superset/db_engine_specs/netezza.py
+++ b/superset/db_engine_specs/netezza.py
@@ -31,7 +31,7 @@ class NetezzaEngineSpec(PostgresBaseEngineSpec):
         "P1D": "DATE_TRUNC('day', {col})",
         "P1W": "DATE_TRUNC('week', {col})",
         "P1M": "DATE_TRUNC('month', {col})",
-        "P3M": "DATE_TRUNC('quarter', {col})",
+        "P3M": "ADD_MONTHS(DATE_TRUNC('quarter', {col}), 1)",
         "P1Y": "DATE_TRUNC('year', {col})",
     }
 

--- a/superset/db_engine_specs/oracle.py
+++ b/superset/db_engine_specs/oracle.py
@@ -36,7 +36,7 @@ class OracleEngineSpec(BaseEngineSpec):
         "P1D": "TRUNC(CAST({col} as DATE), 'DDD')",
         "P1W": "TRUNC(CAST({col} as DATE), 'WW')",
         "P1M": "TRUNC(CAST({col} as DATE), 'MONTH')",
-        "P3M": "TRUNC(CAST({col} as DATE), 'Q')",
+        "P3M": "ADD_MONTHS(TRUNC(CAST({col} as DATE), 'Q'), 1)",
         "P1Y": "TRUNC(CAST({col} as DATE), 'YEAR')",
     }
 

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -89,7 +89,7 @@ class PostgresBaseEngineSpec(BaseEngineSpec):
         "P1D": "DATE_TRUNC('day', {col})",
         "P1W": "DATE_TRUNC('week', {col})",
         "P1M": "DATE_TRUNC('month', {col})",
-        "P3M": "DATE_TRUNC('quarter', {col})",
+        "P3M": "DATE_TRUNC('quarter', {col}) + INTERVAL '1' month",
         "P1Y": "DATE_TRUNC('year', {col})",
     }
 

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -153,7 +153,7 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
         "P1D": "date_trunc('day', CAST({col} AS TIMESTAMP))",
         "P1W": "date_trunc('week', CAST({col} AS TIMESTAMP))",
         "P1M": "date_trunc('month', CAST({col} AS TIMESTAMP))",
-        "P3M": "date_trunc('quarter', CAST({col} AS TIMESTAMP))",
+        "P3M": "date_add('month', 1, date_trunc('quarter', CAST({col} AS TIMESTAMP)))",
         "P1Y": "date_trunc('year', CAST({col} AS TIMESTAMP))",
         "P1W/1970-01-03T00:00:00Z": "date_add('day', 5, date_trunc('week', "
         "date_add('day', 1, CAST({col} AS TIMESTAMP))))",

--- a/superset/db_engine_specs/rockset.py
+++ b/superset/db_engine_specs/rockset.py
@@ -37,7 +37,7 @@ class RocksetEngineSpec(BaseEngineSpec):
         "P1D": "DATE_TRUNC('day', {col})",
         "P1W": "DATE_TRUNC('week', {col})",
         "P1M": "DATE_TRUNC('month', {col})",
-        "P3M": "DATE_TRUNC('quarter', {col})",
+        "P3M": "DATE_TRUNC('quarter', {col}) + INTERVAL 1 MONTH",
         "P1Y": "DATE_TRUNC('year', {col})",
     }
 

--- a/superset/db_engine_specs/snowflake.py
+++ b/superset/db_engine_specs/snowflake.py
@@ -91,7 +91,7 @@ class SnowflakeEngineSpec(PostgresBaseEngineSpec):
         "P1D": "DATE_TRUNC('DAY', {col})",
         "P1W": "DATE_TRUNC('WEEK', {col})",
         "P1M": "DATE_TRUNC('MONTH', {col})",
-        "P3M": "DATE_TRUNC('QUARTER', {col})",
+        "P3M": "ADD_MONTHS(DATE_TRUNC('QUARTER', {col}), 1)",
         "P1Y": "DATE_TRUNC('YEAR', {col})",
     }
 

--- a/superset/db_engine_specs/sqlite.py
+++ b/superset/db_engine_specs/sqlite.py
@@ -49,7 +49,8 @@ class SqliteEngineSpec(BaseEngineSpec):
             "DATETIME(STRFTIME('%Y-', {col}) || "  # year
             "SUBSTR('00' || "  # pad with zeros to 2 chars
             "((CAST(STRFTIME('%m', {col}) AS INTEGER)) - "  # month as integer
-            "(((CAST(STRFTIME('%m', {col}) AS INTEGER)) - 1) % 3) + 1), "  # month in quarter
+            "(((CAST(STRFTIME('%m', {col}) AS INTEGER)) - 1) % 3)"  # month in quarter
+            " + 1), "  # add 1 month to return middle date of each quarter
             "-2) || "  # close pad
             "'-01T00:00:00')"
         ),

--- a/superset/db_engine_specs/sqlite.py
+++ b/superset/db_engine_specs/sqlite.py
@@ -49,7 +49,7 @@ class SqliteEngineSpec(BaseEngineSpec):
             "DATETIME(STRFTIME('%Y-', {col}) || "  # year
             "SUBSTR('00' || "  # pad with zeros to 2 chars
             "((CAST(STRFTIME('%m', {col}) AS INTEGER)) - "  # month as integer
-            "(((CAST(STRFTIME('%m', {col}) AS INTEGER)) - 1) % 3)), "  # month in quarter
+            "(((CAST(STRFTIME('%m', {col}) AS INTEGER)) - 1) % 3) + 1), "  # month in quarter
             "-2) || "  # close pad
             "'-01T00:00:00')"
         ),

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -46,7 +46,7 @@ class TrinoEngineSpec(BaseEngineSpec):
         "P1D": "date_trunc('day', CAST({col} AS TIMESTAMP))",
         "P1W": "date_trunc('week', CAST({col} AS TIMESTAMP))",
         "P1M": "date_trunc('month', CAST({col} AS TIMESTAMP))",
-        "P3M": "date_trunc('quarter', CAST({col} AS TIMESTAMP))",
+        "P3M": "date_trunc('quarter', CAST({col} AS TIMESTAMP)) + interval '1' month",
         "P1Y": "date_trunc('year', CAST({col} AS TIMESTAMP))",
         # "1969-12-28T00:00:00Z/P1W",  # Week starting Sunday
         # "1969-12-29T00:00:00Z/P1W",  # Week starting Monday


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Before this change, we are facing wrong Q1, Q2, Q3, Q4 duration. 

It should be
Q1: Jan - Mar
Q2: Apr - Jun
Q3: Jul - Sep
Q4: Oct - Dec

The reason is that time grain expression against database returns date as the first date of each quarter. (e.g.: Q1: 1st Jan, Q2: 1st Apr). But when we visualize this data using time_series bar chart v2, the returned date is the middle date of the bar chart. 

Solution: added 1 month to time grain expression for each database.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
<img width="1530" alt="image" src="https://user-images.githubusercontent.com/39701522/162277520-07970d5f-94a6-4648-9d51-2e845a9ef85f.png">

After:
<img width="1532" alt="image" src="https://user-images.githubusercontent.com/39701522/162277294-94e264e6-04f8-4f51-b912-7022a50393c9.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Chart a time series V2 chart using netflix demo data
   Time: Date added grain as day
   Metric: Count
   Time range: 01/01/2019 - 01/01/2020
2. Run graph
3. Toggle to “Quarter” time grain

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Bug fix