### PR TITLE
chore: clean up dynamic translation strings

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
@@ -316,7 +316,7 @@ export default function transformProps(
           type: 'text',
           ...getTotalValuePadding({ chartPadding, donut, width, height }),
           style: {
-            text: t(`Total: ${numberFormatter(totalValue)}`),
+            text: t('Total: %s', numberFormatter(totalValue)),
             fontSize: 16,
             fontWeight: 'bold',
           },

--- a/superset-frontend/src/dashboard/actions/dashboardLayout.js
+++ b/superset-frontend/src/dashboard/actions/dashboardLayout.js
@@ -210,7 +210,7 @@ export function handleComponentDrop(dropResult) {
       destination.id !== rootChildId
     ) {
       return dispatch(
-        addWarningToast(t(`Can not move top level tab into nested tabs`)),
+        addWarningToast(t('Can not move top level tab into nested tabs')),
       );
     } else if (
       destination &&

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/Footer/Footer.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/Footer/Footer.tsx
@@ -46,7 +46,7 @@ const Footer: FC<FooterProps> = ({
         onConfirm={onConfirmCancel}
         onDismiss={onDismiss}
       >
-        {t(`Are you sure you want to cancel?`)}
+        {t('Are you sure you want to cancel?')}
       </CancelConfirmationAlert>
     );
   }

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -557,7 +557,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
             return;
           }
 
-          addSuccessToast(t(`${data.type} updated`));
+          addSuccessToast(t('%s updated', data.type));
 
           if (onAdd) {
             onAdd();
@@ -573,7 +573,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
           return;
         }
 
-        addSuccessToast(t(`${data.type} updated`));
+        addSuccessToast(t('%s updated', data.type));
 
         if (onAdd) {
           onAdd(response);

--- a/superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx
+++ b/superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx
@@ -262,7 +262,7 @@ function AnnotationList({
       <SubMenu
         name={
           <StyledHeader>
-            <span>{t(`Annotation Layer ${annotationLayerName}`)}</span>
+            <span>{t('Annotation Layer %s', annotationLayerName)}</span>
             <span>
               {hasHistory ? (
                 <Link to="/annotationlayermodelview/list/">Back to all</Link>

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -1035,7 +1035,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
           }
           validationMethods={{ onBlur: () => {} }}
           errorMessage={validationErrors?.password_needed}
-          label={t(`${database.slice(10)} PASSWORD`)}
+          label={t('%s PASSWORD', database.slice(10))}
           css={formScrollableStyles}
         />
       </>

--- a/superset-frontend/src/views/CRUD/welcome/EmptyState.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/EmptyState.tsx
@@ -122,11 +122,10 @@ export default function EmptyState({ tableName, tab }: EmptyStateProps) {
                 <i className="fa fa-plus" />
                 {tableName === 'SAVED_QUERIES'
                   ? t('SQL query')
-                  : t(`${tableName
+                  : tableName
                       .split('')
                       .slice(0, tableName.length - 1)
                       .join('')}
-                    `)}
               </Button>
             </ButtonContainer>
           )}


### PR DESCRIPTION
### SUMMARY
Fix some translations that include variables in the translation string (see here for details why this doesn't work: https://stackoverflow.com/questions/34579316/flask-babel-how-to-translate-variables)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
