### PR TITLE
fix(legacy-plugin-chart-sunburst): linear color scheme not work when secondary metric is provided

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-sunburst/src/Sunburst.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-sunburst/src/Sunburst.js
@@ -489,7 +489,7 @@ function Sunburst(element, props) {
     // For efficiency, filter nodes to keep only those large enough to see.
     const nodes = partition.nodes(root).filter(d => d.dx > 0.005); // 0.005 radians = 0.29 degrees
 
-    if (metrics[0] !== metrics[1] && metrics[1] && !colorScheme) {
+    if (metrics[0] !== metrics[1] && metrics[1]) {
       colorByCategory = false;
       const ext = d3.extent(nodes, d => d.m2 / d.m1);
       linearColorScale = getSequentialSchemeRegistry()

--- a/superset-frontend/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts
@@ -17,7 +17,11 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
-import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
+import {
+  ControlPanelConfig,
+  ControlPanelsContainerProps,
+  sections,
+} from '@superset-ui/chart-controls';
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
@@ -71,11 +75,21 @@ const config: ControlPanelConfig = {
       description: t(
         'When only a primary metric is provided, a categorical color scale is used.',
       ),
+      visibility: ({ controls }: ControlPanelsContainerProps) =>
+        Boolean(
+          !controls?.secondary_metric?.value ||
+            controls?.secondary_metric?.value === controls?.metric.value,
+        ),
     },
     linear_color_scheme: {
       description: t(
         'When a secondary metric is provided, a linear color scale is used.',
       ),
+      visibility: ({ controls }: ControlPanelsContainerProps) =>
+        Boolean(
+          controls?.secondary_metric?.value &&
+            controls?.secondary_metric?.value !== controls?.metric.value,
+        ),
     },
     groupby: {
       label: t('Hierarchy'),


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In the sunburst chart, there is a color policy that normally uses the category color, but when second metric value is provided and is different from the first metric value, the gradient color is used. The category color was previously introduced in color consistency, but the gradient failed in the scenario described above, so we fix it here.

- Normally, category colors are used and the color scheme control is displayed
- When the second metric value is provided and differs from the first metric value, the gradient color is used and the gradient color control is displayed

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### after

https://user-images.githubusercontent.com/11830681/171091015-cf33d2dd-533a-4ab7-a9a4-292739497a07.mov



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/20150
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
