### PR TITLE
chore: Changes the no-literal-colors lint rule to throw errors instead of warnings

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -210,7 +210,7 @@ module.exports = {
     },
   ],
   rules: {
-    'theme-colors/no-literal-colors': 1,
+    'theme-colors/no-literal-colors': 'error',
     'translation-vars/no-template-vars': ['error', true],
     camelcase: [
       'error',


### PR DESCRIPTION
### SUMMARY
Changes the `no-literal-colors` lint rule to throw errors instead of warnings.

The following PRs removed the hard-coded colors from the codebase allowing this rule to be changed: https://github.com/apache/superset/pull/20006, https://github.com/apache/superset/pull/20016, https://github.com/apache/superset/pull/19923, https://github.com/apache/superset/pull/19493, https://github.com/apache/superset/pull/19466, https://github.com/apache/superset/pull/19443, https://github.com/apache/superset/pull/19439

### TESTING INSTRUCTIONS
Check that there are no literal color lint-related errors.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
