### PR TITLE
docs(contribute): update compatible Python versions in local environment setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -413,7 +413,7 @@ For example, the image referenced above actually lives in `superset-frontend/src
 Make sure your machine meets the [OS dependencies](https://superset.apache.org/docs/installation/installing-superset-from-scratch#os-dependencies) before following these steps.
 You also need to install MySQL or [MariaDB](https://mariadb.com/downloads).
 
-Ensure that you are using Python version 3.7 or 3.8, then proceed with:
+Ensure that you are using Python version 3.8 or higher, then proceed with:
 
 ```bash
 # Create a virtual environment and activate it (recommended)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -413,7 +413,7 @@ For example, the image referenced above actually lives in `superset-frontend/src
 Make sure your machine meets the [OS dependencies](https://superset.apache.org/docs/installation/installing-superset-from-scratch#os-dependencies) before following these steps.
 You also need to install MySQL or [MariaDB](https://mariadb.com/downloads).
 
-Ensure that you are using Python version 3.8 or higher, then proceed with:
+Ensure that you are using Python version 3.8 or 3.9, then proceed with:
 
 ```bash
 # Create a virtual environment and activate it (recommended)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
At the moment, contributors are instructed to use to ensure they're using Python 3.7 or 3.8 when setting up the local development environment. However, Python 3.7 is no longer compatible with apache-superset, and the pip install fails when using this version of Python.

A quick check on `setup.py` confirms 3.7 is incompatible:
```python
python_requires="~=3.8",
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Successfully installing with 3.9
![3.9](https://i.imgur.com/RRjVNSU.png)
Succesfsfully installing with 3.8
![3.8](https://i.imgur.com/utTNcGA.png)
Unsuccessfully installing with 3.7
![3.7](https://i.imgur.com/rk7FoS8.png)

### TESTING INSTRUCTIONS
n/a

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
