### PR TITLE
feat(sip-68): Allow explore/form_data cache to accept sl_id + sl_type for downstream queries execution

### DIFF
--- a/superset/explore/form_data/api.py
+++ b/superset/explore/form_data/api.py
@@ -109,7 +109,9 @@ class ExploreFormDataRestApi(BaseApi, ABC):
             tab_id = request.args.get("tab_id")
             args = CommandParameters(
                 actor=g.user,
-                dataset_id=item["dataset_id"],
+                sl_id=item.get("sl_id"),
+                sl_type=item.get("sl_type"),
+                dataset_id=item.get("dataset_id"),
                 chart_id=item.get("chart_id"),
                 tab_id=tab_id,
                 form_data=item["form_data"],

--- a/superset/explore/form_data/commands/parameters.py
+++ b/superset/explore/form_data/commands/parameters.py
@@ -23,8 +23,10 @@ from flask_appbuilder.security.sqla.models import User
 @dataclass
 class CommandParameters:
     actor: User
-    dataset_id: int = 0
+    dataset_id: Optional[int] = 0
     chart_id: int = 0
     tab_id: Optional[int] = None
     key: Optional[str] = None
     form_data: Optional[str] = None
+    sl_id: Optional[int] = 0
+    sl_type: Optional[str] = None

--- a/superset/explore/form_data/commands/state.py
+++ b/superset/explore/form_data/commands/state.py
@@ -21,6 +21,8 @@ from typing_extensions import TypedDict
 
 class TemporaryExploreState(TypedDict):
     owner: int
-    dataset_id: int
+    dataset_id: Optional[int]
     chart_id: Optional[int]
     form_data: str
+    sl_id: Optional[int]
+    sl_type: Optional[str]

--- a/superset/explore/form_data/commands/update.py
+++ b/superset/explore/form_data/commands/update.py
@@ -76,6 +76,8 @@ class UpdateFormDataCommand(BaseCommand, ABC):
                     "dataset_id": dataset_id,
                     "chart_id": chart_id,
                     "form_data": form_data,
+                    "sl_id": None,
+                    "sl_type": None,
                 }
                 cache_manager.explore_form_data_cache.set(key, new_state)
             return key

--- a/superset/explore/form_data/schemas.py
+++ b/superset/explore/form_data/schemas.py
@@ -19,11 +19,23 @@ from marshmallow import fields, Schema
 
 class FormDataPostSchema(Schema):
     dataset_id = fields.Integer(
-        required=True, allow_none=False, description="The dataset ID"
+        required=False, allow_none=True, description="The dataset ID"
     )
     chart_id = fields.Integer(required=False, description="The chart ID")
     form_data = fields.String(
         required=True, allow_none=False, description="Any type of JSON supported text."
+    )
+
+    """
+    SIP - 68 Integration
+    sl_type: enum for sl_types (Query:sl_query, Dataset: sl_dataset, SavedQuery: sl_saved_query, Table: sl_table)
+    sl_id: index lookup id for given type(Query, Dataset, SavedQuery, Table) to look up
+    """
+    sl_id = fields.Integer(
+        required=False, allow_none=True, description="SIP-68 semantic layer type"
+    )
+    sl_type = fields.String(
+        required=False, allow_none=True, description="SIP-68 semantic layer id"
     )
 
 

--- a/superset/explore/utils.py
+++ b/superset/explore/utils.py
@@ -45,9 +45,10 @@ def check_dataset_access(dataset_id: int) -> Optional[bool]:
 
 
 def check_access(
-    dataset_id: int, chart_id: Optional[int], actor: User
+    dataset_id: Optional[int], chart_id: Optional[int], actor: User
 ) -> Optional[bool]:
-    check_dataset_access(dataset_id)
+    if dataset_id:
+        check_dataset_access(dataset_id)
     if not chart_id:
         return True
     chart = ChartDAO.find_by_id(chart_id)

--- a/tests/integration_tests/explore/form_data/api_tests.py
+++ b/tests/integration_tests/explore/form_data/api_tests.py
@@ -74,6 +74,8 @@ def cache(chart_id, admin_id, dataset_id):
         "dataset_id": dataset_id,
         "chart_id": chart_id,
         "form_data": INITIAL_FORM_DATA,
+        "sl_type": None,
+        "sl_id": None,
     }
     cache_manager.explore_form_data_cache.set(KEY, entry)
 
@@ -84,6 +86,28 @@ def test_post(client, chart_id: int, dataset_id: int):
         "dataset_id": dataset_id,
         "chart_id": chart_id,
         "form_data": INITIAL_FORM_DATA,
+    }
+    resp = client.post("api/v1/explore/form_data", json=payload)
+    assert resp.status_code == 201
+
+
+def test_post_with_sqllab_query(client, chart_id: int):
+    login(client, "admin")
+    form_data = {
+        "datasource": "100__query",  # using {id}__{type} format
+        "adhoc_filters": [],
+        "viz_type": "sankey",
+        "groupby": ["target"],
+        "metric": "sum__value",
+        "row_limit": 5000,
+        "slice_id": chart_id,
+        "time_range_endpoints": ["inclusive", "exclusive"],
+    }
+    payload = {
+        "sl_type": "query",
+        "sl_id": 100,
+        "chart_id": chart_id,
+        "form_data": json.dumps(form_data),
     }
     resp = client.post("api/v1/explore/form_data", json=payload)
     assert resp.status_code == 201
@@ -372,6 +396,8 @@ def test_delete_not_owner(client, chart_id: int, dataset_id: int, admin_id: int)
         "dataset_id": dataset_id,
         "chart_id": chart_id,
         "form_data": INITIAL_FORM_DATA,
+        "sl_type": None,
+        "sl_id": None,
     }
     cache_manager.explore_form_data_cache.set(another_key, entry)
     login(client, "admin")


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
For us to power a chart using SIP-68 models we are rewriting the API to allow users to submit both the `type` and `id` for `Query`, `SavedQuery`, `Table`, `Dataset` in this example we are prioritizing queries and will add more type later.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
