### PR TITLE
feat(chart & legend): make to enable show legend by default

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts
@@ -274,7 +274,7 @@ const config: ControlPanelConfig = {
               type: 'CheckboxControl',
               label: t('Legend'),
               renderTrigger: true,
-              default: false,
+              default: true,
               description: t('Whether to display the legend (toggles)'),
             },
           },

--- a/superset-frontend/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts
@@ -128,7 +128,7 @@ const config: ControlPanelConfig = {
               type: 'CheckboxControl',
               label: t('Legend'),
               renderTrigger: true,
-              default: false,
+              default: true,
               description: t('Whether to display the legend (toggles)'),
             },
           },

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx
@@ -148,7 +148,7 @@ export const showLegend: CustomControlItem = {
     type: 'CheckboxControl',
     label: t('Legend'),
     renderTrigger: true,
-    default: false,
+    default: true,
     description: t('Whether to display the legend (toggles)'),
   },
 };

--- a/superset-frontend/plugins/plugin-chart-echarts/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/types.ts
@@ -87,7 +87,7 @@ export const DEFAULT_LEGEND_FORM_DATA: EchartsLegendFormData = {
   legendMargin: null,
   legendOrientation: LegendOrientation.Top,
   legendType: LegendType.Scroll,
-  showLegend: false,
+  showLegend: true,
 };
 
 export type EventHandlers = Record<string, { (props: any): void }>;


### PR DESCRIPTION
### SUMMARY
Enable Legend by Default

- For any new charts created that have a "Show Legend" option, enable it by default
- User should be able to see the legend checkbox checked and can disable it if they want

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:

https://user-images.githubusercontent.com/47900232/166304808-6618443c-6395-4820-8be9-b165e1143dfe.mov

AFTER:

https://user-images.githubusercontent.com/47900232/166305156-3234ce32-20f8-42e6-9277-ebec09e06f31.mov


### TESTING INSTRUCTIONS
1. Create New Chart.
2. Go to Customize of Chart options
3. Find `Show Legend` or `Legend` Option

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
