### PR TITLE
chore: add custom eslint plugin to prevent translation variables

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -67,7 +67,13 @@ module.exports = {
       version: 'detect',
     },
   },
-  plugins: ['prettier', 'react', 'file-progress', 'theme-colors'],
+  plugins: [
+    'prettier',
+    'react',
+    'file-progress',
+    'theme-colors',
+    'translation-vars',
+  ],
   overrides: [
     {
       files: ['*.ts', '*.tsx'],
@@ -198,12 +204,14 @@ module.exports = {
       ],
       rules: {
         'theme-colors/no-literal-colors': 0,
+        'translation-vars/no-template-vars': 0,
         'no-restricted-imports': 0,
       },
     },
   ],
   rules: {
     'theme-colors/no-literal-colors': 1,
+    'translation-vars/no-template-vars': ['error', true],
     camelcase: [
       'error',
       {

--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -19,7 +19,7 @@
 
 module.exports = {
   testRegex:
-    '\\/superset-frontend\\/(spec|src|plugins|packages)\\/.*(_spec|\\.test)\\.[jt]sx?$',
+    '\\/superset-frontend\\/(spec|src|plugins|packages|tools)\\/.*(_spec|\\.test)\\.[jt]sx?$',
   moduleNameMapper: {
     '\\.(css|less|geojson)$': '<rootDir>/spec/__mocks__/mockExportObject.js',
     '\\.(gif|ttf|eot|png|jpg)$': '<rootDir>/spec/__mocks__/mockExportString.js',

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -293,6 +293,7 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-testing-library": "^3.10.1",
     "eslint-plugin-theme-colors": "file:tools/eslint-plugin-theme-colors",
+    "eslint-plugin-translation-vars": "file:tools/eslint-plugin-translation-vars",
     "exports-loader": "^0.7.0",
     "fetch-mock": "^7.7.3",
     "fork-ts-checker-webpack-plugin": "^6.3.3",

--- a/superset-frontend/src/SqlLab/utils/newQueryTabName.ts
+++ b/superset-frontend/src/SqlLab/utils/newQueryTabName.ts
@@ -40,7 +40,7 @@ export const newQueryTabName = (
       // When there are query tabs open, and at least one is called "Untitled Query #"
       // Where # is a valid number
       const largestNumber: number = Math.max(...untitledQueryNumbers);
-      return t(`${untitledQuery}%s`, largestNumber + 1);
+      return t('%s%s', untitledQuery, largestNumber + 1);
     }
     return resultTitle;
   }

--- a/superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx
+++ b/superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx
@@ -280,7 +280,8 @@ function AnnotationList({
       {annotationCurrentlyDeleting && (
         <DeleteModal
           description={t(
-            `Are you sure you want to delete ${annotationCurrentlyDeleting?.short_descr}?`,
+            'Are you sure you want to delete %s?',
+            annotationCurrentlyDeleting?.short_descr,
           )}
           onConfirm={() => {
             if (annotationCurrentlyDeleting) {

--- a/superset-frontend/tools/eslint-plugin-translation-vars/index.js
+++ b/superset-frontend/tools/eslint-plugin-translation-vars/index.js
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @fileoverview Rule to warn about translation template variables
+ * @author Apache
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  rules: {
+    'no-template-vars': {
+      create(context) {
+        function handler(node) {
+          if (node.arguments.length) {
+            const firstArgs = node.arguments[0];
+            if (
+              firstArgs.type === 'TemplateLiteral' &&
+              firstArgs.expressions.length
+            ) {
+              context.report({
+                node,
+                message:
+                  "Don't use variables in translation string templates. Flask-babel is a static translation translation service, so it can’t handle strings that include variables",
+              });
+            }
+          }
+        }
+        return {
+          "CallExpression[callee.name='t']": handler,
+          "CallExpression[callee.name='tn']": handler,
+        };
+      },
+    },
+  },
+};

--- a/superset-frontend/tools/eslint-plugin-translation-vars/no-template-vars.test.js
+++ b/superset-frontend/tools/eslint-plugin-translation-vars/no-template-vars.test.js
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @fileoverview Rule to warn about translation template variables
+ * @author Apache
+ */
+/* eslint-disable no-template-curly-in-string */
+const { RuleTester } = require('eslint');
+const plugin = require('.');
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
+const rule = plugin.rules['no-template-vars'];
+
+const errors = [
+  {
+    type: 'CallExpression',
+  },
+];
+
+ruleTester.run('no-template-vars', rule, {
+  valid: [
+    't(`foo`)',
+    'tn(`foo`)',
+    't(`foo %s bar`)',
+    'tn(`foo %s bar`)',
+    't(`foo %s bar %s`)',
+    'tn(`foo %s bar %s`)',
+  ],
+  invalid: [
+    {
+      code: 't(`foo${bar}`)',
+      errors,
+    },
+    {
+      code: 't(`foo${bar} ${baz}`)',
+      errors,
+    },
+    {
+      code: 'tn(`foo${bar}`)',
+      errors,
+    },
+    {
+      code: 'tn(`foo${bar} ${baz}`)',
+      errors,
+    },
+  ],
+});

--- a/superset-frontend/tools/eslint-plugin-translation-vars/package.json
+++ b/superset-frontend/tools/eslint-plugin-translation-vars/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "eslint-plugin-translation-vars",
+  "version": "1.0.0",
+  "description": "Warns about translation variables",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "license": "Apache-2.0",
+  "author": "Apache",
+  "dependencies": {},
+  "peerDependencies": {
+    "eslint": ">=0.8.0"
+  },
+  "engines": {
+    "node": "^16.9.1",
+    "npm": "^7.5.4"
+  }
+}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Since flask-babel is a static translation translation service, it can’t handle strings that include variables.(refer to https://github.com/apache/superset/pull/19641). This PR adds a custom eslint plugin to catch these.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### before
<img width="1048" alt="WeChate0e5c68e6cfe29327a6415ef0122fe59" src="https://user-images.githubusercontent.com/11830681/164982376-2edb5a96-fe8b-4cb1-beda-37426a592ba1.png">

### after
<img width="582" alt="WeChat137288c0d44b2fe669013b794badf966" src="https://user-images.githubusercontent.com/11830681/164982379-55e8f62c-a64d-4ece-a407-1ad8080598f5.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
**Test Rule**
```
cd superset-frontend
npm run test ./tools/eslint-plugin-translation-vars
```
**Lint**

```
npm run _lint
```
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @villebro @zhaoyongjie @geido 