### PR TITLE
fix: lost renameOperator in mixed timeseries chart

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/buildQuery.ts
@@ -22,7 +22,11 @@ import {
   QueryObject,
   normalizeOrderBy,
 } from '@superset-ui/core';
-import { flattenOperator, pivotOperator } from '@superset-ui/chart-controls';
+import {
+  pivotOperator,
+  renameOperator,
+  flattenOperator,
+} from '@superset-ui/chart-controls';
 
 export default function buildQuery(formData: QueryFormData) {
   const {
@@ -66,7 +70,11 @@ export default function buildQuery(formData: QueryFormData) {
       is_timeseries: true,
       post_processing: [
         pivotOperator(formData1, { ...baseQueryObject, is_timeseries: true }),
-        flattenOperator(formData1, { ...baseQueryObject, is_timeseries: true }),
+        renameOperator(formData1, {
+          ...baseQueryObject,
+          ...{ is_timeseries: true },
+        }),
+        flattenOperator(formData1, baseQueryObject),
       ],
     } as QueryObject;
     return [normalizeOrderBy(queryObjectA)];
@@ -78,7 +86,11 @@ export default function buildQuery(formData: QueryFormData) {
       is_timeseries: true,
       post_processing: [
         pivotOperator(formData2, { ...baseQueryObject, is_timeseries: true }),
-        flattenOperator(formData2, { ...baseQueryObject, is_timeseries: true }),
+        renameOperator(formData2, {
+          ...baseQueryObject,
+          ...{ is_timeseries: true },
+        }),
+        flattenOperator(formData2, baseQueryObject),
       ],
     } as QueryObject;
     return [normalizeOrderBy(queryObjectB)];


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add renameOperator into MixedTimeseries chart.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### After

![image](https://user-images.githubusercontent.com/2016594/164386632-f5f0635e-a1b6-40d4-ba06-7d15d3564802.png)


#### Before

![image](https://user-images.githubusercontent.com/2016594/164386719-e3125b64-e8b1-48c1-b7f9-347793a9d66e.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
