### PR TITLE
feat: query results accuracy test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,13 +108,13 @@ def data_loader(
     )
 
 
-@fixture(scope="session")
+@fixture
 def superset_app_ctx():
     with app.app_context() as ctx:
         yield ctx
 
 
-@fixture()
+@fixture
 def load_sales_dataset():
     with app.app_context():
         loader = CsvDatasetLoader(
@@ -124,5 +124,5 @@ def load_sales_dataset():
         loader.load_table()
         dataset = loader.load_dataset()
         yield dataset
-        loader.remove_dataset()
+        # loader.remove_dataset()
         loader.remove_table()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,13 +115,14 @@ def superset_app_ctx():
 
 
 @fixture()
-def load_sales_dataset(superset_app_ctx):
-    loader = CsvDatasetLoader(
-        "https://raw.githubusercontent.com/apache-superset/examples-data/lowercase_columns_examples/datasets/examples/sales.csv",
-        parse_dates=["order_date"],
-    )
-    loader.load_table()
-    dataset = loader.load_dataset()
-    yield dataset
-    loader.remove_dataset()
-    loader.remove_table()
+def load_sales_dataset():
+    with app.app_context():
+        loader = CsvDatasetLoader(
+            "https://raw.githubusercontent.com/apache-superset/examples-data/lowercase_columns_examples/datasets/examples/sales.csv",
+            parse_dates=["order_date"],
+        )
+        loader.load_table()
+        dataset = loader.load_dataset()
+        yield dataset
+        loader.remove_dataset()
+        loader.remove_table()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 from typing import Callable, TYPE_CHECKING
 from unittest.mock import MagicMock, Mock, PropertyMock
 
-from flask.ctx import AppContext
 from pytest import fixture
 
 from tests.example_data.data_loading.csv_dataset_loader import CsvDatasetLoader
@@ -124,5 +123,5 @@ def load_sales_dataset():
         loader.load_table()
         dataset = loader.load_dataset()
         yield dataset
-        # loader.remove_dataset()
+        loader.remove_dataset()
         loader.remove_table()

--- a/tests/example_data/data_loading/csv_dataset_loader.py
+++ b/tests/example_data/data_loading/csv_dataset_loader.py
@@ -1,0 +1,125 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+from __future__ import annotations
+
+import ctypes
+import os.path
+from pathlib import Path
+from typing import List, TYPE_CHECKING
+from urllib.parse import urlparse
+
+import pandas as pd
+from sqlalchemy import event
+
+from superset import config, db
+from superset.utils.database import get_example_database
+
+if TYPE_CHECKING:
+    from superset.connectors.sqla.models import SqlaTable
+
+
+class CsvDatasetLoader:
+    # A simple csvloader, this DataLoader should run in Superset AppContext
+    csv_path: str
+    df: pd.DataFrame
+    table_name: str
+    dataset: SqlaTable
+
+    def __init__(
+        self,
+        csv_path: str,
+        cache: bool = True,
+        parse_dates: List[str] = [],
+    ):
+        # todo: remove this method after dataset model stop shallow writing
+        self._clear_event_listeners()
+
+        # read from http
+        if csv_path.startswith("http") and csv_path.endswith(".csv"):
+            filename = urlparse(csv_path).path.split("/")[-1]
+            filepath = os.path.join(config.DATA_DIR, filename)
+            if os.path.exists(filepath) and cache:
+                self.csv_path = filepath
+                self.df = pd.read_csv(filepath, parse_dates=parse_dates)
+                self.table_name = filename.replace(".csv", "")
+            else:
+                self.df = pd.read_csv(csv_path, parse_dates=parse_dates)
+                if cache:
+                    self.df.to_csv(filepath, index=False)
+                self.csv_path = filepath
+                self.table_name = filename.replace(".csv", "")
+
+        # read from fs
+        if os.path.exists(csv_path) and csv_path.endswith(".csv"):
+            self.csv_path = csv_path
+            self.df = pd.read_csv(csv_path, parse_dates=parse_dates)
+            self.table_name = Path(csv_path).name.replace(".csv", "")
+
+    def load_table(self) -> None:
+        # load table to the default schema
+        example_database = get_example_database()
+        self.df.to_sql(
+            name=self.table_name,
+            con=example_database.get_sqla_engine(),
+            index=False,
+            if_exists="replace",
+        )
+
+    def remove_table(self) -> None:
+        example_database = get_example_database()
+        example_database.get_sqla_engine().execute(
+            f"DROP TABLE IF EXISTS {self.table_name}"
+        )
+
+    def load_dataset(self) -> SqlaTable:
+        from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
+        from superset.connectors.sqla.utils import get_physical_table_metadata
+
+        example_database = get_example_database()
+
+        self.dataset = SqlaTable(
+            table_name=self.table_name,
+            database=example_database,
+        )
+        columns = get_physical_table_metadata(example_database, self.table_name)
+        for col in columns:
+            TableColumn(
+                column_name=col["name"],
+                type=col["type"],
+                table=self.dataset,
+                is_dttm=col["is_dttm"],
+            )
+        SqlMetric(metric_name="count", expression="count(*)", table=self.dataset)
+        return self.dataset
+
+    def remove_dataset(self) -> None:
+        for m in self.dataset.metrics:
+            db.session.delete(m)
+        for col in self.dataset.columns:
+            db.session.delete(col)
+        db.session.delete(self.dataset)
+        db.session.commit()
+
+    def _clear_event_listeners(self) -> None:
+        from superset.connectors.sqla.models import SqlaTable
+
+        keys = [k for k in event.registry._key_to_collection if k[0] == id(SqlaTable)]
+        for key in keys:
+            target = SqlaTable
+            identifier = key[1]
+            fn = ctypes.cast(key[2], ctypes.py_object).value
+            event.remove(target, identifier, fn)

--- a/tests/example_data/data_loading/csv_dataset_loader.py
+++ b/tests/example_data/data_loading/csv_dataset_loader.py
@@ -46,7 +46,7 @@ class CsvDatasetLoader:
         parse_dates: List[str] = [],
     ):
         # todo: remove this method after dataset model stop shallow writing
-        self._clear_event_listeners()
+        # self._clear_event_listeners()
 
         # read from http
         if csv_path.startswith("http") and csv_path.endswith(".csv"):

--- a/tests/integration_tests/query_context/test_time_comparion.py
+++ b/tests/integration_tests/query_context/test_time_comparion.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
+
 from datetime import datetime
 from typing import TYPE_CHECKING
 

--- a/tests/integration_tests/query_context/test_time_comparion.py
+++ b/tests/integration_tests/query_context/test_time_comparion.py
@@ -1,0 +1,124 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
+from superset.common.query_context import QueryContext
+from superset.common.query_object import QueryObject
+
+if TYPE_CHECKING:
+    from superset.connectors.sqla.models import SqlaTable
+
+
+def test_time_comparison(load_sales_dataset: SqlaTable) -> None:
+    query_context = QueryContext(
+        datasource=load_sales_dataset,
+        queries=[],
+        form_data={},
+        result_type=ChartDataResultType.FULL,
+        result_format=ChartDataResultFormat.JSON,
+        force=True,
+        cache_values={},
+    )
+    query_object = QueryObject(
+        metrics=["count"],
+        columns=["order_date"],
+        orderby=[
+            (
+                "order_date",
+                True,
+            )
+        ],
+        granularity="order_date",
+        extras={"time_grain_sqla": "P1M"},
+        from_dttm=datetime(2004, 1, 1),
+        to_dttm=datetime(2005, 1, 1),
+        row_limit=100000,
+    )
+    rv_2014 = query_context.get_df_payload(query_object, force_cached=True)
+    """
+    >>> rv_2014['df']
+           order_date  count
+    0  2004-01-01     91
+    1  2004-02-01     86
+    2  2004-03-01     56
+    3  2004-04-01     64
+    4  2004-05-01     74
+    5  2004-06-01     85
+    6  2004-07-01     91
+    7  2004-08-01    133
+    8  2004-09-01     95
+    9  2004-10-01    159
+    10 2004-11-01    301
+    11 2004-12-01    110
+    """
+
+    query_object = QueryObject(
+        metrics=["count"],
+        columns=["order_date"],
+        orderby=[
+            (
+                "order_date",
+                True,
+            )
+        ],
+        granularity="order_date",
+        extras={"time_grain_sqla": "P1M"},
+        from_dttm=datetime(2003, 1, 1),
+        to_dttm=datetime(2004, 1, 1),
+        row_limit=100000,
+    )
+    rv_2013 = query_context.get_df_payload(query_object, force_cached=True)
+    """
+    >>> rv_2013['df']
+           order_date  count
+    0  2003-01-01     39
+    1  2003-02-01     41
+    2  2003-03-01     50
+    3  2003-04-01     58
+    4  2003-05-01     58
+    5  2003-06-01     46
+    6  2003-07-01     50
+    7  2003-08-01     58
+    8  2003-09-01     76
+    9  2003-10-01    158
+    10 2003-11-01    296
+    11 2003-12-01     70
+    """
+
+    query_object = QueryObject(
+        metrics=["count"],
+        columns=["order_date"],
+        orderby=[
+            (
+                "order_date",
+                True,
+            )
+        ],
+        granularity="order_date",
+        extras={"time_grain_sqla": "P1M"},
+        from_dttm=datetime(2004, 1, 1),
+        to_dttm=datetime(2005, 1, 1),
+        row_limit=100000,
+        time_offsets=["1 year ago"],
+    )
+    rv_2014_2013 = query_context.get_df_payload(query_object, force_cached=True)
+
+    assert rv_2014_2013["df"]["order_date"].equals(rv_2014["df"]["order_date"])
+    assert rv_2014_2013["df"]["count"].equals(rv_2014["df"]["count"])
+    assert rv_2014_2013["df"]["count__1 year ago"].equals(rv_2013["df"]["count"])

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -23,8 +23,8 @@ import pytest
 
 import numpy as np
 import pandas as pd
-import sqlalchemy as sa
 from flask import Flask
+from flask.ctx import AppContext
 from pytest_mock import MockFixture
 from sqlalchemy.sql import text
 from sqlalchemy.sql.elements import TextClause
@@ -662,51 +662,52 @@ def test_filter_on_text_column(text_column_table):
     assert result_object.df["count"][0] == 1
 
 
-def test_should_generate_closed_and_open_time_filter_range():
-    with app.app_context():
-        if backend() != "postgresql":
-            pytest.skip(f"{backend()} has different dialect for datetime column")
+def test_should_generate_closed_and_open_time_filter_range(
+    superset_app_ctx: AppContext,
+):
+    if backend() != "postgresql":
+        pytest.skip(f"{backend()} has different dialect for datetime column")
 
-        table = SqlaTable(
-            table_name="temporal_column_table",
-            sql=(
-                "SELECT '2021-12-31'::timestamp as datetime_col "
-                "UNION SELECT '2022-01-01'::timestamp "
-                "UNION SELECT '2022-03-10'::timestamp "
-                "UNION SELECT '2023-01-01'::timestamp "
-                "UNION SELECT '2023-03-10'::timestamp "
-            ),
-            database=get_example_database(),
-        )
-        TableColumn(
-            column_name="datetime_col",
-            type="TIMESTAMP",
-            table=table,
-            is_dttm=True,
-        )
-        SqlMetric(metric_name="count", expression="count(*)", table=table)
-        result_object = table.query(
-            {
-                "metrics": ["count"],
-                "is_timeseries": False,
-                "filter": [],
-                "from_dttm": datetime(2022, 1, 1),
-                "to_dttm": datetime(2023, 1, 1),
-                "granularity": "datetime_col",
-            }
-        )
-        """ >>> result_object.query
-                SELECT count(*) AS count
-                FROM
-                  (SELECT '2021-12-31'::timestamp as datetime_col
-                   UNION SELECT '2022-01-01'::timestamp
-                   UNION SELECT '2022-03-10'::timestamp
-                   UNION SELECT '2023-01-01'::timestamp
-                   UNION SELECT '2023-03-10'::timestamp) AS virtual_table
-                WHERE datetime_col >= TO_TIMESTAMP('2022-01-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
-                  AND datetime_col < TO_TIMESTAMP('2023-01-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
-        """
-        assert result_object.df.iloc[0]["count"] == 2
+    table = SqlaTable(
+        table_name="temporal_column_table",
+        sql=(
+            "SELECT '2021-12-31'::timestamp as datetime_col "
+            "UNION SELECT '2022-01-01'::timestamp "
+            "UNION SELECT '2022-03-10'::timestamp "
+            "UNION SELECT '2023-01-01'::timestamp "
+            "UNION SELECT '2023-03-10'::timestamp "
+        ),
+        database=get_example_database(),
+    )
+    TableColumn(
+        column_name="datetime_col",
+        type="TIMESTAMP",
+        table=table,
+        is_dttm=True,
+    )
+    SqlMetric(metric_name="count", expression="count(*)", table=table)
+    result_object = table.query(
+        {
+            "metrics": ["count"],
+            "is_timeseries": False,
+            "filter": [],
+            "from_dttm": datetime(2022, 1, 1),
+            "to_dttm": datetime(2023, 1, 1),
+            "granularity": "datetime_col",
+        }
+    )
+    """ >>> result_object.query
+            SELECT count(*) AS count
+            FROM
+              (SELECT '2021-12-31'::timestamp as datetime_col
+               UNION SELECT '2022-01-01'::timestamp
+               UNION SELECT '2022-03-10'::timestamp
+               UNION SELECT '2023-01-01'::timestamp
+               UNION SELECT '2023-03-10'::timestamp) AS virtual_table
+            WHERE datetime_col >= TO_TIMESTAMP('2022-01-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
+              AND datetime_col < TO_TIMESTAMP('2023-01-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
+    """
+    assert result_object.df.iloc[0]["count"] == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### SUMMARY
Currently, we don't have tests that ensure query accuracy. For example, we should combine database results and post-processing calculation if the user applies time comparison, then verify the results and the expected results.

This PR introduces a pattern that the developer easily constructs **query context** and **query object**, and verifies the query results and expected results.

This PR should wait for [relative PR](https://github.com/apache/superset/pull/19752) to merge first. 19752 fixed `SqlaTable` can't trigger delete event issue.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
pass Python integration test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
