### PR TITLE
fix(embedded): accessing variable response before initialization

### DIFF
--- a/superset/utils/csv.py
+++ b/superset/utils/csv.py
@@ -85,8 +85,8 @@ def get_chart_csv_data(
         opener.addheaders.append(("Cookie", cookie_str))
         response = opener.open(chart_url)
         content = response.read()
-    if response.getcode() != 200:
-        raise URLError(response.getcode())
+        if response.getcode() != 200:
+            raise URLError(response.getcode())
     if content:
         return content
     return None


### PR DESCRIPTION
### SUMMARY
https://github.com/apache/superset/blob/4f77824e550bc70d2f6365221b9078004d49b78c/superset/utils/csv.py#L83 At line 83, if auth_cookies is false, before returning an URLError, line 83 will fail with error message saying `Failed generating csv local variable 'response' referenced before assignment`. More details reported at https://github.com/apache/superset/issues/20262

### ADDITIONAL INFORMATION
- [x] Has associated issue: #20262 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
