### PR TITLE
chore(build): upgrade less-loader

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -305,7 +305,7 @@
     "jsdom": "^16.4.0",
     "lerna": "^4.0.0",
     "less": "^3.12.2",
-    "less-loader": "^5.0.0",
+    "less-loader": "^10.2.0",
     "mini-css-extract-plugin": "^2.3.0",
     "mock-socket": "^9.0.3",
     "node-fetch": "^2.6.1",

--- a/superset-frontend/tools/eslint-plugin-theme-colors/package.json
+++ b/superset-frontend/tools/eslint-plugin-theme-colors/package.json
@@ -9,9 +9,5 @@
   "keywords": [],
   "license": "Apache-2.0",
   "author": "Apache",
-  "dependencies": {},
-  "engines": {
-    "node": "^16.9.1",
-    "npm": "^7.5.4"
-  }
+  "dependencies": {}
 }

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -383,7 +383,9 @@ const config = {
             loader: 'less-loader',
             options: {
               sourceMap: true,
-              javascriptEnabled: true,
+              lessOptions: {
+                javascriptEnabled: true,
+              },
             },
           },
         ],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

`npm install` starts to complain about incompatible peerDependencies:

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: less-loader@5.0.0
npm ERR! Found: webpack@5.52.1
npm ERR! node_modules/webpack
npm ERR!   dev webpack@"^5.52.1" from the root project
npm ERR!   peerOptional webpack@">=4" from @cypress/react@5.10.1
npm ERR!   node_modules/@cypress/react
npm ERR!     dev @cypress/react@"^5.10.0" from the root project
npm ERR!   33 more (@storybook/addon-essentials, @storybook/addon-docs, ...)
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer webpack@"^2.0.0 || ^3.0.0 || ^4.0.0" from less-loader@5.0.0
npm ERR! node_modules/less-loader
npm ERR!   dev less-loader@"^5.0.0" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: webpack@4.46.0
npm ERR! node_modules/webpack
npm ERR!   peer webpack@"^2.0.0 || ^3.0.0 || ^4.0.0" from less-loader@5.0.0
npm ERR!   node_modules/less-loader
npm ERR!     dev less-loader@"^5.0.0" from the root project
npm ERR! 
```

Let's upgrade less-loader to fix it.

Also removing engine requirement in the eslint-plugin-theme-colors plugin as it's throwing unnecessary warnings.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Tested locally and all CSS seems still work

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
