### PR TITLE
fix(allow-db-explore): make to check the allow virtual table explore option by default

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -184,7 +184,7 @@ function dbReducer(
   };
   let query = {};
   let query_input = '';
-  let deserializeExtraJSON = {};
+  let deserializeExtraJSON = { allows_virtual_table_explore: true };
   let extra_json: DatabaseObject['extra_json'];
 
   switch (action.type) {
@@ -312,6 +312,7 @@ function dbReducer(
       };
     case ActionType.fetched:
       // convert all the keys in this payload into strings
+      console.log('action.payload--->>>', action.payload);
       if (action.payload.extra) {
         extra_json = {
           ...JSON.parse(action.payload.extra || ''),

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -312,7 +312,6 @@ function dbReducer(
       };
     case ActionType.fetched:
       // convert all the keys in this payload into strings
-      console.log('action.payload--->>>', action.payload);
       if (action.payload.extra) {
         extra_json = {
           ...JSON.parse(action.payload.extra || ''),


### PR DESCRIPTION
### SUMMARY
The "Allow this database to be explored" setting should be checked by default in the Database Connection UI.

**Description**
When creating a new database connection, users are able to control which actions should be allowed on this database:
By default, Allow this database to be explored is un-checked, however this functionality is enabled on the application.

The functionality of Exploring from SQL Lab should match the Database connection UI checkbox. Since the functionality is enabled, the checkbox should be checked by default when creating a new connection.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:

https://user-images.githubusercontent.com/47900232/165761337-588d83db-a192-4e2d-997c-191388536a7d.mov

AFTER:

https://user-images.githubusercontent.com/47900232/165761311-a7c1c606-6613-44b3-8e27-2119d06d78f4.mov


### TESTING INSTRUCTIONS
**How to reproduce the bug**

1. Create a new Database connection. (Google sheets is a quick one to create)
2. Expand the SQL Lab section under the ADVANCED tab, and make sure that Allow this database to be explored is disabled.
3. Save the connection.
4. However, the functionality is working as if the box was checked:
5. Navigate to SQL Lab > SQL Editor on the top navigation bar.
6. Execute a query on this newly connected database.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
