### PR TITLE
chore: Update font-sizes in QueryPreviewModal

### DIFF
--- a/superset-frontend/src/views/CRUD/data/query/QueryPreviewModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/query/QueryPreviewModal.tsx
@@ -30,14 +30,14 @@ import { QueryObject } from 'src/views/CRUD/types';
 
 const QueryTitle = styled.div`
   color: ${({ theme }) => theme.colors.secondary.light2};
-  font-size: ${({ theme }) => theme.typography.sizes.s - 1}px;
+  font-size: ${({ theme }) => theme.typography.sizes.s}px;
   margin-bottom: 0;
   text-transform: uppercase;
 `;
 
 const QueryLabel = styled.div`
   color: ${({ theme }) => theme.colors.grayscale.dark2};
-  font-size: ${({ theme }) => theme.typography.sizes.m - 1}px;
+  font-size: ${({ theme }) => theme.typography.sizes.m}px;
   padding: 4px 0 24px 0;
 `;
 

--- a/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryPreviewModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryPreviewModal.tsx
@@ -28,14 +28,14 @@ import { useQueryPreviewState } from 'src/views/CRUD/data/hooks';
 
 const QueryTitle = styled.div`
   color: ${({ theme }) => theme.colors.secondary.light2};
-  font-size: ${({ theme }) => theme.typography.sizes.s - 1}px;
+  font-size: ${({ theme }) => theme.typography.sizes.s}px;
   margin-bottom: 0;
   text-transform: uppercase;
 `;
 
 const QueryLabel = styled.div`
   color: ${({ theme }) => theme.colors.grayscale.dark2};
-  font-size: ${({ theme }) => theme.typography.sizes.m - 1}px;
+  font-size: ${({ theme }) => theme.typography.sizes.m}px;
   padding: 4px 0 16px 0;
 `;
 


### PR DESCRIPTION
### SUMMARY
This PR removes hacky usages of font-sizes by replacing them with the exact font-sizes available in the theme config.

### BEFORE

<img width="862" alt="Screen Shot 2022-04-08 at 18 13 56" src="https://user-images.githubusercontent.com/60598000/162471510-c407466b-6f28-42b2-9ee4-d7c88a05ae2f.png">

### AFTER

<img width="930" alt="Screen Shot 2022-04-08 at 18 11 18" src="https://user-images.githubusercontent.com/60598000/162471337-cf68215b-91c0-43d2-89d3-baa94d447370.png">


### TESTING INSTRUCTIONS
1. Open the QueryPreview modal from the Query History or Saved Queries
2. Make sure the font-sizes look balanced

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
