### PR TITLE
fix: drop the first level of MultiIndex

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/flattenOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/flattenOperator.ts
@@ -17,10 +17,21 @@
  * specific language governing permissions and limitationsxw
  * under the License.
  */
-import { PostProcessingFlatten } from '@superset-ui/core';
+import { ensureIsArray, PostProcessingFlatten } from '@superset-ui/core';
 import { PostProcessingFactory } from './types';
 
 export const flattenOperator: PostProcessingFactory<PostProcessingFlatten> = (
   formData,
   queryObject,
-) => ({ operation: 'flatten' });
+) => {
+  const drop_levels: number[] = [];
+  if (ensureIsArray(queryObject.metrics).length === 1) {
+    drop_levels.push(0);
+  }
+  return {
+    operation: 'flatten',
+    options: {
+      drop_levels,
+    },
+  };
+};

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/operators/flattenOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/operators/flattenOperator.test.ts
@@ -51,9 +51,40 @@ const queryObject: QueryObject = {
     },
   ],
 };
+const singleMetricQueryObject: QueryObject = {
+  metrics: ['count(*)'],
+  time_range: '2015 : 2016',
+  granularity: 'month',
+  post_processing: [
+    {
+      operation: 'pivot',
+      options: {
+        index: ['__timestamp'],
+        columns: ['nation'],
+        aggregates: {
+          'count(*)': {
+            operator: 'sum',
+          },
+        },
+      },
+    },
+  ],
+};
 
 test('should do flattenOperator', () => {
   expect(flattenOperator(formData, queryObject)).toEqual({
     operation: 'flatten',
+    options: {
+      drop_levels: [],
+    },
+  });
+});
+
+test('should add drop level', () => {
+  expect(flattenOperator(formData, singleMetricQueryObject)).toEqual({
+    operation: 'flatten',
+    options: {
+      drop_levels: [0],
+    },
   });
 });

--- a/superset-frontend/packages/superset-ui-core/src/query/types/PostProcessing.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/PostProcessing.ts
@@ -205,6 +205,7 @@ interface _PostProcessingFlatten {
   operation: 'flatten';
   options?: {
     reset_index?: boolean;
+    drop_levels?: number[] | string[];
   };
 }
 export type PostProcessingFlatten =

--- a/superset/utils/pandas_postprocessing/flatten.py
+++ b/superset/utils/pandas_postprocessing/flatten.py
@@ -34,7 +34,7 @@ def flatten(
 
     :param df: N-dimensional DataFrame.
     :param reset_index: Convert index to column when df.index isn't RangeIndex
-    :param drop_levels: index of levels or name of level might be dropped if df is N-dimensional
+    :param drop_levels: index of level or names of level might be dropped if df is N-dimensional
     :return: a flat DataFrame
 
     Examples

--- a/superset/utils/pandas_postprocessing/flatten.py
+++ b/superset/utils/pandas_postprocessing/flatten.py
@@ -17,6 +17,7 @@
 from typing import Sequence, Union
 
 import pandas as pd
+from numpy.distutils.misc_util import is_sequence
 
 from superset.utils.pandas_postprocessing.utils import (
     _is_multi_index_on_columns,
@@ -83,10 +84,7 @@ def flatten(
         # every cell should be converted to string
         df.columns = [
             FLAT_COLUMN_SEPARATOR.join(
-                [
-                    str(cell)
-                    for cell in ([series] if isinstance(series, str) else series)
-                ]
+                [str(cell) for cell in (series if is_sequence(series) else [series])]
             )
             for series in df.columns.to_flat_index()
         ]

--- a/superset/utils/pandas_postprocessing/flatten.py
+++ b/superset/utils/pandas_postprocessing/flatten.py
@@ -78,7 +78,6 @@ def flatten(
     1  2021-01-02        1        1        1        1
     2  2021-01-03        1        1        1        1
     """
-
     if _is_multi_index_on_columns(df):
         df.columns = df.columns.droplevel(drop_levels)
         # every cell should be converted to string

--- a/superset/utils/pandas_postprocessing/flatten.py
+++ b/superset/utils/pandas_postprocessing/flatten.py
@@ -34,7 +34,7 @@ def flatten(
 
     :param df: N-dimensional DataFrame.
     :param reset_index: Convert index to column when df.index isn't RangeIndex
-    :param drop_levels: index or name of level needs to ignore
+    :param drop_levels: index of levels or name of level might be dropped if df is N-dimensional
     :return: a flat DataFrame
 
     Examples
@@ -76,12 +76,17 @@ def flatten(
     1  2021-01-02        1        1        1        1
     2  2021-01-03        1        1        1        1
     """
-    df.columns = df.columns.droplevel(drop_levels)
 
     if _is_multi_index_on_columns(df):
+        df.columns = df.columns.droplevel(drop_levels)
         # every cell should be converted to string
         df.columns = [
-            FLAT_COLUMN_SEPARATOR.join([str(cell) for cell in series])
+            FLAT_COLUMN_SEPARATOR.join(
+                [
+                    str(cell)
+                    for cell in ([series] if isinstance(series, str) else series)
+                ]
+            )
             for series in df.columns.to_flat_index()
         ]
 

--- a/superset/utils/pandas_postprocessing/flatten.py
+++ b/superset/utils/pandas_postprocessing/flatten.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Tuple, Union
+from typing import Sequence, Union
 
 import pandas as pd
 
@@ -27,7 +27,7 @@ from superset.utils.pandas_postprocessing.utils import (
 def flatten(
     df: pd.DataFrame,
     reset_index: bool = True,
-    drop_levels: Union[Tuple[int, ...], Tuple[str, ...]] = (),
+    drop_levels: Union[Sequence[int], Sequence[str]] = (),
 ) -> pd.DataFrame:
     """
     Convert N-dimensional DataFrame to a flat DataFrame

--- a/superset/utils/pandas_postprocessing/flatten.py
+++ b/superset/utils/pandas_postprocessing/flatten.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 from typing import Sequence, Union
 
 import pandas as pd
@@ -83,6 +84,7 @@ def flatten(
         # every cell should be converted to string
         df.columns = [
             FLAT_COLUMN_SEPARATOR.join(
+                # pylint: disable=superfluous-parens
                 [str(cell) for cell in (series if is_sequence(series) else [series])]
             )
             for series in df.columns.to_flat_index()

--- a/superset/utils/pandas_postprocessing/flatten.py
+++ b/superset/utils/pandas_postprocessing/flatten.py
@@ -34,7 +34,8 @@ def flatten(
 
     :param df: N-dimensional DataFrame.
     :param reset_index: Convert index to column when df.index isn't RangeIndex
-    :param drop_levels: index of level or names of level might be dropped if df is N-dimensional
+    :param drop_levels: index of level or names of level might be dropped
+                        if df is N-dimensional
     :return: a flat DataFrame
 
     Examples

--- a/superset/utils/pandas_postprocessing/flatten.py
+++ b/superset/utils/pandas_postprocessing/flatten.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Tuple, Union
+
 import pandas as pd
 
 from superset.utils.pandas_postprocessing.utils import (
@@ -25,12 +27,14 @@ from superset.utils.pandas_postprocessing.utils import (
 def flatten(
     df: pd.DataFrame,
     reset_index: bool = True,
+    drop_levels: Union[Tuple[int, ...], Tuple[str, ...]] = (),
 ) -> pd.DataFrame:
     """
     Convert N-dimensional DataFrame to a flat DataFrame
 
     :param df: N-dimensional DataFrame.
     :param reset_index: Convert index to column when df.index isn't RangeIndex
+    :param drop_levels: index or name of level needs to ignore
     :return: a flat DataFrame
 
     Examples
@@ -72,6 +76,8 @@ def flatten(
     1  2021-01-02        1        1        1        1
     2  2021-01-03        1        1        1        1
     """
+    df.columns = df.columns.droplevel(drop_levels)
+
     if _is_multi_index_on_columns(df):
         # every cell should be converted to string
         df.columns = [

--- a/tests/unit_tests/pandas_postprocessing/test_flatten.py
+++ b/tests/unit_tests/pandas_postprocessing/test_flatten.py
@@ -73,3 +73,35 @@ def test_flat_should_flat_multiple_index():
             }
         )
     )
+
+
+def test_flat_should_drop_index_level():
+    index = pd.to_datetime(["2021-01-01", "2021-01-02", "2021-01-03"])
+    index.name = "__timestamp"
+    columns = pd.MultiIndex.from_arrays(
+        [["a"] * 3, ["b"] * 3, ["c", "d", "e"], ["f", "i", "g"]],
+        names=["level1", "level2", "level3", "level4"],
+    )
+    df = pd.DataFrame(index=index, columns=columns, data=1)
+
+    assert pp.flatten(df.copy(), drop_levels=(0, 1,)).equals(
+        pd.DataFrame(
+            {
+                "__timestamp": index,
+                FLAT_COLUMN_SEPARATOR.join(["c", "f"]): [1, 1, 1],
+                FLAT_COLUMN_SEPARATOR.join(["d", "i"]): [1, 1, 1],
+                FLAT_COLUMN_SEPARATOR.join(["e", "g"]): [1, 1, 1],
+            }
+        )
+    )
+
+    assert pp.flatten(df.copy(), drop_levels=("level1", "level2")).equals(
+        pd.DataFrame(
+            {
+                "__timestamp": index,
+                FLAT_COLUMN_SEPARATOR.join(["c", "f"]): [1, 1, 1],
+                FLAT_COLUMN_SEPARATOR.join(["d", "i"]): [1, 1, 1],
+                FLAT_COLUMN_SEPARATOR.join(["e", "g"]): [1, 1, 1],
+            }
+        )
+    )

--- a/tests/unit_tests/pandas_postprocessing/test_flatten.py
+++ b/tests/unit_tests/pandas_postprocessing/test_flatten.py
@@ -18,6 +18,7 @@ import pandas as pd
 
 from superset.utils import pandas_postprocessing as pp
 from superset.utils.pandas_postprocessing.utils import FLAT_COLUMN_SEPARATOR
+from tests.unit_tests.fixtures.dataframes import timeseries_df
 
 
 def test_flat_should_not_change():
@@ -79,29 +80,57 @@ def test_flat_should_drop_index_level():
     index = pd.to_datetime(["2021-01-01", "2021-01-02", "2021-01-03"])
     index.name = "__timestamp"
     columns = pd.MultiIndex.from_arrays(
-        [["a"] * 3, ["b"] * 3, ["c", "d", "e"], ["f", "i", "g"]],
+        [["a"] * 3, ["b"] * 3, ["c", "d", "e"], ["ff", "ii", "gg"]],
         names=["level1", "level2", "level3", "level4"],
     )
     df = pd.DataFrame(index=index, columns=columns, data=1)
 
+    # drop level by index
     assert pp.flatten(df.copy(), drop_levels=(0, 1,)).equals(
         pd.DataFrame(
             {
                 "__timestamp": index,
-                FLAT_COLUMN_SEPARATOR.join(["c", "f"]): [1, 1, 1],
-                FLAT_COLUMN_SEPARATOR.join(["d", "i"]): [1, 1, 1],
-                FLAT_COLUMN_SEPARATOR.join(["e", "g"]): [1, 1, 1],
+                FLAT_COLUMN_SEPARATOR.join(["c", "ff"]): [1, 1, 1],
+                FLAT_COLUMN_SEPARATOR.join(["d", "ii"]): [1, 1, 1],
+                FLAT_COLUMN_SEPARATOR.join(["e", "gg"]): [1, 1, 1],
             }
         )
     )
 
+    # drop level by name
     assert pp.flatten(df.copy(), drop_levels=("level1", "level2")).equals(
         pd.DataFrame(
             {
                 "__timestamp": index,
-                FLAT_COLUMN_SEPARATOR.join(["c", "f"]): [1, 1, 1],
-                FLAT_COLUMN_SEPARATOR.join(["d", "i"]): [1, 1, 1],
-                FLAT_COLUMN_SEPARATOR.join(["e", "g"]): [1, 1, 1],
+                FLAT_COLUMN_SEPARATOR.join(["c", "ff"]): [1, 1, 1],
+                FLAT_COLUMN_SEPARATOR.join(["d", "ii"]): [1, 1, 1],
+                FLAT_COLUMN_SEPARATOR.join(["e", "gg"]): [1, 1, 1],
+            }
+        )
+    )
+
+    # only leave 1 level
+    assert pp.flatten(df.copy(), drop_levels=(0, 1, 2)).equals(
+        pd.DataFrame(
+            {
+                "__timestamp": index,
+                FLAT_COLUMN_SEPARATOR.join(["ff"]): [1, 1, 1],
+                FLAT_COLUMN_SEPARATOR.join(["ii"]): [1, 1, 1],
+                FLAT_COLUMN_SEPARATOR.join(["gg"]): [1, 1, 1],
+            }
+        )
+    )
+
+
+def test_flat_should_not_droplevel():
+    assert pp.flatten(timeseries_df, drop_levels=(0,)).equals(
+        pd.DataFrame(
+            {
+                "index": pd.to_datetime(
+                    ["2019-01-01", "2019-01-02", "2019-01-05", "2019-01-07"]
+                ),
+                "label": ["x", "y", "z", "q"],
+                "y": [1.0, 2.0, 3.0, 4.0],
             }
         )
     )

--- a/tests/unit_tests/pandas_postprocessing/test_flatten.py
+++ b/tests/unit_tests/pandas_postprocessing/test_flatten.py
@@ -134,3 +134,25 @@ def test_flat_should_not_droplevel():
             }
         )
     )
+
+
+def test_flat_integer_column_name():
+    index = pd.to_datetime(["2021-01-01", "2021-01-02", "2021-01-03"])
+    index.name = "__timestamp"
+    columns = pd.MultiIndex.from_arrays(
+        [["a"] * 3, [100, 200, 300]],
+        names=["level1", "level2"],
+    )
+    df = pd.DataFrame(index=index, columns=columns, data=1)
+    assert pp.flatten(df, drop_levels=(0,)).equals(
+        pd.DataFrame(
+            {
+                "__timestamp": pd.to_datetime(
+                    ["2021-01-01", "2021-01-02", "2021-01-03"]
+                ),
+                "100": [1, 1, 1],
+                "200": [1, 1, 1],
+                "300": [1, 1, 1],
+            }
+        )
+    )


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Drop the first level of MultiIndex when there is only 1 metric in the query object

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### After
![image](https://user-images.githubusercontent.com/2016594/163378823-4fc80e25-6a16-486f-831b-bdce34e2559e.png)

<img width="1460" alt="image" src="https://user-images.githubusercontent.com/2016594/163408673-aa84771e-be41-4873-b117-eed68860c2fa.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closed https://github.com/apache/superset/issues/19654
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
