### PR TITLE
fix: Support the Clipboard API in modern browsers

### DIFF
--- a/superset-frontend/src/components/CopyToClipboard/index.jsx
+++ b/superset-frontend/src/components/CopyToClipboard/index.jsx
@@ -57,10 +57,10 @@ class CopyToClipboard extends React.Component {
   onClick() {
     if (this.props.getText) {
       this.props.getText(d => {
-        this.copyToClipboard(d);
+        this.copyToClipboard(Promise.resolve(d));
       });
     } else {
-      this.copyToClipboard(this.props.text);
+      this.copyToClipboard(Promise.resolve(this.props.text));
     }
   }
 
@@ -72,7 +72,7 @@ class CopyToClipboard extends React.Component {
   }
 
   copyToClipboard(textToCopy) {
-    copyTextToClipboard(textToCopy)
+    copyTextToClipboard(() => textToCopy)
       .then(() => {
         this.props.addSuccessToast(t('Copied to clipboard!'));
       })

--- a/superset-frontend/src/dashboard/components/menu/ShareMenuItems/ShareMenuItems.test.tsx
+++ b/superset-frontend/src/dashboard/components/menu/ShareMenuItems/ShareMenuItems.test.tsx
@@ -102,9 +102,10 @@ test('Click on "Copy dashboard URL" and succeed', async () => {
 
   userEvent.click(screen.getByRole('button', { name: 'Copy dashboard URL' }));
 
-  await waitFor(() => {
+  await waitFor(async () => {
     expect(spy).toBeCalledTimes(1);
-    expect(spy).toBeCalledWith('http://localhost/superset/dashboard/p/123/');
+    const value = await spy.mock.calls[0][0]();
+    expect(value).toBe('http://localhost/superset/dashboard/p/123/');
     expect(props.addSuccessToast).toBeCalledTimes(1);
     expect(props.addSuccessToast).toBeCalledWith('Copied to clipboard!');
     expect(props.addDangerToast).toBeCalledTimes(0);
@@ -128,9 +129,10 @@ test('Click on "Copy dashboard URL" and fail', async () => {
 
   userEvent.click(screen.getByRole('button', { name: 'Copy dashboard URL' }));
 
-  await waitFor(() => {
+  await waitFor(async () => {
     expect(spy).toBeCalledTimes(1);
-    expect(spy).toBeCalledWith('http://localhost/superset/dashboard/p/123/');
+    const value = await spy.mock.calls[0][0]();
+    expect(value).toBe('http://localhost/superset/dashboard/p/123/');
     expect(props.addSuccessToast).toBeCalledTimes(0);
     expect(props.addDangerToast).toBeCalledTimes(1);
     expect(props.addDangerToast).toBeCalledWith(

--- a/superset-frontend/src/dashboard/components/menu/ShareMenuItems/index.tsx
+++ b/superset-frontend/src/dashboard/components/menu/ShareMenuItems/index.tsx
@@ -64,8 +64,7 @@ const ShareMenuItems = (props: ShareMenuItemProps) => {
 
   async function onCopyLink() {
     try {
-      const url = await generateUrl();
-      await copyTextToClipboard(url);
+      await copyTextToClipboard(generateUrl);
       addSuccessToast(t('Copied to clipboard!'));
     } catch (error) {
       logging.error(error);

--- a/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.test.tsx
@@ -175,9 +175,9 @@ describe('DataTablesPane', () => {
     expect(await screen.findByText('1 row')).toBeVisible();
 
     userEvent.click(screen.getByLabelText('Copy'));
-    expect(copyToClipboardSpy).toHaveBeenCalledWith(
-      '2009-01-01 00:00:00\tAction\n',
-    );
+    expect(copyToClipboardSpy).toHaveBeenCalledTimes(1);
+    const value = await copyToClipboardSpy.mock.calls[0][0]();
+    expect(value).toBe('2009-01-01 00:00:00\tAction\n');
     copyToClipboardSpy.mockRestore();
     fetchMock.restore();
   });

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
@@ -168,8 +168,7 @@ export const useExploreAdditionalActionsMenu = (
       if (!latestQueryFormData) {
         throw new Error();
       }
-      const url = await getChartPermalink(latestQueryFormData);
-      await copyTextToClipboard(url);
+      await copyTextToClipboard(() => getChartPermalink(latestQueryFormData));
       addSuccessToast(t('Copied to clipboard!'));
     } catch (error) {
       addDangerToast(t('Sorry, something went wrong. Try again later.'));

--- a/superset-frontend/src/utils/common.js
+++ b/superset-frontend/src/utils/common.js
@@ -94,7 +94,7 @@ export function prepareCopyToClipboardTabularData(data, columns) {
   for (let i = 0; i < data.length; i += 1) {
     const row = {};
     for (let j = 0; j < columns.length; j += 1) {
-      // JavaScript does not mantain the order of a mixed set of keys (i.e integers and strings)
+      // JavaScript does not maintain the order of a mixed set of keys (i.e integers and strings)
       // the below function orders the keys based on the column names.
       const key = columns[j].name || columns[j];
       if (data[i][key]) {

--- a/superset-frontend/src/utils/common.js
+++ b/superset-frontend/src/utils/common.js
@@ -145,4 +145,10 @@ export const detectOS = () => {
   return 'Unknown OS';
 };
 
+export const isSafari = () => {
+  const { userAgent } = navigator;
+
+  return userAgent && /^((?!chrome|android).)*safari/i.test(userAgent);
+};
+
 export const isNullish = value => value === null || value === undefined;

--- a/superset-frontend/src/utils/copy.ts
+++ b/superset-frontend/src/utils/copy.ts
@@ -41,49 +41,47 @@ const copyTextWithClipboardApi = async (getText: () => Promise<string>) => {
   }
 };
 
-const copyTextToClipboard = async (getText: () => Promise<string>) => {
-  try {
-    await copyTextWithClipboardApi(getText);
-  } catch {
+const copyTextToClipboard = (getText: () => Promise<string>) =>
+  copyTextWithClipboardApi(getText)
     // If the Clipboard API is not supported, fallback to the older method.
-    const text = await getText();
-    const copyPromise = new Promise<void>((resolve, reject) => {
-      const selection: Selection | null = document.getSelection();
-      if (selection) {
-        selection.removeAllRanges();
-        const range = document.createRange();
-        const span = document.createElement('span');
-        span.textContent = text;
-        span.style.position = 'fixed';
-        span.style.top = '0';
-        span.style.clip = 'rect(0, 0, 0, 0)';
-        span.style.whiteSpace = 'pre';
+    .catch(() =>
+      getText().then(
+        text =>
+          new Promise<void>((resolve, reject) => {
+            const selection: Selection | null = document.getSelection();
+            if (selection) {
+              selection.removeAllRanges();
+              const range = document.createRange();
+              const span = document.createElement('span');
+              span.textContent = text;
+              span.style.position = 'fixed';
+              span.style.top = '0';
+              span.style.clip = 'rect(0, 0, 0, 0)';
+              span.style.whiteSpace = 'pre';
 
-        document.body.appendChild(span);
-        range.selectNode(span);
-        selection.addRange(range);
+              document.body.appendChild(span);
+              range.selectNode(span);
+              selection.addRange(range);
 
-        try {
-          if (!document.execCommand('copy')) {
-            reject();
-          }
-        } catch (err) {
-          reject();
-        }
+              try {
+                if (!document.execCommand('copy')) {
+                  reject();
+                }
+              } catch (err) {
+                reject();
+              }
 
-        document.body.removeChild(span);
-        if (selection.removeRange) {
-          selection.removeRange(range);
-        } else {
-          selection.removeAllRanges();
-        }
-      }
+              document.body.removeChild(span);
+              if (selection.removeRange) {
+                selection.removeRange(range);
+              } else {
+                selection.removeAllRanges();
+              }
+            }
 
-      resolve();
-    });
-
-    await copyPromise;
-  }
-};
+            resolve();
+          }),
+      ),
+    );
 
 export default copyTextToClipboard;

--- a/superset-frontend/src/views/CRUD/data/components/SyntaxHighlighterCopy/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/components/SyntaxHighlighterCopy/index.tsx
@@ -65,7 +65,7 @@ export default function SyntaxHighlighterCopy({
   language: 'sql' | 'markdown' | 'html' | 'json';
 }) {
   function copyToClipboard(textToCopy: string) {
-    copyTextToClipboard(textToCopy)
+    copyTextToClipboard(() => Promise.resolve(textToCopy))
       .then(() => {
         if (addSuccessToast) {
           addSuccessToast(t('SQL Copied!'));

--- a/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx
+++ b/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx
@@ -210,8 +210,10 @@ function SavedQueryList({
 
   const copyQueryLink = useCallback(
     (id: number) => {
-      copyTextToClipboard(
-        `${window.location.origin}/superset/sqllab?savedQueryId=${id}`,
+      copyTextToClipboard(() =>
+        Promise.resolve(
+          `${window.location.origin}/superset/sqllab?savedQueryId=${id}`,
+        ),
       )
         .then(() => {
           addSuccessToast(t('Link Copied!'));

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -611,8 +611,10 @@ export const copyQueryLink = (
   addDangerToast: (arg0: string) => void,
   addSuccessToast: (arg0: string) => void,
 ) => {
-  copyTextToClipboard(
-    `${window.location.origin}/superset/sqllab?savedQueryId=${id}`,
+  copyTextToClipboard(() =>
+    Promise.resolve(
+      `${window.location.origin}/superset/sqllab?savedQueryId=${id}`,
+    ),
   )
     .then(() => {
       addSuccessToast(t('Link Copied!'));


### PR DESCRIPTION
### SUMMARY
[The copy command](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand), though largely still supported, is deprecated.

In Safari, latest versions, the copy to clipboard of a permalink no longer works because of it.

This PR adds support for the Clipboard API, with all the nuances and small differences between the different browser engines. Be sure to read the comments & associated discussions linked for more information.

[The new API is not yet fully supported by all browsers](https://caniuse.com/?search=clipboard%20api), so the current copy code was left as a fallback.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/17252075/168292759-62bde4f0-c7bd-4491-a1a1-2e0706a3c9c9.mov

After:

https://user-images.githubusercontent.com/17252075/168292801-ce6471e6-4f9a-4bb3-8498-459dd38605c9.mov

### TESTING INSTRUCTIONS
Go to any chart/dashboard and ensure the copy to permalink works across browsers.

### ADDITIONAL INFORMATION
Fixes #19994
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
