### PR TITLE
chore(frontend): captialize reports for ocd relief

### DIFF
--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -428,7 +428,7 @@ function AlertList({
     <>
       <SubMenu
         activeChild={pathName}
-        name={t('Alerts & reports')}
+        name={t('Alerts & Reports')}
         tabs={[
           {
             name: 'Alerts',

--- a/superset/translations/de/LC_MESSAGES/messages.json
+++ b/superset/translations/de/LC_MESSAGES/messages.json
@@ -300,7 +300,7 @@
       ],
       "Alerts": ["Alarme"],
       "Alerts & Reports": ["Alarme und Reporte"],
-      "Alerts & reports": ["Alarme und Reports"],
+      "Alerts & Reports": ["Alarme und Reports"],
       "Align +/-": ["Ausrichten +/-"],
       "All": ["Alle"],
       "All Text": ["Gesamter Texte"],

--- a/superset/translations/de/LC_MESSAGES/messages.po
+++ b/superset/translations/de/LC_MESSAGES/messages.po
@@ -1071,7 +1071,7 @@ msgid "Alerts & Reports"
 msgstr "Alarme und Reporte"
 
 #: superset-frontend/src/views/CRUD/alert/AlertList.tsx:432
-msgid "Alerts & reports"
+msgid "Alerts & Reports"
 msgstr "Alarme und Reports"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:127

--- a/superset/translations/en/LC_MESSAGES/messages.json
+++ b/superset/translations/en/LC_MESSAGES/messages.json
@@ -1723,7 +1723,7 @@
       "${AlertState.error}": [""],
       "${AlertState.noop}": [""],
       "${AlertState.grace}": [""],
-      "Alerts & reports": [""],
+      "Alerts & Reports": [""],
       "Reports": [""],
       "This action will permanently delete %s.": [""],
       "Delete %s?": [""],

--- a/superset/translations/en/LC_MESSAGES/messages.po
+++ b/superset/translations/en/LC_MESSAGES/messages.po
@@ -958,7 +958,7 @@ msgid "Alerts & Reports"
 msgstr ""
 
 #: superset-frontend/src/views/CRUD/alert/AlertList.tsx:432
-msgid "Alerts & reports"
+msgid "Alerts & Reports"
 msgstr ""
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:127

--- a/superset/translations/es/LC_MESSAGES/messages.json
+++ b/superset/translations/es/LC_MESSAGES/messages.json
@@ -2342,7 +2342,7 @@
       "${AlertState.error}": [""],
       "${AlertState.noop}": [""],
       "${AlertState.grace}": [""],
-      "Alerts & reports": ["Alertas e informes"],
+      "Alerts & Reports": ["Alertas e informes"],
       "Reports": ["Informes"],
       "This action will permanently delete %s.": [
         "Esta acción eliminará permanentemente %s."

--- a/superset/translations/es/LC_MESSAGES/messages.po
+++ b/superset/translations/es/LC_MESSAGES/messages.po
@@ -1006,7 +1006,7 @@ msgid "Alerts & Reports"
 msgstr "Alertas y reportes"
 
 #: superset-frontend/src/views/CRUD/alert/AlertList.tsx:432
-msgid "Alerts & reports"
+msgid "Alerts & Reports"
 msgstr "Alertas e informes"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:127

--- a/superset/translations/fr/LC_MESSAGES/messages.json
+++ b/superset/translations/fr/LC_MESSAGES/messages.json
@@ -3145,7 +3145,7 @@
       "${AlertState.error}": ["${AlertState.error}"],
       "${AlertState.noop}": ["${AlertState.noop}"],
       "${AlertState.grace}": ["${AlertState.grace}"],
-      "Alerts & reports": ["Alertes et rapports"],
+      "Alerts & Reports": ["Alertes et rapports"],
       "Reports": ["Rapports"],
       "Delete %s?": ["Effacer %s ?"],
       "Please confirm": ["Veuillez confirmer"],

--- a/superset/translations/fr/LC_MESSAGES/messages.po
+++ b/superset/translations/fr/LC_MESSAGES/messages.po
@@ -1045,7 +1045,7 @@ msgid "Alerts & Reports"
 msgstr "Alertes et rapports"
 
 #: superset-frontend/src/views/CRUD/alert/AlertList.tsx:432
-msgid "Alerts & reports"
+msgid "Alerts & Reports"
 msgstr "Alertes et rapports"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:127

--- a/superset/translations/it/LC_MESSAGES/messages.json
+++ b/superset/translations/it/LC_MESSAGES/messages.json
@@ -1836,7 +1836,7 @@
       "${AlertState.error}": [""],
       "${AlertState.noop}": [""],
       "${AlertState.grace}": [""],
-      "Alerts & reports": ["Importa"],
+      "Alerts & Reports": ["Importa"],
       "Reports": ["Importa"],
       "This action will permanently delete %s.": [""],
       "Delete %s?": ["Cancella"],

--- a/superset/translations/it/LC_MESSAGES/messages.po
+++ b/superset/translations/it/LC_MESSAGES/messages.po
@@ -983,7 +983,7 @@ msgid "Alerts & Reports"
 msgstr ""
 
 #: superset-frontend/src/views/CRUD/alert/AlertList.tsx:432
-msgid "Alerts & reports"
+msgid "Alerts & Reports"
 msgstr "Importa"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:127

--- a/superset/translations/ja/LC_MESSAGES/messages.json
+++ b/superset/translations/ja/LC_MESSAGES/messages.json
@@ -2169,7 +2169,7 @@
       "${AlertState.error}": [""],
       "${AlertState.noop}": [""],
       "${AlertState.grace}": [""],
-      "Alerts & reports": ["アラートとレポート"],
+      "Alerts & Reports": ["アラートとレポート"],
       "Reports": ["レポート"],
       "This action will permanently delete %s.": [""],
       "Delete %s?": ["%s を削除しますか?"],

--- a/superset/translations/ja/LC_MESSAGES/messages.po
+++ b/superset/translations/ja/LC_MESSAGES/messages.po
@@ -977,7 +977,7 @@ msgid "Alerts & Reports"
 msgstr "アラートとレポート"
 
 #: superset-frontend/src/views/CRUD/alert/AlertList.tsx:432
-msgid "Alerts & reports"
+msgid "Alerts & Reports"
 msgstr "アラートとレポート"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:127

--- a/superset/translations/ko/LC_MESSAGES/messages.json
+++ b/superset/translations/ko/LC_MESSAGES/messages.json
@@ -1893,7 +1893,7 @@
       "${AlertState.error}": [""],
       "${AlertState.noop}": [""],
       "${AlertState.grace}": [""],
-      "Alerts & reports": [""],
+      "Alerts & Reports": [""],
       "Reports": [""],
       "This action will permanently delete %s.": [""],
       "Delete %s?": ["삭제"],

--- a/superset/translations/ko/LC_MESSAGES/messages.po
+++ b/superset/translations/ko/LC_MESSAGES/messages.po
@@ -977,7 +977,7 @@ msgid "Alerts & Reports"
 msgstr "경고 및 리포트"
 
 #: superset-frontend/src/views/CRUD/alert/AlertList.tsx:432
-msgid "Alerts & reports"
+msgid "Alerts & Reports"
 msgstr ""
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:127

--- a/superset/translations/messages.pot
+++ b/superset/translations/messages.pot
@@ -964,7 +964,7 @@ msgid "Alerts & Reports"
 msgstr ""
 
 #: superset-frontend/src/views/CRUD/alert/AlertList.tsx:432
-msgid "Alerts & reports"
+msgid "Alerts & Reports"
 msgstr ""
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:127

--- a/superset/translations/nl/LC_MESSAGES/messages.json
+++ b/superset/translations/nl/LC_MESSAGES/messages.json
@@ -4244,7 +4244,7 @@
         "Er is een fout opgetreden tijdens het ophalen van gecreeerd door waarden: %s"
       ],
       "Status": ["Status"],
-      "Alerts & reports": ["Waarschuwingen & rapporten"],
+      "Alerts & Reports": ["Waarschuwingen & rapporten"],
       "Reports": ["Rapporten"],
       "Delete %s?": ["%s verwijderen?"],
       "Please confirm": ["Gelieve te bevestigen"],

--- a/superset/translations/nl/LC_MESSAGES/messages.po
+++ b/superset/translations/nl/LC_MESSAGES/messages.po
@@ -14229,7 +14229,7 @@ msgid "Status"
 msgstr "Status"
 
 #: superset-frontend/src/views/CRUD/alert/AlertList.tsx:432
-msgid "Alerts & reports"
+msgid "Alerts & Reports"
 msgstr "Waarschuwingen & rapporten"
 
 #: superset-frontend/src/views/CRUD/alert/AlertList.tsx:443

--- a/superset/translations/pt_BR/LC_MESSAGES/messages.json
+++ b/superset/translations/pt_BR/LC_MESSAGES/messages.json
@@ -2381,7 +2381,7 @@
       "${AlertState.error}": ["${AlertState.error}"],
       "${AlertState.noop}": ["${AlertState.noop}"],
       "${AlertState.grace}": ["${AlertState.grace}"],
-      "Alerts & reports": ["Alertas e relatórios"],
+      "Alerts & Reports": ["Alertas e relatórios"],
       "Reports": ["Relatórios"],
       "This action will permanently delete %s.": [
         "Esta ação vai permanentemente deletar %s."

--- a/superset/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/superset/translations/pt_BR/LC_MESSAGES/messages.po
@@ -1046,7 +1046,7 @@ msgid "Alerts & Reports"
 msgstr "Alertas e relatórios"
 
 #: superset-frontend/src/views/CRUD/alert/AlertList.tsx:432
-msgid "Alerts & reports"
+msgid "Alerts & Reports"
 msgstr "Alertas e relatórios"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:127

--- a/superset/translations/ru/LC_MESSAGES/messages.json
+++ b/superset/translations/ru/LC_MESSAGES/messages.json
@@ -2261,7 +2261,7 @@
       "${AlertState.error}": ["${AlertState.error}"],
       "${AlertState.noop}": ["${AlertState.noop}"],
       "${AlertState.grace}": ["${AlertState.grace}"],
-      "Alerts & reports": ["Оповещения и рассылки"],
+      "Alerts & Reports": ["Оповещения и рассылки"],
       "Reports": ["Рассылки"],
       "This action will permanently delete %s.": [
         "Это действие навсегда удалит %s."

--- a/superset/translations/ru/LC_MESSAGES/messages.po
+++ b/superset/translations/ru/LC_MESSAGES/messages.po
@@ -1023,7 +1023,7 @@ msgid "Alerts & Reports"
 msgstr "Оповещения и Рассылка"
 
 #: superset-frontend/src/views/CRUD/alert/AlertList.tsx:432
-msgid "Alerts & reports"
+msgid "Alerts & Reports"
 msgstr "Оповещения и рассылки"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:127

--- a/superset/translations/sk/LC_MESSAGES/messages.json
+++ b/superset/translations/sk/LC_MESSAGES/messages.json
@@ -1935,7 +1935,7 @@
       "${AlertState.error}": [""],
       "${AlertState.noop}": [""],
       "${AlertState.grace}": [""],
-      "Alerts & reports": [""],
+      "Alerts & Reports": [""],
       "Reports": [""],
       "This action will permanently delete %s.": [""],
       "Delete %s?": [""],

--- a/superset/translations/sk/LC_MESSAGES/messages.po
+++ b/superset/translations/sk/LC_MESSAGES/messages.po
@@ -958,7 +958,7 @@ msgid "Alerts & Reports"
 msgstr ""
 
 #: superset-frontend/src/views/CRUD/alert/AlertList.tsx:432
-msgid "Alerts & reports"
+msgid "Alerts & Reports"
 msgstr ""
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:127

--- a/superset/translations/sl/LC_MESSAGES/messages.json
+++ b/superset/translations/sl/LC_MESSAGES/messages.json
@@ -3140,7 +3140,7 @@
       "${AlertState.error}": ["${AlertState.error}"],
       "${AlertState.noop}": ["${AlertState.noop}"],
       "${AlertState.grace}": ["${AlertState.grace}"],
-      "Alerts & reports": ["Opozorila in poročila"],
+      "Alerts & Reports": ["Opozorila in poročila"],
       "Reports": ["Poročila"],
       "Delete %s?": ["Izbrišem %s?"],
       "Please confirm": ["Prosim, potrdite"],

--- a/superset/translations/sl/LC_MESSAGES/messages.po
+++ b/superset/translations/sl/LC_MESSAGES/messages.po
@@ -1045,7 +1045,7 @@ msgid "Alerts & Reports"
 msgstr "Opozorila in poročila"
 
 #: superset-frontend/src/views/CRUD/alert/AlertList.tsx:432
-msgid "Alerts & reports"
+msgid "Alerts & Reports"
 msgstr "Opozorila in poročila"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:127

--- a/superset/translations/zh/LC_MESSAGES/messages.json
+++ b/superset/translations/zh/LC_MESSAGES/messages.json
@@ -2038,7 +2038,7 @@
       "Error": ["错误"],
       "Not triggered": ["没有触发"],
       "On Grace": ["在宽限期内"],
-      "Alerts & reports": ["警报和报告"],
+      "Alerts & Reports": ["警报和报告"],
       "Reports": ["报告"],
       "This action will permanently delete %s.": ["此操作将永久删除 %s 。"],
       "Delete %s?": ["需要删除 %s 吗？"],

--- a/superset/translations/zh/LC_MESSAGES/messages.po
+++ b/superset/translations/zh/LC_MESSAGES/messages.po
@@ -1008,7 +1008,7 @@ msgid "Alerts & Reports"
 msgstr "警报和报告"
 
 #: superset-frontend/src/views/CRUD/alert/AlertList.tsx:432
-msgid "Alerts & reports"
+msgid "Alerts & Reports"
 msgstr "警报和报告"
 
 #: superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx:127


### PR DESCRIPTION
### SUMMARY

Capitalize `reports` so that page title is `Alerts & Reports`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

AFTER

![image](https://user-images.githubusercontent.com/1297759/163442353-d29bd962-a1ef-4464-bcac-1ee4c9d1b35c.png)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
