### PR TITLE
fix(sql lab): SQL Lab Compile Query Delay

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -917,9 +917,13 @@ export function updateSavedQuery(query) {
 }
 
 export function queryEditorSetSql(queryEditor, sql) {
+  return { type: QUERY_EDITOR_SET_SQL, queryEditor, sql };
+}
+
+export function queryEditorSetAndSaveSql(queryEditor, sql) {
   return function (dispatch) {
     // saved query and set tab state use this action
-    dispatch({ type: QUERY_EDITOR_SET_SQL, queryEditor, sql });
+    dispatch(queryEditorSetSql(queryEditor, sql));
     if (isFeatureEnabled(FeatureFlag.SQLLAB_BACKEND_PERSISTENCE)) {
       return SupersetClient.put({
         endpoint: encodeURI(`/tabstateview/${queryEditor.id}`),

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.js
@@ -635,7 +635,7 @@ describe('async actions', () => {
       });
     });
 
-    describe('queryEditorSetSql', () => {
+    describe('queryEditorSetAndSaveSql', () => {
       const sql = 'SELECT * ';
       const expectedActions = [
         {
@@ -651,7 +651,7 @@ describe('async actions', () => {
           const store = mockStore({});
 
           return store
-            .dispatch(actions.queryEditorSetSql(queryEditor, sql))
+            .dispatch(actions.queryEditorSetAndSaveSql(queryEditor, sql))
             .then(() => {
               expect(store.getActions()).toEqual(expectedActions);
               expect(fetchMock.calls(updateTabStateEndpoint)).toHaveLength(1);
@@ -668,7 +668,7 @@ describe('async actions', () => {
 
           const store = mockStore({});
 
-          store.dispatch(actions.queryEditorSetSql(queryEditor, sql));
+          store.dispatch(actions.queryEditorSetAndSaveSql(queryEditor, sql));
 
           expect(store.getActions()).toEqual(expectedActions);
           expect(fetchMock.calls(updateTabStateEndpoint)).toHaveLength(0);

--- a/superset-frontend/src/SqlLab/components/QueryHistory/QueryHistory.test.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryHistory/QueryHistory.test.tsx
@@ -24,7 +24,7 @@ const NOOP = () => {};
 const mockedProps = {
   queries: [],
   actions: {
-    queryEditorSetSql: NOOP,
+    queryEditorSetAndSaveSql: NOOP,
     cloneQueryToNewTab: NOOP,
     fetchQueryResults: NOOP,
     clearQueryResults: NOOP,

--- a/superset-frontend/src/SqlLab/components/QueryHistory/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryHistory/index.tsx
@@ -25,7 +25,7 @@ import QueryTable from 'src/SqlLab/components/QueryTable';
 interface QueryHistoryProps {
   queries: Query[];
   actions: {
-    queryEditorSetSql: Function;
+    queryEditorSetAndSaveSql: Function;
     cloneQueryToNewTab: Function;
     fetchQueryResults: Function;
     clearQueryResults: Function;

--- a/superset-frontend/src/SqlLab/components/QuerySearch/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QuerySearch/index.tsx
@@ -37,7 +37,7 @@ interface QuerySearchProps {
   actions: {
     addDangerToast: (msg: string) => void;
     setDatabases: (data: Record<string, any>) => Record<string, any>;
-    queryEditorSetSql: Function;
+    queryEditorSetAndSaveSql: Function;
     cloneQueryToNewTab: Function;
     fetchQueryResults: Function;
     clearQueryResults: Function;

--- a/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
@@ -46,7 +46,7 @@ interface QueryTableQuery
 interface QueryTableProps {
   columns?: string[];
   actions: {
-    queryEditorSetSql: Function;
+    queryEditorSetAndSaveSql: Function;
     cloneQueryToNewTab: Function;
     fetchQueryResults: Function;
     clearQueryResults: Function;
@@ -94,7 +94,7 @@ const QueryTable = ({
   const user = useSelector<RootState, User>(state => state.sqlLab.user);
 
   const {
-    queryEditorSetSql,
+    queryEditorSetAndSaveSql,
     cloneQueryToNewTab,
     fetchQueryResults,
     clearQueryResults,
@@ -103,7 +103,7 @@ const QueryTable = ({
 
   const data = useMemo(() => {
     const restoreSql = (query: Query) => {
-      queryEditorSetSql({ id: query.sqlEditorId }, query.sql);
+      queryEditorSetAndSaveSql({ id: query.sqlEditorId }, query.sql);
     };
 
     const openQueryInNewTab = (query: Query) => {
@@ -314,7 +314,7 @@ const QueryTable = ({
     clearQueryResults,
     cloneQueryToNewTab,
     fetchQueryResults,
-    queryEditorSetSql,
+    queryEditorSetAndSaveSql,
     removeQuery,
   ]);
 

--- a/superset-frontend/src/SqlLab/components/SouthPane/SouthPane.test.jsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/SouthPane.test.jsx
@@ -80,7 +80,7 @@ const mockedEmptyProps = {
   latestQueryId: '',
   dataPreviewQueries: [],
   actions: {
-    queryEditorSetSql: NOOP,
+    queryEditorSetAndSaveSql: NOOP,
     cloneQueryToNewTab: NOOP,
     fetchQueryResults: NOOP,
     clearQueryResults: NOOP,

--- a/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
@@ -46,7 +46,7 @@ interface SouthPanePropTypes {
   latestQueryId?: string;
   dataPreviewQueries: any[];
   actions: {
-    queryEditorSetSql: Function;
+    queryEditorSetAndSaveSql: Function;
     cloneQueryToNewTab: Function;
     fetchQueryResults: Function;
     clearQueryResults: Function;


### PR DESCRIPTION
### SUMMARY
There's currently a lag when entering a query in the SQL Lab.
If you set some text and immediately submit the query, you'll most likely get the previous stored query executed.
This is specially notorious if you use keyboard shortcuts to fire the query.

This PR removes the sql query stored locally in the component in favor of the one stored in the redux store, to prevent the two states to be out of sync.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: 

https://user-images.githubusercontent.com/17252075/170585323-f8f785a3-e2f9-4c32-9e6b-1734eda8750d.mov

After:

https://user-images.githubusercontent.com/17252075/170585343-f2fbc6bd-9683-4950-a696-9cb61576be82.mov

### TESTING INSTRUCTIONS
1. Type Select 1 in SQL Lab
2. Immediately change to 1 to 2
3. Use ctrl+enter to run the query

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
