### PR TITLE
fix: failed samples should throw exception

### DIFF
--- a/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useState, useEffect, useMemo } from 'react';
-import { GenericDataType, styled, t } from '@superset-ui/core';
+import { ensureIsArray, GenericDataType, styled, t } from '@superset-ui/core';
 import Loading from 'src/components/Loading';
 import { EmptyStateMedium } from 'src/components/EmptyState';
 import TableView, { EmptyWrapperType } from 'src/components/TableView';
@@ -63,9 +63,9 @@ export const SamplesPane = ({
       setIsLoading(true);
       getDatasetSamples(datasource.id, queryForce)
         .then(response => {
-          setData(response.data);
-          setColnames(response.colnames);
-          setColtypes(response.coltypes);
+          setData(ensureIsArray(response.data));
+          setColnames(ensureIsArray(response.colnames));
+          setColtypes(ensureIsArray(response.coltypes));
           setResponseError('');
           cache.add(datasource);
           if (queryForce && actions) {

--- a/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
@@ -73,6 +73,9 @@ export const SamplesPane = ({
           }
         })
         .catch(error => {
+          setData([]);
+          setColnames([]);
+          setColtypes([]);
           setResponseError(`${error.name}: ${error.message}`);
         })
         .finally(() => {

--- a/superset/common/utils/query_cache_manager.py
+++ b/superset/common/utils/query_cache_manager.py
@@ -187,3 +187,18 @@ class QueryCacheManager:
         """
         if key:
             set_and_log_cache(_cache[region], key, value, timeout, datasource_uid)
+
+    @staticmethod
+    def delete(
+        key: Optional[str],
+        region: CacheRegion = CacheRegion.DEFAULT,
+    ) -> None:
+        if key:
+            _cache[region].delete(key)
+
+    @staticmethod
+    def has(
+        key: Optional[str],
+        region: CacheRegion = CacheRegion.DEFAULT,
+    ) -> bool:
+        return bool(_cache[region].get(key)) if key else False

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -825,10 +825,4 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         except DatasetForbiddenError:
             return self.response_403()
         except DatasetSamplesFailedError as ex:
-            logger.error(
-                "Error get dataset samples %s: %s",
-                self.__class__.__name__,
-                str(ex),
-                exc_info=True,
-            )
-            return self.response_422(message=str(ex))
+            return self.response_400(message=str(ex))

--- a/superset/datasets/commands/samples.py
+++ b/superset/datasets/commands/samples.py
@@ -30,6 +30,7 @@ from superset.datasets.commands.exceptions import (
 )
 from superset.datasets.dao import DatasetDAO
 from superset.exceptions import SupersetSecurityException
+from superset.utils.core import QueryStatus
 from superset.views.base import check_ownership
 
 logger = logging.getLogger(__name__)
@@ -58,7 +59,11 @@ class SamplesDatasetCommand(BaseCommand):
         )
         results = qc_instance.get_payload()
         try:
-            return results["queries"][0]
+            sample_data = results["queries"][0]
+            error_msg = sample_data.get("error")
+            if sample_data.get("status") == QueryStatus.FAILED and error_msg:
+                raise DatasetSamplesFailedError(error_msg)
+            return sample_data
         except (IndexError, KeyError) as exc:
             raise DatasetSamplesFailedError from exc
 

--- a/superset/datasets/commands/samples.py
+++ b/superset/datasets/commands/samples.py
@@ -22,7 +22,9 @@ from flask_appbuilder.security.sqla.models import User
 from superset.commands.base import BaseCommand
 from superset.common.chart_data import ChartDataResultType
 from superset.common.query_context_factory import QueryContextFactory
+from superset.common.utils.query_cache_manager import QueryCacheManager
 from superset.connectors.sqla.models import SqlaTable
+from superset.constants import CacheRegion
 from superset.datasets.commands.exceptions import (
     DatasetForbiddenError,
     DatasetNotFoundError,
@@ -62,6 +64,8 @@ class SamplesDatasetCommand(BaseCommand):
             sample_data = results["queries"][0]
             error_msg = sample_data.get("error")
             if sample_data.get("status") == QueryStatus.FAILED and error_msg:
+                cache_key = sample_data.get("cache_key")
+                QueryCacheManager.delete(cache_key, region=CacheRegion.DATA)
                 raise DatasetSamplesFailedError(error_msg)
             return sample_data
         except (IndexError, KeyError) as exc:

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -27,7 +27,9 @@ import pytest
 import yaml
 from sqlalchemy.sql import func
 
+from superset.common.utils.query_cache_manager import QueryCacheManager
 from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
+from superset.constants import CacheRegion
 from superset.dao.exceptions import (
     DAOCreateFailedError,
     DAODeleteFailedError,
@@ -1883,6 +1885,8 @@ class TestDatasetApi(SupersetTestCase):
         assert rv.status_code == 200
         assert "result" in rv_data
         assert rv_data["result"]["cached_dttm"] is not None
+        cache_key1 = rv_data["result"]["cache_key"]
+        assert QueryCacheManager.has(cache_key1, region=CacheRegion.DATA)
 
         # 2. should through cache
         uri2 = f"api/v1/dataset/{dataset.id}/samples?force=true"
@@ -1892,6 +1896,8 @@ class TestDatasetApi(SupersetTestCase):
         rv2 = self.client.get(uri2)
         rv_data2 = json.loads(rv2.data)
         assert rv_data2["result"]["cached_dttm"] is None
+        cache_key2 = rv_data2["result"]["cache_key"]
+        assert QueryCacheManager.has(cache_key2, region=CacheRegion.DATA)
 
         # 3. data precision
         assert "colnames" in rv_data2["result"]
@@ -1909,13 +1915,13 @@ class TestDatasetApi(SupersetTestCase):
         dataset = self.get_fixture_datasets()[0]
 
         self.login(username="admin")
-        uri = f"api/v1/dataset/{dataset.id}/samples"
         failed_column = TableColumn(
             column_name="DUMMY CC",
             type="VARCHAR(255)",
             table=dataset,
             expression="INCORRECT SQL",
         )
+        uri = f"api/v1/dataset/{dataset.id}/samples"
         dataset.columns.append(failed_column)
         rv = self.client.get(uri)
         assert rv.status_code == 400
@@ -1923,3 +1929,29 @@ class TestDatasetApi(SupersetTestCase):
         assert "message" in rv_data
         if dataset.database.db_engine_spec.engine_name == "PostgreSQL":
             assert "INCORRECT SQL" in rv_data.get("message")
+
+    def test_get_dataset_samples_on_virtual_dataset(self):
+        virtual_dataset = SqlaTable(
+            table_name="virtual_dataset",
+            sql=("SELECT 'foo' as foo, 'bar' as bar"),
+            database=get_example_database(),
+        )
+        TableColumn(column_name="foo", type="VARCHAR(255)", table=virtual_dataset)
+        TableColumn(column_name="bar", type="VARCHAR(255)", table=virtual_dataset)
+        SqlMetric(metric_name="count", expression="count(*)", table=virtual_dataset)
+
+        self.login(username="admin")
+        uri = f"api/v1/dataset/{virtual_dataset.id}/samples"
+        rv = self.client.get(uri)
+        assert rv.status_code == 200
+        rv_data = json.loads(rv.data)
+        cache_key = rv_data["result"]["cache_key"]
+        assert QueryCacheManager.has(cache_key, region=CacheRegion.DATA)
+
+        # remove original column in dataset
+        virtual_dataset.sql = "SELECT 'foo' as foo"
+        rv = self.client.get(uri)
+        assert rv.status_code == 400
+
+        db.session.delete(virtual_dataset)
+        db.session.commit()


### PR DESCRIPTION
### SUMMARY
Recently, added a [new endpoint](https://github.com/apache/superset/pull/20170) for getting samples of data. The original PR didn't throw correct HTTP status codes when a dataset contains an incorrect `column` or `calculated column`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### After


https://user-images.githubusercontent.com/2016594/171314792-798eee1d-0bb7-4bdb-abaa-59613868a0e5.mov

#### Before


https://user-images.githubusercontent.com/2016594/171314981-68ca93dd-0390-4723-857f-f1ad04302c74.mov



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Make a chart
2. Add a incorrect calculated column in current dataset
3. Click `Samples Pane` in explore page

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
