### PR TITLE
fix: deck.gl GeoJsonLayer Autozoom & fill/stroke options

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/package.json
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/package.json
@@ -23,6 +23,7 @@
     "lib"
   ],
   "dependencies": {
+    "@mapbox/geojson-extent": "^1.0.1",
     "@math.gl/web-mercator": "^3.2.2",
     "@types/d3-array": "^2.0.0",
     "bootstrap-slider": "^10.0.0",

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Geojson/Geojson.jsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Geojson/Geojson.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-array-index-key */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -20,13 +19,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { GeoJsonLayer } from 'deck.gl';
-// TODO import geojsonExtent from 'geojson-extent';
+import geojsonExtent from '@mapbox/geojson-extent';
 
 import { DeckGLContainerStyledWrapper } from '../../DeckGLContainer';
 import { hexToRGB } from '../../utils/colors';
 import sandboxedEval from '../../utils/sandbox';
 import { commonLayerProps } from '../common';
 import TooltipRow from '../../TooltipRow';
+import fitViewport from '../../utils/fitViewport';
+import { Point } from '../../types';
 
 const propertyMap = {
   fillColor: 'fillColor',
@@ -94,6 +95,9 @@ function setTooltipContent(o) {
   );
 }
 
+const getFillColor = feature => feature?.properties?.fillColor;
+const getLineColor = feature => feature?.properties?.strokeColor;
+
 export function getLayer(formData, payload, onAddFilter, setTooltip) {
   const fd = formData;
   const fc = fd.fill_color_picker;
@@ -125,6 +129,9 @@ export function getLayer(formData, payload, onAddFilter, setTooltip) {
     stroked: fd.stroked,
     extruded: fd.extruded,
     pointRadiusScale: fd.point_radius_scale,
+    getFillColor,
+    getLineWidth: fd.line_width || 1,
+    getLineColor,
     ...commonLayerProps(fd, setTooltip, setTooltipContent),
   });
 }
@@ -151,13 +158,29 @@ class DeckGLGeoJson extends React.Component {
   };
 
   render() {
-    const { formData, payload, setControlValue, onAddFilter, viewport } =
+    const { formData, payload, setControlValue, onAddFilter, height, width } =
       this.props;
 
-    // TODO get this to work
-    // if (formData.autozoom) {
-    //   viewport = common.fitViewport(viewport, geojsonExtent(payload.data.features));
-    // }
+    let { viewport } = this.props;
+    if (formData.autozoom) {
+      const points =
+        payload?.data?.features?.reduce?.((acc, feature) => {
+          const bounds = geojsonExtent(feature);
+          if (bounds) {
+            return [...acc, [bounds[0], bounds[1]], [bounds[2], bounds[3]]];
+          }
+
+          return acc;
+        }, []) || [];
+
+      if (points.length) {
+        viewport = fitViewport(viewport, {
+          width,
+          height,
+          points,
+        });
+      }
+    }
 
     const layer = getLayer(formData, payload, onAddFilter, this.setTooltip);
 
@@ -169,6 +192,8 @@ class DeckGLGeoJson extends React.Component {
         layers={[layer]}
         mapStyle={formData.mapbox_style}
         setControlValue={setControlValue}
+        height={height}
+        width={width}
       />
     );
   }

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Geojson/Geojson.jsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Geojson/Geojson.jsx
@@ -27,7 +27,6 @@ import sandboxedEval from '../../utils/sandbox';
 import { commonLayerProps } from '../common';
 import TooltipRow from '../../TooltipRow';
 import fitViewport from '../../utils/fitViewport';
-import { Point } from '../../types';
 
 const propertyMap = {
   fillColor: 'fillColor',

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Geojson/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Geojson/controlPanel.ts
@@ -38,6 +38,8 @@ import {
   viewport,
   mapboxStyle,
   geojsonColumn,
+  autozoom,
+  lineWidth,
 } from '../../utilities/Shared_DeckGL';
 import { dndGeojsonColumn } from '../../utilities/sharedDndControls';
 
@@ -60,10 +62,7 @@ const config: ControlPanelConfig = {
     },
     {
       label: t('Map'),
-      controlSetRows: [
-        [mapboxStyle, viewport],
-        // TODO [autozoom, null], // import { autozoom } from './Shared_DeckGL'
-      ],
+      controlSetRows: [[mapboxStyle, viewport], [autozoom]],
     },
     {
       label: t('GeoJson Settings'),
@@ -71,6 +70,7 @@ const config: ControlPanelConfig = {
         [fillColorPicker, strokeColorPicker],
         [filled, stroked],
         [extruded, null],
+        [lineWidth, null],
         [
           {
             name: 'point_radius_scale',


### PR DESCRIPTION
### SUMMARY
The autozoom feature is not currently working on the GeoJson chart from deck.gl
Also, the fill/stroke options for said plugin are not respected, yielding a black color no matter what option is passed in.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/17252075/164027087-c1f32c3e-8dbb-4fab-ad8d-8b5d7cb21916.mov

After:

https://user-images.githubusercontent.com/17252075/164026387-3ba0ca62-bd44-4cdd-8aba-50b42182d2df.mov

### TESTING INSTRUCTIONS
1. Create a dataset with valid geojson structure (you can use [this csv table](https://github.com/apache/superset/files/8513711/geojson.csv))
2. Create a deck.gl geojson visualization
3. Configure the visualization to use the column with the geojson.
4. Set to autozoom
5. Set a fill color

Ensure the map is zoomed to the db features involved with the proper color

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
