### PR TITLE
feat(sip-68): Add DatasourceDAO class to manage querying different datasources easier

### DIFF
--- a/superset/dao/datasource/dao.py
+++ b/superset/dao/datasource/dao.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from superset.connectors.sqla.models import SqlaTable
 from superset.dao.base import BaseDAO
+from superset.dao.exceptions import DatasourceNotFound, DatasourceTypeNotSupportedError
 from superset.datasets.commands.exceptions import DatasetNotFoundError
 from superset.datasets.models import Dataset
 from superset.models.core import Database
@@ -46,10 +47,10 @@ class DatasourceDAO(BaseDAO):
 
     @classmethod
     def get_datasource(
-        cls, datasource_type: DatasourceType, datasource_id: int, session: Session
+        cls, session: Session, datasource_type: DatasourceType, datasource_id: int
     ) -> Datasource:
         if datasource_type not in cls.sources:
-            raise DatasetNotFoundError()
+            raise DatasourceTypeNotSupportedError()
 
         datasource = (
             session.query(cls.sources[datasource_type])
@@ -58,19 +59,16 @@ class DatasourceDAO(BaseDAO):
         )
 
         if not datasource:
-            raise DatasetNotFoundError()
+            raise DatasourceNotFound()
 
         return datasource
 
     @classmethod
-    def get_all_datasources(cls, session: Session) -> List[Datasource]:
-        datasources: List[Datasource] = []
-        for source_class in DatasourceDAO.sources.values():
-            qry = session.query(source_class)
-            if isinstance(source_class, SqlaTable):
-                qry = source_class.default_query(qry)
-            datasources.extend(qry.all())
-        return datasources
+    def get_all_sqlatables_datasources(cls, session: Session) -> List[Datasource]:
+        source_class = DatasourceDAO.sources[DatasourceType.SQLATABLE]
+        qry = session.query(source_class)
+        qry = source_class.default_query(qry)
+        return qry.all()
 
     @classmethod
     def get_datasource_by_name(  # pylint: disable=too-many-arguments
@@ -78,8 +76,8 @@ class DatasourceDAO(BaseDAO):
         session: Session,
         datasource_type: DatasourceType,
         datasource_name: str,
-        schema: str,
         database_name: str,
+        schema: str,
     ) -> Optional[Datasource]:
         datasource_class = DatasourceDAO.sources[datasource_type]
         if isinstance(datasource_class, SqlaTable):
@@ -96,21 +94,22 @@ class DatasourceDAO(BaseDAO):
         permissions: Set[str],
         schema_perms: Set[str],
     ) -> List[Datasource]:
-        # TODO(bogdan): add unit test
+        # TODO(hughhhh): add unit test
         datasource_class = DatasourceDAO.sources[DatasourceType[database.type]]
-        if isinstance(datasource_class, SqlaTable):
-            return (
-                session.query(datasource_class)
-                .filter_by(database_id=database.id)
-                .filter(
-                    or_(
-                        datasource_class.perm.in_(permissions),
-                        datasource_class.schema_perm.in_(schema_perms),
-                    )
+        if not isinstance(datasource_class, SqlaTable):
+            return []
+
+        return (
+            session.query(datasource_class)
+            .filter_by(database_id=database.id)
+            .filter(
+                or_(
+                    datasource_class.perm.in_(permissions),
+                    datasource_class.schema_perm.in_(schema_perms),
                 )
-                .all()
             )
-        return []
+            .all()
+        )
 
     @classmethod
     def get_eager_datasource(
@@ -118,17 +117,17 @@ class DatasourceDAO(BaseDAO):
     ) -> Optional[Datasource]:
         """Returns datasource with columns and metrics."""
         datasource_class = DatasourceDAO.sources[DatasourceType[datasource_type]]
-        if isinstance(datasource_class, SqlaTable):
-            return (
-                session.query(datasource_class)
-                .options(
-                    subqueryload(datasource_class.columns),
-                    subqueryload(datasource_class.metrics),
-                )
-                .filter_by(id=datasource_id)
-                .one()
+        if not isinstance(datasource_class, SqlaTable):
+            return None
+        return (
+            session.query(datasource_class)
+            .options(
+                subqueryload(datasource_class.columns),
+                subqueryload(datasource_class.metrics),
             )
-        return None
+            .filter_by(id=datasource_id)
+            .one()
+        )
 
     @classmethod
     def query_datasources_by_name(
@@ -139,8 +138,9 @@ class DatasourceDAO(BaseDAO):
         schema: Optional[str] = None,
     ) -> List[Datasource]:
         datasource_class = DatasourceDAO.sources[DatasourceType[database.type]]
-        if isinstance(datasource_class, SqlaTable):
-            return datasource_class.query_datasources_by_name(
-                session, database, datasource_name, schema=schema
-            )
-        return []
+        if not isinstance(datasource_class, SqlaTable):
+            return []
+
+        return datasource_class.query_datasources_by_name(
+            session, database, datasource_name, schema=schema
+        )

--- a/superset/dao/datasource/dao.py
+++ b/superset/dao/datasource/dao.py
@@ -15,7 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Any, Dict, List, Optional, Set, Union
+from enum import Enum
+from typing import Any, Dict, List, Optional, Set, Type, Union
 
 from flask_babel import _
 from sqlalchemy import or_
@@ -32,12 +33,12 @@ from superset.models.sql_lab import Query, SavedQuery
 from superset.tables.models import Table
 from superset.utils.core import DatasourceType
 
-Datasource = Union[Dataset, SqlaTable, Table, Query, SavedQuery, Any]
+Datasource = Union[Dataset, SqlaTable, Table, Query, SavedQuery]
 
 
 class DatasourceDAO(BaseDAO):
 
-    sources: Dict[DatasourceType, Datasource] = {
+    sources: Dict[DatasourceType, Type[Datasource]] = {
         DatasourceType.SQLATABLE: SqlaTable,
         DatasourceType.QUERY: Query,
         DatasourceType.SAVEDQUERY: SavedQuery,

--- a/superset/dao/datasource/dao.py
+++ b/superset/dao/datasource/dao.py
@@ -15,37 +15,38 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
 from flask_babel import _
 from sqlalchemy import or_
 from sqlalchemy.orm import Session, subqueryload
 from sqlalchemy.orm.exc import NoResultFound
 
-from superset.connectors.sqla.models import SqlaTable, Table
+from superset.connectors.sqla.models import SqlaTable
 from superset.dao.base import BaseDAO
 from superset.datasets.commands.exceptions import DatasetNotFoundError
 from superset.datasets.models import Dataset
 from superset.models.core import Database
 from superset.models.sql_lab import Query, SavedQuery
+from superset.tables.models import Table
+from superset.utils.core import DatasourceType
 
-Datasource = Union[Dataset, SqlaTable, Table, Query, SavedQuery]
+Datasource = Union[Dataset, SqlaTable, Table, Query, SavedQuery, Any]
 
 
 class DatasourceDAO(BaseDAO):
 
-    sources = {
-        # using table -> SqlaTable for backward compatibility at the moment
-        "table": SqlaTable,
-        "query": Query,
-        "saved_query": SavedQuery,
-        "sl_dataset": Dataset,
-        "sl_table": Table,
+    sources: Dict[DatasourceType, Datasource] = {
+        DatasourceType.SQLATABLE: SqlaTable,
+        DatasourceType.QUERY: Query,
+        DatasourceType.SAVEDQUERY: SavedQuery,
+        DatasourceType.DATASET: Dataset,
+        DatasourceType.TABLE: Table,
     }
 
     @classmethod
     def get_datasource(
-        cls, datasource_type: str, datasource_id: int, session: Session
+        cls, datasource_type: DatasourceType, datasource_id: int, session: Session
     ) -> Datasource:
         if datasource_type not in cls.sources:
             raise DatasetNotFoundError()
@@ -61,91 +62,85 @@ class DatasourceDAO(BaseDAO):
 
         return datasource
 
-    def get_all_datasources(self, session: Session) -> List[Datasource]:
-        datasources: List["Datasource"] = []
+    @classmethod
+    def get_all_datasources(cls, session: Session) -> List[Datasource]:
+        datasources: List[Datasource] = []
         for source_class in DatasourceDAO.sources.values():
             qry = session.query(source_class)
-            qry = source_class.default_query(qry)
+            if isinstance(source_class, SqlaTable):
+                qry = source_class.default_query(qry)
             datasources.extend(qry.all())
         return datasources
 
-    def get_datasource_by_id(self, session: Session, datasource_id: int) -> Datasource:
-        """
-        Find a datasource instance based on the unique id.
-        :param session: Session to use
-        :param datasource_id: unique id of datasource
-        :return: Datasource corresponding to the id
-        :raises NoResultFound: if no datasource is found corresponding to the id
-        """
-        for datasource_class in DatasourceDAO.sources.values():
-            try:
-                return (
-                    session.query(datasource_class)
-                    .filter(datasource_class.id == datasource_id)
-                    .one()
-                )
-            except NoResultFound:
-                # proceed to next datasource type
-                pass
-        raise NoResultFound(_("Datasource id not found: %(id)s", id=datasource_id))
-
+    @classmethod
     def get_datasource_by_name(  # pylint: disable=too-many-arguments
-        self,
+        cls,
         session: Session,
-        datasource_type: str,
+        datasource_type: DatasourceType,
         datasource_name: str,
         schema: str,
         database_name: str,
     ) -> Optional[Datasource]:
         datasource_class = DatasourceDAO.sources[datasource_type]
-        return datasource_class.get_datasource_by_name(
-            session, datasource_name, schema, database_name
-        )
+        if isinstance(datasource_class, SqlaTable):
+            return datasource_class.get_datasource_by_name(
+                session, datasource_name, schema, database_name
+            )
+        return None
 
+    @classmethod
     def query_datasources_by_permissions(  # pylint: disable=invalid-name
-        self,
+        cls,
         session: Session,
         database: Database,
         permissions: Set[str],
         schema_perms: Set[str],
     ) -> List[Datasource]:
         # TODO(bogdan): add unit test
-        datasource_class = DatasourceDAO.sources[database.type]
-        return (
-            session.query(datasource_class)
-            .filter_by(database_id=database.id)
-            .filter(
-                or_(
-                    datasource_class.perm.in_(permissions),
-                    datasource_class.schema_perm.in_(schema_perms),
+        datasource_class = DatasourceDAO.sources[DatasourceType[database.type]]
+        if isinstance(datasource_class, SqlaTable):
+            return (
+                session.query(datasource_class)
+                .filter_by(database_id=database.id)
+                .filter(
+                    or_(
+                        datasource_class.perm.in_(permissions),
+                        datasource_class.schema_perm.in_(schema_perms),
+                    )
                 )
+                .all()
             )
-            .all()
-        )
+        return []
 
+    @classmethod
     def get_eager_datasource(
-        self, session: Session, datasource_type: str, datasource_id: int
-    ) -> Datasource:
+        cls, session: Session, datasource_type: str, datasource_id: int
+    ) -> Optional[Datasource]:
         """Returns datasource with columns and metrics."""
-        datasource_class = DatasourceDAO.sources[datasource_type]
-        return (
-            session.query(datasource_class)
-            .options(
-                subqueryload(datasource_class.columns),
-                subqueryload(datasource_class.metrics),
+        datasource_class = DatasourceDAO.sources[DatasourceType[datasource_type]]
+        if isinstance(datasource_class, SqlaTable):
+            return (
+                session.query(datasource_class)
+                .options(
+                    subqueryload(datasource_class.columns),
+                    subqueryload(datasource_class.metrics),
+                )
+                .filter_by(id=datasource_id)
+                .one()
             )
-            .filter_by(id=datasource_id)
-            .one()
-        )
+        return None
 
+    @classmethod
     def query_datasources_by_name(
-        self,
+        cls,
         session: Session,
         database: Database,
         datasource_name: str,
         schema: Optional[str] = None,
     ) -> List[Datasource]:
-        datasource_class = DatasourceDAO.sources[database.type]
-        return datasource_class.query_datasources_by_name(
-            session, database, datasource_name, schema=schema
-        )
+        datasource_class = DatasourceDAO.sources[DatasourceType[database.type]]
+        if isinstance(datasource_class, SqlaTable):
+            return datasource_class.query_datasources_by_name(
+                session, database, datasource_name, schema=schema
+            )
+        return []

--- a/superset/dao/datasource/dao.py
+++ b/superset/dao/datasource/dao.py
@@ -1,0 +1,151 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import List, Optional, Set, Union
+
+from flask_babel import _
+from sqlalchemy import or_
+from sqlalchemy.orm import Session, subqueryload
+from sqlalchemy.orm.exc import NoResultFound
+
+from superset.connectors.sqla.models import SqlaTable, Table
+from superset.dao.base import BaseDAO
+from superset.datasets.commands.exceptions import DatasetNotFoundError
+from superset.datasets.models import Dataset
+from superset.models.core import Database
+from superset.models.sql_lab import Query, SavedQuery
+
+Datasource = Union[Dataset, SqlaTable, Table, Query, SavedQuery]
+
+
+class DatasourceDAO(BaseDAO):
+
+    sources = {
+        # using table -> SqlaTable for backward compatibility at the moment
+        "table": SqlaTable,
+        "query": Query,
+        "saved_query": SavedQuery,
+        "sl_dataset": Dataset,
+        "sl_table": Table,
+    }
+
+    @classmethod
+    def get_datasource(
+        cls, datasource_type: str, datasource_id: int, session: Session
+    ) -> Datasource:
+        if datasource_type not in cls.sources:
+            raise DatasetNotFoundError()
+
+        datasource = (
+            session.query(cls.sources[datasource_type])
+            .filter_by(id=datasource_id)
+            .one_or_none()
+        )
+
+        if not datasource:
+            raise DatasetNotFoundError()
+
+        return datasource
+
+    def get_all_datasources(self, session: Session) -> List[Datasource]:
+        datasources: List["Datasource"] = []
+        for source_class in DatasourceDAO.sources.values():
+            qry = session.query(source_class)
+            qry = source_class.default_query(qry)
+            datasources.extend(qry.all())
+        return datasources
+
+    def get_datasource_by_id(self, session: Session, datasource_id: int) -> Datasource:
+        """
+        Find a datasource instance based on the unique id.
+        :param session: Session to use
+        :param datasource_id: unique id of datasource
+        :return: Datasource corresponding to the id
+        :raises NoResultFound: if no datasource is found corresponding to the id
+        """
+        for datasource_class in DatasourceDAO.sources.values():
+            try:
+                return (
+                    session.query(datasource_class)
+                    .filter(datasource_class.id == datasource_id)
+                    .one()
+                )
+            except NoResultFound:
+                # proceed to next datasource type
+                pass
+        raise NoResultFound(_("Datasource id not found: %(id)s", id=datasource_id))
+
+    def get_datasource_by_name(  # pylint: disable=too-many-arguments
+        self,
+        session: Session,
+        datasource_type: str,
+        datasource_name: str,
+        schema: str,
+        database_name: str,
+    ) -> Optional[Datasource]:
+        datasource_class = DatasourceDAO.sources[datasource_type]
+        return datasource_class.get_datasource_by_name(
+            session, datasource_name, schema, database_name
+        )
+
+    def query_datasources_by_permissions(  # pylint: disable=invalid-name
+        self,
+        session: Session,
+        database: Database,
+        permissions: Set[str],
+        schema_perms: Set[str],
+    ) -> List[Datasource]:
+        # TODO(bogdan): add unit test
+        datasource_class = DatasourceDAO.sources[database.type]
+        return (
+            session.query(datasource_class)
+            .filter_by(database_id=database.id)
+            .filter(
+                or_(
+                    datasource_class.perm.in_(permissions),
+                    datasource_class.schema_perm.in_(schema_perms),
+                )
+            )
+            .all()
+        )
+
+    def get_eager_datasource(
+        self, session: Session, datasource_type: str, datasource_id: int
+    ) -> Datasource:
+        """Returns datasource with columns and metrics."""
+        datasource_class = DatasourceDAO.sources[datasource_type]
+        return (
+            session.query(datasource_class)
+            .options(
+                subqueryload(datasource_class.columns),
+                subqueryload(datasource_class.metrics),
+            )
+            .filter_by(id=datasource_id)
+            .one()
+        )
+
+    def query_datasources_by_name(
+        self,
+        session: Session,
+        database: Database,
+        datasource_name: str,
+        schema: Optional[str] = None,
+    ) -> List[Datasource]:
+        datasource_class = DatasourceDAO.sources[database.type]
+        return datasource_class.query_datasources_by_name(
+            session, database, datasource_name, schema=schema
+        )

--- a/superset/dao/exceptions.py
+++ b/superset/dao/exceptions.py
@@ -53,3 +53,15 @@ class DAOConfigError(DAOException):
     """
 
     message = "DAO is not configured correctly missing model definition"
+
+
+class DatasourceTypeNotSupportedError(DAOException):
+    """
+    DAO datasource query source type is not supported
+    """
+
+    message = "DAO datasource query source type is not supported"
+
+
+class DatasourceNotFound(DAOException):
+    message = "Datasource does not exist"

--- a/tests/unit_tests/dao/datasource_test.py
+++ b/tests/unit_tests/dao/datasource_test.py
@@ -1,0 +1,116 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+from sqlalchemy.orm.session import Session
+
+
+def create_test_data(session: Session) -> None:
+    from superset.columns.models import Column
+    from superset.connectors.sqla.models import SqlaTable, TableColumn
+    from superset.models.core import Database
+    from superset.models.sql_lab import Query, SavedQuery
+
+    engine = session.get_bind()
+    SqlaTable.metadata.create_all(engine)  # pylint: disable=no-member
+
+    db = Database(database_name="my_database", sqlalchemy_uri="sqlite://")
+
+    columns = [
+        TableColumn(column_name="a", type="INTEGER"),
+    ]
+
+    sqla_table = SqlaTable(
+        table_name="my_sqla_table",
+        columns=columns,
+        metrics=[],
+        database=db,
+    )
+
+    query_obj = Query(
+        client_id="foo",
+        database=db,
+        tab_name="test_tab",
+        sql_editor_id="test_editor_id",
+        sql="select * from bar",
+        select_sql="select * from bar",
+        executed_sql="select * from bar",
+        limit=100,
+        select_as_cta=False,
+        rows=100,
+        error_message="none",
+        results_key="abc",
+    )
+
+    saved_query = SavedQuery(database=db, sql="select * from foo")
+
+    session.add(saved_query)
+    session.add(query_obj)
+    session.add(db)
+    session.add(sqla_table)
+    session.flush()
+
+
+def test_get_datasource_sqlatable(app_context: None, session: Session) -> None:
+    from superset.connectors.sqla.models import SqlaTable
+    from superset.dao.datasource.dao import DatasourceDAO
+
+    create_test_data(session)
+
+    result = DatasourceDAO.get_datasource(
+        datasource_type="table", datasource_id=1, session=session
+    )
+
+    assert 1 == result.id
+    assert "my_sqla_table" == result.table_name
+    assert isinstance(result, SqlaTable)
+
+
+def test_get_datasource_query(app_context: None, session: Session) -> None:
+    from superset.dao.datasource.dao import DatasourceDAO
+    from superset.models.sql_lab import Query
+
+    create_test_data(session)
+
+    result = DatasourceDAO.get_datasource(
+        datasource_type="query", datasource_id=1, session=session
+    )
+
+    assert result.id == 1
+    assert isinstance(result, Query)
+
+
+def test_get_datasource_saved_query(app_context: None, session: Session) -> None:
+    from superset.dao.datasource.dao import DatasourceDAO
+    from superset.models.sql_lab import SavedQuery
+
+    create_test_data(session)
+
+    result = DatasourceDAO.get_datasource(
+        datasource_type="saved_query", datasource_id=1, session=session
+    )
+
+    assert result.id == 1
+    assert isinstance(result, SavedQuery)
+
+
+def test_get_datasource_sl_table(app_context: None, session: Session) -> None:
+    pass
+
+
+def test_get_datasource_sl_dataset(app_context: None, session: Session) -> None:
+    pass


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Building a data access object for Datasource to make it easier to query a source based upon id and type. With sip-68 work we'll be allowing users to power charts with different data object such as (queries, savedqueries, sl_datasets, and sl_tables) this work will make it easier to do quick look up of these objects with out having to write and ORM query.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
