### PR TITLE
fix: While exporting CSV , only the entries on first page are getting downloaded even when user is on other pages #17861

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -299,6 +299,7 @@ export default class Chart extends React.Component {
       resultType: 'full',
       resultFormat: 'csv',
       force: true,
+      ownState: this.props.ownState,
     });
   }
 

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
@@ -65,6 +65,7 @@ export const ExploreChartHeader = ({
   slice,
   actions,
   formData,
+  ownState,
   chart,
   user,
   canOverwrite,
@@ -138,6 +139,7 @@ export const ExploreChartHeader = ({
       slice,
       actions.redirectSQLLab,
       openPropertiesModal,
+      ownState,
     );
 
   const oldSliceName = slice?.slice_name;

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -522,6 +522,7 @@ function ExploreViewContainer(props) {
         table_name={props.table_name}
         formData={props.form_data}
         chart={props.chart}
+        ownState={props.ownState}
         user={props.user}
         reports={props.reports}
         onSaveChart={toggleModal}

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
@@ -95,6 +95,7 @@ export const useExploreAdditionalActionsMenu = (
   slice,
   onOpenInEditor,
   onOpenPropertiesModal,
+  ownState,
 ) => {
   const theme = useTheme();
   const { addDangerToast, addSuccessToast } = useToasts();
@@ -132,6 +133,7 @@ export const useExploreAdditionalActionsMenu = (
       canDownloadCSV
         ? exportChart({
             formData: latestQueryFormData,
+            ownState,
             resultType: 'full',
             resultFormat: 'csv',
           })


### PR DESCRIPTION
### SUMMARY
Passed ownState property to export as csv api call.

### AFTER VIDEO RECORDING
https://user-images.githubusercontent.com/31275446/170707907-46b291d8-8a28-47e5-af25-061529ab40d2.mp4


### TESTING INSTRUCTIONS
- Navigate to any table where server side pagination is enabled (test it on both the explore and the dashboard pages)
- Click on export CSV(both explore and dashboard pages)

### ADDITIONAL INFORMATION
- [x] Has associated issue:[17861](https://github.com/apache/superset/issues/17861)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API