### PR TITLE
style(typo): occured -> occurred

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/chart/components/FallbackComponent.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/FallbackComponent.tsx
@@ -41,7 +41,7 @@ export default function FallbackComponent({
     >
       <div>
         <div>
-          <b>Oops! An error occured!</b>
+          <b>Oops! An error occurred!</b>
         </div>
         <code>{error ? error.toString() : 'Unknown Error'}</code>
       </div>

--- a/superset-frontend/packages/superset-ui-core/src/chart/components/FallbackComponent.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/FallbackComponent.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+
 import React from 'react';
 import { SupersetTheme } from '../../style';
 import { FallbackPropsWithDimension } from './SuperChart';

--- a/superset-frontend/packages/superset-ui-core/src/chart/components/FallbackComponent.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/FallbackComponent.tsx
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-
 import React from 'react';
 import { SupersetTheme } from '../../style';
 import { FallbackPropsWithDimension } from './SuperChart';

--- a/superset-frontend/packages/superset-ui-core/test/chart/components/SuperChart.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/chart/components/SuperChart.test.tsx
@@ -121,7 +121,7 @@ describe('SuperChart', () => {
       );
       await new Promise(resolve => setImmediate(resolve));
       wrapper.update();
-      expect(wrapper.text()).toContain('Oops! An error occured!');
+      expect(wrapper.text()).toContain('Oops! An error occurred!');
     });
     it('renders custom FallbackComponent', () => {
       expectedErrors = 1;

--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -325,7 +325,7 @@ export function saveDashboardRequest(data, id, saveType) {
 
     const onError = async response => {
       const { error, message } = await getClientErrorObject(response);
-      let errorText = t('Sorry, an unknown error occured');
+      let errorText = t('Sorry, an unknown error occurred');
 
       if (error) {
         errorText = t(

--- a/superset/translations/nl/LC_MESSAGES/messages.json
+++ b/superset/translations/nl/LC_MESSAGES/messages.json
@@ -3478,7 +3478,7 @@
       "This dashboard was saved successfully.": [
         "Dit dashboard is succesvol opgeslagen."
       ],
-      "Sorry, an unknown error occured": [""],
+      "Sorry, an unknown error occurred": [""],
       "Sorry, there was an error saving this dashboard: %s": [""],
       "You do not have permission to edit this dashboard": [
         "U hebt geen toestemming om dit dashboard te bewerken"


### PR DESCRIPTION
### SUMMARY
Changed the 4 instance of "occured" in error messages to "occurred", the conventional spelling which appears 82 times in the repo currently.