### PR TITLE
feat(dashboard): Add create chart button in dashboard edit mode

### DIFF
--- a/superset-frontend/src/dashboard/components/SliceAdder.jsx
+++ b/superset-frontend/src/dashboard/components/SliceAdder.jsx
@@ -21,10 +21,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { List } from 'react-virtualized';
 import { createFilter } from 'react-search-input';
-import { t, styled, isFeatureEnabled, FeatureFlag } from '@superset-ui/core';
+import {
+  t,
+  styled,
+  isFeatureEnabled,
+  FeatureFlag,
+  css,
+} from '@superset-ui/core';
 import { Input } from 'src/components/Input';
 import { Select } from 'src/components';
 import Loading from 'src/components/Loading';
+import Button from 'src/components/Button';
+import Icons from 'src/components/Icons';
 import {
   CHART_TYPE,
   NEW_COMPONENT_SOURCE_TYPE,
@@ -79,11 +87,34 @@ const Controls = styled.div`
   display: flex;
   flex-direction: row;
   padding: ${({ theme }) => theme.gridUnit * 3}px;
+  padding-top: ${({ theme }) => theme.gridUnit * 4}px;
 `;
 
 const StyledSelect = styled(Select)`
   margin-left: ${({ theme }) => theme.gridUnit * 2}px;
   min-width: 150px;
+`;
+
+const NewChartButtonContainer = styled.div`
+  ${({ theme }) => css`
+    display: flex;
+    justify-content: flex-end;
+    padding-right: ${theme.gridUnit * 2}px;
+  `}
+`;
+
+const NewChartButton = styled(Button)`
+  ${({ theme }) => css`
+    height: auto;
+    & > .anticon + span {
+      margin-left: 0;
+    }
+    & > [role='img']:first-of-type {
+      margin-right: ${theme.gridUnit}px;
+      padding-bottom: 1px;
+      line-height: 0;
+    }
+  `}
 `;
 
 class SliceAdder extends React.Component {
@@ -240,6 +271,18 @@ class SliceAdder extends React.Component {
       MARGIN_BOTTOM;
     return (
       <div className="slice-adder-container">
+        <NewChartButtonContainer>
+          <NewChartButton
+            buttonStyle="link"
+            buttonSize="xsmall"
+            onClick={() =>
+              window.open('/chart/add', '_blank', 'noopener noreferrer')
+            }
+          >
+            <Icons.PlusSmall />
+            {t('Create new chart')}
+          </NewChartButton>
+        </NewChartButtonContainer>
         <Controls>
           <Input
             placeholder={t('Filter your charts')}

--- a/superset-frontend/src/dashboard/stylesheets/builder-sidepane.less
+++ b/superset-frontend/src/dashboard/stylesheets/builder-sidepane.less
@@ -49,6 +49,7 @@
     width: @builder-pane-width;
     height: 100%;
     box-shadow: -4px 0 4px 0 fade(@darkest, @opacity-light);
+    background-color: @lightest;
   }
 
   .slider-container {


### PR DESCRIPTION
### SUMMARY
Clicking on "Create new chart" in "Charts" tab in dashboard edit mode button redirects to `/chart/add` view in a new tab.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<img width="536" alt="image" src="https://user-images.githubusercontent.com/15073128/169251205-2c0f36bb-17e0-4549-aa84-66a58a377603.png">

### TESTING INSTRUCTIONS
1. Go to dashboard edit mode -> Charts tab
2. Click "Create new chart" button
3. Verify that you've were redirected to `/chart/add` page

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @kasiazjc 