### PR TITLE
fix(dnd&column): make to fix the blank state issue when only one column select

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
@@ -127,14 +127,7 @@ export function DndColumnSelect(props: DndColumnSelectProps) {
   );
 
   const popoverOptions = useMemo(
-    () =>
-      Object.values(options).filter(
-        col =>
-          !optionSelector.values
-            .filter(isColumnMeta)
-            .map((val: ColumnMeta) => val.column_name)
-            .includes(col.column_name),
-      ),
+    () => Object.values(options),
     [optionSelector.values, options],
   );
 


### PR DESCRIPTION
### SUMMARY
Single Temporal Column Should Appear in a dropdown instead of Blank State

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
![image](https://user-images.githubusercontent.com/47900232/162795782-1909f918-ea90-4723-80a4-bc7f7a905412.png)

AFTER:
![image](https://user-images.githubusercontent.com/47900232/162795511-542ec503-3a0e-49cb-9145-5032c3fc8c53.png)

### TESTING INSTRUCTIONS
**How to reproduce bugs**

1. Create a chart using a dataset that has only one temporal column (you can edit the dataset and uncheck "is temporal" on all columns but one if that helps with quicker testing)
2. Click on the time column in the Customize panel

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
