### PR TITLE
fix(generic-chart-axes): set x-axis if unset and ff is enabled

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-event-flow/src/controlPanel.tsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-event-flow/src/controlPanel.tsx
@@ -19,13 +19,14 @@
 import React from 'react';
 import { t, validateNonEmpty } from '@superset-ui/core';
 import {
-  formatSelectOptionsForRange,
-  ColumnOption,
   columnChoices,
+  ColumnOption,
+  ColumnMeta,
   ControlPanelConfig,
+  ControlState,
+  formatSelectOptionsForRange,
   sections,
   SelectControlConfig,
-  ColumnMeta,
 } from '@superset-ui/chart-controls';
 
 const config: ControlPanelConfig = {
@@ -46,10 +47,8 @@ const config: ControlPanelConfig = {
                 choices: columnChoices(state?.datasource),
               }),
               // choices is from `mapStateToProps`
-              default: (control: { choices?: string[] }) =>
-                control.choices && control.choices.length > 0
-                  ? control.choices[0][0]
-                  : null,
+              default: (control: ControlState) =>
+                control.choices?.[0]?.[0] || null,
               validators: [validateNonEmpty],
             },
           },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
@@ -17,9 +17,15 @@
  * under the License.
  */
 import React from 'react';
-import { t, validateNonEmpty } from '@superset-ui/core';
+import {
+  FeatureFlag,
+  isFeatureEnabled,
+  t,
+  validateNonEmpty,
+} from '@superset-ui/core';
 import {
   ControlPanelsContainerProps,
+  ControlPanelState,
   ControlSetItem,
   ControlSetRow,
   sharedControls,
@@ -143,7 +149,21 @@ export const xAxisControl: ControlSetItem = {
   config: {
     ...sharedControls.groupby,
     label: t('X-axis'),
-    default: null,
+    default: (
+      control: { value: any },
+      controlPanel: Partial<ControlPanelState>,
+    ) => {
+      // default to the chosen time column if x-axis is unset and the
+      // GENERIC_CHART_AXES feature flag is enabled
+      const { value } = control;
+      if (value || !controlPanel) {
+        return value;
+      }
+      if (isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES)) {
+        return controlPanel?.controls?.granularity_sqla?.value;
+      }
+      return value;
+    },
     multi: false,
     description: t('Dimension to use on x-axis.'),
     validators: [validateNonEmpty],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
@@ -28,6 +28,7 @@ import {
   ControlPanelState,
   ControlSetItem,
   ControlSetRow,
+  ControlState,
   sharedControls,
 } from '@superset-ui/chart-controls';
 import { DEFAULT_LEGEND_FORM_DATA } from './types';
@@ -150,17 +151,18 @@ export const xAxisControl: ControlSetItem = {
     ...sharedControls.groupby,
     label: t('X-axis'),
     default: (
-      control: { value: any },
+      control: ControlState,
       controlPanel: Partial<ControlPanelState>,
     ) => {
       // default to the chosen time column if x-axis is unset and the
       // GENERIC_CHART_AXES feature flag is enabled
       const { value } = control;
-      if (value || !controlPanel) {
+      if (value) {
         return value;
       }
-      if (isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES)) {
-        return controlPanel?.form_data?.granularity_sqla;
+      const timeColumn = controlPanel?.form_data?.granularity_sqla;
+      if (isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) && timeColumn) {
+        return timeColumn;
       }
       return null;
     },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
@@ -162,7 +162,7 @@ export const xAxisControl: ControlSetItem = {
       if (isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES)) {
         return controlPanel?.form_data?.granularity_sqla;
       }
-      return value;
+      return null;
     },
     multi: false,
     description: t('Dimension to use on x-axis.'),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
@@ -160,7 +160,7 @@ export const xAxisControl: ControlSetItem = {
         return value;
       }
       if (isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES)) {
-        return controlPanel?.controls?.granularity_sqla?.value;
+        return controlPanel?.form_data?.granularity_sqla;
       }
       return value;
     },

--- a/superset-frontend/src/explore/controlUtils/getControlState.ts
+++ b/superset-frontend/src/explore/controlUtils/getControlState.ts
@@ -123,11 +123,7 @@ export function getControlStateFromControlConfig<T = ControlType>(
     return null;
   }
   const controlState = { ...controlConfig, value } as ControlState<T>;
-  // only apply mapStateToProps when control states have been initialized
-  if (controlPanelState.controls) {
-    return applyMapStateToPropsToControl(controlState, controlPanelState);
-  }
-  return controlState;
+  return applyMapStateToPropsToControl(controlState, controlPanelState);
 }
 
 export function getControlState(

--- a/superset-frontend/src/explore/controlUtils/getControlState.ts
+++ b/superset-frontend/src/explore/controlUtils/getControlState.ts
@@ -85,7 +85,7 @@ export function applyMapStateToPropsToControl<T = ControlType>(
   const { mapStateToProps } = controlState;
   let state = { ...controlState };
   let { value } = state; // value is current user-input value
-  if (mapStateToProps && controlPanelState) {
+  if (mapStateToProps) {
     state = {
       ...controlState,
       ...mapStateToProps.call(controlState, controlPanelState, controlState),
@@ -124,11 +124,7 @@ export function getControlStateFromControlConfig<T = ControlType>(
   }
   const controlState = { ...controlConfig, value } as ControlState<T>;
   // only apply mapStateToProps when control states have been initialized
-  // or when explicitly didn't provide control panel state (mostly for testing)
-  if (
-    (controlPanelState && controlPanelState.controls) ||
-    controlPanelState === null
-  ) {
+  if (controlPanelState.controls) {
     return applyMapStateToPropsToControl(controlState, controlPanelState);
   }
   return controlState;

--- a/superset-frontend/src/explore/controlUtils/getControlState.ts
+++ b/superset-frontend/src/explore/controlUtils/getControlState.ts
@@ -17,12 +17,7 @@
  * under the License.
  */
 import { ReactNode } from 'react';
-import {
-  DatasourceType,
-  ensureIsArray,
-  JsonValue,
-  QueryFormData,
-} from '@superset-ui/core';
+import { DatasourceType, ensureIsArray, JsonValue } from '@superset-ui/core';
 import {
   ControlConfig,
   ControlPanelState,
@@ -155,8 +150,7 @@ export function getControlState(
 export function getAllControlsState(
   vizType: string,
   datasourceType: DatasourceType,
-  state: ControlPanelState,
-  formData: QueryFormData,
+  state: Partial<ControlPanelState>,
 ) {
   const controlsState = {};
   getSectionsToRender(vizType, datasourceType).forEach(section =>
@@ -167,7 +161,7 @@ export function getAllControlsState(
           controlsState[name] = getControlStateFromControlConfig(
             config,
             state,
-            formData[name],
+            state.form_data?.[name],
           );
         }
       }),

--- a/superset-frontend/src/explore/store.js
+++ b/superset-frontend/src/explore/store.js
@@ -64,8 +64,14 @@ export function getControlsState(state, inputFormData) {
 export function applyDefaultFormData(inputFormData) {
   const datasourceType = inputFormData.datasource.split('__')[1];
   const vizType = inputFormData.viz_type;
-  const controlsState = getAllControlsState(vizType, datasourceType, null, {
-    ...inputFormData,
+  let controlsState = getAllControlsState(vizType, datasourceType, {
+    form_data: inputFormData,
+  });
+  // do a new pass, so we can check the control values of other controls in
+  // the control's default value callback
+  controlsState = getAllControlsState(vizType, datasourceType, {
+    controls: controlsState,
+    form_data: inputFormData,
   });
   const controlFormData = getFormDataFromControls(controlsState);
 

--- a/superset-frontend/src/explore/store.js
+++ b/superset-frontend/src/explore/store.js
@@ -64,9 +64,12 @@ export function getControlsState(state, inputFormData) {
 export function applyDefaultFormData(inputFormData) {
   const datasourceType = inputFormData.datasource.split('__')[1];
   const vizType = inputFormData.viz_type;
-  const controlsState = getAllControlsState(vizType, datasourceType, {
-    form_data: inputFormData,
-  });
+  const controlsState = getAllControlsState(
+    vizType,
+    datasourceType,
+    null,
+    inputFormData,
+  );
   const controlFormData = getFormDataFromControls(controlsState);
 
   const formData = {};

--- a/superset-frontend/src/explore/store.js
+++ b/superset-frontend/src/explore/store.js
@@ -64,13 +64,7 @@ export function getControlsState(state, inputFormData) {
 export function applyDefaultFormData(inputFormData) {
   const datasourceType = inputFormData.datasource.split('__')[1];
   const vizType = inputFormData.viz_type;
-  let controlsState = getAllControlsState(vizType, datasourceType, {
-    form_data: inputFormData,
-  });
-  // do a new pass, so we can check the control values of other controls in
-  // the control's default value callback
-  controlsState = getAllControlsState(vizType, datasourceType, {
-    controls: controlsState,
+  const controlsState = getAllControlsState(vizType, datasourceType, {
     form_data: inputFormData,
   });
   const controlFormData = getFormDataFromControls(controlsState);


### PR DESCRIPTION
### SUMMARY
After enabling the `GENERIC_CHART_AXES` feature flag, timeseries charts that were created before enabling the flag won't render in Explore due to the required x-axis control being unset. This PR checks if the feature flag is enabled, and sets the default value of the x-axis control to the value of the `granularity_sqla` flag if the value of the x-axis control is unset.

Due to mixing of JS and TS and inconsistent function calls (e.g. calling a function with `null` when it was expecting `ControlPanelState`, all while having logic for when the value was in fact `null`), some of this code was slightly difficult to follow. I tried to refactor it to be more intuitive, but even minor refactoring seemed to cause weird regressions, so I decided to postpone the refactor to a follow-up PR.

### AFTER
Now the timeseries chart that was saved before the feature flag was enabled opens up correctly:

https://user-images.githubusercontent.com/33317356/169009593-9a494ef1-6f52-483d-a1c3-2f91df433886.mp4

### BEFORE
Previously, the chart would not render, as the required x-axis control was unset in the chart form data:

https://user-images.githubusercontent.com/33317356/169009759-044e4a77-3936-4990-beef-aa2edf1bb212.mp4

### TESTING INSTRUCTIONS
1. Create a Chart using the Time - Series Bar Chart V2.
2. Add it to a Dashboard.
3. Enable the GENERIC_CHART_AXES FF.
4. Access the Dashboard - note that the Chart is still working.
5. Click on "Edit Chart" and notice how the chart no longer renders in Explore

<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
