### PR TITLE
docs(install): ubuntu default-libmysqlclient-dev

### DIFF
--- a/docs/docs/installation/installing-superset-from-scratch.mdx
+++ b/docs/docs/installation/installing-superset-from-scratch.mdx
@@ -18,13 +18,13 @@ level dependencies.
 The following command will ensure that the required dependencies are installed:
 
 ```
-sudo apt-get install build-essential libssl-dev libffi-dev python-dev python-pip libsasl2-dev libldap2-dev
+sudo apt-get install build-essential libssl-dev libffi-dev python-dev python-pip libsasl2-dev libldap2-dev default-libmysqlclient-dev
 ```
 
 In Ubuntu 20.04 the following command will ensure that the required dependencies are installed:
 
 ```
-sudo apt-get install build-essential libssl-dev libffi-dev python3-dev python3-pip libsasl2-dev libldap2-dev
+sudo apt-get install build-essential libssl-dev libffi-dev python3-dev python3-pip libsasl2-dev libldap2-dev default-libmysqlclient-dev
 ```
 
 **Fedora and RHEL-derivative Linux distributions**


### PR DESCRIPTION
### SUMMARY

add `default-libmysqlclient-dev` to required OS dependencies for ubuntu. 

`pip install -r requirements/testing.txt` will not complete without it.

