### PR TITLE
fix: trap SQLAlchemy common exceptions & throw 422 error instead

### DIFF
--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -45,7 +45,7 @@ from flask_jwt_extended.exceptions import NoAuthorizationError
 from flask_wtf.csrf import CSRFError
 from flask_wtf.form import FlaskForm
 from pkg_resources import resource_filename
-from sqlalchemy import or_
+from sqlalchemy import exc, or_
 from sqlalchemy.orm import Query
 from werkzeug.exceptions import HTTPException
 from wtforms import Form
@@ -231,6 +231,9 @@ def handle_api_exception(
             return json_error_response(
                 utils.error_msg_from_exception(ex), status=cast(int, ex.code)
             )
+        except (exc.IntegrityError, exc.DatabaseError, exc.DataError) as ex:
+            logger.exception(ex)
+            return json_error_response(utils.error_msg_from_exception(ex), status=422)
         except Exception as ex:  # pylint: disable=broad-except
             logger.exception(ex)
             return json_error_response(utils.error_msg_from_exception(ex))

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -39,6 +39,7 @@ from superset.sql_lab import Query as SqllabQuery
 from superset.stats_logger import BaseStatsLogger
 from superset.superset_typing import FlaskResponse
 from superset.utils.core import time_function
+from superset.views.base import handle_api_exception
 
 logger = logging.getLogger(__name__)
 get_related_schema = {
@@ -386,6 +387,7 @@ class BaseSupersetModelRestApi(ModelRestApi):
         object_ref=False,
         log_to_statsd=False,
     )
+    @handle_api_exception
     def info_headless(self, **kwargs: Any) -> Response:
         """
         Add statsd metrics to builtin FAB _info endpoint
@@ -399,6 +401,7 @@ class BaseSupersetModelRestApi(ModelRestApi):
         object_ref=False,
         log_to_statsd=False,
     )
+    @handle_api_exception
     def get_headless(self, pk: int, **kwargs: Any) -> Response:
         """
         Add statsd metrics to builtin FAB GET endpoint
@@ -412,6 +415,7 @@ class BaseSupersetModelRestApi(ModelRestApi):
         object_ref=False,
         log_to_statsd=False,
     )
+    @handle_api_exception
     def get_list_headless(self, **kwargs: Any) -> Response:
         """
         Add statsd metrics to builtin FAB GET list endpoint
@@ -425,6 +429,7 @@ class BaseSupersetModelRestApi(ModelRestApi):
         object_ref=False,
         log_to_statsd=False,
     )
+    @handle_api_exception
     def post_headless(self) -> Response:
         """
         Add statsd metrics to builtin FAB POST endpoint
@@ -438,6 +443,7 @@ class BaseSupersetModelRestApi(ModelRestApi):
         object_ref=False,
         log_to_statsd=False,
     )
+    @handle_api_exception
     def put_headless(self, pk: int) -> Response:
         """
         Add statsd metrics to builtin FAB PUT endpoint
@@ -451,6 +457,7 @@ class BaseSupersetModelRestApi(ModelRestApi):
         object_ref=False,
         log_to_statsd=False,
     )
+    @handle_api_exception
     def delete_headless(self, pk: int) -> Response:
         """
         Add statsd metrics to builtin FAB DELETE endpoint
@@ -464,6 +471,7 @@ class BaseSupersetModelRestApi(ModelRestApi):
     @safe
     @statsd_metrics
     @rison(get_related_schema)
+    @handle_api_exception
     def related(self, column_name: str, **kwargs: Any) -> FlaskResponse:
         """Get related fields data
         ---
@@ -542,6 +550,7 @@ class BaseSupersetModelRestApi(ModelRestApi):
     @safe
     @statsd_metrics
     @rison(get_related_schema)
+    @handle_api_exception
     def distinct(self, column_name: str, **kwargs: Any) -> FlaskResponse:
         """Get distinct values from field data
         ---


### PR DESCRIPTION
### SUMMARY
This PR adds exception handling for the most common SQLAlchemy exceptions, returning a 422 response instead of a plain 500 error.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
_not applicable_

### TESTING INSTRUCTIONS
This can only be verified in code, raising one of the added errors and inspecting the response, ensuring it's a 422 one.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
