### PR TITLE
fix: can not correctly set force in store

### DIFF
--- a/superset-frontend/src/explore/actions/exploreActions.ts
+++ b/superset-frontend/src/explore/actions/exploreActions.ts
@@ -164,6 +164,14 @@ export function unsetTimeFormattedColumn(
   };
 }
 
+export const SET_FORCE_QUERY = 'SET_FORCE_QUERY';
+export function setForceQuery(force: boolean) {
+  return {
+    type: SET_FORCE_QUERY,
+    force,
+  };
+}
+
 export const exploreActions = {
   ...toastActions,
   setDatasourceType,
@@ -181,6 +189,7 @@ export const exploreActions = {
   sliceUpdated,
   setTimeFormattedColumn,
   unsetTimeFormattedColumn,
+  setForceQuery,
 };
 
 export type ExploreActions = typeof exploreActions;

--- a/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.test.tsx
@@ -54,6 +54,7 @@ const createProps = () => ({
     sort_y_axis: 'alpha_asc',
     extra_form_data: {},
   },
+  queryForce: false,
   chartStatus: 'rendered',
   onCollapseChange: jest.fn(),
   queriesResponse: [

--- a/superset-frontend/src/explore/components/DataTablesPane/index.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/index.tsx
@@ -233,6 +233,7 @@ const TableControls = ({
 
 export const DataTablesPane = ({
   queryFormData,
+  queryForce,
   onCollapseChange,
   chartStatus,
   ownState,
@@ -240,6 +241,7 @@ export const DataTablesPane = ({
   queriesResponse,
 }: {
   queryFormData: Record<string, any>;
+  queryForce: boolean;
   chartStatus: string;
   ownState?: JsonObject;
   onCollapseChange: (isOpen: boolean) => void;
@@ -271,6 +273,7 @@ export const DataTablesPane = ({
       }));
       return getChartDataRequest({
         formData: queryFormData,
+        force: queryForce,
         resultFormat: 'json',
         resultType,
         ownState,

--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -189,6 +189,7 @@ const ExploreChartPanel = ({
   }, []);
 
   const refreshCachedQuery = useCallback(() => {
+    actions.setForceQuery(true);
     actions.postChartFormData(
       formData,
       true,
@@ -387,6 +388,7 @@ const ExploreChartPanel = ({
           <DataTablesPane
             ownState={ownState}
             queryFormData={queryFormData}
+            queryForce={force}
             onCollapseChange={onCollapseChange}
             chartStatus={chart.chartStatus}
             errorMessage={errorMessage}

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -285,6 +285,7 @@ function ExploreViewContainer(props) {
   }, [props.actions, props.chart.id, props.timeout]);
 
   const onQuery = useCallback(() => {
+    props.actions.setForceQuery(false);
     props.actions.triggerQuery(true, props.chart.id);
     addHistory();
     setLastQueriedControls(props.controls);

--- a/superset-frontend/src/explore/reducers/exploreReducer.js
+++ b/superset-frontend/src/explore/reducers/exploreReducer.js
@@ -273,6 +273,12 @@ export default function exploreReducer(state = {}, action) {
       );
       return { ...state, timeFormattedColumns: newTimeFormattedColumns };
     },
+    [actions.SET_FORCE_QUERY]() {
+      return {
+        ...state,
+        force: action.force,
+      };
+    },
   };
 
   if (action.type in actionHandlers) {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The data panel should force query when clicking the force button.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### After

https://user-images.githubusercontent.com/2016594/166398718-225544a8-523e-4d5c-ae75-dd8382ca1cc8.mov

#### Before

https://user-images.githubusercontent.com/2016594/166399167-cad19690-5acc-4dcc-ab26-48b235c11cd2.mov




### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. ensure that the data cache is used in `config.py`.
2. make a chart
3. open inspector in any browser, and switch to the network panel
4. verify the `force=true` in both requests when you click the `cached` button.



### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
