### PR TITLE
fix(top&nav): make to allow add and setting menu when edit dashboard

### DIFF
--- a/superset-frontend/src/dashboard/stylesheets/dashboard.less
+++ b/superset-frontend/src/dashboard/stylesheets/dashboard.less
@@ -19,6 +19,7 @@
 /* header has mysterious extra margin */
 header.top {
   margin-bottom: 2px;
+  z-index: 2;
 }
 
 body {


### PR DESCRIPTION
### SUMMARY
Add and Settings menus in global nav inaccessible in dashboard edit mode

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
![screenshot-before]https://user-images.githubusercontent.com/47900232/164293987-541f0123-6a40-4450-a0ee-62d54d21a96f.mov

AFTER:
![screenshot-after]https://user-images.githubusercontent.com/47900232/164293736-6f60130a-2a59-4a93-8e92-e2d7afd81422.mov


### TESTING INSTRUCTIONS
1. Go to Dashboard edit mode
2. you are unable to access add and setting menu on top menu.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
