### PR TITLE
chore: bumping react-markdown to ^5.0.3 for downstream dependencies

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -174,7 +174,7 @@
     "react-jsonschema-form": "^1.2.0",
     "react-lines-ellipsis": "^0.15.0",
     "react-loadable": "^5.5.0",
-    "react-markdown": "^4.3.1",
+    "react-markdown": "^5.0.3",
     "react-query": "^3.39.2",
     "react-redux": "^7.2.0",
     "react-resize-detector": "^6.7.6",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Wanted to bump this package in order to bump it's innards. According to the changelog, this should be no biggie.

<img width="943" alt="Pasted_Image_4_26_22__9_44_PM" src="https://user-images.githubusercontent.com/812905/165437371-868314de-9ea7-4ef4-baf6-c67ce0651684.png">


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Spin up a test env, and make sure markdown components don't fail spectacularly :) 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
