### PR TITLE
fix: dbmodal test connection error timeout

### DIFF
--- a/superset/databases/commands/test_connection.py
+++ b/superset/databases/commands/test_connection.py
@@ -23,9 +23,8 @@ from flask import current_app as app
 from flask_appbuilder.security.sqla.models import User
 from flask_babel import gettext as _
 from func_timeout import func_timeout, FunctionTimedOut
-from sqlalchemy.exc import DBAPIError, NoSuchModuleError
-
 from sqlalchemy.engine import Engine
+from sqlalchemy.exc import DBAPIError, NoSuchModuleError
 
 from superset.commands.base import BaseCommand
 from superset.databases.commands.exceptions import (

--- a/superset/databases/commands/test_connection.py
+++ b/superset/databases/commands/test_connection.py
@@ -25,6 +25,8 @@ from flask_babel import gettext as _
 from func_timeout import func_timeout, FunctionTimedOut
 from sqlalchemy.exc import DBAPIError, NoSuchModuleError
 
+from sqlalchemy.engine import Engine
+
 from superset.commands.base import BaseCommand
 from superset.databases.commands.exceptions import (
     DatabaseSecurityUnsafeError,
@@ -74,7 +76,10 @@ class TestConnectionDatabaseCommand(BaseCommand):
             )
 
             database.set_sqlalchemy_uri(uri)
+            database.set_sqlalchemy_uri(uri)
+            database.set_sqlalchemy_uri(uri)
             database.db_engine_spec.mutate_db_for_connection_test(database)
+<<<<<<< HEAD
 
             with override_user(self._actor):
                 engine = database.get_sqla_engine()
@@ -112,6 +117,45 @@ class TestConnectionDatabaseCommand(BaseCommand):
                         alive = False
                     if not alive:
                         raise DBAPIError(None, None, None)
+=======
+            username = self._actor.username if self._actor is not None else None
+            engine = database.get_sqla_engine(user_name=username)
+            event_logger.log_with_context(
+                action="test_connection_attempt",
+                engine=database.db_engine_spec.__name__,
+            )
+
+            def ping(engine: Engine) -> bool:
+                with closing(engine.raw_connection()) as conn:
+                    return engine.dialect.do_ping(conn)
+
+            try:
+                alive = func_timeout(
+                    int(app.config["TEST_DATABASE_CONNECTION_TIMEOUT"].total_seconds()),
+                    ping,
+                    args=(engine,),
+                )
+
+            except (sqlite3.ProgrammingError, RuntimeError):
+                # SQLite can't run on a separate thread, so ``func_timeout`` fails
+                # RuntimeError catches the equivalent error from duckdb.
+                alive = engine.dialect.do_ping(engine)
+            except FunctionTimedOut as ex:
+                raise SupersetTimeoutException(
+                    error_type=SupersetErrorType.CONNECTION_DATABASE_TIMEOUT,
+                    message=(
+                        "Please check your connection details and database settings, "
+                        "and ensure that your database is accepting connections, "
+                        "then try connecting again."
+                    ),
+                    level=ErrorLevel.ERROR,
+                    extra={"sqlalchemy_uri": database.sqlalchemy_uri},
+                ) from ex
+            except Exception:  # pylint: disable=broad-except
+                alive = False
+            if not alive:
+                raise DBAPIError(None, None, None)
+>>>>>>> 54a2385d2... fix: check for connect on ping
 
             # Log succesful connection test with engine
             event_logger.log_with_context(
@@ -144,6 +188,7 @@ class TestConnectionDatabaseCommand(BaseCommand):
             )
             raise DatabaseSecurityUnsafeError(message=str(ex)) from ex
         except SupersetTimeoutException as ex:
+
             event_logger.log_with_context(
                 action=f"test_connection_error.{ex.__class__.__name__}",
                 engine=database.db_engine_spec.__name__,

--- a/superset/databases/commands/test_connection.py
+++ b/superset/databases/commands/test_connection.py
@@ -76,48 +76,7 @@ class TestConnectionDatabaseCommand(BaseCommand):
             )
 
             database.set_sqlalchemy_uri(uri)
-            database.set_sqlalchemy_uri(uri)
-            database.set_sqlalchemy_uri(uri)
             database.db_engine_spec.mutate_db_for_connection_test(database)
-<<<<<<< HEAD
-
-            with override_user(self._actor):
-                engine = database.get_sqla_engine()
-                event_logger.log_with_context(
-                    action="test_connection_attempt",
-                    engine=database.db_engine_spec.__name__,
-                )
-                with closing(engine.raw_connection()) as conn:
-                    try:
-                        alive = func_timeout(
-                            int(
-                                app.config[
-                                    "TEST_DATABASE_CONNECTION_TIMEOUT"
-                                ].total_seconds()
-                            ),
-                            engine.dialect.do_ping,
-                            args=(conn,),
-                        )
-                    except (sqlite3.ProgrammingError, RuntimeError):
-                        # SQLite can't run on a separate thread, so ``func_timeout`` fails
-                        # RuntimeError catches the equivalent error from duckdb.
-                        alive = engine.dialect.do_ping(conn)
-                    except FunctionTimedOut as ex:
-                        raise SupersetTimeoutException(
-                            error_type=SupersetErrorType.CONNECTION_DATABASE_TIMEOUT,
-                            message=(
-                                "Please check your connection details and database "
-                                "settings, and ensure that your database is accepting "
-                                "connections, then try connecting again."
-                            ),
-                            level=ErrorLevel.ERROR,
-                            extra={"sqlalchemy_uri": database.sqlalchemy_uri},
-                        ) from ex
-                    except Exception:  # pylint: disable=broad-except
-                        alive = False
-                    if not alive:
-                        raise DBAPIError(None, None, None)
-=======
             username = self._actor.username if self._actor is not None else None
             engine = database.get_sqla_engine(user_name=username)
             event_logger.log_with_context(
@@ -155,7 +114,6 @@ class TestConnectionDatabaseCommand(BaseCommand):
                 alive = False
             if not alive:
                 raise DBAPIError(None, None, None)
->>>>>>> 54a2385d2... fix: check for connect on ping
 
             # Log succesful connection test with engine
             event_logger.log_with_context(

--- a/superset/databases/commands/test_connection.py
+++ b/superset/databases/commands/test_connection.py
@@ -77,43 +77,48 @@ class TestConnectionDatabaseCommand(BaseCommand):
 
             database.set_sqlalchemy_uri(uri)
             database.db_engine_spec.mutate_db_for_connection_test(database)
-            username = self._actor.username if self._actor is not None else None
-            engine = database.get_sqla_engine(user_name=username)
-            event_logger.log_with_context(
-                action="test_connection_attempt",
-                engine=database.db_engine_spec.__name__,
-            )
 
-            def ping(engine: Engine) -> bool:
-                with closing(engine.raw_connection()) as conn:
-                    return engine.dialect.do_ping(conn)
-
-            try:
-                alive = func_timeout(
-                    int(app.config["TEST_DATABASE_CONNECTION_TIMEOUT"].total_seconds()),
-                    ping,
-                    args=(engine,),
+            with override_user(self._actor):
+                engine = database.get_sqla_engine()
+                event_logger.log_with_context(
+                    action="test_connection_attempt",
+                    engine=database.db_engine_spec.__name__,
                 )
 
-            except (sqlite3.ProgrammingError, RuntimeError):
-                # SQLite can't run on a separate thread, so ``func_timeout`` fails
-                # RuntimeError catches the equivalent error from duckdb.
-                alive = engine.dialect.do_ping(engine)
-            except FunctionTimedOut as ex:
-                raise SupersetTimeoutException(
-                    error_type=SupersetErrorType.CONNECTION_DATABASE_TIMEOUT,
-                    message=(
-                        "Please check your connection details and database settings, "
-                        "and ensure that your database is accepting connections, "
-                        "then try connecting again."
-                    ),
-                    level=ErrorLevel.ERROR,
-                    extra={"sqlalchemy_uri": database.sqlalchemy_uri},
-                ) from ex
-            except Exception:  # pylint: disable=broad-except
-                alive = False
-            if not alive:
-                raise DBAPIError(None, None, None)
+                def ping(engine: Engine) -> bool:
+                    with closing(engine.raw_connection()) as conn:
+                        return engine.dialect.do_ping(conn)
+
+                try:
+                    alive = func_timeout(
+                        int(
+                            app.config[
+                                "TEST_DATABASE_CONNECTION_TIMEOUT"
+                            ].total_seconds()
+                        ),
+                        ping,
+                        args=(engine,),
+                    )
+
+                except (sqlite3.ProgrammingError, RuntimeError):
+                    # SQLite can't run on a separate thread, so ``func_timeout`` fails
+                    # RuntimeError catches the equivalent error from duckdb.
+                    alive = engine.dialect.do_ping(engine)
+                except FunctionTimedOut as ex:
+                    raise SupersetTimeoutException(
+                        error_type=SupersetErrorType.CONNECTION_DATABASE_TIMEOUT,
+                        message=(
+                            "Please check your connection details and database settings, "
+                            "and ensure that your database is accepting connections, "
+                            "then try connecting again."
+                        ),
+                        level=ErrorLevel.ERROR,
+                        extra={"sqlalchemy_uri": database.sqlalchemy_uri},
+                    ) from ex
+                except Exception:  # pylint: disable=broad-except
+                    alive = False
+                if not alive:
+                    raise DBAPIError(None, None, None)
 
             # Log succesful connection test with engine
             event_logger.log_with_context(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
There was an issue where when testing the dbconnection string would not error out after the 30 second timeout because the checking of the connection would happen before the timeout is initiated. This pr solve that issue by ensuring that if error the timeout will be enforced.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

before


after
<img width="1789" alt="Screen Shot 2022-05-16 at 11 31 35 AM" src="https://user-images.githubusercontent.com/17326228/168659063-a7723f78-b897-40ae-92e6-a6ace5684e17.png">


### TESTING INSTRUCTIONS
Go to db connection modal and input an expired db uri. Test the connection by pressing the test connection button and it should error out in ~30 seconds.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
