### PR TITLE
chore: Run Applitools + Cypress nightly

### DIFF
--- a/.github/workflows/superset-applitool-cypress.yml
+++ b/.github/workflows/superset-applitool-cypress.yml
@@ -1,15 +1,17 @@
 name: Applitools Cypress
 
-on: pull_request_target
+on:
+  schedule:
+    - cron: "0 1 * * *"
 
 jobs:
   cypress-applitools:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         browser: ["chrome"]
+        node: [16]
     env:
       FLASK_ENV: development
       SUPERSET_CONFIG: tests.integration_tests.superset_test_config
@@ -34,80 +36,48 @@ jobs:
         ports:
           - 16379:6379
     steps:
-      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v2
-        with:
-          persist-credentials: false
-          submodules: recursive
-      - name: Check if python or frontend changes are present
-        id: check
-        env:
-          GITHUB_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        continue-on-error: true
-        run: ./scripts/ci_check_no_file_changes.sh python frontend
+      - uses: actions/checkout@v3
       - name: Setup Python
-        if: steps.check.outcome == 'failure'
         uses: actions/setup-python@v2
         with:
           python-version: "3.8"
       - name: OS dependencies
-        if: steps.check.outcome == 'failure'
         uses: ./.github/actions/cached-dependencies
         with:
           run: apt-get-install
       - name: Install python dependencies
-        if: steps.check.outcome == 'failure'
         uses: ./.github/actions/cached-dependencies
         with:
           run: |
             pip-upgrade
             pip install -r requirements/testing.txt
       - name: Setup postgres
-        if: steps.check.outcome == 'failure'
         uses: ./.github/actions/cached-dependencies
         with:
           run: setup-postgres
       - name: Import test data
-        if: steps.check.outcome == 'failure'
         uses: ./.github/actions/cached-dependencies
         with:
           run: testdata
-      - name: Setup Node.js
-        uses: actions/setup-node@v2
+      - name: Set up Node.js
+        uses: actions/setup-node@v3.1.1
         with:
-          node-version: "16"
+          node-version: ${{ matrix.node }}
       - name: Install npm dependencies
-        if: steps.check.outcome == 'failure'
         uses: ./.github/actions/cached-dependencies
         with:
           run: npm-install
       - name: Build javascript packages
-        if: steps.check.outcome == 'failure'
         uses: ./.github/actions/cached-dependencies
         with:
           run: build-instrumented-assets
       - name: Install cypress
-        if: steps.check.outcome == 'failure'
         uses: ./.github/actions/cached-dependencies
         with:
           run: cypress-install
       - name: Run Applitools Cypress
-        if: steps.check.outcome == 'failure'
         uses: ./.github/actions/cached-dependencies
         env:
           CYPRESS_BROWSER: ${{ matrix.browser }}
         with:
           run: cypress-run-applitools
-  batch-completion-notification:
-    if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    needs: cypress-applitools
-    steps:
-      - name: Update Applitools batch status
-        uses: wei/curl@v1.1.1
-        env:
-          APPLITOOLS_BATCH_ID: ${{ github.sha }}
-          APPLITOOLS_API_KEY: ${{ secrets.APPLITOOLS_API_KEY }}
-        with:
-          args: -d "" -X POST https://eyesapi.applitools.com/api/externals/github/servers/github.com/commit/${{ env.APPLITOOLS_BATCH_ID }}/complete?apiKey=${{ env.APPLITOOLS_API_KEY }}


### PR DESCRIPTION
### SUMMARY
We have identified that we are about to hit the rate limits of Applitools. For that reason, we are changing the workflow to run nightly on master and monitor the executions this way.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
