### PR TITLE
fix: dashboard top level tabs edit

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -18,7 +18,14 @@
  */
 /* eslint-env browser */
 import cx from 'classnames';
-import React, { FC, useCallback, useEffect, useState, useMemo } from 'react';
+import React, {
+  FC,
+  useCallback,
+  useEffect,
+  useState,
+  useMemo,
+  useRef,
+} from 'react';
 import { JsonObject, styled, css, t } from '@superset-ui/core';
 import { Global } from '@emotion/react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -318,6 +325,27 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
     }),
     [dashboardFiltersOpen, editMode, nativeFiltersEnabled],
   );
+
+  // If a new tab was added, update the directPathToChild to reflect it
+  const currentTopLevelTabs = useRef(topLevelTabs);
+  useEffect(() => {
+    const currentTabsLength = currentTopLevelTabs.current?.children?.length;
+    const newTabsLength = topLevelTabs?.children?.length;
+
+    if (
+      currentTabsLength !== undefined &&
+      newTabsLength !== undefined &&
+      newTabsLength > currentTabsLength
+    ) {
+      const lastTab = getDirectPathToTabIndex(
+        getRootLevelTabsComponent(dashboardLayout),
+        newTabsLength - 1,
+      );
+      dispatch(setDirectPathToChild(lastTab));
+    }
+
+    currentTopLevelTabs.current = topLevelTabs;
+  }, [topLevelTabs]);
 
   const renderDraggableContent = useCallback(
     ({ dropIndicatorProps }: { dropIndicatorProps: JsonObject }) => (

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
@@ -18,7 +18,7 @@
  */
 // ParentSize uses resize observer so the dashboard will update size
 // when its container size changes, due to e.g., builder side panel opening
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import React, { FC, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   FeatureFlag,
@@ -36,7 +36,6 @@ import {
   LayoutItem,
   RootState,
 } from 'src/dashboard/types';
-import getLeafComponentIdFromPath from 'src/dashboard/util/getLeafComponentIdFromPath';
 import {
   DASHBOARD_GRID_ID,
   DASHBOARD_ROOT_DEPTH,
@@ -68,29 +67,27 @@ const useNativeFilterScopes = () => {
 };
 
 const DashboardContainer: FC<DashboardContainerProps> = ({ topLevelTabs }) => {
+  const nativeFilterScopes = useNativeFilterScopes();
+  const dispatch = useDispatch();
+
   const dashboardLayout = useSelector<RootState, DashboardLayout>(
     state => state.dashboardLayout.present,
   );
-  const nativeFilterScopes = useNativeFilterScopes();
   const directPathToChild = useSelector<RootState, string[]>(
     state => state.dashboardState.directPathToChild,
   );
   const charts = useSelector<RootState, ChartsState>(state => state.charts);
-  const [tabIndex, setTabIndex] = useState(
-    getRootLevelTabIndex(dashboardLayout, directPathToChild),
-  );
 
-  const dispatch = useDispatch();
-
-  useEffect(() => {
+  const tabIndex = useMemo(() => {
     const nextTabIndex = findTabIndexByComponentId({
       currentComponent: getRootLevelTabsComponent(dashboardLayout),
       directPathToChild,
     });
-    if (nextTabIndex > -1) {
-      setTabIndex(nextTabIndex);
-    }
-  }, [getLeafComponentIdFromPath(directPathToChild)]);
+
+    return nextTabIndex > -1
+      ? nextTabIndex
+      : getRootLevelTabIndex(dashboardLayout, directPathToChild);
+  }, [dashboardLayout, directPathToChild]);
 
   useEffect(() => {
     if (


### PR DESCRIPTION
### SUMMARY
This PR addresses several small issues detected when editing the top level tabs in the dashboard.

The main problem behind them is that the tab & the content, being different components, were not 100% in sync after re-order/add/remove actions on them.
This PR hoists the state handling up for this scenarios and ensure the state is driven in the same way.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Issue 1
When adding a new tab, the container gets selected & the "Collapse tab content" popup appears.

Before:

https://user-images.githubusercontent.com/17252075/163430295-bab4a35d-0153-4c6c-8b1f-eae99574faff.mov

After:

https://user-images.githubusercontent.com/17252075/163431027-21727e56-54dc-4024-9dec-c9e0f4629b12.mov

#### Issue 2
When adding a new tab, said tab is selected, but the content still reflects the one from a previous tab

Before:

https://user-images.githubusercontent.com/17252075/163430063-b473481c-698e-47ed-8aca-e0dab1513629.mov

After:

https://user-images.githubusercontent.com/17252075/163431201-f4b4237d-7e83-4769-844e-1a2a05c55240.mov

#### Issue 3
Reordering tabs makes the tab & content out of sync, so the current tab content is lost.

Before:

https://user-images.githubusercontent.com/17252075/163430509-87f70220-88ad-46c7-80f8-46b846931613.mov

After:

https://user-images.githubusercontent.com/17252075/163431430-dc3dab83-f59f-441e-b059-04b5d79a1686.mov

#### Issue 4
Deleting a tab always switches to the last one. This should only happen if the tab being deleted is the current one the user is seeing, otherwise, nothing should change.

Before:

https://user-images.githubusercontent.com/17252075/163430688-3faf2133-390e-40c9-bc0c-896332fc2d7e.mov

After:

https://user-images.githubusercontent.com/17252075/163431781-94f819e3-1e66-4de9-901b-0d39763fa28c.mov

### TESTING INSTRUCTIONS
Check each individual "Before" video for reproduction steps

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
