### PR TITLE
fix(permalink): remove memoize on get salt func

### DIFF
--- a/superset/key_value/shared_entries.py
+++ b/superset/key_value/shared_entries.py
@@ -20,7 +20,6 @@ from uuid import uuid3
 
 from superset.key_value.types import KeyValueResource, SharedKey
 from superset.key_value.utils import get_uuid_namespace, random_key
-from superset.utils.memoized import memoized
 
 RESOURCE = KeyValueResource.APP
 NAMESPACE = get_uuid_namespace("")
@@ -42,7 +41,6 @@ def set_shared_value(key: SharedKey, value: Any) -> None:
     CreateKeyValueCommand(resource=RESOURCE, value=value, key=uuid_key).run()
 
 
-@memoized
 def get_permalink_salt(key: SharedKey) -> str:
     salt = get_shared_value(key)
     if salt is None:


### PR DESCRIPTION
### SUMMARY
Currently the util function that fetches the permalink salt is memoized. This can cause trouble if the workers need to reference different metastores. While removal of the `memoized` decorator will have a performance impact, it should be negligible, as it's very light weight and occurs fairly infrequently. I will look into a better solution for avoiding refetching the salt on each permalink action.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Decoding a permalink with a salt different to that with which it was encrypted results in the following error:
<img width="1271" alt="image" src="https://user-images.githubusercontent.com/33317356/163769791-8ae96dbc-f06d-45bd-9f8b-a77820201e35.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
