### PR TITLE
refactor(frontend): Make dashboard search box the first filter

### DIFF
--- a/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
@@ -464,6 +464,12 @@ function DashboardList(props: DashboardListProps) {
   const filters: Filters = useMemo(
     () => [
       {
+        Header: t('Search'),
+        id: 'dashboard_title',
+        input: 'search',
+        operator: FilterOperator.titleOrSlug,
+      },
+      {
         Header: t('Owner'),
         key: 'owner',
         id: 'owners',
@@ -533,13 +539,7 @@ function DashboardList(props: DashboardListProps) {
           { label: t('No'), value: false },
         ],
       },
-      {
-        Header: t('Search'),
         key: 'search',
-        id: 'dashboard_title',
-        input: 'search',
-        operator: FilterOperator.titleOrSlug,
-      },
     ],
     [addDangerToast, favoritesFilter, props.user],
   );

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
@@ -465,6 +465,7 @@ function DashboardList(props: DashboardListProps) {
     () => [
       {
         Header: t('Search'),
+        key: 'search',
         id: 'dashboard_title',
         input: 'search',
         operator: FilterOperator.titleOrSlug,
@@ -539,7 +540,6 @@ function DashboardList(props: DashboardListProps) {
           { label: t('No'), value: false },
         ],
       },
-        key: 'search',
     ],
     [addDangerToast, favoritesFilter, props.user],
   );


### PR DESCRIPTION
### SUMMARY

Searching is the most natural filter so most people are looking for it first before checking others. This PR moves `Search` to the beginning of the dashboard filters in an attempt to provide easier accessibility.

Feel free to close this PR if this is not suitable for core team.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

** BEFORE **

![image](https://user-images.githubusercontent.com/1297759/163425745-7b3881f2-87dc-4e12-b4c6-3df72f9dda64.png)


**AFTER**

![image](https://user-images.githubusercontent.com/1297759/163425590-cd8c9ce4-88a9-4f21-b416-4ef1232183ca.png)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
