### PR TITLE
test: freeze time for dashboard export test

### DIFF
--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -1425,6 +1425,7 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
         "load_world_bank_dashboard_with_slices",
         "load_birth_names_dashboard_with_slices",
     )
+    @freeze_time("2022-01-01")
     def test_export(self):
         """
         Dashboard API: Test dashboard export


### PR DESCRIPTION
### SUMMARY

This fix a flaky test fail where server side time vs test case assertion time did not happen within 1 second:

<img width="781" alt="Xnip2022-04-08_20-18-44" src="https://user-images.githubusercontent.com/335541/162554781-0b2b5518-8a9c-4930-b3b4-63b2af616534.png">

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
