### PR TITLE
feat(explore): Implement data panel redesign

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
@@ -121,13 +121,11 @@ describe('Test datatable', () => {
     cy.visitChartByName('Daily Totals');
   });
   it('Data Pane opens and loads results', () => {
-    cy.get('[data-test="data-tab"]').click();
     cy.get('[data-test="row-count-label"]').contains('26 rows retrieved');
     cy.contains('View results');
     cy.get('.ant-empty-description').should('not.exist');
   });
   it('Datapane loads view samples', () => {
-    cy.get('[data-test="data-tab"]').click();
     cy.contains('View samples').click();
     cy.get('[data-test="row-count-label"]').contains('1k rows retrieved');
     cy.get('.ant-empty-description').should('not.exist');

--- a/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
@@ -121,12 +121,12 @@ describe('Test datatable', () => {
     cy.visitChartByName('Daily Totals');
   });
   it('Data Pane opens and loads results', () => {
+    cy.contains('Results').click();
     cy.get('[data-test="row-count-label"]').contains('26 rows retrieved');
-    cy.contains('View results');
     cy.get('.ant-empty-description').should('not.exist');
   });
   it('Datapane loads view samples', () => {
-    cy.contains('View samples').click();
+    cy.contains('Samples').click();
     cy.get('[data-test="row-count-label"]').contains('1k rows retrieved');
     cy.get('.ant-empty-description').should('not.exist');
   });

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -85,6 +85,8 @@ export const CopyToClipboardButton = ({
         <Icons.CopyOutlined
           iconColor={theme.colors.grayscale.base}
           iconSize="l"
+          aria-label={t('Copy')}
+          role="button"
           css={css`
             &.anticon > * {
               line-height: 0;

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -67,41 +67,54 @@ export const CopyButton = styled(Button)`
   }
 `;
 
-const CopyNode = (
-  <CopyButton buttonSize="xsmall" aria-label={t('Copy')}>
-    <i className="fa fa-clipboard" />
-  </CopyButton>
-);
-
 export const CopyToClipboardButton = ({
   data,
   columns,
 }: {
   data?: Record<string, any>;
   columns?: string[];
-}) => (
-  <CopyToClipboard
-    text={
-      data && columns ? prepareCopyToClipboardTabularData(data, columns) : ''
-    }
-    wrapped={false}
-    copyNode={CopyNode}
-  />
-);
+}) => {
+  const theme = useTheme();
+  return (
+    <CopyToClipboard
+      text={
+        data && columns ? prepareCopyToClipboardTabularData(data, columns) : ''
+      }
+      wrapped={false}
+      copyNode={
+        <Icons.CopyOutlined
+          iconColor={theme.colors.grayscale.base}
+          iconSize="l"
+          css={css`
+            &.anticon > * {
+              line-height: 0;
+            }
+          `}
+        />
+      }
+    />
+  );
+};
 
 export const FilterInput = ({
   onChangeHandler,
 }: {
   onChangeHandler(filterText: string): void;
 }) => {
+  const theme = useTheme();
   const debouncedChangeHandler = debounce(onChangeHandler, SLOW_DEBOUNCE);
   return (
     <Input
+      prefix={<Icons.Search iconColor={theme.colors.grayscale.base} />}
       placeholder={t('Search')}
       onChange={(event: any) => {
         const filterText = event.target.value;
         debouncedChangeHandler(filterText);
       }}
+      css={css`
+        width: 200px;
+        margin-right: ${theme.gridUnit * 2}px;
+      `}
     />
   );
 };

--- a/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.test.tsx
@@ -21,7 +21,11 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import * as copyUtils from 'src/utils/copy';
-import { render, screen } from 'spec/helpers/testing-library';
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from 'spec/helpers/testing-library';
 import { DataTablesPane } from '.';
 
 const createProps = () => ({
@@ -50,7 +54,6 @@ const createProps = () => ({
     sort_y_axis: 'alpha_asc',
     extra_form_data: {},
   },
-  tableSectionHeight: 156.9,
   chartStatus: 'rendered',
   onCollapseChange: jest.fn(),
   queriesResponse: [
@@ -60,91 +63,162 @@ const createProps = () => ({
   ],
 });
 
-test('Rendering DataTablesPane correctly', () => {
-  const props = createProps();
-  render(<DataTablesPane {...props} />, { useRedux: true });
-  expect(screen.getByTestId('some-purposeful-instance')).toBeVisible();
-  expect(screen.getByRole('tablist')).toBeVisible();
-  expect(screen.getByRole('tab', { name: 'right Data' })).toBeVisible();
-  expect(screen.getByRole('img', { name: 'right' })).toBeVisible();
-});
-
-test('Should show tabs', async () => {
-  const props = createProps();
-  render(<DataTablesPane {...props} />, { useRedux: true });
-  expect(screen.queryByText('View results')).not.toBeInTheDocument();
-  expect(screen.queryByText('View samples')).not.toBeInTheDocument();
-  userEvent.click(await screen.findByText('Data'));
-  expect(await screen.findByText('View results')).toBeVisible();
-  expect(screen.getByText('View samples')).toBeVisible();
-});
-
-test('Should show tabs: View results', async () => {
-  const props = createProps();
-  render(<DataTablesPane {...props} />, {
-    useRedux: true,
+describe('DataTablesPane', () => {
+  // Collapsed/expanded state depends on local storage
+  // We need to clear it manually - otherwise initial state would depend on the order of tests
+  beforeEach(() => {
+    localStorage.clear();
   });
-  userEvent.click(await screen.findByText('Data'));
-  userEvent.click(await screen.findByText('View results'));
-  expect(screen.getByText('0 rows retrieved')).toBeVisible();
-});
 
-test('Should show tabs: View samples', async () => {
-  const props = createProps();
-  render(<DataTablesPane {...props} />, {
-    useRedux: true,
+  afterAll(() => {
+    localStorage.clear();
   });
-  userEvent.click(await screen.findByText('Data'));
-  expect(screen.queryByText('0 rows retrieved')).not.toBeInTheDocument();
-  userEvent.click(await screen.findByText('View samples'));
-  expect(await screen.findByText('0 rows retrieved')).toBeVisible();
-});
 
-test('Should copy data table content correctly', async () => {
-  fetchMock.post(
-    'glob:*/api/v1/chart/data?form_data=%7B%22slice_id%22%3A456%7D',
-    {
-      result: [
-        {
-          data: [{ __timestamp: 1230768000000, genre: 'Action' }],
-          colnames: ['__timestamp', 'genre'],
-          coltypes: [2, 1],
-        },
-      ],
-    },
-  );
-  const copyToClipboardSpy = jest.spyOn(copyUtils, 'default');
-  const props = createProps();
-  render(
-    <DataTablesPane
-      {...{
-        ...props,
-        chartStatus: 'success',
-        queriesResponse: [
+  test('Rendering DataTablesPane correctly', () => {
+    const props = createProps();
+    render(<DataTablesPane {...props} />, { useRedux: true });
+    expect(screen.getByText('Results')).toBeVisible();
+    expect(screen.getByText('Samples')).toBeVisible();
+    expect(screen.getByLabelText('Expand data panel')).toBeVisible();
+  });
+
+  test('Collapse/Expand buttons', async () => {
+    const props = createProps();
+    render(<DataTablesPane {...props} />, {
+      useRedux: true,
+    });
+    expect(
+      screen.queryByLabelText('Collapse data panel'),
+    ).not.toBeInTheDocument();
+    userEvent.click(screen.getByLabelText('Expand data panel'));
+    expect(await screen.findByLabelText('Collapse data panel')).toBeVisible();
+    expect(
+      screen.queryByLabelText('Expand data panel'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('Should show tabs: View results', async () => {
+    const props = createProps();
+    render(<DataTablesPane {...props} />, {
+      useRedux: true,
+    });
+    userEvent.click(screen.getByText('Results'));
+    expect(await screen.findByText('0 rows retrieved')).toBeVisible();
+    expect(await screen.findByLabelText('Collapse data panel')).toBeVisible();
+    localStorage.clear();
+  });
+
+  test('Should show tabs: View samples', async () => {
+    const props = createProps();
+    render(<DataTablesPane {...props} />, {
+      useRedux: true,
+    });
+    userEvent.click(screen.getByText('Samples'));
+    expect(await screen.findByText('0 rows retrieved')).toBeVisible();
+    expect(await screen.findByLabelText('Collapse data panel')).toBeVisible();
+  });
+
+  test('Should copy data table content correctly', async () => {
+    fetchMock.post(
+      'glob:*/api/v1/chart/data?form_data=%7B%22slice_id%22%3A456%7D',
+      {
+        result: [
           {
+            data: [{ __timestamp: 1230768000000, genre: 'Action' }],
             colnames: ['__timestamp', 'genre'],
             coltypes: [2, 1],
           },
         ],
-      }}
-    />,
-    {
-      useRedux: true,
-      initialState: {
-        explore: {
-          timeFormattedColumns: {
-            '34__table': ['__timestamp'],
+      },
+    );
+    const copyToClipboardSpy = jest.spyOn(copyUtils, 'default');
+    const props = createProps();
+    render(
+      <DataTablesPane
+        {...{
+          ...props,
+          chartStatus: 'success',
+          queriesResponse: [
+            {
+              colnames: ['__timestamp', 'genre'],
+              coltypes: [2, 1],
+            },
+          ],
+        }}
+      />,
+      {
+        useRedux: true,
+        initialState: {
+          explore: {
+            timeFormattedColumns: {
+              '34__table': ['__timestamp'],
+            },
           },
         },
       },
-    },
-  );
-  userEvent.click(await screen.findByText('Data'));
-  expect(await screen.findByText('1 rows retrieved')).toBeVisible();
+    );
+    userEvent.click(screen.getByText('Results'));
+    expect(await screen.findByText('1 rows retrieved')).toBeVisible();
 
-  userEvent.click(screen.getByRole('button', { name: 'Copy' }));
-  expect(copyToClipboardSpy).toHaveBeenCalledWith(
-    '2009-01-01 00:00:00\tAction\n',
-  );
-  fetchMock.done();
+    userEvent.click(screen.getByLabelText('Copy'));
+    expect(copyToClipboardSpy).toHaveBeenCalledWith(
+      '2009-01-01 00:00:00\tAction\n',
+    );
+    copyToClipboardSpy.mockRestore();
+    fetchMock.restore();
+  });
+
+  test('Search table', async () => {
+    fetchMock.post(
+      'glob:*/api/v1/chart/data?form_data=%7B%22slice_id%22%3A456%7D',
+      {
+        result: [
+          {
+            data: [
+              { __timestamp: 1230768000000, genre: 'Action' },
+              { __timestamp: 1230768000010, genre: 'Horror' },
+            ],
+            colnames: ['__timestamp', 'genre'],
+            coltypes: [2, 1],
+          },
+        ],
+      },
+    );
+    const props = createProps();
+    render(
+      <DataTablesPane
+        {...{
+          ...props,
+          chartStatus: 'success',
+          queriesResponse: [
+            {
+              colnames: ['__timestamp', 'genre'],
+              coltypes: [2, 1],
+            },
+          ],
+        }}
+      />,
+      {
+        useRedux: true,
+        initialState: {
+          explore: {
+            timeFormattedColumns: {
+              '34__table': ['__timestamp'],
+            },
+          },
+        },
+      },
+    );
+    userEvent.click(screen.getByText('Results'));
+    expect(await screen.findByText('2 rows retrieved')).toBeVisible();
+    expect(screen.getByText('Action')).toBeVisible();
+    expect(screen.getByText('Horror')).toBeVisible();
+
+    userEvent.type(screen.getByPlaceholderText('Search'), 'hor');
+
+    await waitForElementToBeRemoved(() => screen.queryByText('Action'));
+    expect(screen.getByText('Horror')).toBeVisible();
+    expect(screen.queryByText('Action')).not.toBeInTheDocument();
+    fetchMock.restore();
+  });
 });

--- a/superset-frontend/src/explore/components/DataTablesPane/index.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/index.tsx
@@ -80,38 +80,44 @@ const TableControlsWrapper = styled.div`
 `;
 
 const SouthPane = styled.div`
-  position: relative;
-  background-color: ${({ theme }) => theme.colors.grayscale.light5};
-  z-index: 5;
-  overflow: hidden;
-`;
+  ${({ theme }) => `
+    position: relative;
+    background-color: ${theme.colors.grayscale.light5};
+    z-index: 5;
+    overflow: hidden;
 
-const TabsWrapper = styled.div`
-  height: 100%;
-  overflow: hidden;
+    .ant-tabs {
+      height: 100%;
+    }
 
-  .ant-tabs {
-    height: 100%;
-  }
+    .ant-tabs-content-holder {
+      height: 100%;
+    }
 
-  .ant-tabs-content-holder {
-    height: 100%;
-  }
+    .ant-tabs-content {
+      height: 100%;
+    }
 
-  .ant-tabs-content {
-    height: 100%;
-  }
+    .ant-tabs-tabpane {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
 
-  .table-condensed {
-    height: 100%;
-    overflow: auto;
-  }
+      .table-condensed {
+        height: 100%;
+        overflow: auto;
+        margin-bottom: ${theme.gridUnit * 4}px;
 
-  .ant-tabs-tabpane {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-  }
+        .table {
+          margin-bottom: ${theme.gridUnit * 2}px;
+        }
+      }
+
+      .pagination-container > ul[role='navigation'] {
+        margin-top: 0;
+      }
+    }
+  `}
 `;
 
 const Error = styled.pre`
@@ -425,9 +431,15 @@ export const DataTablesPane = ({
 
   const CollapseButton = useMemo(() => {
     const caretIcon = panelOpen ? (
-      <Icons.CaretUp iconColor={theme.colors.grayscale.base} />
+      <Icons.CaretUp
+        iconColor={theme.colors.grayscale.base}
+        aria-label={t('Collapse data panel')}
+      />
     ) : (
-      <Icons.CaretDown iconColor={theme.colors.grayscale.base} />
+      <Icons.CaretDown
+        iconColor={theme.colors.grayscale.base}
+        aria-label={t('Expand data panel')}
+      />
     );
     return (
       <TableControlsWrapper>
@@ -454,65 +466,63 @@ export const DataTablesPane = ({
 
   return (
     <SouthPane data-test="some-purposeful-instance">
-      <TabsWrapper>
-        <Tabs
-          fullWidth={false}
-          tabBarExtraContent={CollapseButton}
-          activeKey={panelOpen ? activeTabKey : ''}
-          onTabClick={handleTabClick}
-        >
-          <Tabs.TabPane tab={t('Results')} key={RESULT_TYPES.results}>
-            <TableControls
-              data={data[RESULT_TYPES.results]}
-              columnNames={columnNames[RESULT_TYPES.results]}
-              datasourceId={queryFormData?.datasource}
-              onInputChange={input =>
-                setFilterText(prevState => ({
-                  ...prevState,
-                  [RESULT_TYPES.results]: input,
-                }))
-              }
-              isLoading={isLoading[RESULT_TYPES.results]}
-            />
-            <DataTable
-              isLoading={isLoading[RESULT_TYPES.results]}
-              data={data[RESULT_TYPES.results]}
-              datasource={queryFormData?.datasource}
-              columnNames={columnNames[RESULT_TYPES.results]}
-              columnTypes={columnTypes[RESULT_TYPES.results]}
-              filterText={filterText[RESULT_TYPES.results]}
-              error={error[RESULT_TYPES.results]}
-              errorMessage={errorMessage}
-              type={RESULT_TYPES.results}
-            />
-          </Tabs.TabPane>
-          <Tabs.TabPane tab={t('Samples')} key={RESULT_TYPES.samples}>
-            <TableControls
-              data={data[RESULT_TYPES.samples]}
-              columnNames={columnNames[RESULT_TYPES.samples]}
-              datasourceId={queryFormData?.datasource}
-              onInputChange={input =>
-                setFilterText(prevState => ({
-                  ...prevState,
-                  [RESULT_TYPES.samples]: input,
-                }))
-              }
-              isLoading={isLoading[RESULT_TYPES.samples]}
-            />
-            <DataTable
-              isLoading={isLoading[RESULT_TYPES.samples]}
-              data={data[RESULT_TYPES.samples]}
-              datasource={queryFormData?.datasource}
-              columnNames={columnNames[RESULT_TYPES.samples]}
-              columnTypes={columnTypes[RESULT_TYPES.samples]}
-              filterText={filterText[RESULT_TYPES.samples]}
-              error={error[RESULT_TYPES.samples]}
-              errorMessage={errorMessage}
-              type={RESULT_TYPES.samples}
-            />
-          </Tabs.TabPane>
-        </Tabs>
-      </TabsWrapper>
+      <Tabs
+        fullWidth={false}
+        tabBarExtraContent={CollapseButton}
+        activeKey={panelOpen ? activeTabKey : ''}
+        onTabClick={handleTabClick}
+      >
+        <Tabs.TabPane tab={t('Results')} key={RESULT_TYPES.results}>
+          <TableControls
+            data={data[RESULT_TYPES.results]}
+            columnNames={columnNames[RESULT_TYPES.results]}
+            datasourceId={queryFormData?.datasource}
+            onInputChange={input =>
+              setFilterText(prevState => ({
+                ...prevState,
+                [RESULT_TYPES.results]: input,
+              }))
+            }
+            isLoading={isLoading[RESULT_TYPES.results]}
+          />
+          <DataTable
+            isLoading={isLoading[RESULT_TYPES.results]}
+            data={data[RESULT_TYPES.results]}
+            datasource={queryFormData?.datasource}
+            columnNames={columnNames[RESULT_TYPES.results]}
+            columnTypes={columnTypes[RESULT_TYPES.results]}
+            filterText={filterText[RESULT_TYPES.results]}
+            error={error[RESULT_TYPES.results]}
+            errorMessage={errorMessage}
+            type={RESULT_TYPES.results}
+          />
+        </Tabs.TabPane>
+        <Tabs.TabPane tab={t('Samples')} key={RESULT_TYPES.samples}>
+          <TableControls
+            data={data[RESULT_TYPES.samples]}
+            columnNames={columnNames[RESULT_TYPES.samples]}
+            datasourceId={queryFormData?.datasource}
+            onInputChange={input =>
+              setFilterText(prevState => ({
+                ...prevState,
+                [RESULT_TYPES.samples]: input,
+              }))
+            }
+            isLoading={isLoading[RESULT_TYPES.samples]}
+          />
+          <DataTable
+            isLoading={isLoading[RESULT_TYPES.samples]}
+            data={data[RESULT_TYPES.samples]}
+            datasource={queryFormData?.datasource}
+            columnNames={columnNames[RESULT_TYPES.samples]}
+            columnTypes={columnTypes[RESULT_TYPES.samples]}
+            filterText={filterText[RESULT_TYPES.samples]}
+            error={error[RESULT_TYPES.samples]}
+            errorMessage={errorMessage}
+            type={RESULT_TYPES.samples}
+          />
+        </Tabs.TabPane>
+      </Tabs>
     </SouthPane>
   );
 };

--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -60,7 +60,7 @@ const propTypes = {
 const GUTTER_SIZE_FACTOR = 1.25;
 
 const INITIAL_SIZES = [100, 0];
-const MIN_SIZES = [300, 50];
+const MIN_SIZES = [300, 65];
 const DEFAULT_SOUTH_PANE_HEIGHT_PERCENT = 40;
 
 const Styles = styled.div`

--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -19,7 +19,7 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import Split from 'react-split';
-import { styled, SupersetClient, useTheme } from '@superset-ui/core';
+import { css, styled, SupersetClient, useTheme } from '@superset-ui/core';
 import { useResizeDetector } from 'react-resize-detector';
 import { chartPropShape } from 'src/dashboard/util/propShapes';
 import ChartContainer from 'src/components/Chart/ChartContainer';
@@ -41,8 +41,6 @@ const propTypes = {
   dashboardId: PropTypes.number,
   column_formats: PropTypes.object,
   containerId: PropTypes.string.isRequired,
-  height: PropTypes.string.isRequired,
-  width: PropTypes.string.isRequired,
   isStarred: PropTypes.bool.isRequired,
   slice: PropTypes.object,
   sliceName: PropTypes.string,
@@ -60,9 +58,6 @@ const propTypes = {
 };
 
 const GUTTER_SIZE_FACTOR = 1.25;
-
-const CHART_PANEL_PADDING_HORIZ = 30;
-const CHART_PANEL_PADDING_VERTICAL = 15;
 
 const INITIAL_SIZES = [100, 0];
 const MIN_SIZES = [300, 50];
@@ -109,7 +104,22 @@ const Styles = styled.div`
   }
 `;
 
-const ExploreChartPanel = props => {
+const ExploreChartPanel = ({
+  chart,
+  slice,
+  vizType,
+  ownState,
+  triggerRender,
+  force,
+  datasource,
+  errorMessage,
+  form_data: formData,
+  onQuery,
+  refreshOverlayVisible,
+  actions,
+  timeout,
+  standalone,
+}) => {
   const theme = useTheme();
   const gutterMargin = theme.gridUnit * GUTTER_SIZE_FACTOR;
   const gutterHeight = theme.gridUnit * GUTTER_SIZE_FACTOR;
@@ -121,20 +131,15 @@ const ExploreChartPanel = props => {
     refreshMode: 'debounce',
     refreshRate: 300,
   });
-  const { height: pillsHeight, ref: pillsRef } = useResizeDetector({
-    refreshMode: 'debounce',
-    refreshRate: 1000,
-  });
   const [splitSizes, setSplitSizes] = useState(
     getItem(LocalStorageKeys.chart_split_sizes, INITIAL_SIZES),
   );
-  const { slice } = props;
   const updateQueryContext = useCallback(
     async function fetchChartData() {
       if (slice && slice.query_context === null) {
         const queryContext = buildV1ChartDataPayload({
           formData: slice.form_data,
-          force: props.force,
+          force,
           resultFormat: 'json',
           resultType: 'full',
           setDataMask: null,
@@ -158,25 +163,6 @@ const ExploreChartPanel = props => {
     updateQueryContext();
   }, [updateQueryContext]);
 
-  const calcSectionHeight = useCallback(
-    percent => {
-      let containerHeight = parseInt(props.height, 10);
-      // if (pillsHeight) {
-      //   containerHeight -= pillsHeight;
-      // }
-      return (
-        containerHeight -
-        Math.max(
-          (containerHeight * (100 - percent)) / 100,
-          MIN_SIZES[1] - gutterHeight - gutterMargin,
-        ) -
-        (gutterHeight / 2 + gutterMargin) -
-        (pillsHeight || 0)
-      );
-    },
-    [gutterHeight, gutterMargin, pillsHeight, props.height, props.standalone],
-  );
-
   useEffect(() => {
     setItem(LocalStorageKeys.chart_split_sizes, splitSizes);
   }, [splitSizes]);
@@ -186,13 +172,13 @@ const ExploreChartPanel = props => {
   };
 
   const refreshCachedQuery = () => {
-    props.actions.postChartFormData(
-      props.form_data,
+    actions.postChartFormData(
+      formData,
       true,
-      props.timeout,
-      props.chart.id,
+      timeout,
+      chart.id,
       undefined,
-      props.ownState,
+      ownState,
     );
   };
 
@@ -209,53 +195,82 @@ const ExploreChartPanel = props => {
     setSplitSizes(splitSizes);
   }, []);
 
-  const renderChart = useCallback(() => {
-    const { chart, vizType } = props;
-    const newHeight =
-      vizType === 'filter_box'
-        ? calcSectionHeight(100) - CHART_PANEL_PADDING_VERTICAL
-        : calcSectionHeight(splitSizes[0]) - CHART_PANEL_PADDING_VERTICAL;
-    const chartWidth = chartPanelWidth - CHART_PANEL_PADDING_HORIZ;
-    console.log(newHeight, chartPanelHeight);
-    return (
-      chartWidth > 0 && (
-        <ChartContainer
-          width={Math.floor(chartWidth)}
-          height={newHeight}
-          ownState={props.ownState}
-          annotationData={chart.annotationData}
-          chartAlert={chart.chartAlert}
-          chartStackTrace={chart.chartStackTrace}
-          chartId={chart.id}
-          chartStatus={chart.chartStatus}
-          triggerRender={props.triggerRender}
-          force={props.force}
-          datasource={props.datasource}
-          errorMessage={props.errorMessage}
-          formData={props.form_data}
-          onQuery={props.onQuery}
-          queriesResponse={chart.queriesResponse}
-          refreshOverlayVisible={props.refreshOverlayVisible}
-          setControlValue={props.actions.setControlValue}
-          timeout={props.timeout}
-          triggerQuery={chart.triggerQuery}
-          vizType={props.vizType}
-        />
-      )
-    );
-  }, [calcSectionHeight, chartPanelWidth, props, splitSizes]);
+  const renderChart = useCallback(
+    () => (
+      <div
+        css={css`
+          min-height: 0;
+          flex: 1;
+        `}
+        ref={chartPanelRef}
+      >
+        {chartPanelWidth && chartPanelHeight && (
+          <ChartContainer
+            width={Math.floor(chartPanelWidth)}
+            height={chartPanelHeight}
+            ownState={ownState}
+            annotationData={chart.annotationData}
+            chartAlert={chart.chartAlert}
+            chartStackTrace={chart.chartStackTrace}
+            chartId={chart.id}
+            chartStatus={chart.chartStatus}
+            triggerRender={triggerRender}
+            force={force}
+            datasource={datasource}
+            errorMessage={errorMessage}
+            formData={formData}
+            onQuery={onQuery}
+            queriesResponse={chart.queriesResponse}
+            refreshOverlayVisible={refreshOverlayVisible}
+            setControlValue={actions.setControlValue}
+            timeout={timeout}
+            triggerQuery={chart.triggerQuery}
+            vizType={vizType}
+          />
+        )}
+      </div>
+    ),
+    [
+      actions.setControlValue,
+      chart.annotationData,
+      chart.chartAlert,
+      chart.chartStackTrace,
+      chart.chartStatus,
+      chart.id,
+      chart.queriesResponse,
+      chart.triggerQuery,
+      chartPanelHeight,
+      chartPanelRef,
+      chartPanelWidth,
+      datasource,
+      errorMessage,
+      force,
+      formData,
+      onQuery,
+      ownState,
+      refreshOverlayVisible,
+      timeout,
+      triggerRender,
+      vizType,
+    ],
+  );
 
   const panelBody = useMemo(
     () => (
-      <div className="panel-body" ref={chartPanelRef}>
+      <div
+        className="panel-body"
+        css={css`
+          display: flex;
+          flex-direction: column;
+        `}
+      >
         <ChartPills
-          queriesResponse={props.chart.queriesResponse}
-          chartStatus={props.chart.chartStatus}
-          chartUpdateStartTime={props.chart.chartUpdateStartTime}
-          chartUpdateEndTime={props.chart.chartUpdateEndTime}
+          queriesResponse={chart.queriesResponse}
+          chartStatus={chart.chartStatus}
+          chartUpdateStartTime={chart.chartUpdateStartTime}
+          chartUpdateEndTime={chart.chartUpdateEndTime}
           refreshCachedQuery={refreshCachedQuery}
-          rowLimit={props.form_data?.row_limit}
-          ref={pillsRef}
+          rowLimit={formData?.row_limit}
         />
         {renderChart()}
       </div>
@@ -263,14 +278,9 @@ const ExploreChartPanel = props => {
     [chartPanelRef, renderChart],
   );
 
-  const standaloneChartBody = useMemo(
-    () => <div ref={chartPanelRef}>{renderChart()}</div>,
-    [chartPanelRef, renderChart],
-  );
+  const standaloneChartBody = useMemo(() => renderChart(), [renderChart]);
 
-  const [queryFormData, setQueryFormData] = useState(
-    props.chart.latestQueryFormData,
-  );
+  const [queryFormData, setQueryFormData] = useState(chart.latestQueryFormData);
 
   useEffect(() => {
     // only update when `latestQueryFormData` changes AND `triggerRender`
@@ -278,13 +288,13 @@ const ExploreChartPanel = props => {
     // as this can trigger a query downstream based on incomplete form data.
     // (`latestQueryFormData` is only updated when a a valid request has been
     // triggered).
-    if (!props.triggerRender) {
-      setQueryFormData(props.chart.latestQueryFormData);
+    if (!triggerRender) {
+      setQueryFormData(chart.latestQueryFormData);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.chart.latestQueryFormData]);
+  }, [chart.latestQueryFormData]);
 
-  if (props.standalone) {
+  if (standalone) {
     // dom manipulation hack to get rid of the boostrap theme's body background
     const standaloneClass = 'background-transparent';
     const bodyClasses = document.body.className.split(' ');
@@ -299,8 +309,8 @@ const ExploreChartPanel = props => {
   });
 
   return (
-    <Styles className="panel panel-default chart-container" ref={chartPanelRef}>
-      {props.vizType === 'filter_box' ? (
+    <Styles className="panel panel-default chart-container">
+      {vizType === 'filter_box' ? (
         panelBody
       ) : (
         <Split
@@ -314,12 +324,12 @@ const ExploreChartPanel = props => {
         >
           {panelBody}
           <DataTablesPane
-            ownState={props.ownState}
+            ownState={ownState}
             queryFormData={queryFormData}
             onCollapseChange={onCollapseChange}
-            chartStatus={props.chart.chartStatus}
-            errorMessage={props.errorMessage}
-            queriesResponse={props.chart.queriesResponse}
+            chartStatus={chart.chartStatus}
+            errorMessage={errorMessage}
+            queriesResponse={chart.queriesResponse}
           />
         </Split>
       )}

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -135,6 +135,7 @@ const ExplorePanelContainer = styled.div`
       flex: 1;
       min-width: ${theme.gridUnit * 128}px;
       border-left: 1px solid ${theme.colors.grayscale.light2};
+      padding: 0 ${theme.gridUnit * 4}px;
       .panel {
         margin-bottom: 0;
       }

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -63,8 +63,6 @@ import ConnectedExploreChartHeader from '../ExploreChartHeader';
 
 const propTypes = {
   ...ExploreChartPanel.propTypes,
-  height: PropTypes.string,
-  width: PropTypes.string,
   actions: PropTypes.object.isRequired,
   datasource_type: PropTypes.string.isRequired,
   dashboardId: PropTypes.number,
@@ -173,23 +171,6 @@ const ExplorePanelContainer = styled.div`
   `};
 `;
 
-const getWindowSize = () => ({
-  height: window.innerHeight,
-  width: window.innerWidth,
-});
-
-function useWindowSize({ delayMs = 250 } = {}) {
-  const [size, setSize] = useState(getWindowSize());
-
-  useEffect(() => {
-    const onWindowResize = debounce(() => setSize(getWindowSize()), delayMs);
-    window.addEventListener('resize', onWindowResize);
-    return () => window.removeEventListener('resize', onWindowResize);
-  }, []);
-
-  return size;
-}
-
 const updateHistory = debounce(
   async (formData, datasetId, isReplace, standalone, force, title, tabId) => {
     const payload = { ...formData };
@@ -247,7 +228,6 @@ function ExploreViewContainer(props) {
   const [lastQueriedControls, setLastQueriedControls] = useState(
     props.controls,
   );
-  const windowSize = useWindowSize();
 
   const [showingModal, setShowingModal] = useState(false);
   const [isCollapsed, setIsCollapsed] = useState(false);
@@ -255,11 +235,6 @@ function ExploreViewContainer(props) {
   const tabId = useTabId();
 
   const theme = useTheme();
-  const width = `${windowSize.width}px`;
-  const navHeight = props.standalone ? 0 : 120;
-  const height = props.forcedHeight
-    ? `${props.forcedHeight}px`
-    : `${windowSize.height - navHeight}px`;
 
   const defaultSidebarsWidth = {
     controls_width: 320,
@@ -516,8 +491,6 @@ function ExploreViewContainer(props) {
   function renderChartContainer() {
     return (
       <ExploreChartPanel
-        width={width}
-        height={height}
         {...props}
         errorMessage={errorMessage}
         refreshOverlayVisible={chartIsStale}


### PR DESCRIPTION
### SUMMARY
This PR implements the redesign of data panel in Explore (below the chart container).

1. Removed the "Data" header that expands/collapses on click
2. Moved expand/collapse functionality to tabs header. When collapsed, clicking on expand button opens tabs showing "Results" by default OR the last active tab before collapsing
3. When collapsed, user can also click on tab name to expand with that tab active
4. When expanded, user can hide the tables by clicking on collapse button OR by clicking on active tab name
5. Moved row count, copy button and search from tabs header to tab content - now they look more in context of currently displayed table
6. Now Results and Samples have separate searches - the search text is no longer shared between those 2 tables
7. Refactored ChartPanel - now we no longer manually calculate widths and heights of chart panel and tables panel. It's all based on css flex.
8. Tables functionality remains unchanged - the request is sent only when the table is activated the first time or there were changes to query

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1786" alt="image" src="https://user-images.githubusercontent.com/15073128/163774386-0af6c816-48bf-4362-be70-0cf36fb19054.png">
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/15073128/163774419-642c9a8c-02e2-483f-b433-a6967f0b8c6f.png">

After:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/15073128/163785258-aa293ede-90e4-4d63-950b-5309f41cc3ff.png">
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/15073128/163774710-9967adf7-6a0f-47a9-9d74-a24554f255f2.png">


### TESTING INSTRUCTIONS
1. Create a chart
2. Verify that collapsing/expanding works as described in PR's summary
3. Verify that copy button and row counter work as before for both results and samples
4. Verify that typing search text in 1 table doesn't affect search filter in second table
5. Verify that chart panel and data table panel don't overflow on each other and scale well when window width changes

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @kasiazjc 