### PR TITLE
fix: Database import with cancel_query.. extra field

### DIFF
--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -624,6 +624,7 @@ class ImportV1DatabaseExtraSchema(Schema):
     schemas_allowed_for_csv_upload = fields.List(fields.String())
     cost_estimate_enabled = fields.Boolean()
     allows_virtual_table_explore = fields.Boolean(required=False)
+    cancel_query_on_windows_unload = fields.Boolean(required=False)
 
 
 class ImportV1DatabaseSchema(Schema):


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When we export database with `cancel_query_on_windows_unload` key in extra field, importing db is failed. 
It is because the `ImportV1DatabaseExtraSchema` doesn't contain `cancel_query_on_windows_unload` as a property.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
BEFORE: 
importing database failed.

AFTER:
[Sublime Text - PostgreSQL.yaml - 25 May 2022 - Watch Video](https://www.loom.com/share/f0ea7b70489540e684d9b989d39db674)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Edit a Database connection.
2. Switch to the ADVANCED tab.
3. Expand Performance.
4. Enable/Disable Cancel query on window unload event.
5. Save changes.
6. Export the Database.
7. Try to import it.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
