### PR TITLE
fix: Alpha should not be able to edit datasets that they don't own

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -91,6 +91,11 @@ export const PRIMARY_COLOR = { r: 0, g: 122, b: 135, a: 1 };
 const ROW_LIMIT_OPTIONS = [10, 50, 100, 250, 500, 1000, 5000, 10000, 50000];
 const SERIES_LIMITS = [5, 10, 25, 50, 100, 500];
 
+const appContainer = document.getElementById('app');
+const { user } = JSON.parse(
+  appContainer?.getAttribute('data-bootstrap') || '{}',
+);
+
 type Control = {
   savedMetrics?: Metric[] | null;
   default?: unknown;
@@ -167,6 +172,7 @@ const datasourceControl: SharedControlConfig<'DatasourceControl'> = {
   mapStateToProps: ({ datasource, form_data }) => ({
     datasource,
     form_data,
+    user,
   }),
 };
 

--- a/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanel.test.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanel.test.tsx
@@ -49,6 +49,20 @@ const datasource = {
   description: 'desc',
   owners: [{ username: 'admin', userId: 1 }],
 };
+
+const mockUser = {
+  createdOn: '2021-04-27T18:12:38.952304',
+  email: 'admin',
+  firstName: 'admin',
+  isActive: true,
+  lastName: 'admin',
+  permissions: {},
+  roles: { Admin: Array(173) },
+  userId: 1,
+  username: 'admin',
+  isAnonymous: false,
+};
+
 const props: DatasourcePanelProps = {
   datasource,
   controls: {
@@ -58,6 +72,7 @@ const props: DatasourcePanelProps = {
       type: DatasourceControl,
       label: 'hello',
       datasource,
+      user: mockUser,
     },
   },
   actions: {
@@ -155,6 +170,7 @@ test('should render a warning', async () => {
         datasource: {
           ...props.controls.datasource,
           datasource: deprecatedDatasource,
+          user: mockUser,
         },
       },
     }),

--- a/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanel.test.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanel.test.tsx
@@ -47,6 +47,7 @@ const datasource = {
   main_dttm_col: 'None',
   datasource_name: 'table1',
   description: 'desc',
+  owners: [{ username: 'admin', userId: 1 }],
 };
 const props: DatasourcePanelProps = {
   datasource,

--- a/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
@@ -31,12 +31,14 @@ import { FAST_DEBOUNCE } from 'src/constants';
 import { FeatureFlag, isFeatureEnabled } from 'src/featureFlags';
 import { ExploreActions } from 'src/explore/actions/exploreActions';
 import Control from 'src/explore/components/Control';
+import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 import DatasourcePanelDragOption from './DatasourcePanelDragOption';
 import { DndItemType } from '../DndItemType';
 import { StyledColumnOption, StyledMetricOption } from '../optionRenderers';
 
 interface DatasourceControl extends ControlConfig {
   datasource?: DatasourceMeta;
+  user: UserWithPermissionsAndRoles;
 }
 
 export interface Props {

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.jsx
@@ -29,7 +29,6 @@ import {
 import DatasourceControl from 'src/explore/components/controls/DatasourceControl';
 import Icons from 'src/components/Icons';
 import { Tooltip } from 'src/components/Tooltip';
-import { user } from 'src/SqlLab/fixtures';
 
 const defaultProps = {
   name: 'datasource',
@@ -53,7 +52,17 @@ const defaultProps = {
     setDatasource: sinon.spy(),
   },
   onChange: sinon.spy(),
-  user,
+  user: {
+    createdOn: '2021-04-27T18:12:38.952304',
+    email: 'admin',
+    firstName: 'admin',
+    isActive: true,
+    lastName: 'admin',
+    permissions: {},
+    roles: { Admin: Array(173) },
+    userId: 1,
+    username: 'admin',
+  },
 };
 
 describe('DatasourceControl', () => {
@@ -110,6 +119,7 @@ describe('DatasourceControl', () => {
         id: 1,
         columns: [],
         metrics: [],
+        owners: [{ username: 'admin', userId: 1 }],
         database: {
           backend: 'druid',
           name: 'main',

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.jsx
@@ -29,6 +29,7 @@ import {
 import DatasourceControl from 'src/explore/components/controls/DatasourceControl';
 import Icons from 'src/components/Icons';
 import { Tooltip } from 'src/components/Tooltip';
+import { user } from 'src/SqlLab/fixtures';
 
 const defaultProps = {
   name: 'datasource',
@@ -52,6 +53,7 @@ const defaultProps = {
     setDatasource: sinon.spy(),
   },
   onChange: sinon.spy(),
+  user,
 };
 
 describe('DatasourceControl', () => {

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.jsx
@@ -41,6 +41,7 @@ const defaultProps = {
     id: 1,
     columns: [],
     metrics: [],
+    owners: [{ username: 'admin', userId: 1 }],
     database: {
       backend: 'mysql',
       name: 'main',

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
@@ -48,6 +48,17 @@ const createProps = () => ({
   name: 'datasource',
   actions: {},
   isEditable: true,
+  user: {
+    createdOn: '2021-04-27T18:12:38.952304',
+    email: 'admin',
+    firstName: 'admin',
+    isActive: true,
+    lastName: 'admin',
+    permissions: {},
+    roles: { Admin: Array(173) },
+    userId: 1,
+    username: 'admin',
+  },
   onChange: jest.fn(),
   onDatasourceSave: jest.fn(),
 });

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -198,10 +198,9 @@ class DatasourceControl extends React.PureComponent {
 
     const isSqlSupported = datasource.type === 'table';
     const appContainer = document.getElementById('app');
-    const bootstrapData = JSON.parse(
+    const { user } = JSON.parse(
       appContainer?.getAttribute('data-bootstrap') || '{}',
     );
-    const user = bootstrapData.user;
     const allowEdit =
       datasource.owners.map(o => o.id).includes(user.userId) ||
       isUserAdmin(user);

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -196,7 +196,6 @@ class DatasourceControl extends React.PureComponent {
       }
     }
 
-    console.log(this.props);
     const isSqlSupported = datasource.type === 'table';
     const { user } = this.props;
     const allowEdit =

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -196,11 +196,9 @@ class DatasourceControl extends React.PureComponent {
       }
     }
 
+    console.log(this.props);
     const isSqlSupported = datasource.type === 'table';
-    const appContainer = document.getElementById('app');
-    const { user } = JSON.parse(
-      appContainer?.getAttribute('data-bootstrap') || '{}',
-    );
+    const { user } = this.props;
     const allowEdit =
       datasource.owners.map(o => o.id).includes(user.userId) ||
       isUserAdmin(user);

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -205,6 +205,8 @@ class DatasourceControl extends React.PureComponent {
       datasource.owners.map(o => o.id).includes(user.userId) ||
       isUserAdmin(user);
 
+    const editText = t('Edit dataset');
+
     const datasourceMenu = (
       <Menu onClick={this.handleMenuItemClick}>
         {this.props.isEditable && (
@@ -213,7 +215,17 @@ class DatasourceControl extends React.PureComponent {
             data-test="edit-dataset"
             disabled={!allowEdit}
           >
-            {t('Edit dataset')}
+            {!allowEdit ? (
+              <Tooltip
+                title={t(
+                  'You must be a dataset owner in order to edit. Please reach out to a dataset owner to request modifications or edit access.',
+                )}
+              >
+                {editText}
+              </Tooltip>
+            ) : (
+              editText
+            )}
           </Menu.Item>
         )}
         <Menu.Item key={CHANGE_DATASET}>{t('Change dataset')}</Menu.Item>

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -35,6 +35,7 @@ import Button from 'src/components/Button';
 import ErrorAlert from 'src/components/ErrorMessage/ErrorAlert';
 import WarningIconWithTooltip from 'src/components/WarningIconWithTooltip';
 import { URL_PARAMS } from 'src/constants';
+import { isUserAdmin } from 'src/dashboard/util/findPermission';
 
 const propTypes = {
   actions: PropTypes.object.isRequired,
@@ -196,11 +197,23 @@ class DatasourceControl extends React.PureComponent {
     }
 
     const isSqlSupported = datasource.type === 'table';
+    const appContainer = document.getElementById('app');
+    const bootstrapData = JSON.parse(
+      appContainer?.getAttribute('data-bootstrap') || '{}',
+    );
+    const user = bootstrapData.user;
+    const allowEdit =
+      datasource.owners.map(o => o.id).includes(user.userId) ||
+      isUserAdmin(user);
 
     const datasourceMenu = (
       <Menu onClick={this.handleMenuItemClick}>
         {this.props.isEditable && (
-          <Menu.Item key={EDIT_DATASET} data-test="edit-dataset">
+          <Menu.Item
+            key={EDIT_DATASET}
+            data-test="edit-dataset"
+            disabled={!allowEdit}
+          >
             {t('Edit dataset')}
           </Menu.Item>
         )}

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.test.jsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.test.jsx
@@ -55,6 +55,7 @@ const mockdatasets = [...new Array(3)].map((_, i) => ({
   id: i,
   schema: `schema ${i}`,
   table_name: `coolest table ${i}`,
+  owners: [{ username: 'admin', userId: 1 }],
 }));
 
 const mockUser = {

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
@@ -367,7 +367,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
         Cell: ({ row: { original } }: any) => {
           // Verify owner or isAdmin
           const allowEdit =
-            original.owners.map((o: any) => o.id).includes(user.userId) ||
+            original.owners.map((o: Owner) => o.id).includes(user.userId) ||
             isUserAdmin(user);
 
           const handleEdit = () => openDatasetEditModal(original);

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
@@ -62,8 +62,9 @@ import InfoTooltip from 'src/components/InfoTooltip';
 import ImportModelsModal from 'src/components/ImportModal/index';
 import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 import WarningIconWithTooltip from 'src/components/WarningIconWithTooltip';
-import AddDatasetModal from './AddDatasetModal';
 import { isUserAdmin } from 'src/dashboard/util/findPermission';
+import AddDatasetModal from './AddDatasetModal';
+
 import {
   PAGE_SIZE,
   SORT_BY,
@@ -84,10 +85,21 @@ const Actions = styled.div`
   color: ${({ theme }) => theme.colors.grayscale.base};
 
   .disabled {
+    svg,
+    i {
+      &:hover {
+        path {
+          fill: ${({ theme }) => theme.colors.grayscale.light1};
+        }
+      }
+    }
     color: ${({ theme }) => theme.colors.grayscale.light1};
     .ant-menu-item:hover {
-      color: ${({ theme }) => theme.colors.grayscale.base};
+      color: ${({ theme }) => theme.colors.grayscale.light1};
       cursor: default;
+    }
+    &::after {
+      color: ${({ theme }) => theme.colors.grayscale.light1};
     }
   }
 `;
@@ -178,7 +190,6 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
         endpoint: `/api/v1/dataset/${id}`,
       })
         .then(({ json = {} }) => {
-          console.log(json);
           const addCertificationFields = json.result.columns.map(
             (column: ColumnObject) => {
               const {
@@ -360,15 +371,6 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
       },
       {
         Cell: ({ row: { original } }: any) => {
-          console.log(
-            'original.owners',
-            original.owners.map((o: any) => o.id),
-          );
-          console.log(
-            'allow edit',
-            original.owners.map((o: any) => o.id).includes(user.userId),
-          );
-
           // Verify owner or isAdmin
           const allowEdit =
             original.owners.map((o: any) => o.id).includes(user.userId) ||
@@ -424,7 +426,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
                           'You must be a dataset owner in order to edit. Please reach out to a dataset owner to request modifications or edit access.',
                         )
                   }
-                  placement="bottom"
+                  placement="bottomRight"
                 >
                   <span
                     role="button"

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
@@ -16,13 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  SupersetClient,
-  t,
-  styled,
-  SupersetTheme,
-  css,
-} from '@superset-ui/core';
+import { SupersetClient, t, styled } from '@superset-ui/core';
 import React, {
   FunctionComponent,
   useState,

--- a/superset/views/datasource/views.py
+++ b/superset/views/datasource/views.py
@@ -81,29 +81,15 @@ class Datasource(BaseSupersetView):
 
         if "owners" in datasource_dict and orm_datasource.owner_class is not None:
             # Check ownership
-            if app.config.get("OLD_API_CHECK_DATASET_OWNERSHIP"):
-                # mimic the behavior of the new dataset command that
-                # checks ownership and ensures that non-admins aren't locked out
-                # of the object
-                try:
-                    check_ownership(orm_datasource)
-                except SupersetSecurityException as ex:
-                    raise DatasetForbiddenError() from ex
-                user = security_manager.get_user_by_id(g.user.id)
-                datasource_dict["owners"] = populate_owners(
-                    user, datasource_dict["owners"], default_to_user=False
-                )
-            else:
-                # legacy behavior
-                datasource_dict["owners"] = (
-                    db.session.query(orm_datasource.owner_class)
-                    .filter(
-                        orm_datasource.owner_class.id.in_(
-                            datasource_dict["owners"] or []
-                        )
-                    )
-                    .all()
-                )
+            try:
+                check_ownership(orm_datasource)
+            except SupersetSecurityException as ex:
+                raise DatasetForbiddenError() from ex
+
+        user = security_manager.get_user_by_id(g.user.id)
+        datasource_dict["owners"] = populate_owners(
+            user, datasource_dict["owners"], default_to_user=False
+        )
 
         duplicates = [
             name

--- a/superset/views/datasource/views.py
+++ b/superset/views/datasource/views.py
@@ -27,7 +27,7 @@ from marshmallow import ValidationError
 from sqlalchemy.exc import NoSuchTableError
 from sqlalchemy.orm.exc import NoResultFound
 
-from superset import app, db, event_logger
+from superset import db, event_logger
 from superset.commands.utils import populate_owners
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.connectors.sqla.utils import get_physical_table_metadata

--- a/tests/integration_tests/datasource_tests.py
+++ b/tests/integration_tests/datasource_tests.py
@@ -278,6 +278,7 @@ class TestDatasource(SupersetTestCase):
 
         datasource_post = get_datasource_post()
         datasource_post["id"] = tbl_id
+        datasource_post["owners"] = [1]
         data = dict(data=json.dumps(datasource_post))
         resp = self.get_json_resp("/datasource/save/", data)
         for k in datasource_post:
@@ -321,10 +322,12 @@ class TestDatasource(SupersetTestCase):
 
     def test_save_duplicate_key(self):
         self.login(username="admin")
+        admin_user = self.get_user("admin")
         tbl_id = self.get_table(name="birth_names").id
 
         datasource_post = get_datasource_post()
         datasource_post["id"] = tbl_id
+        datasource_post["owners"] = [admin_user.id]
         datasource_post["columns"].extend(
             [
                 {
@@ -349,10 +352,12 @@ class TestDatasource(SupersetTestCase):
 
     def test_get_datasource(self):
         self.login(username="admin")
+        admin_user = self.get_user("admin")
         tbl = self.get_table(name="birth_names")
 
         datasource_post = get_datasource_post()
         datasource_post["id"] = tbl.id
+        datasource_post["owners"] = [admin_user.id]
         data = dict(data=json.dumps(datasource_post))
         self.get_json_resp("/datasource/save/", data)
         url = f"/datasource/get/{tbl.type}/{tbl.id}/"

--- a/tests/integration_tests/datasource_tests.py
+++ b/tests/integration_tests/datasource_tests.py
@@ -299,11 +299,14 @@ class TestDatasource(SupersetTestCase):
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_change_database(self):
         self.login(username="admin")
+        admin_user = self.get_user("admin")
+
         tbl = self.get_table(name="birth_names")
         tbl_id = tbl.id
         db_id = tbl.database_id
         datasource_post = get_datasource_post()
         datasource_post["id"] = tbl_id
+        datasource_post["owners"] = [admin_user.id]
 
         new_db = self.create_fake_db()
         datasource_post["database"]["id"] = new_db.id
@@ -313,6 +316,26 @@ class TestDatasource(SupersetTestCase):
         datasource_post["database"]["id"] = db_id
         resp = self.save_datasource_from_dict(datasource_post)
         self.assertEqual(resp["database"]["id"], db_id)
+
+        self.delete_fake_db()
+
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+    def test_edit_alpha_not_owner(self):
+        self.login(username="alpha")
+        alpha_user = self.get_user("alpha")
+
+        tbl = self.get_table(name="birth_names")
+        tbl_id = tbl.id
+        datasource_post = get_datasource_post()
+        datasource_post["id"] = tbl_id
+        datasource_post["owners"] = [alpha_user.id]
+
+        new_db = self.create_fake_db()
+        datasource_post["database"]["id"] = new_db.id
+
+        data = dict(data=json.dumps(datasource_post))
+        resp = self.get_json_resp("/datasource/save/", data, raise_on_error=False)
+        self.assertIn("Changing this dataset is forbidden", resp["error"])
 
         self.delete_fake_db()
 

--- a/tests/integration_tests/datasource_tests.py
+++ b/tests/integration_tests/datasource_tests.py
@@ -319,7 +319,6 @@ class TestDatasource(SupersetTestCase):
 
         self.delete_fake_db()
 
-    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_edit_alpha_not_owner(self):
         self.login(username="alpha")
         alpha_user = self.get_user("alpha")

--- a/tests/integration_tests/datasource_tests.py
+++ b/tests/integration_tests/datasource_tests.py
@@ -319,25 +319,6 @@ class TestDatasource(SupersetTestCase):
 
         self.delete_fake_db()
 
-    def test_edit_alpha_not_owner(self):
-        self.login(username="alpha")
-        alpha_user = self.get_user("alpha")
-
-        tbl = self.get_table(name="birth_names")
-        tbl_id = tbl.id
-        datasource_post = get_datasource_post()
-        datasource_post["id"] = tbl_id
-        datasource_post["owners"] = [alpha_user.id]
-
-        new_db = self.create_fake_db()
-        datasource_post["database"]["id"] = new_db.id
-
-        data = dict(data=json.dumps(datasource_post))
-        resp = self.get_json_resp("/datasource/save/", data, raise_on_error=False)
-        self.assertIn("Changing this dataset is forbidden", resp["error"])
-
-        self.delete_fake_db()
-
     def test_save_duplicate_key(self):
         self.login(username="admin")
         tbl_id = self.get_table(name="birth_names").id


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There is no longer a config value for `OLD_API_CHECK_DATASET_OWNERSHIP` due to 2.0 release. This is now allowing all users who have write permissions to edit any dataset. Adding this logic will verify if this user is an admin or owner before completing this request.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

https://user-images.githubusercontent.com/27827808/165382733-f4402f07-232c-4fb8-b445-4106302eb75f.mov

<img width="418" alt="Screen Shot 2022-04-26 at 8 50 12 PM" src="https://user-images.githubusercontent.com/27827808/165437793-a764e721-5090-4c17-88cd-e3d8d7594bf7.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
