### PR TITLE
feat(api): Added "kind" to dataset/<pk> endpoint

### DIFF
--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -4399,6 +4399,9 @@
             "nullable": true,
             "type": "boolean"
           },
+          "kind": {
+            "readOnly": true
+          },
           "main_dttm_col": {
             "maxLength": 250,
             "nullable": true,

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -162,7 +162,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         "datasource_type",
         "url",
         "extra",
-        "kind"
+        "kind",
     ]
     show_columns = show_select_columns + [
         "columns.type_generic",

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -162,6 +162,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         "datasource_type",
         "url",
         "extra",
+        "kind"
     ]
     show_columns = show_select_columns + [
         "columns.type_generic",

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -252,6 +252,7 @@ class TestDatasetApi(SupersetTestCase):
             "fetch_values_predicate": None,
             "filter_select_enabled": False,
             "is_sqllab_view": False,
+            "kind": "physical"
             "main_dttm_col": None,
             "offset": 0,
             "owners": [],

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -252,7 +252,7 @@ class TestDatasetApi(SupersetTestCase):
             "fetch_values_predicate": None,
             "filter_select_enabled": False,
             "is_sqllab_view": False,
-            "kind": "physical"
+            "kind": "physical",
             "main_dttm_col": None,
             "offset": 0,
             "owners": [],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
The “kind” field is already returned by the main dataset GET endpoint. Having the “kind” field returned by the dataset/<pk> endpoint is needed for external services.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
Perform a GET request on the /api/v1/dataset/<pk> endpoint.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #20110
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
