### PR TITLE
fix: create virtual table with exotic type

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -2374,11 +2374,10 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
             referenced_tables = parsed.tables
             tables = load_or_create_tables(
                 session,
-                dataset.database_id,
+                database,
                 dataset.schema,
                 referenced_tables,
                 conditional_quote,
-                engine,
             )
 
         # create the new dataset

--- a/superset/connectors/sqla/utils.py
+++ b/superset/connectors/sqla/utils.py
@@ -16,11 +16,11 @@
 # under the License.
 from contextlib import closing
 from datetime import date, datetime, time, timedelta
-from typing import Callable, Dict, List, Optional, Set, TYPE_CHECKING
+from typing import Any, Callable, Dict, List, Optional, Set, TYPE_CHECKING
 
 import sqlparse
 from flask_babel import lazy_gettext as _
-from sqlalchemy import and_, inspect, or_
+from sqlalchemy import and_, or_
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import NoSuchTableError
 from sqlalchemy.orm import Session
@@ -42,14 +42,11 @@ if TYPE_CHECKING:
     from superset.connectors.sqla.models import SqlaTable
 
 
-TEMPORAL_TYPES = {date, datetime, time, timedelta}
-
-
 def get_physical_table_metadata(
     database: Database,
     table_name: str,
     schema_name: Optional[str] = None,
-) -> List[Dict[str, str]]:
+) -> List[Dict[str, Any]]:
     """Use SQLAlchemy inspector to get table metadata"""
     db_engine_spec = database.db_engine_spec
     db_dialect = database.get_dialect()
@@ -86,7 +83,7 @@ def get_physical_table_metadata(
             col.update(
                 {
                     "type": "UNKNOWN",
-                    "generic_type": None,
+                    "type_generic": None,
                     "is_dttm": None,
                 }
             )
@@ -173,20 +170,12 @@ def validate_adhoc_subquery(
     return ";\n".join(str(statement) for statement in statements)
 
 
-def is_column_type_temporal(column_type: TypeEngine) -> bool:
-    try:
-        return column_type.python_type in TEMPORAL_TYPES
-    except NotImplementedError:
-        return False
-
-
 def load_or_create_tables(  # pylint: disable=too-many-arguments
     session: Session,
-    database_id: int,
+    database: Database,
     default_schema: Optional[str],
     tables: Set[Table],
     conditional_quote: Callable[[str], str],
-    engine: Engine,
 ) -> List[NewTable]:
     """
     Load or create new table model instances.
@@ -206,7 +195,7 @@ def load_or_create_tables(  # pylint: disable=too-many-arguments
     predicate = or_(
         *[
             and_(
-                NewTable.database_id == database_id,
+                NewTable.database_id == database.id,
                 NewTable.schema == table.schema,
                 NewTable.name == table.table,
             )
@@ -219,19 +208,17 @@ def load_or_create_tables(  # pylint: disable=too-many-arguments
     existing = {(table.schema, table.name) for table in new_tables}
     for table in tables:
         if (table.schema, table.table) not in existing:
-            try:
-                inspector = inspect(engine)
-                column_metadata = inspector.get_columns(
-                    table.table, schema=table.schema
-                )
-            except Exception:  # pylint: disable=broad-except
-                continue
+            column_metadata = get_physical_table_metadata(
+                database=database,
+                table_name=table.table,
+                schema_name=table.schema,
+            )
             columns = [
                 NewColumn(
                     name=column["name"],
                     type=str(column["type"]),
                     expression=conditional_quote(column["name"]),
-                    is_temporal=is_column_type_temporal(column["type"]),
+                    is_temporal=column["is_dttm"],
                     is_aggregation=False,
                     is_physical=True,
                     is_spatial=False,
@@ -245,7 +232,7 @@ def load_or_create_tables(  # pylint: disable=too-many-arguments
                     name=table.table,
                     schema=table.schema,
                     catalog=None,
-                    database_id=database_id,
+                    database_id=database.id,
                     columns=columns,
                 )
             )

--- a/superset/connectors/sqla/utils.py
+++ b/superset/connectors/sqla/utils.py
@@ -15,13 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 from contextlib import closing
-from datetime import date, datetime, time, timedelta
 from typing import Any, Callable, Dict, List, Optional, Set, TYPE_CHECKING
 
 import sqlparse
 from flask_babel import lazy_gettext as _
 from sqlalchemy import and_, or_
-from sqlalchemy.engine import Engine
 from sqlalchemy.exc import NoSuchTableError
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.type_api import TypeEngine
@@ -208,11 +206,14 @@ def load_or_create_tables(  # pylint: disable=too-many-arguments
     existing = {(table.schema, table.name) for table in new_tables}
     for table in tables:
         if (table.schema, table.table) not in existing:
-            column_metadata = get_physical_table_metadata(
-                database=database,
-                table_name=table.table,
-                schema_name=table.schema,
-            )
+            try:
+                column_metadata = get_physical_table_metadata(
+                    database=database,
+                    table_name=table.table,
+                    schema_name=table.schema,
+                )
+            except Exception:  # pylint: disable=broad-except
+                continue
             columns = [
                 NewColumn(
                     name=column["name"],


### PR DESCRIPTION
### SUMMARY
This is an alternative implementation of #19701, which reuses the same data type inference logic that's already being used when creating physical datasets. While I did this fix I started adding types for the column type objects, but that turned into a HUGE rabbit hole going well beyond the scope of this PR. Therefore the changes in this PR are kept to a minimum to fix the issue at hand, but once this is merged I'll open up a PR that introduces proper types to to these code paths.

### TESTING INSTRUCTIONS
1. create a dataset on BigQuery that contains at least a String array type (Type: STRING, Mode: REPEATED)
2. Add a single row to the dataset (can be all nulls)
2. Go to SQL Lab and run the following query `select * from schema.table`
3. Hit "Explore" and see an error.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #19609
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
