### PR TITLE
fix: Query execution time is displayed as invalid date

### DIFF
--- a/superset-frontend/src/views/CRUD/data/query/QueryList.tsx
+++ b/superset-frontend/src/views/CRUD/data/query/QueryList.tsx
@@ -181,9 +181,12 @@ function QueryList({ addDangerToast, addSuccessToast }: QueryListProps) {
         accessor: QueryObjectColumns.start_time,
         Header: t('Time'),
         size: 'xl',
-        Cell: ({ row: { original } }: any) => {
-          const startTime = parseFloat(original.start_time);
-          const startMoment = moment.utc(startTime).local();
+        Cell: ({
+          row: {
+            original: { start_time, end_time },
+          },
+        }: any) => {
+          const startMoment = moment.utc(start_time).local();
           const formattedStartTimeData = startMoment
             .format(DATETIME_WITH_TIME_ZONE)
             .split(' ');
@@ -195,13 +198,11 @@ function QueryList({ addDangerToast, addSuccessToast }: QueryListProps) {
             </>
           );
 
-          return original.end_time ? (
+          return end_time ? (
             <Tooltip
               title={t(
                 'Duration: %s',
-                moment(
-                  moment.utc(parseFloat(original.end_time) - startTime),
-                ).format(TIME_WITH_MS),
+                moment(moment.utc(end_time - start_time)).format(TIME_WITH_MS),
               )}
               placement="bottom"
             >

--- a/superset-frontend/src/views/CRUD/data/query/QueryList.tsx
+++ b/superset-frontend/src/views/CRUD/data/query/QueryList.tsx
@@ -181,12 +181,9 @@ function QueryList({ addDangerToast, addSuccessToast }: QueryListProps) {
         accessor: QueryObjectColumns.start_time,
         Header: t('Time'),
         size: 'xl',
-        Cell: ({
-          row: {
-            original: { start_time, end_time },
-          },
-        }: any) => {
-          const startMoment = moment.utc(start_time).local();
+        Cell: ({ row: { original } }: any) => {
+          const startTime = parseFloat(original.start_time);
+          const startMoment = moment.utc(startTime).local();
           const formattedStartTimeData = startMoment
             .format(DATETIME_WITH_TIME_ZONE)
             .split(' ');
@@ -198,11 +195,13 @@ function QueryList({ addDangerToast, addSuccessToast }: QueryListProps) {
             </>
           );
 
-          return end_time ? (
+          return original.end_time ? (
             <Tooltip
               title={t(
                 'Duration: %s',
-                moment(moment.utc(end_time - start_time)).format(TIME_WITH_MS),
+                moment(
+                  moment.utc(parseFloat(original.end_time) - startTime),
+                ).format(TIME_WITH_MS),
               )}
               placement="bottom"
             >

--- a/superset/queries/api.py
+++ b/superset/queries/api.py
@@ -22,7 +22,7 @@ from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP, RouteMethod
 from superset.databases.filters import DatabaseFilter
 from superset.models.sql_lab import Query
 from superset.queries.filters import QueryFilter
-from superset.queries.schemas import openapi_spec_methods_override
+from superset.queries.schemas import openapi_spec_methods_override, QuerySchema
 from superset.views.base_api import BaseSupersetModelRestApi, RelatedFieldFilter
 from superset.views.filters import FilterRelatedOwners
 
@@ -94,6 +94,7 @@ class QueryRestApi(BaseSupersetModelRestApi):
     ]
     base_filters = [["id", QueryFilter, lambda: []]]
     base_order = ("changed_on", "desc")
+    list_model_schema = QuerySchema()
 
     openapi_spec_tag = "Queries"
     openapi_spec_methods = openapi_spec_methods_override

--- a/superset/queries/schemas.py
+++ b/superset/queries/schemas.py
@@ -17,7 +17,6 @@
 from typing import List
 
 from marshmallow import fields, Schema
-from marshmallow_sqlalchemy import SQLAlchemyAutoSchema
 
 from superset.dashboards.schemas import UserSchema
 from superset.models.sql_lab import Query
@@ -65,5 +64,6 @@ class QuerySchema(Schema):
         load_instance = True
         include_relationships = True
 
-    def get_sql_tables(_, obj: Query) -> List[Table]:
+    # pylint: disable=no-self-use
+    def get_sql_tables(self, obj: Query) -> List[Table]:
         return obj.sql_tables

--- a/superset/queries/schemas.py
+++ b/superset/queries/schemas.py
@@ -39,16 +39,26 @@ class DatabaseSchema(Schema):
     database_name = fields.String()
 
 
-class QuerySchema(SQLAlchemyAutoSchema):
+class QuerySchema(Schema):
     """
     Schema for the ``Query`` model.
     """
 
-    start_time = fields.Float(attribute="start_time")
-    end_time = fields.Float(attribute="end_time")
-    user = fields.Nested(UserSchema)
+    changed_on = fields.DateTime()
     database = fields.Nested(DatabaseSchema)
+    end_time = fields.Float(attribute="end_time")
+    executed_sql = fields.String()
+    id = fields.Int()
+    rows = fields.Int()
+    schema = fields.String()
+    sql = fields.String()
     sql_tables = fields.Method("get_sql_tables")
+    start_time = fields.Float(attribute="start_time")
+    status = fields.String()
+    tab_name = fields.String()
+    tmp_table_name = fields.String()
+    tracking_url = fields.String()
+    user = fields.Nested(UserSchema)
 
     class Meta:  # pylint: disable=too-few-public-methods
         model = Query

--- a/superset/queries/schemas.py
+++ b/superset/queries/schemas.py
@@ -14,6 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from marshmallow import fields
+from marshmallow_sqlalchemy import SQLAlchemyAutoSchema
+
+from superset.models.sql_lab import Query
 
 openapi_spec_methods_override = {
     "get": {"get": {"description": "Get query detail information."}},
@@ -25,3 +29,17 @@ openapi_spec_methods_override = {
         }
     },
 }
+
+
+class QuerySchema(SQLAlchemyAutoSchema):
+    """
+    Schema for the ``Query`` model.
+    """
+
+    start_time = fields.Float(attribute="start_time")
+    end_time = fields.Float(attribute="end_time")
+
+    class Meta:  # pylint: disable=too-few-public-methods
+        model = Query
+        load_instance = True
+        include_relationships = True


### PR DESCRIPTION
### SUMMARY
The Time column in the Query History is being displayed as an Invalid date.

The reason being the underlying data type is numeric with precision, to get sub-second precision.
That means the returned json value is a string (to keep the precision) and in turn, it fails the conversion to a moment object.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:
<img width="1728" alt="Screen Shot 2022-04-07 at 20 23 25" src="https://user-images.githubusercontent.com/17252075/162336157-b1eae912-8882-44d9-858c-dd9e79fbf88a.png">

After:
<img width="1710" alt="new" src="https://user-images.githubusercontent.com/17252075/162336108-33aeaf4a-6f8f-469d-a39d-115894339ec8.png">

### TESTING INSTRUCTIONS
1. Go to SQL lab -> SQL Editor
2. Run any query
3. Go to SQL lab -> Query History

Ensure the time column is displaying the proper start time.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
