### PR TITLE
fix: revert chore(deps): bump d3-svg-legend in /superset-frontend (#19846)

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-heatmap/package.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-heatmap/package.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "d3": "^3.5.17",
-    "d3-svg-legend": "^2.x",
+    "d3-svg-legend": "^1.x",
     "d3-tip": "^0.9.1",
     "prop-types": "^15.6.2"
   },


### PR DESCRIPTION
### SUMMARY
`d3-svg-legend` version 2 is incompatible with `d3` version 3 (see: https://github.com/susielu/d3-legend/issues/58), causing the Heatmap chart to fail to render. I contemplated the option of bumping `d3` to version 4, but decided against it due to the following reasons:
- The API has been totally overhauled in `d3` version 4 and would have required fairly big changes
- `d3` is now on version 7
- `d3-svg-legend` has been stale for 4 years

Instead I think we should just migrate this plugin to `d3` version 7 or the equivalent ECharts version (https://echarts.apache.org/examples/en/editor.html?c=heatmap-cartesian) while migrating this plugin to the v1 chart data endpoint.

Related PR: #19846

### AFTER
<img width="1186" alt="image" src="https://user-images.githubusercontent.com/33317356/167073379-5c5bcef8-f653-44c8-8dea-2bf6dc6c64e8.png">

### BEFORE
<img width="1185" alt="image" src="https://user-images.githubusercontent.com/33317356/167073502-375494f1-56e1-4be3-a064-c74a8707790c.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
