### PR TITLE
fix(plugin-chart-echarts): [feature-parity] apply button of annotation layer doesn't work as expected

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/sections/annotationsAndLayers.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/sections/annotationsAndLayers.tsx
@@ -24,6 +24,7 @@ export const annotationLayers = [];
 export const annotationsAndLayersControls: ControlPanelSectionConfig = {
   label: t('Annotations and Layers'),
   expanded: false,
+  tabOverride: 'data',
   controlSetRows: [
     [
       {
@@ -33,6 +34,7 @@ export const annotationsAndLayersControls: ControlPanelSectionConfig = {
           label: '',
           default: annotationLayers,
           description: t('Annotation Layers'),
+          renderTrigger: true,
         },
       },
     ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -289,23 +289,7 @@ const config: ControlPanelConfig = {
     createAdvancedAnalyticsSection(t('Advanced analytics Query A'), ''),
     createQuerySection(t('Query B'), '_b'),
     createAdvancedAnalyticsSection(t('Advanced analytics Query B'), '_b'),
-    {
-      label: t('Annotations and Layers'),
-      expanded: false,
-      controlSetRows: [
-        [
-          {
-            name: 'annotation_layers',
-            config: {
-              type: 'AnnotationLayerControl',
-              label: '',
-              default: annotationLayers,
-              description: t('Annotation Layers'),
-            },
-          },
-        ],
-      ],
-    },
+    sections.annotationsAndLayersControls,
     sections.titleControls,
     {
       label: t('Chart Options'),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -35,7 +35,6 @@ import { legendSection, richTooltipSection, xAxisControl } from '../controls';
 
 const {
   area,
-  annotationLayers,
   logAxis,
   markerEnabled,
   markerSize,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -81,9 +81,8 @@ export default function transformProps(
     filterState,
     datasource,
     theme,
+    annotationData = {},
   } = chartProps;
-  const { annotation_data: annotationData_ } = queriesData[0];
-  const annotationData = annotationData_ || {};
   const { verboseMap = {} } = datasource;
   const data1 = (queriesData[0].data || []) as TimeseriesDataRecord[];
   const data2 = (queriesData[1].data || []) as TimeseriesDataRecord[];

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -84,13 +84,12 @@ export default function transformProps(
     queriesData,
     datasource,
     theme,
+    annotationData = {},
   } = chartProps;
   const { verboseMap = {} } = datasource;
   const [queryData] = queriesData;
-  const { annotation_data: annotationData_, data = [] } =
-    queryData as TimeseriesChartDataResponseResult;
+  const { data = [] } = queryData as TimeseriesChartDataResponseResult;
   const dataTypes = getColtypesMapping(queryData);
-  const annotationData = annotationData_ || {};
 
   const {
     area,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -180,54 +180,54 @@ describe('EchartsTimeseries transformProps', () => {
         ...formData,
         annotationLayers: [event, interval, timeseries],
       },
-      queriesData: [
-        {
-          ...queriesData[0],
-          annotation_data: {
-            'My Event': {
-              columns: [
-                'start_dttm',
-                'end_dttm',
-                'short_descr',
-                'long_descr',
-                'json_metadata',
-              ],
-              records: [
-                {
-                  start_dttm: 0,
-                  end_dttm: 1000,
-                  short_descr: '',
-                  long_descr: '',
-                  json_metadata: null,
-                },
-              ],
+      annotationData: {
+        'My Event': {
+          columns: [
+            'start_dttm',
+            'end_dttm',
+            'short_descr',
+            'long_descr',
+            'json_metadata',
+          ],
+          records: [
+            {
+              start_dttm: 0,
+              end_dttm: 1000,
+              short_descr: '',
+              long_descr: '',
+              json_metadata: null,
             },
-            'My Interval': {
-              columns: ['start', 'end', 'title'],
-              records: [
-                {
-                  start: 2000,
-                  end: 3000,
-                  title: 'My Title',
-                },
-              ],
+          ],
+        },
+        'My Interval': {
+          columns: ['start', 'end', 'title'],
+          records: [
+            {
+              start: 2000,
+              end: 3000,
+              title: 'My Title',
             },
-            'My Timeseries': [
+          ],
+        },
+        'My Timeseries': [
+          {
+            key: 'My Line',
+            values: [
               {
-                key: 'My Line',
-                values: [
-                  {
-                    x: 10000,
-                    y: 11000,
-                  },
-                  {
-                    x: 20000,
-                    y: 21000,
-                  },
-                ],
+                x: 10000,
+                y: 11000,
+              },
+              {
+                x: 20000,
+                y: 21000,
               },
             ],
           },
+        ],
+      },
+      queriesData: [
+        {
+          ...queriesData[0],
         },
       ],
     });


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes the problem with the behavior of apply button in the annotation layer modal.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### before
#### nvd3. not trigger the overlay of run query

https://user-images.githubusercontent.com/11830681/163836194-ce52953e-f06a-4f1e-aba7-d890fa6e19df.mov

#### echart

https://user-images.githubusercontent.com/11830681/163836552-70f3413a-6d76-4e29-96eb-ef4db9272fb8.mov


### after

https://user-images.githubusercontent.com/11830681/163836388-815603eb-5512-4ab6-aa29-3bc93e12bc25.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
