### PR TITLE
fix(chart & explore): Show labels for `SliderControl`

### DIFF
--- a/superset-frontend/src/explore/components/controls/SliderControl.tsx
+++ b/superset-frontend/src/explore/components/controls/SliderControl.tsx
@@ -16,48 +16,33 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { ReactNode } from 'react';
+import React from 'react';
 import Slider from 'src/components/Slider';
-import ControlHeader from 'src/explore/components/ControlHeader';
+import ControlHeader, {ControlHeaderProps} from 'src/explore/components/ControlHeader';
 
-type SliderControlProps = {
+type SliderControlProps = ControlHeaderProps & {
   onChange: (value: number) => void;
   value: number;
   default?: number;
-  name: string;
-  description: string;
-
-  // ControlHeader props
-  label: string;
-  renderTrigger?: boolean;
-  validationErrors?: string[];
-  rightNode?: ReactNode;
-  leftNode?: ReactNode;
-  hovered?: boolean;
-  warning?: string;
-  danger?: string;
-  onClick?: () => void;
-  tooltipOnClick?: () => void;
 };
 
-export default function SliderControl(props: SliderControlProps) {
-  const {
-    default: defaultValue,
-    name,
-    label,
-    description,
-    renderTrigger,
-    rightNode,
-    leftNode,
-    validationErrors,
-    hovered,
-    warning,
-    danger,
-    onClick,
-    tooltipOnClick,
-    onChange = () => {},
-    ...rest
-  } = props;
+export default function SliderControl({
+  default: defaultValue,
+  name,
+  label,
+  description,
+  renderTrigger,
+  rightNode,
+  leftNode,
+  validationErrors,
+  hovered,
+  warning,
+  danger,
+  onClick,
+  tooltipOnClick,
+  onChange = () => {},
+  ...rest}: SliderControlProps) {
+
   const headerProps = {
     name,
     label,

--- a/superset-frontend/src/explore/components/controls/SliderControl.tsx
+++ b/superset-frontend/src/explore/components/controls/SliderControl.tsx
@@ -18,7 +18,9 @@
  */
 import React from 'react';
 import Slider from 'src/components/Slider';
-import ControlHeader, {ControlHeaderProps} from 'src/explore/components/ControlHeader';
+import ControlHeader, {
+  ControlHeaderProps,
+} from 'src/explore/components/ControlHeader';
 
 type SliderControlProps = ControlHeaderProps & {
   onChange: (value: number) => void;
@@ -41,8 +43,8 @@ export default function SliderControl({
   onClick,
   tooltipOnClick,
   onChange = () => {},
-  ...rest}: SliderControlProps) {
-
+  ...rest
+}: SliderControlProps) {
   const headerProps = {
     name,
     label,

--- a/superset-frontend/src/explore/components/controls/SliderControl.tsx
+++ b/superset-frontend/src/explore/components/controls/SliderControl.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
+import React, { ReactNode } from 'react';
 import Slider from 'src/components/Slider';
 import ControlHeader from 'src/explore/components/ControlHeader';
 
@@ -24,13 +24,57 @@ type SliderControlProps = {
   onChange: (value: number) => void;
   value: number;
   default?: number;
+  name: string;
+  description: string;
+
+  // ControlHeader props
+  label: string;
+  renderTrigger?: boolean;
+  validationErrors?: string[];
+  rightNode?: ReactNode;
+  leftNode?: ReactNode;
+  hovered?: boolean;
+  warning?: string;
+  danger?: string;
+  onClick?: () => void;
+  tooltipOnClick?: () => void;
 };
 
 export default function SliderControl(props: SliderControlProps) {
-  const { onChange = () => {}, default: defaultValue, ...rest } = props;
+  const {
+    default: defaultValue,
+    name,
+    label,
+    description,
+    renderTrigger,
+    rightNode,
+    leftNode,
+    validationErrors,
+    hovered,
+    warning,
+    danger,
+    onClick,
+    tooltipOnClick,
+    onChange = () => {},
+    ...rest
+  } = props;
+  const headerProps = {
+    name,
+    label,
+    description,
+    renderTrigger,
+    rightNode,
+    leftNode,
+    validationErrors,
+    onClick,
+    hovered,
+    tooltipOnClick,
+    warning,
+    danger,
+  };
   return (
     <>
-      <ControlHeader />
+      <ControlHeader {...headerProps} />
       <Slider {...rest} onChange={onChange} defaultValue={defaultValue} />
     </>
   );


### PR DESCRIPTION
### SUMMARY
[Charts in explore] Labels are missing for some controls on Customize tab (Graph chart)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
![image](https://user-images.githubusercontent.com/47900232/163846843-648ae65a-d44d-4b13-bb41-13b2ae106cca.png)

AFTER:
![Screenshot-GraphChart](https://user-images.githubusercontent.com/47900232/163846414-0c300db3-e230-4fc9-8ee5-3f407fcf52c1.png)

### TESTING INSTRUCTIONS
**How to reproduce issues**

1. Open a graph chart in explore
2. Toggle to Customize tab
3. Pay attention to the controls at the bottom

This issue is happened on some other charts as well as Graph chart

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
