### PR TITLE
fix(database-api): allow search for all columns

### DIFF
--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -169,8 +169,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
 
     edit_columns = add_columns
 
-    search_columns = ["allow_file_upload", "expose_in_sqllab"]
-
     search_filters = {
         "allow_file_upload": [DatabaseUploadEnabledFilter],
         "expose_in_sqllab": [DatabaseFilter],


### PR DESCRIPTION
### SUMMARY
#19051 broke filtering databases by other than `allow_file_upload` and `expose_in_sqllab`, causing trouble in both SQL Lab and the database list view. This removes the list of explicit `search_columns` so that filtering by all properties is again possible.

### AFTER
SQL Lab:
<img width="1241" alt="image" src="https://user-images.githubusercontent.com/33317356/162934415-f2ec3490-c69f-4f65-908d-8510a994baae.png">

Database list view sorting by AQE:
<img width="1478" alt="image" src="https://user-images.githubusercontent.com/33317356/162934266-18310180-7d04-41a7-80a6-9d7cf4e7e54a.png">

### BEFORE
SQL Lab:
<img width="1236" alt="image" src="https://user-images.githubusercontent.com/33317356/162933425-87b6eca2-4f08-4f2b-ba16-e57c8eede6c7.png">

Database list view:
<img width="1071" alt="image" src="https://user-images.githubusercontent.com/33317356/162933526-54768f39-3fa6-42ba-a77a-0c41a1a7d6ca.png">


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #19655
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
