### PR TITLE
fix(migrations): coalesce is_temporal  when inserting into sl_columns 

### DIFF
--- a/superset/migrations/versions/a9422eeaae74_new_dataset_models_take_2.py
+++ b/superset/migrations/versions/a9422eeaae74_new_dataset_models_take_2.py
@@ -430,7 +430,7 @@ def copy_columns(session: Session) -> None:
                 ),
                 sa.literal(False).label("is_aggregation"),
                 is_physical_column.label("is_physical"),
-                TableColumn.is_dttm.label("is_temporal"),
+                func.coalesce(TableColumn.is_dttm, False).label("is_temporal"),
                 func.coalesce(TableColumn.type, UNKNOWN_TYPE).label("type"),
                 TableColumn.extra.label("extra_json"),
             ]


### PR DESCRIPTION
### SUMMARY

null value in column "is_temporal" of relation "sl_columns" violates not-null constraint when mapping existing data.

```
INFO  [alembic.runtime.migration] Running upgrade ad07e4fdbaba -> a9422eeaae74, new_dataset_models_take_2
>> Copy 12 physical tables to sl_tables...
>> Copy 41 SqlaTable to sl_datasets...
   Copy dataset owners...
   Link physical datasets with tables...
>> Copy 2,326 table columns to sl_columns...
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1276, in _execute_context
    self.dialect.do_execute(
  File "/usr/local/lib/python3.8/site-packages/sqlalchemy/engine/default.py", line 608, in do_execute
    cursor.execute(statement, parameters)
psycopg2.errors.NotNullViolation: null value in column "is_temporal" of relation "sl_columns" violates not-null constraint
DETAIL:  Failing row contains (368c1f15-f08d-440b-b21d-b113e1a4e42d, 2021-12-03 08:09:13.776918, 2021-12-03 21:20:46.402427, 27, null, f, f, t, t, t, f, f, t, null, f, default_serial_num, STRING, null, , null, null, null, {"warning_markdown":null}, 1, 1).
```


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
