### PR TITLE
refactor(frontend): remove names from timezone selector

### DIFF
--- a/superset-frontend/src/components/TimezoneSelector/TimezoneSelector.test.tsx
+++ b/superset-frontend/src/components/TimezoneSelector/TimezoneSelector.test.tsx
@@ -88,10 +88,10 @@ test('render timezones in correct oder for standard time', async () => {
   );
   await openSelectMenu();
   const options = await getSelectOptions();
-  expect(options[0]).toHaveTextContent('GMT -05:00 (Eastern Standard Time)');
-  expect(options[1]).toHaveTextContent('GMT -11:00 (Pacific/Pago_Pago)');
-  expect(options[2]).toHaveTextContent('GMT -10:00 (Hawaii Standard Time)');
-  expect(options[3]).toHaveTextContent('GMT -10:00 (America/Adak)');
+  expect(options[0]).toHaveTextContent('GMT -05:00');
+  expect(options[1]).toHaveTextContent('GMT -11:00');
+  expect(options[2]).toHaveTextContent('GMT -10:00');
+  expect(options[3]).toHaveTextContent('GMT -10:00');
 });
 
 test('render timezones in correct order for daylight saving time', async () => {
@@ -106,10 +106,10 @@ test('render timezones in correct order for daylight saving time', async () => {
   await openSelectMenu();
   const options = await getSelectOptions();
   // first option is always current timezone
-  expect(options[0]).toHaveTextContent('GMT -04:00 (Eastern Daylight Time)');
-  expect(options[1]).toHaveTextContent('GMT -11:00 (Pacific/Pago_Pago)');
-  expect(options[2]).toHaveTextContent('GMT -10:00 (Hawaii Standard Time)');
-  expect(options[3]).toHaveTextContent('GMT -09:30 (Pacific/Marquesas)');
+  expect(options[0]).toHaveTextContent('GMT -04:00');
+  expect(options[1]).toHaveTextContent('GMT -11:00');
+  expect(options[2]).toHaveTextContent('GMT -10:00');
+  expect(options[3]).toHaveTextContent('GMT -09:30');
 });
 
 test('can select a timezone values and returns canonical timezone name', async () => {
@@ -127,7 +127,7 @@ test('can select a timezone values and returns canonical timezone name', async (
   const searchInput = screen.getByRole('combobox');
   // search for mountain time
   await userEvent.type(searchInput, 'mou', { delay: 10 });
-  const findTitle = 'GMT -07:00 (Mountain Standard Time)';
+  const findTitle = 'GMT -07:00';
   const selectOption = await screen.findByTitle(findTitle);
   userEvent.click(selectOption);
   expect(onTimezoneChange).toHaveBeenCalledTimes(1);
@@ -143,13 +143,13 @@ test('can update props and rerender with different values', async () => {
       timezone="Asia/Dubai"
     />,
   );
-  expect(screen.getByTitle('GMT +04:00 (Asia/Dubai)')).toBeInTheDocument();
+  expect(screen.getByTitle('GMT +04:00')).toBeInTheDocument();
   rerender(
     <TimezoneSelector
       onTimezoneChange={onTimezoneChange}
       timezone="Australia/Perth"
     />,
   );
-  expect(screen.getByTitle('GMT +08:00 (Australia/Perth)')).toBeInTheDocument();
+  expect(screen.getByTitle('GMT +08:00')).toBeInTheDocument();
   expect(onTimezoneChange).toHaveBeenCalledTimes(0);
 });

--- a/superset-frontend/src/components/TimezoneSelector/index.tsx
+++ b/superset-frontend/src/components/TimezoneSelector/index.tsx
@@ -29,22 +29,6 @@ const DEFAULT_TIMEZONE = {
 
 const MIN_SELECT_WIDTH = '400px';
 
-const offsetsToName = {
-  '-300-240': ['Eastern Standard Time', 'Eastern Daylight Time'],
-  '-360-300': ['Central Standard Time', 'Central Daylight Time'],
-  '-420-360': ['Mountain Standard Time', 'Mountain Daylight Time'],
-  '-420-420': [
-    'Mountain Standard Time - Phoenix',
-    'Mountain Standard Time - Phoenix',
-  ],
-  '-480-420': ['Pacific Standard Time', 'Pacific Daylight Time'],
-  '-540-480': ['Alaska Standard Time', 'Alaska Daylight Time'],
-  '-600-600': ['Hawaii Standard Time', 'Hawaii Daylight Time'],
-  '60120': ['Central European Time', 'Central European Daylight Time'],
-  '00': [DEFAULT_TIMEZONE.name, DEFAULT_TIMEZONE.name],
-  '060': ['GMT Standard Time - London', 'British Summer Time'],
-};
-
 const currentDate = moment();
 const JANUARY = moment([2021, 1]);
 const JULY = moment([2021, 7]);
@@ -52,15 +36,6 @@ const JULY = moment([2021, 7]);
 const getOffsetKey = (name: string) =>
   JANUARY.tz(name).utcOffset().toString() +
   JULY.tz(name).utcOffset().toString();
-
-const getTimezoneName = (name: string) => {
-  const offsets = getOffsetKey(name);
-  return (
-    (currentDate.tz(name).isDST()
-      ? offsetsToName[offsets]?.[1]
-      : offsetsToName[offsets]?.[0]) || name
-  );
-};
 
 const ALL_ZONES = moment.tz
   .countries()
@@ -81,7 +56,7 @@ ALL_ZONES.forEach(zone => {
 const TIMEZONE_OPTIONS = TIMEZONES.map(zone => ({
   label: `GMT ${moment
     .tz(currentDate, zone.name)
-    .format('Z')} (${getTimezoneName(zone.name)})`,
+    .format('Z')}`,
   value: zone.name,
   offsets: getOffsetKey(zone.name),
   timezoneName: zone.name,

--- a/superset-frontend/src/components/TimezoneSelector/index.tsx
+++ b/superset-frontend/src/components/TimezoneSelector/index.tsx
@@ -54,9 +54,7 @@ ALL_ZONES.forEach(zone => {
 });
 
 const TIMEZONE_OPTIONS = TIMEZONES.map(zone => ({
-  label: `GMT ${moment
-    .tz(currentDate, zone.name)
-    .format('Z')}`,
+  label: `GMT ${moment.tz(currentDate, zone.name).format('Z')}`,
   value: zone.name,
   offsets: getOffsetKey(zone.name),
   timezoneName: zone.name,


### PR DESCRIPTION
### SUMMARY

Although showing names is a very nice feature, not showing all of them creates confusion. 

For example, for GMT +03:00 our users are expecting `Europe/Istanbul` but instead are seeing `Antartica/Syowa` as the name.

I believe, if we are deduplicating zones, showing just the timezone offset should be enough and concise.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

BEFORE

![image](https://user-images.githubusercontent.com/1297759/163347905-b9d6221d-688a-4500-8e81-eb9cf82fce15.png)

AFTER

![image](https://user-images.githubusercontent.com/1297759/163347801-aba3f27a-c2fb-4a63-9093-6eed8d5e680c.png)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
