### PR TITLE
fix: Table Autosizing Has Unnecessary Horizontal Scroll Bars

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/hooks/useSticky.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/hooks/useSticky.tsx
@@ -183,7 +183,9 @@ function StickyWrap({
       .clientHeight;
     const ths = bodyThead.childNodes[0]
       .childNodes as NodeListOf<HTMLTableHeaderCellElement>;
-    const widths = Array.from(ths).map(th => th.clientWidth);
+    const widths = Array.from(ths).map(
+      th => th.getBoundingClientRect()?.width || th.clientWidth,
+    );
     const [hasVerticalScroll, hasHorizontalScroll] = needScrollBar({
       width: maxWidth,
       height: maxHeight - theadHeight - tfootHeight,


### PR DESCRIPTION
### SUMMARY
On Table Charts, the auto-sizing in table charts forces a scroll bar in and expands the cells even when there is space available.
This implements a scroll bar and takes away additional space that isn't needed. For example - a table chart with 6 columns and enough empty space will still implement a scroll.

The issue why this is happening is that, when calculating the columns width, we're using the `clientWidth`, which rounds the number. So, the total width of the table could be 1000, but due to rounding, the sum of the columns could yield 1001 and thus causing the scrollbar to appear.

This PR switches the width calculation to `getBoundingClientRect`, which does gives the result without rounding (we're still defaulting to clientWidth, just in case).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://user-images.githubusercontent.com/17252075/162524426-0e9ed1a9-9207-438b-a34c-5e1aaa65ec16.mov

After:

https://user-images.githubusercontent.com/17252075/162524290-4ec1ce06-6030-4bb7-abc9-c585c451162e.mov

### TESTING INSTRUCTIONS
1. Create a chart table
2. Add some columns to it
3. Run the query

The chart, if no width is specified to any of it's column, should take the width of the panel and don't show the horizontal scrollbar

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
