### PR TITLE
fix(database): retrival of tables and views from schema for exasol backend

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ setup(
         "druid": ["pydruid>=0.6.1,<0.7"],
         "solr": ["sqlalchemy-solr >= 0.2.0"],
         "elasticsearch": ["elasticsearch-dbapi>=0.2.0, <0.3.0"],
-        "exasol": ["sqlalchemy-exasol>=2.1.0, <2.2"],
+        "exasol": ["sqlalchemy-exasol >= 2.4.0, <3.0"],
         "excel": ["xlrd>=1.2.0, <1.3"],
         "firebird": ["sqlalchemy-firebird>=0.7.0, <0.8"],
         "firebolt": ["firebolt-sqlalchemy>=0.0.1"],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updates the dependencies of the `exasol` feature flag, to address #20105 which have been caused by a [bug](https://github.com/exasol/sqlalchemy-exasol/issues/136) in the [sqlalchemy-exasol](https://github.com/exasol/sqlalchemy-exasol) dependency.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before**
![image](https://user-images.githubusercontent.com/600911/169251134-e53d519d-b159-4b57-98c0-7ff4361a9727.png)

**After**
![image](https://user-images.githubusercontent.com/600911/169251157-29421248-7247-45ec-b712-3aa02863ddb4.png)

### TESTING INSTRUCTIONS

1. Go to 'Datasets'
2. Click on '+ DATASET'
3. Select the Exasol DB as database
4. Select a schema containing views and tables
5. Try to select a Table/Schema
6. No Tables/Schemas are shown

For more details see #20105 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Fixes #20105 
- [x] Has associated issue: #20105 
- [x] Required feature flags: `exasol`
