### PR TITLE
feat: add samples endpoint

### DIFF
--- a/superset/constants.py
+++ b/superset/constants.py
@@ -129,6 +129,7 @@ MODEL_API_RW_METHOD_PERMISSION_MAP = {
     "available": "read",
     "validate_sql": "read",
     "get_data": "read",
+    "samples": "read",
 }
 
 EXTRA_FORM_DATA_APPEND_KEYS = {

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -45,11 +45,13 @@ from superset.datasets.commands.exceptions import (
     DatasetInvalidError,
     DatasetNotFoundError,
     DatasetRefreshFailedError,
+    DatasetSamplesFailedError,
     DatasetUpdateFailedError,
 )
 from superset.datasets.commands.export import ExportDatasetsCommand
 from superset.datasets.commands.importers.dispatcher import ImportDatasetsCommand
 from superset.datasets.commands.refresh import RefreshDatasetCommand
+from superset.datasets.commands.samples import SamplesDatasetCommand
 from superset.datasets.commands.update import UpdateDatasetCommand
 from superset.datasets.dao import DatasetDAO
 from superset.datasets.filters import DatasetCertifiedFilter, DatasetIsNullOrEmptyFilter
@@ -90,6 +92,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         "bulk_delete",
         "refresh",
         "related_objects",
+        "samples",
     }
     list_columns = [
         "id",
@@ -760,3 +763,64 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         )
         command.run()
         return self.response(200, message="OK")
+
+    @expose("/<pk>/samples")
+    @protect()
+    @safe
+    @statsd_metrics
+    @event_logger.log_this_with_context(
+        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}" f".samples",
+        log_to_statsd=False,
+    )
+    def samples(self, pk: int) -> Response:
+        """get samples from a Dataset
+        ---
+        put:
+          description: >-
+            get samples from a Dataset
+          parameters:
+          - in: path
+            schema:
+              type: integer
+            name: pk
+          - in: query
+            schema:
+              type: boolean
+            name: force
+          responses:
+            200:
+              description: Dataset samples
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      samples:
+                        type: object
+            401:
+              $ref: '#/components/responses/401'
+            403:
+              $ref: '#/components/responses/403'
+            404:
+              $ref: '#/components/responses/404'
+            422:
+              $ref: '#/components/responses/422'
+            500:
+              $ref: '#/components/responses/500'
+        """
+        try:
+            force = parse_boolean_string(request.args.get("force"))
+            rv = SamplesDatasetCommand(g.user, pk).run(force_cached=force)
+            return self.response(200, samples=rv)
+        except DatasetNotFoundError:
+            return self.response_404()
+        except DatasetForbiddenError:
+            return self.response_403()
+        except DatasetSamplesFailedError as ex:
+            logger.error(
+                "Error refreshing dataset %s: %s",
+                self.__class__.__name__,
+                str(ex),
+                exc_info=True,
+            )
+            return self.response_422(message=str(ex))

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -769,13 +769,13 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}" f".samples",
+        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.samples",
         log_to_statsd=False,
     )
     def samples(self, pk: int) -> Response:
         """get samples from a Dataset
         ---
-        put:
+        get:
           description: >-
             get samples from a Dataset
           parameters:
@@ -796,6 +796,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
                     type: object
                     properties:
                       samples:
+                        description: dataset samples
                         type: object
             401:
               $ref: '#/components/responses/401'
@@ -810,7 +811,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         """
         try:
             force = parse_boolean_string(request.args.get("force"))
-            rv = SamplesDatasetCommand(g.user, pk).run(force_cached=force)
+            rv = SamplesDatasetCommand(g.user, pk, force).run()
             return self.response(200, samples=rv)
         except DatasetNotFoundError:
             return self.response_404()
@@ -818,7 +819,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
             return self.response_403()
         except DatasetSamplesFailedError as ex:
             logger.error(
-                "Error refreshing dataset %s: %s",
+                "Error get dataset samples %s: %s",
                 self.__class__.__name__,
                 str(ex),
                 exc_info=True,

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -796,8 +796,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
                     type: object
                     properties:
                       samples:
-                        description: dataset samples
-                        type: object
+                        $ref: '#/components/schemas/ChartDataResponseResult'
             401:
               $ref: '#/components/responses/401'
             403:

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -795,7 +795,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
                   schema:
                     type: object
                     properties:
-                      samples:
+                      result:
                         $ref: '#/components/schemas/ChartDataResponseResult'
             401:
               $ref: '#/components/responses/401'
@@ -811,7 +811,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         try:
             force = parse_boolean_string(request.args.get("force"))
             rv = SamplesDatasetCommand(g.user, pk, force).run()
-            return self.response(200, samples=rv)
+            return self.response(200, result=rv)
         except DatasetNotFoundError:
             return self.response_404()
         except DatasetForbiddenError:

--- a/superset/datasets/commands/exceptions.py
+++ b/superset/datasets/commands/exceptions.py
@@ -174,7 +174,7 @@ class DatasetRefreshFailedError(UpdateFailedError):
 
 
 class DatasetSamplesFailedError(CommandInvalidError):
-    message = _("Dataset could not be sampled.")
+    message = _("Samples for dataset could not be retrieved.")
 
 
 class DatasetForbiddenError(ForbiddenError):

--- a/superset/datasets/commands/exceptions.py
+++ b/superset/datasets/commands/exceptions.py
@@ -173,6 +173,10 @@ class DatasetRefreshFailedError(UpdateFailedError):
     message = _("Dataset could not be updated.")
 
 
+class DatasetSamplesFailedError(CommandInvalidError):
+    message = _("Dataset could not be sampled.")
+
+
 class DatasetForbiddenError(ForbiddenError):
     message = _("Changing this dataset is forbidden")
 

--- a/superset/datasets/commands/samples.py
+++ b/superset/datasets/commands/samples.py
@@ -1,0 +1,73 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import logging
+from typing import Any, Dict, Optional
+
+from flask_appbuilder.security.sqla.models import User
+
+from superset.commands.base import BaseCommand
+from superset.common.chart_data import ChartDataResultType
+from superset.common.query_context_factory import QueryContextFactory
+from superset.connectors.sqla.models import SqlaTable
+from superset.datasets.commands.exceptions import (
+    DatasetForbiddenError,
+    DatasetNotFoundError,
+    DatasetSamplesFailedError,
+)
+from superset.datasets.dao import DatasetDAO
+from superset.exceptions import SupersetSecurityException
+from superset.views.base import check_ownership
+
+logger = logging.getLogger(__name__)
+
+
+class SamplesDatasetCommand(BaseCommand):
+    def __init__(self, user: User, model_id: int):
+        self._actor = user
+        self._model_id = model_id
+        self._model: Optional[SqlaTable] = None
+
+    def run(self, force_cached: bool = False) -> Dict[str, Any]:
+        self.validate()
+        if not self._model:
+            raise DatasetNotFoundError()
+
+        qc_instance = QueryContextFactory().create(
+            datasource={
+                "type": self._model.type,
+                "id": self._model.id,
+            },
+            queries=[{}],
+            result_type=ChartDataResultType.SAMPLES,
+            force=force_cached,
+        )
+        results = qc_instance.get_payload()
+        try:
+            return results["queries"][0]
+        except (IndexError, KeyError):
+            raise DatasetSamplesFailedError
+
+    def validate(self) -> None:
+        # Validate/populate model exists
+        self._model = DatasetDAO.find_by_id(self._model_id)
+        if not self._model:
+            raise DatasetNotFoundError()
+        # Check ownership
+        try:
+            check_ownership(self._model)
+        except SupersetSecurityException as ex:
+            raise DatasetForbiddenError() from ex

--- a/superset/datasets/commands/samples.py
+++ b/superset/datasets/commands/samples.py
@@ -36,12 +36,13 @@ logger = logging.getLogger(__name__)
 
 
 class SamplesDatasetCommand(BaseCommand):
-    def __init__(self, user: User, model_id: int):
+    def __init__(self, user: User, model_id: int, force: bool):
         self._actor = user
         self._model_id = model_id
+        self._force = force
         self._model: Optional[SqlaTable] = None
 
-    def run(self, force_cached: bool = False) -> Dict[str, Any]:
+    def run(self) -> Dict[str, Any]:
         self.validate()
         if not self._model:
             raise DatasetNotFoundError()
@@ -53,13 +54,13 @@ class SamplesDatasetCommand(BaseCommand):
             },
             queries=[{}],
             result_type=ChartDataResultType.SAMPLES,
-            force=force_cached,
+            force=self._force,
         )
         results = qc_instance.get_payload()
         try:
             return results["queries"][0]
-        except (IndexError, KeyError):
-            raise DatasetSamplesFailedError
+        except (IndexError, KeyError) as exc:
+            raise DatasetSamplesFailedError from exc
 
     def validate(self) -> None:
         # Validate/populate model exists

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -1842,3 +1842,30 @@ class TestDatasetApi(SupersetTestCase):
 
         db.session.delete(table_w_certification)
         db.session.commit()
+
+    @pytest.mark.usefixtures("create_datasets")
+    def test_get_dataset_samples(self):
+        """
+        Dataset API: Test get dataset samples
+        """
+        dataset = self.get_fixture_datasets()[0]
+
+        self.login(username="admin")
+        uri = f"api/v1/dataset/{dataset.id}/samples"
+        # feeds data
+        self.client.get(uri)
+        # get from cache
+        rv = self.client.get(uri)
+        rv_data = json.loads(rv.data)
+        assert rv.status_code == 200
+        assert "samples" in rv_data
+        assert rv_data["samples"]["cached_dttm"] is not None
+
+        # force query
+        uri2 = f"api/v1/dataset/{dataset.id}/samples?force=true"
+        # feeds data
+        self.client.get(uri2)
+        # force query
+        rv2 = self.client.get(uri2)
+        rv_data2 = json.loads(rv2.data)
+        assert rv_data2["samples"]["cached_dttm"] is None

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -1860,8 +1860,8 @@ class TestDatasetApi(SupersetTestCase):
         rv = self.client.get(uri)
         rv_data = json.loads(rv.data)
         assert rv.status_code == 200
-        assert "samples" in rv_data
-        assert rv_data["samples"]["cached_dttm"] is not None
+        assert "result" in rv_data
+        assert rv_data["result"]["cached_dttm"] is not None
 
         # 2. should through cache
         uri2 = f"api/v1/dataset/{dataset.id}/samples?force=true"
@@ -1870,15 +1870,15 @@ class TestDatasetApi(SupersetTestCase):
         # force query
         rv2 = self.client.get(uri2)
         rv_data2 = json.loads(rv2.data)
-        assert rv_data2["samples"]["cached_dttm"] is None
+        assert rv_data2["result"]["cached_dttm"] is None
 
         # 3. data precision
-        assert "colnames" in rv_data2["samples"]
-        assert "coltypes" in rv_data2["samples"]
-        assert "data" in rv_data2["samples"]
+        assert "colnames" in rv_data2["result"]
+        assert "coltypes" in rv_data2["result"]
+        assert "data" in rv_data2["result"]
 
         eager_samples = dataset.database.get_df(
             f"select * from {dataset.table_name}"
             f' limit {self.app.config["SAMPLES_ROW_LIMIT"]}'
         ).to_dict(orient="records")
-        assert eager_samples == rv_data2["samples"]["data"]
+        assert eager_samples == rv_data2["result"]["data"]


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add a new samples endpoint for getting dataset sampling

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. run `superset init`
2. login Superset
3. open `http://localhost:9000/api/v1/dataset/<dataset_id>/samples` in browser
4. open `http://localhost:9000/api/v1/dataset/<dataset_id>/samples?force=true` to force query



### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
