### PR TITLE
fix: add sql limit to async queries

### DIFF
--- a/tests/integration_tests/celery_tests.py
+++ b/tests/integration_tests/celery_tests.py
@@ -330,7 +330,7 @@ def test_run_async_cta_query_with_lower_limit(setup_sqllab, ctas_method):
     assert QUERY == query.sql
 
     assert query.rows == (1 if backend() == "presto" else 0)
-    assert query.limit == 10000
+    assert query.limit == 1
     assert query.select_as_cta
     assert query.select_as_cta_used
 

--- a/tests/integration_tests/sqllab_tests.py
+++ b/tests/integration_tests/sqllab_tests.py
@@ -568,7 +568,9 @@ class TestSqlLab(SupersetTestCase):
             query_limit=test_limit + 1,
         )
         self.assertEqual(len(data["data"]), test_limit)
-        self.assertEqual(data["query"]["limitingFactor"], LimitingFactor.QUERY)
+        self.assertEqual(
+            data["query"]["limitingFactor"], LimitingFactor.QUERY_AND_DROPDOWN
+        )
 
         data = self.run_sql(
             "SELECT * FROM birth_names LIMIT {}".format(test_limit + 1),


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

There was an issue where limits written in the sql were not being respected by async queries. This parses the sql and returns a limit, then compares this to queryLimit that was already present. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

https://user-images.githubusercontent.com/48933336/172240847-3a55044c-f138-45ba-acf1-ae17c850c725.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
