### PR TITLE
fix: advanced data type API spec and permission name

### DIFF
--- a/superset/advanced_data_type/api.py
+++ b/superset/advanced_data_type/api.py
@@ -90,15 +90,9 @@ class AdvancedDataTypeRestApi(BaseApi):
             500:
               $ref: '#/components/responses/500'
         """
-        items = kwargs["rison"]
-        advanced_data_type = items.get("type")
-        if not advanced_data_type:
-            return self.response(
-                400, message=_("Missing advanced data type in request")
-            )
-        values = items["values"]
-        if not values:
-            return self.response(400, message=_("Missing values in request"))
+        item = kwargs["rison"]
+        advanced_data_type = item["type"]
+        values = item["values"]
         addon = ADVANCED_DATA_TYPES.get(advanced_data_type)
         if not addon:
             return self.response(

--- a/superset/advanced_data_type/api.py
+++ b/superset/advanced_data_type/api.py
@@ -40,26 +40,28 @@ class AdvancedDataTypeRestApi(BaseApi):
     allow_browser_login = True
     include_route_methods = {"get", "get_types"}
     resource_name = "advanced_data_type"
+    class_permission_name = "AdvancedDataType"
 
     openapi_spec_tag = "Advanced Data Type"
     apispec_parameter_schemas = {
         "advanced_data_type_convert_schema": advanced_data_type_convert_schema,
     }
+    openapi_spec_component_schemas = (AdvancedDataTypeResponse,)
 
     @protect()
     @safe
     @expose("/convert", methods=["GET"])
-    @permission_name("get")
+    @permission_name("read")
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.get",
         log_to_statsd=False,  # pylint: disable-arguments-renamed
     )
-    @rison()
+    @rison(advanced_data_type_convert_schema)
     def get(self, **kwargs: Any) -> Response:
         """Returns a AdvancedDataTypeResponse object populated with the passed in args
         ---
         get:
-          description: >-
+          summary: >-
             Returns a AdvancedDataTypeResponse object populated with the passed in args.
           parameters:
           - in: query
@@ -77,16 +79,7 @@ class AdvancedDataTypeRestApi(BaseApi):
                   schema:
                     type: object
                     properties:
-                      status:
-                        type: string
-                      values:
-                        type: array
-                      formatted_value:
-                        type: string
-                      error_message:
-                        type: string
-                      valid_filter_operators:
-                        type: string
+                      $ref: '#/components/schemas/AdvancedDataTypeResponse'
             400:
               $ref: '#/components/responses/400'
             401:

--- a/superset/advanced_data_type/api.py
+++ b/superset/advanced_data_type/api.py
@@ -21,7 +21,10 @@ from flask.wrappers import Response
 from flask_appbuilder.api import BaseApi, expose, permission_name, protect, rison, safe
 from flask_babel import lazy_gettext as _
 
-from superset.advanced_data_type.schemas import advanced_data_type_convert_schema
+from superset.advanced_data_type.schemas import (
+    advanced_data_type_convert_schema,
+    AdvancedDataTypeSchema,
+)
 from superset.advanced_data_type.types import AdvancedDataTypeResponse
 from superset.extensions import event_logger
 
@@ -46,7 +49,7 @@ class AdvancedDataTypeRestApi(BaseApi):
     apispec_parameter_schemas = {
         "advanced_data_type_convert_schema": advanced_data_type_convert_schema,
     }
-    openapi_spec_component_schemas = (AdvancedDataTypeResponse,)
+    openapi_spec_component_schemas = (AdvancedDataTypeSchema,)
 
     @protect()
     @safe
@@ -77,9 +80,7 @@ class AdvancedDataTypeRestApi(BaseApi):
               content:
                 application/json:
                   schema:
-                    type: object
-                    properties:
-                      $ref: '#/components/schemas/AdvancedDataTypeResponse'
+                    $ref: '#/components/schemas/AdvancedDataTypeSchema'
             400:
               $ref: '#/components/responses/400'
             401:
@@ -117,7 +118,7 @@ class AdvancedDataTypeRestApi(BaseApi):
     @protect()
     @safe
     @expose("/types", methods=["GET"])
-    @permission_name("get")
+    @permission_name("read")
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.get",
         log_to_statsd=False,  # pylint: disable-arguments-renamed
@@ -140,8 +141,8 @@ class AdvancedDataTypeRestApi(BaseApi):
                     properties:
                       result:
                         type: array
-            400:
-              $ref: '#/components/responses/400'
+                        items:
+                          type: string
             401:
               $ref: '#/components/responses/401'
             404:

--- a/superset/advanced_data_type/schemas.py
+++ b/superset/advanced_data_type/schemas.py
@@ -22,13 +22,14 @@ from marshmallow import fields, Schema
 advanced_data_type_convert_schema = {
     "type": "object",
     "properties": {
-        "type": {"type": "string"},
+        "type": {"type": "string", "default": "port"},
         "values": {
             "type": "array",
+            "items": {"type": "string", "default": "http"},
             "minItems": 1,
         },
     },
-    "required": ["types", "values"],
+    "required": ["type", "values"],
 }
 
 

--- a/superset/advanced_data_type/schemas.py
+++ b/superset/advanced_data_type/schemas.py
@@ -19,16 +19,16 @@ Schemas for advanced data types
 """
 from marshmallow import fields, Schema
 
-
 advanced_data_type_convert_schema = {
-    "type": "array",
-    "items": {
-        "type": "object",
-        "properties": {
-            "type": {"type": "string"},
-            "values": {"type": "array"},
+    "type": "object",
+    "properties": {
+        "type": {"type": "string"},
+        "values": {
+            "type": "array",
+            "minItems": 1,
         },
     },
+    "required": ["types", "values"],
 }
 
 

--- a/superset/advanced_data_type/schemas.py
+++ b/superset/advanced_data_type/schemas.py
@@ -17,6 +17,8 @@
 """
 Schemas for advanced data types
 """
+from marshmallow import fields, Schema
+
 
 advanced_data_type_convert_schema = {
     "type": "array",
@@ -28,3 +30,16 @@ advanced_data_type_convert_schema = {
         },
     },
 }
+
+
+class AdvancedDataTypeSchema(Schema):
+    """
+    AdvancedDataType response schema
+    """
+
+    error_message = fields.String()
+    values = fields.List(fields.String(description="parsed value (can be any value)"))
+    display_value = fields.String(
+        description="The string representation of the parsed values"
+    )
+    valid_filter_operators = fields.List(fields.String())

--- a/superset/advanced_data_type/schemas.py
+++ b/superset/advanced_data_type/schemas.py
@@ -25,7 +25,7 @@ advanced_data_type_convert_schema = {
         "type": {"type": "string", "default": "port"},
         "values": {
             "type": "array",
-            "items": {"type": "string", "default": "http"},
+            "items": {"default": "http"},
             "minItems": 1,
         },
     },


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Simple fix for the new advanced type REST API, we currently use `can_read` permissions instead of FAB default `can_get`
also simplified the OpenAPI spec and added the rison schema to the decorator so that JSON schema will actually be evaluated

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
