### PR TITLE
fix(plugin-chart-table): Resetting controls when switching query mode

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -117,6 +117,7 @@ const all_columns: typeof sharedControls.groupby = {
         : [],
   }),
   visibility: isRawMode,
+  resetOnHide: false,
 };
 
 const dnd_all_columns: typeof sharedControls.groupby = {
@@ -140,6 +141,7 @@ const dnd_all_columns: typeof sharedControls.groupby = {
     return newState;
   },
   visibility: isRawMode,
+  resetOnHide: false,
 };
 
 const percent_metrics: typeof sharedControls.metrics = {
@@ -150,6 +152,7 @@ const percent_metrics: typeof sharedControls.metrics = {
   ),
   multi: true,
   visibility: isAggMode,
+  resetOnHide: false,
   mapStateToProps: ({ datasource, controls }, controlState) => ({
     columns: datasource?.columns || [],
     savedMetrics: datasource?.metrics || [],
@@ -190,6 +193,7 @@ const config: ControlPanelConfig = {
             name: 'groupby',
             override: {
               visibility: isAggMode,
+              resetOnHide: false,
               mapStateToProps: (
                 state: ControlPanelState,
                 controlState: ControlState,
@@ -220,6 +224,7 @@ const config: ControlPanelConfig = {
             override: {
               validators: [],
               visibility: isAggMode,
+              resetOnHide: false,
               mapStateToProps: (
                 { controls, datasource, form_data }: ControlPanelState,
                 controlState: ControlState,
@@ -263,6 +268,7 @@ const config: ControlPanelConfig = {
             name: 'timeseries_limit_metric',
             override: {
               visibility: isAggMode,
+              resetOnHide: false,
             },
           },
           {
@@ -277,6 +283,7 @@ const config: ControlPanelConfig = {
                 choices: datasource?.order_by_choices || [],
               }),
               visibility: isRawMode,
+              resetOnHide: false,
             },
           },
         ],
@@ -329,6 +336,7 @@ const config: ControlPanelConfig = {
               ),
               default: false,
               visibility: isAggMode,
+              resetOnHide: false,
             },
           },
           {
@@ -339,6 +347,7 @@ const config: ControlPanelConfig = {
               default: true,
               description: t('Whether to sort descending or ascending'),
               visibility: isAggMode,
+              resetOnHide: false,
             },
           },
         ],
@@ -353,6 +362,7 @@ const config: ControlPanelConfig = {
                 'Show total aggregations of selected metrics. Note that row limit does not apply to the result.',
               ),
               visibility: isAggMode,
+              resetOnHide: false,
             },
           },
         ],

--- a/superset-frontend/src/explore/components/Control.tsx
+++ b/superset-frontend/src/explore/components/Control.tsx
@@ -46,6 +46,7 @@ export type ControlProps = {
   renderTrigger?: boolean;
   default?: JsonValue;
   isVisible?: boolean;
+  resetOnHide?: boolean;
 };
 
 /**
@@ -65,6 +66,7 @@ export default function Control(props: ControlProps) {
     type,
     hidden,
     isVisible,
+    resetOnHide = true,
   } = props;
 
   const [hovered, setHovered] = useState(false);
@@ -79,7 +81,8 @@ export default function Control(props: ControlProps) {
       wasVisible === true &&
       isVisible === false &&
       props.default !== undefined &&
-      !isEqual(props.value, props.default)
+      !isEqual(props.value, props.default) &&
+      resetOnHide
     ) {
       // reset control value if setting to invisible
       setControlValue?.(name, props.default);


### PR DESCRIPTION
### SUMMARY
As a result of changes in PR https://github.com/apache/superset/pull/19039, when user switched query mode in table chart between Aggregate and Raw Records, the controls in currently inactive mode were being reset. This PR fixes that problem by introducing a new prop `resetOnHide`, which is true by default and set to false in table chart controls.
Please consider this PR as a hotfix - we should probably figure out a more sturdy, foolproof solution.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/15073128/164252120-0641eae7-c268-4fbe-bd3c-9f50cd98656d.mov

After:

https://user-images.githubusercontent.com/15073128/164252307-2b3af4a7-fd52-40fb-9d87-bca68e81f51a.mov


### TESTING INSTRUCTIONS
1. Open a table chart
2. Add some values to controls in aggregate mode
3. Add some values to controls in raw records mode
4. Switch between the modes a few times, verify that controls are not being reset
5. Run query, verify that values of currently hidden controls are not included in the query

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
