### PR TITLE
feat(explore): Show confirmation modal if user exits Explore without saving changes

### DIFF
--- a/superset-frontend/src/components/AlteredSliceTag/AlteredSliceTag.test.jsx
+++ b/superset-frontend/src/components/AlteredSliceTag/AlteredSliceTag.test.jsx
@@ -308,34 +308,4 @@ describe('AlteredSliceTag', () => {
       ).toBe(expected);
     });
   });
-  describe('isEqualish', () => {
-    it('considers null, undefined, {} and [] as equal', () => {
-      const inst = wrapper.instance();
-      expect(inst.isEqualish(null, undefined)).toBe(true);
-      expect(inst.isEqualish(null, [])).toBe(true);
-      expect(inst.isEqualish(null, {})).toBe(true);
-      expect(inst.isEqualish(undefined, {})).toBe(true);
-    });
-    it('considers empty strings are the same as null', () => {
-      const inst = wrapper.instance();
-      expect(inst.isEqualish(undefined, '')).toBe(true);
-      expect(inst.isEqualish(null, '')).toBe(true);
-    });
-    it('considers deeply equal objects as equal', () => {
-      const inst = wrapper.instance();
-      expect(inst.isEqualish('', '')).toBe(true);
-      expect(inst.isEqualish({ a: 1, b: 2, c: 3 }, { a: 1, b: 2, c: 3 })).toBe(
-        true,
-      );
-      // Out of order
-      expect(inst.isEqualish({ a: 1, b: 2, c: 3 }, { b: 2, a: 1, c: 3 })).toBe(
-        true,
-      );
-
-      // Actually  not equal
-      expect(inst.isEqualish({ a: 1, b: 2, z: 9 }, { a: 1, b: 2, c: 3 })).toBe(
-        false,
-      );
-    });
-  });
 });

--- a/superset-frontend/src/components/AlteredSliceTag/index.jsx
+++ b/superset-frontend/src/components/AlteredSliceTag/index.jsx
@@ -20,7 +20,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { isEqual, isEmpty } from 'lodash';
 import { styled, t } from '@superset-ui/core';
-import { sanitizeFormData } from 'src/explore/exploreUtils/formData';
+import { getFormDataDiffs } from 'src/explore/exploreUtils/formData';
 import getControlsForVizType from 'src/utils/getControlsForVizType';
 import { safeStringify } from 'src/utils/safeStringify';
 import { Tooltip } from 'src/components/Tooltip';
@@ -43,24 +43,6 @@ const StyledLabel = styled.span`
     }
   `}
 `;
-
-function alterForComparison(value) {
-  // Considering `[]`, `{}`, `null` and `undefined` as identical
-  // for this purpose
-  if (value === undefined || value === null || value === '') {
-    return null;
-  }
-  if (typeof value === 'object') {
-    if (Array.isArray(value) && value.length === 0) {
-      return null;
-    }
-    const keys = Object.keys(value);
-    if (keys && keys.length === 0) {
-      return null;
-    }
-  }
-  return value;
-}
 
 export default class AlteredSliceTag extends React.Component {
   constructor(props) {
@@ -95,27 +77,7 @@ export default class AlteredSliceTag extends React.Component {
   getDiffs(props) {
     // Returns all properties that differ in the
     // current form data and the saved form data
-    const ofd = sanitizeFormData(props.origFormData);
-    const cfd = sanitizeFormData(props.currentFormData);
-
-    const fdKeys = Object.keys(cfd);
-    const diffs = {};
-    fdKeys.forEach(fdKey => {
-      if (!ofd[fdKey] && !cfd[fdKey]) {
-        return;
-      }
-      if (['filters', 'having', 'having_filters', 'where'].includes(fdKey)) {
-        return;
-      }
-      if (!this.isEqualish(ofd[fdKey], cfd[fdKey])) {
-        diffs[fdKey] = { before: ofd[fdKey], after: cfd[fdKey] };
-      }
-    });
-    return diffs;
-  }
-
-  isEqualish(val1, val2) {
-    return isEqual(alterForComparison(val1), alterForComparison(val2));
+    return getFormDataDiffs(props.origFormData, props.currentFormData);
   }
 
   formatValue(value, key, controlsMap) {

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -252,6 +252,7 @@ function ExploreViewContainer(props) {
   const theme = useTheme();
 
   const isBeforeUnloadActive = useRef(false);
+  const initialFormData = useRef(props.form_data);
 
   const defaultSidebarsWidth = {
     controls_width: 320,
@@ -384,7 +385,7 @@ function ExploreViewContainer(props) {
 
   useEffect(() => {
     const formDataChanged = !isEmpty(
-      getFormDataDiffs(props.chart.sliceFormData, props.form_data),
+      getFormDataDiffs(initialFormData.current, props.form_data),
     );
     if (formDataChanged && !isBeforeUnloadActive.current) {
       window.addEventListener('beforeunload', handleUnloadEvent);
@@ -394,7 +395,7 @@ function ExploreViewContainer(props) {
       window.removeEventListener('beforeunload', handleUnloadEvent);
       isBeforeUnloadActive.current = false;
     }
-  }, [props.chart.sliceFormData, props.form_data]);
+  }, [props.form_data]);
 
   // cleanup beforeunload event listener
   // we use separate useEffect to call it only on component unmount instead of on every form data change

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -226,6 +226,11 @@ const updateHistory = debounce(
   1000,
 );
 
+const handleUnloadEvent = e => {
+  e.preventDefault();
+  e.returnValue = 'Controls changed';
+};
+
 function ExploreViewContainer(props) {
   const dynamicPluginContext = usePluginContext();
   const dynamicPlugin = dynamicPluginContext.dynamicPlugins[props.vizType];
@@ -378,23 +383,25 @@ function ExploreViewContainer(props) {
   }, [handleKeydown, previousHandleKeyDown]);
 
   useEffect(() => {
-    const handleCloseEvent = e => {
-      e.preventDefault();
-      e.returnValue = 'Controls changed';
-    };
     const formDataChanged = !isEmpty(
       getFormDataDiffs(props.chart.sliceFormData, props.form_data),
     );
     if (formDataChanged && !isBeforeUnloadActive.current) {
-      window.addEventListener('beforeunload', handleCloseEvent);
+      window.addEventListener('beforeunload', handleUnloadEvent);
       isBeforeUnloadActive.current = true;
     }
     if (!formDataChanged && isBeforeUnloadActive.current) {
-      window.removeEventListener('beforeunload', handleCloseEvent);
+      window.removeEventListener('beforeunload', handleUnloadEvent);
       isBeforeUnloadActive.current = false;
     }
-    return () => window.removeEventListener('beforeunload', handleCloseEvent);
   }, [props.chart.sliceFormData, props.form_data]);
+
+  // cleanup beforeunload event listener
+  // we use separate useEffect to call it only on component unmount instead of on every form data change
+  useEffect(
+    () => () => window.removeEventListener('beforeunload', handleUnloadEvent),
+    [],
+  );
 
   useEffect(() => {
     if (wasDynamicPluginLoading && !isDynamicPluginLoading) {

--- a/superset-frontend/src/explore/exploreUtils/formData.test.ts
+++ b/superset-frontend/src/explore/exploreUtils/formData.test.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { sanitizeFormData } from './formData';
+import { sanitizeFormData, isEqualish } from './formData';
 
 test('sanitizeFormData removes temporary control values', () => {
   expect(
@@ -25,4 +25,26 @@ test('sanitizeFormData removes temporary control values', () => {
       metrics: ['foo', 'bar'],
     }),
   ).toEqual({ metrics: ['foo', 'bar'] });
+});
+
+test('isEqualish', () => {
+  // considers null, undefined, {} and [] as equal
+  expect(isEqualish(null, undefined)).toBe(true);
+  expect(isEqualish(null, [])).toBe(true);
+  expect(isEqualish(null, {})).toBe(true);
+  expect(isEqualish(undefined, {})).toBe(true);
+
+  // considers empty strings are the same as null
+  expect(isEqualish(undefined, '')).toBe(true);
+  expect(isEqualish(null, '')).toBe(true);
+
+  // considers deeply equal objects as equal
+  expect(isEqualish('', '')).toBe(true);
+  expect(isEqualish({ a: 1, b: 2, c: 3 }, { a: 1, b: 2, c: 3 })).toBe(true);
+
+  // Out of order
+  expect(isEqualish({ a: 1, b: 2, c: 3 }, { b: 2, a: 1, c: 3 })).toBe(true);
+
+  // Actually  not equal
+  expect(isEqualish({ a: 1, b: 2, z: 9 }, { a: 1, b: 2, c: 3 })).toBe(false);
 });

--- a/superset-frontend/src/explore/exploreUtils/formData.ts
+++ b/superset-frontend/src/explore/exploreUtils/formData.ts
@@ -30,20 +30,24 @@ const TEMPORARY_CONTROLS = ['url_params'];
 export const sanitizeFormData = (formData: JsonObject): JsonObject =>
   omit(formData, TEMPORARY_CONTROLS);
 
-export const getNullIfEmpty = (value: JsonValue | undefined) => {
+export const alterForComparison = (value: JsonValue | undefined) => {
   // Considering `[]`, `{}`, `null` and `undefined` as identical
   // for this purpose
-  if (value === undefined || value === null || value === '') {
+  if (
+    value === undefined ||
+    value === null ||
+    value === '' ||
+    (Array.isArray(value) && value.length === 0) ||
+    (typeof value === 'object' && Object.keys(value).length === 0)
+  ) {
     return null;
   }
+  if (Array.isArray(value)) {
+    // omit prototype for comparison of class instances with json objects
+    return value.map(v => (typeof v === 'object' ? omit(v, ['__proto__']) : v));
+  }
   if (typeof value === 'object') {
-    if (Array.isArray(value) && value.length === 0) {
-      return null;
-    }
-    const keys = Object.keys(value);
-    if (keys && keys.length === 0) {
-      return null;
-    }
+    return omit(value, ['__proto__']);
   }
   return value;
 };
@@ -51,7 +55,7 @@ export const getNullIfEmpty = (value: JsonValue | undefined) => {
 export const isEqualish = (
   val1: JsonValue | undefined,
   val2: JsonValue | undefined,
-) => isEqual(getNullIfEmpty(val1), getNullIfEmpty(val2));
+) => isEqual(alterForComparison(val1), alterForComparison(val2));
 
 export const getFormDataDiffs = (
   formData1: JsonObject,
@@ -69,7 +73,7 @@ export const getFormDataDiffs = (
     if (['filters', 'having', 'having_filters', 'where'].includes(fdKey)) {
       return;
     }
-    if (!isEqual(getNullIfEmpty(ofd[fdKey]), getNullIfEmpty(cfd[fdKey]))) {
+    if (!isEqualish(ofd[fdKey], cfd[fdKey])) {
       diffs[fdKey] = { before: ofd[fdKey], after: cfd[fdKey] };
     }
   });

--- a/superset-frontend/src/explore/exploreUtils/formData.ts
+++ b/superset-frontend/src/explore/exploreUtils/formData.ts
@@ -16,8 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { omit } from 'lodash';
-import { SupersetClient, JsonObject } from '@superset-ui/core';
+import { isEqual, omit } from 'lodash';
+import { SupersetClient, JsonObject, JsonValue } from '@superset-ui/core';
 
 type Payload = {
   dataset_id: number;
@@ -29,6 +29,52 @@ const TEMPORARY_CONTROLS = ['url_params'];
 
 export const sanitizeFormData = (formData: JsonObject): JsonObject =>
   omit(formData, TEMPORARY_CONTROLS);
+
+export const getNullIfEmpty = (value: JsonValue | undefined) => {
+  // Considering `[]`, `{}`, `null` and `undefined` as identical
+  // for this purpose
+  if (value === undefined || value === null || value === '') {
+    return null;
+  }
+  if (typeof value === 'object') {
+    if (Array.isArray(value) && value.length === 0) {
+      return null;
+    }
+    const keys = Object.keys(value);
+    if (keys && keys.length === 0) {
+      return null;
+    }
+  }
+  return value;
+};
+
+export const isEqualish = (
+  val1: JsonValue | undefined,
+  val2: JsonValue | undefined,
+) => isEqual(getNullIfEmpty(val1), getNullIfEmpty(val2));
+
+export const getFormDataDiffs = (
+  formData1: JsonObject,
+  formData2: JsonObject,
+) => {
+  const ofd = sanitizeFormData(formData1);
+  const cfd = sanitizeFormData(formData2);
+
+  const fdKeys = Object.keys(cfd);
+  const diffs = {};
+  fdKeys.forEach(fdKey => {
+    if (!ofd[fdKey] && !cfd[fdKey]) {
+      return;
+    }
+    if (['filters', 'having', 'having_filters', 'where'].includes(fdKey)) {
+      return;
+    }
+    if (!isEqual(getNullIfEmpty(ofd[fdKey]), getNullIfEmpty(cfd[fdKey]))) {
+      diffs[fdKey] = { before: ofd[fdKey], after: cfd[fdKey] };
+    }
+  });
+  return diffs;
+};
 
 const assembleEndpoint = (key?: string, tabId?: string) => {
   let endpoint = 'api/v1/explore/form_data';


### PR DESCRIPTION
### SUMMARY
This PR adds a browser confirmation modal (similar to the one that we have in dashboard edit mode) when user makes a change in control panel and then tries to close Explore (either by closing the tab or moving to another page) without clicking Save button.
Currently, that modal is not customizable. However, when we implement Single Page Application in Superset, we'll probably be able to customize the modal when navigating within Superset.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/15073128/167422541-da6709f4-605b-4740-8cb5-80f693b956ea.png">


### TESTING INSTRUCTIONS
Changes made without saving:
1. Open a chart
2. Make some changes in control panel
3. Try to leave the page (close tab or navigate to another page)
4. Verify that browser confirmation modal appears

Changes made and saved:
1. Open a chart
2. Make some changes in control panel and save.
3. Leave the page, verify that the modal didn't appear

Changes made and then reverted:
1. Open a chart
2. Make some changes in control panel.
3. Revert those changes (for example add and remove a metric)
4. Leave the page, verify that the modal didn't appear

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
