### PR TITLE
fix: avoid while cycle in computeMaxFontSize for big Number run forever when css rule applied

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/dimension/computeMaxFontSize.ts
+++ b/superset-frontend/packages/superset-ui-core/src/dimension/computeMaxFontSize.ts
@@ -27,8 +27,20 @@ function decreaseSizeUntil(
 ): number {
   let size = startSize;
   let dimension = computeDimension(size);
+
   while (!condition(dimension)) {
     size -= 1;
+
+    // Here if the size goes below zero most likely is because it
+    // has additional style applied in which case we assume the user
+    // knows what it's doing and we just let them use that.
+    // Visually it works, although it could have another
+    // check in place.
+    if (size < 0) {
+      size = startSize;
+      break;
+    }
+
     dimension = computeDimension(size);
   }
 
@@ -66,7 +78,7 @@ export default function computeMaxFontSize(
     size = decreaseSizeUntil(
       size,
       computeDimension,
-      dim => dim.width <= maxWidth,
+      dim => dim.width > 0 && dim.width <= maxWidth,
     );
   }
 
@@ -74,7 +86,7 @@ export default function computeMaxFontSize(
     size = decreaseSizeUntil(
       size,
       computeDimension,
-      dim => dim.height <= maxHeight,
+      dim => dim.height > 0 && dim.height <= maxHeight,
     );
   }
 

--- a/superset-frontend/packages/superset-ui-core/test/dimension/computeMaxFontSize.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/dimension/computeMaxFontSize.test.ts
@@ -59,5 +59,14 @@ describe('computeMaxFontSize(input)', () => {
         }),
       ).toEqual(25);
     });
+    it('ensure idealFontSize is used if the maximum font size calculation goes below zero', () => {
+      expect(
+        computeMaxFontSize({
+          maxWidth: 5,
+          idealFontSize: 34,
+          text: SAMPLE_TEXT[0],
+        }),
+      ).toEqual(34);
+    });
   });
 });


### PR DESCRIPTION
### SUMMARY

Adding custom CSS to a dashboard with a bigInt chart would activate a while loop that didn't ever finished, which somehow wasn't caught by the surrounding ErrorBoundary cause the whole app crashed before running out of memory (my guess)

Follow up on #20067, adding the missing titles

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/17252075/170134690-c289c318-221c-4331-a3a9-c360bce77215.mov

### TESTING INSTRUCTIONS
1. Create a Dashboard.
2. Access it on edit mode.
3. Click on the three ellipses on the top right corner > Edit CSS.
4. Add below CSS code to it:
```css
.header-line {
  font-size: 170px!important;
}
```
5. Add a Big Number Chart to the Dashboard.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
