### PR TITLE
fix: SQL Lab UI Error: Objects are not valid as a React child

### DIFF
--- a/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
@@ -254,6 +254,8 @@ const QueryTable = ({
               responsive
             />
           );
+        } else {
+          q.results = <></>;
         }
 
         q.progress =


### PR DESCRIPTION
### SUMMARY
When the query result doesn't have any information nor is it stored in the api, the `resultsKey` returns null (as expected) and the query table in the SQL Lab crashes.

This PR renders a placeholder in that case to prevent it, since if the query failed, there's nothing to display in the "results" column.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/17252075/164089693-181108cd-4998-401f-a53d-1f2ef6a29066.mov

After:

https://user-images.githubusercontent.com/17252075/164089864-a4063f43-c792-41b6-962a-55771723de38.mov

### TESTING INSTRUCTIONS
Follow the instructions from https://github.com/apache/superset/issues/19746

### ADDITIONAL INFORMATION
Fixes https://github.com/apache/superset/issues/19746
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
