### PR TITLE
fix(explore): make to show the null value as N/A in view result

### DIFF
--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -278,9 +278,8 @@ export const useTableColumns = (
   datasourceId?: string,
   timeFormattedColumns: string[] = [],
   moreConfigs?: { [key: string]: Partial<Column> },
-) => {
-  console.log('data', data);
-  return useMemo(
+) =>
+  useMemo(
     () =>
       colnames && data?.length
         ? colnames
@@ -326,4 +325,3 @@ export const useTableColumns = (
         : [],
     [colnames, data, coltypes, datasourceId, moreConfigs, timeFormattedColumns],
   );
-};

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -250,7 +250,9 @@ export const useFilteredTableData = (
   const rowsAsStrings = useMemo(
     () =>
       data?.map((row: Record<string, any>) =>
-        Object.values(row).map(value => value?.toString().toLowerCase()),
+        Object.values(row).map(value =>
+          value ? value.toString().toLowerCase() : 'N/A',
+        ),
       ) ?? [],
     [data],
   );
@@ -276,8 +278,9 @@ export const useTableColumns = (
   datasourceId?: string,
   timeFormattedColumns: string[] = [],
   moreConfigs?: { [key: string]: Partial<Column> },
-) =>
-  useMemo(
+) => {
+  console.log('data', data);
+  return useMemo(
     () =>
       colnames && data?.length
         ? colnames
@@ -302,6 +305,7 @@ export const useTableColumns = (
                     key
                   ),
                 Cell: ({ value }) => {
+                  console.log('value', value);
                   if (value === true) {
                     return BOOL_TRUE_DISPLAY;
                   }
@@ -322,3 +326,4 @@ export const useTableColumns = (
         : [],
     [colnames, data, coltypes, datasourceId, moreConfigs, timeFormattedColumns],
   );
+};

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -304,7 +304,6 @@ export const useTableColumns = (
                     key
                   ),
                 Cell: ({ value }) => {
-                  console.log('value', value);
                   if (value === true) {
                     return BOOL_TRUE_DISPLAY;
                   }

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -251,7 +251,7 @@ export const useFilteredTableData = (
     () =>
       data?.map((row: Record<string, any>) =>
         Object.values(row).map(value =>
-          value ? value.toString().toLowerCase() : 'N/A',
+          value ? value.toString().toLowerCase() : t('N/A'),
         ),
       ) ?? [],
     [data],


### PR DESCRIPTION
### SUMMARY
NULL values not showing up in View Results in Explore

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
![image](https://user-images.githubusercontent.com/47900232/162296999-36c71667-2b44-4e96-a22e-baf397b7d405.png)

AFTER:
![image](https://user-images.githubusercontent.com/47900232/162296390-26b7605d-b421-4d9e-8bc8-278ea63d9ec6.png)

### TESTING INSTRUCTIONS
**How to reproduce bugs**

1. Go to Explore.
2. Create or Open the Table Chart
3. When looking at a table with Null values, the View Results section didn't show the null values.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
