### PR TITLE
fix: can't trigger delete event on SqlaTable

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -2042,6 +2042,9 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
         dataset = (
             session.query(NewDataset).filter_by(sqlatable_id=target.id).one_or_none()
         )
+        for tbl in dataset.tables:
+            session.delete(tbl)
+
         if dataset:
             session.delete(dataset)
 

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -2042,9 +2042,10 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
         dataset = (
             session.query(NewDataset).filter_by(sqlatable_id=target.id).one_or_none()
         )
-        for tbl in dataset.tables:
-            if len(tbl.datasets) == 1 and tbl.datasets[0] == dataset:
-                session.delete(tbl)
+        if dataset:
+            for tbl in dataset.tables:
+                if len(tbl.datasets) == 1 and tbl.datasets[0] == dataset:
+                    session.delete(tbl)
 
         if dataset:
             session.delete(dataset)

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -2043,7 +2043,8 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
             session.query(NewDataset).filter_by(sqlatable_id=target.id).one_or_none()
         )
         for tbl in dataset.tables:
-            session.delete(tbl)
+            if len(tbl.datasets) == 1 and tbl.datasets[0] == dataset:
+                session.delete(tbl)
 
         if dataset:
             session.delete(dataset)

--- a/superset/datasets/models.py
+++ b/superset/datasets/models.py
@@ -76,7 +76,11 @@ class Dataset(Model, AuditMixinNullable, ExtraJSONMixin, ImportExportMixin):
     expression = sa.Column(sa.Text)
 
     # n:n relationship
-    tables: List[Table] = relationship("Table", secondary=table_association_table)
+    tables: List[Table] = relationship(
+        "Table",
+        backref="datasets",
+        secondary=table_association_table,
+    )
 
     # The relationship between datasets and columns is 1:n, but we use a many-to-many
     # association to differentiate between the relationship between tables and columns.

--- a/tests/integration_tests/datasets/commands_tests.py
+++ b/tests/integration_tests/datasets/commands_tests.py
@@ -250,6 +250,7 @@ class TestImportDatasetsCommand(SupersetTestCase):
         }
         command = v0.ImportDatasetsCommand(contents)
         command.run()
+        db.session.commit()
 
         new_num_datasets = db.session.query(SqlaTable).count()
         assert new_num_datasets == num_datasets + 1
@@ -290,6 +291,7 @@ class TestImportDatasetsCommand(SupersetTestCase):
         }
         command = v0.ImportDatasetsCommand(contents)
         command.run()
+        db.session.commit()
 
         new_num_datasets = db.session.query(SqlaTable).count()
         assert new_num_datasets == num_datasets + 1

--- a/tests/unit_tests/datasets/test_models.py
+++ b/tests/unit_tests/datasets/test_models.py
@@ -485,6 +485,7 @@ def test_create_physical_sqlatable(app_context: None, session: Session) -> None:
             "changed_by": None,
             "is_managed_externally": False,
             "external_url": None,
+            "datasets": [1],
         }
     ]
 
@@ -1235,6 +1236,7 @@ def test_update_physical_sqlatable(
             "schema": None,
             "id": 1,
             "is_managed_externally": False,
+            "datasets": [],
         },
         {
             "created_by": None,
@@ -1248,6 +1250,7 @@ def test_update_physical_sqlatable(
             "schema": None,
             "id": 2,
             "is_managed_externally": False,
+            "datasets": [1],
         },
     ]
 


### PR DESCRIPTION
### SUMMARY
The SqlaTable model can't remove associative sl_tables when triggering delete event.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
