### PR TITLE
fix: The dynamic form to connect to Snowflake DB is not returning any errors

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -1101,7 +1101,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
           type="error"
           css={(theme: SupersetTheme) => antDErrorAlertStyles(theme)}
           message={t('Database Creation Error')}
-          description={alertErrors?.[0]}
+          description={t(alertErrors[0])}
         />
       );
     }

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -85,8 +85,13 @@ import {
 } from './styles';
 import ModalHeader, { DOCUMENTATION_LINK } from './ModalHeader';
 
+enum Engines {
+  GSheet = 'gsheets',
+  Snowflake = 'snowflake',
+}
+
 const engineSpecificAlertMapping = {
-  gsheets: {
+  [Engines.GSheet]: {
     message: 'Why do I need to create a database?',
     description:
       'To begin using your Google Sheets, you need to create a database first. ' +
@@ -108,8 +113,6 @@ const TabsStyled = styled(Tabs)`
     }
   }
 `;
-
-const googleSheetConnectionEngine = 'gsheets';
 
 interface DatabaseModalProps {
   addDangerToast: (msg: string) => void;
@@ -586,7 +589,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       // cast the new encrypted extra object into a string
       dbToUpdate.encrypted_extra = JSON.stringify(additionalEncryptedExtra);
       // this needs to be added by default to gsheets
-      if (dbToUpdate.engine === 'gsheets') {
+      if (dbToUpdate.engine === Engines.GSheet) {
         dbToUpdate.impersonate_user = true;
       }
     }
@@ -605,8 +608,8 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       dbToUpdate.extra = serializeExtra(dbToUpdate?.extra_json);
     }
 
+    setLoading(true);
     if (db?.id) {
-      setLoading(true);
       const result = await updateResource(
         db.id as number,
         dbToUpdate as DatabaseObject,
@@ -621,7 +624,6 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       }
     } else if (db) {
       // Create
-      setLoading(true);
       const dbId = await createResource(
         dbToUpdate as DatabaseObject,
         dbToUpdate.configuration_method === CONFIGURATION_METHOD.DYNAMIC_FORM, // onShow toast on SQLA Forms
@@ -636,14 +638,14 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
           addSuccessToast(t('Database connected'));
         }
       }
-    }
-
-    // Import - doesn't use db state
-    if (!db) {
-      setLoading(true);
+    } else {
+      // Import - doesn't use db state
       setImportingModal(true);
 
-      if (!(fileList[0].originFileObj instanceof File)) return;
+      if (!(fileList[0].originFileObj instanceof File)) {
+        return;
+      }
+
       const dbId = await importResource(
         fileList[0].originFileObj,
         passwords,
@@ -1083,15 +1085,23 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
 
   // eslint-disable-next-line consistent-return
   const errorAlert = () => {
+    let alertErrors: string[] = [];
     if (isEmpty(dbErrors) === false) {
-      const message: Array<string> =
-        typeof dbErrors === 'object' ? Object.values(dbErrors) : [];
+      alertErrors = typeof dbErrors === 'object' ? Object.values(dbErrors) : [];
+    } else if (db?.engine === Engines.Snowflake) {
+      alertErrors =
+        validationErrors?.error_type === 'GENERIC_DB_ENGINE_ERROR'
+          ? [validationErrors?.description]
+          : [];
+    }
+
+    if (alertErrors.length) {
       return (
         <Alert
           type="error"
           css={(theme: SupersetTheme) => antDErrorAlertStyles(theme)}
           message={t('Database Creation Error')}
-          description={message?.[0] || dbErrors}
+          description={alertErrors?.[0]}
         />
       );
     }
@@ -1523,7 +1533,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
                   validationErrors={validationErrors}
                 />
                 <div css={(theme: SupersetTheme) => infoTooltip(theme)}>
-                  {dbModel.engine !== googleSheetConnectionEngine && (
+                  {dbModel.engine !== Engines.GSheet && (
                     <>
                       <Button
                         data-test="sqla-connect-btn"


### PR DESCRIPTION
### SUMMARY
There are two ways to create a connection with a Snowflake DB:

Using the dynamic form.
Using a SQLAlchemy URI string.
However, the dynamic form is not displaying authentication errors to the user, in case the authentication fails.

This PR reintroduces the fixes from #19491 that were overridden in #19165

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/17252075/167658332-b60cfbd3-91c6-4090-b618-dbdb33f33f56.mov

After:

https://user-images.githubusercontent.com/17252075/167658212-592ab2b0-e295-4bea-ad82-2d1aaffe2e79.mp4

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
