### PR TITLE
fix(csv): Ensure df_to_escaped_csv does not coerce integer columns to float

### DIFF
--- a/superset/utils/csv.py
+++ b/superset/utils/csv.py
@@ -19,6 +19,7 @@ import urllib.request
 from typing import Any, Dict, Optional
 from urllib.error import URLError
 
+import numpy as np
 import pandas as pd
 import simplejson
 
@@ -64,8 +65,12 @@ def df_to_escaped_csv(df: pd.DataFrame, **kwargs: Any) -> Any:
     # Escape csv headers
     df = df.rename(columns=escape_values)
 
-    # Escape csv rows
-    df = df.applymap(escape_values)
+    # Escape csv values
+    for name, column in df.items():
+        if column.dtype == np.dtype(object):
+            for idx, value in enumerate(column.values):
+                if isinstance(value, str):
+                    df.at[idx, name] = escape_value(value)
 
     return df.to_csv(**kwargs)
 

--- a/tests/integration_tests/utils/csv_tests.py
+++ b/tests/integration_tests/utils/csv_tests.py
@@ -17,6 +17,7 @@
 import io
 
 import pandas as pd
+import pyarrow as pa
 import pytest
 
 from superset.utils import csv
@@ -77,3 +78,6 @@ def test_df_to_escaped_csv():
         ["a", "'=b"],  # pandas seems to be removing the leading ""
         ["' =a", "b"],
     ]
+
+    df = pa.array([1, None]).to_pandas(integer_object_nulls=True).to_frame()
+    assert csv.df_to_escaped_csv(df, encoding="utf8", index=False) == '0\n1\n""\n'


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

When exporting a SQL Lab result set with a integer column containing `NULL` values, Numpy/Pandas coerces them to floats during the `pd.DataFrame.applymap(...)` call given that `NaN` is actually a float, i.e., 

```
>>> import pyarrow as pa
>>>
>>> df = pa.array([1, 2, None]).to_pandas(integer_object_nulls=True).to_frame()
>>> df
      0
0     1
1     2
2  None
>>>
>>> df.applymap(lambda x: x)
     0
0  1.0
1  2.0
2  NaN
```

Type coercion in Pandas is overly magical and often undesirable. The fix is somewhat yuck as well, iterating over the columns and rows of the DataFrame and escaping only those cells which are actually `str`.

I tried a number of more performant/vectorized solutions but at the end of the day they rely on `numpy.array`s which require a priori declared types otherwise coercion is performed. Note the `numpy.dtype(object)`  data type is used to handled both strings an integers—as a byproduct of how data is exported from PyArrow—given special handling is required for dealing wiith missing values with integers per [here](https://pandas.pydata.org/docs/user_guide/gotchas.html#support-for-integer-na). The TL;DR is this is all very unpleasant.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Added unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
