### PR TITLE
fix: Fixes issue where results panel height was incorrect [sc-49045]

### DIFF
--- a/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
@@ -62,9 +62,13 @@ interface SouthPanePropTypes {
   defaultQueryLimit: number;
 }
 
-const StyledPane = styled.div`
-  width: 100%;
+type StyledPaneProps = {
+  height: number;
+};
 
+const StyledPane = styled.div<StyledPaneProps>`
+  width: 100%;
+  height: ${props => props.height}px;
   .ant-tabs .ant-tabs-content-holder {
     overflow: visible;
   }
@@ -207,7 +211,7 @@ export default function SouthPane({
   return offline ? (
     renderOfflineStatus()
   ) : (
-    <StyledPane className="SouthPane" ref={southPaneRef}>
+    <StyledPane className="SouthPane" height={height} ref={southPaneRef}>
       <Tabs
         activeKey={activeSouthPaneTab}
         className="SouthPaneTabs"


### PR DESCRIPTION
This commit fixes a dynamic height assignment issue where the SQL Editor results panel would be clipped offscreen and user could not see bottom of results, the height got assigned to zero after toggling online, then offline, and height would be calculated wrong if the result set rows returned message above the results table was long enough for a line wrap.

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes a dynamic height assignment issue where the SQL Editor results panel would be clipped offscreen and user could not see bottom of results, the height got assigned to zero after toggling online, then offline, and height would be calculated wrong if the result set rows returned message above the results table was long enough for a line wrap.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before Fix:
https://drive.google.com/file/d/1A0mMm-1HoO2ol-65Tv3ENpv1e1tMRg_g/view?usp=sharing

After Fix:
https://drive.google.com/file/d/1Y7GFbvo_hfEsl6hhD1WI6if6m0BA128C/view

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1.Open SQL Editor
2.Create new or use existing Query
3. Click "RUN"
4. You should see the results under the SQL Editor
5. In Chrome Developer tools -> Network -> Change network speed from "No throttling" to "Offline"
6. Click "RUN"
7. Wait for UI to show the red "Offline" pill
8. In Chrome Developer tools -> Network -> Change network speed from "Offline" to "No throttling"
9. Click "RUN"

Expected results (with fix)
After re-enabling the network connection and clicking run you should see query results again

Actual results (before fix)
The results panel is hidden with a CSS height of zero and will stay hidden until the browser is refreshed, or the user toggles between open Sql Editor tabs

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
