### PR TITLE
feat(Helm Chart): Support resource limits and requests for each component

### DIFF
--- a/helm/superset/Chart.lock
+++ b/helm/superset/Chart.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 11.1.22
-- name: redis
-  repository: https://charts.bitnami.com/bitnami
-  version: 16.3.1
-digest: sha256:f80cc4ec2bb6f327d348bc15e9192cc6ab2163781c1e35f85720565a36a1cb14
-generated: "2022-04-29T21:12:17.889093837+02:00"

--- a/helm/superset/Chart.lock
+++ b/helm/superset/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 11.1.22
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 16.3.1
+digest: sha256:f80cc4ec2bb6f327d348bc15e9192cc6ab2163781c1e35f85720565a36a1cb14
+generated: "2022-04-29T21:12:17.889093837+02:00"

--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
   - name: craig-rueda
     email: craig@craigrueda.com
     url: https://github.com/craig-rueda
-version: 0.6.1
+version: 0.6.2
 dependencies:
 - name: postgresql
   version: 11.1.22

--- a/helm/superset/templates/deployment-beat.yaml
+++ b/helm/superset/templates/deployment-beat.yaml
@@ -98,7 +98,11 @@ spec:
           {{- tpl (toYaml .) $ | nindent 12 -}}
           {{- end }}
           resources:
+          {{- if .Values.supersetCeleryBeat.resources }}
+{{ toYaml .Values.supersetCeleryBeat.resources | indent 12 }}
+          {{- else }}
 {{ toYaml .Values.resources | indent 12 }}
+          {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/helm/superset/templates/deployment-worker.yaml
+++ b/helm/superset/templates/deployment-worker.yaml
@@ -99,7 +99,11 @@ spec:
           {{- tpl (toYaml .) $ | nindent 12 -}}
           {{- end }}
           resources:
+          {{- if .Values.supersetWorker.resources }}
+{{ toYaml .Values.supersetWorker.resources | indent 12 }}
+          {{- else }}
 {{ toYaml .Values.resources | indent 12 }}
+          {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/helm/superset/templates/deployment.yaml
+++ b/helm/superset/templates/deployment.yaml
@@ -115,7 +115,11 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           resources:
+          {{- if .Values.supersetNode.resources }}
+{{ toYaml .Values.supersetNode.resources | indent 12 }}
+          {{- else }}
 {{ toYaml .Values.resources | indent 12 }}
+          {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/helm/superset/values.schema.json
+++ b/helm/superset/values.schema.json
@@ -275,6 +275,9 @@
                 },
                 "podLabels": {
                     "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.23.0/_definitions.json##/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+                },
+                "resources": {
+                    "type": "object"
                 }
             },
             "required": [
@@ -305,6 +308,9 @@
                 },
                 "podLabels": {
                     "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.23.0/_definitions.json##/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+                },
+                "resources": {
+                    "type": "object"
                 }
             },
             "required": [
@@ -336,6 +342,9 @@
                 },
                 "podLabels": {
                     "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.23.0/_definitions.json##/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+                },
+                "resources": {
+                    "type": "object"
                 }
             },
             "required": [

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -203,6 +203,8 @@ resources: {}
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # The limits below will apply to all Superset components. To set individual resource limitations refer to the pod specific values below.
+  # The pod specific values will overwrite anything that is set here.
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
@@ -253,6 +255,14 @@ supersetNode:
   podAnnotations: {}
   ## Labels to be added to supersetNode pods
   podLabels: {}
+  # Resource settings for the supersetNode pods - these settings overwrite might existing values from the global resources object defined above.
+  resources: {}
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
 ##
 ## Superset worker configuration
 supersetWorker:
@@ -275,6 +285,14 @@ supersetWorker:
   podAnnotations: {}
   ## Labels to be added to supersetWorker pods
   podLabels: {}
+  # Resource settings for the supersetWorker pods - these settings overwrite might existing values from the global resources object defined above.
+  resources: {}
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
 ##
 ## Superset beat configuration (to trigger scheduled jobs like reports)
 supersetCeleryBeat:
@@ -299,6 +317,14 @@ supersetCeleryBeat:
   podAnnotations: {}
   ## Labels to be added to supersetCeleryBeat pods
   podLabels: {}
+  # Resource settings for the CeleryBeat pods - these settings overwrite might existing values from the global resources object defined above.
+  resources: {}
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
 ##
 ## Init job configuration
 init:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We implemented the possibility to set individual resource limitations for every Superset component including _supersetNode_, _supersetWorker_ and _supersetCeleryBeat_. For this reason, we added the values _supersetNode.resources_, _supersetWorker.resources_ and _supersetCeleryBeat.resources_ to the values file, the Helm Schema and the Helm Templates. These pod specific values overwrite the global resource limits and requests set via the values resources. This feature introduction will not break current deployments using the value resources and only implement additional functionality.
This change allows for a more customizable experience and a more optimized user experience when deploying Superset using the Helm Chart.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Using the command Helm template it is possible to verify if the resources limit and requests are set correctly.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #19250
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
