### PR TITLE
feat(alerts-reports): config timestamp fn for alerts/reports

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -1055,6 +1055,10 @@ MACHINE_AUTH_PROVIDER_CLASS = "superset.utils.machine_auth.MachineAuthProvider"
 # sliding cron window size, should be synced with the celery beat config minus 1 second
 ALERT_REPORTS_CRON_WINDOW_SIZE = 59
 ALERT_REPORTS_WORKING_TIME_OUT_KILL = True
+
+# Custom timestamp function for labeling notifications
+ALERT_REPORTS_TIMESTAMP = lambda: ""
+
 # if ALERT_REPORTS_WORKING_TIME_OUT_KILL is True, set a celery hard timeout
 # Equal to working timeout + ALERT_REPORTS_WORKING_TIME_OUT_LAG
 ALERT_REPORTS_WORKING_TIME_OUT_LAG = int(timedelta(seconds=10).total_seconds())

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -136,7 +136,13 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
         )
 
         if self._content.csv:
-            csv_data = {__("%(name)s.csv", name=self._content.name): self._content.csv}
+            csv_data = {
+                __(
+                    "%(name)s%(timestamp)s.csv",
+                    name=self._content.name,
+                    timestamp=app.config["ALERT_REPORTS_TIMESTAMP"](),
+                ): self._content.csv
+            }
         return EmailContent(body=body, images=images, data=csv_data)
 
     def _get_subject(self) -> str:


### PR DESCRIPTION
### SUMMARY
This PR adds config option for defining a timestamp function to be used with alerts & reports such as labeling attachments

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
