### PR TITLE
feat(explore): Rearrange controls in most popular charts

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/sections/sections.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/sections/sections.tsx
@@ -22,7 +22,7 @@ import { ControlPanelSectionConfig } from '../types';
 // A few standard controls sections that are used internally.
 // Not recommended for use in third-party plugins.
 
-const baseTimeSection = {
+export const baseTimeSection = {
   label: t('Time'),
   expanded: true,
   description: t('Time related form attributes'),

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/ColumnConfigItem.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/ColumnConfigItem.tsx
@@ -48,8 +48,10 @@ export default React.memo(function ColumnConfigItem({
     >
       <div
         css={{
+          display: 'flex',
+          alignItems: 'center',
           cursor: 'pointer',
-          padding: `${1.5 * gridUnit}px ${2 * gridUnit}px`,
+          padding: `${gridUnit}px ${2 * gridUnit}px`,
           borderBottom: `1px solid ${colors.grayscale.light2}`,
           position: 'relative',
           paddingRight: caretWidth,

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts
@@ -25,12 +25,10 @@ import {
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
-    sections.legacyRegularTime,
     {
-      label: t('Query'),
+      label: t('Chart'),
       expanded: true,
       controlSetRows: [
-        ['entity'],
         [
           {
             name: 'country_fieldtype',
@@ -51,8 +49,20 @@ const config: ControlPanelConfig = {
             },
           },
         ],
+        ['entity'],
         ['metric'],
-        ['adhoc_filters'],
+      ],
+    },
+    sections.legacyRegularTime,
+    {
+      label: t('Filter'),
+      expanded: true,
+      controlSetRows: [['adhoc_filters']],
+    },
+    {
+      label: t('Advanced query settings'),
+      expanded: true,
+      controlSetRows: [
         ['row_limit'],
         [
           {
@@ -69,7 +79,7 @@ const config: ControlPanelConfig = {
       ],
     },
     {
-      label: t('Options'),
+      label: t('Bubble settings'),
       expanded: true,
       controlSetRows: [
         [

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts
@@ -61,7 +61,7 @@ const config: ControlPanelConfig = {
     },
     {
       label: t('Advanced query settings'),
-      expanded: true,
+      expanded: false,
       controlSetRows: [
         ['row_limit'],
         [

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts
@@ -40,15 +40,21 @@ import {
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
+    {
+      label: t('Chart'),
+      expanded: true,
+      controlSetRows: [['metrics'], ['groupby'], ['columns']],
+    },
     sections.legacyRegularTime,
     {
-      label: t('Query'),
+      label: t('Filter'),
+      expanded: true,
+      controlSetRows: [['adhoc_filters']],
+    },
+    {
+      label: t('Advanced query settings'),
       expanded: true,
       controlSetRows: [
-        ['metrics'],
-        ['adhoc_filters'],
-        ['groupby'],
-        ['columns'],
         ['row_limit'],
         ['timeseries_limit_metric'],
         ['order_desc'],
@@ -105,8 +111,11 @@ const config: ControlPanelConfig = {
     },
   ],
   controlOverrides: {
+    metrics: {
+      label: t('Metrics (Y-Axis)'),
+    },
     groupby: {
-      label: t('Dimensions'),
+      label: t('Series (X-Axis)'),
       validators: [validateNonEmpty],
       mapStateToProps: (state, controlState) => {
         const groupbyProps =

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts
@@ -53,7 +53,7 @@ const config: ControlPanelConfig = {
     },
     {
       label: t('Advanced query settings'),
-      expanded: true,
+      expanded: false,
       controlSetRows: [
         ['row_limit'],
         ['timeseries_limit_metric'],

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts
@@ -43,7 +43,7 @@ const config: ControlPanelConfig = {
     {
       label: t('Chart'),
       expanded: true,
-      controlSetRows: [['metrics'], ['groupby'], ['columns']],
+      controlSetRows: [['groupby'], ['metrics'], ['columns']],
     },
     sections.legacyRegularTime,
     {
@@ -115,7 +115,7 @@ const config: ControlPanelConfig = {
       label: t('Metrics (Y-Axis)'),
     },
     groupby: {
-      label: t('Series (X-Axis)'),
+      label: t('X-axis'),
       validators: [validateNonEmpty],
       mapStateToProps: (state, controlState) => {
         const groupbyProps =
@@ -129,7 +129,7 @@ const config: ControlPanelConfig = {
       rerender: ['columns'],
     },
     columns: {
-      label: t('Breakdowns'),
+      label: t('Dimensions'),
       description: t('Defines how each series is broken down'),
       mapStateToProps: (state, controlState) => {
         const columnsProps =

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/controlPanel.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/controlPanel.ts
@@ -27,11 +27,16 @@ import { headerFontSize, subheaderFontSize } from '../sharedControls';
 
 export default {
   controlPanelSections: [
+    {
+      label: t('Chart'),
+      expanded: true,
+      controlSetRows: [['metric']],
+    },
     sections.legacyTimeseriesTime,
     {
-      label: t('Query'),
+      label: t('Filter'),
       expanded: true,
-      controlSetRows: [['metric'], ['adhoc_filters']],
+      controlSetRows: [['adhoc_filters']],
     },
     {
       label: t('Display settings'),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/controlPanel.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/controlPanel.ts
@@ -40,7 +40,7 @@ export default {
     },
     {
       label: t('Display settings'),
-      expanded: true,
+      expanded: false,
       tabOverride: 'data',
       controlSetRows: [
         [

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/controlPanel.tsx
@@ -43,7 +43,7 @@ const config: ControlPanelConfig = {
     {
       label: t('Trendline settings'),
       tabOverride: 'data',
-      expanded: true,
+      expanded: false,
       controlSetRows: [
         [
           {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/controlPanel.tsx
@@ -29,14 +29,19 @@ import { headerFontSize, subheaderFontSize } from '../sharedControls';
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
+    {
+      label: t('Chart'),
+      expanded: true,
+      controlSetRows: [['metric']],
+    },
     sections.legacyTimeseriesTime,
     {
-      label: t('Query'),
+      label: t('Filter'),
       expanded: true,
-      controlSetRows: [['metric'], ['adhoc_filters']],
+      controlSetRows: [['adhoc_filters']],
     },
     {
-      label: t('Options'),
+      label: t('Trendline settings'),
       tabOverride: 'data',
       expanded: true,
       controlSetRows: [
@@ -45,7 +50,7 @@ const config: ControlPanelConfig = {
             name: 'compare_lag',
             config: {
               type: 'TextControl',
-              label: t('Comparison Period Lag'),
+              label: t('Comparison period lag'),
               isInt: true,
               description: t(
                 'Based on granularity, number of time periods to compare against',
@@ -68,7 +73,7 @@ const config: ControlPanelConfig = {
             name: 'show_timestamp',
             config: {
               type: 'CheckboxControl',
-              label: t('Show Timestamp'),
+              label: t('Show timestamp'),
               renderTrigger: true,
               default: false,
               description: t('Whether to display the timestamp'),
@@ -80,7 +85,7 @@ const config: ControlPanelConfig = {
             name: 'show_trend_line',
             config: {
               type: 'CheckboxControl',
-              label: t('Show Trend Line'),
+              label: t('Show trend line'),
               renderTrigger: true,
               default: true,
               description: t('Whether to display the trend line'),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
@@ -88,7 +88,7 @@ const config: ControlPanelConfig = {
     },
     {
       label: t('Advanced query settings'),
-      expanded: true,
+      expanded: false,
       controlSetRows: [
         ['limit'],
         ['row_limit'],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
@@ -55,9 +55,8 @@ const {
 } = DEFAULT_FORM_DATA;
 const config: ControlPanelConfig = {
   controlPanelSections: [
-    sections.legacyTimeseriesTime,
     {
-      label: t('Query'),
+      label: t('Chart'),
       expanded: true,
       controlSetRows: [
         isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) ? [xAxisControl] : [],
@@ -79,12 +78,22 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        ['adhoc_filters'],
-        emitFilterControl,
+      ],
+    },
+    sections.legacyTimeseriesTime,
+    {
+      label: t('Filter'),
+      expanded: true,
+      controlSetRows: [['adhoc_filters'], emitFilterControl],
+    },
+    {
+      label: t('Advanced query settings'),
+      expanded: true,
+      controlSetRows: [
         ['limit'],
+        ['row_limit'],
         ['timeseries_limit_metric'],
         ['order_desc'],
-        ['row_limit'],
       ],
     },
     sections.advancedAnalyticsControls,
@@ -276,6 +285,9 @@ const config: ControlPanelConfig = {
     },
   ],
   controlOverrides: {
+    metrics: {
+      label: t('Metrics (Y-Axis)'),
+    },
     row_limit: {
       default: rowLimit,
     },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -85,7 +85,7 @@ const config: ControlPanelConfig = {
     },
     {
       label: t('Advanced query settings'),
-      expanded: true,
+      expanded: false,
       controlSetRows: [
         ['limit'],
         ['row_limit'],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -52,9 +52,8 @@ const {
 } = DEFAULT_FORM_DATA;
 const config: ControlPanelConfig = {
   controlPanelSections: [
-    sections.legacyTimeseriesTime,
     {
-      label: t('Query'),
+      label: t('Chart'),
       expanded: true,
       controlSetRows: [
         isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) ? [xAxisControl] : [],
@@ -76,12 +75,22 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        ['adhoc_filters'],
-        emitFilterControl,
+      ],
+    },
+    sections.legacyTimeseriesTime,
+    {
+      label: t('Filter'),
+      expanded: true,
+      controlSetRows: [['adhoc_filters'], emitFilterControl],
+    },
+    {
+      label: t('Advanced query settings'),
+      expanded: true,
+      controlSetRows: [
         ['limit'],
+        ['row_limit'],
         ['timeseries_limit_metric'],
         ['order_desc'],
-        ['row_limit'],
       ],
     },
     sections.advancedAnalyticsControls,
@@ -239,6 +248,9 @@ const config: ControlPanelConfig = {
     },
   ],
   controlOverrides: {
+    metrics: {
+      label: t('Metrics (Y-Axis)'),
+    },
     row_limit: {
       default: rowLimit,
     },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
@@ -65,7 +65,7 @@ const config: ControlPanelConfig = {
     },
     {
       label: t('Advanced query settings'),
-      expanded: true,
+      expanded: false,
       controlSetRows: [
         ['limit'],
         ['row_limit'],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
@@ -48,20 +48,29 @@ const {
 } = DEFAULT_FORM_DATA;
 const config: ControlPanelConfig = {
   controlPanelSections: [
-    sections.legacyTimeseriesTime,
     {
-      label: t('Query'),
+      label: t('Chart'),
       expanded: true,
       controlSetRows: [
         isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) ? [xAxisControl] : [],
         ['metrics'],
         ['groupby'],
-        ['adhoc_filters'],
-        emitFilterControl,
+      ],
+    },
+    sections.legacyTimeseriesTime,
+    {
+      label: t('Filter'),
+      expanded: true,
+      controlSetRows: [['adhoc_filters'], emitFilterControl],
+    },
+    {
+      label: t('Advanced query settings'),
+      expanded: true,
+      controlSetRows: [
         ['limit'],
+        ['row_limit'],
         ['timeseries_limit_metric'],
         ['order_desc'],
-        ['row_limit'],
       ],
     },
     sections.advancedAnalyticsControls,
@@ -219,6 +228,9 @@ const config: ControlPanelConfig = {
     },
   ],
   controlOverrides: {
+    metrics: {
+      label: t('Metrics (Y-Axis)'),
+    },
     row_limit: {
       default: rowLimit,
     },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/controlPanel.tsx
@@ -82,7 +82,7 @@ const config: ControlPanelConfig = {
     },
     {
       label: t('Advanced query settings'),
-      expanded: true,
+      expanded: false,
       controlSetRows: [
         ['limit'],
         ['row_limit'],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/controlPanel.tsx
@@ -49,9 +49,8 @@ const {
 } = DEFAULT_FORM_DATA;
 const config: ControlPanelConfig = {
   controlPanelSections: [
-    sections.legacyTimeseriesTime,
     {
-      label: t('Query'),
+      label: t('Chart'),
       expanded: true,
       controlSetRows: [
         isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) ? [xAxisControl] : [],
@@ -73,12 +72,22 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        ['adhoc_filters'],
-        emitFilterControl,
+      ],
+    },
+    sections.legacyTimeseriesTime,
+    {
+      label: t('Filter'),
+      expanded: true,
+      controlSetRows: [['adhoc_filters'], emitFilterControl],
+    },
+    {
+      label: t('Advanced query settings'),
+      expanded: true,
+      controlSetRows: [
         ['limit'],
+        ['row_limit'],
         ['timeseries_limit_metric'],
         ['order_desc'],
-        ['row_limit'],
       ],
     },
     sections.advancedAnalyticsControls,
@@ -236,6 +245,9 @@ const config: ControlPanelConfig = {
     },
   ],
   controlOverrides: {
+    metrics: {
+      label: t('Metrics (Y-Axis)'),
+    },
     row_limit: {
       default: rowLimit,
     },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
@@ -88,7 +88,7 @@ const config: ControlPanelConfig = {
     },
     {
       label: t('Advanced query settings'),
-      expanded: true,
+      expanded: false,
       controlSetRows: [
         ['limit'],
         ['row_limit'],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
@@ -55,9 +55,8 @@ const {
 } = DEFAULT_FORM_DATA;
 const config: ControlPanelConfig = {
   controlPanelSections: [
-    sections.legacyTimeseriesTime,
     {
-      label: t('Query'),
+      label: t('Chart'),
       expanded: true,
       controlSetRows: [
         isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) ? [xAxisControl] : [],
@@ -79,12 +78,22 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        ['adhoc_filters'],
-        emitFilterControl,
+      ],
+    },
+    sections.legacyTimeseriesTime,
+    {
+      label: t('Filter'),
+      expanded: true,
+      controlSetRows: [['adhoc_filters'], emitFilterControl],
+    },
+    {
+      label: t('Advanced query settings'),
+      expanded: true,
+      controlSetRows: [
         ['limit'],
+        ['row_limit'],
         ['timeseries_limit_metric'],
         ['order_desc'],
-        ['row_limit'],
       ],
     },
     sections.advancedAnalyticsControls,
@@ -292,6 +301,9 @@ const config: ControlPanelConfig = {
     },
   ],
   controlOverrides: {
+    metrics: {
+      label: t('Metrics (Y-Axis)'),
+    },
     row_limit: {
       default: rowLimit,
     },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
@@ -89,7 +89,7 @@ const config: ControlPanelConfig = {
     },
     {
       label: t('Advanced query settings'),
-      expanded: true,
+      expanded: false,
       controlSetRows: [
         ['limit'],
         ['timeseries_limit_metric'],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
@@ -56,9 +56,8 @@ const {
 } = DEFAULT_FORM_DATA;
 const config: ControlPanelConfig = {
   controlPanelSections: [
-    sections.legacyTimeseriesTime,
     {
-      label: t('Query'),
+      label: t('Chart'),
       expanded: true,
       controlSetRows: [
         isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) ? [xAxisControl] : [],
@@ -80,8 +79,18 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        ['adhoc_filters'],
-        emitFilterControl,
+      ],
+    },
+    sections.legacyTimeseriesTime,
+    {
+      label: t('Filter'),
+      expanded: true,
+      controlSetRows: [['adhoc_filters'], emitFilterControl],
+    },
+    {
+      label: t('Advanced query settings'),
+      expanded: true,
+      controlSetRows: [
         ['limit'],
         ['timeseries_limit_metric'],
         ['order_desc'],

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
@@ -97,7 +97,7 @@ const config: ControlPanelConfig = {
     },
     {
       label: t('Advanced query settings'),
-      expanded: true,
+      expanded: false,
       controlSetRows: [
         ['series_limit'],
         [

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
@@ -35,9 +35,8 @@ import { MetricsLayoutEnum } from '../types';
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
-    { ...sections.legacyTimeseriesTime, expanded: false },
     {
-      label: t('Query'),
+      label: t('Table'),
       expanded: true,
       controlSetRows: [
         [
@@ -88,8 +87,18 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        ['adhoc_filters'],
-        emitFilterControl,
+      ],
+    },
+    { ...sections.legacyTimeseriesTime, expanded: false },
+    {
+      label: t('Filter'),
+      expanded: true,
+      controlSetRows: [['adhoc_filters'], emitFilterControl],
+    },
+    {
+      label: t('Advanced query settings'),
+      expanded: true,
+      controlSetRows: [
         ['series_limit'],
         [
           {
@@ -128,7 +137,7 @@ const config: ControlPanelConfig = {
       ],
     },
     {
-      label: t('Options'),
+      label: t('Display table settings'),
       expanded: true,
       tabOverride: 'data',
       controlSetRows: [

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -294,7 +294,7 @@ const config: ControlPanelConfig = {
     },
     {
       label: t('Advanced query settings'),
-      expanded: true,
+      expanded: false,
       controlSetRows: [
         [
           {

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -86,7 +86,6 @@ const validateAggControlValues = (
 
 const queryMode: ControlConfig<'RadioButtonControl'> = {
   type: 'RadioButtonControl',
-  label: t('Query mode'),
   default: null,
   options: [
     [QueryMode.aggregate, QueryModeLabel[QueryMode.aggregate]],
@@ -177,45 +176,14 @@ const dnd_percent_metrics = {
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
-    sections.legacyTimeseriesTime,
     {
-      label: t('Query'),
+      label: t('Table'),
       expanded: true,
       controlSetRows: [
         [
           {
             name: 'query_mode',
             config: queryMode,
-          },
-        ],
-        [
-          {
-            name: 'groupby',
-            override: {
-              visibility: isAggMode,
-              resetOnHide: false,
-              mapStateToProps: (
-                state: ControlPanelState,
-                controlState: ControlState,
-              ) => {
-                const { controls } = state;
-                const originalMapStateToProps =
-                  sharedControls?.groupby?.mapStateToProps;
-                const newState =
-                  originalMapStateToProps?.(state, controlState) ?? {};
-                newState.externalValidationErrors = validateAggControlValues(
-                  controls,
-                  [
-                    controls.metrics?.value,
-                    controls.percent_metrics?.value,
-                    controlState.value,
-                  ],
-                );
-
-                return newState;
-              },
-              rerender: ['metrics', 'percent_metrics'],
-            },
           },
         ],
         [
@@ -262,7 +230,72 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        ['adhoc_filters'],
+        [
+          {
+            name: 'groupby',
+            override: {
+              visibility: isAggMode,
+              resetOnHide: false,
+              mapStateToProps: (
+                state: ControlPanelState,
+                controlState: ControlState,
+              ) => {
+                const { controls } = state;
+                const originalMapStateToProps =
+                  sharedControls?.groupby?.mapStateToProps;
+                const newState =
+                  originalMapStateToProps?.(state, controlState) ?? {};
+                newState.externalValidationErrors = validateAggControlValues(
+                  controls,
+                  [
+                    controls.metrics?.value,
+                    controls.percent_metrics?.value,
+                    controlState.value,
+                  ],
+                );
+
+                return newState;
+              },
+              rerender: ['metrics', 'percent_metrics'],
+            },
+          },
+        ],
+      ],
+    },
+    {
+      ...sections.baseTimeSection,
+      controlSetRows: [
+        ['granularity'],
+        ['druid_time_origin'],
+        ['granularity_sqla'],
+        [
+          {
+            name: 'include_time',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Include time column in table'),
+              description: t(
+                'Whether to include the time granularity as defined in the time section',
+              ),
+              default: false,
+              visibility: isAggMode,
+              resetOnHide: false,
+            },
+          },
+        ],
+        ['time_grain_sqla'],
+        ['time_range'],
+      ],
+    },
+    {
+      label: t('Filter'),
+      expanded: true,
+      controlSetRows: [['adhoc_filters'], emitFilterControl],
+    },
+    {
+      label: t('Advanced query settings'),
+      expanded: true,
+      controlSetRows: [
         [
           {
             name: 'timeseries_limit_metric',
@@ -283,6 +316,19 @@ const config: ControlPanelConfig = {
                 choices: datasource?.order_by_choices || [],
               }),
               visibility: isRawMode,
+              resetOnHide: false,
+            },
+          },
+        ],
+        [
+          {
+            name: 'order_desc',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Sort descending'),
+              default: true,
+              description: t('Whether to sort descending or ascending'),
+              visibility: isAggMode,
               resetOnHide: false,
             },
           },
@@ -327,32 +373,6 @@ const config: ControlPanelConfig = {
         ],
         [
           {
-            name: 'include_time',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Include time'),
-              description: t(
-                'Whether to include the time granularity as defined in the time section',
-              ),
-              default: false,
-              visibility: isAggMode,
-              resetOnHide: false,
-            },
-          },
-          {
-            name: 'order_desc',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Sort descending'),
-              default: true,
-              description: t('Whether to sort descending or ascending'),
-              visibility: isAggMode,
-              resetOnHide: false,
-            },
-          },
-        ],
-        [
-          {
             name: 'show_totals',
             config: {
               type: 'CheckboxControl',
@@ -366,7 +386,6 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        emitFilterControl,
       ],
     },
     {


### PR DESCRIPTION
### SUMMARY
Rearrange controls in some of the most popular charts:
- Table
- Bar (nvd3)
- Echarts Timeseries (generic, line, area, bar, stepped, smooth line, scatter)
- Big number (total + trendline)
- World map
- Pivot table v2
Sections "Chart", "Time" and "Filter" are expanded, other sections are collapsed by default.

This is the first stage of changing order and names of controls in charts. Updates for the rest of the charts coming in the next couple of weeks!

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/15073128/164293537-9954f6c0-b492-4579-b84d-704fa0b797c3.mov

### TESTING INSTRUCTIONS
Make sure that the charts listed in summary work like before

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @kasiazjc @lauderbaugh