### PR TITLE
chore: Update font-sizes in ImportModal

### DIFF
--- a/superset-frontend/src/components/ImportModal/index.tsx
+++ b/superset-frontend/src/components/ImportModal/index.tsx
@@ -29,7 +29,7 @@ import { ImportResourceName } from 'src/views/CRUD/types';
 const HelperMessage = styled.div`
   display: block;
   color: ${({ theme }) => theme.colors.grayscale.base};
-  font-size: ${({ theme }) => theme.typography.sizes.s - 1}px;
+  font-size: ${({ theme }) => theme.typography.sizes.s}px;
 `;
 
 const StyledInputContainer = styled.div`


### PR DESCRIPTION
### SUMMARY
This PR removes hacky usages of font-sizes by replacing them with the exact font-sizes available in the theme config.

### BEFORE

<img width="841" alt="importmodal-b4" src="https://user-images.githubusercontent.com/60598000/162419771-9f87db25-71da-4d2e-a797-4c23aae6fe77.png">

### AFTER

<img width="824" alt="Screen Shot 2022-04-08 at 13 37 48" src="https://user-images.githubusercontent.com/60598000/162419811-d5c18c06-84ee-4532-8572-e58e98ba0678.png">


### TESTING INSTRUCTIONS
1. Go to databases
2. Import a database
3. Make sure the font-size in the info text looks balanced

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
