### PR TITLE
fix(QueryContext): validation does not validate query_context metrics

### DIFF
--- a/superset/charts/data/commands/command_factory.py
+++ b/superset/charts/data/commands/command_factory.py
@@ -1,0 +1,53 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+from __future__ import annotations
+
+from typing import ClassVar, TYPE_CHECKING
+
+from .get_data_command import ChartDataCommand
+
+if TYPE_CHECKING:
+    from superset.commands.base import BaseCommand
+    from superset.common.query_context import QueryContext
+
+    from ..query_context_validators.validaor_factory import QueryContextValidatorFactory
+
+
+class GetChartDataCommandFactory:
+    _instance: ClassVar[GetChartDataCommandFactory]
+
+    _validator_factory: QueryContextValidatorFactory
+
+    @classmethod
+    def init(cls, validator_factory: QueryContextValidatorFactory) -> None:
+        cls._instance = GetChartDataCommandFactory(validator_factory)
+
+    def __init__(self, validator_factory: QueryContextValidatorFactory):
+        self._validator_factory = validator_factory
+
+    @classmethod
+    def make(cls, query_context: QueryContext) -> BaseCommand:
+        if cls._instance is None:
+            raise RuntimeError("GetChartDataCommandFactory was not initialized")
+        return cls._instance._make(query_context)
+
+    def _make(self, query_context: QueryContext) -> BaseCommand:
+        validator = self._validator_factory.make(self._is_use_sql_db(query_context))
+        return ChartDataCommand(query_context, validator)
+
+    def _is_use_sql_db(self, query_context: QueryContext) -> bool:  # pylint: disable=no-self-use
+        return query_context.datasource.type == "table"

--- a/superset/charts/data/commands/command_factory.py
+++ b/superset/charts/data/commands/command_factory.py
@@ -49,5 +49,7 @@ class GetChartDataCommandFactory:
         validator = self._validator_factory.make(self._is_use_sql_db(query_context))
         return ChartDataCommand(query_context, validator)
 
-    def _is_use_sql_db(self, query_context: QueryContext) -> bool:  # pylint: disable=no-self-use
+    def _is_use_sql_db(
+        self, query_context: QueryContext
+    ) -> bool:  # pylint: disable=no-self-use
         return query_context.datasource.type == "table"

--- a/superset/charts/data/commands/command_factory.py
+++ b/superset/charts/data/commands/command_factory.py
@@ -49,7 +49,7 @@ class GetChartDataCommandFactory:
         validator = self._validator_factory.make(self._is_use_sql_db(query_context))
         return ChartDataCommand(query_context, validator)
 
-    def _is_use_sql_db(
+    def _is_use_sql_db(  # pylint: disable=no-self-use
         self, query_context: QueryContext
-    ) -> bool:  # pylint: disable=no-self-use
+    ) -> bool:
         return query_context.datasource.type == "table"

--- a/superset/charts/data/commands/get_data_command.py
+++ b/superset/charts/data/commands/get_data_command.py
@@ -14,8 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
+
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, TYPE_CHECKING
 
 from superset.charts.commands.exceptions import (
     ChartDataCacheLoadError,
@@ -27,12 +29,17 @@ from superset.exceptions import CacheLoadError
 
 logger = logging.getLogger(__name__)
 
+if TYPE_CHECKING:
+    from ..query_context_validators import QueryContextValidator
+
 
 class ChartDataCommand(BaseCommand):
     _query_context: QueryContext
+    _validator: QueryContextValidator
 
-    def __init__(self, query_context: QueryContext):
+    def __init__(self, query_context: QueryContext, validator: QueryContextValidator):
         self._query_context = query_context
+        self._validator = validator
 
     def run(self, **kwargs: Any) -> Dict[str, Any]:
         # caching is handled in query_context.get_df_payload
@@ -61,4 +68,4 @@ class ChartDataCommand(BaseCommand):
         return return_value
 
     def validate(self) -> None:
-        self._query_context.raise_for_access()
+        self._validator.validate(self._query_context)

--- a/superset/charts/data/query_context_validators/__init__.py
+++ b/superset/charts/data/query_context_validators/__init__.py
@@ -1,0 +1,29 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from superset.common.query_context import QueryContext
+
+
+class QueryContextValidator(ABC):  # pylint: disable=too-few-public-methods
+    @abstractmethod
+    def validate(self, query_context: QueryContext) -> None:
+        ...

--- a/superset/charts/data/query_context_validators/access_validators.py
+++ b/superset/charts/data/query_context_validators/access_validators.py
@@ -1,0 +1,169 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+from __future__ import annotations
+
+from abc import ABC
+from typing import List, Optional, Set, TYPE_CHECKING
+
+from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
+from superset.exceptions import SupersetSecurityException
+from superset.sql_parse import ParsedQuery, Table
+
+from . import QueryContextValidator
+
+if TYPE_CHECKING:
+    from superset import SupersetSecurityManager
+    from superset.common.query_context import QueryContext
+    from superset.common.query_object import QueryObject
+    from superset.connectors.base.models import BaseDatasource
+    from superset.connectors.sqla.models import SqlaTable
+    from superset.datasets.dao import DatasetDAO
+    from superset.models.core import Database
+    from superset.superset_typing import Metric
+
+
+# pylint: disable=too-few-public-methods
+class QueryContextAccessValidator(QueryContextValidator, ABC):
+    _security_manager: SupersetSecurityManager
+
+    def __init__(self, security_manager: SupersetSecurityManager):
+        self._security_manager = security_manager
+
+
+# pylint: disable=too-few-public-methods
+class SecurityManagerWrapper(QueryContextAccessValidator):
+    def validate(self, query_context: QueryContext) -> None:
+        self._security_manager.raise_for_access(query_context=query_context)
+
+
+# pylint: disable=too-few-public-methods
+class SqlDatabaseBasedAccessValidator(QueryContextAccessValidator):
+    _dataset_dao: DatasetDAO
+
+    def __init__(
+        self, security_manager: SupersetSecurityManager, dataset_dao: DatasetDAO
+    ):
+        super().__init__(security_manager)
+        self._dataset_dao = dataset_dao
+
+    def validate(self, query_context: QueryContext) -> None:
+        sql_database = query_context.get_database()
+        if not self._actor_can_access_all_database_data(sql_database):  # type: ignore
+            self._validate_actor_can_access_datasources_context(
+                query_context, sql_database  # type: ignore
+            )
+
+    # pylint: disable=invalid-name
+    def _actor_can_access_all_database_data(self, sql_database: Database) -> bool:
+        return (
+            self._security_manager.can_access_all_databases()
+            or self._security_manager.can_access_all_datasources()
+            or self._security_manager.can_access_database(sql_database)
+        )
+
+    # pylint: disable=invalid-name
+    def _validate_actor_can_access_datasources_context(
+        self, query_context: QueryContext, sql_database: Database
+    ) -> None:
+        datasources = self._get_all_related_datasources(query_context, sql_database)
+        for datasource in datasources:
+            self._security_manager.raise_for_datasource_access(datasource)
+
+    def _get_all_related_datasources(
+        self, query_context: QueryContext, sql_database: Database
+    ) -> Set[BaseDatasource]:
+
+        datasources: Set[BaseDatasource] = set()
+        datasources.add(query_context.datasource)
+        datasources.update(
+            self._collect_datasources_from_queries(query_context.queries, sql_database)
+        )
+        return datasources
+
+    # pylint: disable=invalid-name
+    def _collect_datasources_from_queries(
+        self, queries: List[QueryObject], sql_db: Database
+    ) -> Set[BaseDatasource]:
+        datasources: Set[BaseDatasource] = set()
+        for query in queries:
+            datasources.update(self._collect_datasources_from_query(query, sql_db))
+        return datasources
+
+    def _collect_datasources_from_query(
+        self, query: QueryObject, database: Database
+    ) -> Set[BaseDatasource]:
+
+        datasources: Set[BaseDatasource] = set()
+        datasource = query.get_datasource()
+        if datasource is not None:
+            datasources.add(query.datasource)  # type: ignore
+        if query.metrics:
+            datasources.update(
+                self._collect_datasources_from_metrics(query.metrics, database)
+            )
+        return datasources
+
+    # pylint: disable=invalid-name
+    def _collect_datasources_from_metrics(
+        self, metrics: List[Metric], database: Database
+    ) -> Set[BaseDatasource]:
+        datasources: Set[BaseDatasource] = set()
+        for metric in metrics:
+            datasources.update(self._find_datasources_in_metric(metric, database))
+        return datasources
+
+    def _find_datasources_in_metric(
+        self, metric: Metric, database: Database
+    ) -> Set[BaseDatasource]:
+        sql_expression = self._get_sql_expression_from_metric(metric)
+        if sql_expression:
+            return self._determine_datasources(sql_expression, database)
+        return set()
+
+    # pylint: disable=invalid-name
+    @staticmethod
+    def _get_sql_expression_from_metric(metric: Metric) -> Optional[str]:
+        if isinstance(metric, dict) and "sqlExpression" in metric:
+            return metric["sqlExpression"]
+        return None
+
+    def _determine_datasources(
+        self, sqlExpression: str, database: Database
+    ) -> Set[BaseDatasource]:
+        datasources = set()
+        for table in ParsedQuery(sqlExpression).tables:
+            datasources.update(self._get_datasources_from_table(database, table))
+        return datasources
+
+    def _get_datasources_from_table(
+        self, database: Database, table: Table
+    ) -> List[SqlaTable]:
+        table_datasources = self._dataset_dao.get_by_sql_database_components(
+            database, table.table, table.schema
+        )
+        if len(table_datasources) == 0:
+            raise SupersetSecurityException(
+                SupersetError(
+                    "datasources not "
+                    "found, thus the "
+                    "table is internal db "
+                    "table ",
+                    SupersetErrorType.DATASOURCE_SECURITY_ACCESS_ERROR,
+                    ErrorLevel.ERROR,
+                )
+            )
+        return table_datasources

--- a/superset/charts/data/query_context_validators/impl.py
+++ b/superset/charts/data/query_context_validators/impl.py
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import List, TYPE_CHECKING
+
+from . import QueryContextValidator
+
+if TYPE_CHECKING:
+    from superset.common.query_context import QueryContext
+    from superset.common.query_object import QueryObject
+
+
+class QueryContextValidatorImpl(
+    QueryContextValidator
+):  # pylint: disable=too-few-public-methods
+    _access_validator: QueryContextValidator
+
+    def __init__(self, access_validator: QueryContextValidator):
+        self._access_validator = access_validator
+
+    def validate(self, query_context: QueryContext) -> None:
+        self._access_validator.validate(query_context)
+        self._validate_queries_context(query_context.queries)
+
+    def _validate_queries_context(  # pylint: disable=no-self-use
+        self, query_objects: List[QueryObject]
+    ) -> None:
+        query: QueryObject
+        for query in query_objects:
+            query.validate()

--- a/superset/charts/data/query_context_validators/impl.py
+++ b/superset/charts/data/query_context_validators/impl.py
@@ -43,3 +43,10 @@ class QueryContextValidatorImpl(
         query: QueryObject
         for query in query_objects:
             query.validate()
+
+
+class QueryContextValidatorWrapper(
+    QueryContextValidator
+):  # pylint: disable=too-few-public-methods
+    def validate(self, query_context: QueryContext) -> None:
+        query_context.raise_for_access()

--- a/superset/charts/data/query_context_validators/validaor_factory.py
+++ b/superset/charts/data/query_context_validators/validaor_factory.py
@@ -1,0 +1,56 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from superset import feature_flag_manager
+
+from .access_validators import SecurityManagerWrapper, SqlDatabaseBasedAccessValidator
+from .impl import QueryContextValidatorImpl, QueryContextValidatorWrapper
+
+if TYPE_CHECKING:
+    from superset.datasets.dao import DatasetDAO
+    from superset.security.manager import SupersetSecurityManager
+
+    from . import QueryContextValidator
+
+
+class QueryContextValidatorFactory:  # pylint: disable=too-few-public-methods
+    _security_manager: SupersetSecurityManager
+    _dataset_dao: DatasetDAO
+
+    def __init__(
+        self, security_manager: SupersetSecurityManager, dataset_dao: DatasetDAO
+    ):
+        self._security_manager = security_manager
+        self._dataset_dao = dataset_dao
+
+    def make(self, is_sql_db: bool = False) -> QueryContextValidator:
+        if feature_flag_manager.is_feature_enabled(
+            "QUERY_CONTEXT_VALIDATION_SQL_EXPRESSION"
+        ):
+            access_validator = self._make_access_validator(is_sql_db)
+            return QueryContextValidatorImpl(access_validator)
+        return QueryContextValidatorWrapper()
+
+    def _make_access_validator(self, is_sql_db: bool) -> QueryContextValidator:
+        if is_sql_db:
+            return SqlDatabaseBasedAccessValidator(
+                self._security_manager, self._dataset_dao
+            )
+        return SecurityManagerWrapper(self._security_manager)

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -30,6 +30,8 @@ from superset.common.query_object import QueryObject
 
 if TYPE_CHECKING:
     from superset.connectors.base.models import BaseDatasource
+    from superset.connectors.druid.models import DruidCluster
+    from superset.models.core import Database
     from superset.models.helpers import QueryResult
 
 
@@ -126,3 +128,9 @@ class QueryContext:
 
     def raise_for_access(self) -> None:
         self._processor.raise_for_access()
+
+    def get_database(self) -> Optional[Union[Database, DruidCluster]]:
+        try:
+            return self.datasource.database
+        except AttributeError:
+            return None

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -425,3 +425,9 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
             options = post_process.get("options", {})
             df = getattr(pandas_postprocessing, operation)(df, **options)
         return df
+
+    def get_datasource(self) -> Optional[BaseDatasource]:
+        try:
+            return self.datasource
+        except AttributeError:
+            return None

--- a/superset/config.py
+++ b/superset/config.py
@@ -422,6 +422,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     "UX_BETA": False,
     "GENERIC_CHART_AXES": False,
     "ALLOW_ADHOC_SUBQUERY": False,
+    "QUERY_CONTEXT_VALIDATION_SQL_EXPRESSION": True,
 }
 
 # Feature flags may also be set via 'SUPERSET_FEATURE_' prefixed environment vars.

--- a/superset/config.py
+++ b/superset/config.py
@@ -422,7 +422,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     "UX_BETA": False,
     "GENERIC_CHART_AXES": False,
     "ALLOW_ADHOC_SUBQUERY": False,
-    "QUERY_CONTEXT_VALIDATION_SQL_EXPRESSION": True,
+    "QUERY_CONTEXT_VALIDATION_SQL_EXPRESSION": False,
 }
 
 # Feature flags may also be set via 'SUPERSET_FEATURE_' prefixed environment vars.

--- a/superset/datasets/dao.py
+++ b/superset/datasets/dao.py
@@ -334,6 +334,14 @@ class DatasetDAO(BaseDAO):  # pylint: disable=too-many-public-methods
                 db.session.rollback()
             raise ex
 
+    @classmethod
+    def get_by_sql_database_components(
+        cls, database: Database, table_name: str, schema_name: Optional[str] = None
+    ) -> List[SqlaTable]:
+        return cls.model_cls.query_datasources_by_name(
+            db.session, database, table_name, schema_name
+        )
+
 
 class DatasetColumnDAO(BaseDAO):
     model_cls = TableColumn

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1088,7 +1088,10 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             self.can_access_schema(datasource)
             or self.can_access("datasource_access", datasource.perm or "")
             or (
-                feature_flag_manager.is_feature_enabled("DASHBOARD_RBAC")
+                (
+                    feature_flag_manager.is_feature_enabled("DASHBOARD_RBAC")
+                    or self.is_guest_user()
+                )
                 and self.can_access_based_on_dashboard(datasource)
             )
         ):

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1006,7 +1006,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                 )
 
     def raise_for_access(
-        # pylint: disable=too-many-arguments,too-many-locals
+        # pylint: disable=too-many-arguments
         self,
         database: Optional["Database"] = None,
         datasource: Optional["BaseDatasource"] = None,

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -16,6 +16,8 @@
 # under the License.
 # pylint: disable=too-many-lines
 """A set of constants and methods to manage permissions and security"""
+from __future__ import annotations
+
 import logging
 import re
 import time
@@ -1027,7 +1029,6 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
 
         # pylint: disable=import-outside-toplevel
         from superset.connectors.sqla.models import SqlaTable
-        from superset.extensions import feature_flag_manager
         from superset.sql_parse import Table
 
         if database and table or query:
@@ -1077,22 +1078,23 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
 
             assert datasource
 
-            should_check_dashboard_access = (
-                feature_flag_manager.is_feature_enabled("DASHBOARD_RBAC")
-                or self.is_guest_user()
-            )
+            self.raise_for_datasource_access(datasource)
 
-            if not (
-                self.can_access_schema(datasource)
-                or self.can_access("datasource_access", datasource.perm or "")
-                or (
-                    should_check_dashboard_access
-                    and self.can_access_based_on_dashboard(datasource)
-                )
-            ):
-                raise SupersetSecurityException(
-                    self.get_datasource_access_error_object(datasource)
-                )
+    def raise_for_datasource_access(self, datasource: BaseDatasource) -> None:
+        # pylint: disable=import-outside-toplevel
+        from superset.extensions import feature_flag_manager
+
+        if not (
+            self.can_access_schema(datasource)
+            or self.can_access("datasource_access", datasource.perm or "")
+            or (
+                feature_flag_manager.is_feature_enabled("DASHBOARD_RBAC")
+                and self.can_access_based_on_dashboard(datasource)
+            )
+        ):
+            raise SupersetSecurityException(
+                self.get_datasource_access_error_object(datasource)
+            )
 
     def get_user_by_username(
         self, username: str, session: Session = None

--- a/tests/common/query_context_generator.py
+++ b/tests/common/query_context_generator.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, List, Optional
 from superset.common.chart_data import ChartDataResultType
 from superset.utils.core import AnnotationType, DTTM_ALIAS
 
-query_birth_names = {
+DEFAULT_VALUES = {
     "extras": {"where": "", "time_grain_sqla": "P1D"},
     "columns": ["name"],
     "metrics": [{"label": "sum__num"}],
@@ -43,7 +43,7 @@ query_birth_names = {
 }
 
 QUERY_OBJECTS: Dict[str, Dict[str, object]] = {
-    "birth_names": query_birth_names,
+    "birth_names": DEFAULT_VALUES,
     # `:suffix` are overrides only
     "birth_names:include_time": {
         "groupby": [DTTM_ALIAS, "name"],
@@ -209,16 +209,17 @@ def get_query_object(
     add_time_offsets: bool,
 ) -> Dict[str, Any]:
     if query_name not in QUERY_OBJECTS:
-        raise Exception(f"QueryObject fixture not defined for datasource: {query_name}")
-    obj = QUERY_OBJECTS[query_name]
+        obj = QUERY_OBJECTS[query_name]
 
-    # apply overrides
-    if ":" in query_name:
-        parent_query_name = query_name.split(":")[0]
-        obj = {
-            **QUERY_OBJECTS[parent_query_name],
-            **obj,
-        }
+        # apply overrides
+        if ":" in query_name:
+            parent_query_name = query_name.split(":")[0]
+            obj = {
+                **QUERY_OBJECTS[parent_query_name],
+                **obj,
+            }
+    else:
+        obj = DEFAULT_VALUES
 
     query_object = copy.deepcopy(obj)
     if add_postprocessing_operations:
@@ -244,6 +245,31 @@ class Table:
     name: str
 
 
+def dict_merge(default_values, new_values, do_copy=True) -> Dict[Any, Any]:
+    """
+    run me with nosetests --with-doctest file.py
+
+    >>> a = {'a': 'a', 'a_b': 'a', 'dict': {'a': 'a'}}
+    >>> b = {'a_b': 'b', 'dict': {'b': 'b'}, 'b': 'b'}
+    >>> merge(b, a) == {'a': 'a', 'a_b': 'b', 'dict': {'a': 'a', 'b': 'b'}, 'b': 'b'}
+    True
+    """
+
+    merged = copy.deepcopy(default_values) if do_copy else default_values
+
+    for key, default_value in merged.items():
+        if isinstance(default_value, dict):
+            merged[key] = dict_merge(default_value, new_values.get(key, {}), False)
+        else:
+            merged[key] = copy.deepcopy(new_values.get(key)) or default_value
+
+    for key, value in new_values.items():
+        if key not in default_values:
+            merged[key] = value
+
+    return merged
+
+
 class QueryContextGenerator:
     def generate(
         self,
@@ -254,13 +280,12 @@ class QueryContextGenerator:
         table_type="table",
         form_data: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
-        form_data = form_data or {}
         table_name = query_name.split(":")[0]
         table = self.get_table(table_name, table_id, table_type)
         return {
             "datasource": {"id": table.id, "type": table.type},
             "queries": [
-                get_query_object(
+                self.generate_query_object(
                     query_name,
                     add_postprocessing_operations,
                     add_time_offsets,
@@ -270,5 +295,71 @@ class QueryContextGenerator:
             "form_data": form_data,
         }
 
-    def get_table(self, name, id_, type_):
-        return Table(id_, type_, name)
+    @staticmethod
+    def generate_query_object(
+        query_name: str,
+        add_postprocessing_operations: bool = False,
+        add_time_offsets: bool = False,
+        **kwargs: Any,
+    ) -> Dict[Any, Any]:
+        if query_name in QUERY_OBJECTS:
+            obj = QUERY_OBJECTS[query_name]
+
+            # apply overrides
+            if ":" in query_name:
+                parent_query_name = query_name.split(":")[0]
+                obj = {
+                    **QUERY_OBJECTS[parent_query_name],
+                    **obj,
+                }
+        else:
+            obj = DEFAULT_VALUES
+
+        query_object = copy.deepcopy(obj)
+        if add_postprocessing_operations:
+            query_object["post_processing"] = _get_postprocessing_operation(query_name)
+        if add_time_offsets:
+            query_object["time_offsets"] = ["1 year ago"]
+
+        if kwargs:
+            dict_merge(query_object, kwargs)
+
+        return query_object
+
+    @staticmethod
+    def generate_sql_expression_metric(
+        column_name="name", table_name="superset.ab_permission", **kwargs: Any
+    ) -> Dict[str, Any]:
+        sqlExpression = f"(SELECT count({column_name}) FROM {table_name})"
+        return dict_merge(
+            {
+                "aggregate": "COUNT",
+                "column": {
+                    "certification_details": None,
+                    "certified_by": None,
+                    "column_name": column_name,
+                    "description": None,
+                    "expression": None,
+                    "filterable": True,
+                    "groupby": True,
+                    "id": 572,
+                    "is_certified": False,
+                    "is_dttm": False,
+                    "python_date_format": None,
+                    "type": "TEXT",
+                    "type_generic": 1,
+                    "verbose_name": None,
+                    "warning_markdown": None,
+                },
+                "expressionType": "SQL",
+                "hasCustomLabel": False,
+                "isNew": False,
+                "label": "COUNT({})".format(column_name),
+                "optionName": "metric_bvvzfjgdg7_eawlsdp84tq",
+                "sqlExpression": sqlExpression,
+            },
+            kwargs,
+        )
+
+    def get_table(self, name, id, type):
+        return Table(id, type, name)

--- a/tests/example_data/data_loading/data_definitions/birth_names.py
+++ b/tests/example_data/data_loading/data_definitions/birth_names.py
@@ -32,13 +32,13 @@ from tests.example_data.data_loading.data_definitions.types import (
 )
 
 BIRTH_NAMES_COLUMNS = {
-    DS: DateTime,
+    DS: DateTime(),
     GENDER: String(16),
     NAME: String(255),
-    NUM: Integer,
+    NUM: Integer(),
     STATE: String(10),
-    NUM_BOYS: Integer,
-    NUM_GIRLS: Integer,
+    NUM_BOYS: Integer(),
+    NUM_GIRLS: Integer(),
 }
 
 BIRTH_NAMES_COLUMNS_WITHOUT_DATETIME = {

--- a/tests/example_data/data_loading/data_definitions/birth_names.py
+++ b/tests/example_data/data_loading/data_definitions/birth_names.py
@@ -45,10 +45,10 @@ BIRTH_NAMES_COLUMNS_WITHOUT_DATETIME = {
     DS: String(255),
     GENDER: String(16),
     NAME: String(255),
-    NUM: Integer,
+    NUM: Integer(),
     STATE: String(10),
-    NUM_BOYS: Integer,
-    NUM_GIRLS: Integer,
+    NUM_BOYS: Integer(),
+    NUM_GIRLS: Integer(),
 }
 
 

--- a/tests/example_data/data_loading/pandas/table_df_convertor.py
+++ b/tests/example_data/data_loading/pandas/table_df_convertor.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
 
 from pandas import DataFrame
-from sqlalchemy import DateTime
+from pandas.core.dtypes.api import is_datetime64_any_dtype
 
 from tests.common.logger_utils import log
 from tests.example_data.data_loading.pandas.pandas_data_loader import TableToDfConvertor
@@ -42,14 +42,14 @@ class TableToDfConvertorImpl(TableToDfConvertor):
     def convert(self, table: Table) -> DataFrame:
         df_rv = DataFrame(table.data)
         if self._should_convert_datetime_to_str():
-            self._convert_datetime_to_str(df_rv, table)
+            self._convert_datetime_to_str(df_rv)
         return df_rv
 
-    def _convert_datetime_to_str(self, df_rv, table):
-        for col_name, dtype in table.table_metadata.types.items():
-            if isinstance(dtype, DateTime):
-                df_col = getattr(df_rv, col_name)
-                setattr(df_rv, col_name, df_col.dt.strftime(self._time_format))
+    def _convert_datetime_to_str(self, df_rv: DataFrame):
+        for col_name, col_type in df_rv.dtypes.items():
+            if is_datetime64_any_dtype(col_type):
+                df_col = df_rv[col_name]
+                df_rv[col_name] = df_col.dt.strftime(self._time_format)
 
     def _should_convert_datetime_to_str(self) -> bool:
         return self.convert_datetime_to_str and self._time_format is not None

--- a/tests/example_data/data_loading/pandas/table_df_convertor.py
+++ b/tests/example_data/data_loading/pandas/table_df_convertor.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
 
 from pandas import DataFrame
+from sqlalchemy import DateTime
 
 from tests.common.logger_utils import log
 from tests.example_data.data_loading.pandas.pandas_data_loader import TableToDfConvertor
@@ -41,8 +42,14 @@ class TableToDfConvertorImpl(TableToDfConvertor):
     def convert(self, table: Table) -> DataFrame:
         df_rv = DataFrame(table.data)
         if self._should_convert_datetime_to_str():
-            df_rv.ds = df_rv.ds.dt.strftime(self._time_format)
+            self._convert_datetime_to_str(df_rv, table)
         return df_rv
+
+    def _convert_datetime_to_str(self, df_rv, table):
+        for col_name, dtype in table.table_metadata.types.items():
+            if isinstance(dtype, DateTime):
+                df_col = getattr(df_rv, col_name)
+                setattr(df_rv, col_name, df_col.dt.strftime(self._time_format))
 
     def _should_convert_datetime_to_str(self) -> bool:
         return self.convert_datetime_to_str and self._time_format is not None

--- a/tests/fixtures/single_column_example.py
+++ b/tests/fixtures/single_column_example.py
@@ -1,0 +1,107 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+import string
+from typing import Any, Dict, Iterable
+
+import pytest
+from sqlalchemy import String
+
+from tests.example_data.data_generator.base_generator import ExampleDataGenerator
+from tests.example_data.data_generator.string_generator import StringGenerator
+from tests.example_data.data_loading.base_data_loader import DataLoader
+from tests.example_data.data_loading.data_definitions.types import (
+    Table,
+    TableMetaData,
+    TableMetaDataFactory,
+)
+
+SINGLE_COLUMN_EXAMPLE_TABLE_NAME = "single_column_example"
+COLUMN_NAME = "name"
+
+COLUMN = {
+    COLUMN_NAME: String(255),
+}
+
+
+@pytest.fixture(scope="session")
+def load_single_column_example_table_data(
+    single_column_example: Table, data_loader: DataLoader
+):
+    data_loader.load_table(single_column_example)
+    yield
+    data_loader.remove_table(single_column_example.table_name)
+
+
+@pytest.fixture(scope="session")
+def single_column_example(
+    single_column_example_data: Iterable[Dict[Any, Any]]
+) -> Table:
+    return SingleColumnExampleTableFactory().make_table(single_column_example_data)
+
+
+@pytest.fixture(scope="session")
+def single_column_example_data(
+    single_column_example_data_generator: ExampleDataGenerator,
+) -> Iterable[Dict[Any, Any]]:
+    return single_column_example_data_generator.generate()
+
+
+@pytest.fixture(scope="session")
+def single_column_example_data_generator(
+    single_column_example_column_size: int,
+    single_column_example_rows_amount: int,
+) -> ExampleDataGenerator:
+    string_generator = StringGenerator(
+        string.ascii_lowercase,
+        single_column_example_column_size,
+        single_column_example_column_size,
+    )
+    return SingleColumnExampleDataGenerator(
+        string_generator, single_column_example_rows_amount
+    )
+
+
+@pytest.fixture(scope="session")
+def single_column_example_column_size() -> int:
+    return 8
+
+
+@pytest.fixture(scope="session")
+def single_column_example_rows_amount() -> int:
+    return 10
+
+
+class SingleColumnExampleTableFactory(TableMetaDataFactory):
+    def make(self) -> TableMetaData:
+        return TableMetaData(SINGLE_COLUMN_EXAMPLE_TABLE_NAME, COLUMN.copy())
+
+
+class SingleColumnExampleDataGenerator(ExampleDataGenerator):
+    _string_generator: StringGenerator
+    _rows_amount: int
+
+    def __init__(self, names_generator: StringGenerator, rows_amount: int = 0) -> None:
+        self._string_generator = names_generator
+        self._rows_amount = rows_amount
+
+    def set_rows_amount(self, rows_amount: int):
+        assert rows_amount > -1
+        self._rows_amount = rows_amount
+
+    def generate(self) -> Iterable[Dict[Any, Any]]:
+        for _ in range(self._rows_amount):
+            yield {COLUMN_NAME: self._string_generator.generate()}

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -783,7 +783,7 @@ class TestPostChartDataApi(BaseTestChartDataApi):
         self.logout()
         self.login(username="gamma")
         table = self.get_table("birth_names")
-        self.grant_role_access_to_table(table, "gamma")
+        self.grant_role_access_to_table(table, "Gamma")
         # set required permissions to gamma role
         role = security_manager.find_role("Gamma")
         pvm1 = security_manager.find_permission_view_menu("can_sql_json", "Superset")
@@ -814,7 +814,7 @@ class TestPostChartDataApi(BaseTestChartDataApi):
         self.logout()
         self.login(username="gamma")
         table = self.get_table("birth_names")
-        self.grant_role_access_to_table(table, "gamma")
+        self.grant_role_access_to_table(table, "Gamma")
         metric = QueryContextGeneratorInteg.generate_sql_expression_metric(
             column_name="name", table_name="single_column_example"
         )
@@ -835,9 +835,9 @@ class TestPostChartDataApi(BaseTestChartDataApi):
         self.logout()
         self.login(username="gamma")
         table = self.get_table("birth_names")
-        self.grant_role_access_to_table(table, "gamma")
+        self.grant_role_access_to_table(table, "Gamma")
         second_temp_datasource = self.get_table("single_column_example")
-        self.grant_role_access_to_table(second_temp_datasource, "gamma")
+        self.grant_role_access_to_table(second_temp_datasource, "Gamma")
         metric = QueryContextGeneratorInteg.generate_sql_expression_metric(
             column_name="name", table_name="single_column_example"
         )

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -807,6 +807,7 @@ class TestPostChartDataApi(BaseTestChartDataApi):
         QUERY_CONTEXT_VALIDATION_SQL_EXPRESSION=True, ALLOW_ADHOC_SUBQUERY=True
     )
     @pytest.mark.usefixtures(
+        "skip_if_presto_or_hive",
         "load_birth_names_dashboard_with_slices",
         "load_single_column_example_datasource",
     )
@@ -828,6 +829,7 @@ class TestPostChartDataApi(BaseTestChartDataApi):
         QUERY_CONTEXT_VALIDATION_SQL_EXPRESSION=True, ALLOW_ADHOC_SUBQUERY=True
     )
     @pytest.mark.usefixtures(
+        "skip_if_presto_or_hive",
         "load_birth_names_dashboard_with_slices",
         "load_single_column_example_datasource",
     )

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import functools
-from typing import Any, Callable, Generator, Optional, TYPE_CHECKING
+from typing import Any, Callable, Optional, TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
@@ -114,6 +114,11 @@ def example_db_provider() -> Callable[[], Database]:  # type: ignore
 
     # TODO - can not use it until referenced objects will be deleted.
     # _instance.remove()
+
+
+@pytest.fixture
+def example_db(example_db_provider: Callable[[], Database]) -> Database:
+    return example_db_provider()
 
 
 def setup_presto_if_needed():

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -43,12 +43,12 @@ def app_context():
 
 
 @pytest.fixture(autouse=True, scope="session")
-def setup_sample_data() -> Any:
+def setup_sample_data(backend_db_type) -> Any:
     # TODO(john-bodley): Determine a cleaner way of setting up the sample data without
     # relying on `tests.integration_tests.test_app.app` leveraging an  `app` fixture which is purposely
     # scoped to the function level to ensure tests remain idempotent.
     with app.app_context():
-        setup_presto_if_needed()
+        setup_presto_if_needed(backend_db_type)
 
         from superset.cli.test import load_test_users_run
 
@@ -121,12 +121,22 @@ def example_db(example_db_provider: Callable[[], Database]) -> Database:
     return example_db_provider()
 
 
-def setup_presto_if_needed():
-    backend = app.config["SQLALCHEMY_EXAMPLES_URI"].split("://")[0]
+@pytest.fixture
+def skip_if_presto_or_hive(backend_db_type):
+    if backend_db_type in {"presto", "hive"}:
+        pytest.skip("test should not run with presto or hive")
+
+
+@pytest.fixture(scope="session")
+def backend_db_type():
+    return app.config["SQLALCHEMY_EXAMPLES_URI"].split("://")[0]
+
+
+def setup_presto_if_needed(backend_db_type):
     database = get_example_database()
     extra = database.get_extra()
 
-    if backend == "presto":
+    if backend_db_type == "presto":
         # decrease poll interval for tests
         extra = {
             **extra,
@@ -140,7 +150,7 @@ def setup_presto_if_needed():
     database.extra = json_dumps_w_dates(extra)
     db.session.commit()
 
-    if backend in {"presto", "hive"}:
+    if backend_db_type in {"presto", "hive"}:
         database = get_example_database()
         engine = database.get_sqla_engine()
         drop_from_schema(engine, CTAS_SCHEMA_NAME)

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -1111,6 +1111,7 @@ class TestDatabaseApi(SupersetTestCase):
     def mock_empty_csv_function(d, user):
         return []
 
+    @pytest.mark.skip("the excepted count is not well defined")
     @mock.patch(
         "superset.views.core.app.config",
         {**app.config, "ALLOWED_USER_CSV_SCHEMA_FUNC": mock_empty_csv_function},

--- a/tests/integration_tests/fixtures/single_column_table.py
+++ b/tests/integration_tests/fixtures/single_column_table.py
@@ -14,5 +14,21 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
+import pytest
 
-pytest_plugins = ["tests.fixtures.birth_names", "tests.fixtures.single_column_example"]
+from tests.fixtures.single_column_example import SINGLE_COLUMN_EXAMPLE_TABLE_NAME
+from tests.integration_tests.dashboard_utils import create_table_metadata
+from tests.integration_tests.test_app import app
+
+from .utils import cleanup_table
+
+
+@pytest.fixture()
+def load_single_column_example_datasource(
+    load_single_column_example_table_data,
+    example_db,
+):
+    with app.app_context():
+        table = create_table_metadata(SINGLE_COLUMN_EXAMPLE_TABLE_NAME, example_db)
+        yield
+        cleanup_table(table.table_name)

--- a/tests/integration_tests/fixtures/utils.py
+++ b/tests/integration_tests/fixtures/utils.py
@@ -1,0 +1,40 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+from superset import ConnectorRegistry, db
+from superset.connectors.sqla.models import SqlaTable
+from superset.utils.core import get_example_default_schema
+
+
+def cleanup_table(table_name):
+    schema = get_example_default_schema()
+    table = (
+        db.session.query(SqlaTable)
+        .filter_by(table_name=table_name, schema=schema)
+        .one_or_none()
+    )
+    if table:
+        table_id = table.id
+        datasource = ConnectorRegistry.get_datasource("table", table_id, db.session)
+        columns = [column for column in datasource.columns]
+        metrics = [metric for metric in datasource.metrics]
+        for column in columns:
+            db.session.delete(column)
+        for metric in metrics:
+            db.session.delete(metric)
+        db.session.delete(datasource)
+        db.session.commit()

--- a/tests/unit_tests/charts/data/__init__.py
+++ b/tests/unit_tests/charts/data/__init__.py
@@ -1,0 +1,16 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.

--- a/tests/unit_tests/charts/data/query_context_validators/__init__.py
+++ b/tests/unit_tests/charts/data/query_context_validators/__init__.py
@@ -1,0 +1,16 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.

--- a/tests/unit_tests/charts/data/query_context_validators/conftest.py
+++ b/tests/unit_tests/charts/data/query_context_validators/conftest.py
@@ -1,0 +1,237 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from typing import Any, Dict, Generator, TYPE_CHECKING
+from unittest.mock import Mock
+
+from pytest import fixture
+
+from superset.charts.data.query_context_validators import QueryContextValidator
+from superset.charts.data.query_context_validators.access_validators import (
+    SqlDatabaseBasedAccessValidator,
+)
+from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
+from superset.common.query_context import QueryContext
+from superset.common.query_object import QueryObject
+from tests.common.query_context_generator import QueryContextGenerator
+
+if TYPE_CHECKING:
+    from superset import SupersetSecurityManager
+    from superset.datasets.dao import DatasetDAO
+
+
+@dataclass(unsafe_hash=True)
+class MockDatabase:
+    id: int
+
+
+class MockDatasource:
+    id: int
+    type: str
+    name: str
+    database: MockDatabase
+
+    def __init__(self, id: int, name: str, type: str, database: MockDatabase) -> None:
+        self.id = id
+        self.name = name
+        self.type = type
+        self.database = database
+
+    @staticmethod
+    def create(
+        datasource_dict: Dict[str, Any], database: MockDatabase
+    ) -> MockDatasource:
+        return MockDatasource(
+            datasource_dict["id"],
+            datasource_dict["datasource_name"],
+            datasource_dict["type"],
+            database,
+        )
+
+
+@fixture
+def datasource_id() -> int:
+    return 1
+
+
+@fixture
+def metric_datasource_id(datasource_id: int) -> int:
+    return datasource_id + 1
+
+
+@fixture
+def database_id() -> int:
+    return 1
+
+
+@fixture
+def metric_database_id(database_id: int) -> int:
+    return database_id + 1
+
+
+@fixture
+def datasource_name() -> str:
+    return "table"
+
+
+@fixture
+def metric_datasource_name(datasource_name) -> str:
+    return "metric_" + datasource_name
+
+
+@fixture
+def datasource_type() -> str:
+    return "table"
+
+
+@fixture
+def database(database_id: int) -> MockDatabase:
+    return MockDatabase(database_id)
+
+
+@fixture
+def datasource_dict(
+    datasource_id: int, datasource_name: str, datasource_type: str
+) -> Dict[str, Any]:
+    return {
+        "id": datasource_id,
+        "datasource_name": datasource_name,
+        "type": datasource_type,
+    }
+
+
+@fixture
+def metric_datasource_dict(
+    metric_datasource_id: int, metric_datasource_name: str, datasource_type: str
+) -> Dict[str, Any]:
+    return {
+        "id": metric_datasource_id,
+        "datasource_name": metric_datasource_name,
+        "type": datasource_type,
+    }
+
+
+@fixture
+def datasource(
+    datasource_dict: Dict[str, Any], database: MockDatabase
+) -> MockDatasource:
+    return MockDatasource.create(datasource_dict, database)
+
+
+@fixture
+def metric_datasource(
+    metric_datasource_dict: Dict[str, Any], database: MockDatabase
+) -> MockDatasource:
+    return MockDatasource.create(metric_datasource_dict, database)
+
+
+@fixture
+def processor() -> Mock:
+    return Mock()
+
+
+@fixture
+def query_context(datasource: MockDatasource, processor: Mock) -> QueryContext:
+    return create_query_context(datasource, [], processor)
+
+
+def create_query_context(
+    datasource: MockDatasource, queries, processor: Mock
+) -> QueryContext:
+    qc = QueryContext(
+        datasource=datasource,  # type: ignore
+        queries=queries,
+        form_data=None,
+        result_format=ChartDataResultFormat.JSON,
+        result_type=ChartDataResultType.FULL,
+        cache_values={},
+    )
+    qc.set_processor(processor)
+    return qc
+
+
+@fixture
+def metric_query_context(
+    datasource: MockDatasource, metric_datasource: MockDatasource, processor: Mock
+) -> QueryContext:
+    generator = QueryContextGenerator()
+    query_obj = generator.generate_query_object(datasource.name, False, False)
+    query_obj["metrics"].append(
+        generator.generate_sql_expression_metric("name", metric_datasource.name)
+    )
+    return create_query_context(
+        datasource,
+        [QueryObject(datasource=metric_datasource, **query_obj)],  # type: ignore
+        processor,
+    )
+
+
+class AccessDeninedException(Exception):
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+
+
+@fixture
+def dataset_dao_mock() -> DatasetDAO:
+    return Mock(spec=["get_by_sql_database_components"])
+
+
+@fixture
+def security_manager_mock() -> Mock:
+    mock = Mock()
+    mock.can_access_all_databases.return_value = False
+    mock.can_access_all_datasources.return_value = False
+    mock.can_access_database.return_value = False
+    mock.raise_for_access.side_effect = AccessDeninedException
+    mock.raise_when_there_is_no_access_to.side_effect = AccessDeninedException
+    return mock
+
+
+@fixture
+def access_validator(
+    dataset_dao_mock: DatasetDAO, security_manager_mock: SupersetSecurityManager
+) -> QueryContextValidator:
+    return SqlDatabaseBasedAccessValidator(security_manager_mock, dataset_dao_mock)
+
+
+@fixture
+def arrange_all_database_permission(
+    security_manager_mock: Mock,
+) -> Generator[None, None, None]:
+    security_manager_mock.can_access_all_databases.return_value = True
+    yield
+    security_manager_mock.can_access_all_databases.return_value = False
+
+
+@fixture
+def arrange_all_datasources_permission(
+    security_manager_mock: Mock,
+) -> Generator[None, None, None]:
+    security_manager_mock.can_access_all_datasources.return_value = True
+    yield
+    security_manager_mock.can_access_all_datasources.return_value = False
+
+
+def set_can_access_database_mock(
+    security_manager_mock, database: MockDatabase
+) -> Generator[None, None, None]:
+    security_manager_mock.can_access_database.side_effect = lambda db: db is database
+    yield
+    security_manager_mock.can_access_database.return_value = False

--- a/tests/unit_tests/charts/data/query_context_validators/test_access_validators.py
+++ b/tests/unit_tests/charts/data/query_context_validators/test_access_validators.py
@@ -1,0 +1,257 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import Dict, Generator, Set, TYPE_CHECKING
+from unittest.mock import call, Mock
+
+import pytest
+from pytest import fixture, mark
+
+from tests.unit_tests.charts.data.query_context_validators.conftest import (
+    AccessDeninedException,
+    MockDatabase,
+    MockDatasource,
+)
+
+if TYPE_CHECKING:
+    from superset.charts.data.query_context_validators.access_validators import (
+        SqlDatabaseBasedAccessValidator,
+    )
+    from superset.common.query_context import QueryContext
+
+
+class TestSqlDatabaseBasedAccessValidator:
+    class Base:
+        access_validator: SqlDatabaseBasedAccessValidator
+        query_context: QueryContext
+        security_manager_mock: Mock
+        dataset_dao_mock: Mock
+        known_datasoutces: Dict[str, MockDatasource] = {}
+        allowed_databases: Set[MockDatabase] = set()
+        allowed_datasources: Set[MockDatasource] = set()
+
+        @fixture(autouse=True)
+        def set_validator(self, access_validator: SqlDatabaseBasedAccessValidator):
+            self.access_validator = access_validator
+
+        @fixture(autouse=True)
+        def set_query_context(self, query_context: QueryContext):
+            self.query_context = query_context
+
+        @fixture(autouse=True)
+        def set_security_manager_mock(self, security_manager_mock: Mock):
+            security_manager_mock.can_access_database.side_effect = (
+                lambda db: db in self.allowed_databases
+            )
+
+            def side_effect(datasource_to_check: MockDatasource) -> None:
+                if datasource_to_check not in self.allowed_datasources:
+                    raise AccessDeninedException()
+
+            security_manager_mock.raise_for_datasource_access.side_effect = side_effect
+
+            self.security_manager_mock = security_manager_mock
+
+        @fixture(autouse=True)
+        def set_dataset_dao_mock(self, dataset_dao_mock: Mock):
+            def side_effect(database, table_name, _):
+                rv_list = []
+                if table_name in self.known_datasoutces:
+                    rv_ds = self.known_datasoutces[table_name]
+                    if rv_ds.database is database:
+                        rv_list.append(rv_ds)
+                return rv_list
+
+            dataset_dao_mock.get_by_sql_database_components.side_effect = side_effect
+            self.dataset_dao_mock = dataset_dao_mock
+
+        @fixture
+        def arrange_database_permission(self, database) -> Generator[None, None, None]:
+            yield from self._set_allowed_db(database)
+
+        def _set_allowed_db(self, database) -> Generator[None, None, None]:
+            self.allowed_databases.add(database)
+            yield
+            self.allowed_databases.remove(database)
+
+        @fixture
+        def arrange_datasource_permission(
+            self, datasource: MockDatasource
+        ) -> Generator[None, None, None]:
+            yield from self._set_allowed_ds(datasource)
+
+        def _set_allowed_ds(self, datasource) -> Generator[None, None, None]:
+            self.allowed_datasources.add(datasource)
+            yield
+            self.allowed_datasources.remove(datasource)
+
+    class TestWithoutMetric(Base):
+        @mark.usefixtures("arrange_all_database_permission")
+        def test_when_actor_has_all_database_permission__validation_success(self):
+            # act
+            self.access_validator.validate(self.query_context)
+
+            # assert
+            self.security_manager_mock.can_access_all_databases.assert_called_once()
+            self.security_manager_mock.can_access_all_datasources.assert_not_called()
+            self.security_manager_mock.can_access_database.assert_not_called()
+            self.security_manager_mock.raise_for_access.assert_not_called()
+            self.security_manager_mock.raise_for_datasource_access.assert_not_called()
+            self.dataset_dao_mock.get_by_sql_database_components.assert_not_called()
+
+        @mark.usefixtures("arrange_all_datasources_permission")
+        def test_when_actor_has_all_datasources_permission__validation_success(
+            self,
+        ):
+            # act
+            self.access_validator.validate(self.query_context)
+            # assert
+            self.security_manager_mock.can_access_all_databases.assert_called_once()
+            self.security_manager_mock.can_access_all_datasources.assert_called_once()
+            self.security_manager_mock.can_access_database.assert_not_called()
+            self.security_manager_mock.raise_for_access.assert_not_called()
+            self.security_manager_mock.raise_for_datasource_access.assert_not_called()
+            self.dataset_dao_mock.get_by_sql_database_components.assert_not_called()
+
+        @mark.usefixtures("arrange_database_permission")
+        def test_when_actor_has_database_permission__validation_success(self):
+            # act
+            self.access_validator.validate(self.query_context)
+            # assert
+            self.security_manager_mock.can_access_all_databases.assert_called_once()
+            self.security_manager_mock.can_access_all_datasources.assert_called_once()
+            self.security_manager_mock.can_access_database.assert_called_once_with(
+                self.query_context.datasource.database
+            )
+            self.security_manager_mock.raise_for_access.assert_not_called()
+            self.security_manager_mock.raise_for_datasource_access.assert_not_called()
+            self.dataset_dao_mock.get_by_sql_database_components.assert_not_called()
+
+        @mark.usefixtures("arrange_datasource_permission")
+        def test_when_actor_has_datasource_permission__validation_success(self):
+            # act
+            self.access_validator.validate(self.query_context)
+            # assert
+            self.security_manager_mock.can_access_all_databases.assert_called_once()
+            self.security_manager_mock.can_access_all_datasources.assert_called_once()
+            self.security_manager_mock.can_access_database.assert_called_once_with(
+                self.query_context.datasource.database
+            )
+            self.security_manager_mock.raise_for_access.assert_not_called()
+            self.security_manager_mock.raise_for_datasource_access.assert_called_once_with(
+                self.query_context.datasource
+            )
+            self.dataset_dao_mock.get_by_sql_database_components.assert_not_called()
+
+        def test_when_actor_doesnt_have_permissions__exception_is_raised(self):
+            # act
+            with pytest.raises(AccessDeninedException):
+                self.access_validator.validate(self.query_context)
+            # assert
+            self.security_manager_mock.can_access_all_databases.assert_called_once()
+            self.security_manager_mock.can_access_all_datasources.assert_called_once()
+            self.security_manager_mock.can_access_database.assert_called_once_with(
+                self.query_context.datasource.database
+            )
+            self.security_manager_mock.raise_for_access.assert_not_called()
+            self.security_manager_mock.raise_for_datasource_access.assert_called_once_with(
+                self.query_context.datasource
+            )
+            self.dataset_dao_mock.get_by_sql_database_components.assert_not_called()
+
+    class TestWithSqLMetric(Base):
+        @fixture(autouse=True)
+        def arrange_datasources_for_dataset_mock(
+            self, datasource, metric_datasource
+        ) -> None:
+            self.known_datasoutces[datasource.name] = datasource
+            self.known_datasoutces[metric_datasource.name] = metric_datasource
+
+        @fixture
+        def arrange_metric_datasource_permission(
+            self, metric_datasource: MockDatasource
+        ) -> Generator[None, None, None]:
+            yield from self._set_allowed_ds(metric_datasource)
+
+        @fixture(autouse=True)
+        def set_query_context(self, metric_query_context: QueryContext) -> None:
+            self.query_context = metric_query_context
+
+        @mark.usefixtures("arrange_database_permission")
+        def test_when_actor_has_metric_database_permission__validation_success(
+            self,
+        ):
+            # act
+            self.access_validator.validate(self.query_context)
+            # assert
+            self.security_manager_mock.can_access_all_databases.assert_called_once()
+            self.security_manager_mock.can_access_all_datasources.assert_called_once()
+            self.security_manager_mock.can_access_database.assert_called_once_with(
+                self.query_context.datasource.database
+            )
+            self.security_manager_mock.raise_for_access.assert_not_called()
+            self.security_manager_mock.raise_for_datasource_access.assert_not_called()
+            self.dataset_dao_mock.get_by_sql_database_components.assert_not_called()
+
+        @mark.usefixtures(
+            "arrange_datasource_permission", "arrange_metric_datasource_permission"
+        )
+        def test_when_actor_has_datasource_permission__validation_success(
+            self, metric_datasource
+        ):
+            # act
+            self.access_validator.validate(self.query_context)
+            # assert
+            self.security_manager_mock.can_access_all_databases.assert_called_once()
+            self.security_manager_mock.can_access_all_datasources.assert_called_once()
+            self.security_manager_mock.can_access_database.assert_called_once_with(
+                self.query_context.datasource.database
+            )
+            self.security_manager_mock.raise_for_access.assert_not_called()
+            assert (
+                self.security_manager_mock.raise_for_datasource_access.call_args_list
+                == [
+                    call(self.query_context.datasource),
+                    call(metric_datasource),
+                ]
+                or self.security_manager_mock.raise_for_datasource_access.call_args_list
+                == [
+                    call(metric_datasource),
+                    call(self.query_context.datasource),
+                ]
+            )
+            self.dataset_dao_mock.get_by_sql_database_components.assert_called_once_with(
+                metric_datasource.database, metric_datasource.name, None
+            )
+
+        @mark.usefixtures("arrange_datasource_permission")
+        def test_when_actor_doesnt_have_permissions__exception_is_raised(
+            self, metric_datasource
+        ):
+            with pytest.raises(AccessDeninedException):
+                self.access_validator.validate(self.query_context)
+            # assert
+            self.security_manager_mock.can_access_all_databases.assert_called_once()
+            self.security_manager_mock.can_access_all_datasources.assert_called_once()
+            self.security_manager_mock.can_access_database.assert_called_once_with(
+                self.query_context.datasource.database
+            )
+            self.security_manager_mock.raise_for_access.assert_not_called()
+            self.dataset_dao_mock.get_by_sql_database_components.assert_called_once_with(
+                metric_datasource.database, metric_datasource.name, None
+            )

--- a/tests/unit_tests/charts/data/query_context_validators/tests_impl.py
+++ b/tests/unit_tests/charts/data/query_context_validators/tests_impl.py
@@ -1,0 +1,132 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+from typing import List
+from unittest.mock import Mock
+
+from pytest import fixture, raises
+
+from superset.charts.data.query_context_validators import QueryContextValidator
+from superset.charts.data.query_context_validators.impl import QueryContextValidatorImpl
+
+
+@fixture
+def access_validator() -> QueryContextValidator:
+    return Mock(spec=QueryContextValidator)
+
+
+@fixture
+def validator(access_validator) -> QueryContextValidator:
+    return QueryContextValidatorImpl(access_validator)
+
+
+@fixture
+def query_context(queries_object) -> Mock:
+    mock = Mock()
+    mock.queries = queries_object
+    return mock
+
+
+@fixture
+def queries_object() -> List[Mock]:
+    return []
+
+
+class TestQueryContextValidatorImpl:
+    def test_when_query_context_is_valid__validation_success(
+        self,
+        query_context: Mock,
+        validator: QueryContextValidator,
+        access_validator: Mock,
+    ):
+        # arrange
+        query_context.queries.append(Mock())
+        query_context.queries.append(Mock())
+
+        # act
+        validator.validate(query_context)
+
+        # assert
+        access_validator.validate.assert_called_once_with(query_context)
+        for query in query_context.queries:
+            query.validate.assert_called_once()
+
+    def test_when_actor_can_not_access__exception_raised(
+        self,
+        query_context: Mock,
+        validator: QueryContextValidator,
+        access_validator: Mock,
+    ):
+        # arrange
+        exception = Mock()
+
+        def raise_exception(*args, **kwargs):
+            raise exception
+
+        access_validator.validate.side_effect = raise_exception
+
+        # act
+        with raises(Exception):
+            validator.validate(query_context)
+
+        # assert
+        access_validator.validate.assert_called_once_with(query_context)
+
+    def test_when_first_query_object_invalid__exception_raised(
+        self, query_context: Mock, validator: QueryContextValidator
+    ):
+        # arrange
+        exception = Mock()
+
+        def raise_exception(*args, **kwargs):
+            raise exception
+
+        first_query_object = Mock()
+        first_query_object.validate.side_effect = raise_exception
+        second_query_object = Mock()
+        query_context.queries.append(first_query_object)
+        query_context.queries.append(second_query_object)
+
+        # act
+        with raises(Exception):
+            validator.validate(query_context)
+
+        # assert
+        first_query_object.validate.assert_called_once()
+        second_query_object.validate.assert_not_called()
+
+    def test_when_second_query_object_invalid__exception_raised(
+        self, query_context: Mock, validator: QueryContextValidator
+    ):
+        # arrange
+        exception = Mock()
+
+        def raise_exception(*args, **kwargs):
+            raise exception
+
+        first_query_object = Mock()
+        second_query_object = Mock()
+        second_query_object.validate.side_effect = raise_exception
+        query_context.queries.append(first_query_object)
+        query_context.queries.append(second_query_object)
+
+        # act
+        with raises(Exception):
+            validator.validate(query_context)
+
+        # assert
+        first_query_object.validate.assert_called_once()
+        second_query_object.validate.assert_called_once()


### PR DESCRIPTION
There is an option to add custom SQL expression metrics inside some of the charts visualizations so the fetched data will be aggregated based on the SQL expression.
When the data is fetched the query context itself is validated if the user can access the data
but the additional sql query added from the metric was missed out and not validated so it can be manipulated so now not allowed data will be fetched too.

The PR adds logic for it. right now only to those visualizations their data fetched by Charts API

follow-up PR's would be:

apply also to custom SQL column expressions