### PR TITLE
feat: make CTA text in Alerts & Reports mails configurable

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -1068,6 +1068,9 @@ ALERT_REPORTS_NOTIFICATION_DRY_RUN = False
 # A custom prefix to use on all Alerts & Reports emails
 EMAIL_REPORTS_SUBJECT_PREFIX = "[Report] "
 
+# The text for call-to-action link in Alerts & Reports emails
+EMAIL_REPORTS_CTA = "Explore in Superset"
+
 # Slack API token for the superset reports, either string or callable
 SLACK_API_TOKEN: Optional[Union[Callable[[], str], str]] = None
 SLACK_PROXY = None

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -94,7 +94,7 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
         else:
             html_table = ""
 
-        call_to_action = __("Explore in Superset")
+        call_to_action = __(app.config["EMAIL_REPORTS_CTA"])
         url = (
             modify_url_query(self._content.url, standalone="0")
             if self._content.url is not None


### PR DESCRIPTION
### SUMMARY

This PR makes call-to-action link text used in Alerts & Reports emails configurable

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
