### PR TITLE
refactor: decouple DataTableControl

### DIFF
--- a/superset-frontend/src/explore/actions/exploreActions.ts
+++ b/superset-frontend/src/explore/actions/exploreActions.ts
@@ -140,32 +140,6 @@ export function sliceUpdated(slice: Slice) {
   return { type: SLICE_UPDATED, slice };
 }
 
-export const SET_ORIGINAL_FORMATTED_TIME_COLUMN =
-  'SET_ORIGINAL_FORMATTED_TIME_COLUMN';
-export function setOriginalFormattedTimeColumn(
-  datasourceId: string,
-  columnName: string,
-) {
-  return {
-    type: SET_ORIGINAL_FORMATTED_TIME_COLUMN,
-    datasourceId,
-    columnName,
-  };
-}
-
-export const UNSET_ORIGINAL_FORMATTED_TIME_COLUMN =
-  'UNSET_ORIGINAL_FORMATTED_TIME_COLUMN';
-export function unsetOriginalFormattedTimeColumn(
-  datasourceId: string,
-  columnIndex: number,
-) {
-  return {
-    type: UNSET_ORIGINAL_FORMATTED_TIME_COLUMN,
-    datasourceId,
-    columnIndex,
-  };
-}
-
 export const SET_FORCE_QUERY = 'SET_FORCE_QUERY';
 export function setForceQuery(force: boolean) {
   return {
@@ -189,8 +163,6 @@ export const exploreActions = {
   updateChartTitle,
   createNewSlice,
   sliceUpdated,
-  setOriginalFormattedTimeColumn,
-  unsetOriginalFormattedTimeColumn,
   setForceQuery,
 };
 

--- a/superset-frontend/src/explore/components/DataTableControl/useTableColumns.test.ts
+++ b/superset-frontend/src/explore/components/DataTableControl/useTableColumns.test.ts
@@ -107,7 +107,7 @@ test('useTableColumns with no options', () => {
           name: 'DataTableTemporalHeaderCell',
         }),
         props: expect.objectContaining({
-          originalFormattedTimeColumnIndex: -1,
+          onTimeColumnChange: expect.any(Function),
         }),
       }),
       accessor: expect.any(Function),
@@ -135,7 +135,7 @@ test('useTableColumns with no options', () => {
 
 test('useTableColumns with options', () => {
   const hook = renderHook(() =>
-    useTableColumns(colnames, coltypes, data, undefined, [], {
+    useTableColumns(colnames, coltypes, data, undefined, true, {
       col01: { Header: 'Header' },
     }),
   );
@@ -171,7 +171,7 @@ test('useTableColumns with options', () => {
           name: 'DataTableTemporalHeaderCell',
         }),
         props: expect.objectContaining({
-          originalFormattedTimeColumnIndex: -1,
+          onTimeColumnChange: expect.any(Function),
         }),
       }),
       accessor: expect.any(Function),

--- a/superset-frontend/src/explore/components/DataTableControl/utils.ts
+++ b/superset-frontend/src/explore/components/DataTableControl/utils.ts
@@ -16,12 +16,34 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useSelector } from 'react-redux';
-import { ExplorePageState } from '../reducers/getInitialState';
+import { ensureIsArray } from '@superset-ui/core';
+import {
+  LocalStorageKeys,
+  setItem,
+  getItem,
+} from 'src/utils/localStorageHelpers';
 
-export const useOriginalFormattedTimeColumns = (datasourceId?: string) =>
-  useSelector<ExplorePageState, string[]>(state =>
-    datasourceId
-      ? state?.explore?.originalFormattedTimeColumns?.[datasourceId] ?? []
-      : [],
+export const getTimeColumns = (datasourceId?: string): string[] => {
+  const colsMap = getItem(
+    LocalStorageKeys.explore__data_table_original_formatted_time_columns,
+    {},
   );
+  if (datasourceId === undefined) {
+    return [];
+  }
+  return ensureIsArray(colsMap[datasourceId]);
+};
+
+export const setTimeColumns = (datasourceId: string, columns: string[]) => {
+  const colsMap = getItem(
+    LocalStorageKeys.explore__data_table_original_formatted_time_columns,
+    {},
+  );
+  setItem(
+    LocalStorageKeys.explore__data_table_original_formatted_time_columns,
+    {
+      ...colsMap,
+      [datasourceId]: columns,
+    },
+  );
+};

--- a/superset-frontend/src/explore/components/DataTablesPane/components/DataTableControls.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/DataTableControls.tsx
@@ -50,7 +50,7 @@ export const TableControls = ({
   isLoading,
 }: TableControlsProps) => {
   const originalTimeColumns = getTimeColumns(datasourceId);
-  const formttedTimeColumns = zip<string, GenericDataType>(
+  const formattedTimeColumns = zip<string, GenericDataType>(
     columnNames,
     columnTypes,
   )
@@ -62,8 +62,8 @@ export const TableControls = ({
     )
     .map(([colname]) => colname);
   const formattedData = useMemo(
-    () => applyFormattingToTabularData(data, formttedTimeColumns),
-    [data, formttedTimeColumns],
+    () => applyFormattingToTabularData(data, formattedTimeColumns),
+    [data, formattedTimeColumns],
   );
   return (
     <TableControlsWrapper>

--- a/superset-frontend/src/explore/components/DataTablesPane/components/DataTableControls.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/DataTableControls.tsx
@@ -17,14 +17,16 @@
  * under the License.
  */
 import React, { useMemo } from 'react';
-import { css, styled } from '@superset-ui/core';
+import { zip } from 'lodash';
+import { css, GenericDataType, styled } from '@superset-ui/core';
 import {
   CopyToClipboardButton,
   FilterInput,
   RowCount,
 } from 'src/explore/components/DataTableControl';
 import { applyFormattingToTabularData } from 'src/utils/common';
-import { useOriginalFormattedTimeColumns } from 'src/explore/components/useOriginalFormattedTimeColumns';
+import { getTimeColumns } from 'src/explore/components/DataTableControl/utils';
+import { TableControlsProps } from '../types';
 
 export const TableControlsWrapper = styled.div`
   ${({ theme }) => `
@@ -44,19 +46,24 @@ export const TableControls = ({
   datasourceId,
   onInputChange,
   columnNames,
+  columnTypes,
   isLoading,
-}: {
-  data: Record<string, any>[];
-  datasourceId?: string;
-  onInputChange: (input: string) => void;
-  columnNames: string[];
-  isLoading: boolean;
-}) => {
-  const originalFormattedTimeColumns =
-    useOriginalFormattedTimeColumns(datasourceId);
+}: TableControlsProps) => {
+  const originalTimeColumns = getTimeColumns(datasourceId);
+  const formttedTimeColumns = zip<string, GenericDataType>(
+    columnNames,
+    columnTypes,
+  )
+    .filter(
+      ([name, type]) =>
+        type === GenericDataType.TEMPORAL &&
+        name &&
+        !originalTimeColumns.includes(name),
+    )
+    .map(([colname]) => colname);
   const formattedData = useMemo(
-    () => applyFormattingToTabularData(data, originalFormattedTimeColumns),
-    [data, originalFormattedTimeColumns],
+    () => applyFormattingToTabularData(data, formttedTimeColumns),
+    [data, formttedTimeColumns],
   );
   return (
     <TableControlsWrapper>

--- a/superset-frontend/src/explore/components/DataTablesPane/components/ResultsPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/ResultsPane.tsx
@@ -25,7 +25,6 @@ import {
   useFilteredTableData,
   useTableColumns,
 } from 'src/explore/components/DataTableControl';
-import { useOriginalFormattedTimeColumns } from 'src/explore/components/useOriginalFormattedTimeColumns';
 import { getChartDataRequest } from 'src/components/Chart/chartAction';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 import { TableControls } from './DataTableControls';
@@ -111,9 +110,6 @@ export const ResultsPane = ({
     }
   }, [errorMessage]);
 
-  const originalFormattedTimeColumns = useOriginalFormattedTimeColumns(
-    queryFormData.datasource,
-  );
   // this is to preserve the order of the columns, even if there are integer values,
   // while also only grabbing the first column's keys
   const columns = useTableColumns(
@@ -121,7 +117,7 @@ export const ResultsPane = ({
     coltypes,
     data,
     queryFormData.datasource,
-    originalFormattedTimeColumns,
+    isRequest,
   );
   const filteredData = useFilteredTableData(filterText, data);
 
@@ -140,6 +136,7 @@ export const ResultsPane = ({
         <TableControls
           data={filteredData}
           columnNames={colnames}
+          columnTypes={coltypes}
           datasourceId={queryFormData?.datasource}
           onInputChange={input => setFilterText(input)}
           isLoading={isLoading}
@@ -159,6 +156,7 @@ export const ResultsPane = ({
       <TableControls
         data={filteredData}
         columnNames={colnames}
+        columnTypes={coltypes}
         datasourceId={queryFormData?.datasource}
         onInputChange={input => setFilterText(input)}
         isLoading={isLoading}

--- a/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
@@ -25,7 +25,6 @@ import {
   useFilteredTableData,
   useTableColumns,
 } from 'src/explore/components/DataTableControl';
-import { useOriginalFormattedTimeColumns } from 'src/explore/components/useOriginalFormattedTimeColumns';
 import { getDatasetSamples } from 'src/components/Chart/chartAction';
 import { TableControls } from './DataTableControls';
 import { SamplesPaneProps } from '../types';
@@ -84,8 +83,6 @@ export const SamplesPane = ({
     }
   }, [datasource, isRequest, queryForce]);
 
-  const originalFormattedTimeColumns =
-    useOriginalFormattedTimeColumns(datasourceId);
   // this is to preserve the order of the columns, even if there are integer values,
   // while also only grabbing the first column's keys
   const columns = useTableColumns(
@@ -93,7 +90,7 @@ export const SamplesPane = ({
     coltypes,
     data,
     datasourceId,
-    originalFormattedTimeColumns,
+    isRequest,
   );
   const filteredData = useFilteredTableData(filterText, data);
 
@@ -107,6 +104,7 @@ export const SamplesPane = ({
         <TableControls
           data={filteredData}
           columnNames={colnames}
+          columnTypes={coltypes}
           datasourceId={datasourceId}
           onInputChange={input => setFilterText(input)}
           isLoading={isLoading}
@@ -126,6 +124,7 @@ export const SamplesPane = ({
       <TableControls
         data={filteredData}
         columnNames={colnames}
+        columnTypes={coltypes}
         datasourceId={datasourceId}
         onInputChange={input => setFilterText(input)}
         isLoading={isLoading}

--- a/superset-frontend/src/explore/components/DataTablesPane/types.ts
+++ b/superset-frontend/src/explore/components/DataTablesPane/types.ts
@@ -16,7 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Datasource, JsonObject, QueryFormData } from '@superset-ui/core';
+import {
+  Datasource,
+  GenericDataType,
+  JsonObject,
+  QueryFormData,
+} from '@superset-ui/core';
 import { ExploreActions } from 'src/explore/actions/exploreActions';
 import { ChartStatus } from 'src/explore/types';
 
@@ -47,4 +52,14 @@ export interface SamplesPaneProps {
   queryForce: boolean;
   actions?: ExploreActions;
   dataSize?: number;
+}
+
+export interface TableControlsProps {
+  data: Record<string, any>[];
+  // {datasource.id}__{datasource.type}, eg: 1__table
+  datasourceId: string;
+  onInputChange: (input: string) => void;
+  columnNames: string[];
+  columnTypes: GenericDataType[];
+  isLoading: boolean;
 }

--- a/superset-frontend/src/explore/reducers/exploreReducer.js
+++ b/superset-frontend/src/explore/reducers/exploreReducer.js
@@ -28,7 +28,6 @@ import {
   getControlValuesCompatibleWithDatasource,
 } from 'src/explore/controlUtils';
 import * as actions from 'src/explore/actions/exploreActions';
-import { LocalStorageKeys, setItem } from 'src/utils/localStorageHelpers';
 
 export default function exploreReducer(state = {}, action) {
   const actionHandlers = {
@@ -263,52 +262,6 @@ export default function exploreReducer(state = {}, action) {
           owners: action.slice.owners ?? null,
         },
         sliceName: action.slice.slice_name ?? state.sliceName,
-      };
-    },
-    [actions.SET_ORIGINAL_FORMATTED_TIME_COLUMN]() {
-      const { datasourceId, columnName } = action;
-      const newOriginalFormattedColumns = {
-        ...state.originalFormattedTimeColumns,
-      };
-      const newOriginalFormattedColumnsForDatasource = ensureIsArray(
-        newOriginalFormattedColumns[datasourceId],
-      ).slice();
-
-      newOriginalFormattedColumnsForDatasource.push(columnName);
-      newOriginalFormattedColumns[datasourceId] =
-        newOriginalFormattedColumnsForDatasource;
-      setItem(
-        LocalStorageKeys.explore__data_table_original_formatted_time_columns,
-        newOriginalFormattedColumns,
-      );
-      return {
-        ...state,
-        originalFormattedTimeColumns: newOriginalFormattedColumns,
-      };
-    },
-    [actions.UNSET_ORIGINAL_FORMATTED_TIME_COLUMN]() {
-      const { datasourceId, columnIndex } = action;
-      const newOriginalFormattedColumns = {
-        ...state.originalFormattedTimeColumns,
-      };
-      const newOriginalFormattedColumnsForDatasource = ensureIsArray(
-        newOriginalFormattedColumns[datasourceId],
-      ).slice();
-
-      newOriginalFormattedColumnsForDatasource.splice(columnIndex, 1);
-      newOriginalFormattedColumns[datasourceId] =
-        newOriginalFormattedColumnsForDatasource;
-
-      if (newOriginalFormattedColumnsForDatasource.length === 0) {
-        delete newOriginalFormattedColumns[datasourceId];
-      }
-      setItem(
-        LocalStorageKeys.explore__data_table_original_formatted_time_columns,
-        newOriginalFormattedColumns,
-      );
-      return {
-        ...state,
-        originalFormattedTimeColumns: newOriginalFormattedColumns,
       };
     },
     [actions.SET_FORCE_QUERY]() {

--- a/superset-frontend/src/explore/reducers/getInitialState.ts
+++ b/superset-frontend/src/explore/reducers/getInitialState.ts
@@ -35,7 +35,6 @@ import {
   getFormDataFromControls,
   applyMapStateToPropsToControl,
 } from 'src/explore/controlUtils';
-import { getItem, LocalStorageKeys } from 'src/utils/localStorageHelpers';
 
 export interface ExplorePageBootstrapData extends JsonObject {
   can_add: boolean;
@@ -78,10 +77,6 @@ export default function getInitialState(
       initialFormData,
     ) as ControlStateMapping,
     controlsTransferred: [],
-    originalFormattedTimeColumns: getItem(
-      LocalStorageKeys.explore__data_table_original_formatted_time_columns,
-      {},
-    ),
   };
 
   // apply initial mapStateToProps for all controls, must execute AFTER


### PR DESCRIPTION
### SUMMARY
The DataTableControl is a component in DataTablePane, it has an important function is to switch the format of the time columns. Currently, this toggle was implemented by Redux, and saved state in the *Explore's* store.

![image](https://user-images.githubusercontent.com/2016594/171134762-a5d13751-7bb1-4699-be3b-6db08fc42f7d.png)

We intend to move DataPane into Dashboard([PR](https://github.com/apache/superset/pull/20144)), the Dashboard store and the Explore store are separated store, so I have to remove the *time column state* from the explore state. 


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### After


https://user-images.githubusercontent.com/2016594/171137553-f53af14a-fe8f-472f-84dc-1e880dc3e29c.mov


#### copy to clipboard


https://user-images.githubusercontent.com/2016594/171140350-6bd498ea-1723-49bc-a40f-67ab54b12b9c.mov




### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. The DataTablePane work as before.
2. Copy to clipboard work as expected.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
