### PR TITLE
fix(legacy-plugin-chart-sunburst): chart broken when secondary metric is removed

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -237,9 +237,9 @@ export const DndMetricSelect = (props: any) => {
       const valuesCopy = [...value];
       valuesCopy.splice(index, 1);
       setValue(valuesCopy);
-      onChange(valuesCopy);
+      handleChange(valuesCopy);
     },
-    [onChange, value],
+    [handleChange, value],
   );
 
   const moveLabel = useCallback(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes the problem that sunburst broken when secondary metric is removed
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### before

https://user-images.githubusercontent.com/11830681/171107024-59cd58de-39ed-46de-9fad-99bce287c7ef.mov


### after

https://user-images.githubusercontent.com/11830681/171107028-38ee1654-bcbf-4834-ae91-cd99d5a1ebcc.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
