### PR TITLE
fix: Cannot re-order metrics by drag and drop

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
@@ -47,6 +47,7 @@ export interface MetricOptionProps {
   showType?: boolean;
   url?: string;
   labelRef?: React.RefObject<any>;
+  shouldShowTooltip?: boolean;
 }
 
 export function MetricOption({
@@ -55,6 +56,7 @@ export function MetricOption({
   openInNewWindow = false,
   showFormula = true,
   showType = false,
+  shouldShowTooltip = true,
   url = '',
 }: MetricOptionProps) {
   const verbose = metric.verbose_name || metric.metric_name || metric.label;
@@ -64,6 +66,20 @@ export function MetricOption({
     </a>
   ) : (
     verbose
+  );
+
+  const label = (
+    <span
+      className="option-label metric-option-label"
+      css={(theme: SupersetTheme) =>
+        css`
+          margin-right: ${theme.gridUnit}px;
+        `
+      }
+      ref={labelRef}
+    >
+      {link}
+    </span>
   );
 
   const warningMarkdown = metric.warning_markdown || metric.warning_text;
@@ -77,19 +93,13 @@ export function MetricOption({
   return (
     <FlexRowContainer className="metric-option">
       {showType && <ColumnTypeLabel type="expression" />}
-      <Tooltip id="metric-name-tooltip" title={tooltipText}>
-        <span
-          className="option-label metric-option-label"
-          css={(theme: SupersetTheme) =>
-            css`
-              margin-right: ${theme.gridUnit}px;
-            `
-          }
-          ref={labelRef}
-        >
-          {link}
-        </span>
-      </Tooltip>
+      {shouldShowTooltip ? (
+        <Tooltip id="metric-name-tooltip" title={tooltipText}>
+          {label}
+        </Tooltip>
+      ) : (
+        label
+      )}
       {showFormula && metric.expression && (
         <SQLPopover sqlExpression={metric.expression} />
       )}

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
@@ -87,7 +87,11 @@ export default function DndSelectLabel({
       <HeaderContainer>
         <ControlHeader {...props} />
       </HeaderContainer>
-      <DndLabelsContainer canDrop={canDrop} isOver={isOver}>
+      <DndLabelsContainer
+        data-test="dnd-labels-container"
+        canDrop={canDrop}
+        isOver={isOver}
+      >
         {props.valuesRenderer()}
         {displayGhostButton && renderGhostButton()}
       </DndLabelsContainer>

--- a/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
+++ b/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
@@ -279,7 +279,13 @@ export const OptionControlLabel = ({
         labelRef.current.scrollWidth > labelRef.current.clientWidth);
 
     if (savedMetric && hasMetricName) {
-      return <StyledMetricOption metric={savedMetric} labelRef={labelRef} />;
+      return (
+        <StyledMetricOption
+          metric={savedMetric}
+          labelRef={labelRef}
+          shouldShowTooltip={!isDragging}
+        />
+      );
     }
     if (!shouldShowTooltip) {
       return <LabelText ref={labelRef}>{label}</LabelText>;


### PR DESCRIPTION
### SUMMARY
The metric tooltip gets in the way of re-ordering metrics, dragging over to lower the metric in the list doesn't work.

There's an architecture already in place to handle the dragging for other scenarios. This PR expands that to include the metrics, by disabling the tooltip on drag.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/17252075/165657399-4773ac88-2627-4be1-9858-484cb8dd60d3.mov

After:

https://user-images.githubusercontent.com/17252075/165657360-ee745dce-6232-4bc9-af2b-6c17821e6d13.mov


### TESTING INSTRUCTIONS
Create a chart and add to it several metrics.
Before trying to drag and drop, hover over the metric until the tooltip appears.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
