### PR TITLE
fix(post_processing): remove indices from csv output

### DIFF
--- a/superset/charts/post_processing.py
+++ b/superset/charts/post_processing.py
@@ -357,9 +357,6 @@ def apply_post_process(
         if query["result_format"] == ChartDataResultFormat.JSON:
             query["data"] = processed_df.to_dict()
         elif query["result_format"] == ChartDataResultFormat.CSV:
-            buf = StringIO()
-            processed_df.to_csv(buf)
-            buf.seek(0)
-            query["data"] = buf.getvalue()
+            query["data"] = processed_df.to_csv(index=False)
 
     return result


### PR DESCRIPTION
### SUMMARY
This PR removes the pseudo range index  added in post_processing when converting to csv. 

When sending reports as csv or inline text, this id is also included. I believe it does not add any value to output however if it is somehow useful, it is better to include it either via query or make it optional.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

BEFORE:

![a](https://user-images.githubusercontent.com/1297759/163580652-d167acbd-0799-4ce1-bd6f-d453a948ae67.png)

AFTER:

![b](https://user-images.githubusercontent.com/1297759/163580663-71a94fbb-1275-4d75-b1f9-5407361cf948.png)

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
