### PR TITLE
fix(dashboard-css): make to load saved css template

### DIFF
--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 import { render, screen } from 'spec/helpers/testing-library';
@@ -208,7 +208,7 @@ test('should show the properties modal', async () => {
 describe('UNSAFE_componentWillReceiveProps', () => {
   let wrapper: any;
   const mockedProps = createProps();
-  const props = {...mockedProps, customCss: ''};
+  const props = { ...mockedProps, customCss: '' };
 
   beforeEach(() => {
     wrapper = shallow(<HeaderActionsDropdown {...props} />);
@@ -226,9 +226,7 @@ describe('UNSAFE_componentWillReceiveProps', () => {
       customCss: mockedProps.customCss,
     });
     expect(wrapper.instance().setState.calledOnce).toBe(true);
-    const stateKeys = Object.keys(
-      wrapper.instance().setState.lastCall.args[0],
-    );
+    const stateKeys = Object.keys(wrapper.instance().setState.lastCall.args[0]);
     expect(stateKeys).toContain('css');
-  })
+  });
 });

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
@@ -16,7 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
+import React, { ReactNode } from 'react';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
 import { render, screen } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
@@ -201,4 +203,32 @@ test('should show the properties modal', async () => {
   await openDropdown();
   userEvent.click(screen.getByText('Edit dashboard properties'));
   expect(editModeOnProps.showPropertiesModal).toHaveBeenCalledTimes(1);
+});
+
+describe('UNSAFE_componentWillReceiveProps', () => {
+  let wrapper: any;
+  const mockedProps = createProps();
+  const props = {...mockedProps, customCss: ''};
+
+  beforeEach(() => {
+    wrapper = shallow(<HeaderActionsDropdown {...props} />);
+    wrapper.setState({ css: props.customCss });
+    sinon.spy(wrapper.instance(), 'setState');
+  });
+
+  afterEach(() => {
+    wrapper.instance().setState.restore();
+  });
+
+  it('css should update state and inject custom css', () => {
+    wrapper.instance().UNSAFE_componentWillReceiveProps({
+      ...props,
+      customCss: mockedProps.customCss,
+    });
+    expect(wrapper.instance().setState.calledOnce).toBe(true);
+    const stateKeys = Object.keys(
+      wrapper.instance().setState.lastCall.args[0],
+    );
+    expect(stateKeys).toContain('css');
+  })
 });

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
@@ -110,6 +110,7 @@ class HeaderActionsDropdown extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
+      css: props.customCss,
       cssTemplates: [],
     };
 
@@ -135,8 +136,16 @@ class HeaderActionsDropdown extends React.PureComponent {
       });
   }
 
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    if (this.props.customCss !== nextProps.customCss) {
+      this.setState({ css: nextProps.customCss });
+    }
+  }
+
   changeCss(css) {
-    injectCustomCss(css);
+    this.setState({ css }, () => {
+      injectCustomCss(css);
+    });
     this.props.onChange();
     this.props.updateCss(css);
   }
@@ -311,7 +320,7 @@ class HeaderActionsDropdown extends React.PureComponent {
           <Menu.Item key={MENU_KEYS.EDIT_CSS}>
             <CssEditor
               triggerNode={<span>{t('Edit CSS')}</span>}
-              initialCss={customCss}
+              initialCss={this.state.css}
               templates={this.state.cssTemplates}
               onChange={this.changeCss}
             />

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
@@ -138,14 +138,13 @@ class HeaderActionsDropdown extends React.PureComponent {
 
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (this.props.customCss !== nextProps.customCss) {
-      this.setState({ css: nextProps.customCss });
+      this.setState({ css: nextProps.customCss }, () => {
+        injectCustomCss(nextProps.customCss);
+      });
     }
   }
 
   changeCss(css) {
-    this.setState({ css }, () => {
-      injectCustomCss(css);
-    });
     this.props.onChange();
     this.props.updateCss(css);
   }

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
@@ -110,7 +110,6 @@ class HeaderActionsDropdown extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      css: props.customCss,
       cssTemplates: [],
     };
 
@@ -137,9 +136,7 @@ class HeaderActionsDropdown extends React.PureComponent {
   }
 
   changeCss(css) {
-    this.setState({ css }, () => {
-      injectCustomCss(css);
-    });
+    injectCustomCss(css);
     this.props.onChange();
     this.props.updateCss(css);
   }
@@ -314,7 +311,7 @@ class HeaderActionsDropdown extends React.PureComponent {
           <Menu.Item key={MENU_KEYS.EDIT_CSS}>
             <CssEditor
               triggerNode={<span>{t('Edit CSS')}</span>}
-              initialCss={this.state.css}
+              initialCss={customCss}
               templates={this.state.cssTemplates}
               onChange={this.changeCss}
             />


### PR DESCRIPTION
### SUMMARY
CSS template not saving

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
![CSS template not saving](https://user-images.githubusercontent.com/47900232/165147303-ce288f35-bb7d-4d06-b560-ac26944f2b3e.gif)

AFTER:
https://user-images.githubusercontent.com/47900232/165148019-2adf38ac-dd71-4989-84be-9c78b7a72ab6.mov

### TESTING INSTRUCTIONS
**How to reproduce issues**

1. Create a dashboard
2. Edit CSS and load a CSS template, for instance the one that shows up by default
3. Save the changes to the dashboard
4. Reload the page
5. Edit the dashboard again

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
