### PR TITLE
fix(homepage): make to show indicator when tab is chosen

### DIFF
--- a/superset-frontend/src/views/components/SubMenu.tsx
+++ b/superset-frontend/src/views/components/SubMenu.tsx
@@ -110,6 +110,10 @@ const StyledHeader = styled.div`
         padding: ${({ theme }) => theme.gridUnit * 2}px
           ${({ theme }) => theme.gridUnit * 4}px;
       }
+
+      &.active a {
+        text-decoration: underline;
+      }
     }
 
     li.active > a,


### PR DESCRIPTION
### SUMMARY
[home page] no indicator for which tab is chosen on recent/dashboard/charts/save query section

Tabs in recents/dashboards/charts/save queries should be indicator when those are chosen.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
![image](https://user-images.githubusercontent.com/47900232/168123869-cb81ef9a-a285-4ca7-8c57-66b797864a24.png)

AFTER:
![image](https://user-images.githubusercontent.com/47900232/168123722-1cf2585d-ffab-4cc5-9d53-30a84247a0b4.png)

### TESTING INSTRUCTIONS
**Repro steps**
1, go to home page
2, click on the tabs in recents/dashboards/charts/save queries

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
