### PR TITLE
fix(sql-lab): do not replace undefined schema with empty object

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -791,7 +791,7 @@ export function queryEditorSetSchema(queryEditor, schema) {
         dispatch({
           type: QUERY_EDITOR_SET_SCHEMA,
           queryEditor: queryEditor || {},
-          schema: schema || {},
+          schema,
         }),
       )
       .catch(() =>

--- a/superset-frontend/src/SqlLab/types.ts
+++ b/superset-frontend/src/SqlLab/types.ts
@@ -61,7 +61,7 @@ export type Query = {
     query: { limit: number };
   };
   resultsKey: string | null;
-  schema: string;
+  schema?: string;
   sql: string;
   sqlEditorId: string;
   state: QueryState;


### PR DESCRIPTION
### SUMMARY
In a change introduced in #18609, SQL Lab incorrectly replaces a missing schema with an empty object when dispatching the query action, which causes the query to fail in the backend, which later breaks the whole UI and makes it impossible to enter SQL Lab again.

See a few examples of what a valid schema is in this context:
https://github.com/apache/superset/blob/3a231f6b871cdab00b9dfb6192af76cf4cf9832a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx#L42
https://github.com/apache/superset/blob/3a231f6b871cdab00b9dfb6192af76cf4cf9832a/superset-frontend/src/components/DatabaseSelector/index.tsx#L96
https://github.com/apache/superset/blob/3a231f6b871cdab00b9dfb6192af76cf4cf9832a/superset-frontend/src/components/DatabaseSelector/index.tsx#L99

### AFTER
Now SQL Lab executes correctly even when not selecting a schema:
<img width="1651" alt="image" src="https://user-images.githubusercontent.com/33317356/162948581-8a7f041a-6544-4135-84e6-3ea6d48a942a.png">

### BEFORE
Previously the schema would fail to execute due to the empty object not being compatible with the column type in the metastore:
<img width="1651" alt="image" src="https://user-images.githubusercontent.com/33317356/162949053-262308c6-b0a7-4bd6-90da-a2240147a728.png">

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #19658
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
