### PR TITLE
fix(dashboard): copy permalink to dashboard chart

### DIFF
--- a/superset-frontend/src/components/URLShortLinkButton/index.jsx
+++ b/superset-frontend/src/components/URLShortLinkButton/index.jsx
@@ -57,11 +57,11 @@ class URLShortLinkButton extends React.Component {
     if (this.props.dashboardId) {
       getFilterValue(this.props.dashboardId, nativeFiltersKey)
         .then(filterState =>
-          getDashboardPermalink(
-            String(this.props.dashboardId),
+          getDashboardPermalink({
+            dashboardId: this.props.dashboardId,
             filterState,
-            this.props.anchorLinkId,
-          )
+            hash: this.props.anchorLinkId,
+          })
             .then(this.onShortUrlSuccess)
             .catch(this.props.addDangerToast),
         )

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -213,6 +213,8 @@ class SliceHeaderControls extends React.PureComponent<
 
   render() {
     const {
+      componentId,
+      dashboardId,
       slice,
       isFullSize,
       cachedDttm = [],
@@ -221,7 +223,6 @@ class SliceHeaderControls extends React.PureComponent<
       addDangerToast = () => {},
       supersetCanShare = false,
       isCached = [],
-      formData,
     } = this.props;
     const crossFilterItems = getChartMetadataRegistry().items;
     const isTable = slice.viz_type === 'table';
@@ -310,13 +311,14 @@ class SliceHeaderControls extends React.PureComponent<
 
         {supersetCanShare && (
           <ShareMenuItems
+            dashboardId={dashboardId}
+            hash={componentId}
             copyMenuItemTitle={t('Copy permalink to clipboard')}
             emailMenuItemTitle={t('Share permalink by email')}
             emailSubject={t('Superset chart')}
             emailBody={t('Check out this chart: ')}
             addSuccessToast={addSuccessToast}
             addDangerToast={addDangerToast}
-            formData={formData}
           />
         )}
 

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -312,7 +312,7 @@ class SliceHeaderControls extends React.PureComponent<
         {supersetCanShare && (
           <ShareMenuItems
             dashboardId={dashboardId}
-            hash={componentId}
+            dashboardComponentId={componentId}
             copyMenuItemTitle={t('Copy permalink to clipboard')}
             emailMenuItemTitle={t('Share permalink by email')}
             emailSubject={t('Superset chart')}

--- a/superset-frontend/src/dashboard/components/menu/ShareMenuItems/index.tsx
+++ b/superset-frontend/src/dashboard/components/menu/ShareMenuItems/index.tsx
@@ -33,7 +33,7 @@ interface ShareMenuItemProps {
   addDangerToast: Function;
   addSuccessToast: Function;
   dashboardId: string | number;
-  hash?: string;
+  dashboardComponentId?: string;
 }
 
 const ShareMenuItems = (props: ShareMenuItemProps) => {
@@ -45,7 +45,7 @@ const ShareMenuItems = (props: ShareMenuItemProps) => {
     addDangerToast,
     addSuccessToast,
     dashboardId,
-    hash,
+    dashboardComponentId,
     ...rest
   } = props;
 
@@ -55,7 +55,11 @@ const ShareMenuItems = (props: ShareMenuItemProps) => {
     if (nativeFiltersKey && dashboardId) {
       filterState = await getFilterValue(dashboardId, nativeFiltersKey);
     }
-    return getDashboardPermalink(String(dashboardId), filterState, hash);
+    return getDashboardPermalink({
+      dashboardId,
+      filterState,
+      hash: dashboardComponentId,
+    });
   }
 
   async function onCopyLink() {

--- a/superset-frontend/src/dashboard/components/menu/ShareMenuItems/index.tsx
+++ b/superset-frontend/src/dashboard/components/menu/ShareMenuItems/index.tsx
@@ -18,14 +18,10 @@
  */
 import React from 'react';
 import copyTextToClipboard from 'src/utils/copy';
-import { t, logging, QueryFormData } from '@superset-ui/core';
+import { t, logging } from '@superset-ui/core';
 import { Menu } from 'src/components/Menu';
-import {
-  getChartPermalink,
-  getDashboardPermalink,
-  getUrlParam,
-} from 'src/utils/urlUtils';
-import { RESERVED_DASHBOARD_URL_PARAMS, URL_PARAMS } from 'src/constants';
+import { getDashboardPermalink, getUrlParam } from 'src/utils/urlUtils';
+import { URL_PARAMS } from 'src/constants';
 import { getFilterValue } from 'src/dashboard/components/nativeFilters/FilterBar/keyValue';
 
 interface ShareMenuItemProps {
@@ -37,7 +33,7 @@ interface ShareMenuItemProps {
   addDangerToast: Function;
   addSuccessToast: Function;
   dashboardId?: string;
-  formData?: Pick<QueryFormData, 'slice_id' | 'datasource'>;
+  hash?: string;
 }
 
 const ShareMenuItems = (props: ShareMenuItemProps) => {
@@ -49,23 +45,17 @@ const ShareMenuItems = (props: ShareMenuItemProps) => {
     addDangerToast,
     addSuccessToast,
     dashboardId,
-    formData,
+    hash,
     ...rest
   } = props;
 
   async function generateUrl() {
-    // chart
-    if (formData) {
-      // we need to remove reserved dashboard url params
-      return getChartPermalink(formData, RESERVED_DASHBOARD_URL_PARAMS);
-    }
-    // dashboard
     const nativeFiltersKey = getUrlParam(URL_PARAMS.nativeFiltersKey);
     let filterState = {};
     if (nativeFiltersKey && dashboardId) {
       filterState = await getFilterValue(dashboardId, nativeFiltersKey);
     }
-    return getDashboardPermalink(String(dashboardId), filterState);
+    return getDashboardPermalink(String(dashboardId), filterState, hash);
   }
 
   async function onCopyLink() {

--- a/superset-frontend/src/dashboard/components/menu/ShareMenuItems/index.tsx
+++ b/superset-frontend/src/dashboard/components/menu/ShareMenuItems/index.tsx
@@ -32,7 +32,7 @@ interface ShareMenuItemProps {
   emailBody: string;
   addDangerToast: Function;
   addSuccessToast: Function;
-  dashboardId?: string;
+  dashboardId: string | number;
   hash?: string;
 }
 

--- a/superset-frontend/src/utils/urlUtils.ts
+++ b/superset-frontend/src/utils/urlUtils.ts
@@ -154,11 +154,15 @@ export function getChartPermalink(
   });
 }
 
-export function getDashboardPermalink(
-  dashboardId: string,
-  filterState: JsonObject,
-  hash?: string,
-) {
+export function getDashboardPermalink({
+  dashboardId,
+  filterState,
+  hash, // the anchor part of the link which corresponds to the tab/chart id
+}: {
+  dashboardId: string | number;
+  filterState: JsonObject;
+  hash?: string;
+}) {
   // only encode filter box state if non-empty
   return getPermalink(`/api/v1/dashboard/${dashboardId}/permalink`, {
     filterState,


### PR DESCRIPTION
### SUMMARY
The PR #18181 changed dashboard chart permalinks to link to explore view, while previously they would create a permalink to the dashboard with an anchor pointing to the chart. This changes this behavior back to how it was originally implemented.

### AFTER
Now the permalink will link to the dashboard with the chart anchor:

https://user-images.githubusercontent.com/33317356/163965896-dfa1f844-901b-4927-bebf-41120c78c076.mp4

### BEFORE
Before the permalink sent the user to explore:

https://user-images.githubusercontent.com/33317356/163966169-6f89f746-8af0-4370-848e-82121b259e4b.mp4

### TESTING INSTRUCTIONS
1. go to the Video Games Dashboard
2. Go to the "Explore Trends" tab
3. Copy a permalink from one of the charts
4. follow the permalink and see where you end up

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
