### PR TITLE
fix(sql lab): View result button is not showing consistently

### DIFF
--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -340,6 +340,12 @@ export default function sqlLabReducer(state = {}, action) {
         errorMessage: null,
         cached: false,
       };
+
+      const resultsKey = action?.results?.query?.resultsKey;
+      if (resultsKey) {
+        alts.resultsKey = resultsKey;
+      }
+
       return alterInObject(state, 'queries', action.query, alts);
     },
     [actions.QUERY_FAILED]() {

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -548,6 +548,7 @@ def execute_sql_statements(  # pylint: disable=too-many-arguments, too-many-loca
 
     if store_results and results_backend:
         key = str(uuid.uuid4())
+        payload["query"]["resultsKey"] = key
         logger.info(
             "Query %s: Storing results in results backend, key: %s", str(query_id), key
         )


### PR DESCRIPTION
### SUMMARY
In order to display the 'View' button in the history tab of the SQL Lab, the query must have a resultsKey.
When the query is executed in sync mode, that key was not properly propagated from the API to the FE, thus, the button did not appeared after execution.

The button did appeared once the running polling watching for queries updated, since that fetches fresh results from the api.

This PR forwards that key to make the button show for every successfully executed query.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/17252075/169911455-0efe3c95-ca74-4c53-89fc-dd44443c1243.mov

After:

https://user-images.githubusercontent.com/17252075/169911632-cb68efb8-04ca-451c-a6bc-3bca5ac930a9.mov

### TESTING INSTRUCTIONS
1. Configure a database for sync mode
2. Run queries in SQL Lab in that database
3. Check query history

Ensure that, if the queries are successful, the 'View' button always displays.
Ensure it works for both sync/async query execution flows.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
