### PR TITLE
docs(contributing): add local vscode config for backend debugging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -864,7 +864,7 @@ npm run cypress open
 
 ### Debugging Server App
 
-#### Locally
+#### Local
 
 For debugging locally using VSCode, you can configure a launch configuration file .vscode/launch.json such as
 
@@ -895,7 +895,7 @@ For debugging locally using VSCode, you can configure a launch configuration fil
 }
 ```
 
-#### Docker container
+#### Docker
 
 Follow these instructions to debug the Flask app running inside a docker container.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -864,6 +864,8 @@ npm run cypress open
 
 ### Debugging Server App
 
+#### Locally
+
 For debugging locally using VSCode, you can configure a launch configuration file .vscode/launch.json such as
 
 ```json
@@ -892,6 +894,8 @@ For debugging locally using VSCode, you can configure a launch configuration fil
     ]
 }
 ```
+
+#### Docker container
 
 Follow these instructions to debug the Flask app running inside a docker container.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -864,6 +864,35 @@ npm run cypress open
 
 ### Debugging Server App
 
+For debugging locally using VSCode, you can configure a launch configuration file .vscode/launch.json such as
+
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Flask",
+            "type": "python",
+            "request": "launch",
+            "module": "flask",
+            "env": {
+                "FLASK_APP": "superset",
+                "FLASK_ENV": "development"
+            },
+            "args": [
+                "run",
+                "-p 8088",
+                "--with-threads",
+                "--reload",
+                "--debugger"
+            ],
+            "jinja": true,
+            "justMyCode": true
+        }
+    ]
+}
+```
+
 Follow these instructions to debug the Flask app running inside a docker container.
 
 First add the following to the ./docker-compose.yaml file
@@ -941,7 +970,7 @@ tcp        0      0 0.0.0.0:8088            0.0.0.0:*               LISTEN      
 
 You are now ready to attach a debugger to the process. Using VSCode you can configure a launch configuration file .vscode/launch.json like so.
 
-```
+```json
 {
     "version": "0.2.0",
     "configurations": [


### PR DESCRIPTION
Add simple example launch.json file for local backend debugging
