### PR TITLE
docs: Added details to Druid connection string

### DIFF
--- a/docs/docs/databases/druid.mdx
+++ b/docs/docs/databases/druid.mdx
@@ -18,7 +18,12 @@ The connection string looks like:
 ```
 druid://<User>:<password>@<Host>:<Port-default-9088>/druid/v2/sql
 ```
-Where User and password are the credentials of your **Druid Database** , Host is your machine's IP address and Port is the port at which **Druid Database** is running.
+Here's a breakdown of the key components of this connection string:
+
+User: username portion of the credentials needed to connect to your database
+Password: password portion of the credentials needed to connect to your database
+Host: IP address (or URL) of the host machine that's running your database
+Port: specific port that's exposed on your host machine where your database is running
 
 ### Customizing Druid Connection
 

--- a/docs/docs/databases/druid.mdx
+++ b/docs/docs/databases/druid.mdx
@@ -18,6 +18,7 @@ The connection string looks like:
 ```
 druid://<User>:<password>@<Host>:<Port-default-9088>/druid/v2/sql
 ```
+Where User and password are the credentials of your **Druid Database** , Host is your machine's IP address and Port is the port at which **Druid Database** is running.
 
 ### Customizing Druid Connection
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
While linking Superset to Druid the correct connection string is very important however in the docs it is not well explained , so I added a little description to it.
