### PR TITLE
fix: Dashboard report creation error handling

### DIFF
--- a/superset-frontend/src/components/ReportModal/index.tsx
+++ b/superset-frontend/src/components/ReportModal/index.tsx
@@ -129,7 +129,7 @@ type ReportActionType =
     }
   | {
       type: ActionType.error;
-      payload: { name: string[] };
+      payload: { name?: string[] };
     };
 
 const TEXT_BASED_VISUALIZATION_TYPES = [
@@ -175,7 +175,7 @@ const reportReducer = (
     case ActionType.error:
       return {
         ...state,
-        error: action.payload?.name[0] || defaultErrorMsg,
+        error: action.payload?.name?.[0] || defaultErrorMsg,
       };
     default:
       return state;


### PR DESCRIPTION
### SUMMARY
We hit this error internally because we allow non owners to view dashboards that are in draft mode, but then when the report DAO returned a dashboard not found error, it crashed the page. While the true fix for us is overriding the access controls for draft mode dashboards, this is also a clear bug where the error payload may not contain a `name` attribute, and thus trying to get the first element of that isn't possible.

### TESTING INSTRUCTIONS
CI, will test in our local environment to verify

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @rusackas @michael-s-molina @john-bodley 
