### PR TITLE
FIX-18980 Added two small error handlers

### DIFF
--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -380,6 +380,10 @@ class Dashboard(Model, AuditMixinNullable, ImportExportMixin):
             # remove ids and relations (like owners, created by, slices, ...)
             copied_dashboard = dashboard.copy()
             for slc in dashboard.slices:
+                if slc.datasource is None:
+                    logger.info("Datasource is none")
+                    continue
+
                 datasource_ids.add((slc.datasource_id, slc.datasource_type))
                 copied_slc = slc.copy()
                 # save original id into json
@@ -395,6 +399,10 @@ class Dashboard(Model, AuditMixinNullable, ImportExportMixin):
                 # set slices without creating ORM relations
                 slices = copied_dashboard.__dict__.setdefault("slices", [])
                 slices.append(copied_slc)
+
+            if dashboard.json_metadata is None:
+                logger.info("JSON is None")
+                continue
 
             json_metadata = json.loads(dashboard.json_metadata)
             native_filter_configuration: List[Dict[str, Any]] = json_metadata.get(


### PR DESCRIPTION
<!---
fix(dashboard.py): export-dashboards threw errors
-->

### SUMMARY
Following the documentation here: 
https://support.websoft9.com/docs/superset/solution-cli.html
Trying to export all your dashboards into a JSON file or STDOUT
Threw the following errors documented here: 
https://github.com/apache/superset/issues/18980


### TESTING INSTRUCTIONS
Follow the documentation and enter the following command:
```bash
superset export-dashboards
```
This should result in dashboards being successfully exported

### ADDITIONAL INFORMATION
- [X] Has associated issue: #18980
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
