### PR TITLE
fix(modal): add primary button loading state to modals

### DIFF
--- a/superset-frontend/src/components/Modal/Modal.tsx
+++ b/superset-frontend/src/components/Modal/Modal.tsx
@@ -34,6 +34,7 @@ export interface ModalProps {
   className?: string;
   children: React.ReactNode;
   disablePrimaryButton?: boolean;
+  primaryButtonLoading?: boolean;
   onHide: () => void;
   onHandledPrimaryAction?: () => void;
   primaryButtonName?: string;
@@ -190,6 +191,7 @@ export const StyledModal = styled(BaseModal)<StyledModalProps>`
 const CustomModal = ({
   children,
   disablePrimaryButton = false,
+  primaryButtonLoading = false,
   onHide,
   onHandledPrimaryAction,
   primaryButtonName = t('OK'),
@@ -240,6 +242,7 @@ const CustomModal = ({
           key="submit"
           buttonStyle={primaryButtonType}
           disabled={disablePrimaryButton}
+          loading={primaryButtonLoading}
           onClick={onHandledPrimaryAction}
           cta
           data-test="modal-confirm-button"

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDatasetModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDatasetModal.tsx
@@ -56,7 +56,10 @@ const DatasetModal: FunctionComponent<DatasetModalProps> = ({
   const [currentSchema, setSchema] = useState<string | undefined>('');
   const [currentTableName, setTableName] = useState('');
   const [disableSave, setDisableSave] = useState(true);
-  const { createResource } = useSingleViewResource<Partial<DatasetAddObject>>(
+  const {
+    createResource,
+    state: { loading },
+  } = useSingleViewResource<Partial<DatasetAddObject>>(
     'dataset',
     t('dataset'),
     addDangerToast,
@@ -114,6 +117,7 @@ const DatasetModal: FunctionComponent<DatasetModalProps> = ({
   return (
     <Modal
       disablePrimaryButton={disableSave}
+      primaryButtonLoading={loading}
       onHandledPrimaryAction={onSave}
       onHide={hide}
       primaryButtonName={t('Add')}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Rationale: Saving a resource is not always instantaneous. In the `AddDatasetModal`, while a dataset is being saved, the primary "Add" button is not disabled - allowing user to click on the "Add" button multiple times while the resource is being saved. This allows the user to add duplicate datasets
* This PR adds a `primaryButtonLoading` prop to the `Modal` component
* The `AddDatasetModal` passes a loading prop to the `Modal` component while the resource creation is loading


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
https://user-images.githubusercontent.com/23270317/167711073-cefa43b5-0eb1-4dc0-9bba-566e74dd3091.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
* Add delay to `superset.datasets.api.py` in the POST function on the `\` path (dataset creation path)
* Add a new dataset and verify that the button is disabled & loading while the dataset is being created

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
