### PR TITLE
fix: convert column type to str during dual read/write

### DIFF
--- a/superset/connectors/sqla/utils.py
+++ b/superset/connectors/sqla/utils.py
@@ -22,7 +22,7 @@ import sqlparse
 from flask_babel import lazy_gettext as _
 from sqlalchemy import and_, inspect, or_
 from sqlalchemy.engine import Engine
-from sqlalchemy.exc import NoSuchTableError, UnsupportedCompilationError
+from sqlalchemy.exc import NoSuchTableError
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.type_api import TypeEngine
 
@@ -181,13 +181,11 @@ def is_column_type_temporal(column_type: TypeEngine) -> bool:
 
 
 def convert_column_type(column_type: TypeEngine) -> str:
-    try:
-        if column_type.python_type == list:
-            return "ARRAY"
-        else:
-            return str(column_type)
-    except UnsupportedCompilationError:
-        return "STRING"
+    if column_type.python_type == list:
+        return "ARRAY"
+    if column_type.python_type == dict:
+        return "JSON"
+    return str(column_type.python_type.__name__.upper())
 
 
 def load_or_create_tables(  # pylint: disable=too-many-arguments

--- a/tests/unit_tests/datasets/test_models.py
+++ b/tests/unit_tests/datasets/test_models.py
@@ -19,9 +19,23 @@
 
 import json
 from datetime import datetime, timezone
+from unittest.mock import MagicMock
 
 from pytest_mock import MockFixture
 from sqlalchemy.orm.session import Session
+
+
+def test_convert_column_type(app_context: None, session: Session) -> None:
+    from sqlalchemy.sql.sqltypes import ARRAY, JSON, STRINGTYPE
+
+    from superset.connectors.sqla.utils import convert_column_type
+
+    ARRAY.python_type = list
+    JSON.python_type = dict
+
+    assert "ARRAY" == convert_column_type(ARRAY)
+    assert "JSON" == convert_column_type(JSON)
+    assert "STR" == convert_column_type(STRINGTYPE)
 
 
 def test_dataset_model(app_context: None, session: Session) -> None:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Users are blocked when trying to save a dataset on a query/table that has an ARRAY column in it. Due the python_type returning a list instead of a str for the type. To fix this i've added a util function to check if the type is a list and convert it to a string like this `ARRAY`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
