### PR TITLE
fix(test): make test_clean_requests_after_schema_grant more idempotent

### DIFF
--- a/tests/integration_tests/access_tests.py
+++ b/tests/integration_tests/access_tests.py
@@ -374,6 +374,7 @@ class TestRequestAccess(SupersetTestCase):
             .filter_by(table_name="wb_health_population")
             .first()
         )
+        original_schema = ds.schema
 
         ds.schema = "temp_schema"
         security_manager.add_permission_view_menu("schema_access", ds.schema_perm)
@@ -394,13 +395,7 @@ class TestRequestAccess(SupersetTestCase):
         gamma_user = security_manager.find_user(username="gamma")
         gamma_user.roles.remove(security_manager.find_role(SCHEMA_ACCESS_ROLE))
 
-        ds = (
-            session.query(SqlaTable)
-            .filter_by(table_name="wb_health_population")
-            .first()
-        )
-        ds.schema = None
-
+        ds.schema = original_schema
         session.commit()
 
     @mock.patch("superset.utils.core.send_mime_email")


### PR DESCRIPTION
### SUMMARY

Fix a potential table name conflict in integration tests `test_clean_requests_after_schema_grant`.

Sometimes when the example database has `wb_health_population`'s schema in another name---for example, `public` instead of `None` when in postgres (depending on how you configure `SQLALCHEMY_EXAMPLES_URI`), rerunning this test will fail and report "table already exists" error from [here](https://github.com/apache/superset/blob/34b55765c4b0cbd8f0b9f89c6ca0f62f4478270e/superset/connectors/sqla/models.py#L1893-L1896). It seems the intention of the test was to reset table.schema to its original schema, but simply assumed it used to be `None`. This PR makes this test more idempotent by actually changing the schema of the same table to the original schema.
 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

Make sure CI passes.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
