### PR TITLE
fix(explore): Make that see more/see less works correctly with scrolling when error msg is long text.

### DIFF
--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -220,6 +220,7 @@ const ExploreChartPanel = ({
         css={css`
           min-height: 0;
           flex: 1;
+          overflow: auto;
         `}
         ref={chartPanelRef}
       >


### PR DESCRIPTION
### SUMMARY
[explore] layout - long error messages render funky and don't scroll properly under the data pane

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
![image](https://user-images.githubusercontent.com/47900232/172211598-6ece9896-7653-4595-be60-e10daff5f655.png)

AFTER:
![image](https://user-images.githubusercontent.com/47900232/172211265-8194154e-68b1-4066-85af-a98b644dadfa.png)

### TESTING INSTRUCTIONS
1. Go to the explore
2. Display the long error message in North panel body
3. The long error message is broken.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
