### PR TITLE
chore: Add the tnum font property to Table components

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-paired-t-test/src/PairedTTest.jsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-paired-t-test/src/PairedTTest.jsx
@@ -59,6 +59,10 @@ const StyledDiv = styled.div`
       margin-left: ${theme.gridUnit}px;
     }
 
+    .reactable-data tr {
+      font-feature-settings: 'tnum' 1;
+    }
+
     .reactable-data tr,
     .reactable-header-sortable {
       -webkit-transition: ease-in-out 0.1s;

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.js
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.js
@@ -36,6 +36,10 @@ export const Styles = styled.div`
       top: 0;
     }
 
+    table tbody tr {
+      font-feature-settings: 'tnum' 1;
+    }
+
     table.pvtTable thead tr th,
     table.pvtTable tbody tr th {
       background-color: ${theme.colors.grayscale.light5};

--- a/superset-frontend/src/components/Chart/Chart.jsx
+++ b/superset-frontend/src/components/Chart/Chart.jsx
@@ -105,6 +105,10 @@ const Styles = styled.div`
 
   .slice_container {
     height: ${p => p.height}px;
+
+    .pivot_table tbody tr {
+      font-feature-settings: 'tnum' 1;
+    }
   }
 `;
 

--- a/superset-frontend/src/components/TableCollection/index.tsx
+++ b/superset-frontend/src/components/TableCollection/index.tsx
@@ -172,6 +172,7 @@ export const Table = styled.table`
     }
 
     .table-cell {
+      font-feature-settings: 'tnum' 1;
       text-overflow: ellipsis;
       overflow: hidden;
       max-width: 320px;


### PR DESCRIPTION
### SUMMARY
Added the `tnum` property to the TableCollection component which is used in most lists and Time-series Table chart

### BEFORE

<img width="1677" alt="lists_before" src="https://user-images.githubusercontent.com/60598000/168775345-6b06aa3b-f516-4860-b881-abb06c206e5f.png">

### AFTER

<img width="1677" alt="lists_after" src="https://user-images.githubusercontent.com/60598000/168775395-7c0d36bb-2d17-4733-8e1e-7dc3dfd44f63.png">

Added the `tnum` property to the Pivot Table v2 component

### BEFORE

<img width="1374" alt="pivot_table_v2_before" src="https://user-images.githubusercontent.com/60598000/168775531-4c642a30-3b16-4de7-8289-6490bb4bb6b3.png">

### AFTER

<img width="1380" alt="pivot_table_v2_after" src="https://user-images.githubusercontent.com/60598000/168775579-950e9591-480b-44c7-ba1a-26eee6201737.png">

Added the tnum` `property to the Pivot Table v1 component

### BEFORE

<img width="1382" alt="pivot_table_before" src="https://user-images.githubusercontent.com/60598000/168775636-cd5c90b3-b1de-4a28-9cba-84f765353dc4.png">

### AFTER

<img width="1381" alt="pivot_table_after" src="https://user-images.githubusercontent.com/60598000/168775690-d75fc243-205b-4d97-80e7-b0f6c43e45c1.png">

Added the `tnum` property to the Paired t-test table component

### BEFORE

<img width="1381" alt="paired_t_test_before" src="https://user-images.githubusercontent.com/60598000/168775733-eb1165a6-cf0d-47b9-bc33-a6a7c6573404.png">

### AFTER

<img width="1383" alt="paired_t_test_after" src="https://user-images.githubusercontent.com/60598000/168775764-0a3dddb2-226a-4586-aa0e-ed7f43734fd4.png">

CollectionTable used in the Datasource modal already has the `tnum` property. No additional changes are required. The same applies to all tables using Antdesign

FilterableTable used in the result set of SqlLab already has the `tnum` property. No additional changes are required. The same applies to all tables using react-virtualized

The viz type Table has the `tnum` property. No additional changes are required

### TESTING INSTRUCTIONS
1. Open all Tables as presented above
2. Make sure the numbers in the cells are using the [tnum](https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings) font property 
3. Make sure all tables are still appearing as intended

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
