### PR TITLE
fix(hive): Workaround for Python 3.9 s3 transfer issue

### DIFF
--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -65,6 +65,7 @@ def upload_to_s3(filename: str, upload_prefix: str, table: Table) -> str:
 
     # pylint: disable=import-outside-toplevel
     import boto3
+    from boto3.s3.transfer import TransferConfig
 
     bucket_path = current_app.config["CSV_TO_HIVE_UPLOAD_S3_BUCKET"]
 
@@ -80,6 +81,7 @@ def upload_to_s3(filename: str, upload_prefix: str, table: Table) -> str:
         filename,
         bucket_path,
         os.path.join(upload_prefix, table.table, os.path.basename(filename)),
+        Config=TransferConfig(use_threads=False),
     )
     return location
 

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -81,7 +81,7 @@ def upload_to_s3(filename: str, upload_prefix: str, table: Table) -> str:
         filename,
         bucket_path,
         os.path.join(upload_prefix, table.table, os.path.basename(filename)),
-        Config=TransferConfig(use_threads=False),
+        Config=TransferConfig(use_threads=False),  # Threading is broken in Python 3.9.
     )
     return location
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR remedies an issue we (Airbnb) were facing after upgrading to Python 3.9. Per https://github.com/boto/s3transfer/issues/197#issuecomment-1016026027 there seems to be an s3 threading with Python 3.9+ causing the transfer to fail. Disabling threading seems to mitigate the issue. Note it's unclear what the potential performance impact is, especially when uploading large files.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI and verified within an Airbnb environment.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
