### PR TITLE
fix: Regression on Data and Alerts & Reports Headers

### DIFF
--- a/superset-frontend/src/views/components/SubMenu.tsx
+++ b/superset-frontend/src/views/components/SubMenu.tsx
@@ -67,7 +67,7 @@ const StyledHeader = styled.div`
     padding-left: 10px;
   }
   .menu {
-    background-color: white;
+    background-color: ${({ theme }) => theme.colors.grayscale.light5};
     .ant-menu-horizontal {
       line-height: inherit;
       .ant-menu-item {
@@ -88,7 +88,8 @@ const StyledHeader = styled.div`
   }
 
   .menu .ant-menu-item {
-    li {
+    li,
+    div {
       a,
       div {
         font-size: ${({ theme }) => theme.typography.sizes.s}px;
@@ -98,6 +99,10 @@ const StyledHeader = styled.div`
           margin: 0;
           padding: ${({ theme }) => theme.gridUnit * 4}px;
           line-height: ${({ theme }) => theme.gridUnit * 5}px;
+
+          &:hover {
+            text-decoration: none;
+          }
         }
       }
 
@@ -106,11 +111,14 @@ const StyledHeader = styled.div`
           ${({ theme }) => theme.gridUnit * 4}px;
       }
     }
+
     li.active > a,
     li.active > div,
+    div.active > div,
     li > a:hover,
     li > a:focus,
-    li > div:hover {
+    li > div:hover,
+    div > div:hover {
       background: ${({ theme }) => theme.colors.secondary.light4};
       border-bottom: none;
       border-radius: ${({ theme }) => theme.borderRadius}px;
@@ -148,6 +156,7 @@ const StyledHeader = styled.div`
 const styledDisabled = (theme: SupersetTheme) => css`
   color: ${theme.colors.grayscale.base};
   backgroundColor: ${theme.colors.grayscale.light2}};
+
   .ant-menu-item:hover {
     color: ${theme.colors.grayscale.base};
     cursor: default;


### PR DESCRIPTION
### SUMMARY
Fixes a regression that happened when trying to fix a "li inside li" error. Switching the tag removed some of the styles applied to the submenu.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://user-images.githubusercontent.com/17252075/165293562-a04eef41-d5dd-4a53-80d2-92f27e8d0882.mov

After:

https://user-images.githubusercontent.com/17252075/165289539-518699b5-f45d-4847-a74d-0504194e0da1.mov

### TESTING INSTRUCTIONS

Visit the Data subsection (Databases/Datasets/Saved queries/Saved history) and ensure the tabs display as showcased in the after video.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
