### PR TITLE
feat: deprecate old API on core superset fave_dashboards

### DIFF
--- a/superset-frontend/src/profile/components/Favorites.tsx
+++ b/superset-frontend/src/profile/components/Favorites.tsx
@@ -17,12 +17,13 @@
  * under the License.
  */
 import React from 'react';
+import rison from 'rison';
 import moment from 'moment';
 import { t } from '@superset-ui/core';
 
 import TableLoader from '../../components/TableLoader';
 import { Slice } from '../types';
-import { User, Dashboard } from '../../types/bootstrapTypes';
+import { User, DashboardResponse } from '../../types/bootstrapTypes';
 
 interface FavoritesProps {
   user: User;
@@ -50,19 +51,29 @@ export default class Favorites extends React.PureComponent<FavoritesProps> {
   }
 
   renderDashboardTable() {
-    const mutator = (data: Dashboard[]) =>
-      data.map(dash => ({
-        dashboard: <a href={dash.url}>{dash.title}</a>,
-        creator: <a href={dash.creator_url}>{dash.creator}</a>,
-        favorited: moment.utc(dash.dttm).fromNow(),
+    const search = [{ col: 'id', opr: 'dashboard_is_favorite', value: true }];
+    const query = rison.encode({
+      keys: ['none'],
+      columns: ['created_on_delta_humanized', 'dashboard_title', 'url'],
+      filters: search,
+      order_column: 'changed_on',
+      order_direction: 'desc',
+      page: 0,
+      page_size: 100,
+    });
+    const mutator = (data: DashboardResponse[]) =>
+      data.result.map(dash => ({
+        dashboard: <a href={dash.url}>{dash.dashboard_title}</a>,
+        created: dash.created_on_delta_humanized,
+        _created: dash.created_on_delta_humanized,
       }));
     return (
       <TableLoader
         className="table-condensed"
         mutator={mutator}
-        dataEndpoint={`/superset/fave_dashboards/${this.props.user.userId}/`}
+        dataEndpoint={`/api/v1/dashboard/?q=${query}`}
         noDataText={t('No favorite dashboards yet, go click on stars!')}
-        columns={['dashboard', 'creator', 'favorited']}
+        columns={['dashboard', 'creator', 'created']}
         sortable
       />
     );

--- a/superset-frontend/src/profile/components/Favorites.tsx
+++ b/superset-frontend/src/profile/components/Favorites.tsx
@@ -61,7 +61,7 @@ export default class Favorites extends React.PureComponent<FavoritesProps> {
       page: 0,
       page_size: 100,
     });
-    const mutator = (data: DashboardResponse[]) =>
+    const mutator = (data: DashboardResponse) =>
       data.result.map(dash => ({
         dashboard: <a href={dash.url}>{dash.dashboard_title}</a>,
         created: dash.created_on_delta_humanized,

--- a/superset-frontend/src/types/bootstrapTypes.ts
+++ b/superset-frontend/src/types/bootstrapTypes.ts
@@ -40,15 +40,6 @@ export interface UserWithPermissionsAndRoles extends User {
 
 export type UndefinedUser = {};
 
-export type Dashboard = {
-  dttm: number;
-  id: number;
-  url: string;
-  title: string;
-  creator?: string;
-  creator_url?: string;
-};
-
 export type DashboardData = {
   dashboard_title?: string;
   created_on_delta_humanized?: string;

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1543,6 +1543,11 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @expose("/fave_dashboards_by_username/<username>/", methods=["GET"])
     def fave_dashboards_by_username(self, username: str) -> FlaskResponse:
         """This lets us use a user's username to pull favourite dashboards"""
+        logger.warning(
+            "%s.fave_dashboards_by_username "
+            "This API endpoint is deprecated and will be removed in version 3.0.0",
+            self.__class__.__name__,
+        )
         user = security_manager.find_user(username=username)
         return self.fave_dashboards(user.id)
 
@@ -1551,6 +1556,11 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @event_logger.log_this
     @expose("/fave_dashboards/<int:user_id>/", methods=["GET"])
     def fave_dashboards(self, user_id: int) -> FlaskResponse:
+        logger.warning(
+            "%s.fave_dashboards "
+            "This API endpoint is deprecated and will be removed in version 3.0.0",
+            self.__class__.__name__,
+        )
         error_obj = self.get_user_activity_access_error(user_id)
         if error_obj:
             return error_obj


### PR DESCRIPTION
### SUMMARY

Following plan to gradually deprecate "REST" endpoints on `/superset` namespace.

Deprecates `/superset//fave_dashboards/<int:user_id>/`. Proposed removal on Superset 3.0
Deprecates `/fave_dashboards_by_username/<username>/`. Proposed removal on Superset 3.0

Replaced by an existing endpoint /api/v1/dashboard/, includes the necessary frontend migration.

NOTE: The use of the generic get list endpoint will not fetch the date when the dashboard was favorited, this would force us to create a new endpoint specifically for this query or always enforce N+1 queries on the get list (not an option). 

I've Replaced this date by the humanised version of the dashboard creation date.



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

## Before:
<img width="867" alt="Screenshot 2022-04-18 at 12 22 01" src="https://user-images.githubusercontent.com/4025227/163801287-3c88ef89-f2d0-4a45-b248-c6afc95b3c9b.png">


## After:
<img width="873" alt="Screenshot 2022-04-18 at 12 17 21" src="https://user-images.githubusercontent.com/4025227/163800851-01938198-94b9-4934-9de7-10af8cb349d3.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
