### PR TITLE
feat(reports): email attachment suffix

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -1068,6 +1068,9 @@ ALERT_REPORTS_NOTIFICATION_DRY_RUN = False
 # A custom prefix to use on all Alerts & Reports emails
 EMAIL_REPORTS_SUBJECT_PREFIX = "[Report] "
 
+# A function which returns a custom suffix for all Alerts & Reports email attachments
+EMAIL_REPORTS_ATTACH_SUFFIX = lambda: ""
+
 # Slack API token for the superset reports, either string or callable
 SLACK_API_TOKEN: Optional[Union[Callable[[], str], str]] = None
 SLACK_PROXY = None

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -136,7 +136,13 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
         )
 
         if self._content.csv:
-            csv_data = {__("%(name)s.csv", name=self._content.name): self._content.csv}
+            csv_data = {
+                __(
+                    "%(name)s%(suffix)s.csv",
+                    name=self._content.name,
+                    suffix=app.config["EMAIL_REPORTS_ATTACH_SUFFIX"](),
+                ): self._content.csv
+            }
         return EmailContent(body=body, images=images, data=csv_data)
 
     def _get_subject(self) -> str:


### PR DESCRIPTION
### SUMMARY
Usually report consumers would like to have a date on the attachments itself as a suffix so that they can archive them easier.

This PR allows a custom suffix function to be configured for email attachments.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
