### PR TITLE
fix(chart & heatmap): make to fix that y label is rendering out of bounds

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-heatmap/src/Heatmap.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-heatmap/src/Heatmap.js
@@ -111,7 +111,7 @@ function Heatmap(element, props) {
   let showY = true;
   let showX = true;
   const pixelsPerCharX = 4.5; // approx, depends on font size
-  const pixelsPerCharY = 6; // approx, depends on font size
+  let pixelsPerCharY = 6; // approx, depends on font size
 
   const valueFormatter = getNumberFormatter(numberFormat);
 
@@ -121,6 +121,7 @@ function Heatmap(element, props) {
     let longestY = 1;
 
     records.forEach(datum => {
+      if (typeof datum.y === 'number') pixelsPerCharY = 7;
       longestX = Math.max(
         longestX,
         (datum.x && datum.x.toString().length) || 1,


### PR DESCRIPTION
### SUMMARY
[viz] heatmap Y axis labels rendering out-of-bounds

**Description**
Heatmap Y axis label rendering out-of-bounds, despite using `auto` for the `LEFT MARGIN` control.
This issue is happened when the Y axis value is number type and in case of that Y axis value is string type, Y axis label is rendering correctly in bounds. So I fixed this issue by increasing the pixel value per char in case of number type.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:

https://user-images.githubusercontent.com/47900232/167644335-1400b0c2-a963-4978-a57a-f40c3eeca70e.mov

AFTER:

https://user-images.githubusercontent.com/47900232/167642557-84d5f4c1-9d55-4ec9-b656-f484c317912f.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
