### PR TITLE
fix: allow_browser_login in import/export API

### DIFF
--- a/superset/importexport/api.py
+++ b/superset/importexport/api.py
@@ -40,6 +40,7 @@ class ImportExportRestApi(BaseApi):
 
     resource_name = "assets"
     openapi_spec_tag = "Import/export"
+    allow_browser_login = True
 
     @expose("/export/", methods=["GET"])
     @protect()


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add missing `allow_browser_login` to the new (introduced in https://github.com/apache/superset/pull/19220) import/export API, otherwise users can't interact with it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Log in and visit https://example.org/api/v1/assets/export/, a ZIP should be downloaded.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
