### PR TITLE
feat: add json_metadata field for `Query` object

### DIFF
--- a/superset/migrations/versions/126264a82d27_add_json_metadata_query_obj.py
+++ b/superset/migrations/versions/126264a82d27_add_json_metadata_query_obj.py
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add_json_metadata_query_obj
+
+Revision ID: 126264a82d27
+Revises: a9422eeaae74
+Create Date: 2022-05-11 21:04:08.101050
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "126264a82d27"
+down_revision = "a9422eeaae74"
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+def upgrade():
+    op.add_column("query", sa.Column("json_metadata", sa.Text(), nullable=True))
+
+
+def downgrade():
+    try:
+        op.drop_column("query", "json_metadata")
+    except Exception:
+        pass

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -99,6 +99,7 @@ class Query(Model, ExtraJSONMixin):
     end_time = Column(Numeric(precision=20, scale=6))
     end_result_backend_time = Column(Numeric(precision=20, scale=6))
     tracking_url = Column(Text)
+    json_metadata = Column(Text)
 
     changed_on = Column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=True


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding `json_metadata` field to `Query` to allow us to save columns data whenever a user wants to execute a query from explore view. This is needed to power the columns dropdown in the left side of the explore page.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


### Benchmark Results:
```
Results:

Current: 0.35 s
10+: 0.27 s
100+: 0.22 s
1000+: 0.23 s
Cleaning up DB

```