### PR TITLE
fix(explore): handle null control sections

### DIFF
--- a/superset-frontend/src/explore/controlUtils/getControlConfig.ts
+++ b/superset-frontend/src/explore/controlUtils/getControlConfig.ts
@@ -65,5 +65,10 @@ export const getControlConfig = function getControlConfig(
   vizType: string,
 ) {
   const controlPanelConfig = getChartControlPanelRegistry().get(vizType) || {};
-  return getMemoizedControlConfig(controlKey, controlPanelConfig);
+  return getMemoizedControlConfig(
+    controlKey,
+    // TODO: the ChartControlPanelRegistry is incorrectly typed and needs to
+    // be fixed
+    controlPanelConfig as ControlPanelConfig,
+  );
 };

--- a/superset-frontend/src/explore/controlUtils/getControlConfig.ts
+++ b/superset-frontend/src/explore/controlUtils/getControlConfig.ts
@@ -19,19 +19,22 @@
 import memoizeOne from 'memoize-one';
 import { getChartControlPanelRegistry } from '@superset-ui/core';
 import {
+  ControlPanelConfig,
   ControlPanelSectionConfig,
   expandControlConfig,
+  isControlPanelSectionConfig,
 } from '@superset-ui/chart-controls';
 
 /**
  * Find control item from control panel config.
  */
 export function findControlItem(
-  controlPanelSections: ControlPanelSectionConfig[],
+  controlPanelSections: (ControlPanelSectionConfig | null)[],
   controlKey: string,
 ) {
   return (
     controlPanelSections
+      .filter(isControlPanelSectionConfig)
       .map(section => section.controlSetRows)
       .flat(2)
       .find(
@@ -46,7 +49,7 @@ export function findControlItem(
 }
 
 const getMemoizedControlConfig = memoizeOne(
-  (controlKey, controlPanelConfig) => {
+  (controlKey, controlPanelConfig: ControlPanelConfig) => {
     const { controlOverrides = {}, controlPanelSections = [] } =
       controlPanelConfig;
     const control = expandControlConfig(

--- a/superset-frontend/src/explore/fixtures.tsx
+++ b/superset-frontend/src/explore/fixtures.tsx
@@ -26,47 +26,49 @@ import {
   ControlPanelSectionConfig,
 } from '@superset-ui/chart-controls';
 
-export const controlPanelSectionsChartOptions: ControlPanelSectionConfig[] = [
-  {
-    label: t('Chart Options'),
-    expanded: true,
-    controlSetRows: [
-      [
-        'color_scheme',
-        {
-          name: 'rose_area_proportion',
-          config: {
-            type: 'CheckboxControl',
-            label: t('Use Area Proportions'),
-            description: t(
-              'Check if the Rose Chart should use segment area instead of ' +
-                'segment radius for proportioning',
-            ),
-            default: false,
-            renderTrigger: true,
+export const controlPanelSectionsChartOptions: (ControlPanelSectionConfig | null)[] =
+  [
+    null,
+    {
+      label: t('Chart Options'),
+      expanded: true,
+      controlSetRows: [
+        [
+          'color_scheme',
+          {
+            name: 'rose_area_proportion',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Use Area Proportions'),
+              description: t(
+                'Check if the Rose Chart should use segment area instead of ' +
+                  'segment radius for proportioning',
+              ),
+              default: false,
+              renderTrigger: true,
+            },
           },
-        },
-      ],
-      [
-        {
-          name: 'stacked_style',
-          config: {
-            type: 'SelectControl',
-            label: t('Stacked Style'),
-            renderTrigger: true,
-            choices: [
-              ['stack', 'stack'],
-              ['stream', 'stream'],
-              ['expand', 'expand'],
-            ],
-            default: 'stack',
-            description: '',
+        ],
+        [
+          {
+            name: 'stacked_style',
+            config: {
+              type: 'SelectControl',
+              label: t('Stacked Style'),
+              renderTrigger: true,
+              choices: [
+                ['stack', 'stack'],
+                ['stream', 'stream'],
+                ['expand', 'expand'],
+              ],
+              default: 'stack',
+              description: '',
+            },
           },
-        },
+        ],
       ],
-    ],
-  },
-];
+    },
+  ];
 
 export const controlPanelSectionsChartOptionsOnlyColorScheme: ControlPanelSectionConfig[] =
   [

--- a/superset-frontend/src/utils/getControlsForVizType.js
+++ b/superset-frontend/src/utils/getControlsForVizType.js
@@ -18,26 +18,29 @@
  */
 
 import memoize from 'lodash/memoize';
+import { isControlPanelSectionConfig } from '@superset-ui/chart-controls';
 import { getChartControlPanelRegistry } from '@superset-ui/core';
 import { controls } from '../explore/controls';
 
 const memoizedControls = memoize((vizType, controlPanel) => {
   const controlsMap = {};
-  (controlPanel?.controlPanelSections || []).forEach(section => {
-    section.controlSetRows.forEach(row => {
-      row.forEach(control => {
-        if (!control) return;
-        if (typeof control === 'string') {
-          // For now, we have to look in controls.jsx to get the config for some controls.
-          // Once everything is migrated out, delete this if statement.
-          controlsMap[control] = controls[control];
-        } else if (control.name && control.config) {
-          // condition needed because there are elements, e.g. <hr /> in some control configs (I'm looking at you, FilterBox!)
-          controlsMap[control.name] = control.config;
-        }
+  (controlPanel?.controlPanelSections || [])
+    .filter(isControlPanelSectionConfig)
+    .forEach(section => {
+      section.controlSetRows.forEach(row => {
+        row.forEach(control => {
+          if (!control) return;
+          if (typeof control === 'string') {
+            // For now, we have to look in controls.jsx to get the config for some controls.
+            // Once everything is migrated out, delete this if statement.
+            controlsMap[control] = controls[control];
+          } else if (control.name && control.config) {
+            // condition needed because there are elements, e.g. <hr /> in some control configs (I'm looking at you, FilterBox!)
+            controlsMap[control.name] = control.config;
+          }
+        });
       });
     });
-  });
   return controlsMap;
 });
 


### PR DESCRIPTION
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
The recent PR #20097 added explicit support for `null`-valued control panel sections. However, due to lacking TS coverage and type declarations in the codebase, these weren't always being checked properly. This caused Explore to fail to render when opening a Mixted timeseries chart with the `GENERIC_CHART_AXES` feature flag disabled.

This PR adds some missing types and filtering using the new type guard introduced in the aforementioned PR to ensure null sections are always skipped. A null value is also added to a control panel section fixture to make sure it doesn't break the utils.

Tip: enable "Hide whitespace" when reviewing the diff:
<img width="243" alt="image" src="https://user-images.githubusercontent.com/33317356/169534051-4e79cc8c-c323-4f82-8597-54588259529d.png">

Note that this regression uncovered a pretty serious mistyping of the chart control panel config registry, but fixing it is beyond the scope of this PR.

### TESTING INSTRUCTIONS
1. Disable the `GENERIC_CHART_AXES` feature flag
2. Open a mixed timeseries chart
3. Notice Explore fail to render

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
