### PR TITLE
fix: Cypress tests reliability improvements

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/chart_list/list_view.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/chart_list/list_view.test.ts
@@ -21,11 +21,12 @@ import { CHART_LIST } from './chart_list.helper';
 describe('chart list view', () => {
   beforeEach(() => {
     cy.login();
-    cy.visit(CHART_LIST);
-    cy.get('[aria-label="list-view"]').click();
   });
 
   it('should load rows', () => {
+    cy.visit(CHART_LIST);
+    cy.get('[aria-label="list-view"]').click();
+
     cy.get('[data-test="listview-table"]').should('be.visible');
     // check chart list view header
     cy.get('[data-test="sort-header"]').eq(1).contains('Chart');
@@ -49,6 +50,17 @@ describe('chart list view', () => {
   });
 
   it('should bulk delete correctly', () => {
+    // Load the chart list order by name asc.
+    // This will ensure the tests stay consistent, and the
+    // same charts get deleted every time
+    cy.visit(CHART_LIST, {
+      qs: {
+        sortColumn: 'slice_name',
+        sortOrder: 'asc',
+      },
+    });
+    cy.get('[aria-label="list-view"]').click();
+
     cy.get('[data-test="listview-table"]').should('be.visible');
     cy.get('[data-test="bulk-select"]').eq(0).click();
     cy.get('[aria-label="checkbox-off"]').eq(1).siblings('input').click();


### PR DESCRIPTION
### SUMMARY

This PR aims to solve the intermittent issues we're having with our integration tests, to make them deterministic.

#### Exploration & findings

The issue we're having, seemingly randomly, is with one of the following:
* `AdhocFilters`
* `AdhocMetrics`
* `Advanced analytics`
* `Annotations`

Some examples of these tests failing in the past:
* https://github.com/apache/superset/actions/runs/2190832016
* https://github.com/apache/superset/actions/runs/2065080717

Looking at several of these errors, the snapshots show something very similar to each other:
![AdhocMetrics -- Clear metric and set simple adhoc metric -- before each hook (failed) (attempt 3)](https://user-images.githubusercontent.com/17252075/164773820-d61b7f9d-e8b2-410b-86bd-df21cc5c3b67.png)

The error `The URL is missing the dataset_id or slice_id parameters.` occurs when these params are not found.
Back to the tests, we're trying to explore the same chart, `Num Births Trend`, by performing the following action:

```js
cy.visitChartByName('Num Births Trend');
```

In turn, `visitChartByName`, does the following:
```js
cy.request(`/chart/api/read?_flt_3_slice_name=${name}`).then(response => {
  cy.visit(`${BASE_EXPLORE_URL}{"slice_id": ${response.body.pks[0]}}`);
});
```

So, we try to fetch the slice information by name, to get the id and route to the explore.
The `/chart/api/read` works (aka, returns 200) for the failed tests, but, it returns 0 results.
So, that's why we're seeing the error, and why the test is failing.

#### Root cause
The chart we're trying to access exists, and the test is correct.
If it's not deterministic then, it must be that other test is messing with the data these tests are using.
I can think of two potential causes:
1. The chart is renamed by other test
2. The chart is deleted by other test

Investigating, I found a test inside `chart list view` suite that performs a bulk delete, which seems to be the culprit.
This test bulk deletes the first two charts.

This explains the issue and why the tests are non-deterministic:
* We have a test that potentially deletes our chart
* That deletion could delete different charts depending on execution

This happens because, when we load the chart list view, the charts are ordered by modification date, which means, if other test modified the `Num Births Trend` chart before the bulk delete, then that chart is getting deleted.

#### Solution

If we sort the chart list view by name, then we ensure this test always deletes the same charts, and it does not impact the charts other tests rely on.

#### Note
Our integration tests have dependencies (whether expected or not) and we need to consider/restructure the execution to ensure we get the same deterministic result, always.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
