### PR TITLE
feat(explore): Fill dashboard name when adding new chart from dashboard view

### DIFF
--- a/superset-frontend/src/addSlice/AddSliceContainer.tsx
+++ b/superset-frontend/src/addSlice/AddSliceContainer.tsx
@@ -27,6 +27,9 @@ import { Tooltip } from 'src/components/Tooltip';
 import VizTypeGallery, {
   MAX_ADVISABLE_VIZ_GALLERY_WIDTH,
 } from 'src/explore/components/controls/VizTypeControl/VizTypeGallery';
+import { getUrlParam } from '../utils/urlUtils';
+import { URL_PARAMS } from '../constants';
+import { isNullish } from '../utils/common';
 
 type Dataset = {
   id: number;
@@ -195,10 +198,12 @@ export default class AddSliceContainer extends React.PureComponent<
   }
 
   exploreUrl() {
+    const dashboardId = getUrlParam(URL_PARAMS.dashboardId);
     const formData = encodeURIComponent(
       JSON.stringify({
         viz_type: this.state.visType,
         datasource: this.state.datasource?.value,
+        ...(!isNullish(dashboardId) && { dashboardId }),
       }),
     );
     return `/superset/explore/?form_data=${formData}`;

--- a/superset-frontend/src/addSlice/AddSliceContainer.tsx
+++ b/superset-frontend/src/addSlice/AddSliceContainer.tsx
@@ -19,6 +19,9 @@
 import React, { ReactNode } from 'react';
 import rison from 'rison';
 import { styled, t, SupersetClient, JsonResponse } from '@superset-ui/core';
+import { getUrlParam } from 'src/utils/urlUtils';
+import { URL_PARAMS } from 'src/constants';
+import { isNullish } from 'src/utils/common';
 import Button from 'src/components/Button';
 import { Select, Steps } from 'src/components';
 import { FormLabel } from 'src/components/Form';
@@ -27,9 +30,6 @@ import { Tooltip } from 'src/components/Tooltip';
 import VizTypeGallery, {
   MAX_ADVISABLE_VIZ_GALLERY_WIDTH,
 } from 'src/explore/components/controls/VizTypeControl/VizTypeGallery';
-import { getUrlParam } from '../utils/urlUtils';
-import { URL_PARAMS } from '../constants';
-import { isNullish } from '../utils/common';
 
 type Dataset = {
   id: number;

--- a/superset-frontend/src/constants.ts
+++ b/superset-frontend/src/constants.ts
@@ -71,6 +71,10 @@ export const URL_PARAMS = {
     name: 'dataset_id',
     type: 'string',
   },
+  dashboardId: {
+    name: 'dashboard_id',
+    type: 'string',
+  },
   force: {
     name: 'force',
     type: 'boolean',

--- a/superset-frontend/src/dashboard/components/DashboardGrid.jsx
+++ b/superset-frontend/src/dashboard/components/DashboardGrid.jsx
@@ -35,6 +35,7 @@ const propTypes = {
   resizeComponent: PropTypes.func.isRequired,
   setDirectPathToChild: PropTypes.func.isRequired,
   width: PropTypes.number.isRequired,
+  dashboardId: PropTypes.number,
 };
 
 const defaultProps = {};
@@ -143,6 +144,7 @@ class DashboardGrid extends React.PureComponent {
       editMode,
       canEdit,
       setEditMode,
+      dashboardId,
     } = this.props;
     const columnPlusGutterWidth =
       (width + GRID_GUTTER_SIZE) / GRID_COLUMN_COUNT;
@@ -167,7 +169,11 @@ class DashboardGrid extends React.PureComponent {
           </>
         }
         buttonAction={() => {
-          window.open('/chart/add', '_blank', 'noopener noreferrer');
+          window.open(
+            `/chart/add?dashboard_id=${dashboardId}`,
+            '_blank',
+            'noopener noreferrer',
+          );
         }}
         image="chart.svg"
       />
@@ -186,7 +192,11 @@ class DashboardGrid extends React.PureComponent {
           </>
         }
         buttonAction={() => {
-          window.open('/chart/add', '_blank', 'noopener noreferrer');
+          window.open(
+            `/chart/add?dashboard_id=${dashboardId}`,
+            '_blank',
+            'noopener noreferrer',
+          );
         }}
         image="chart.svg"
       />

--- a/superset-frontend/src/dashboard/components/SliceAdder.jsx
+++ b/superset-frontend/src/dashboard/components/SliceAdder.jsx
@@ -58,6 +58,7 @@ const propTypes = {
   editMode: PropTypes.bool,
   height: PropTypes.number,
   filterboxMigrationState: FILTER_BOX_MIGRATION_STATES,
+  dashboardId: PropTypes.number,
 };
 
 const defaultProps = {
@@ -276,7 +277,11 @@ class SliceAdder extends React.Component {
             buttonStyle="link"
             buttonSize="xsmall"
             onClick={() =>
-              window.open('/chart/add', '_blank', 'noopener noreferrer')
+              window.open(
+                `/chart/add?dashboard_id=${this.props.dashboardId}`,
+                '_blank',
+                'noopener noreferrer',
+              )
             }
           >
             <Icons.PlusSmall />

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
@@ -150,6 +150,7 @@ class Tab extends React.PureComponent {
       isComponentVisible,
       canEdit,
       setEditMode,
+      dashboardId,
     } = this.props;
 
     const shouldDisplayEmptyState = tabComponent.children.length === 0;
@@ -183,7 +184,7 @@ class Tab extends React.PureComponent {
                 <span>
                   {t('You can')}{' '}
                   <a
-                    href="/chart/add"
+                    href={`/chart/add?dashboard_id=${dashboardId}`}
                     rel="noopener noreferrer"
                     target="_blank"
                   >

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab.test.tsx
@@ -294,5 +294,5 @@ test('Render tab content with no children, editMode: true, canEdit: true', () =>
   ).toBeVisible();
   expect(
     screen.getByRole('link', { name: 'create a new chart' }),
-  ).toHaveAttribute('href', '/chart/add');
+  ).toHaveAttribute('href', '/chart/add?dashboard_id=23');
 });

--- a/superset-frontend/src/dashboard/containers/DashboardGrid.jsx
+++ b/superset-frontend/src/dashboard/containers/DashboardGrid.jsx
@@ -30,6 +30,7 @@ function mapStateToProps({ dashboardState, dashboardInfo }) {
   return {
     editMode: dashboardState.editMode,
     canEdit: dashboardInfo.dash_edit_perm,
+    dashboardId: dashboardInfo.id,
   };
 }
 

--- a/superset-frontend/src/dashboard/containers/SliceAdder.jsx
+++ b/superset-frontend/src/dashboard/containers/SliceAdder.jsx
@@ -29,6 +29,7 @@ function mapStateToProps(
   return {
     height: ownProps.height,
     userId: dashboardInfo.userId,
+    dashboardId: dashboardInfo.id,
     selectedSliceIds: dashboardState.sliceIds,
     slices: sliceEntities.slices,
     isLoading: sliceEntities.isLoading,

--- a/superset-frontend/src/dashboard/stylesheets/dashboard.less
+++ b/superset-frontend/src/dashboard/stylesheets/dashboard.less
@@ -19,6 +19,7 @@
 /* header has mysterious extra margin */
 header.top {
   margin-bottom: 2px;
+  z-index: 10;
 }
 
 body {

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -678,12 +678,17 @@ function mapStateToProps(state) {
   const chartKey = Object.keys(charts)[0];
   const chart = charts[chartKey];
 
+  let dashboardId = Number(explore.form_data?.dashboardId);
+  if (Number.isNaN(dashboardId)) {
+    dashboardId = undefined;
+  }
+
   return {
     isDatasourceMetaLoading: explore.isDatasourceMetaLoading,
     datasource: explore.datasource,
     datasource_type: explore.datasource.type,
     datasourceId: explore.datasource_id,
-    dashboardId: explore.form_data ? explore.form_data.dashboardId : undefined,
+    dashboardId,
     controls: explore.controls,
     can_overwrite: !!explore.can_overwrite,
     can_add: !!explore.can_add,

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -256,8 +256,7 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
               checked={this.state.action === 'saveas'}
               onChange={() => this.changeAction('saveas')}
             >
-              {' '}
-              {t('Save as ...')} &nbsp;
+              {t('Save as...')}
             </Radio>
           </FormItem>
           <hr />

--- a/superset-frontend/src/views/components/MenuRight.tsx
+++ b/superset-frontend/src/views/components/MenuRight.tsx
@@ -166,7 +166,7 @@ const RightMenu = ({
     },
     {
       label: t('Chart'),
-      url: !Number.isNaN(dashboardId)
+      url: Number.isInteger(dashboardId)
         ? `/chart/add?dashboard_id=${dashboardId}`
         : '/chart/add',
       icon: 'fa-fw fa-bar-chart',

--- a/superset-frontend/src/views/components/MenuRight.tsx
+++ b/superset-frontend/src/views/components/MenuRight.tsx
@@ -18,7 +18,8 @@
  */
 import React, { Fragment, useState, useEffect } from 'react';
 import rison from 'rison';
-import { MainNav as Menu } from 'src/components/Menu';
+import { useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
 import {
   t,
   styled,
@@ -26,12 +27,12 @@ import {
   SupersetTheme,
   SupersetClient,
 } from '@superset-ui/core';
+import { MainNav as Menu } from 'src/components/Menu';
 import { Tooltip } from 'src/components/Tooltip';
-import { Link } from 'react-router-dom';
 import Icons from 'src/components/Icons';
 import findPermission, { isUserAdmin } from 'src/dashboard/util/findPermission';
-import { useSelector } from 'react-redux';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
+import { RootState } from 'src/dashboard/types';
 import LanguagePicker from './LanguagePicker';
 import DatabaseModal from '../CRUD/data/database/DatabaseModal';
 import { uploadUserPerms } from '../CRUD/utils';
@@ -88,6 +89,9 @@ const RightMenu = ({
 }: RightMenuProps) => {
   const user = useSelector<any, UserWithPermissionsAndRoles>(
     state => state.user,
+  );
+  const dashboardId = useSelector<RootState, number | undefined>(
+    state => state.dashboardInfo?.id,
   );
 
   const { roles } = user;
@@ -162,7 +166,9 @@ const RightMenu = ({
     },
     {
       label: t('Chart'),
-      url: '/chart/add',
+      url: !Number.isNaN(dashboardId)
+        ? `/chart/add?dashboard_id=${dashboardId}`
+        : '/chart/add',
       icon: 'fa-fw fa-bar-chart',
       perm: 'can_write',
       view: 'Chart',


### PR DESCRIPTION
### SUMMARY
When user enters chart creation flow starting from a dashboard (e.g. with "Create chart" button in empty state or charts list in dashboard edit mode), the chart's save modal should have that dashboard's name prefilled. To achieve that, we pass `dashboard_id` as a url param to `/chart/add` page and from there to `explore`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

https://user-images.githubusercontent.com/15073128/169276098-5a2578a0-7ed4-4029-aa40-2f112e3af13a.mov



### TESTING INSTRUCTIONS
1. Open a dashboard -> edit mode -> charts tab -> click "Create new chart" OR Open a dashboard and create a new chart using the plus icon button in top right corner.
2. Create a chart and click save
3. Verify that dashboard's name is prefilled
4. Create a new dashboard and click "Create new chart" button in empty state. Create a chart and verify that dashboard's name is prefilled in save modal
5. Create a chart from any other view (for example from Welcome page). Verify that save modal is not prefilled

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @kasiazjc 