### PR TITLE
chore: Remove TwoTone icons

### DIFF
--- a/superset-frontend/src/components/Icons/AntdEnhanced.tsx
+++ b/superset-frontend/src/components/Icons/AntdEnhanced.tsx
@@ -23,6 +23,7 @@ import { StyledIcon } from './Icon';
 import IconType from './IconType';
 
 const AntdEnhancedIcons = Object.keys(AntdIcons)
+  .filter(k => !k.includes('TwoTone'))
   .map(k => ({
     [k]: (props: IconType) => (
       <StyledIcon component={AntdIcons[k]} {...props} />

--- a/superset-frontend/src/components/Icons/IconType.ts
+++ b/superset-frontend/src/components/Icons/IconType.ts
@@ -21,7 +21,6 @@ import { IconComponentProps } from '@ant-design/icons/lib/components/Icon';
 type AntdIconType = IconComponentProps;
 type IconType = AntdIconType & {
   iconColor?: string;
-  twoToneColor?: string;
   iconSize?: 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl';
 };
 

--- a/superset-frontend/src/components/Icons/Icons.stories.tsx
+++ b/superset-frontend/src/components/Icons/Icons.stories.tsx
@@ -78,11 +78,6 @@ InteractiveIcons.argTypes = {
     defaultValue: null,
     control: { type: 'select', options: palette },
   },
-  // @TODO twoToneColor is being ignored
-  twoToneColor: {
-    defaultValue: null,
-    control: { type: 'select', options: palette },
-  },
   theme: {
     table: {
       disable: true,


### PR DESCRIPTION
### SUMMARY
Antdesign TwoTone icons are unused in the application. In order to avoid misuse of these icons, this PR filters them out.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No visual changes

### TESTING INSTRUCTIONS
1. Open Storybook and make sure no TwoTone icons are present

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
