### PR TITLE
feat(css): adds `chartId`-based class to dashboard chart holder

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/ChartHolder.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/ChartHolder.jsx
@@ -344,6 +344,7 @@ class ChartHolder extends React.Component {
               className={cx(
                 'dashboard-component',
                 'dashboard-component-chart-holder',
+                // The following class is added to support custom dashboard styling via the CSS editor
                 `dashboard-chart-id-${chartId}`,
                 this.state.outlinedComponentId ? 'fade-in' : 'fade-out',
                 isFullSize && 'full-size',

--- a/superset-frontend/src/dashboard/components/gridComponents/ChartHolder.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/ChartHolder.jsx
@@ -344,6 +344,7 @@ class ChartHolder extends React.Component {
               className={cx(
                 'dashboard-component',
                 'dashboard-component-chart-holder',
+                `dashboard-chart-id-${chartId}`,
                 this.state.outlinedComponentId ? 'fade-in' : 'fade-out',
                 isFullSize && 'full-size',
               )}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds a class to all dashboard charts, referencing their `chartID` as `dashboard-chart-id-{X}` as seen here:

<img width="665" alt="Screen_Shot_2022-04-26_at_11_28_15_PM" src="https://user-images.githubusercontent.com/812905/165609687-0edc7129-a13b-45dc-a9b7-ffb7b05a90a3.png">

This allows you to more reliably target a particular chart and do wacky CSS things with it, like so:

<img width="1219" alt="Screen Shot 2022-04-26 at 11 26 10 PM" src="https://user-images.githubusercontent.com/812905/165610573-46ff3a7d-8114-41ef-8baf-733348d6adad.png">

What you do with this new found power is up to you, and at your own risk... but it's easier to do it for a particular chart now, anyway, even if someone moves charts around on a dashboard, which was the main point of fragility in `nth-of-type` selector approaches.

The world is now your oyster
<img width="314" alt="Screen Shot 2022-04-26 at 11 26 45 PM" src="https://user-images.githubusercontent.com/812905/165618904-94965289-475d-4251-aab0-ab8f1ab058da.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Poke around at it! It shouldn't cause any harm to add a new class that has no styles attached to it.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
