### PR TITLE
fix(css): transparent linear gradient not working in safari

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/style/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/style/index.tsx
@@ -160,7 +160,6 @@ const defaultTheme = {
   },
   transitionTiming: 0.3,
   gridUnit: 4,
-  transparent: 'rgba(255, 255, 255, 0)',
 };
 
 export type SupersetTheme = typeof defaultTheme;

--- a/superset-frontend/packages/superset-ui-core/src/style/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/style/index.tsx
@@ -160,6 +160,7 @@ const defaultTheme = {
   },
   transitionTiming: 0.3,
   gridUnit: 4,
+  transparent: 'rgba(255, 255, 255, 0)',
 };
 
 export type SupersetTheme = typeof defaultTheme;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
@@ -53,7 +53,10 @@ const ActionButtonsContainer = styled.div`
     padding: ${theme.gridUnit * 4}px;
     padding-top: ${theme.gridUnit * 6}px;
 
-    background: linear-gradient(transparent, white 25%);
+    background: linear-gradient(
+      ${theme.transparent},
+      ${theme.colors.grayscale.light5} ${theme.opacity.mediumLight}
+    );
 
     pointer-events: none;
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
@@ -27,6 +27,7 @@ import {
 import Button from 'src/components/Button';
 import { isNullish } from 'src/utils/common';
 import { OPEN_FILTER_BAR_WIDTH } from 'src/dashboard/constants';
+import { rgba } from 'emotion-rgba';
 import { getFilterBarTestId } from '../index';
 
 interface ActionButtonsProps {
@@ -54,7 +55,7 @@ const ActionButtonsContainer = styled.div`
     padding-top: ${theme.gridUnit * 6}px;
 
     background: linear-gradient(
-      ${theme.transparent},
+      ${rgba(theme.colors.grayscale.light5, 0)},
       ${theme.colors.grayscale.light5} ${theme.opacity.mediumLight}
     );
 

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -94,7 +94,7 @@ const actionButtonsContainerStyles = (theme: SupersetTheme) => css`
   padding: ${theme.gridUnit * 4}px;
   z-index: 999;
   background: linear-gradient(
-    transparent,
+    ${theme.transparent},
     ${theme.colors.grayscale.light5} ${theme.opacity.mediumLight}
   );
 

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -58,6 +58,7 @@ import { ExplorePageState } from 'src/explore/reducers/getInitialState';
 import { ChartState } from 'src/explore/types';
 import { Tooltip } from 'src/components/Tooltip';
 
+import { rgba } from 'emotion-rgba';
 import ControlRow from './ControlRow';
 import Control from './Control';
 import { ExploreAlert } from './ExploreAlert';
@@ -94,7 +95,7 @@ const actionButtonsContainerStyles = (theme: SupersetTheme) => css`
   padding: ${theme.gridUnit * 4}px;
   z-index: 999;
   background: linear-gradient(
-    ${theme.transparent},
+    ${rgba(theme.colors.grayscale.light5, 0)},
     ${theme.colors.grayscale.light5} ${theme.opacity.mediumLight}
   );
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes the problem that transparent linear gradient not working in safari. refer to https://css-tricks.com/thing-know-gradients-transparent-black/.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### before

<img width="355" alt="image" src="https://user-images.githubusercontent.com/11830681/168640875-8d7eb539-73fa-4972-889f-8de4643aa5e3.png">

### after

<img width="375" alt="image" src="https://user-images.githubusercontent.com/11830681/168640604-7aefbd00-2cdb-409b-9206-0ecd813c0fac.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #20047
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
