### PR TITLE
fix(plugin-chart-echarts): xAxis scale is not correct when time grain is quarter 

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -28,6 +28,7 @@ import {
   isFormulaAnnotationLayer,
   isIntervalAnnotationLayer,
   isTimeseriesAnnotationLayer,
+  TimeGranularity,
   TimeseriesChartDataResponseResult,
 } from '@superset-ui/core';
 import { EChartsCoreOption, SeriesOption } from 'echarts';
@@ -68,6 +69,14 @@ import {
   transformTimeseriesAnnotation,
 } from './transformers';
 import { TIMESERIES_CONSTANTS } from '../constants';
+
+const TimeGrainToTimestamp = {
+  [TimeGranularity.HOUR]: 3600 * 1000,
+  [TimeGranularity.DAY]: 3600 * 1000 * 24,
+  [TimeGranularity.MONTH]: 3600 * 1000 * 24 * 31,
+  [TimeGranularity.QUARTER]: 3600 * 1000 * 24 * 31 * 3,
+  [TimeGranularity.YEAR]: 3600 * 1000 * 24 * 31 * 12,
+};
 
 export default function transformProps(
   chartProps: EchartsTimeseriesChartProps,
@@ -126,6 +135,7 @@ export default function transformProps(
     yAxisTitleMargin,
     yAxisTitlePosition,
     sliceId,
+    timeGrainSqla,
   }: EchartsTimeseriesFormData = { ...DEFAULT_FORM_DATA, ...formData };
 
   const colorScale = CategoricalColorNamespace.getScale(colorScheme as string);
@@ -324,6 +334,10 @@ export default function transformProps(
         formatter: xAxisFormatter,
         rotate: xAxisLabelRotation,
       },
+      minInterval:
+        xAxisType === 'time' && timeGrainSqla
+          ? TimeGrainToTimestamp[timeGrainSqla]
+          : 0,
     },
     yAxis: {
       ...defaultYAxis,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes the xAxis scale in the time series chart V2 when time grain is quarter, which is different from the time series chart V1. The bar chart looks like it contains three months. Actually, the bar width does not represent how many months it contains but is an optimization done by echart itself to look better, echart does not know whether it is month or quarter.

So here we use [echart.minInterval](https://echarts.apache.org/en/option.html#xAxis.minInterval) to make sure that xAxis scale is the same as time grain, which does not lead to user misunderstanding.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### before
#### Time-series chart (nvd3)
![image](https://user-images.githubusercontent.com/11830681/163138430-43ab07c1-6c35-4c2f-a548-2f058d02d235.png)
#### Time-series chart V2 (echart)
![image](https://user-images.githubusercontent.com/11830681/163138227-b228cbe3-6ba9-481a-8773-47dd589a89b2.png)
### after
![image](https://user-images.githubusercontent.com/11830681/163138166-d1a1f402-5844-496f-9aaf-29d46f520536.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
