### PR TITLE
feat(reports): xlsx attachments

### DIFF
--- a/superset-frontend/src/components/ReportModal/index.tsx
+++ b/superset-frontend/src/components/ReportModal/index.tsx
@@ -254,7 +254,7 @@ function ReportModal({
             {t('Formatted CSV attached in email')}
           </StyledRadio>
           <StyledRadio value={NOTIFICATION_FORMATS.XLSX}>
-            {t('Formatted XLSX attached in email')}
+            {t('Formatted Excel attached in email')}
           </StyledRadio>
         </StyledRadioGroup>
       </div>

--- a/superset-frontend/src/components/ReportModal/index.tsx
+++ b/superset-frontend/src/components/ReportModal/index.tsx
@@ -81,6 +81,7 @@ const TEXT_BASED_VISUALIZATION_TYPES = [
 ];
 
 const INITIAL_STATE = {
+  XLSX: 'XLSX',
   crontab: '0 12 * * 1',
 };
 
@@ -252,6 +253,9 @@ function ReportModal({
           </StyledRadio>
           <StyledRadio value={NOTIFICATION_FORMATS.CSV}>
             {t('Formatted CSV attached in email')}
+          </StyledRadio>
+          <StyledRadio value={NOTIFICATION_FORMATS.XLSX}>
+            {t('Formatted XLSX attached in email')}
           </StyledRadio>
         </StyledRadioGroup>
       </div>

--- a/superset-frontend/src/components/ReportModal/index.tsx
+++ b/superset-frontend/src/components/ReportModal/index.tsx
@@ -81,7 +81,6 @@ const TEXT_BASED_VISUALIZATION_TYPES = [
 ];
 
 const INITIAL_STATE = {
-  XLSX: 'XLSX',
   crontab: '0 12 * * 1',
 };
 

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -405,6 +405,7 @@ const TRANSLATIONS = {
   CHART_TEXT: t('Chart'),
   SEND_AS_PNG_TEXT: t('Send as PNG'),
   SEND_AS_CSV_TEXT: t('Send as CSV'),
+  SEND_AS_XLSX: t('Send as XLSX'),
   SEND_AS_TEXT: t('Send as text'),
   IGNORE_CACHE_TEXT: t('Ignore cache when generating screenshot'),
   NOTIFICATION_METHOD_TEXT: t('Notification method'),
@@ -1461,6 +1462,9 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                     </StyledRadio>
                     <StyledRadio value="CSV">
                       {TRANSLATIONS.SEND_AS_CSV_TEXT}
+                    </StyledRadio>
+                    <StyledRadio value="XLSX">
+                      {TRANSLATIONS.SEND_AS_XLSX}
                     </StyledRadio>
                     {TEXT_BASED_VISUALIZATION_TYPES.includes(chartVizType) && (
                       <StyledRadio value="TEXT">

--- a/superset-frontend/src/reports/types.ts
+++ b/superset-frontend/src/reports/types.ts
@@ -34,6 +34,7 @@ export enum NOTIFICATION_FORMATS {
   TEXT = 'TEXT',
   PNG = 'PNG',
   CSV = 'CSV',
+  XLSX = 'XLSX',
 }
 export interface ReportObject {
   id?: number;

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -159,6 +159,7 @@ class BaseReportState:
         if self._report_schedule.chart:
             if result_format in {
                 ChartDataResultFormat.CSV,
+                ChartDataResultFormat.XLSX,
                 ChartDataResultFormat.JSON,
             }:
                 return get_url_path(
@@ -331,7 +332,7 @@ class BaseReportState:
         }
         return log_data
 
-    def _get_xlsx_data(self):
+    def _get_xlsx_data(self) -> bytes:
         csv_data = self._get_csv_data()
 
         df = pd.read_csv(BytesIO(csv_data))

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -39,8 +39,6 @@ from superset.reports.commands.alert import AlertCommand
 from superset.reports.commands.exceptions import (
     ReportScheduleAlertGracePeriodError,
     ReportScheduleClientErrorsException,
-    ReportScheduleCsvFailedError,
-    ReportScheduleCsvTimeout,
     ReportScheduleDataFrameFailedError,
     ReportScheduleDataFrameTimeout,
     ReportScheduleExecuteUnexpectedError,
@@ -73,7 +71,7 @@ from superset.reports.notifications.exceptions import NotificationError
 from superset.tasks.utils import get_executor
 from superset.utils.celery import session_scope
 from superset.utils.core import HeaderDataType, override_user
-from superset.utils.csv import df_to_csv, get_chart_csv_data, get_chart_dataframe
+from superset.utils.csv import df_to_csv, get_chart_dataframe
 from superset.utils.excel import df_to_excel
 from superset.utils.screenshots import ChartScreenshot, DashboardScreenshot
 from superset.utils.urls import get_url_path
@@ -259,7 +257,7 @@ class BaseReportState:
                 f"Failed generating dataframe {str(ex)}"
             ) from ex
         if dataframe is None:
-            raise ReportScheduleCsvFailedError()
+            raise ReportScheduleDataFrameFailedError()
         return dataframe
 
     def _update_query_context(self) -> None:
@@ -277,7 +275,7 @@ class BaseReportState:
             ReportScheduleScreenshotFailedError,
             ReportScheduleScreenshotTimeout,
         ) as ex:
-            raise ReportScheduleCsvFailedError(
+            raise ReportScheduleDataFrameFailedError(
                 "Unable to fetch data because the chart has no query context "
                 "saved, and an error occurred when fetching it via a screenshot. "
                 "Please try loading the chart and saving it again."

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -325,7 +325,7 @@ class BaseReportState:
                 screenshot_data = self._get_screenshots()
                 if not screenshot_data:
                     error_text = "Unexpected missing screenshot"
-            elif self._report_schedule.report_format in ReportDataFormat.table_like:
+            elif self._report_schedule.report_format in ReportDataFormat.table_like():
                 df = self._get_data()
                 data = None
                 if self._report_schedule.report_format == ReportDataFormat.CSV:

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -235,6 +235,9 @@ class BaseReportState:
         return [image]
 
     def _get_data(self) -> pd.DataFrame:
+        """
+        Return data as a Pandas dataframe, to embed in notifications as a table.
+        """
         url = self._get_url(result_format=ChartDataResultFormat.JSON)
         _, username = get_executor(
             executor_types=app.config["ALERT_REPORTS_EXECUTE_AS"],
@@ -323,11 +326,12 @@ class BaseReportState:
                 if not screenshot_data:
                     error_text = "Unexpected missing screenshot"
             elif self._report_schedule.report_format in ReportDataFormat.table_like:
-                dataframe = self._get_data()
+                df = self._get_data()
+                data = None
                 if self._report_schedule.report_format == ReportDataFormat.CSV:
-                    data = df_to_csv(dataframe)
+                    data = df_to_csv(df)
                 elif self._report_schedule.report_format == ReportDataFormat.XLSX:
-                    data = df_to_excel(dataframe)
+                    data = df_to_excel(df)
 
                 if not data:
                     error_text = "Unexpected missing data"

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -18,7 +18,6 @@ import json
 import logging
 from datetime import datetime, timedelta
 from typing import Any, Optional, Union
-from io import BytesIO
 from uuid import UUID
 
 import pandas as pd

--- a/superset/reports/models.py
+++ b/superset/reports/models.py
@@ -16,6 +16,7 @@
 # under the License.
 """A collection of ORM sqlalchemy models for Superset"""
 import enum
+from typing import Set
 
 from cron_descriptor import get_description
 from flask_appbuilder import Model

--- a/superset/reports/models.py
+++ b/superset/reports/models.py
@@ -76,6 +76,10 @@ class ReportDataFormat(str, enum.Enum):
     XLSX = "XLSX"
     TEXT = "TEXT"
 
+    @classmethod
+    def table_like(cls) -> Set["ReportDataFormat"]:
+        return {cls.CSV} | {cls.XLSX}
+
 
 class ReportCreationMethod(str, enum.Enum):
     CHARTS = "charts"

--- a/superset/reports/models.py
+++ b/superset/reports/models.py
@@ -72,7 +72,8 @@ class ReportState(str, enum.Enum):
 
 class ReportDataFormat(str, enum.Enum):
     VISUALIZATION = "PNG"
-    DATA = "CSV"
+    CSV = "CSV"
+    XLSX = "XLSX"
     TEXT = "TEXT"
 
 

--- a/superset/reports/models.py
+++ b/superset/reports/models.py
@@ -16,7 +16,6 @@
 # under the License.
 """A collection of ORM sqlalchemy models for Superset"""
 import enum
-from typing import Set
 
 from cron_descriptor import get_description
 from flask_appbuilder import Model
@@ -76,10 +75,6 @@ class ReportDataFormat(str, enum.Enum):
     CSV = "CSV"
     XLSX = "XLSX"
     TEXT = "TEXT"
-
-    @classmethod
-    def table_like(cls) -> Set["ReportDataFormat"]:
-        return {cls.CSV} | {cls.XLSX}
 
 
 class ReportCreationMethod(str, enum.Enum):

--- a/superset/reports/notifications/base.py
+++ b/superset/reports/notifications/base.py
@@ -27,8 +27,9 @@ from superset.utils.core import HeaderDataType
 class NotificationContent:
     name: str
     header_data: HeaderDataType  # this is optional to account for error states
-    csv: Optional[bytes] = None  # bytes for csv file
+    data: Optional[bytes] = None  # bytes for data attachment
     screenshots: Optional[list[bytes]] = None  # bytes for a list of screenshots
+    data_format: Optional[str] = None  # data attachment format (csv, xlsx, etc)
     text: Optional[str] = None
     description: Optional[str] = ""
     url: Optional[str] = None  # url to chart/dashboard for this screenshot

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -97,7 +97,7 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
             return EmailContent(body=self._error_template(self._content.text))
         # Get the domain from the 'From' address ..
         # and make a message id without the < > in the end
-        csv_data = None
+        attachment = None
         domain = self._get_smtp_domain()
         images = {}
 
@@ -166,8 +166,14 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
             """
         )
 
-        if self._content.csv:
-            csv_data = {__("%(name)s.csv", name=self._content.name): self._content.csv}
+        if self._content.data and self._content.data_format:
+            attachment = {
+                __(
+                    "%(name)s.%(format)s",
+                    name=self._content.name,
+                    format=self._content.data_format.lower(),
+                ): self._content.data
+            }
         return EmailContent(
             body=body,
             images=images,

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -177,7 +177,7 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
         return EmailContent(
             body=body,
             images=images,
-            data=csv_data,
+            data=attachment,
             header_data=self._content.header_data,
         )
 

--- a/superset/reports/notifications/slack.py
+++ b/superset/reports/notifications/slack.py
@@ -149,8 +149,8 @@ Error: %(text)s
         return self._message_template(table)
 
     def _get_inline_files(self) -> Sequence[Union[str, IOBase, bytes]]:
-        if self._content.csv:
-            return [self._content.csv]
+        if self._content.data:
+            return [self._content.data]
         if self._content.screenshots:
             return self._content.screenshots
         return []
@@ -162,7 +162,6 @@ Error: %(text)s
         title = self._content.name
         channel = self._get_channel()
         body = self._get_body()
-        file_type = "csv" if self._content.csv else "png"
         try:
             token = app.config["SLACK_API_TOKEN"]
             if callable(token):
@@ -176,7 +175,7 @@ Error: %(text)s
                         file=file,
                         initial_comment=body,
                         title=title,
-                        filetype=file_type,
+                        filetype=self._content.data_format,
                     )
             else:
                 client.chat_postMessage(channel=channel, text=body)

--- a/superset/utils/csv.py
+++ b/superset/utils/csv.py
@@ -80,10 +80,6 @@ def df_to_escaped_csv(df: pd.DataFrame, **kwargs: Any) -> Any:
     return df.to_csv(**kwargs)
 
 
-def df_to_csv(df: pd.DataFrame, **kwargs: Any) -> bytes:
-    return bytes(df.to_csv(**kwargs), "utf-8")
-
-
 def get_chart_csv_data(
     chart_url: str, auth_cookies: Optional[dict[str, str]] = None
 ) -> Optional[bytes]:

--- a/superset/utils/csv.py
+++ b/superset/utils/csv.py
@@ -80,6 +80,10 @@ def df_to_escaped_csv(df: pd.DataFrame, **kwargs: Any) -> Any:
     return df.to_csv(**kwargs)
 
 
+def df_to_csv(df: pd.DataFrame, **kwargs: Any) -> bytes:
+    return bytes(df.to_csv(**kwargs), "utf-8")
+
+
 def get_chart_csv_data(
     chart_url: str, auth_cookies: Optional[dict[str, str]] = None
 ) -> Optional[bytes]:

--- a/superset/utils/excel.py
+++ b/superset/utils/excel.py
@@ -20,7 +20,7 @@ from typing import Any
 import pandas as pd
 
 
-def df_to_excel(df: pd.DataFrame, **kwargs: Any) -> Any:
+def df_to_excel(df: pd.DataFrame, **kwargs: Any) -> bytes:
     output = io.BytesIO()
     # pylint: disable=abstract-class-instantiated
     with pd.ExcelWriter(output, engine="xlsxwriter") as writer:

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -205,7 +205,7 @@ def create_report_email_chart_with_csv():
         report_schedule = create_report_notification(
             email_target="target@email.com",
             chart=chart,
-            report_format=ReportDataFormat.DATA,
+            report_format=ReportDataFormat.CSV,
         )
         yield report_schedule
         cleanup_report_schedule(report_schedule)
@@ -233,7 +233,7 @@ def create_report_email_chart_with_csv_no_query_context():
         report_schedule = create_report_notification(
             email_target="target@email.com",
             chart=chart,
-            report_format=ReportDataFormat.DATA,
+            report_format=ReportDataFormat.CSV,
             name="report_csv_no_query_context",
         )
         yield report_schedule
@@ -284,7 +284,7 @@ def create_report_slack_chart_with_csv():
         report_schedule = create_report_notification(
             slack_channel="slack_channel",
             chart=chart,
-            report_format=ReportDataFormat.DATA,
+            report_format=ReportDataFormat.CSV,
         )
         yield report_schedule
 

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -210,6 +210,7 @@ def create_report_email_chart_with_csv():
         yield report_schedule
         cleanup_report_schedule(report_schedule)
 
+
 @pytest.fixture()
 def create_report_email_chart_with_xlsx():
     with app.app_context():
@@ -222,6 +223,7 @@ def create_report_email_chart_with_xlsx():
         )
         yield report_schedule
         cleanup_report_schedule(report_schedule)
+
 
 @pytest.fixture()
 def create_report_email_chart_with_text():
@@ -251,6 +253,7 @@ def create_report_email_chart_with_csv_no_query_context():
         yield report_schedule
         cleanup_report_schedule(report_schedule)
 
+
 @pytest.fixture()
 def create_report_email_chart_with_xlsx_no_query_context():
     with app.app_context():
@@ -264,6 +267,7 @@ def create_report_email_chart_with_xlsx_no_query_context():
         )
         yield report_schedule
         cleanup_report_schedule(report_schedule)
+
 
 @pytest.fixture()
 def create_report_email_dashboard():
@@ -315,6 +319,7 @@ def create_report_slack_chart_with_csv():
 
         cleanup_report_schedule(report_schedule)
 
+
 @pytest.fixture()
 def create_report_slack_chart_with_xlsx():
     with app.app_context():
@@ -328,6 +333,7 @@ def create_report_slack_chart_with_xlsx():
         yield report_schedule
 
         cleanup_report_schedule(report_schedule)
+
 
 @pytest.fixture()
 def create_report_slack_chart_with_text():

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -210,6 +210,18 @@ def create_report_email_chart_with_csv():
         yield report_schedule
         cleanup_report_schedule(report_schedule)
 
+@pytest.fixture()
+def create_report_email_chart_with_xlsx():
+    with app.app_context():
+        chart = db.session.query(Slice).first()
+        chart.query_context = '{"mock": "query_context"}'
+        report_schedule = create_report_notification(
+            email_target="target@email.com",
+            chart=chart,
+            report_format=ReportDataFormat.XLSX,
+        )
+        yield report_schedule
+        cleanup_report_schedule(report_schedule)
 
 @pytest.fixture()
 def create_report_email_chart_with_text():
@@ -239,6 +251,19 @@ def create_report_email_chart_with_csv_no_query_context():
         yield report_schedule
         cleanup_report_schedule(report_schedule)
 
+@pytest.fixture()
+def create_report_email_chart_with_xlsx_no_query_context():
+    with app.app_context():
+        chart = db.session.query(Slice).first()
+        chart.query_context = None
+        report_schedule = create_report_notification(
+            email_target="target@email.com",
+            chart=chart,
+            report_format=ReportDataFormat.XLSX,
+            name="report_xlsx_no_query_context",
+        )
+        yield report_schedule
+        cleanup_report_schedule(report_schedule)
 
 @pytest.fixture()
 def create_report_email_dashboard():
@@ -290,6 +315,19 @@ def create_report_slack_chart_with_csv():
 
         cleanup_report_schedule(report_schedule)
 
+@pytest.fixture()
+def create_report_slack_chart_with_xlsx():
+    with app.app_context():
+        chart = db.session.query(Slice).first()
+        chart.query_context = '{"mock": "query_context"}'
+        report_schedule = create_report_notification(
+            slack_channel="slack_channel",
+            chart=chart,
+            report_format=ReportDataFormat.XLSX,
+        )
+        yield report_schedule
+
+        cleanup_report_schedule(report_schedule)
 
 @pytest.fixture()
 def create_report_slack_chart_with_text():


### PR DESCRIPTION
### SUMMARY

Most people and departments in enterprise companies are addicted to spreadsheets. Currently our customers are heavily demanding Excel reports and, unfortunately, we have failed to persuade them to continue with CSV.

So here I am with a PR that adds the ability to attach XLSX files as report data and notifications (slack). If this one gets approved, I will also attempt to implement PDF in a similar way.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

![image](https://user-images.githubusercontent.com/1297759/164520812-b36c4285-5a03-4f72-903d-646db17b43d9.png)

![image](https://user-images.githubusercontent.com/1297759/164520865-d877faa7-a245-4179-bb1d-3d556a0c16c0.png)

### TESTING INSTRUCTIONS
Try sending an xlsx report or notification. I wasn't able to test slack since I don't use it actively but implemented it nevertheless for completeness.

### Known Problems

Currently the first column is displayed like 

![image](https://user-images.githubusercontent.com/1297759/164610592-7a974a1a-b3ba-4aa1-b72e-7d342a215a43.png)

It can be monkey patched but it should be fixed naturally once/if #19735 lands.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
