### PR TITLE
fix(chart & gallery): make to add mixed time-series into recommended charts

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/index.ts
@@ -67,6 +67,7 @@ export default class EchartsTimeseriesChartPlugin extends ChartPlugin<
         name: t('Mixed Time-Series'),
         thumbnail,
         tags: [
+          t('Advanced-Analytics'),
           t('Aesthetic'),
           t('ECharts'),
           t('Experimental'),


### PR DESCRIPTION
### SUMMARY
[Gallery] Mixed time series chart should have advanced-analytics tag

**Expected results**
mixed time series chart has advanced analytics tag, this is a new feature that we add for this release

**Actual results**
mixed time series chart do not have advanced analytics tag

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
![image](https://user-images.githubusercontent.com/47900232/168377046-f3ee5a72-a79c-4b0f-a2b8-3c273d081433.png)

AFTER:
![image](https://user-images.githubusercontent.com/47900232/168376939-d9e07b34-9225-4d5c-ab00-d1aaea3452f8.png)


### TESTING INSTRUCTIONS
**Repro steps**
1, add new chart and go to chart gallery
2, select Advanced analytics tag and look for mixed time series chart

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
