### PR TITLE
chore: add doc link for db migration conflict warning

### DIFF
--- a/.github/workflows/check_db_migration_confict.yml
+++ b/.github/workflows/check_db_migration_confict.yml
@@ -50,10 +50,11 @@ jobs:
                   repo: context.repo.repo,
                   issue_number: pull.number,
                   body:
-                    `⚠️ @${pull.user.login} Your base branch \`${currentBranch}\` has just ` +
+                    `# 🙅‍♂️ 🙅‍♂️ 🙅‍♂️ 🙅‍♂️ 🙅‍♂️ 🙅‍♂️ 🙅‍♂️ 🙅‍♂️ 🙅‍♂️ 🙅‍♂️ 🙅‍♂️ 🙅‍♂️ 🙅‍♂️ 🙅‍♂️ 🙅‍♂️ 🙅‍♂️` +
+                    `❗ @${pull.user.login} Your base branch \`${currentBranch}\` has ` +
                     'also updated `superset/migrations`.\n' +
                     '\n' +
-                    '❗ **Please consider rebasing your branch to avoid db migration conflicts.**',
+                    '**Please consider rebasing your branch and [resolving potential db migration conflicts](https://github.com/apache/superset/blob/master/CONTRIBUTING.md#merging-db-migrations).**',
                 });
               }
             }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This makes the warning message from the Check DB Migration Conflict action more prominent so people are less likely to ignore it (hopefully).

Also add a link to the contribution doc to guide committers to resolve the conflict.

Properly resolve the merge conflict by pointing current WIP PR to the latest HEAD will help us avoid unnecessary merge points like https://github.com/apache/superset/pull/19577

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

<img width="940" alt="image" src="https://user-images.githubusercontent.com/335541/167013236-f6014c2f-66a0-4bbf-965d-8b200bd0a481.png">

#### After
<img width="944" alt="Xnip2022-05-05_12-04-29" src="https://user-images.githubusercontent.com/335541/167013171-cd2ed960-91bd-493c-a8e0-81556de56f06.png">



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
