### PR TITLE
feat: (Explore) Pre-populate dashboard in Explore

### DIFF
--- a/superset-frontend/src/addSlice/AddSliceContainer.test.tsx
+++ b/superset-frontend/src/addSlice/AddSliceContainer.test.tsx
@@ -81,7 +81,7 @@ describe('AddSliceContainer', () => {
       visType: 'table',
     });
     const formattedUrl =
-      '/superset/explore/?form_data=%7B%22viz_type%22%3A%22table%22%2C%22datasource%22%3A%221%22%7D';
+      '/superset/explore/?form_data=%7B%22viz_type%22%3A%22table%22%2C%22datasource%22%3A%221%22%7D&';
     expect(wrapper.instance().exploreUrl()).toBe(formattedUrl);
   });
 });

--- a/superset-frontend/src/addSlice/AddSliceContainer.tsx
+++ b/superset-frontend/src/addSlice/AddSliceContainer.tsx
@@ -195,13 +195,13 @@ export default class AddSliceContainer extends React.PureComponent<
   }
 
   exploreUrl() {
-    const url = window.location.href;
-    const dashboardTitleIndex = url.search('dashboardTitle:');
-    const dashboardExists = dashboardTitleIndex !== -1;
+    const url = window.location.search;
+    const urlParams = new URLSearchParams(url);
+    const dashboardExists = urlParams.has('dashboardInfo');
+    const dashboardInfo = urlParams.get('dashboardInfo');
     const dashboardTitle = dashboardExists
-      ? `dashboardTitle: ${url.slice(dashboardTitleIndex + 15)}`
+      ? `dashboardInfo=${dashboardInfo}`
       : '';
-    // 15 is how long dashboardtitle: is//
     const formData = encodeURIComponent(
       JSON.stringify({
         viz_type: this.state.visType,

--- a/superset-frontend/src/addSlice/AddSliceContainer.tsx
+++ b/superset-frontend/src/addSlice/AddSliceContainer.tsx
@@ -195,13 +195,20 @@ export default class AddSliceContainer extends React.PureComponent<
   }
 
   exploreUrl() {
+    const url = window.location.href;
+    const dashboardTitleIndex = url.search('dashboardTitle:');
+    const dashboardExists = dashboardTitleIndex !== -1;
+    const dashboardTitle = dashboardExists
+      ? `dashboardTitle: ${url.slice(dashboardTitleIndex + 15)}`
+      : '';
+    // 15 is how long dashboardtitle: is//
     const formData = encodeURIComponent(
       JSON.stringify({
         viz_type: this.state.visType,
         datasource: this.state.datasource?.value,
       }),
     );
-    return `/superset/explore/?form_data=${formData}`;
+    return `/superset/explore/?form_data=${formData}&${dashboardTitle}`;
   }
 
   gotoSlice() {

--- a/superset-frontend/src/dashboard/components/DashboardGrid.jsx
+++ b/superset-frontend/src/dashboard/components/DashboardGrid.jsx
@@ -154,6 +154,12 @@ class DashboardGrid extends React.PureComponent {
     const shouldDisplayTopLevelTabEmptyState =
       shouldDisplayEmptyState && gridComponent.type === TAB_TYPE;
 
+    const dashboardProps = encodeURIComponent(
+      JSON.stringify({
+        value: this.props.dashboardId,
+      }),
+    );
+
     const dashboardEmptyState = editMode && (
       <EmptyStateBig
         title={t('Drag and drop components and charts to the dashboard')}
@@ -168,7 +174,7 @@ class DashboardGrid extends React.PureComponent {
         }
         buttonAction={() => {
           window.open(
-            `/chart/add?dashboardTitle:${this.props.dashboardTitle}`,
+            `/chart/add?dashboardInfo=${dashboardProps}`,
             '_blank',
             'noopener noreferrer',
           );
@@ -190,11 +196,7 @@ class DashboardGrid extends React.PureComponent {
           </>
         }
         buttonAction={() => {
-          window.open(
-            `/chart/add?${this.props.dashboardTitle}`,
-            '_blank',
-            'noopener noreferrer',
-          );
+          window.open('/chart/add', '_blank', 'noopener noreferrer');
         }}
         image="chart.svg"
       />

--- a/superset-frontend/src/dashboard/components/DashboardGrid.jsx
+++ b/superset-frontend/src/dashboard/components/DashboardGrid.jsx
@@ -167,7 +167,11 @@ class DashboardGrid extends React.PureComponent {
           </>
         }
         buttonAction={() => {
-          window.open('/chart/add', '_blank', 'noopener noreferrer');
+          window.open(
+            `/chart/add?dashboardTitle:${this.props.dashboardTitle}`,
+            '_blank',
+            'noopener noreferrer',
+          );
         }}
         image="chart.svg"
       />
@@ -186,7 +190,11 @@ class DashboardGrid extends React.PureComponent {
           </>
         }
         buttonAction={() => {
-          window.open('/chart/add', '_blank', 'noopener noreferrer');
+          window.open(
+            `/chart/add?${this.props.dashboardTitle}`,
+            '_blank',
+            'noopener noreferrer',
+          );
         }}
         image="chart.svg"
       />

--- a/superset-frontend/src/dashboard/containers/DashboardGrid.jsx
+++ b/superset-frontend/src/dashboard/containers/DashboardGrid.jsx
@@ -30,7 +30,7 @@ function mapStateToProps({ dashboardState, dashboardInfo }) {
   return {
     editMode: dashboardState.editMode,
     canEdit: dashboardInfo.dash_edit_perm,
-    dashboardTitle: dashboardInfo.dashboard_title,
+    dashboardId: dashboardInfo.id,
   };
 }
 

--- a/superset-frontend/src/dashboard/containers/DashboardGrid.jsx
+++ b/superset-frontend/src/dashboard/containers/DashboardGrid.jsx
@@ -30,6 +30,7 @@ function mapStateToProps({ dashboardState, dashboardInfo }) {
   return {
     editMode: dashboardState.editMode,
     canEdit: dashboardInfo.dash_edit_perm,
+    dashboardTitle: dashboardInfo.dashboard_title,
   };
 }
 

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -32,7 +32,9 @@ import { connect } from 'react-redux';
 
 // Session storage key for recent dashboard
 const SK_DASHBOARD_ID = 'save_chart_recent_dashboard';
-const SELECT_PLACEHOLDER = t('**Select** a dashboard OR **create** a new one');
+const SELECT_PLACEHOLDER = t(
+  '**Select** a dashboard OR type in a title to **create** a new one',
+);
 
 type SaveModalProps = {
   onHide: () => void;
@@ -55,6 +57,7 @@ type SaveModalState = {
   newDashboardName?: string;
   alert: string | null;
   action: ActionType;
+  newlyCreatedDashboard?: number;
 };
 
 export const StyledModal = styled(Modal)`
@@ -174,9 +177,20 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
     this.setState({ alert: null });
   }
 
+  newlyCreatedDashboardName(): number | null {
+    const url = window.location.search;
+    const urlParams = new URLSearchParams(url);
+    const dashInfoExists = urlParams.has('dashboardInfo');
+    const stringifiedDash = dashInfoExists && urlParams.get('dashboardInfo');
+    const dashboardInfo = stringifiedDash && JSON.parse(stringifiedDash);
+    return dashboardInfo.value;
+  }
+
   render() {
     const dashboardSelectValue =
-      this.state.saveToDashboardId || this.state.newDashboardName;
+      this.state.saveToDashboardId ||
+      this.state.newDashboardName ||
+      this.newlyCreatedDashboardName();
     return (
       <StyledModal
         show


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This pre-populates the save to dashboard file if you came from an empty dashboard.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
https://user-images.githubusercontent.com/48933336/167210045-76590777-7c7e-4280-ae62-aebb96496719.mov

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
