### PR TITLE
fix: URI form is blank when trying to connect from sql lab

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -18,6 +18,7 @@
  */
 import {
   t,
+  styled,
   SupersetTheme,
   FeatureFlag,
   isFeatureEnabled,
@@ -95,6 +96,18 @@ const engineSpecificAlertMapping = {
       'you choose to connect here.',
   },
 };
+
+const TabsStyled = styled(Tabs)`
+  .ant-tabs-content {
+    display: flex;
+    width: 100%;
+    overflow: inherit;
+
+    & > .ant-tabs-tabpane {
+      position: relative;
+    }
+  }
+`;
 
 const googleSheetConnectionEngine = 'gsheets';
 
@@ -1232,7 +1245,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
           />
         </TabHeader>
       </StyledStickyHeader>
-      <Tabs
+      <TabsStyled
         defaultActiveKey={DEFAULT_TAB_KEY}
         activeKey={tabKey}
         onTabClick={tabChange}
@@ -1385,7 +1398,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
           />
           {showDBError && errorAlert()}
         </Tabs.TabPane>
-      </Tabs>
+      </TabsStyled>
     </Modal>
   ) : (
     <Modal
@@ -1421,7 +1434,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
         </>
       ) : (
         <>
-          {/* Dyanmic Form Step 1 */}
+          {/* Dynamic Form Step 1 */}
           {!isLoading &&
             (!db ? (
               <SelectDatabaseStyles>


### PR DESCRIPTION
### SUMMARY
The connect a database modal, when in the SQL Lab, is not displaying the information in the URI form.

The reason is that the SQL Lab uses and customizes the antd Tabs component, and by changing the design it also affects this modal.

This PR sets the proper styles for the modal, to set and prevent this issue

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://user-images.githubusercontent.com/17252075/167487441-ada4571e-24ba-4b3d-aead-104aec340ca2.mov

After:

https://user-images.githubusercontent.com/17252075/167487491-abdcc684-e889-491a-b7e4-3d6019ced02c.mov

### TESTING INSTRUCTIONS
* Go to sql lab
* Select the + menu
* Select the data menu
* Connect a new database
* Select a database
* Switch to the URI form

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
