### PR TITLE
fix(chart & filters): make to padding between textarea and buttons

### DIFF
--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.jsx
@@ -87,7 +87,7 @@ const FilterPopoverContentContainer = styled.div`
 `;
 
 const FilterActionsContainer = styled.div`
-  margin-top: ${({ theme }) => theme.gridUnit * 2}px;;
+  margin-top: ${({ theme }) => theme.gridUnit * 2}px;
 `;
 
 export default class AdhocFilterEditPopover extends React.Component {

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.jsx
@@ -87,7 +87,7 @@ const FilterPopoverContentContainer = styled.div`
 `;
 
 const FilterActionsContainer = styled.div`
-  margin-top: 8px;
+  margin-top: ${({ theme }) => theme.gridUnit * 2}px;;
 `;
 
 export default class AdhocFilterEditPopover extends React.Component {

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.jsx
@@ -86,6 +86,10 @@ const FilterPopoverContentContainer = styled.div`
   }
 `;
 
+const FilterActionsContainer = styled.div`
+  margin-top: 8px;
+`;
+
 export default class AdhocFilterEditPopover extends React.Component {
   constructor(props) {
     super(props);
@@ -242,7 +246,7 @@ export default class AdhocFilterEditPopover extends React.Component {
             </ErrorBoundary>
           </Tabs.TabPane>
         </Tabs>
-        <div>
+        <FilterActionsContainer>
           <Button buttonSize="small" onClick={this.props.onClose} cta>
             {t('Close')}
           </Button>
@@ -266,7 +270,7 @@ export default class AdhocFilterEditPopover extends React.Component {
             onMouseDown={this.onDragDown}
             className="fa fa-expand edit-popover-resize text-muted"
           />
-        </div>
+        </FilterActionsContainer>
       </FilterPopoverContentContainer>
     );
   }


### PR DESCRIPTION
### SUMMARY
Padding between TextArea and Buttons.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
![image](https://user-images.githubusercontent.com/47900232/167853241-8657540b-e2c9-4edb-86ce-e2151ff6c78d.png)

AFTER:
![image](https://user-images.githubusercontent.com/47900232/167853032-ff27dd5b-a952-43d6-b1eb-7d1ca0d8ac29.png)


### TESTING INSTRUCTIONS
**How to reproduce issues**
1. Go to any chart
2. Go to Filter options of any chart

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
