### PR TITLE
fix(world-map): remove categorical color control

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
@@ -23,7 +23,6 @@ import { extent as d3Extent } from 'd3-array';
 import {
   getNumberFormatter,
   getSequentialSchemeRegistry,
-  CategoricalColorNamespace,
 } from '@superset-ui/core';
 import Datamap from 'datamaps/dist/datamaps.world.min';
 
@@ -56,8 +55,6 @@ function WorldMap(element, props) {
     showBubbles,
     linearColorScheme,
     color,
-    colorScheme,
-    sliceId,
   } = props;
   const div = d3.select(element);
   div.classed('superset-legacy-chart-world-map', true);
@@ -72,24 +69,15 @@ function WorldMap(element, props) {
     .domain([extRadius[0], extRadius[1]])
     .range([1, maxBubbleSize]);
 
-  const linearColorScale = getSequentialSchemeRegistry()
+  const colorScale = getSequentialSchemeRegistry()
     .get(linearColorScheme)
     .createLinearScale(d3Extent(filteredData, d => d.m1));
 
-  const colorScale = CategoricalColorNamespace.getScale(colorScheme);
-
-  const processedData = filteredData.map(d => {
-    let color = linearColorScale(d.m1);
-    if (colorScheme) {
-      // use color scheme instead
-      color = colorScale(d.name, sliceId);
-    }
-    return {
-      ...d,
-      radius: radiusScale(Math.sqrt(d.m2)),
-      fillColor: color,
-    };
-  });
+  const processedData = filteredData.map(d => ({
+    ...d,
+    radius: radiusScale(Math.sqrt(d.m2)),
+    fillColor: colorScale(d.m1),
+  }));
 
   const mapData = {};
   processedData.forEach(d => {

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts
@@ -106,7 +106,6 @@ const config: ControlPanelConfig = {
           },
         ],
         ['color_picker'],
-        ['color_scheme'],
         ['linear_color_scheme'],
       ],
     },
@@ -126,9 +125,6 @@ const config: ControlPanelConfig = {
     },
     color_picker: {
       label: t('Bubble Color'),
-    },
-    color_scheme: {
-      label: t('Categorical Color Scheme'),
     },
     linear_color_scheme: {
       label: t('Country Color Scheme'),

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/transformProps.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/transformProps.js
@@ -20,14 +20,8 @@ import { rgb } from 'd3-color';
 
 export default function transformProps(chartProps) {
   const { width, height, formData, queriesData } = chartProps;
-  const {
-    maxBubbleSize,
-    showBubbles,
-    linearColorScheme,
-    colorPicker,
-    colorScheme,
-    sliceId,
-  } = formData;
+  const { maxBubbleSize, showBubbles, linearColorScheme, colorPicker } =
+    formData;
   const { r, g, b } = colorPicker;
 
   return {
@@ -38,7 +32,5 @@ export default function transformProps(chartProps) {
     showBubbles,
     linearColorScheme,
     color: rgb(r, g, b).hex(),
-    colorScheme,
-    sliceId,
   };
 }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This PR reverts the changes in #19038 that affected world maps. #19038 added a control `CATEGORICAL COLOR SCHEME` to world maps which could override the linear color scheme if specified. This inadvertently broke all linear coloring for our world map charts because it was not possible to specify a null categorical color scheme.

<img width="583" alt="image" src="https://user-images.githubusercontent.com/14146019/164065408-b2c056bf-504f-4ea5-8105-460d30c0328f.png">

Rather than fix the behavior of the categorical color scheme, I thought a better fix might be to just remove the categorical color scheme feature from world maps. World maps _require_ the `METRIC FOR COLOR` control, so I'm not sure it makes sense to support a categorical color scheme.

### TESTING INSTRUCTIONS
Make world map chart with linear color scheme, confirm colors applied as expected

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [X] Removes existing feature or API


@stephenLYZ @zhaoyongjie 