### PR TITLE
fix(explore): Double divider if no permissions for adding reports

### DIFF
--- a/superset-frontend/src/explore/components/ExploreAdditionalActionsMenu/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreAdditionalActionsMenu/index.jsx
@@ -370,31 +370,35 @@ const ExploreAdditionalActionsMenu = ({
               </Menu.Item>
             </Menu.SubMenu>
             <Menu.Divider />
-            {canAddReports &&
-              (report ? (
-                <Menu.SubMenu
-                  title={t('Manage email report')}
-                  key={MENU_KEYS.REPORT_SUBMENU}
-                >
-                  <Menu.Item key={MENU_KEYS.SET_REPORT_ACTIVE}>
-                    <MenuItemWithCheckboxContainer>
-                      <Checkbox checked={isReportActive} onChange={noOp} />
-                      {t('Email reports active')}
-                    </MenuItemWithCheckboxContainer>
+            {canAddReports && (
+              <>
+                {report ? (
+                  <Menu.SubMenu
+                    title={t('Manage email report')}
+                    key={MENU_KEYS.REPORT_SUBMENU}
+                  >
+                    <Menu.Item key={MENU_KEYS.SET_REPORT_ACTIVE}>
+                      <MenuItemWithCheckboxContainer>
+                        <Checkbox checked={isReportActive} onChange={noOp} />
+                        {t('Email reports active')}
+                      </MenuItemWithCheckboxContainer>
+                    </Menu.Item>
+                    <Menu.Item key={MENU_KEYS.EDIT_REPORT}>
+                      {t('Edit email report')}
+                    </Menu.Item>
+                    <Menu.Item key={MENU_KEYS.DELETE_REPORT}>
+                      {t('Delete email report')}
+                    </Menu.Item>
+                  </Menu.SubMenu>
+                ) : (
+                  <Menu.Item key={MENU_KEYS.SET_UP_REPORT}>
+                    {t('Set up an email report')}
                   </Menu.Item>
-                  <Menu.Item key={MENU_KEYS.EDIT_REPORT}>
-                    {t('Edit email report')}
-                  </Menu.Item>
-                  <Menu.Item key={MENU_KEYS.DELETE_REPORT}>
-                    {t('Delete email report')}
-                  </Menu.Item>
-                </Menu.SubMenu>
-              ) : (
-                <Menu.Item key={MENU_KEYS.SET_UP_REPORT}>
-                  {t('Set up an email report')}
-                </Menu.Item>
-              ))}
-            <Menu.Divider />
+                )}
+                <Menu.Divider />
+              </>
+            )}
+
             <Menu.Item key={MENU_KEYS.VIEW_QUERY}>
               <ModalTrigger
                 triggerNode={


### PR DESCRIPTION
### SUMMARY
Fix displaying double divider in actions menu in explore if user doesn't have permissions for managing reports

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://user-images.githubusercontent.com/15073128/164026400-568f5f6a-b798-4424-8a6e-06fc1473ac39.png)

After:
<img width="243" alt="image" src="https://user-images.githubusercontent.com/15073128/164026325-d45f0aab-7b22-4d0c-8db3-a42d918c4576.png">

### TESTING INSTRUCTIONS
1. Log in as a user without reports permissions
2. Verify that there is only 1 divider between "Share" and "View query" in actions dropdown in explore

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @kasiazjc 