### PR TITLE
fix(key_value): use longblob on mysql

### DIFF
--- a/superset/migrations/versions/6766938c6065_add_key_value_store.py
+++ b/superset/migrations/versions/6766938c6065_add_key_value_store.py
@@ -30,7 +30,6 @@ from uuid import uuid4
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.dialects.mysql import LONGBLOB
 from sqlalchemy_utils import UUIDType
 
 
@@ -39,9 +38,7 @@ def upgrade():
         "key_value",
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("resource", sa.String(32), nullable=False),
-        sa.Column(
-            "value", sa.LargeBinary().with_variant(LONGBLOB, "mysql"), nullable=False
-        ),
+        sa.Column("value", sa.LargeBinary(length=2**31), nullable=False),
         sa.Column("uuid", UUIDType(binary=True), default=uuid4),
         sa.Column("created_on", sa.DateTime(), nullable=True),
         sa.Column("created_by_fk", sa.Integer(), nullable=True),

--- a/superset/migrations/versions/6766938c6065_add_key_value_store.py
+++ b/superset/migrations/versions/6766938c6065_add_key_value_store.py
@@ -30,6 +30,7 @@ from uuid import uuid4
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects.mysql import LONGBLOB
 from sqlalchemy_utils import UUIDType
 
 
@@ -38,7 +39,9 @@ def upgrade():
         "key_value",
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("resource", sa.String(32), nullable=False),
-        sa.Column("value", sa.LargeBinary(), nullable=False),
+        sa.Column(
+            "value", sa.LargeBinary().with_variant(LONGBLOB, "mysql"), nullable=False
+        ),
         sa.Column("uuid", UUIDType(binary=True), default=uuid4),
         sa.Column("created_on", sa.DateTime(), nullable=True),
         sa.Column("created_by_fk", sa.Integer(), nullable=True),


### PR DESCRIPTION
### SUMMARY
On Postgres `LongBinary` equates to `BYTEA` which can store 1 Gb values. However, it turns out `LongBinary` without a specified `length` creates `BLOB` on MySQL, which is limited to 64 kb. To make sure the `value` column on the `key_value` table is as wide on MySQL as it is on Postgres, we specify the length to ensure that an appropriately sized column is created.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
