### PR TITLE
feat: showing results pane in dashboard

### DIFF
--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
@@ -90,7 +90,7 @@ const createProps = (viz_type = 'sunburst') => ({
   chartStatus: 'rendered',
   showControls: true,
   supersetCanShare: true,
-  formData: { slice_id: 1, datasource: '58__table' },
+  formData: { slice_id: 1, datasource: '58__table', viz_type: 'sunburst' },
 });
 
 test('Should render', () => {

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -34,7 +34,9 @@ import { FeatureFlag, isFeatureEnabled } from 'src/featureFlags';
 import CrossFilterScopingModal from 'src/dashboard/components/CrossFilterScopingModal/CrossFilterScopingModal';
 import Icons from 'src/components/Icons';
 import ModalTrigger from 'src/components/ModalTrigger';
+import Button from 'src/components/Button';
 import ViewQueryModal from 'src/explore/components/controls/ViewQueryModal';
+import { ResultsPane } from 'src/explore/components/DataTablesPane';
 
 const MENU_KEYS = {
   CROSS_FILTER_SCOPING: 'cross_filter_scoping',
@@ -46,6 +48,7 @@ const MENU_KEYS = {
   FULLSCREEN: 'fullscreen',
   TOGGLE_CHART_DESCRIPTION: 'toggle_chart_description',
   VIEW_QUERY: 'view_query',
+  VIEW_RESULTS: 'view_results',
 };
 
 const VerticalDotsContainer = styled.div`
@@ -102,7 +105,7 @@ export interface SliceHeaderControlsProps {
   updatedDttm: number | null;
   isFullSize?: boolean;
   isDescriptionExpanded?: boolean;
-  formData: Pick<QueryFormData, 'slice_id' | 'datasource'>;
+  formData: QueryFormData;
   onExploreChart: () => void;
 
   forceRefresh: (sliceId: number, dashboardId: number) => void;
@@ -319,6 +322,41 @@ class SliceHeaderControls extends React.PureComponent<
               modalTitle={t('View query')}
               modalBody={
                 <ViewQueryModal latestQueryFormData={this.props.formData} />
+              }
+              draggable
+              resizable
+              responsive
+            />
+          </Menu.Item>
+        )}
+
+        {this.props.supersetCanExplore && (
+          <Menu.Item key={MENU_KEYS.VIEW_RESULTS}>
+            <ModalTrigger
+              triggerNode={
+                <span data-test="view-query-menu-item">
+                  {t('View results')}
+                </span>
+              }
+              modalTitle={t('Chart Data: %s', slice.slice_name)}
+              modalBody={
+                <ResultsPane
+                  queryFormData={this.props.formData}
+                  queryForce={false}
+                  dataSize={20}
+                  isRequest
+                />
+              }
+              modalFooter={
+                <>
+                  <Button
+                    buttonStyle="secondary"
+                    buttonSize="small"
+                    onClick={this.props.onExploreChart}
+                  >
+                    {t('Edit chart')}
+                  </Button>
+                </>
               }
               draggable
               resizable

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -335,7 +335,7 @@ class SliceHeaderControls extends React.PureComponent<
             <ModalTrigger
               triggerNode={
                 <span data-test="view-query-menu-item">
-                  {t('View results')}
+                  {t('Drill to detail')}
                 </span>
               }
               modalTitle={t('Chart Data: %s', slice.slice_name)}
@@ -348,15 +348,13 @@ class SliceHeaderControls extends React.PureComponent<
                 />
               }
               modalFooter={
-                <>
-                  <Button
-                    buttonStyle="secondary"
-                    buttonSize="small"
-                    onClick={this.props.onExploreChart}
-                  >
-                    {t('Edit chart')}
-                  </Button>
-                </>
+                <Button
+                  buttonStyle="secondary"
+                  buttonSize="small"
+                  onClick={this.props.onExploreChart}
+                >
+                  {t('Edit chart')}
+                </Button>
               }
               draggable
               resizable


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR has finally come to the end after completing these PRs:
- https://github.com/apache/superset/pull/20226
- https://github.com/apache/superset/pull/20201
- https://github.com/apache/superset/pull/20109
- https://github.com/apache/superset/pull/20170

Show `ResultsPane` in Dashboard and keep all functions as `ResultsPane` on explore page.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### Mulitple charts
https://user-images.githubusercontent.com/2016594/169540783-bec01028-ba4e-409d-a475-1e0166b522db.mov

### Results data copy to clipboard and formatted time switching


https://user-images.githubusercontent.com/2016594/171773659-568081e9-188a-4f72-a349-fc3f700ce6c1.mov


### TESTING INSTRUCTIONS
1. The functionality in ResultsPane should same between Dashboard and Explore
2. The HTTP request should not resend if chart not apply new filter on Dashboard. (for example, the results data will be cached until apply a new native filter)
3. Should correctly copy results data to clipboard both in Dashboard and Explore

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
