### PR TITLE
fix: Add missing migration to drop deprecated alert tables

### DIFF
--- a/superset/migrations/versions/276a69d83b28_drop_alerts.py
+++ b/superset/migrations/versions/276a69d83b28_drop_alerts.py
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""drop alerts
+
+Revision ID: 276a69d83b28
+Revises: a9422eeaae74
+Create Date: 2022-05-02 18:46:30.124352
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '276a69d83b28'
+down_revision = 'a9422eeaae74'
+
+from importlib import import_module
+
+modules = [
+    import_module("superset.migrations.versions.2f1d15e8a6af_add_alerts")
+    import_module("superset.migrations.versions.2e5a0ee25ed4_refractor_alerting")
+]
+
+def upgrade():
+    for module in reversed(module):
+        module.downgrade()
+
+
+def downgrade():
+    for module in modules:
+        module.upgrade()


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

I was misguided when spelunking through our database to try to find the various tables which house the alerting logic. It seems that the `alerts`, `alert_logs`, and `alert_owners` tables are obsolete having been replaced with various `report_*` tables. This PR simply drops the unused tables.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
