### PR TITLE
fix(explore): ignore temporary controls in altered pill

### DIFF
--- a/superset-frontend/src/components/AlteredSliceTag/AlteredSliceTag.test.jsx
+++ b/superset-frontend/src/components/AlteredSliceTag/AlteredSliceTag.test.jsx
@@ -69,6 +69,17 @@ describe('AlteredSliceTag', () => {
     expect(wrapper.instance().render()).toBeNull();
   });
 
+  it('does not run when temporary controls have changes', () => {
+    props = {
+      origFormData: { ...props.origFormData, url_params: { foo: 'foo' } },
+      currentFormData: { ...props.origFormData, url_params: { bar: 'bar' } },
+    };
+    wrapper = mount(<AlteredSliceTag {...props} />);
+    expect(wrapper.instance().state.rows).toEqual([]);
+    expect(wrapper.instance().state.hasDiffs).toBe(false);
+    expect(wrapper.instance().render()).toBeNull();
+  });
+
   it('sets new rows when receiving new props', () => {
     const testRows = ['testValue'];
     const getRowsFromDiffsStub = jest

--- a/superset-frontend/src/components/AlteredSliceTag/index.jsx
+++ b/superset-frontend/src/components/AlteredSliceTag/index.jsx
@@ -20,6 +20,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { isEqual, isEmpty } from 'lodash';
 import { t } from '@superset-ui/core';
+import { sanitizeFormData } from 'src/explore/exploreUtils/formData';
 import getControlsForVizType from 'src/utils/getControlsForVizType';
 import { safeStringify } from 'src/utils/safeStringify';
 import { Tooltip } from 'src/components/Tooltip';
@@ -82,8 +83,8 @@ export default class AlteredSliceTag extends React.Component {
   getDiffs(props) {
     // Returns all properties that differ in the
     // current form data and the saved form data
-    const ofd = props.origFormData;
-    const cfd = props.currentFormData;
+    const ofd = sanitizeFormData(props.origFormData);
+    const cfd = sanitizeFormData(props.currentFormData);
 
     const fdKeys = Object.keys(cfd);
     const diffs = {};


### PR DESCRIPTION
### SUMMARY
Currently the `AlteredSliceTag` pill appears when there are changes to `url_params` in the form data. Since these are not persisted in chart metadata (see #18960), we should ignore temporary control values when comparing old vs new form data. A test is also added to ensure the pill doesn't render when there are changes present in `url_params`.

### AFTER
Now the pill no longer appears when refreshing a chart with a change to `url_params`:
<img width="1269" alt="image" src="https://user-images.githubusercontent.com/33317356/165238959-23c964f3-17da-4221-9452-5dd62152a489.png">

### BEFORE
Previously the pill would always appear when refreshing the chart due to `explore_form_data` and other url params being present in the URL:
<img width="1269" alt="image" src="https://user-images.githubusercontent.com/33317356/165239309-d3d724e3-2180-4009-ad1b-992e7c2e1f87.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
