### PR TITLE
docs(security): a typo: Gamma should be in quotes

### DIFF
--- a/docs/docs/security.mdx
+++ b/docs/docs/security.mdx
@@ -49,7 +49,7 @@ to all databases by default, both **Alpha** and **Gamma** users need to be given
 
 To allow logged-out users to access some Superset features, you can use the `PUBLIC_ROLE_LIKE` config setting and assign it to another role whose permissions you want passed to this role.
 
-For example, by setting `PUBLIC_ROLE_LIKE = Gamma` in your `superset_config.py` file, you grant
+For example, by setting `PUBLIC_ROLE_LIKE = "Gamma"` in your `superset_config.py` file, you grant
 public role the same set of permissions as for the **Gamma** role. This is useful if one
 wants to enable anonymous users to view dashboards. Explicit grant on specific datasets is
 still required, meaning that you need to edit the **Public** role and add the public data sources to the role manually.


### PR DESCRIPTION
### SUMMARY
`PUBLIC_ROLE_LIKE = ` in superset config python files expects `"Gamma"`, not just `Gamma`.

### TESTING INSTRUCTIONS
Test the config option by adding it superset_config_docker.py.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
