### PR TITLE
fix: allow time_range_endpoints to in ChartDataExtrasSchema for Reports/Alerts

### DIFF
--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -844,7 +844,10 @@ class ChartDataFilterSchema(Schema):
 
 
 class ChartDataExtrasSchema(Schema):
-
+    
+    # todo(hugh): remedy for data currently still being processed by reports
+    # need to write a proper migration to remove all time_range_endpoints
+    time_range_endpoints = fields.List(str, by_value=True))
     relative_start = fields.String(
         description="Start time for relative time deltas. "
         'Default: `config["DEFAULT_RELATIVE_START_TIME"]`',

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -844,7 +844,7 @@ class ChartDataFilterSchema(Schema):
 
 
 class ChartDataExtrasSchema(Schema):
-    
+
     # todo(hugh): remedy for data currently still being processed by reports
     # need to write a proper migration to remove all time_range_endpoints
     time_range_endpoints = fields.List(fields.String())

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -847,7 +847,7 @@ class ChartDataExtrasSchema(Schema):
     
     # todo(hugh): remedy for data currently still being processed by reports
     # need to write a proper migration to remove all time_range_endpoints
-    time_range_endpoints = fields.List(str)
+    time_range_endpoints = fields.List(fields.String())
     relative_start = fields.String(
         description="Start time for relative time deltas. "
         'Default: `config["DEFAULT_RELATIVE_START_TIME"]`',

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -847,7 +847,7 @@ class ChartDataExtrasSchema(Schema):
     
     # todo(hugh): remedy for data currently still being processed by reports
     # need to write a proper migration to remove all time_range_endpoints
-    time_range_endpoints = fields.List(str, by_value=True))
+    time_range_endpoints = fields.List(str)
     relative_start = fields.String(
         description="Start time for relative time deltas. "
         'Default: `config["DEFAULT_RELATIVE_START_TIME"]`',

--- a/superset/connectors/sqla/utils.py
+++ b/superset/connectors/sqla/utils.py
@@ -168,7 +168,7 @@ def validate_adhoc_subquery(
     return ";\n".join(str(statement) for statement in statements)
 
 
-def load_or_create_tables(  # pylint: disable=too-many-arguments
+def load_or_create_tables(
     session: Session,
     database: Database,
     default_schema: Optional[str],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Alerts/Reports are failing due to time_range_endpoints keys that are still available in reports/alerts metastore. Looking to use this fix as a remedy as we continue to figure out to properly clean up the data

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
