### PR TITLE
chore: bump postgres from 10 to 14

### DIFF
--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -31,7 +31,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     services:
       postgres:
-        image: postgres:10-alpine
+        image: postgres:14-alpine
         env:
           POSTGRES_USER: superset
           POSTGRES_PASSWORD: superset

--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -88,7 +88,7 @@ jobs:
       SUPERSET__SQLALCHEMY_DATABASE_URI: postgresql+psycopg2://superset:superset@127.0.0.1:15432/superset
     services:
       postgres:
-        image: postgres:10-alpine
+        image: postgres:14-alpine
         env:
           POSTGRES_USER: superset
           POSTGRES_PASSWORD: superset

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -23,7 +23,7 @@ jobs:
       SUPERSET__SQLALCHEMY_EXAMPLES_URI: presto://localhost:15433/memory/default
     services:
       postgres:
-        image: postgres:10-alpine
+        image: postgres:14-alpine
         env:
           POSTGRES_USER: superset
           POSTGRES_PASSWORD: superset
@@ -101,7 +101,7 @@ jobs:
       UPLOAD_FOLDER: /tmp/.superset/uploads/
     services:
       postgres:
-        image: postgres:10-alpine
+        image: postgres:14-alpine
         env:
           POSTGRES_USER: superset
           POSTGRES_PASSWORD: superset

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
 
   db:
     env_file: docker/.env
-    image: postgres:10
+    image: postgres:14
     container_name: superset_db
     restart: unless-stopped
     ports:

--- a/docs/docs/installation/configuring-superset.mdx
+++ b/docs/docs/installation/configuring-superset.mdx
@@ -85,14 +85,14 @@ Superset supports the following database engines/versions:
 
 Use the following database drivers and connection strings:
 
-| Database                               | PyPI package                      | Connection String                                                        |
-| -------------------------------------- | --------------------------------- | ------------------------------------------------------------------------ |
-| [PostgreSQL](/docs/databases/postgres) | `pip install psycopg2`            | `postgresql://<UserName>:<DBPassword>@<Database Host>/<Database Name>`   |
-| [MySQL](/docs/databases/mysql)         | `pip install mysqlclient`         | `mysql://<UserName>:<DBPassword>@<Database Host>/<Database Name>`        |
-| SQLite                                 | No additional library needed      | `sqlite://`                                                              |
+| Database                                  | PyPI package                      | Connection String                                                        |
+| ----------------------------------------- | --------------------------------- | ------------------------------------------------------------------------ |
+| [PostgreSQL](https://www.postgresql.org/) | `pip install psycopg2`            | `postgresql://<UserName>:<DBPassword>@<Database Host>/<Database Name>`   |
+| [MySQL](https://www.mysql.com/)           | `pip install mysqlclient`         | `mysql://<UserName>:<DBPassword>@<Database Host>/<Database Name>`        |
+| SQLite                                    | No additional library needed      | `sqlite://`                                                              |
 
-To configure Superset metadata database set `SQLALCHEMY_DATABASE_URI` config key on `superset_config`
-to the appropriate connection string:
+To configure Superset metastore set `SQLALCHEMY_DATABASE_URI` config key on `superset_config`
+to the appropriate connection string.
 
 
 ### Running on a WSGI HTTP Server

--- a/docs/docs/installation/configuring-superset.mdx
+++ b/docs/docs/installation/configuring-superset.mdx
@@ -69,6 +69,32 @@ you can add the endpoints to `WTF_CSRF_EXEMPT_LIST`:
 WTF_CSRF_EXEMPT_LIST = [‘’]
 ```
 
+### Using a production metadata database
+
+By default Superset is configured to use SQLlite, since it's a simple and fast way to get you started
+(no installation needed) but for production environments you should a different database engine on a separate host or
+container.
+
+Superset supports the following database engines/versions:
+
+| Database Engine                                           | Supported Versions                |
+| --------------------------------------------------------- | --------------------------------- |
+| [MySQL](https://www.mysql.com/)                           | 5.X                               |
+| [PostgreSQL](https://www.postgresql.org/)                 | 10.X, 11.X, 12.X, 13.X, 14.X      |
+
+
+Use the following database drivers and connection strings:
+
+| Database                               | PyPI package                      | Connection String                                                        |
+| -------------------------------------- | --------------------------------- | ------------------------------------------------------------------------ |
+| [MySQL](/docs/databases/mysql)         | `pip install mysqlclient`         | `mysql://<UserName>:<DBPassword>@<Database Host>/<Database Name>`        |
+| [PostgreSQL](/docs/databases/postgres) | `pip install psycopg2`            | `postgresql://<UserName>:<DBPassword>@<Database Host>/<Database Name>`   |
+| SQLite                                 | No additional library needed      | `sqlite://`                                                              |
+
+To configure Superset metadata database set `SQLALCHEMY_DATABASE_URI` config key on `superset_config`
+to the appropriate connection string:
+
+
 ### Running on a WSGI HTTP Server
 
 While you can run Superset on NGINX or Apache, we recommend using Gunicorn in async mode. This

--- a/docs/docs/installation/configuring-superset.mdx
+++ b/docs/docs/installation/configuring-superset.mdx
@@ -79,8 +79,8 @@ Superset supports the following database engines/versions:
 
 | Database Engine                                           | Supported Versions                |
 | --------------------------------------------------------- | --------------------------------- |
-| [MySQL](https://www.mysql.com/)                           | 5.X                               |
 | [PostgreSQL](https://www.postgresql.org/)                 | 10.X, 11.X, 12.X, 13.X, 14.X      |
+| [MySQL](https://www.mysql.com/)                           | 5.X                               |
 
 
 Use the following database drivers and connection strings:

--- a/docs/docs/installation/configuring-superset.mdx
+++ b/docs/docs/installation/configuring-superset.mdx
@@ -71,9 +71,9 @@ WTF_CSRF_EXEMPT_LIST = [‘’]
 
 ### Using a production metadata database
 
-By default Superset is configured to use SQLlite, since it's a simple and fast way to get you started
-(no installation needed) but for production environments you should a different database engine on a separate host or
-container.
+By default Superset is configured to use SQLite, it's a simple and fast way to get you started
+(no installation needed) but for production environments you should use a different database engine on
+a separate host or container.
 
 Superset supports the following database engines/versions:
 

--- a/docs/docs/installation/configuring-superset.mdx
+++ b/docs/docs/installation/configuring-superset.mdx
@@ -69,7 +69,7 @@ you can add the endpoints to `WTF_CSRF_EXEMPT_LIST`:
 WTF_CSRF_EXEMPT_LIST = [‘’]
 ```
 
-### Using a production metadata database
+### Using a production metastore
 
 By default Superset is configured to use SQLite, it's a simple and fast way to get you started
 (no installation needed). But for production environments you should use a different database engine on
@@ -87,8 +87,8 @@ Use the following database drivers and connection strings:
 
 | Database                               | PyPI package                      | Connection String                                                        |
 | -------------------------------------- | --------------------------------- | ------------------------------------------------------------------------ |
-| [MySQL](/docs/databases/mysql)         | `pip install mysqlclient`         | `mysql://<UserName>:<DBPassword>@<Database Host>/<Database Name>`        |
 | [PostgreSQL](/docs/databases/postgres) | `pip install psycopg2`            | `postgresql://<UserName>:<DBPassword>@<Database Host>/<Database Name>`   |
+| [MySQL](/docs/databases/mysql)         | `pip install mysqlclient`         | `mysql://<UserName>:<DBPassword>@<Database Host>/<Database Name>`        |
 | SQLite                                 | No additional library needed      | `sqlite://`                                                              |
 
 To configure Superset metadata database set `SQLALCHEMY_DATABASE_URI` config key on `superset_config`

--- a/docs/docs/installation/configuring-superset.mdx
+++ b/docs/docs/installation/configuring-superset.mdx
@@ -72,7 +72,7 @@ WTF_CSRF_EXEMPT_LIST = [‘’]
 ### Using a production metadata database
 
 By default Superset is configured to use SQLite, it's a simple and fast way to get you started
-(no installation needed) but for production environments you should use a different database engine on
+(no installation needed). But for production environments you should use a different database engine on
 a separate host or container.
 
 Superset supports the following database engines/versions:

--- a/docs/docs/installation/installing-superset-using-docker-compose.mdx
+++ b/docs/docs/installation/installing-superset-using-docker-compose.mdx
@@ -109,7 +109,7 @@ username: admin
 password: admin
 ```
 
-### 5. Connecting your local database instance to superset
+### 5. Connecting Superset to your local database instance
 
 When running Superset using `docker` or `docker-compose` it runs in its own docker container, as if the Superset was running in a separate machine entirely. Therefore attempts to connect to your local database with hostname `localhost` won't work as `localhost` refers to the docker container Superset is running in, and not your actual host machine. Fortunately, docker provides an easy way to access network resources in the host machine from inside a container, and we will leverage this capability to connect to our local database instance.
 

--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -25,7 +25,7 @@ maintainers:
 version: 0.5.11
 dependencies:
 - name: postgresql
-  version: 10.2.0
+  version: 11.1.22
   repository: https://charts.bitnami.com/bitnami
   condition: postgresql.enabled
 - name: redis

--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
   - name: craig-rueda
     email: craig@craigrueda.com
     url: https://github.com/craig-rueda
-version: 0.5.11
+version: 0.6.0
 dependencies:
 - name: postgresql
   version: 11.1.22


### PR DESCRIPTION
### SUMMARY

Postgres 11.0 change log: https://www.postgresql.org/docs/release/11.0/
Postgres 12.0 change log: https://www.postgresql.org/docs/release/12.0/
Postgres 13.0 change log: https://www.postgresql.org/docs/release/12.0/
Postgres 14.0 change log: https://www.postgresql.org/docs/release/14.0/

Also updates helm postgres bitnami chart to 11.1.22, that sets postgres to 14.2:
https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml#L90

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
