### PR TITLE
feat(explore): Add empty state to annotations

### DIFF
--- a/superset-frontend/src/components/EmptyState/index.tsx
+++ b/superset-frontend/src/components/EmptyState/index.tsx
@@ -106,6 +106,7 @@ const BigDescription = styled(Description)`
 const SmallDescription = styled(Description)`
   ${({ theme }) => css`
     margin-top: ${theme.gridUnit}px;
+    line-height: 1.2;
   `}
 `;
 

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
@@ -107,6 +107,28 @@ const NotFoundContentWrapper = styled.div`
   }
 `;
 
+const NotFoundContent = () => (
+  <NotFoundContentWrapper>
+    <EmptyStateSmall
+      title={t('No annotation layers')}
+      description={
+        <span>
+          {t('Add an annotation layer')}{' '}
+          <a
+            href="/annotationlayermodelview/list"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {t('here')}
+          </a>
+          .
+        </span>
+      }
+      image="empty.svg"
+    />
+  </NotFoundContentWrapper>
+);
+
 class AnnotationLayer extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -425,15 +447,7 @@ class AnnotationLayer extends React.PureComponent {
           onChange={this.handleValue}
           validationErrors={!value ? ['Mandatory'] : []}
           optionRenderer={this.renderOption}
-          notFoundContent={
-            <NotFoundContentWrapper>
-              <EmptyStateSmall
-                title={t('No annotation layers')}
-                description={t('Add an annotation layer here')}
-                image="empty.svg"
-              />
-            </NotFoundContentWrapper>
-          }
+          notFoundContent={<NotFoundContent />}
         />
       );
     }
@@ -781,27 +795,7 @@ class AnnotationLayer extends React.PureComponent {
                   label={t('Annotation source')}
                   name="annotation-source-type"
                   options={supportedSourceTypes}
-                  notFoundContent={
-                    <NotFoundContentWrapper>
-                      <EmptyStateSmall
-                        title={t('No annotation layers')}
-                        description={
-                          <span>
-                            {t('Add an annotation layer')}{' '}
-                            <a
-                              href="/annotationlayermodelview/list"
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            >
-                              {t('here')}
-                            </a>
-                            .
-                          </span>
-                        }
-                        image="empty.svg"
-                      />
-                    </NotFoundContentWrapper>
-                  }
+                  notFoundContent={<NotFoundContent />}
                   value={sourceType}
                   onChange={this.handleAnnotationSourceType}
                   validationErrors={!sourceType ? [t('Mandatory')] : []}

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
@@ -27,6 +27,7 @@ import {
   getChartMetadataRegistry,
   validateNonEmpty,
   isValidExpression,
+  styled,
   withTheme,
 } from '@superset-ui/core';
 
@@ -43,6 +44,7 @@ import {
 } from 'src/modules/AnnotationTypes';
 import PopoverSection from 'src/components/PopoverSection';
 import ControlHeader from 'src/explore/components/ControlHeader';
+import { EmptyStateSmall } from 'src/components/EmptyState';
 
 const AUTOMATIC_COLOR = '';
 
@@ -97,6 +99,13 @@ const defaultProps = {
   removeAnnotationLayer: () => {},
   close: () => {},
 };
+
+const NotFoundContentWrapper = styled.div`
+  && > div:first-child {
+    padding-left: 0;
+    padding-right: 0;
+  }
+`;
 
 class AnnotationLayer extends React.PureComponent {
   constructor(props) {
@@ -416,6 +425,15 @@ class AnnotationLayer extends React.PureComponent {
           onChange={this.handleValue}
           validationErrors={!value ? ['Mandatory'] : []}
           optionRenderer={this.renderOption}
+          notFoundContent={
+            <NotFoundContentWrapper>
+              <EmptyStateSmall
+                title={t('No annotation layers')}
+                description={t('Add an annotation layer here')}
+                image="empty.svg"
+              />
+            </NotFoundContentWrapper>
+          }
         />
       );
     }
@@ -760,9 +778,30 @@ class AnnotationLayer extends React.PureComponent {
                   ariaLabel={t('Annotation source type')}
                   hovered
                   description={t('Choose the source of your annotations')}
-                  label={t('Annotation Source')}
+                  label={t('Annotation source')}
                   name="annotation-source-type"
                   options={supportedSourceTypes}
+                  notFoundContent={
+                    <NotFoundContentWrapper>
+                      <EmptyStateSmall
+                        title={t('No annotation layers')}
+                        description={
+                          <span>
+                            {t('Add an annotation layer')}{' '}
+                            <a
+                              href="/annotationlayermodelview/list"
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              {t('here')}
+                            </a>
+                            .
+                          </span>
+                        }
+                        image="empty.svg"
+                      />
+                    </NotFoundContentWrapper>
+                  }
                   value={sourceType}
                   onChange={this.handleAnnotationSourceType}
                   validationErrors={!sourceType ? [t('Mandatory')] : []}

--- a/superset-frontend/src/explore/components/controls/SelectControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.jsx
@@ -53,6 +53,7 @@ const propTypes = {
   placeholder: PropTypes.string,
   filterOption: PropTypes.func,
   tokenSeparators: PropTypes.arrayOf(PropTypes.string),
+  notFoundContent: PropTypes.object,
 
   // ControlHeader props
   label: PropTypes.string,
@@ -179,6 +180,7 @@ export default class SelectControl extends React.PureComponent {
       showHeader,
       value,
       tokenSeparators,
+      notFoundContent,
       // ControlHeader props
       description,
       renderTrigger,
@@ -245,6 +247,7 @@ export default class SelectControl extends React.PureComponent {
       sortComparator: this.props.sortComparator,
       value: getValue(),
       tokenSeparators,
+      notFoundContent,
     };
 
     return (


### PR DESCRIPTION
### SUMMARY
When there's no annotation sources available, display an empty state with a link to annotation layers view.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="258" alt="image" src="https://user-images.githubusercontent.com/15073128/169838406-c861ccd2-8d3c-46b7-9fe3-c09b90540982.png">

### TESTING INSTRUCTIONS
1. Make sure that you have no annotation sources available
2. Try to add an annotation to a chart, make sure that an empty state with a link to annotation layers page appears when you try to select an annotation source

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @kasiazjc