### PR TITLE
fix: unable to set destroyOnClose on ModalTrigger

### DIFF
--- a/superset-frontend/src/components/Modal/Modal.tsx
+++ b/superset-frontend/src/components/Modal/Modal.tsx
@@ -325,7 +325,7 @@ const CustomModal = ({
       mask={shouldShowMask}
       draggable={draggable}
       resizable={resizable}
-      destroyOnClose={destroyOnClose || resizable || draggable}
+      destroyOnClose={destroyOnClose}
       {...rest}
     >
       {children}


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, the `ModalTrigger` unable to set `destroyOnClose` attribute to *False*, its default value is *False* in [Antd API](https://ant.design/components/modal/#API). The attribute affect showing the results pane in Dashboard[(PR)](https://github.com/apache/superset/pull/20144)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
