### PR TITLE
fix: Use pull_request_target in Cypress Applitools workflow

### DIFF
--- a/.github/workflows/superset-applitool-cypress.yml
+++ b/.github/workflows/superset-applitool-cypress.yml
@@ -1,6 +1,6 @@
 name: Applitools Cypress
 
-on: pull_request
+on: pull_request_target
 
 jobs:
   cypress-applitools:


### PR DESCRIPTION
### SUMMARY
The Applitools API key is not present when a PR is launched by a fork. Using the `pull_request_target` should launch the workflow from the target branch and should avoid failure. This is a temporary change to unblock CI.

Read this for more context: https://github.community/t/can-workflow-changes-be-used-with-pull-request-target/178626

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
