### PR TITLE
fix: Refactor SQL engine username logic

### DIFF
--- a/superset/cli/update.py
+++ b/superset/cli/update.py
@@ -31,6 +31,7 @@ from flask_appbuilder.api.manager import resolver
 
 import superset.utils.database as database_utils
 from superset.extensions import db
+from superset.utils.core import override_user
 from superset.utils.encrypt import SecretsMigrator
 
 logger = logging.getLogger(__name__)
@@ -54,23 +55,34 @@ def set_database_uri(database_name: str, uri: str, skip_create: bool) -> None:
 
 @click.command()
 @with_appcontext
-def update_datasources_cache() -> None:
+@click.option(
+    "--username",
+    "-u",
+    default=None,
+    help=(
+        "Specify which user should execute the underlying SQL queries. If undefined "
+        "defaults to the user registered with the database connection."
+    ),
+)
+def update_datasources_cache(username: Optional[str]) -> None:
     """Refresh sqllab datasources cache"""
     # pylint: disable=import-outside-toplevel
+    from superset import security_manager
     from superset.models.core import Database
 
-    for database in db.session.query(Database).all():
-        if database.allow_multi_schema_metadata_fetch:
-            print("Fetching {} datasources ...".format(database.name))
-            try:
-                database.get_all_table_names_in_database(
-                    force=True, cache=True, cache_timeout=24 * 60 * 60
-                )
-                database.get_all_view_names_in_database(
-                    force=True, cache=True, cache_timeout=24 * 60 * 60
-                )
-            except Exception as ex:  # pylint: disable=broad-except
-                print("{}".format(str(ex)))
+    with override_user(security_manager.find_user(username)):
+        for database in db.session.query(Database).all():
+            if database.allow_multi_schema_metadata_fetch:
+                print("Fetching {} datasources ...".format(database.name))
+                try:
+                    database.get_all_table_names_in_database(
+                        force=True, cache=True, cache_timeout=24 * 60 * 60
+                    )
+                    database.get_all_view_names_in_database(
+                        force=True, cache=True, cache_timeout=24 * 60 * 60
+                    )
+                except Exception as ex:  # pylint: disable=broad-except
+                    print("{}".format(str(ex)))
 
 
 @click.command()

--- a/superset/config.py
+++ b/superset/config.py
@@ -680,7 +680,7 @@ BACKUP_COUNT = 30
 #     database,
 #     query,
 #     schema=None,
-#     user=None,
+#     user=None,  # TODO(john-bodley): Deprecate in 3.0.
 #     client=None,
 #     security_manager=None,
 #     log_params=None,
@@ -1020,9 +1020,14 @@ DB_CONNECTION_MUTATOR = None
 # The use case is can be around adding some sort of comment header
 # with information such as the username and worker node information
 #
-#    def SQL_QUERY_MUTATOR(sql, user_name=user_name, security_manager=security_manager, database=database):
+#    def SQL_QUERY_MUTATOR(
+#        sql,
+#        user_name=user_name,  # TODO(john-bodley): Deprecate in 3.0.
+#        security_manager=security_manager,
+#        database=database,
+#    ):
 #        dttm = datetime.now().isoformat()
-#        return f"-- [SQL LAB] {username} {dttm}\n{sql}"
+#        return f"-- [SQL LAB] {user_name} {dttm}\n{sql}"
 # For backward compatibility, you can unpack any of the above arguments in your
 # function definition, but keep the **kwargs as the last argument to allow new args
 # to be added later without any errors.

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -120,6 +120,7 @@ from superset.utils import core as utils
 from superset.utils.core import (
     GenericDataType,
     get_column_name,
+    get_username,
     is_adhoc_column,
     MediumText,
     QueryObjectFilterClause,
@@ -917,10 +918,9 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
         Typically adds comments to the query with context"""
         sql_query_mutator = config["SQL_QUERY_MUTATOR"]
         if sql_query_mutator:
-            username = utils.get_username()
             sql = sql_query_mutator(
                 sql,
-                user_name=username,
+                user_name=get_username(),  # TODO(john-bodley): Deprecate in 3.0.
                 security_manager=security_manager,
                 database=self.database,
             )

--- a/superset/databases/commands/validate.py
+++ b/superset/databases/commands/validate.py
@@ -35,6 +35,7 @@ from superset.db_engine_specs.base import BasicParametersMixin
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.extensions import event_logger
 from superset.models.core import Database
+from superset.utils.core import override_user
 
 BYPASS_VALIDATION_ENGINES = {"bigquery"}
 
@@ -115,22 +116,23 @@ class ValidateDatabaseParametersCommand(BaseCommand):
         )
         database.set_sqlalchemy_uri(sqlalchemy_uri)
         database.db_engine_spec.mutate_db_for_connection_test(database)
-        username = self._actor.username if self._actor is not None else None
-        engine = database.get_sqla_engine(user_name=username)
-        try:
-            with closing(engine.raw_connection()) as conn:
-                alive = engine.dialect.do_ping(conn)
-        except Exception as ex:
-            url = make_url_safe(sqlalchemy_uri)
-            context = {
-                "hostname": url.host,
-                "password": url.password,
-                "port": url.port,
-                "username": url.username,
-                "database": url.database,
-            }
-            errors = database.db_engine_spec.extract_errors(ex, context)
-            raise DatabaseTestConnectionFailedError(errors) from ex
+
+        with override_user(self._actor):
+            engine = database.get_sqla_engine()
+            try:
+                with closing(engine.raw_connection()) as conn:
+                    alive = engine.dialect.do_ping(conn)
+            except Exception as ex:
+                url = make_url_safe(sqlalchemy_uri)
+                context = {
+                    "hostname": url.host,
+                    "password": url.password,
+                    "port": url.port,
+                    "username": url.username,
+                    "database": url.database,
+                }
+                errors = database.db_engine_spec.extract_errors(ex, context)
+                raise DatabaseTestConnectionFailedError(errors) from ex
 
         if not alive:
             raise DatabaseOfflineError(

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -25,7 +25,7 @@ from celery.exceptions import SoftTimeLimitExceeded
 from flask_appbuilder.security.sqla.models import User
 from sqlalchemy.orm import Session
 
-from superset import app
+from superset import app, security_manager
 from superset.commands.base import BaseCommand
 from superset.commands.exceptions import CommandException
 from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
@@ -179,11 +179,10 @@ class BaseReportState:
             **kwargs,
         )
 
-    def _get_user(self) -> User:
-        user = (
-            self._session.query(User)
-            .filter(User.username == app.config["THUMBNAIL_SELENIUM_USER"])
-            .one_or_none()
+    @staticmethod
+    def _get_user() -> User:
+        user = security_manager.find_user(
+            username=app.config["THUMBNAIL_SELENIUM_USER"]
         )
         if not user:
             raise ReportScheduleSelleniumUserNotFoundError()

--- a/superset/sql_validators/presto_db.py
+++ b/superset/sql_validators/presto_db.py
@@ -20,13 +20,11 @@ import time
 from contextlib import closing
 from typing import Any, Dict, List, Optional
 
-from flask import g
-
 from superset import app, security_manager
 from superset.models.core import Database
 from superset.sql_parse import ParsedQuery
 from superset.sql_validators.base import BaseSQLValidator, SQLValidationAnnotation
-from superset.utils.core import QuerySource
+from superset.utils.core import get_username, QuerySource
 
 MAX_ERROR_ROWS = 10
 
@@ -45,7 +43,10 @@ class PrestoDBSQLValidator(BaseSQLValidator):
 
     @classmethod
     def validate_statement(
-        cls, statement: str, database: Database, cursor: Any, user_name: str
+        cls,
+        statement: str,
+        database: Database,
+        cursor: Any,
     ) -> Optional[SQLValidationAnnotation]:
         # pylint: disable=too-many-locals
         db_engine_spec = database.db_engine_spec
@@ -57,7 +58,7 @@ class PrestoDBSQLValidator(BaseSQLValidator):
         if sql_query_mutator:
             sql = sql_query_mutator(
                 sql,
-                user_name=user_name,
+                user_name=get_username(),  # TODO(john-bodley): Deprecate in 3.0.
                 security_manager=security_manager,
                 database=database,
             )
@@ -157,26 +158,18 @@ class PrestoDBSQLValidator(BaseSQLValidator):
         For example, "SELECT 1 FROM default.mytable" becomes "EXPLAIN (TYPE
         VALIDATE) SELECT 1 FROM default.mytable.
         """
-        user_name = g.user.username if g.user and hasattr(g.user, "username") else None
         parsed_query = ParsedQuery(sql)
         statements = parsed_query.get_statements()
 
         logger.info("Validating %i statement(s)", len(statements))
-        engine = database.get_sqla_engine(
-            schema=schema,
-            nullpool=True,
-            user_name=user_name,
-            source=QuerySource.SQL_LAB,
-        )
+        engine = database.get_sqla_engine(schema, source=QuerySource.SQL_LAB)
         # Sharing a single connection and cursor across the
         # execution of all statements (if many)
         annotations: List[SQLValidationAnnotation] = []
         with closing(engine.raw_connection()) as conn:
             cursor = conn.cursor()
             for statement in parsed_query.get_statements():
-                annotation = cls.validate_statement(
-                    statement, database, cursor, user_name
-                )
+                annotation = cls.validate_statement(statement, database, cursor)
                 if annotation:
                     annotations.append(annotation)
         logger.debug("Validation found %i error(s)", len(annotations))

--- a/superset/sqllab/sql_json_executer.py
+++ b/superset/sqllab/sql_json_executer.py
@@ -22,7 +22,6 @@ import logging
 from abc import ABC
 from typing import Any, Callable, Dict, Optional, TYPE_CHECKING
 
-from flask import g
 from flask_babel import gettext as __
 
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
@@ -34,6 +33,7 @@ from superset.exceptions import (
 )
 from superset.sqllab.command_status import SqlJsonExecutionStatus
 from superset.utils import core as utils
+from superset.utils.core import get_username
 from superset.utils.dates import now_as_float
 
 if TYPE_CHECKING:
@@ -139,9 +139,7 @@ class SynchronousSqlJsonExecutor(SqlJsonExecutorBase):
             rendered_query,
             return_results=True,
             store_results=self._is_store_results(execution_context),
-            user_name=g.user.username
-            if g.user and hasattr(g.user, "username")
-            else None,
+            username=get_username(),
             expand_data=execution_context.expand_data,
             log_params=log_params,
         )
@@ -174,9 +172,7 @@ class ASynchronousSqlJsonExecutor(SqlJsonExecutorBase):
                 rendered_query,
                 return_results=False,
                 store_results=not execution_context.select_as_cta,
-                user_name=g.user.username
-                if g.user and hasattr(g.user, "username")
-                else None,
+                username=get_username(),
                 start_time=now_as_float(),
                 expand_data=execution_context.expand_data,
                 log_params=log_params,

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1367,11 +1367,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             )
             database.set_sqlalchemy_uri(uri)
             database.db_engine_spec.mutate_db_for_connection_test(database)
-
-            username = (
-                g.user.username if g.user and hasattr(g.user, "username") else None
-            )
-            engine = database.get_sqla_engine(user_name=username)
+            engine = database.get_sqla_engine()
 
             with closing(engine.raw_connection()) as conn:
                 if engine.dialect.do_ping(conn):
@@ -2298,7 +2294,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             )
             return self.json_response("OK")
 
-        if not sql_lab.cancel_query(query, g.user.username if g.user else None):
+        if not sql_lab.cancel_query(query):
             raise SupersetCancelQueryException("Could not cancel query")
 
         query.status = QueryStatus.STOPPED

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,8 +28,11 @@ from __future__ import annotations
 from typing import Callable, TYPE_CHECKING
 from unittest.mock import MagicMock, Mock, PropertyMock
 
+from flask import Flask
+from flask.ctx import AppContext
 from pytest import fixture
 
+from superset.app import create_app
 from tests.example_data.data_loading.pandas.pandas_data_loader import PandasDataLoader
 from tests.example_data.data_loading.pandas.pands_data_loading_conf import (
     PandasLoaderConfigurations,

--- a/tests/integration_tests/base_tests.py
+++ b/tests/integration_tests/base_tests.py
@@ -329,7 +329,7 @@ class SupersetTestCase(TestCase):
         self,
         sql,
         client_id=None,
-        user_name=None,
+        username=None,
         raise_on_error=False,
         query_limit=None,
         database_name="examples",
@@ -340,9 +340,9 @@ class SupersetTestCase(TestCase):
         ctas_method=CtasMethod.TABLE,
         template_params="{}",
     ):
-        if user_name:
+        if username:
             self.logout()
-            self.login(username=(user_name or "admin"))
+            self.login(username=username)
         dbid = SupersetTestCase.get_database_by_name(database_name).id
         json_payload = {
             "database_id": dbid,
@@ -427,14 +427,14 @@ class SupersetTestCase(TestCase):
         self,
         sql,
         client_id=None,
-        user_name=None,
+        username=None,
         raise_on_error=False,
         database_name="examples",
         template_params=None,
     ):
-        if user_name:
+        if username:
             self.logout()
-            self.login(username=(user_name if user_name else "admin"))
+            self.login(username=username)
         dbid = SupersetTestCase.get_database_by_name(database_name).id
         resp = self.get_json_resp(
             "/superset/validate_sql_json/",

--- a/tests/integration_tests/core_tests.py
+++ b/tests/integration_tests/core_tests.py
@@ -1064,7 +1064,7 @@ class TestCore(SupersetTestCase):
             LIMIT 10;
             """,
             client_id="client_id_1",
-            user_name="admin",
+            username="admin",
         )
         count_ds = []
         count_name = []
@@ -1454,7 +1454,7 @@ class TestCore(SupersetTestCase):
         self.run_sql(
             "SELECT name FROM birth_names",
             "client_id_1",
-            user_name=username,
+            username=username,
             raise_on_error=True,
             sql_editor_id=str(tab_state_id),
         )
@@ -1462,7 +1462,7 @@ class TestCore(SupersetTestCase):
         self.run_sql(
             "SELECT name FROM birth_names",
             "client_id_2",
-            user_name=username,
+            username=username,
             raise_on_error=True,
         )
 

--- a/tests/integration_tests/model_tests.py
+++ b/tests/integration_tests/model_tests.py
@@ -20,8 +20,10 @@ import textwrap
 import unittest
 from unittest import mock
 
+from superset import security_manager
 from superset.connectors.sqla.models import SqlaTable
 from superset.exceptions import SupersetException
+from superset.utils.core import override_user
 from tests.integration_tests.fixtures.birth_names_dashboard import (
     load_birth_names_dashboard_with_slices,
     load_birth_names_data,
@@ -112,21 +114,22 @@ class TestDatabaseModel(SupersetTestCase):
     )
     def test_database_impersonate_user(self):
         uri = "mysql://root@localhost"
-        example_user = "giuseppe"
+        example_user = security_manager.find_user(username="gamma")
         model = Database(database_name="test_database", sqlalchemy_uri=uri)
 
-        model.impersonate_user = True
-        user_name = make_url(model.get_sqla_engine(user_name=example_user).url).username
-        self.assertEqual(example_user, user_name)
+        with override_user(example_user):
+            model.impersonate_user = True
+            username = make_url(model.get_sqla_engine().url).username
+            self.assertEqual(example_user.username, username)
 
-        model.impersonate_user = False
-        user_name = make_url(model.get_sqla_engine(user_name=example_user).url).username
-        self.assertNotEqual(example_user, user_name)
+            model.impersonate_user = False
+            username = make_url(model.get_sqla_engine().url).username
+            self.assertNotEqual(example_user.username, username)
 
     @mock.patch("superset.models.core.create_engine")
     def test_impersonate_user_presto(self, mocked_create_engine):
         uri = "presto://localhost"
-        principal_user = "logged_in_user"
+        principal_user = security_manager.find_user(username="gamma")
         extra = """
                 {
                     "metadata_params": {},
@@ -142,64 +145,66 @@ class TestDatabaseModel(SupersetTestCase):
                 }
                 """
 
-        model = Database(database_name="test_database", sqlalchemy_uri=uri, extra=extra)
+        with override_user(principal_user):
+            model = Database(
+                database_name="test_database", sqlalchemy_uri=uri, extra=extra
+            )
+            model.impersonate_user = True
+            model.get_sqla_engine()
+            call_args = mocked_create_engine.call_args
 
-        model.impersonate_user = True
-        model.get_sqla_engine(user_name=principal_user)
-        call_args = mocked_create_engine.call_args
+            assert str(call_args[0][0]) == "presto://gamma@localhost"
 
-        assert str(call_args[0][0]) == "presto://logged_in_user@localhost"
+            assert call_args[1]["connect_args"] == {
+                "protocol": "https",
+                "username": "original_user",
+                "password": "original_user_password",
+                "principal_username": "gamma",
+            }
 
-        assert call_args[1]["connect_args"] == {
-            "protocol": "https",
-            "username": "original_user",
-            "password": "original_user_password",
-            "principal_username": "logged_in_user",
-        }
+            model.impersonate_user = False
+            model.get_sqla_engine()
+            call_args = mocked_create_engine.call_args
 
-        model.impersonate_user = False
-        model.get_sqla_engine(user_name=principal_user)
-        call_args = mocked_create_engine.call_args
+            assert str(call_args[0][0]) == "presto://localhost"
 
-        assert str(call_args[0][0]) == "presto://localhost"
-
-        assert call_args[1]["connect_args"] == {
-            "protocol": "https",
-            "username": "original_user",
-            "password": "original_user_password",
-        }
+            assert call_args[1]["connect_args"] == {
+                "protocol": "https",
+                "username": "original_user",
+                "password": "original_user_password",
+            }
 
     @mock.patch("superset.models.core.create_engine")
     def test_impersonate_user_trino(self, mocked_create_engine):
-        uri = "trino://localhost"
-        principal_user = "logged_in_user"
+        principal_user = security_manager.find_user(username="gamma")
 
-        model = Database(database_name="test_database", sqlalchemy_uri=uri)
+        with override_user(principal_user):
+            model = Database(
+                database_name="test_database", sqlalchemy_uri="trino://localhost"
+            )
+            model.impersonate_user = True
+            model.get_sqla_engine()
+            call_args = mocked_create_engine.call_args
 
-        model.impersonate_user = True
-        model.get_sqla_engine(user_name=principal_user)
-        call_args = mocked_create_engine.call_args
+            assert str(call_args[0][0]) == "trino://localhost"
+            assert call_args[1]["connect_args"] == {"user": "gamma"}
 
-        assert str(call_args[0][0]) == "trino://localhost"
+            model = Database(
+                database_name="test_database",
+                sqlalchemy_uri="trino://original_user:original_user_password@localhost",
+            )
 
-        assert call_args[1]["connect_args"] == {
-            "user": "logged_in_user",
-        }
+            model.impersonate_user = True
+            model.get_sqla_engine()
+            call_args = mocked_create_engine.call_args
 
-        uri = "trino://original_user:original_user_password@localhost"
-        model = Database(database_name="test_database", sqlalchemy_uri=uri)
-        model.impersonate_user = True
-        model.get_sqla_engine(user_name=principal_user)
-        call_args = mocked_create_engine.call_args
-
-        assert str(call_args[0][0]) == "trino://original_user@localhost"
-
-        assert call_args[1]["connect_args"] == {"user": "logged_in_user"}
+            assert str(call_args[0][0]) == "trino://original_user@localhost"
+            assert call_args[1]["connect_args"] == {"user": "gamma"}
 
     @mock.patch("superset.models.core.create_engine")
     def test_impersonate_user_hive(self, mocked_create_engine):
         uri = "hive://localhost"
-        principal_user = "logged_in_user"
+        principal_user = security_manager.find_user(username="gamma")
         extra = """
                 {
                     "metadata_params": {},
@@ -215,32 +220,34 @@ class TestDatabaseModel(SupersetTestCase):
                 }
                 """
 
-        model = Database(database_name="test_database", sqlalchemy_uri=uri, extra=extra)
+        with override_user(principal_user):
+            model = Database(
+                database_name="test_database", sqlalchemy_uri=uri, extra=extra
+            )
+            model.impersonate_user = True
+            model.get_sqla_engine()
+            call_args = mocked_create_engine.call_args
 
-        model.impersonate_user = True
-        model.get_sqla_engine(user_name=principal_user)
-        call_args = mocked_create_engine.call_args
+            assert str(call_args[0][0]) == "hive://localhost"
 
-        assert str(call_args[0][0]) == "hive://localhost"
+            assert call_args[1]["connect_args"] == {
+                "protocol": "https",
+                "username": "original_user",
+                "password": "original_user_password",
+                "configuration": {"hive.server2.proxy.user": "gamma"},
+            }
 
-        assert call_args[1]["connect_args"] == {
-            "protocol": "https",
-            "username": "original_user",
-            "password": "original_user_password",
-            "configuration": {"hive.server2.proxy.user": "logged_in_user"},
-        }
+            model.impersonate_user = False
+            model.get_sqla_engine()
+            call_args = mocked_create_engine.call_args
 
-        model.impersonate_user = False
-        model.get_sqla_engine(user_name=principal_user)
-        call_args = mocked_create_engine.call_args
+            assert str(call_args[0][0]) == "hive://localhost"
 
-        assert str(call_args[0][0]) == "hive://localhost"
-
-        assert call_args[1]["connect_args"] == {
-            "protocol": "https",
-            "username": "original_user",
-            "password": "original_user_password",
-        }
+            assert call_args[1]["connect_args"] == {
+                "protocol": "https",
+                "username": "original_user",
+                "password": "original_user_password",
+            }
 
     @pytest.mark.usefixtures("load_energy_table_with_slice")
     def test_select_star(self):
@@ -344,19 +351,6 @@ class TestDatabaseModel(SupersetTestCase):
 
             df = main_db.get_df("USE superset; SELECT ';';", None)
             self.assertEqual(df.iat[0, 0], ";")
-
-    @mock.patch("superset.models.core.Database.get_sqla_engine")
-    def test_username_param(self, mocked_get_sqla_engine):
-        main_db = get_example_database()
-        main_db.impersonate_user = True
-        test_username = "test_username_param"
-
-        if main_db.backend == "mysql":
-            main_db.get_df("USE superset; SELECT 1", username=test_username)
-            mocked_get_sqla_engine.assert_called_with(
-                schema=None,
-                user_name="test_username_param",
-            )
 
     @mock.patch("superset.models.core.create_engine")
     def test_get_sqla_engine(self, mocked_create_engine):

--- a/tests/integration_tests/sql_validator_tests.py
+++ b/tests/integration_tests/sql_validator_tests.py
@@ -187,7 +187,7 @@ class TestPrestoValidator(SupersetTestCase):
         "message": "your query isn't how I like it",
     }
 
-    @patch("superset.sql_validators.presto_db.g")
+    @patch("superset.utils.core.g")
     def test_validator_success(self, flask_g):
         flask_g.user.username = "nobody"
         sql = "SELECT 1 FROM default.notarealtable"
@@ -197,7 +197,7 @@ class TestPrestoValidator(SupersetTestCase):
 
         self.assertEqual([], errors)
 
-    @patch("superset.sql_validators.presto_db.g")
+    @patch("superset.utils.core.g")
     def test_validator_db_error(self, flask_g):
         flask_g.user.username = "nobody"
         sql = "SELECT 1 FROM default.notarealtable"
@@ -209,7 +209,7 @@ class TestPrestoValidator(SupersetTestCase):
         with self.assertRaises(PrestoSQLValidationError):
             self.validator.validate(sql, schema, self.database)
 
-    @patch("superset.sql_validators.presto_db.g")
+    @patch("superset.utils.core.g")
     def test_validator_unexpected_error(self, flask_g):
         flask_g.user.username = "nobody"
         sql = "SELECT 1 FROM default.notarealtable"
@@ -221,7 +221,7 @@ class TestPrestoValidator(SupersetTestCase):
         with self.assertRaises(Exception):
             self.validator.validate(sql, schema, self.database)
 
-    @patch("superset.sql_validators.presto_db.g")
+    @patch("superset.utils.core.g")
     def test_validator_query_error(self, flask_g):
         flask_g.user.username = "nobody"
         sql = "SELECT 1 FROM default.notarealtable"

--- a/tests/integration_tests/sqllab_tests.py
+++ b/tests/integration_tests/sqllab_tests.py
@@ -68,9 +68,9 @@ class TestSqlLab(SupersetTestCase):
     def run_some_queries(self):
         db.session.query(Query).delete()
         db.session.commit()
-        self.run_sql(QUERY_1, client_id="client_id_1", user_name="admin")
-        self.run_sql(QUERY_2, client_id="client_id_3", user_name="admin")
-        self.run_sql(QUERY_3, client_id="client_id_2", user_name="gamma_sqllab")
+        self.run_sql(QUERY_1, client_id="client_id_1", username="admin")
+        self.run_sql(QUERY_2, client_id="client_id_3", username="admin")
+        self.run_sql(QUERY_3, client_id="client_id_2", username="gamma_sqllab")
         self.logout()
 
     def tearDown(self):
@@ -162,7 +162,7 @@ class TestSqlLab(SupersetTestCase):
         db.session.commit()
 
         with freeze_time(datetime.now().isoformat(timespec="seconds")):
-            self.run_sql(sql_statement, "1")
+            self.run_sql(sql_statement, "1", username="admin")
             saved_query_ = (
                 db.session.query(SavedQuery)
                 .filter(
@@ -248,7 +248,7 @@ class TestSqlLab(SupersetTestCase):
         # Gamma user, with sqllab and db permission
         self.create_user_with_roles("Gagarin", ["ExampleDBAccess", "Gamma", "sql_lab"])
 
-        data = self.run_sql(QUERY_1, "1", user_name="Gagarin")
+        data = self.run_sql(QUERY_1, "1", username="Gagarin")
         db.session.query(Query).delete()
         db.session.commit()
         self.assertLess(0, len(data["data"]))
@@ -278,14 +278,14 @@ class TestSqlLab(SupersetTestCase):
         )
 
         data = self.run_sql(
-            f"SELECT * FROM {CTAS_SCHEMA_NAME}.test_table", "3", user_name="SchemaUser"
+            f"SELECT * FROM {CTAS_SCHEMA_NAME}.test_table", "3", username="SchemaUser"
         )
         self.assertEqual(1, len(data["data"]))
 
         data = self.run_sql(
             f"SELECT * FROM {CTAS_SCHEMA_NAME}.test_table",
             "4",
-            user_name="SchemaUser",
+            username="SchemaUser",
             schema=CTAS_SCHEMA_NAME,
         )
         self.assertEqual(1, len(data["data"]))
@@ -295,7 +295,7 @@ class TestSqlLab(SupersetTestCase):
             data = self.run_sql(
                 "SELECT * FROM test_table",
                 "5",
-                user_name="SchemaUser",
+                username="SchemaUser",
                 schema=CTAS_SCHEMA_NAME,
             )
             self.assertEqual(1, len(data["data"]))
@@ -441,7 +441,7 @@ class TestSqlLab(SupersetTestCase):
         self.run_sql(
             "SELECT name as col, gender as col FROM birth_names LIMIT 10",
             client_id="2e2df3",
-            user_name="admin",
+            username="admin",
             raise_on_error=True,
         )
 
@@ -747,7 +747,6 @@ class TestSqlLab(SupersetTestCase):
             rendered_query=sql,
             return_results=True,
             store_results=False,
-            user_name="admin",
             session=mock_session,
             start_time=None,
             expand_data=False,
@@ -758,7 +757,6 @@ class TestSqlLab(SupersetTestCase):
                 mock.call(
                     "SET @value = 42",
                     mock_query,
-                    "admin",
                     mock_session,
                     mock_cursor,
                     None,
@@ -767,7 +765,6 @@ class TestSqlLab(SupersetTestCase):
                 mock.call(
                     "SELECT @value AS foo",
                     mock_query,
-                    "admin",
                     mock_session,
                     mock_cursor,
                     None,
@@ -804,7 +801,6 @@ class TestSqlLab(SupersetTestCase):
                 rendered_query=sql,
                 return_results=True,
                 store_results=False,
-                user_name="admin",
                 session=mock_session,
                 start_time=None,
                 expand_data=False,
@@ -858,7 +854,6 @@ class TestSqlLab(SupersetTestCase):
             rendered_query=sql,
             return_results=True,
             store_results=False,
-            user_name="admin",
             session=mock_session,
             start_time=None,
             expand_data=False,
@@ -869,7 +864,6 @@ class TestSqlLab(SupersetTestCase):
                 mock.call(
                     "SET @value = 42",
                     mock_query,
-                    "admin",
                     mock_session,
                     mock_cursor,
                     None,
@@ -878,7 +872,6 @@ class TestSqlLab(SupersetTestCase):
                 mock.call(
                     "SELECT @value AS foo",
                     mock_query,
-                    "admin",
                     mock_session,
                     mock_cursor,
                     None,
@@ -895,7 +888,6 @@ class TestSqlLab(SupersetTestCase):
                 rendered_query=sql,
                 return_results=True,
                 store_results=False,
-                user_name="admin",
                 session=mock_session,
                 start_time=None,
                 expand_data=False,
@@ -929,7 +921,6 @@ class TestSqlLab(SupersetTestCase):
                 rendered_query=sql,
                 return_results=True,
                 store_results=False,
-                user_name="admin",
                 session=mock_session,
                 start_time=None,
                 expand_data=False,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR fixes a number of issues (some cosmetic) with the SQL username. Specifically:

1. The username was referred to  as both `username` and `user_name`. The inconsistency added undue complexity.
2. It a number of places the `g.user.username` was passed as the `username` argument of the `get_sqla_engine` function (or similar) even when it was the default fallback. This added unnecessary complexity, i.e., from reading the code it wasn't apparent when/why the username would be overridden. In reality it mostly isn't, i.e., it should always be the logged in user unless the query is being executed from Celery—where there is no user logged in.
3. The logic introduced in https://github.com/apache/superset/pull/17499 wasn't suffice, in actuality it likely added more complexity, as although it tried to ensure that the `get_df` for the alert was executed by the passed in user, if the underlying query used Jinja templating for fetching the the latest partition or similar those queries were executed by the user defined in the SQLAlchemy URI (if defined; falling back to the system user)—leveraging the SQLAlchemy inspector—per [here](https://github.com/apache/superset/blob/aff10a7fad0b6a48c578e70d2746d04bdf4d753c/superset/models/core.py#L511-L514). 

The fix for (1) was to rename `user_name` to `username` where possible. For (2) and (3) the combined fix was to actually remove overriding the username in functions given the level of nesting, etc. and rely simply on using `g.user.username`, i.e., the logged in user, as the user (or effective user) for all queries. Given we're using globals via `flask.g`—Flask's versions of globals which persist for the duration of the request—why not update it rather than passing around another username everywhere. For instances where there was no user logged in: alerting, async SQL Lab queries, etc. we simply temporarily override the `g.user` using the provided username. Hopefully this approach simplified the code and brought more transparency.

The one doubt I had was with how the app context works with Celery and whether `flask.g` is thread safe, though per [here](https://github.com/apache/superset/blob/060b5c0e177b89eff9b6ace83b7df235f25cc198/superset/initialization/__init__.py#L102-L105) it seems we create a new app context for every task.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI. Updated existing and added new unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
