### PR TITLE
fix(TextControl/TextAreaControl): Make TextControl/TextAreaControl sync state.value from props.value

### DIFF
--- a/superset-frontend/src/explore/components/controls/TextAreaControl.jsx
+++ b/superset-frontend/src/explore/components/controls/TextAreaControl.jsx
@@ -18,6 +18,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { omit } from 'lodash';
 import { TextArea } from 'src/components/Input';
 import { t, withTheme } from '@superset-ui/core';
 
@@ -58,16 +59,34 @@ const defaultProps = {
 };
 
 class TextAreaControl extends React.Component {
+  constructor(props) {
+    super(props);
+    this.initialValue = props.initialValue;
+
+    this.state = {
+      value: this.initialValue,
+    };
+  }
+
   onControlChange(event) {
     const { value } = event.target;
+    this.setState({ value });
     this.props.onChange(value);
   }
 
   onAreaEditorChange(value) {
+    this.setState({ value });
     this.props.onChange(value);
   }
 
   renderEditor(inModal = false) {
+    let { value } = this.state;
+    if (this.initialValue !== this.props.value) {
+      this.initialValue = this.props.value;
+      // eslint-disable-next-line prefer-destructuring
+      value = this.props.value;
+    }
+
     const minLines = inModal ? 40 : this.props.minLines || 12;
     if (this.props.language) {
       const style = {
@@ -86,6 +105,7 @@ class TextAreaControl extends React.Component {
           height={`${minLines}em`}
           editorProps={{ $blockScrolling: true }}
           defaultValue={this.props.initialValue}
+          value={value}
           readOnly={this.props.readOnly}
           key={this.props.name}
           {...this.props}
@@ -93,13 +113,28 @@ class TextAreaControl extends React.Component {
         />
       );
     }
+
+    const textAreaProps = omit(this.props, [
+      'name',
+      'initialValue',
+      'height',
+      'minLines',
+      'maxLines',
+      'offerEditInModal',
+      'language',
+      'aboveEditorSection',
+      'readOnly',
+    ]);
+
     return (
       <TextArea
         placeholder={t('textarea')}
-        onChange={this.onControlChange.bind(this)}
         defaultValue={this.props.initialValue}
+        value={value}
         disabled={this.props.readOnly}
         style={{ height: this.props.height }}
+        {...textAreaProps}
+        onChange={this.onControlChange.bind(this)}
       />
     );
   }

--- a/superset-frontend/src/explore/components/controls/TextAreaControl.jsx
+++ b/superset-frontend/src/explore/components/controls/TextAreaControl.jsx
@@ -79,13 +79,17 @@ class TextAreaControl extends React.Component {
     this.props.onChange(value);
   }
 
-  renderEditor(inModal = false) {
-    let { value } = this.state;
-    if (this.initialValue !== this.props.value) {
-      this.initialValue = this.props.value;
-      // eslint-disable-next-line prefer-destructuring
-      value = this.props.value;
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    if (this.initialValue !== nextProps.value) {
+      this.initialValue = nextProps.value;
+      this.setState({
+        value: nextProps.value,
+      });
     }
+  }
+
+  renderEditor(inModal = false) {
+    const { value } = this.state;
 
     const minLines = inModal ? 40 : this.props.minLines || 12;
     if (this.props.language) {

--- a/superset-frontend/src/explore/components/controls/TextAreaControl.test.jsx
+++ b/superset-frontend/src/explore/components/controls/TextAreaControl.test.jsx
@@ -19,6 +19,7 @@
 /* eslint-disable no-unused-expressions */
 import React from 'react';
 import sinon from 'sinon';
+import { render, screen } from 'spec/helpers/testing-library';
 import { styledMount as mount } from 'spec/helpers/theming';
 import { TextAreaEditor } from 'src/components/AsyncAceEditor';
 import { TextArea } from 'src/components/Input';
@@ -61,5 +62,12 @@ describe('TextArea', () => {
     wrapper = mount(<TextAreaControl {...props} />);
     wrapper.simulate('change', { target: { value: 'x' } });
     expect(defaultProps.onChange.calledWith('x')).toBe(true);
+  });
+
+  it('TextArea renders props.value', async () => {
+    const props = { ...defaultProps };
+    props.value = 'Sample value';
+    render(<TextAreaControl {...props} />);
+    expect(screen.getByDisplayValue('Sample value')).toBeInTheDocument();
   });
 });

--- a/superset-frontend/src/explore/components/controls/TextControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/TextControl/index.tsx
@@ -94,12 +94,21 @@ export default class TextControl<
     });
   };
 
-  render() {
-    let { value } = this.state;
-    if (this.initialValue !== this.props.value) {
-      this.initialValue = this.props.value;
-      value = safeStringify(this.props.value);
+  UNSAFE_componentWillReceiveProps(nextProps: TextControlProps<T>) {
+    if (this.initialValue !== nextProps.value) {
+      this.initialValue = nextProps.value;
+      this.setState({
+        value: safeStringify(nextProps.value),
+      });
     }
+  }
+
+  render() {
+    const { value } = this.state;
+    // if (this.initialValue !== this.props.value) {
+    //   this.initialValue = this.props.value;
+    //   value = safeStringify(this.props.value);
+    // }
     return (
       <div>
         <ControlHeader {...this.props} />


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Make TextAreaControl component to be controlled, the props.value could be injected and be rendered correctly.

TextAreaControl should function the same way as TextControl. 

I tested the cases mentioned [here](https://github.com/apache/superset/pull/17176), and no interrupted.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:

https://user-images.githubusercontent.com/17194685/171592889-a0c5e70f-f954-4293-8a1a-6dd8d098c3f4.mov

After:

https://user-images.githubusercontent.com/17194685/171592939-10fae8ae-4568-4c5d-b10a-38b1e500d756.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Create a instance of TextAreaControl of which value is controlled, then trigger state changing.

TextAreaControl should render the changed value.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
