### PR TITLE
feat(dashboard): Chart title click redirects to Explore in new tab

### DIFF
--- a/superset-frontend/src/components/EditableTitle/index.tsx
+++ b/superset-frontend/src/components/EditableTitle/index.tsx
@@ -18,7 +18,7 @@
  */
 import React, { useEffect, useState, useRef } from 'react';
 import cx from 'classnames';
-import { styled, t } from '@superset-ui/core';
+import { css, styled, t } from '@superset-ui/core';
 import { Tooltip } from 'src/components/Tooltip';
 import CertifiedBadge from '../CertifiedBadge';
 
@@ -37,6 +37,7 @@ export interface EditableTitleProps {
   placeholder?: string;
   certifiedBy?: string;
   certificationDetails?: string;
+  onClickTitle?: () => void;
 }
 
 const StyledCertifiedBadge = styled(CertifiedBadge)`
@@ -57,6 +58,7 @@ export default function EditableTitle({
   placeholder = '',
   certifiedBy,
   certificationDetails,
+  onClickTitle,
   // rest is related to title tooltip
   ...rest
 }: EditableTitleProps) {
@@ -216,7 +218,23 @@ export default function EditableTitle({
   }
   if (!canEdit) {
     // don't actually want an input in this case
-    titleComponent = <span data-test="editable-title-input">{value}</span>;
+    titleComponent = onClickTitle ? (
+      <span
+        role="button"
+        onClick={onClickTitle}
+        tabIndex={0}
+        data-test="editable-title-input"
+        css={css`
+          :hover {
+            text-decoration: underline;
+          }
+        `}
+      >
+        {value}
+      </span>
+    ) : (
+      <span data-test="editable-title-input">{value}</span>
+    );
   }
   return (
     <span

--- a/superset-frontend/src/dashboard/components/SliceHeader/SliceHeader.test.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeader/SliceHeader.test.tsx
@@ -100,7 +100,7 @@ jest.mock('src/dashboard/components/FiltersBadge', () => ({
   ),
 }));
 
-const createProps = () => ({
+const createProps = (overrides: any = {}) => ({
   filters: {}, // is in typing but not being used
   editMode: false,
   annotationQuery: { param01: 'annotationQuery' } as any,
@@ -159,6 +159,7 @@ const createProps = () => ({
   formData: { slice_id: 1, datasource: '58__table' },
   width: 100,
   height: 100,
+  ...overrides,
 });
 
 test('Should render', () => {
@@ -262,6 +263,48 @@ test('Should render title', () => {
   const props = createProps();
   render(<SliceHeader {...props} />, { useRedux: true });
   expect(screen.getByText('Vaccine Candidates per Phase')).toBeInTheDocument();
+});
+
+test('Should render click to edit prompt and run onExploreChart on click', async () => {
+  const props = createProps();
+  render(<SliceHeader {...props} />, { useRedux: true });
+  userEvent.hover(screen.getByText('Vaccine Candidates per Phase'));
+  expect(
+    await screen.findByText(
+      'Click to edit Vaccine Candidates per Phase in a new tab',
+    ),
+  ).toBeInTheDocument();
+
+  userEvent.click(screen.getByText('Vaccine Candidates per Phase'));
+  expect(props.onExploreChart).toHaveBeenCalled();
+});
+
+test('Should not render click to edit prompt and run onExploreChart on click if supersetCanExplore=false', () => {
+  const props = createProps({ supersetCanExplore: false });
+  render(<SliceHeader {...props} />, { useRedux: true });
+  userEvent.hover(screen.getByText('Vaccine Candidates per Phase'));
+  expect(
+    screen.queryByText(
+      'Click to edit Vaccine Candidates per Phase in a new tab',
+    ),
+  ).not.toBeInTheDocument();
+
+  userEvent.click(screen.getByText('Vaccine Candidates per Phase'));
+  expect(props.onExploreChart).not.toHaveBeenCalled();
+});
+
+test('Should not render click to edit prompt and run onExploreChart on click if in edit mode', () => {
+  const props = createProps({ editMode: true });
+  render(<SliceHeader {...props} />, { useRedux: true });
+  userEvent.hover(screen.getByText('Vaccine Candidates per Phase'));
+  expect(
+    screen.queryByText(
+      'Click to edit Vaccine Candidates per Phase in a new tab',
+    ),
+  ).not.toBeInTheDocument();
+
+  userEvent.click(screen.getByText('Vaccine Candidates per Phase'));
+  expect(props.onExploreChart).not.toHaveBeenCalled();
 });
 
 test('Should render "annotationsLoading"', () => {

--- a/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
@@ -104,9 +104,18 @@ const SliceHeader: FC<SliceHeaderProps> = ({
     [crossFilterValue],
   );
 
+  const handleClickTitle =
+    !editMode && supersetCanExplore ? onExploreChart : undefined;
+
   useEffect(() => {
     const headerElement = headerRef.current;
-    if (
+    if (handleClickTitle) {
+      setHeaderTooltip(
+        sliceName
+          ? t('Click to edit %s in a new tab', sliceName)
+          : t('Click to edit chart in a new tab'),
+      );
+    } else if (
       headerElement &&
       (headerElement.scrollWidth > headerElement.offsetWidth ||
         headerElement.scrollHeight > headerElement.offsetHeight)
@@ -115,7 +124,7 @@ const SliceHeader: FC<SliceHeaderProps> = ({
     } else {
       setHeaderTooltip(null);
     }
-  }, [sliceName, width, height]);
+  }, [sliceName, width, height, handleClickTitle]);
 
   return (
     <div className="chart-header" data-test="slice-header" ref={innerRef}>
@@ -132,6 +141,7 @@ const SliceHeader: FC<SliceHeaderProps> = ({
             emptyText=""
             onSaveTitle={updateSliceName}
             showTooltip={false}
+            onClickTitle={handleClickTitle}
           />
         </Tooltip>
         {!!Object.values(annotationQuery).length && (


### PR DESCRIPTION
### SUMMARY
This PR makes the chart title in dashboard clickable - redirects to Explore on click. It's basically a shortcut for clicking options -> Edit chart.
On hover the title gets underlined + tooltip appears with prompt to click "Click to edit _chart name_ in a new tab".
This effect is active only in non edit mode and when user has access to Explore

### BEFORE/AFTER SCREENSHOTS

https://user-images.githubusercontent.com/15073128/169046626-aa1ab0e6-cf6c-43fe-b329-202cc3d78a1a.mov

### TESTING INSTRUCTIONS
Flow 1
1. Go to dashboard
2. Hover over a chart title - it should get underlined and a tooltip should appear
3. Click and verify that you got redirected to Explore in a new tab

Flow 2
1. Go to dashboard's edit mode
2. Hover over chart title - no underline or tooltip should appear
3. Click chart title - you should be able to edit the title, click doesn't redirect to Explore

Flow 3
1. Login as a user without access to Explore and go to dashboard
2. Nothing should happen when you hover over a chart title

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
