### PR TITLE
chore(docs): Remove cache warming documentation

### DIFF
--- a/docs/docs/installation/cache.mdx
+++ b/docs/docs/installation/cache.mdx
@@ -42,26 +42,6 @@ defined in `DATA_CACHE_CONFIG`.
 
 ## Celery beat
 
-Superset has a Celery task that will periodically warm up the cache based on different strategies.
-To use it, add the following to the `CELERYBEAT_SCHEDULE` section in `config.py`:
-
-```python
-CELERYBEAT_SCHEDULE = {
-    'cache-warmup-hourly': {
-        'task': 'cache-warmup',
-        'schedule': crontab(minute=0, hour='*'),  # hourly
-        'kwargs': {
-            'strategy_name': 'top_n_dashboards',
-            'top_n': 5,
-            'since': '7 days ago',
-        },
-    },
-}
-```
-
-This will cache all the charts in the top 5 most popular dashboards every hour. For other
-strategies, check the `superset/tasks/cache.py` file.
-
 ### Caching Thumbnails
 
 This is an optional feature that can be turned on by activating it’s feature flag on config:


### PR DESCRIPTION
### SUMMARY

The cache warming strategies perform unauthorized `GET` requests that are redirected to the login page.

As a result, they do not work as documented. This removes documentation references until these are ready for production use.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #9597, #18933
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
