### PR TITLE
fix(chart & alert): make to show metrics properly

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -263,7 +263,6 @@ const config: ControlPanelConfig = {
           },
         ],
         ['adhoc_filters'],
-        ['metrics'],
         [
           {
             name: 'timeseries_limit_metric',

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -263,6 +263,7 @@ const config: ControlPanelConfig = {
           },
         ],
         ['adhoc_filters'],
+        ['metrics'],
         [
           {
             name: 'timeseries_limit_metric',

--- a/superset-frontend/src/components/AlteredSliceTag/index.jsx
+++ b/superset-frontend/src/components/AlteredSliceTag/index.jsx
@@ -147,11 +147,15 @@ export default class AlteredSliceTag extends React.Component {
     if (controlsMap[key]?.type === 'CollectionControl') {
       return value.map(v => safeStringify(v)).join(', ');
     }
+    if (controlsMap[key]?.type === 'MetricsControl' && value.constructor === Array) {
+      const formattedValue = value.map(v => (v?.label ?? v));
+      return formattedValue.length ? formattedValue.join(', ') : '[]';
+    }
     if (typeof value === 'boolean') {
       return value ? 'true' : 'false';
     }
     if (value.constructor === Array) {
-      const formattedValue = value.map(v => (v.label ? v.label : v));
+      const formattedValue = value.map(v => (v?.label ?? v));
       return formattedValue.length ? formattedValue.join(', ') : '[]';
     }
     if (typeof value === 'string' || typeof value === 'number') {

--- a/superset-frontend/src/components/AlteredSliceTag/index.jsx
+++ b/superset-frontend/src/components/AlteredSliceTag/index.jsx
@@ -147,15 +147,12 @@ export default class AlteredSliceTag extends React.Component {
     if (controlsMap[key]?.type === 'CollectionControl') {
       return value.map(v => safeStringify(v)).join(', ');
     }
-    if (controlsMap[key]?.type === 'MetricsControl' && Array.isArray(value)) {
-      const formattedValue = value.map(v => (v.label ? v.label : v));
-      return formattedValue.length ? formattedValue.join(', ') : '[]';
-    }
     if (typeof value === 'boolean') {
       return value ? 'true' : 'false';
     }
     if (value.constructor === Array) {
-      return value.length ? value.join(', ') : '[]';
+      const formattedValue = value.map(v => (v.label ? v.label : v));
+      return formattedValue.length ? formattedValue.join(', ') : '[]';
     }
     if (typeof value === 'string' || typeof value === 'number') {
       return value;

--- a/superset-frontend/src/components/AlteredSliceTag/index.jsx
+++ b/superset-frontend/src/components/AlteredSliceTag/index.jsx
@@ -147,15 +147,18 @@ export default class AlteredSliceTag extends React.Component {
     if (controlsMap[key]?.type === 'CollectionControl') {
       return value.map(v => safeStringify(v)).join(', ');
     }
-    if (controlsMap[key]?.type === 'MetricsControl' && value.constructor === Array) {
-      const formattedValue = value.map(v => (v?.label ?? v));
+    if (
+      controlsMap[key]?.type === 'MetricsControl' &&
+      value.constructor === Array
+    ) {
+      const formattedValue = value.map(v => v?.label ?? v);
       return formattedValue.length ? formattedValue.join(', ') : '[]';
     }
     if (typeof value === 'boolean') {
       return value ? 'true' : 'false';
     }
     if (value.constructor === Array) {
-      const formattedValue = value.map(v => (v?.label ?? v));
+      const formattedValue = value.map(v => v?.label ?? v);
       return formattedValue.length ? formattedValue.join(', ') : '[]';
     }
     if (typeof value === 'string' || typeof value === 'number') {


### PR DESCRIPTION
### SUMMARY
Altered Modal Doesn't Show Metrics Properly In Table Chart

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
![image](https://user-images.githubusercontent.com/47900232/166524410-76b6cbec-7820-4283-9e5a-ec6a00d3ffc6.png)

AFTER:
![image](https://user-images.githubusercontent.com/47900232/166524271-e1c97852-d123-4e55-a428-d077c3cf2379.png)

### TESTING INSTRUCTIONS
**How to reproduce bug**

1. Open a chart (table chart)
2. Remove the column in the "Metric" field and add a different column
3. Click the yellow "Altered" button at the top of the page

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
