### PR TITLE
feat: add statsd metrics for notifications

### DIFF
--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -150,7 +150,7 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
     def _get_to(self) -> str:
         return json.loads(self._recipient.recipient_config_json)["target"]
 
-    @statsd_gauge("email.send")
+    @statsd_gauge("reports.email.send")
     def send(self) -> None:
         subject = self._get_subject()
         content = self._get_content()

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -150,7 +150,7 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
     def _get_to(self) -> str:
         return json.loads(self._recipient.recipient_config_json)["target"]
 
-    @statsd_gauge
+    @statsd_gauge("email.send")
     def send(self) -> None:
         subject = self._get_subject()
         content = self._get_content()

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -30,6 +30,7 @@ from superset.models.reports import ReportRecipientType
 from superset.reports.notifications.base import BaseNotification
 from superset.reports.notifications.exceptions import NotificationError
 from superset.utils.core import send_email_smtp
+from superset.utils.decorators import statsd_gauge
 from superset.utils.urls import modify_url_query
 
 logger = logging.getLogger(__name__)
@@ -149,6 +150,7 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
     def _get_to(self) -> str:
         return json.loads(self._recipient.recipient_config_json)["target"]
 
+    @statsd_gauge
     def send(self) -> None:
         subject = self._get_subject()
         content = self._get_content()

--- a/superset/reports/notifications/slack.py
+++ b/superset/reports/notifications/slack.py
@@ -148,7 +148,7 @@ Error: %(text)s
         return []
 
     @backoff.on_exception(backoff.expo, SlackApiError, factor=10, base=2, max_tries=5)
-    @statsd_gauge("slack.send")
+    @statsd_gauge("reports.slack.send")
     def send(self) -> None:
         files = self._get_inline_files()
         title = self._content.name

--- a/superset/reports/notifications/slack.py
+++ b/superset/reports/notifications/slack.py
@@ -24,12 +24,12 @@ import backoff
 from flask_babel import gettext as __
 from slack import WebClient
 from slack.errors import SlackApiError, SlackClientError
-from utils.decorators import statsd_gauge
 
 from superset import app
 from superset.models.reports import ReportRecipientType
 from superset.reports.notifications.base import BaseNotification
 from superset.reports.notifications.exceptions import NotificationError
+from superset.utils.decorators import statsd_gauge
 from superset.utils.urls import modify_url_query
 
 logger = logging.getLogger(__name__)

--- a/superset/reports/notifications/slack.py
+++ b/superset/reports/notifications/slack.py
@@ -24,6 +24,7 @@ import backoff
 from flask_babel import gettext as __
 from slack import WebClient
 from slack.errors import SlackApiError, SlackClientError
+from utils.decorators import statsd_gauge
 
 from superset import app
 from superset.models.reports import ReportRecipientType
@@ -147,6 +148,7 @@ Error: %(text)s
         return []
 
     @backoff.on_exception(backoff.expo, SlackApiError, factor=10, base=2, max_tries=5)
+    @statsd_gauge
     def send(self) -> None:
         files = self._get_inline_files()
         title = self._content.name

--- a/superset/reports/notifications/slack.py
+++ b/superset/reports/notifications/slack.py
@@ -148,7 +148,7 @@ Error: %(text)s
         return []
 
     @backoff.on_exception(backoff.expo, SlackApiError, factor=10, base=2, max_tries=5)
-    @statsd_gauge
+    @statsd_gauge("slack.send")
     def send(self) -> None:
         files = self._get_inline_files()
         title = self._content.name

--- a/superset/utils/decorators.py
+++ b/superset/utils/decorators.py
@@ -37,7 +37,7 @@ def statsd_gauge(f: Callable[..., Any]) -> Callable[..., Any]:
     Handle sending statsd gauge metric from any method or function
     """
 
-    def wraps(*args: Any, **kwargs: Any) -> Any:
+    def wrapped(*args: Any, **kwargs: Any) -> Any:
         try:
             result = f(*args, **kwargs)
             current_app.config["STATS_LOGGER"].gauge(f"{f.__name__}.ok", 1)
@@ -46,7 +46,7 @@ def statsd_gauge(f: Callable[..., Any]) -> Callable[..., Any]:
             current_app.config["STATS_LOGGER"].gauge(f"{f.__name__}.error", 1)
             raise ex
 
-    return wraps
+    return wrapped
 
 
 @contextmanager


### PR DESCRIPTION
### SUMMARY

Add a statsd gauge metric for Slack and email notifications.
We want to add more visibility for Alerts & Reports notifications: how many errors, how many notifications were sent

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
