### PR TITLE
fix: can't delete sl_table when trigger after_delete on SqlaTable

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -2150,6 +2150,9 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
             session.query(NewDataset).filter_by(uuid=sqla_table.uuid).one_or_none()
         )
         if dataset:
+            for tbl in dataset.tables:
+                if len(tbl.datasets) == 1 and tbl.datasets[0] == dataset:
+                    session.delete(tbl)
             session.delete(dataset)
 
     @staticmethod


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The SqlaTable model can't remove associative `sl_tables`, `sl_columns` and `sl_table_column` when triggering after_delete event.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
