### PR TITLE
fix(presto,trino): use correct literal dttm separator

### DIFF
--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -761,7 +761,7 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
             utils.TemporalType.TIMESTAMP,
             utils.TemporalType.TIMESTAMP_WITH_TIME_ZONE,
         ):
-            return f"""TIMESTAMP '{dttm.isoformat(timespec="microseconds")}'"""
+            return f"""TIMESTAMP '{dttm.isoformat(timespec="microseconds", sep=" ")}'"""
         return None
 
     @classmethod

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -76,7 +76,7 @@ class TrinoEngineSpec(BaseEngineSpec):
             utils.TemporalType.TIMESTAMP,
             utils.TemporalType.TIMESTAMP_WITH_TIME_ZONE,
         ):
-            return f"""TIMESTAMP '{dttm.isoformat(timespec="microseconds")}'"""
+            return f"""TIMESTAMP '{dttm.isoformat(timespec="microseconds", sep=" ")}'"""
         return None
 
     @classmethod

--- a/tests/integration_tests/db_engine_specs/presto_tests.py
+++ b/tests/integration_tests/db_engine_specs/presto_tests.py
@@ -512,19 +512,6 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
         query_result = str(result.compile(compile_kwargs={"literal_binds": True}))
         self.assertEqual("SELECT  \nWHERE ds = '01-01-19' AND hour = 1", query_result)
 
-    def test_convert_dttm(self):
-        dttm = self.get_dttm()
-
-        self.assertEqual(
-            PrestoEngineSpec.convert_dttm("DATE", dttm),
-            "DATE '2019-01-02'",
-        )
-
-        self.assertEqual(
-            PrestoEngineSpec.convert_dttm("TIMESTAMP", dttm),
-            "TIMESTAMP '2019-01-02T03:04:05.678900'",
-        )
-
     def test_query_cost_formatter(self):
         raw_cost = [
             {

--- a/tests/integration_tests/db_engine_specs/trino_tests.py
+++ b/tests/integration_tests/db_engine_specs/trino_tests.py
@@ -27,19 +27,6 @@ from tests.integration_tests.db_engine_specs.base_tests import TestDbEngineSpec
 
 
 class TestTrinoDbEngineSpec(TestDbEngineSpec):
-    def test_convert_dttm(self):
-        dttm = self.get_dttm()
-
-        self.assertEqual(
-            TrinoEngineSpec.convert_dttm("DATE", dttm),
-            "DATE '2019-01-02'",
-        )
-
-        self.assertEqual(
-            TrinoEngineSpec.convert_dttm("TIMESTAMP", dttm),
-            "TIMESTAMP '2019-01-02T03:04:05.678900'",
-        )
-
     def test_adjust_database_uri(self):
         url = URL(drivername="trino", database="hive")
         TrinoEngineSpec.adjust_database_uri(url, selected_schema="foobar")

--- a/tests/unit_tests/db_engine_specs/test_presto.py
+++ b/tests/unit_tests/db_engine_specs/test_presto.py
@@ -30,17 +30,17 @@ from flask.ctx import AppContext
         (
             "TIMESTAMP",
             datetime(2022, 1, 1, 1, 23, 45, 600000),
-            "TIMESTAMP '2022-01-01T01:23:45.600000'",
+            "TIMESTAMP '2022-01-01 01:23:45.600000'",
         ),
         (
             "TIMESTAMP WITH TIME ZONE",
             datetime(2022, 1, 1, 1, 23, 45, 600000),
-            "TIMESTAMP '2022-01-01T01:23:45.600000'",
+            "TIMESTAMP '2022-01-01 01:23:45.600000'",
         ),
         (
             "TIMESTAMP WITH TIME ZONE",
             datetime(2022, 1, 1, 1, 23, 45, 600000, tzinfo=pytz.UTC),
-            "TIMESTAMP '2022-01-01T01:23:45.600000+00:00'",
+            "TIMESTAMP '2022-01-01 01:23:45.600000+00:00'",
         ),
     ],
 )

--- a/tests/unit_tests/db_engine_specs/test_trino.py
+++ b/tests/unit_tests/db_engine_specs/test_trino.py
@@ -30,17 +30,17 @@ from flask.ctx import AppContext
         (
             "TIMESTAMP",
             datetime(2022, 1, 1, 1, 23, 45, 600000),
-            "TIMESTAMP '2022-01-01T01:23:45.600000'",
+            "TIMESTAMP '2022-01-01 01:23:45.600000'",
         ),
         (
             "TIMESTAMP WITH TIME ZONE",
             datetime(2022, 1, 1, 1, 23, 45, 600000),
-            "TIMESTAMP '2022-01-01T01:23:45.600000'",
+            "TIMESTAMP '2022-01-01 01:23:45.600000'",
         ),
         (
             "TIMESTAMP WITH TIME ZONE",
             datetime(2022, 1, 1, 1, 23, 45, 600000, tzinfo=pytz.UTC),
-            "TIMESTAMP '2022-01-01T01:23:45.600000+00:00'",
+            "TIMESTAMP '2022-01-01 01:23:45.600000+00:00'",
         ),
     ],
 )


### PR DESCRIPTION
### SUMMARY

#19917 migrated the `convert_dttm` functions in the Presto and Trino db engine specs to use the currently recommended literal timestamp type cast over the now deprecated `from_iso8601_*` functions. However, the new literal casts require the separator to be a blank space instead of the "T" separator:

- https://trino.io/docs/current/functions/datetime.html
- https://prestodb.io/docs/current/functions/datetime.html

This PR updates the format to correspond with the supported format and updates the unit tests accordingly. In addition, the `convert_dttm` tests are removed from the legacy integration test suite, as they're already covered by the new unit tests.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
