### PR TITLE
feat(charts): allow query mutator to update queries after splitting original sql

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,6 +1,7 @@
 name: Docker
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,7 @@
 name: Docker
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'master'
@@ -15,28 +16,41 @@ jobs:
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
+        # with:
+        #   persist-credentials: false
+
+      # - shell: bash
+      #   env:
+      #     DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+      #     DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      #   run: |
+      #     .github/workflows/docker_build_push.sh
+
+      # - name: Build ephemeral env image
+      #   if: github.event_name == 'pull_request'
+      #   run: |
+      #     mkdir -p ./build
+      #     echo ${{ github.sha }} > ./build/SHA
+      #     echo ${{ github.event.pull_request.number }} > ./build/PR-NUM
+      #     docker build --target ci -t ${{ github.sha }} -t "pr-${{ github.event.pull_request.number }}" .
+      #     docker save ${{ github.sha }} | gzip > ./build/${{ github.sha }}.tar.gz
+
+      # - name: Upload build artifacts
+      #   if: github.event_name == 'pull_request'
+      #   uses: actions/upload-artifact@v2
+      #   with:
+      #     name: build
+      #     path: build/
+
+      - name: Login to GitHub Packages
+        uses: docker/login-action@v1
         with:
-          persist-credentials: false
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - shell: bash
-        env:
-          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: |
-          .github/workflows/docker_build_push.sh
-
-      - name: Build ephemeral env image
-        if: github.event_name == 'pull_request'
-        run: |
-          mkdir -p ./build
-          echo ${{ github.sha }} > ./build/SHA
-          echo ${{ github.event.pull_request.number }} > ./build/PR-NUM
-          docker build --target ci -t ${{ github.sha }} -t "pr-${{ github.event.pull_request.number }}" .
-          docker save ${{ github.sha }} | gzip > ./build/${{ github.sha }}.tar.gz
-
-      - name: Upload build artifacts
-        if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v2
+      - name: Build and push
+        uses: docker/build-push-action@v2
         with:
-          name: build
-          path: build/
+          push: true
+          tags: ghcr.io/ofs-digital/superset:${{ github.sha }}

--- a/.github/workflows/docker_build_push.sh
+++ b/.github/workflows/docker_build_push.sh
@@ -18,7 +18,7 @@
 set -eo pipefail
 
 SHA=$(git rev-parse HEAD)
-REPO_NAME="apache/superset"
+REPO_NAME="ofs-digital/superset"
 
 if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
   REFSPEC=$(echo "${GITHUB_HEAD_REF}" | sed 's/[^a-zA-Z0-9]/-/g' | head -c 40)

--- a/superset/config.py
+++ b/superset/config.py
@@ -1050,9 +1050,6 @@ def SQL_QUERY_MUTATOR(  # pylint: disable=invalid-name,unused-argument
 ) -> str:
     return sql
 
-MUTATE_AFTER_SPLIT = True
-
-
 # ---------------------------------------------------
 # Alerts & Reports
 # ---------------------------------------------------

--- a/superset/config.py
+++ b/superset/config.py
@@ -1050,6 +1050,8 @@ def SQL_QUERY_MUTATOR(  # pylint: disable=invalid-name,unused-argument
 ) -> str:
     return sql
 
+MUTATE_AFTER_SPLIT = True
+
 
 # ---------------------------------------------------
 # Alerts & Reports

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -775,7 +775,6 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
         Typically adds comments to the query with context"""
         sql_query_mutator = config["SQL_QUERY_MUTATOR"]
         mutate_after_split = config["MUTATE_AFTER_SPLIT"]
-        print("Mutate query function in models.py")
         if sql_query_mutator and not mutate_after_split:
             username = utils.get_username()
             sql = sql_query_mutator(

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -774,7 +774,9 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
 
         Typically adds comments to the query with context"""
         sql_query_mutator = config["SQL_QUERY_MUTATOR"]
-        if sql_query_mutator:
+        mutate_after_split = config["MUTATE_AFTER_SPLIT"]
+        print("Mutate query function in models.py")
+        if sql_query_mutator and not mutate_after_split:
             username = utils.get_username()
             sql = sql_query_mutator(
                 sql,

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1137,7 +1137,8 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         parsed_query = ParsedQuery(statement)
         sql = parsed_query.stripped()
         sql_query_mutator = current_app.config["SQL_QUERY_MUTATOR"]
-        if sql_query_mutator:
+        mutate_after_split = current_app.config["MUTATE_AFTER_SPLIT"]
+        if sql_query_mutator and not mutate_after_split:
             sql = sql_query_mutator(
                 sql,
                 user_name=user_name,

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -441,11 +441,7 @@ class Database(
 
         with closing(engine.raw_connection()) as conn:
             cursor = conn.cursor()
-            print("sqls variable: ", sqls)
-            print("going to loop through: ", sqls[:-1])
             for sql_ in sqls[:-1]:
-                print("sql_ query: ", sql_)
-                print("mutate after split inside for loop: ", mutate_after_split)
                 if mutate_after_split:
                     sql_ = sql_query_mutator(
                         sql_,
@@ -453,7 +449,6 @@ class Database(
                         security_manager=security_manager,
                         database=None
                     )
-                    print("New SQL to execute: ", sql_)
                 _log_query(sql_)
                 self.db_engine_spec.execute(cursor, sql_)
                 cursor.fetchall()

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -424,6 +424,9 @@ class Database(
         username = utils.get_username() or username
         mutate_after_split = config["MUTATE_AFTER_SPLIT"]
         sql_query_mutator = config["SQL_QUERY_MUTATOR"]
+        print("Username: ", username)
+        print("Mutate after split: ", mutate_after_split)
+        
 
         def needs_conversion(df_series: pd.Series) -> bool:
             return (
@@ -442,9 +445,9 @@ class Database(
                 if mutate_after_split:
                     sql_ = sql_query_mutator(
                         sql_,
-                        username=username,
+                        user_name=username,
                         security_manager=security_manager,
-                        database=database
+                        database=None
                     )
                 _log_query(sql_)
                 self.db_engine_spec.execute(cursor, sql_)

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -457,9 +457,19 @@ class Database(
                 _log_query(sql_)
                 self.db_engine_spec.execute(cursor, sql_)
                 cursor.fetchall()
-
-            _log_query(sqls[-1])
-            self.db_engine_spec.execute(cursor, sqls[-1])
+            
+            if mutate_after_split:
+                last_sql = sql_query_mutator(
+                    sqls[-1],
+                    user_name=username,
+                    security_manager=security_manager,
+                    database=None
+                )
+                _log_query(last_sql)
+                self.db_engine_spec.execute(cursor, last_sql)
+            else:
+                _log_query(sqls[-1])
+                self.db_engine_spec.execute(cursor, sqls[-1])
 
             data = self.db_engine_spec.fetch_data(cursor)
             result_set = SupersetResultSet(

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -442,6 +442,8 @@ class Database(
         with closing(engine.raw_connection()) as conn:
             cursor = conn.cursor()
             for sql_ in sqls[:-1]:
+                print("sql_ query: ", sql_)
+                print("mutate after split inside for loop: ", mutate_after_split)
                 if mutate_after_split:
                     sql_ = sql_query_mutator(
                         sql_,
@@ -449,6 +451,7 @@ class Database(
                         security_manager=security_manager,
                         database=None
                     )
+                    print("New SQL to execute: ", sql_)
                 _log_query(sql_)
                 self.db_engine_spec.execute(cursor, sql_)
                 cursor.fetchall()

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -441,6 +441,8 @@ class Database(
 
         with closing(engine.raw_connection()) as conn:
             cursor = conn.cursor()
+            print("sqls variable: ", sqls)
+            print("going to loop through: ", sqls[:-1])
             for sql_ in sqls[:-1]:
                 print("sql_ query: ", sql_)
                 print("mutate after split inside for loop: ", mutate_after_split)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The changes allow a user to use the SQL_QUERY_MUTATOR function to add statements such as SET ROLE without breaking functionality. Currently, adding a statement like this works fine in the SQL Editor, but Charts run individual statements by splitting a passed in query and throw errors since SET ROLE does not return any data on its own. With the new MUTATE_AFTER_SPLIT variable, users can choose to apply the mutator function after the chart's query execution function splits a given query, allowing users to apply a change to all statements in a query and have Chart functionality not be interrupted.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
In the config file, update the SQL_QUERY_MUTATOR function to add a statement which does not return any results on its own and is something which should be run alongside all other statements in a given query. An example of this is adding a SET ROLE statement to the beginning of a query. Create a new Chart and see if queries return errors due to no data being fetched. Now in the config file, set the MUTATE_AFTER_SPLIT equal to True. Create a new Chart and make a query, and verify that the desired results are showing.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
