### PR TITLE
fix(import): Add the error alert on failed database import

### DIFF
--- a/superset-frontend/src/components/ImportModal/ErrorAlert.tsx
+++ b/superset-frontend/src/components/ImportModal/ErrorAlert.tsx
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { FunctionComponent } from 'react';
+import { t, SupersetTheme } from '@superset-ui/core';
+
+import { getDatabaseDocumentationLinks } from 'src/views/CRUD/hooks';
+import Alert from 'src/components/Alert';
+import { antdWarningAlertStyles } from './styles';
+
+const supersetTextDocs = getDatabaseDocumentationLinks();
+export const DOCUMENTATION_LINK = supersetTextDocs
+  ? supersetTextDocs.support
+  : 'https://superset.apache.org/docs/databases/installing-database-drivers';
+
+export interface IProps {
+  errorMessage: string;
+}
+
+const ErrorAlert: FunctionComponent<IProps> = ({ errorMessage }) => (
+  <Alert
+    closable={false}
+    css={(theme: SupersetTheme) => antdWarningAlertStyles(theme)}
+    type="error"
+    showIcon
+    message={errorMessage}
+    description={
+      <>
+        <br />
+        {t(
+          'Database driver for importing maybe not installed. Visit the Superset documentation page for installation instructions:',
+        )}
+        <a
+          href={DOCUMENTATION_LINK}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="additional-fields-alert-description"
+        >
+          {t('here')}
+        </a>
+        .
+      </>
+    }
+  />
+);
+
+export default ErrorAlert;

--- a/superset-frontend/src/components/ImportModal/styles.ts
+++ b/superset-frontend/src/components/ImportModal/styles.ts
@@ -1,0 +1,24 @@
+import { css, SupersetTheme } from '@superset-ui/core';
+
+export const antdWarningAlertStyles = (theme: SupersetTheme) => css`
+  border: 1px solid ${theme.colors.warning.light1};
+  padding: ${theme.gridUnit * 4}px;
+  margin: ${theme.gridUnit * 4}px 0;
+  color: ${theme.colors.warning.dark2};
+
+  .ant-alert-message {
+    margin: 0;
+  }
+
+  .ant-alert-description {
+    font-size: ${theme.typography.sizes.s + 1}px;
+    line-height: ${theme.gridUnit * 4}px;
+
+    .ant-alert-icon {
+      margin-right: ${theme.gridUnit * 2.5}px;
+      font-size: ${theme.typography.sizes.l + 1}px;
+      position: relative;
+      top: ${theme.gridUnit / 4}px;
+    }
+  }
+`;

--- a/superset-frontend/src/components/ImportModal/styles.ts
+++ b/superset-frontend/src/components/ImportModal/styles.ts
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import { css, SupersetTheme } from '@superset-ui/core';
 
 export const antdWarningAlertStyles = (theme: SupersetTheme) => css`


### PR DESCRIPTION
### SUMMARY
Add error message when user tries to import without having db driver installed

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
Not Error Alert Message

AFTER:
![image](https://user-images.githubusercontent.com/47900232/163047092-f1cfe767-a4a4-4042-972f-224ff8a10b4f.png)


### TESTING INSTRUCTIONS
**How to reproduce issues**
Repro steps:

1. Import a file (dashboard, chart, dataset, database) that contains a database where the user doesn't have the database driver installed

Current behavior:  Import hangs
Expected behavior: User sees an error message when they don't have the db driver installed

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
