### PR TITLE
feat(dashboard): Rearrange items in chart header controls dropdown

### DIFF
--- a/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
@@ -205,6 +205,7 @@ const SliceHeader: FC<SliceHeaderProps> = ({
                 addDangerToast={addDangerToast}
                 handleToggleFullSize={handleToggleFullSize}
                 isFullSize={isFullSize}
+                isDescriptionExpanded={isExpanded}
                 chartStatus={chartStatus}
                 formData={formData}
               />

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
@@ -125,16 +125,22 @@ test('Should render default props', () => {
   delete props.sliceCanEdit;
 
   render(<SliceHeaderControls {...props} />, { useRedux: true });
-  userEvent.click(screen.getByRole('menuitem', { name: 'Maximize chart' }));
-  userEvent.click(screen.getByRole('menuitem', { name: /Force refresh/ }));
-  userEvent.click(
-    screen.getByRole('menuitem', { name: 'Toggle chart description' }),
-  );
-  userEvent.click(
-    screen.getByRole('menuitem', { name: 'View chart in Explore' }),
-  );
-  userEvent.click(screen.getByRole('menuitem', { name: 'Export CSV' }));
-  userEvent.click(screen.getByRole('menuitem', { name: /Force refresh/ }));
+  expect(
+    screen.getByRole('menuitem', { name: 'Enter fullscreen' }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole('menuitem', { name: /Force refresh/ }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole('menuitem', { name: 'Show chart description' }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole('menuitem', { name: 'Edit chart' }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole('menuitem', { name: 'Download' }),
+  ).toBeInTheDocument();
+  expect(screen.getByRole('menuitem', { name: 'Share' })).toBeInTheDocument();
 
   expect(
     screen.getByRole('button', { name: 'More Options' }),
@@ -142,12 +148,13 @@ test('Should render default props', () => {
   expect(screen.getByTestId('NoAnimationDropdown')).toBeInTheDocument();
 });
 
-test('Should "export to CSV"', () => {
+test('Should "export to CSV"', async () => {
   const props = createProps();
   render(<SliceHeaderControls {...props} />, { useRedux: true });
 
   expect(props.exportCSV).toBeCalledTimes(0);
-  userEvent.click(screen.getByRole('menuitem', { name: 'Export CSV' }));
+  userEvent.hover(screen.getByText('Download'));
+  userEvent.click(await screen.findByText('Export to .CSV'));
   expect(props.exportCSV).toBeCalledTimes(1);
   expect(props.exportCSV).toBeCalledWith(371);
 });
@@ -155,7 +162,8 @@ test('Should "export to CSV"', () => {
 test('Should not show "Export to CSV" if slice is filter box', () => {
   const props = createProps('filter_box');
   render(<SliceHeaderControls {...props} />, { useRedux: true });
-  expect(screen.queryByRole('menuitem', { name: 'Export CSV' })).toBe(null);
+  userEvent.hover(screen.getByText('Download'));
+  expect(screen.queryByText('Export to .CSV')).toBe(null);
 });
 
 test('Export full CSV is under featureflag', () => {
@@ -165,23 +173,20 @@ test('Export full CSV is under featureflag', () => {
   };
   const props = createProps('table');
   render(<SliceHeaderControls {...props} />, { useRedux: true });
-  expect(screen.queryByRole('menuitem', { name: 'Export full CSV' })).toBe(
-    null,
-  );
+  userEvent.hover(screen.getByText('Download'));
+  expect(screen.queryByText('Export full CSV')).toBe(null);
 });
 
-test('Should "export full CSV"', () => {
+test('Should "export full CSV"', async () => {
   // @ts-ignore
   global.featureFlags = {
     [FeatureFlag.ALLOW_FULL_CSV_EXPORT]: true,
   };
   const props = createProps('table');
   render(<SliceHeaderControls {...props} />, { useRedux: true });
-  expect(screen.queryByRole('menuitem', { name: 'Export full CSV' })).not.toBe(
-    null,
-  );
   expect(props.exportFullCSV).toBeCalledTimes(0);
-  userEvent.click(screen.getByRole('menuitem', { name: 'Export full CSV' }));
+  userEvent.hover(screen.getByText('Download'));
+  userEvent.click(await screen.findByText('Export to full .CSV'));
   expect(props.exportFullCSV).toBeCalledTimes(1);
   expect(props.exportFullCSV).toBeCalledWith(371);
 });
@@ -193,7 +198,8 @@ test('Should not show export full CSV if report is not table', () => {
   };
   const props = createProps();
   render(<SliceHeaderControls {...props} />, { useRedux: true });
-  expect(screen.queryByRole('menuitem', { name: 'Export full CSV' })).toBe(
+  userEvent.hover(screen.getByText('Download'));
+  expect(screen.queryByRole('menuitem', { name: 'Export to full .CSV' })).toBe(
     null,
   );
 });
@@ -205,18 +211,19 @@ test('Should not show export full CSV if slice is filter box', () => {
   };
   const props = createProps('filter_box');
   render(<SliceHeaderControls {...props} />, { useRedux: true });
-  expect(screen.queryByRole('menuitem', { name: 'Export full CSV' })).toBe(
+  userEvent.hover(screen.getByText('Download'));
+  expect(screen.queryByRole('menuitem', { name: 'Export to full .CSV' })).toBe(
     null,
   );
 });
 
-test('Should "Toggle chart description"', () => {
+test('Should "Show chart description"', () => {
   const props = createProps();
   render(<SliceHeaderControls {...props} />, { useRedux: true });
 
   expect(props.toggleExpandSlice).toBeCalledTimes(0);
   userEvent.click(
-    screen.getByRole('menuitem', { name: 'Toggle chart description' }),
+    screen.getByRole('menuitem', { name: 'Show chart description' }),
   );
   expect(props.toggleExpandSlice).toBeCalledTimes(1);
   expect(props.toggleExpandSlice).toBeCalledWith(371);
@@ -233,11 +240,11 @@ test('Should "Force refresh"', () => {
   expect(props.addSuccessToast).toBeCalledTimes(1);
 });
 
-test('Should "Maximize chart"', () => {
+test('Should "Enter fullscreen"', () => {
   const props = createProps();
   render(<SliceHeaderControls {...props} />, { useRedux: true });
 
   expect(props.handleToggleFullSize).toBeCalledTimes(0);
-  userEvent.click(screen.getByRole('menuitem', { name: 'Maximize chart' }));
+  userEvent.click(screen.getByRole('menuitem', { name: 'Enter fullscreen' }));
   expect(props.handleToggleFullSize).toBeCalledTimes(1);
 });

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
@@ -159,14 +159,13 @@ test('Should "export to CSV"', async () => {
   expect(props.exportCSV).toBeCalledWith(371);
 });
 
-test('Should not show "Export to CSV" if slice is filter box', () => {
+test('Should not show "Download" if slice is filter box', () => {
   const props = createProps('filter_box');
   render(<SliceHeaderControls {...props} />, { useRedux: true });
-  userEvent.hover(screen.getByText('Download'));
-  expect(screen.queryByText('Export to .CSV')).toBe(null);
+  expect(screen.queryByText('Download')).not.toBeInTheDocument();
 });
 
-test('Export full CSV is under featureflag', () => {
+test('Export full CSV is under featureflag', async () => {
   // @ts-ignore
   global.featureFlags = {
     [FeatureFlag.ALLOW_FULL_CSV_EXPORT]: false,
@@ -174,7 +173,8 @@ test('Export full CSV is under featureflag', () => {
   const props = createProps('table');
   render(<SliceHeaderControls {...props} />, { useRedux: true });
   userEvent.hover(screen.getByText('Download'));
-  expect(screen.queryByText('Export full CSV')).toBe(null);
+  expect(await screen.findByText('Export to .CSV')).toBeInTheDocument();
+  expect(screen.queryByText('Export to full .CSV')).not.toBeInTheDocument();
 });
 
 test('Should "export full CSV"', async () => {
@@ -191,7 +191,7 @@ test('Should "export full CSV"', async () => {
   expect(props.exportFullCSV).toBeCalledWith(371);
 });
 
-test('Should not show export full CSV if report is not table', () => {
+test('Should not show export full CSV if report is not table', async () => {
   // @ts-ignore
   global.featureFlags = {
     [FeatureFlag.ALLOW_FULL_CSV_EXPORT]: true,
@@ -199,22 +199,8 @@ test('Should not show export full CSV if report is not table', () => {
   const props = createProps();
   render(<SliceHeaderControls {...props} />, { useRedux: true });
   userEvent.hover(screen.getByText('Download'));
-  expect(screen.queryByRole('menuitem', { name: 'Export to full .CSV' })).toBe(
-    null,
-  );
-});
-
-test('Should not show export full CSV if slice is filter box', () => {
-  // @ts-ignore
-  global.featureFlags = {
-    [FeatureFlag.ALLOW_FULL_CSV_EXPORT]: true,
-  };
-  const props = createProps('filter_box');
-  render(<SliceHeaderControls {...props} />, { useRedux: true });
-  userEvent.hover(screen.getByText('Download'));
-  expect(screen.queryByRole('menuitem', { name: 'Export to full .CSV' })).toBe(
-    null,
-  );
+  expect(await screen.findByText('Export to .CSV')).toBeInTheDocument();
+  expect(screen.queryByText('Export to full .CSV')).not.toBeInTheDocument();
 });
 
 test('Should "Show chart description"', () => {
@@ -222,9 +208,7 @@ test('Should "Show chart description"', () => {
   render(<SliceHeaderControls {...props} />, { useRedux: true });
 
   expect(props.toggleExpandSlice).toBeCalledTimes(0);
-  userEvent.click(
-    screen.getByRole('menuitem', { name: 'Show chart description' }),
-  );
+  userEvent.click(screen.getByText('Show chart description'));
   expect(props.toggleExpandSlice).toBeCalledTimes(1);
   expect(props.toggleExpandSlice).toBeCalledWith(371);
 });
@@ -234,7 +218,7 @@ test('Should "Force refresh"', () => {
   render(<SliceHeaderControls {...props} />, { useRedux: true });
 
   expect(props.forceRefresh).toBeCalledTimes(0);
-  userEvent.click(screen.getByRole('menuitem', { name: /Force refresh/ }));
+  userEvent.click(screen.getByText('Force refresh'));
   expect(props.forceRefresh).toBeCalledTimes(1);
   expect(props.forceRefresh).toBeCalledWith(371, 26);
   expect(props.addSuccessToast).toBeCalledTimes(1);
@@ -245,6 +229,6 @@ test('Should "Enter fullscreen"', () => {
   render(<SliceHeaderControls {...props} />, { useRedux: true });
 
   expect(props.handleToggleFullSize).toBeCalledTimes(0);
-  userEvent.click(screen.getByRole('menuitem', { name: 'Enter fullscreen' }));
+  userEvent.click(screen.getByText('Enter fullscreen'));
   expect(props.handleToggleFullSize).toBeCalledTimes(1);
 });

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -34,6 +34,7 @@ import CrossFilterScopingModal from 'src/dashboard/components/CrossFilterScoping
 import Icons from 'src/components/Icons';
 import ModalTrigger from 'src/components/ModalTrigger';
 import ViewQueryModal from 'src/explore/components/controls/ViewQueryModal';
+import { FileImageOutlined, FileOutlined } from '@ant-design/icons';
 
 const MENU_KEYS = {
   CROSS_FILTER_SCOPING: 'cross_filter_scoping',
@@ -99,6 +100,7 @@ export interface SliceHeaderControlsProps {
   isExpanded?: boolean;
   updatedDttm: number | null;
   isFullSize?: boolean;
+  isDescriptionExpanded?: boolean;
   formData: Pick<QueryFormData, 'slice_id' | 'datasource'>;
   onExploreChart: () => void;
 
@@ -256,7 +258,9 @@ class SliceHeaderControls extends React.PureComponent<
           : item}
       </div>
     ));
-    const resizeLabel = isFullSize ? t('Minimize chart') : t('Maximize chart');
+    const resizeLabel = isFullSize
+      ? t('Exit fullscreen')
+      : t('Enter fullscreen');
     const menu = (
       <Menu
         onClick={this.handleMenuClick}
@@ -275,11 +279,15 @@ class SliceHeaderControls extends React.PureComponent<
           </RefreshTooltip>
         </Menu.Item>
 
+        <Menu.Item key={MENU_KEYS.RESIZE_LABEL}>{resizeLabel}</Menu.Item>
+
         <Menu.Divider />
 
         {slice.description && (
           <Menu.Item key={MENU_KEYS.TOGGLE_CHART_DESCRIPTION}>
-            {t('Toggle chart description')}
+            {this.props.isDescriptionExpanded
+              ? t('Hide chart description')
+              : t('Show chart description')}
           </Menu.Item>
         )}
 
@@ -288,7 +296,7 @@ class SliceHeaderControls extends React.PureComponent<
             key={MENU_KEYS.EXPLORE_CHART}
             onClick={this.props.onExploreChart}
           >
-            {t('View chart in Explore')}
+            {t('Edit chart')}
           </Menu.Item>
         )}
 
@@ -309,46 +317,63 @@ class SliceHeaderControls extends React.PureComponent<
           </Menu.Item>
         )}
 
-        {supersetCanShare && (
-          <ShareMenuItems
-            dashboardId={dashboardId}
-            dashboardComponentId={componentId}
-            copyMenuItemTitle={t('Copy permalink to clipboard')}
-            emailMenuItemTitle={t('Share permalink by email')}
-            emailSubject={t('Superset chart')}
-            emailBody={t('Check out this chart: ')}
-            addSuccessToast={addSuccessToast}
-            addDangerToast={addDangerToast}
-          />
+        {(slice.description || this.props.supersetCanExplore) && (
+          <Menu.Divider />
         )}
-
-        <Menu.Item key={MENU_KEYS.RESIZE_LABEL}>{resizeLabel}</Menu.Item>
-
-        <Menu.Item key={MENU_KEYS.DOWNLOAD_AS_IMAGE}>
-          {t('Download as image')}
-        </Menu.Item>
-
-        {this.props.slice.viz_type !== 'filter_box' &&
-          this.props.supersetCanCSV && (
-            <Menu.Item key={MENU_KEYS.EXPORT_CSV}>{t('Export CSV')}</Menu.Item>
-          )}
-
-        {this.props.slice.viz_type !== 'filter_box' &&
-          isFeatureEnabled(FeatureFlag.ALLOW_FULL_CSV_EXPORT) &&
-          this.props.supersetCanCSV &&
-          isTable && (
-            <Menu.Item key={MENU_KEYS.EXPORT_FULL_CSV}>
-              {t('Export full CSV')}
-            </Menu.Item>
-          )}
 
         {isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS) &&
           isCrossFilter &&
           canEmitCrossFilter && (
-            <Menu.Item key={MENU_KEYS.CROSS_FILTER_SCOPING}>
-              {t('Cross-filter scoping')}
-            </Menu.Item>
+            <>
+              <Menu.Item key={MENU_KEYS.CROSS_FILTER_SCOPING}>
+                {t('Cross-filter scoping')}
+              </Menu.Item>
+              <Menu.Divider />
+            </>
           )}
+
+        {supersetCanShare && (
+          <Menu.SubMenu title={t('Share')}>
+            <ShareMenuItems
+              dashboardId={dashboardId}
+              dashboardComponentId={componentId}
+              copyMenuItemTitle={t('Copy permalink to clipboard')}
+              emailMenuItemTitle={t('Share chart by email')}
+              emailSubject={t('Superset chart')}
+              emailBody={t('Check out this chart: ')}
+              addSuccessToast={addSuccessToast}
+              addDangerToast={addDangerToast}
+            />
+          </Menu.SubMenu>
+        )}
+
+        <Menu.SubMenu title={t('Download')}>
+          {this.props.slice.viz_type !== 'filter_box' &&
+            this.props.supersetCanCSV && (
+              <Menu.Item key={MENU_KEYS.EXPORT_CSV} icon={<FileOutlined />}>
+                {t('Export to .CSV')}
+              </Menu.Item>
+            )}
+
+          {this.props.slice.viz_type !== 'filter_box' &&
+            isFeatureEnabled(FeatureFlag.ALLOW_FULL_CSV_EXPORT) &&
+            this.props.supersetCanCSV &&
+            isTable && (
+              <Menu.Item
+                key={MENU_KEYS.EXPORT_FULL_CSV}
+                icon={<FileOutlined />}
+              >
+                {t('Export to full .CSV')}
+              </Menu.Item>
+            )}
+
+          <Menu.Item
+            key={MENU_KEYS.DOWNLOAD_AS_IMAGE}
+            icon={<FileImageOutlined />}
+          >
+            {t('Download as image')}
+          </Menu.Item>
+        </Menu.SubMenu>
       </Menu>
     );
 

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -389,7 +389,7 @@ export default class Chart extends React.Component {
         <SliceHeader
           innerRef={this.setHeaderRef}
           slice={slice}
-          isExpanded={!!isExpanded}
+          isExpanded={isExpanded}
           isCached={isCached}
           cachedDttm={cachedDttm}
           updatedDttm={chartUpdateEndTime}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This PR rearranges and renames menu items in chart's controls dropdown on Dashboard.

- Grouped creating permalink and sending email in "Share" submenu
- Grouped exporting to CSV and downloading image in "Download" submenu
- Renamed "View chart in Explore" to "Edit chart"
- Renamed "Maximize/Minimize chart" to "Enter/Leave fullscreen"

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="424" alt="image" src="https://user-images.githubusercontent.com/15073128/168129407-ae88c9b5-2ec2-44af-aec3-3d21282ef182.png">

After:
<img width="496" alt="image" src="https://user-images.githubusercontent.com/15073128/168129224-be08a1fe-65b6-4d0a-ae72-a821198e394d.png">
<img width="470" alt="image" src="https://user-images.githubusercontent.com/15073128/168129279-0a086d62-612a-4ea0-8660-546efbaaa81a.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @kasiazjc 