### PR TITLE
docs(K8s): Add instructions for loading the examples

### DIFF
--- a/docs/docs/installation/running-on-kubernetes.mdx
+++ b/docs/docs/installation/running-on-kubernetes.mdx
@@ -402,6 +402,3 @@ To load the examples, add the following to the `my_values.yaml` file:
 ```yaml
 init:
   loadExamples: true
-```
-
-

--- a/docs/docs/installation/running-on-kubernetes.mdx
+++ b/docs/docs/installation/running-on-kubernetes.mdx
@@ -402,4 +402,5 @@ To load the examples, add the following to the `my_values.yaml` file:
 ```yaml
 init:
   loadExamples: true
-  
+```
+

--- a/docs/docs/installation/running-on-kubernetes.mdx
+++ b/docs/docs/installation/running-on-kubernetes.mdx
@@ -402,3 +402,4 @@ To load the examples, add the following to the `my_values.yaml` file:
 ```yaml
 init:
   loadExamples: true
+  

--- a/docs/docs/installation/running-on-kubernetes.mdx
+++ b/docs/docs/installation/running-on-kubernetes.mdx
@@ -403,4 +403,3 @@ To load the examples, add the following to the `my_values.yaml` file:
 init:
   loadExamples: true
 ```
-

--- a/docs/docs/installation/running-on-kubernetes.mdx
+++ b/docs/docs/installation/running-on-kubernetes.mdx
@@ -396,3 +396,12 @@ configOverrides:
         "--disable-extensions",
     ]
 ```
+#### Load the Examples data and dashboards
+If you are trying Superset out and want some data and dashboards to explore, you can load some examples by creating a `my_values.yaml` and deploying it as described above in the **Configure your setting overrides** step of the **Running** section.
+To load the examples, add the following to the `my_values.yaml` file:
+```yaml
+init:
+  loadExamples: true
+```
+
+


### PR DESCRIPTION
This took me a long time to figure out because I'm new to Superset, Helm & Kubernetes.
I want to make it easier for others in the future.

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Adding instructions for loading the examples for Kubernetes deployments as this is different from Docker deployments.
This took me a long time to figure out because I'm new to Superset, Helm & Kubernetes, so I want to make it easier for others in the future.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. run `helm upgrade --install superset superset/superset`
Result: Examples will not be loaded and you will not see the `examples` database in Superset

2. Follow added instructions then run `helm upgrade --install --alues my_values.yaml superset superset/superset`
Result: Examples will be loaded and you will see the `examples` database in Superset

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
