### PR TITLE
fix: Fix auto-reversion of label/title in the Metrics popover

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
@@ -17,11 +17,13 @@
  * under the License.
  */
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import {
   render,
   screen,
   within,
   fireEvent,
+  waitFor,
 } from 'spec/helpers/testing-library';
 import { DndMetricSelect } from 'src/explore/components/controls/DndColumnSelectControl/DndMetricSelect';
 import { AGGREGATES } from 'src/explore/constants';
@@ -316,4 +318,82 @@ test('can drag metrics', async () => {
 
   expect(within(firstMetric).getByText('SUM(Column B)')).toBeVisible();
   expect(within(lastMetric).getByText('metric_a')).toBeVisible();
+});
+
+test('title changes on custom SQL text change', async () => {
+  let metricValues = [adhocMetricA, 'metric_b'];
+  const onChange = (val: any[]) => {
+    metricValues = [...val];
+  };
+
+  const { rerender } = render(
+    <DndMetricSelect
+      {...defaultProps}
+      value={metricValues}
+      onChange={onChange}
+      multi
+    />,
+    {
+      useDnd: true,
+    },
+  );
+
+  expect(screen.getByText('SUM(column_a)')).toBeVisible();
+
+  metricValues = [adhocMetricA, 'metric_b', 'metric_a'];
+  rerender(
+    <DndMetricSelect
+      {...defaultProps}
+      value={metricValues}
+      onChange={onChange}
+      multi
+    />,
+  );
+
+  expect(screen.getByText('SUM(column_a)')).toBeVisible();
+  expect(screen.getByText('metric_a')).toBeVisible();
+
+  fireEvent.click(screen.getByText('metric_a'));
+  expect(await screen.findByText('Custom SQL')).toBeInTheDocument();
+
+  fireEvent.click(screen.getByText('Custom SQL'));
+  expect(screen.getByText('Custom SQL').parentElement).toHaveClass(
+    'ant-tabs-tab-active',
+  );
+
+  const container = screen.getByTestId('adhoc-metric-edit-tabs');
+  await waitFor(() => {
+    const textArea = container.getElementsByClassName(
+      'ace_text-input',
+    ) as HTMLCollectionOf<HTMLTextAreaElement>;
+    expect(textArea.length).toBe(1);
+    expect(textArea[0].value).toBe('');
+  });
+
+  expect(screen.getByTestId('AdhocMetricEditTitle#trigger')).toHaveTextContent(
+    'metric_a',
+  );
+
+  const textArea = container.getElementsByClassName(
+    'ace_text-input',
+  )[0] as HTMLTextAreaElement;
+
+  // Changing the ACE editor via pasting, since the component
+  // handles the textarea value internally, and changing it doesn't
+  // trigger the onChange
+  await userEvent.paste(textArea, 'New metric');
+
+  await waitFor(() => {
+    expect(
+      screen.getByTestId('AdhocMetricEditTitle#trigger'),
+    ).toHaveTextContent('New metric');
+  });
+
+  // Ensure the title does not reset on mouse over
+  fireEvent.mouseEnter(screen.getByTestId('AdhocMetricEditTitle#trigger'));
+  fireEvent.mouseOut(screen.getByTestId('AdhocMetricEditTitle#trigger'));
+
+  expect(screen.getByTestId('AdhocMetricEditTitle#trigger')).toHaveTextContent(
+    'New metric',
+  );
 });

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useMemo } from 'react';
 import { useDrop } from 'react-dnd';
 import { t, useTheme } from '@superset-ui/core';
 import ControlHeader from 'src/explore/components/ControlHeader';
@@ -48,6 +48,7 @@ export type DndSelectLabelProps = {
 export default function DndSelectLabel({
   displayGhostButton = true,
   accept,
+  valuesRenderer,
   ...props
 }: DndSelectLabelProps) {
   const theme = useTheme();
@@ -69,6 +70,8 @@ export default function DndSelectLabel({
       type: monitor.getItemType(),
     }),
   });
+
+  const values = useMemo(() => valuesRenderer(), [valuesRenderer]);
 
   function renderGhostButton() {
     return (
@@ -92,7 +95,7 @@ export default function DndSelectLabel({
         canDrop={canDrop}
         isOver={isOver}
       >
-        {props.valuesRenderer()}
+        {values}
         {displayGhostButton && renderGhostButton()}
       </DndLabelsContainer>
     </div>


### PR DESCRIPTION
### SUMMARY
When editing a metric in the Explore, the title label that's automatically set when using the Custom SQL mode gets reset if you hover over it/change tabs/interact with the popover.

The reason is because the component is always being rerender, and in that case, the metric get's a new id and the label state is lost.

This PR caches the metric component so that it only rerenders when needed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/17252075/165856997-4b41bc4b-271e-45d9-9f1c-0b255aad68fc.mov

After:

https://user-images.githubusercontent.com/17252075/165857046-6dfae7b9-25bc-4393-bb75-6e0e1d478a4e.mov

### TESTING INSTRUCTIONS
1. Select any chart to Explore
2. Drag a new metric/edit an existing one
3. Go to Custom SQL mode
4. Enter any custom SQL

Ensure the title changes to match the sql entered.
Ensure hovering the title doesn't reset it.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
