### PR TITLE
chore: use exc_info to pass errors to log warnings

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -576,8 +576,8 @@ class Database(
                 database=self, inspector=self.inspector, schema=schema
             )
             return [(table, schema) for table in tables]
-        except Exception as ex:  # pylint: disable=broad-except
-            logger.warning(ex)
+        except Exception:  # pylint: disable=broad-except
+            logger.warning("Get all table names in schema failed", exc_info=True)
             return []
 
     @cache_util.memoized_func(
@@ -607,8 +607,8 @@ class Database(
                 database=self, inspector=self.inspector, schema=schema
             )
             return [(view, schema) for view in views]
-        except Exception as ex:  # pylint: disable=broad-except
-            logger.warning(ex)
+        except Exception:  # pylint: disable=broad-except
+            logger.warning("Get all view names failed", exc_info=True)
             return []
 
     @cache_util.memoized_func(
@@ -777,8 +777,8 @@ class Database(
         view_names: List[str] = []
         try:
             view_names = dialect.get_view_names(connection=conn, schema=schema)
-        except Exception as ex:  # pylint: disable=broad-except
-            logger.warning(ex)
+        except Exception:  # pylint: disable=broad-except
+            logger.warning("Has view failed", exc_info=True)
         return view_name in view_names
 
     def has_view(self, view_name: str, schema: Optional[str] = None) -> bool:

--- a/superset/utils/async_query_manager.py
+++ b/superset/utils/async_query_manager.py
@@ -158,7 +158,7 @@ class AsyncQueryManager:
         try:
             return jwt.decode(token, self._jwt_secret, algorithms=["HS256"])
         except Exception as ex:
-            logger.warning(ex)
+            logger.warning("Parse jwt failed", exc_info=True)
             raise AsyncQueryTokenException("Failed to parse token") from ex
 
     def init_job(self, channel_id: str, user_id: Optional[str]) -> Dict[str, Any]:

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -446,7 +446,7 @@ def show_http_exception(ex: HTTPException) -> FlaskResponse:
 # or SupersetErrorsException, with a specific status code and error type
 @superset_app.errorhandler(CommandException)
 def show_command_errors(ex: CommandException) -> FlaskResponse:
-    logger.warning("Command Exception", exc_info=True)
+    logger.warning("CommandException", exc_info=True)
     if "text/html" in request.accept_mimetypes and not config["DEBUG"]:
         path = resource_filename("superset", "static/assets/500.html")
         return send_file(path, cache_timeout=0), 500

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -420,7 +420,7 @@ def refresh_csrf_token(ex: CSRFError) -> FlaskResponse:
 
 @superset_app.errorhandler(HTTPException)
 def show_http_exception(ex: HTTPException) -> FlaskResponse:
-    logger.warning("HTTP Exception", exc_info=True)
+    logger.warning("HTTPException", exc_info=True)
     if (
         "text/html" in request.accept_mimetypes
         and not config["DEBUG"]

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -183,8 +183,8 @@ def api(f: Callable[..., FlaskResponse]) -> Callable[..., FlaskResponse]:
     def wraps(self: "BaseSupersetView", *args: Any, **kwargs: Any) -> FlaskResponse:
         try:
             return f(self, *args, **kwargs)
-        except NoAuthorizationError as ex:
-            logger.warning(ex)
+        except NoAuthorizationError:
+            logger.warning("Api failed- no authorization", exc_info=True)
             return json_error_response(get_error_msg(), status=401)
         except Exception as ex:  # pylint: disable=broad-except
             logger.exception(ex)
@@ -206,7 +206,7 @@ def handle_api_exception(
         try:
             return f(self, *args, **kwargs)
         except SupersetSecurityException as ex:
-            logger.warning(ex)
+            logger.warning("SupersetSecurityException", exc_info=True)
             return json_errors_response(
                 errors=[ex.error], status=ex.status, payload=ex.payload
             )
@@ -214,7 +214,7 @@ def handle_api_exception(
             logger.warning(ex, exc_info=True)
             return json_errors_response(errors=ex.errors, status=ex.status)
         except SupersetErrorException as ex:
-            logger.warning(ex)
+            logger.warning("SupersetErrorException", exc_info=True)
             return json_errors_response(errors=[ex.error], status=ex.status)
         except SupersetException as ex:
             if ex.status >= 500:
@@ -397,20 +397,20 @@ def get_error_level_from_status_code(  # pylint: disable=invalid-name
 # SupersetErrorException or SupersetErrorsException
 @superset_app.errorhandler(SupersetErrorException)
 def show_superset_error(ex: SupersetErrorException) -> FlaskResponse:
-    logger.warning(ex)
+    logger.warning("SupersetErrorException", exc_info=True)
     return json_errors_response(errors=[ex.error], status=ex.status)
 
 
 @superset_app.errorhandler(SupersetErrorsException)
 def show_superset_errors(ex: SupersetErrorsException) -> FlaskResponse:
-    logger.warning(ex)
+    logger.warning("SupersetErrorsException", exc_info=True)
     return json_errors_response(errors=ex.errors, status=ex.status)
 
 
 # Redirect to login if the CSRF token is expired
 @superset_app.errorhandler(CSRFError)
 def refresh_csrf_token(ex: CSRFError) -> FlaskResponse:
-    logger.warning(ex)
+    logger.warning("Refresh CSRF token error", exc_info=True)
 
     if request.is_json:
         return show_http_exception(ex)
@@ -420,7 +420,7 @@ def refresh_csrf_token(ex: CSRFError) -> FlaskResponse:
 
 @superset_app.errorhandler(HTTPException)
 def show_http_exception(ex: HTTPException) -> FlaskResponse:
-    logger.warning(ex)
+    logger.warning("HTTP Exception", exc_info=True)
     if (
         "text/html" in request.accept_mimetypes
         and not config["DEBUG"]
@@ -446,7 +446,7 @@ def show_http_exception(ex: HTTPException) -> FlaskResponse:
 # or SupersetErrorsException, with a specific status code and error type
 @superset_app.errorhandler(CommandException)
 def show_command_errors(ex: CommandException) -> FlaskResponse:
-    logger.warning(ex)
+    logger.warning("Command Exception", exc_info=True)
     if "text/html" in request.accept_mimetypes and not config["DEBUG"]:
         path = resource_filename("superset", "static/assets/500.html")
         return send_file(path, cache_timeout=0), 500


### PR DESCRIPTION
### SUMMARY
After looking at our logs, I'm not seeing any exception information being passed through when written `logger.warning(ex)` so I'm updating all of these loggers to use `exc_info=True` instead. 

https://docs.python.org/3/library/logging.html#logging.Logger.debug
By passing `True` we get the results of sys.exc_info https://docs.python.org/3/library/sys.html#sys.exc_info
We could alternatively pass the exception explicitly. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
