### PR TITLE
Fix: raising schedule command exception logging as error

### DIFF
--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -85,7 +85,7 @@ def execute(report_schedule_id: int, scheduled_dttm: str) -> None:
             "An unexpected occurred while executing the report: %s", ex, exc_info=True
         )
     except CommandException as ex:
-        logger.info("Report state: %s", ex)
+        logger.error("Report state: %s", ex)
 
 
 @celery_app.task(name="reports.prune_log")


### PR DESCRIPTION
Fix: raising schedule command exception logging as error

### SUMMARY

commandException error for Scheduler were being logged as info level,  raising the log level to erro

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TESTING INSTRUCTIONS

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
