### PR TITLE
fix(nav): infinite redirect and upload dataset nav permissions

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/connection/SupersetClientClass.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/SupersetClientClass.ts
@@ -34,9 +34,11 @@ import {
 import { DEFAULT_FETCH_RETRY_OPTIONS, DEFAULT_BASE_URL } from './constants';
 
 const defaultUnauthorizedHandler = () => {
-  window.location.href = `/login?next=${
-    window.location.pathname + window.location.search
-  }`;
+  if (!window.location.pathname.startsWith('/login')) {
+    window.location.href = `/login?next=${
+      window.location.pathname + window.location.search
+    }`;
+  }
 };
 
 export default class SupersetClientClass {
@@ -161,7 +163,7 @@ export default class SupersetClientClass {
     headers,
     timeout,
     fetchRetryOptions,
-    ignoreUnauthorized,
+    ignoreUnauthorized = false,
     ...rest
   }: RequestConfig & { parseMethod?: T }) {
     await this.ensureAuth();

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -427,14 +427,20 @@ export const uploadUserPerms = (
   colExt: Array<string>,
   excelExt: Array<string>,
   allowedExt: Array<string>,
-) => ({
-  canUploadCSV:
+) => {
+  const canUploadCSV =
     findPermission('can_this_form_get', 'CsvToDatabaseView', roles) &&
-    checkUploadExtensions(csvExt, allowedExt),
-  canUploadColumnar:
+    checkUploadExtensions(csvExt, allowedExt);
+  const canUploadColumnar =
     checkUploadExtensions(colExt, allowedExt) &&
-    findPermission('can_this_form_get', 'ColumnarToDatabaseView', roles),
-  canUploadExcel:
+    findPermission('can_this_form_get', 'ColumnarToDatabaseView', roles);
+  const canUploadExcel =
     checkUploadExtensions(excelExt, allowedExt) &&
-    findPermission('can_this_form_get', 'ExcelToDatabaseView', roles),
-});
+    findPermission('can_this_form_get', 'ExcelToDatabaseView', roles);
+  return {
+    canUploadCSV,
+    canUploadColumnar,
+    canUploadExcel,
+    canUploadData: canUploadCSV || canUploadColumnar || canUploadExcel,
+  };
+};

--- a/superset-frontend/src/views/CRUD/welcome/ActivityTable.test.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ActivityTable.test.tsx
@@ -100,14 +100,14 @@ describe('ActivityTable', () => {
     expect(wrapper.find(ActivityTable)).toExist();
   });
   it('renders tabs with three buttons', () => {
-    expect(wrapper.find('li.no-router')).toHaveLength(3);
+    expect(wrapper.find('[role="tab"]')).toHaveLength(3);
   });
   it('renders ActivityCards', async () => {
     expect(wrapper.find('ListViewCard')).toExist();
   });
   it('calls the getEdited batch call when edited tab is clicked', async () => {
     act(() => {
-      const handler = wrapper.find('li.no-router a').at(1).prop('onClick');
+      const handler = wrapper.find('[role="tab"] a').at(1).prop('onClick');
       if (handler) {
         handler({} as any);
       }

--- a/superset-frontend/src/views/CRUD/welcome/ChartTable.test.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ChartTable.test.tsx
@@ -79,7 +79,7 @@ describe('ChartTable', () => {
 
   it('fetches chart favorites and renders chart cards', async () => {
     act(() => {
-      const handler = wrapper.find('li.no-router a').at(0).prop('onClick');
+      const handler = wrapper.find('[role="tab"] a').at(0).prop('onClick');
       if (handler) {
         handler({} as any);
       }

--- a/superset-frontend/src/views/CRUD/welcome/DashboardTable.test.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/DashboardTable.test.tsx
@@ -71,10 +71,10 @@ describe('DashboardTable', () => {
 
   it('render a submenu with clickable tabs and buttons', async () => {
     expect(wrapper.find('SubMenu')).toExist();
-    expect(wrapper.find('li.no-router')).toHaveLength(2);
+    expect(wrapper.find('[role="tab"]')).toHaveLength(2);
     expect(wrapper.find('Button')).toHaveLength(6);
     act(() => {
-      const handler = wrapper.find('li.no-router a').at(0).prop('onClick');
+      const handler = wrapper.find('[role="tab"] a').at(0).prop('onClick');
       if (handler) {
         handler({} as any);
       }

--- a/superset-frontend/src/views/CRUD/welcome/SavedQueries.test.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/SavedQueries.test.tsx
@@ -81,7 +81,7 @@ describe('SavedQueries', () => {
 
   const clickTab = (idx: number) => {
     act(() => {
-      const handler = wrapper.find('li.no-router a').at(idx).prop('onClick');
+      const handler = wrapper.find('[role="tab"] a').at(idx).prop('onClick');
       if (handler) {
         handler({} as any);
       }
@@ -105,7 +105,7 @@ describe('SavedQueries', () => {
 
   it('renders a submenu with clickable tables and buttons', async () => {
     expect(wrapper.find(SubMenu)).toExist();
-    expect(wrapper.find('li.no-router')).toHaveLength(1);
+    expect(wrapper.find('[role="tab"]')).toHaveLength(1);
     expect(wrapper.find('button')).toHaveLength(2);
     clickTab(0);
     await waitForComponentToPaint(wrapper);

--- a/superset-frontend/src/views/components/SubMenu.tsx
+++ b/superset-frontend/src/views/components/SubMenu.tsx
@@ -240,7 +240,7 @@ const SubMenuComponent: React.FunctionComponent<SubMenuProps> = props => {
             if ((props.usesRouter || hasHistory) && !!tab.usesRouter) {
               return (
                 <Menu.Item key={tab.label}>
-                  <li
+                  <div
                     role="tab"
                     data-test={tab['data-test']}
                     className={tab.name === props.activeChild ? 'active' : ''}
@@ -248,14 +248,14 @@ const SubMenuComponent: React.FunctionComponent<SubMenuProps> = props => {
                     <div>
                       <Link to={tab.url || ''}>{tab.label}</Link>
                     </div>
-                  </li>
+                  </div>
                 </Menu.Item>
               );
             }
 
             return (
               <Menu.Item key={tab.label}>
-                <li
+                <div
                   className={cx('no-router', {
                     active: tab.name === props.activeChild,
                   })}
@@ -264,7 +264,7 @@ const SubMenuComponent: React.FunctionComponent<SubMenuProps> = props => {
                   <a href={tab.url} onClick={tab.onClick}>
                     {tab.label}
                   </a>
-                </li>
+                </div>
               </Menu.Item>
             );
           })}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Currently there is an infinite redirect on the login page (when users are not logged in) that is triggered by an unfortunate sequence of changes:

1. [#17597](https://github.com/apache/superset/pull/17597) added redirect to login when API request returns 401
2. [#19051](https://github.com/preset-io/superset/blob/0d2ec229f62b01046947d915f0d7d31d63078dfa/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx#L205-L218) starts to call the `/api/v1/database` API to find out whether there are databases with file upload enabled, even when the menu is rendered on a page where users haven't logged in. (Although I'm not sure why the redirects didn't show up in #19051's ephemeral environment.)

While debugging, I also found out that users without admin access will also see an empty "Data" menu, so I fixed that as well. 


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

When logged in as non admin users:

#### Before
<img width="345" alt="Xnip2022-04-13_16-57-59" src="https://user-images.githubusercontent.com/335541/163288964-cbb810d9-9973-4ca6-8b20-ab49693aa6a5.png">

There is an empty `Data` menu item with no submenu.

#### After

<img width="322" alt="Xnip2022-04-13_16-57-21" src="https://user-images.githubusercontent.com/335541/163289000-e715303d-a978-4526-b75d-e39530cb1985.png">


The `Data` menu item is removed

### TESTING INSTRUCTIONS

1. Log out and go to `<superset url>/login`. You may see infinitely redirect without this PR. For example, check the [ephemeral](https://github.com/apache/superset/pull/19703) environment of #19703 
2. Log in as a non-admin user (e.g. `username: alpha,  passwd: general`), check whether the empty menu item still exists.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
