### PR TITLE
feat: simplify `memoized_func`

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -514,7 +514,7 @@ class Database(
         return sqla.inspect(engine)
 
     @cache_util.memoized_func(
-        key=lambda self, *args, **kwargs: f"db:{self.id}:schema:None:table_list",
+        key="db:{self.id}:schema:None:table_list",
         cache=cache_manager.data_cache,
     )
     def get_all_table_names_in_database(  # pylint: disable=unused-argument
@@ -529,7 +529,7 @@ class Database(
         return self.db_engine_spec.get_all_datasource_names(self, "table")
 
     @cache_util.memoized_func(
-        key=lambda self, *args, **kwargs: f"db:{self.id}:schema:None:view_list",
+        key="db:{self.id}:schema:None:view_list",
         cache=cache_manager.data_cache,
     )
     def get_all_view_names_in_database(  # pylint: disable=unused-argument
@@ -544,7 +544,7 @@ class Database(
         return self.db_engine_spec.get_all_datasource_names(self, "view")
 
     @cache_util.memoized_func(
-        key=lambda self, schema, *args, **kwargs: f"db:{self.id}:schema:{schema}:table_list",  # pylint: disable=line-too-long,useless-suppression
+        key="db:{self.id}:schema:{schema}:table_list",
         cache=cache_manager.data_cache,
     )
     def get_all_table_names_in_schema(  # pylint: disable=unused-argument
@@ -577,7 +577,7 @@ class Database(
             return []
 
     @cache_util.memoized_func(
-        key=lambda self, schema, *args, **kwargs: f"db:{self.id}:schema:{schema}:view_list",  # pylint: disable=line-too-long,useless-suppression
+        key="db:{self.id}:schema:{schema}:view_list",
         cache=cache_manager.data_cache,
     )
     def get_all_view_names_in_schema(  # pylint: disable=unused-argument
@@ -608,7 +608,7 @@ class Database(
             return []
 
     @cache_util.memoized_func(
-        key=lambda self, *args, **kwargs: f"db:{self.id}:schema_list",
+        key="db:{self.id}:schema_list",
         cache=cache_manager.data_cache,
     )
     def get_all_schema_names(  # pylint: disable=unused-argument

--- a/tests/unit_tests/utils/cache_test.py
+++ b/tests/unit_tests/utils/cache_test.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# pylint: disable=import-outside-toplevel, unused-argument
+
+from pytest_mock import MockerFixture
+
+
+def test_memoized_func(app_context: None, mocker: MockerFixture) -> None:
+    """
+    Test the ``memoized_func`` decorator.
+    """
+    from superset.utils.cache import memoized_func
+
+    cache = mocker.MagicMock()
+
+    decorator = memoized_func("db:{self.id}:schema:{schema}:view_list", cache)
+    decorated = decorator(lambda self, schema, cache=False: 42)
+
+    self = mocker.MagicMock()
+    self.id = 1
+
+    # skip cache
+    result = decorated(self, "public", cache=False)
+    assert result == 42
+    cache.get.assert_not_called()
+
+    # check cache, no cached value
+    cache.get.return_value = None
+    result = decorated(self, "public", cache=True)
+    assert result == 42
+    cache.get.assert_called_with("db:1:schema:public:view_list")
+
+    # check cache, cached value
+    cache.get.return_value = 43
+    result = decorated(self, "public", cache=True)
+    assert result == 43


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The `memoized_func` decorator takes a function `key` to compute the cache key based on the arguments passed to the decorated function. The same behavior can be obtained by simply passing a string as the key, and formatting it using the arguments.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

I added some unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
