### PR TITLE
fix: avoid while cycle in computeMaxFontSize for big Number run forever when css !important rule applied

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/dimension/computeMaxFontSize.ts
+++ b/superset-frontend/packages/superset-ui-core/src/dimension/computeMaxFontSize.ts
@@ -27,9 +27,17 @@ function decreaseSizeUntil(
 ): number {
   let size = startSize;
   let dimension = computeDimension(size);
+
   while (!condition(dimension)) {
     size -= 1;
-    if (size === 0) {
+
+    // Here if the size goes below zero most likely is because it has additional style applied
+    // in which case we assume the user knows what it's doing and we just let them use that.
+    // And so the size will keep shrinking, visually it works, although it could have another
+    // solution like having an updated reference to the actual element fontSize.
+
+    if (size < 0) {
+      size = startSize;
       break;
     }
     dimension = computeDimension(size);

--- a/superset-frontend/packages/superset-ui-core/src/dimension/computeMaxFontSize.ts
+++ b/superset-frontend/packages/superset-ui-core/src/dimension/computeMaxFontSize.ts
@@ -31,10 +31,11 @@ function decreaseSizeUntil(
   while (!condition(dimension)) {
     size -= 1;
 
-    // Here if the size goes below zero most likely is because it has additional style applied
-    // in which case we assume the user knows what it's doing and we just let them use that.
-    // And so the size will keep shrinking, visually it works, although it could have another
-    // solution like having an updated reference to the actual element fontSize.
+    // Here if the size goes below zero most likely is because it
+    // has additional style applied in which case we assume the user
+    // knows what it's doing and we just let them use that.
+    // Visually it works, although it could have another
+    // check in place.
 
     if (size < 0) {
       size = startSize;

--- a/superset-frontend/packages/superset-ui-core/src/dimension/computeMaxFontSize.ts
+++ b/superset-frontend/packages/superset-ui-core/src/dimension/computeMaxFontSize.ts
@@ -29,6 +29,9 @@ function decreaseSizeUntil(
   let dimension = computeDimension(size);
   while (!condition(dimension)) {
     size -= 1;
+    if (size === 0) {
+      break;
+    }
     dimension = computeDimension(size);
   }
 
@@ -43,7 +46,6 @@ export default function computeMaxFontSize(
   },
 ) {
   const { idealFontSize, maxWidth, maxHeight, style, ...rest } = input;
-
   let size: number;
   if (idealFontSize !== undefined && idealFontSize !== null) {
     size = idealFontSize;
@@ -66,7 +68,7 @@ export default function computeMaxFontSize(
     size = decreaseSizeUntil(
       size,
       computeDimension,
-      dim => dim.width <= maxWidth,
+      dim => dim.width > 0 && dim.width <= maxWidth,
     );
   }
 
@@ -74,7 +76,7 @@ export default function computeMaxFontSize(
     size = decreaseSizeUntil(
       size,
       computeDimension,
-      dim => dim.height <= maxHeight,
+      dim => dim.height > 0 && dim.height <= maxHeight,
     );
   }
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

adding custom CSS to a dashboard with a bigInt chart would activate a while loop that didn't ever finished, which somehow wasn't caught by the surrounding ErrorBoundary cause the whole app crashed before running out of memory (my guess) 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->


https://user-images.githubusercontent.com/22302890/168395532-ef3dc781-3415-4a76-82fa-23d796395bde.mov



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Create a Dashboard.
2. Access it on edit mode.
3. Click on the three ellipses on the top right corner > **Edit CSS**.
4. Add below CSS code to it:
```
.header-line {
font-size: 170px!important;
}
```
5. Add a Big Number Chart to the Dashboard.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
