### PR TITLE
fix(webpack-dev-server): parse env args

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -578,10 +578,10 @@ npm run dev-server
 npm run dev-server -- --port=9001
 
 # Proxy backend requests to a Flask server running on a non-default port
-npm run dev-server -- --supersetPort=8081
+npm run dev-server -- --env=--supersetPort=8081
 
 # Proxy to a remote backend but serve local assets
-npm run dev-server -- --superset=https://superset-dev.example.com
+npm run dev-server -- --env=--superset=https://superset-dev.example.com
 ```
 
 The `--superset=` option is useful in case you want to debug a production issue or have to setup Superset behind a firewall. It allows you to run Flask server in another environment while keep assets building locally for the best developer experience.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -581,7 +581,7 @@ npm run dev-server -- --port=9001
 npm run dev-server -- --supersetPort=8081
 
 # Proxy to a remote backend but serve local assets
-npm run dev-server --superset=https://superset-dev.example.com
+npm run dev-server -- --superset=https://superset-dev.example.com
 ```
 
 The `--superset=` option is useful in case you want to debug a production issue or have to setup Superset behind a firewall. It allows you to run Flask server in another environment while keep assets building locally for the best developer experience.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -581,7 +581,7 @@ npm run dev-server -- --port=9001
 npm run dev-server -- --supersetPort=8081
 
 # Proxy to a remote backend but serve local assets
-npm run dev-server -- --superset=https://superset-dev.example.com
+npm run dev-server --superset=https://superset-dev.example.com
 ```
 
 The `--superset=` option is useful in case you want to debug a production issue or have to setup Superset behind a firewall. It allows you to run Flask server in another environment while keep assets building locally for the best developer experience.

--- a/superset-frontend/webpack.proxy-config.js
+++ b/superset-frontend/webpack.proxy-config.js
@@ -23,9 +23,7 @@ const yargs = require('yargs');
 const parsedArgs = yargs.argv;
 
 const parsedEnvArg = () => {
-  console.log(parsedArgs);
   if (parsedArgs.env) {
-    console.log(yargs(parsedArgs.env).argv);
     return yargs(parsedArgs.env).argv;
   }
   return {};

--- a/superset-frontend/webpack.proxy-config.js
+++ b/superset-frontend/webpack.proxy-config.js
@@ -18,10 +18,20 @@
  */
 const zlib = require('zlib');
 
+const yargs = require('yargs');
 // eslint-disable-next-line import/no-extraneous-dependencies
-const parsedArgs = require('yargs').argv;
+const parsedArgs = yargs.argv;
 
-const { supersetPort = 8088, superset: supersetUrl = null } = parsedArgs;
+const parsedEnvArg = () => {
+  console.log(parsedArgs);
+  if (parsedArgs.env) {
+    console.log(yargs(parsedArgs.env).argv);
+    return yargs(parsedArgs.env).argv;
+  }
+  return {};
+};
+
+const { supersetPort = 8088, superset: supersetUrl = null } = parsedEnvArg();
 const backend = (supersetUrl || `http://localhost:${supersetPort}`).replace(
   '//+$/',
   '',


### PR DESCRIPTION
### SUMMARY
The `--superset` arg is rejected by webpack because it's not well known.  

This PR updates the documentation and changes the flag to use the `--env` arg as a way to override the backend superset environment when running the `webpack-dev-server`.   

### TESTING INSTRUCTIONS
From the `superset-frontend` directory, run the command to use a remote superset backend.  

```bash
npm run dev-server -- --env=--superset=https://my-superset-backend
```

### ADDITIONAL INFORMATION  
- [x] Has associated issue: Fixes #19743 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
