### PR TITLE
fix(generic-axes): apply contribution before flatten

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
@@ -96,11 +96,11 @@ export default function buildQuery(formData: QueryFormData) {
             ...baseQueryObject,
             ...{ is_timeseries },
           }),
-          flattenOperator(formData, baseQueryObject),
-          // todo: move contribution and prophet before flatten
           contributionOperator(formData, baseQueryObject),
+          flattenOperator(formData, baseQueryObject),
+          // todo: move prophet before flatten
           prophetOperator(formData, baseQueryObject),
-        ],
+        ].filter(op => op),
       },
     ];
   });


### PR DESCRIPTION
### SUMMARY
Currently the contribution operation is applied after flattening, despite only being meant to apply to numeric columns. By ensuring that the dataframe is unflattened, the index columns will always be absent from the columns, which ensures that the index is not used in the contribution calculation. Also, in the case of using a numeric index, applying the contribution calculation after flattening would cause the index to leak into the contribution calculation. In addition to the fix, falsy post transformation ops are removed to clean up the request payload (these cause unnecessary cache misses).

There is already a check that should remove any non-numeric columns:

https://github.com/apache/superset/blob/4435e53901df4d64992a540694fbd3d5489c2220/superset/utils/pandas_postprocessing/contribution.py#L51

However, for some reason this currently also returns string-columns (`object`), possibly due to the `Decimal` type extending `object` (seems weird, I know, but the only reason I could come up with). However, I didn't want to make any changes to this logic in this PR, as refining it will probably require additional tests to be added + we should potentially bump Pandas to 1.4 before changing this.

### AFTER
Now calculating contributions works when `GENERIC_CHART_AXES` enabled:
<img width="1281" alt="image" src="https://user-images.githubusercontent.com/33317356/168591012-563cf83e-44fd-4c19-839d-4d1e363b2f31.png">

### BEFORE
Previously it would fail:
<img width="1276" alt="image" src="https://user-images.githubusercontent.com/33317356/168591129-f8f1f0eb-c898-41b9-8c26-689884498516.png">

### TESTING INSTRUCTIONS
1. Enable `GENERIC_CHART_AXES` feature flag
2. Create a chart with a non-temporal x-axis
3. Enable contribution mode (either one is ok)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
