### PR TITLE
feat: Adds the "Select all" option to the Select component

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -139,6 +139,7 @@
         "shortid": "^2.2.6",
         "tinycolor2": "^1.4.2",
         "urijs": "^1.19.8",
+        "use-deep-compare-effect": "^1.8.1",
         "use-immer": "^0.6.0",
         "use-query-params": "^1.1.9",
         "yargs": "^15.4.1"
@@ -26096,6 +26097,14 @@
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true
     },
+    "node_modules/dequal": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -50356,6 +50365,22 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/use-deep-compare-effect": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.8.1.tgz",
+      "integrity": "sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "dequal": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13"
       }
     },
     "node_modules/use-immer": {
@@ -76185,6 +76210,11 @@
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true
     },
+    "dequal": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug=="
+    },
     "des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -95051,6 +95081,15 @@
       "integrity": "sha512-my1lNHGWsSDAhhVAT4MKs6IjBUtG6ZG11uUqexPH9PptiIZDQOzaF4f5tEbJ2+7qvNbtXNBbU3SfmN+fXlWDhg==",
       "requires": {
         "ts-essentials": "^2.0.3"
+      }
+    },
+    "use-deep-compare-effect": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.8.1.tgz",
+      "integrity": "sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "dequal": "^2.0.2"
       }
     },
     "use-immer": {

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -199,6 +199,7 @@
     "shortid": "^2.2.6",
     "tinycolor2": "^1.4.2",
     "urijs": "^1.19.8",
+    "use-deep-compare-effect": "^1.8.1",
     "use-immer": "^0.6.0",
     "use-query-params": "^1.1.9",
     "yargs": "^15.4.1"

--- a/superset-frontend/src/components/Select/Select.stories.tsx
+++ b/superset-frontend/src/components/Select/Select.stories.tsx
@@ -18,6 +18,7 @@
  */
 import React, { ReactNode, useState, useCallback } from 'react';
 import ControlHeader from 'src/explore/components/ControlHeader';
+import { SelectValue } from 'antd/lib/select';
 import Select, { SelectProps, OptionsTypePage, OptionsType } from './Select';
 
 export default {
@@ -210,17 +211,6 @@ InteractiveSelect.argTypes = {
     description: `It adds a header on top of the Select. Can be any ReactNode.`,
     control: { type: 'inline-radio', options: ['none', 'text', 'control'] },
   },
-  pageSize: {
-    description: `It defines how many results should be included in the query response.
-      Works in async mode only (See the options property).
-    `,
-  },
-  fetchOnlyOnSearch: {
-    description: `It fires a request against the server only after searching.
-      Works in async mode only (See the options property).
-      Undefined by default.
-    `,
-  },
 };
 
 InteractiveSelect.story = {
@@ -387,6 +377,7 @@ export const AsyncSelect = ({
   responseTime: number;
 }) => {
   const [requests, setRequests] = useState<ReactNode[]>([]);
+  const [value, setValue] = useState<SelectValue>();
 
   const getResults = (username?: string) => {
     let results: { label: string; value: string }[] = [];
@@ -466,6 +457,7 @@ export const AsyncSelect = ({
               ? { label: 'Valentina', value: 'Valentina' }
               : undefined
           }
+          onChange={value => setValue(value)}
         />
       </div>
       <div
@@ -484,6 +476,20 @@ export const AsyncSelect = ({
           <p key={`request-${index}`}>{request}</p>
         ))}
       </div>
+      <div
+        style={{
+          position: 'absolute',
+          top: 450,
+          left: DEFAULT_WIDTH + 100,
+          height: 200,
+          width: 600,
+          overflowY: 'auto',
+          border: '1px solid #d9d9d9',
+          padding: 20,
+        }}
+      >
+        {value ? JSON.stringify(value) : ''}
+      </div>
     </>
   );
 };
@@ -491,8 +497,6 @@ export const AsyncSelect = ({
 AsyncSelect.args = {
   allowClear: false,
   allowNewOptions: false,
-  fetchOnlyOnSearch: false,
-  pageSize: 10,
   withError: false,
   withInitialValue: false,
   tokenSeparators: ['\n', '\t', ';'],
@@ -511,6 +515,9 @@ AsyncSelect.argTypes = {
     },
   },
   pageSize: {
+    description: `It defines how many results should be included in the query response.
+      Works in async mode only (See the options property).
+    `,
     defaultValue: 10,
     control: {
       type: 'range',
@@ -518,6 +525,13 @@ AsyncSelect.argTypes = {
       max: 50,
       step: 10,
     },
+  },
+  fetchOnlyOnSearch: {
+    description: `It fires a request against the server only after searching.
+      Works in async mode only (See the options property).
+      Undefined by default.
+    `,
+    defaultValue: false,
   },
   responseTime: {
     defaultValue: 0.5,


### PR DESCRIPTION
### SUMMARY
This PR aims to add the "Select all" feature to the Select component. Adding this feature to a synchronous Select is really simple. The problem arises when adding "Select all" to an asynchronous, paginated, searchable, and keep selected on top Select. We have many technical challenges and design considerations as you can see [here](https://ux.stackexchange.com/questions/43937/how-should-the-select-all-select-when-paginating-elements). Some of the requirements we need to address:
- Select all items when only some pages are loaded on the client-side. Selecting only the visible items was discarded because, in our context, the majority of times the user is actually selecting all values. We also don't want to force the user to load all items before being able to select them.
- Load new items as selected when "Selected all" is active 
- Unselect a set of items when "Select all" is active and not all pages have been loaded on the client-side
- Keep the order of selected items during user interactions
- Automatically "Select all" when all items have been selected and not all pages have been loaded on the client-side. One example here is when the user opens the Select, one page is loaded, the user clicks on "Select all", unselects one item, and selects the same item again. At this point, we should go back to the "Select all" mode even though we only have one page loaded.
- Handle the payload size. We shouldn't send all selected items to the server-side because we don't know how many can exist, which could result in huge payload size. What we need to do is to come up with a payload that represents the user selection in an efficient way. One example would be if a user selects all items and unselects a subset, we could send a value representing the "Select all" alongside the subset of unselected items.
- Write tests that are able to scroll the component, trigger new page loads, and test the above scenarios.
- Expand the storybook to account for the new requirements.
- We also need to split the component into two (sync and async). It's very clear that the behaviors are different and we can significantly reduce code complexity if we treat them as different components.
- Add support to the new payload format to the API endpoints

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/169524505-ac812e6c-29ab-4671-a198-03600a02b94d.mov

### TESTING INSTRUCTIONS
TODO

### ADDITIONAL INFORMATION
- [x] Has associated issue: 
- https://github.com/apache/superset/issues/19426
- https://github.com/apache/superset/pull/19979
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
