### PR TITLE
fix: Chart download as image issue

### DIFF
--- a/superset-frontend/src/explore/components/ExploreAdditionalActionsMenu/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreAdditionalActionsMenu/index.jsx
@@ -43,6 +43,8 @@ const propTypes = {
   onOpenInEditor: PropTypes.func,
   latestQueryFormData: PropTypes.object.isRequired,
   slice: PropTypes.object,
+  canDownloadCSV: PropTypes.bool,
+  canAddReports: PropTypes.bool,
 };
 
 const MENU_KEYS = {
@@ -215,7 +217,7 @@ const ExploreAdditionalActionsMenu = ({
           break;
         case MENU_KEYS.DOWNLOAD_AS_IMAGE:
           downloadAsImage(
-            '.panel-body > .chart-container',
+            '.panel-body .chart-container',
             // eslint-disable-next-line camelcase
             slice?.slice_name ?? t('New chart'),
             {},


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This pr resolves the issue which is about downloading chart as image. 

**Why this issue happened:**

We were passing wrong query selector for chart element to `downloadAsImage()` function, which returned undefined from `document.querySelector()`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Goto chart explore page
2. Select any chart
3. Try to download chart as image from 3 dots button on top right corner.

Expected result:
Should be able to see the downloaded image of chart.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Fix Issue.
