### PR TITLE
chore: Remove wrong usage of font-size in ExploreViewContainer

### DIFF
--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -153,7 +153,6 @@ const ExplorePanelContainer = styled.div`
       .horizontal-text {
         text-transform: uppercase;
         color: ${theme.colors.grayscale.light1};
-        font-size: ${theme.typography.sizes.s * 4};
       }
     }
     .no-show {
@@ -613,7 +612,7 @@ function ExploreViewContainer(props) {
           }
         >
           <div className="title-container">
-            <span className="horizont al-text">{t('Dataset')}</span>
+            <span className="horizontal-text">{t('Dataset')}</span>
             <span
               role="button"
               tabIndex={0}

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -151,8 +151,7 @@ const ExplorePanelContainer = styled.div`
       padding: 0 ${theme.gridUnit * 4}px;
       justify-content: space-between;
       .horizontal-text {
-        text-transform: uppercase;
-        color: ${theme.colors.grayscale.light1};
+        font-size: ${theme.typography.sizes.s}px;
       }
     }
     .no-show {


### PR DESCRIPTION
### SUMMARY
It removes an unnecessary font-size and fixes a className to match the right layout as detailed in https://github.com/apache/superset/discussions/19099

### BEFORE

<img width="796" alt="Screen Shot 2022-04-08 at 14 38 43" src="https://user-images.githubusercontent.com/60598000/162428437-50a45d7c-58a3-4537-9204-fb3e2c708be9.png">

### AFTER

<img width="822" alt="Screen Shot 2022-04-08 at 14 37 00" src="https://user-images.githubusercontent.com/60598000/162428266-7aae0c0f-b74a-4fcd-84e5-75bdf20059b5.png">

### TESTING INSTRUCTIONS
1. Open Explore
2. Make sure the title of the left side panel has the right font-size and color

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
