### PR TITLE
docs: correct case of ClickHouse

### DIFF
--- a/docs/docs/databases/clickhouse.mdx
+++ b/docs/docs/databases/clickhouse.mdx
@@ -1,13 +1,13 @@
 ---
-title: Clickhouse
+title: ClickHouse
 hide_title: true
 sidebar_position: 15
 version: 1
 ---
 
-## Clickhouse
+## ClickHouse
 
-To use Clickhouse with Superset, you will need to add the following Python libraries:
+To use ClickHouse with Superset, you will need to add the following Python libraries:
 
 ```
 clickhouse-driver==0.2.0
@@ -21,7 +21,7 @@ clickhouse-driver>=0.2.0
 clickhouse-sqlalchemy>=0.1.6
 ```
 
-The recommended connector library for Clickhouse is
+The recommended connector library for ClickHouse is
 [sqlalchemy-clickhouse](https://github.com/cloudflare/sqlalchemy-clickhouse).
 
 The expected connection string is formatted as follows:


### PR DESCRIPTION
ClickHouse is camel case.

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Simple doc change, uppercase `H` in ClickHouse
