### PR TITLE
fix(table viz): correctly sort by multiple columns in a table

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/utils/sortAlphanumericCaseInsensitive.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/utils/sortAlphanumericCaseInsensitive.ts
@@ -33,5 +33,5 @@ export const sortAlphanumericCaseInsensitive = <D extends {}>(
   if (!valueB || typeof valueB !== 'string') {
     return 1;
   }
-  return valueA.localeCompare(valueB) > 0 ? 1 : -1;
+  return valueA.localeCompare(valueB);
 };

--- a/superset-frontend/plugins/plugin-chart-table/test/sortAlphanumericCaseInsensitive.test.ts
+++ b/superset-frontend/plugins/plugin-chart-table/test/sortAlphanumericCaseInsensitive.test.ts
@@ -17,7 +17,12 @@
  * under the License.
  */
 
+import { defaultOrderByFn, Row } from 'react-table';
 import { sortAlphanumericCaseInsensitive } from '../src/DataTable/utils/sortAlphanumericCaseInsensitive';
+
+type RecursivePartial<T> = {
+  [P in keyof T]?: T[P] | RecursivePartial<T[P]>;
+};
 
 const testData = [
   {
@@ -128,6 +133,109 @@ describe('sortAlphanumericCaseInsensitive', () => {
       {
         values: {
           col: 'test value',
+        },
+      },
+    ]);
+  });
+});
+
+const testDataMulti: Array<RecursivePartial<Row<object>>> = [
+  {
+    values: {
+      colA: 'group 1',
+      colB: '10',
+    },
+  },
+  {
+    values: {
+      colA: 'group 1',
+      colB: '15',
+    },
+  },
+  {
+    values: {
+      colA: 'group 1',
+      colB: '20',
+    },
+  },
+  {
+    values: {
+      colA: 'group 2',
+      colB: '10',
+    },
+  },
+  {
+    values: {
+      colA: 'group 3',
+      colB: '10',
+    },
+  },
+  {
+    values: {
+      colA: 'group 3',
+      colB: '15',
+    },
+  },
+  {
+    values: {
+      colA: 'group 3',
+      colB: '10',
+    },
+  },
+];
+
+describe('sortAlphanumericCaseInsensitiveMulti', () => {
+  it('Sort rows', () => {
+    const sorted = defaultOrderByFn(
+      [...testDataMulti] as Array<Row<object>>,
+      [
+        (a, b) => sortAlphanumericCaseInsensitive(a, b, 'colA'),
+        (a, b) => sortAlphanumericCaseInsensitive(a, b, 'colB'),
+      ],
+      [true, false],
+    );
+
+    expect(sorted).toEqual([
+      {
+        values: {
+          colA: 'group 1',
+          colB: '20',
+        },
+      },
+      {
+        values: {
+          colA: 'group 1',
+          colB: '15',
+        },
+      },
+      {
+        values: {
+          colA: 'group 1',
+          colB: '10',
+        },
+      },
+      {
+        values: {
+          colA: 'group 2',
+          colB: '10',
+        },
+      },
+      {
+        values: {
+          colA: 'group 3',
+          colB: '15',
+        },
+      },
+      {
+        values: {
+          colA: 'group 3',
+          colB: '10',
+        },
+      },
+      {
+        values: {
+          colA: 'group 3',
+          colB: '10',
         },
       },
     ]);


### PR DESCRIPTION
Recent commit to sort alphanumeric columns via case insensitive
comparison broke the multi-column sort option. React-table only sorts
by the second (or third...) column if the first column matches.
Since the alphanumeric sort only returned -1 or 1, it never would move
to the subsequent columns when the earlier column values matched.

### SUMMARY
prior commit only returned -1 or +1, resulting in a value of -1 when two rows had the same value for a given column.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Unsorted:
![table_unsorted](https://user-images.githubusercontent.com/70416691/166261886-b031164f-e9df-474b-8354-86a5d77de5a1.png)

Sorted by Platform:
![table_sortby-platform](https://user-images.githubusercontent.com/70416691/166261914-d3bb7891-105f-4465-9ad5-7d5f33a7bb27.png)

Sorted by Platform AND Global Sales (broken):
![table_sortby-platform-globalsales](https://user-images.githubusercontent.com/70416691/166261972-c7475a19-22a7-43cc-973d-36594d8a6e04.png)

Sorted by Platform and Global Sales (fixed):
![table_sortby-platform-globalsales-correct](https://user-images.githubusercontent.com/70416691/166262017-97f4a991-a37a-48cf-a3f8-928a5177ce71.png)


### TESTING INSTRUCTIONS
I added a new test to check for properly sorting by multiple columns (using react-table's 


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: #19919
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
