### PR TITLE
feat(api): specify query parameters for the embedded chart or dashboard

### DIFF
--- a/superset-embedded-sdk/src/index.ts
+++ b/superset-embedded-sdk/src/index.ts
@@ -49,6 +49,8 @@ export type EmbedDashboardParams = {
   dashboardUiConfig?: UiConfigType
   /** Are we in debug mode? */
   debug?: boolean
+  /** The parameters to provide to the dashboard or chart query string */
+  queryParameters?: {[key: string]: string}
 }
 
 export type Size = {
@@ -69,7 +71,8 @@ export async function embedDashboard({
   mountPoint,
   fetchGuestToken,
   dashboardUiConfig,
-  debug = false
+  debug = false,
+  queryParameters = {}
 }: EmbedDashboardParams): Promise<EmbeddedDashboard> {
   function log(...info: unknown[]) {
     if (debug) {
@@ -99,6 +102,9 @@ export async function embedDashboard({
     return new Promise(resolve => {
       const iframe = document.createElement('iframe');
       const dashboardConfig = dashboardUiConfig ? `?uiConfig=${calculateConfig()}` : ""
+      const queryParams = queryParameters ?
+        (dashboardConfig === "" ? "?" : "&") + new URLSearchParams(queryParameters).toString() :
+        ""
 
       // setup the iframe's sandbox configuration
       iframe.sandbox.add("allow-same-origin"); // needed for postMessage to work
@@ -131,7 +137,7 @@ export async function embedDashboard({
         resolve(new Switchboard({ port: ourPort, name: 'superset-embedded-sdk', debug }));
       });
 
-      iframe.src = `${supersetDomain}/embedded/${id}${dashboardConfig}`;
+      iframe.src = `${supersetDomain}/embedded/${id}${dashboardConfig}${queryParams}`;
       mountPoint.replaceChildren(iframe);
       log('placed the iframe')
     });


### PR DESCRIPTION
### SUMMARY
Add support for specifying query parameters to append to embedded charts or dashboards.

Motivation: we are trying to embed parameterized dashboards and would like to specify the parameters in the `embedDashboard` object.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
I couldn't find existing tests. We've tested the general approach by adding the parameters to the end of the `iframe.src`, and it seems to work. I'd be happy to add tests if I can find out where to add them.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
