### PR TITLE
fix(SIP-68): handle empty table name during migration

### DIFF
--- a/superset/migrations/versions/a9422eeaae74_new_dataset_models_take_2.py
+++ b/superset/migrations/versions/a9422eeaae74_new_dataset_models_take_2.py
@@ -577,7 +577,7 @@ def postprocess_datasets(session: Session) -> None:
             drivername = (sqlalchemy_uri or "").split("://")[0]
             updates = {}
             updated = False
-            if is_physical and drivername:
+            if is_physical and drivername and expression:
                 quoted_expression = get_identifier_quoter(drivername)(expression)
                 if quoted_expression != expression:
                     updates["expression"] = quoted_expression

--- a/superset/migrations/versions/a9422eeaae74_new_dataset_models_take_2.py
+++ b/superset/migrations/versions/a9422eeaae74_new_dataset_models_take_2.py
@@ -42,7 +42,6 @@ from sqlalchemy.sql import functions as func
 from sqlalchemy.sql.expression import and_, or_
 from sqlalchemy_utils import UUIDType
 
-from superset import app, db
 from superset.connectors.sqla.models import ADDITIVE_METRIC_TYPES_LOWER
 from superset.connectors.sqla.utils import get_dialect_name, get_identifier_quoter
 from superset.extensions import encrypted_field_factory
@@ -51,8 +50,6 @@ from superset.sql_parse import extract_table_references, Table
 from superset.utils.core import MediumText
 
 Base = declarative_base()
-custom_password_store = app.config["SQLALCHEMY_CUSTOM_PASSWORD_STORE"]
-DB_CONNECTION_MUTATOR = app.config["DB_CONNECTION_MUTATOR"]
 SHOW_PROGRESS = os.environ.get("SHOW_PROGRESS") == "1"
 UNKNOWN_TYPE = "UNKNOWN"
 
@@ -871,7 +868,7 @@ def reset_postgres_id_sequence(table: str) -> None:
 
 def upgrade() -> None:
     bind = op.get_bind()
-    session: Session = db.Session(bind=bind)
+    session: Session = Session(bind=bind)
     Base.metadata.drop_all(bind=bind, tables=new_tables)
     Base.metadata.create_all(bind=bind, tables=new_tables)
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This should fix https://github.com/apache/superset/pull/19421#issuecomment-1104190086

Reproduced and tested locally by manually setting a local physical SqlaTable to have empty table name:

```sql
update tables set table_name = '' where id = 1;
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
