### PR TITLE
fix(sql-lab): SQL Lab commit connection even if no CTA query is made

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -490,9 +490,9 @@ def execute_sql_statements(  # pylint: disable=too-many-arguments, too-many-loca
                     ex, query, session, payload, prefix_message
                 )
                 return payload
-
         # Commit the connection so CTA queries will create the table.
-        conn.commit()
+        if apply_ctas:
+            conn.commit()
 
     # Success, updating the query entry in database
     query.rows = result_set.size


### PR DESCRIPTION
### SUMMARY
SQL Lab query editor on run commits the connection even if all we do is select a database without CTA enabled. This is not really an issue with most database systems however there are problems when using superset with Mongo BI connector which does not support transactions.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TESTING INSTRUCTIONS

### ADDITIONAL INFORMATION

- [x] Has associated issue: #16036
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
