### PR TITLE
feat: Add Certified filter to Datasets

### DIFF
--- a/superset-frontend/src/components/ListView/types.ts
+++ b/superset-frontend/src/components/ListView/types.ts
@@ -113,4 +113,5 @@ export enum FilterOperator {
   chartIsFav = 'chart_is_favorite',
   chartIsCertified = 'chart_is_certified',
   dashboardIsCertified = 'dashboard_is_certified',
+  datasetIsCertified = 'dataset_is_certified',
 }

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
@@ -512,7 +512,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
         id: 'id',
         urlDisplay: 'certified',
         input: 'select',
-        operator: 'dataset_is_certified',
+        operator: FilterOperator.datasetIsCertified,
         unfilteredLabel: t('Any'),
         selects: [
           { label: t('Yes'), value: true },

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
@@ -258,6 +258,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
         accessor: 'kind_icon',
         disableSortBy: true,
         size: 'xs',
+        id: 'id',
       },
       {
         Cell: ({
@@ -504,6 +505,18 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
         selects: [
           { label: 'Virtual', value: false },
           { label: 'Physical', value: true },
+        ],
+      },
+      {
+        Header: t('Certified'),
+        id: 'id',
+        urlDisplay: 'certified',
+        input: 'select',
+        operator: 'dataset_is_certified',
+        unfilteredLabel: t('Any'),
+        selects: [
+          { label: t('Yes'), value: true },
+          { label: t('No'), value: false },
         ],
       },
       {

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -199,7 +199,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         "sql": [DatasetIsNullOrEmptyFilter],
         "id": [DatasetCertifiedFilter],
     }
-    search_columns = ["id", "sql"]
+    search_columns = ["id", "database", "owners", "sql", "table_name"]
     filter_rel_fields = {"database": [["id", DatabaseFilter, lambda: []]]}
     allowed_rel_fields = {"database", "owners"}
     allowed_distinct_fields = {"schema"}

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -27,6 +27,7 @@ from flask_appbuilder.api import expose, protect, rison, safe
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_babel import ngettext
 from marshmallow import ValidationError
+from sqlalchemy import not_
 
 from superset import event_logger, is_feature_enabled
 from superset.commands.importers.exceptions import NoValidFilesFoundError
@@ -72,6 +73,24 @@ from superset.views.base_api import (
 from superset.views.filters import FilterRelatedOwners
 
 logger = logging.getLogger(__name__)
+
+from flask_babel import lazy_gettext as _
+from sqlalchemy.orm.query import Query
+
+from superset.views.base import BaseFilter
+
+
+class DatasetCertifiedFilter(BaseFilter):
+    name = _("Is certified")
+    arg_name = "dataset_is_certified"
+
+    def apply(self, query: Query, value: Any) -> Query:
+        breakpoint()
+        if value is True:
+            return query.filter(SqlaTable.extra.ilike("%certification%"))
+        if value is False:
+            return query.exclude(SqlaTable.extra.ilike("%certification%"))
+        return query
 
 
 class DatasetRestApi(BaseSupersetModelRestApi):
@@ -195,7 +214,10 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         "owners": RelatedFieldFilter("first_name", FilterRelatedOwners),
         "database": "database_name",
     }
-    search_filters = {"sql": [DatasetIsNullOrEmptyFilter]}
+    search_filters = {
+        "sql": [DatasetIsNullOrEmptyFilter],
+        "sql": [DatasetCertifiedFilter],
+    }
     filter_rel_fields = {"database": [["id", DatabaseFilter, lambda: []]]}
     allowed_rel_fields = {"database", "owners"}
     allowed_distinct_fields = {"schema"}

--- a/superset/datasets/filters.py
+++ b/superset/datasets/filters.py
@@ -14,8 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Any
-
 from flask_babel import lazy_gettext as _
 from sqlalchemy import not_, or_
 from sqlalchemy.orm.query import Query
@@ -41,7 +39,7 @@ class DatasetCertifiedFilter(BaseFilter):  # pylint: disable=too-few-public-meth
     name = _("Is certified")
     arg_name = "dataset_is_certified"
 
-    def apply(self, query: Query, value: Any) -> Query:
+    def apply(self, query: Query, value: bool) -> Query:
         check_value = '%"certification":%'
         if value is True:
             return query.filter(SqlaTable.extra.ilike(check_value))

--- a/superset/datasets/filters.py
+++ b/superset/datasets/filters.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Any
+
 from flask_babel import lazy_gettext as _
 from sqlalchemy import not_, or_
 from sqlalchemy.orm.query import Query
@@ -33,3 +35,20 @@ class DatasetIsNullOrEmptyFilter(BaseFilter):  # pylint: disable=too-few-public-
             filter_clause = not_(filter_clause)
 
         return query.filter(filter_clause)
+
+
+class DatasetCertifiedFilter(BaseFilter):  # pylint: disable=too-few-public-methods
+    name = _("Is certified")
+    arg_name = "dataset_is_certified"
+
+    def apply(self, query: Query, value: Any) -> Query:
+        if value is True:
+            return query.filter(SqlaTable.extra.ilike("%certification%"))
+        if value is False:
+            return query.filter(
+                or_(
+                    SqlaTable.extra.notlike("%certification%"),
+                    SqlaTable.extra.is_(None),
+                )
+            )
+        return query

--- a/superset/datasets/filters.py
+++ b/superset/datasets/filters.py
@@ -42,12 +42,13 @@ class DatasetCertifiedFilter(BaseFilter):  # pylint: disable=too-few-public-meth
     arg_name = "dataset_is_certified"
 
     def apply(self, query: Query, value: Any) -> Query:
+        check_value = '%"certification":%'
         if value is True:
-            return query.filter(SqlaTable.extra.ilike("%certification%"))
+            return query.filter(SqlaTable.extra.ilike(check_value))
         if value is False:
             return query.filter(
                 or_(
-                    SqlaTable.extra.notlike("%certification%"),
+                    SqlaTable.extra.notlike(check_value),
                     SqlaTable.extra.is_(None),
                 )
             )

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -1813,22 +1813,11 @@ class TestDatasetApi(SupersetTestCase):
             ]
         }
 
-    @pytest.mark.usefixtures("create_datasets", "create_virtual_datasets")
+    @pytest.mark.usefixtures("create_datasets")
     def test_get_datasets_is_certified_filter(self):
         """
         Dataset API: Test custom dataset_is_certified filter
         """
-        arguments = {
-            "filters": [{"col": "id", "opr": "dataset_is_certified", "value": False}]
-        }
-        self.login(username="admin")
-        uri = f"api/v1/dataset/?q={prison.dumps(arguments)}"
-        rv = self.client.get(uri)
-
-        assert rv.status_code == 200
-        response = json.loads(rv.data.decode("utf-8"))
-        assert response.get("count") == 5
-
         table_w_certification = SqlaTable(
             table_name="foo",
             schema=None,

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -128,6 +128,7 @@ class TestDatasetApi(SupersetTestCase):
             main_db = get_main_database()
             for tables_name in self.fixture_tables_names:
                 datasets.append(self.insert_dataset(tables_name, [admin.id], main_db))
+
             yield datasets
 
             # rollback changes
@@ -1811,3 +1812,44 @@ class TestDatasetApi(SupersetTestCase):
                 }
             ]
         }
+
+    @pytest.mark.usefixtures("create_datasets", "create_virtual_datasets")
+    def test_get_datasets_is_certified_filter(self):
+        """
+        Dataset API: Test custom dataset_is_certified filter
+        """
+        arguments = {
+            "filters": [{"col": "id", "opr": "dataset_is_certified", "value": False}]
+        }
+        self.login(username="admin")
+        uri = f"api/v1/dataset/?q={prison.dumps(arguments)}"
+        rv = self.client.get(uri)
+
+        assert rv.status_code == 200
+        response = json.loads(rv.data.decode("utf-8"))
+        assert response.get("count") == 5
+
+        table_w_certification = SqlaTable(
+            table_name="foo",
+            schema=None,
+            owners=[],
+            database=get_main_database(),
+            sql=None,
+            extra='{"certification": 1}',
+        )
+        db.session.add(table_w_certification)
+        db.session.commit()
+
+        arguments = {
+            "filters": [{"col": "id", "opr": "dataset_is_certified", "value": True}]
+        }
+        self.login(username="admin")
+        uri = f"api/v1/dataset/?q={prison.dumps(arguments)}"
+        rv = self.client.get(uri)
+
+        assert rv.status_code == 200
+        response = json.loads(rv.data.decode("utf-8"))
+        assert response.get("count") == 1
+
+        db.session.delete(table_w_certification)
+        db.session.commit()


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

https://user-images.githubusercontent.com/27827808/169415026-f4185481-8bac-44c4-b468-db0c0aa5742f.mov
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Allowing users to know filter by `Dataset.extra.certification`. Using is like check in the ORM to validate

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
