### PR TITLE
fix(sql lab): SQL Lab access restrictions not applied to default schema

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1118,6 +1118,9 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                     self.get_session, database, table_.table
                 )
 
+                if not datasources:
+                    continue
+
                 # Access to any datasource is suffice.
                 for datasource_ in datasources:
                     if datasource_.schema != table_.schema:
@@ -1128,7 +1131,9 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                     )
                     if schema_perm and self.can_access("schema_access", schema_perm):
                         break
-                    if self.can_access("datasource_access", datasource_.perm) or self.is_owner(datasource_):
+                    if self.can_access(
+                        "datasource_access", datasource_.perm
+                    ) or self.is_owner(datasource_):
                         break
                 else:
                     denied.add(table_)

--- a/tests/integration_tests/sqllab_tests.py
+++ b/tests/integration_tests/sqllab_tests.py
@@ -277,6 +277,12 @@ class TestSqlLab(SupersetTestCase):
             f"CREATE TABLE IF NOT EXISTS {CTAS_SCHEMA_NAME}.test_table AS SELECT 1 as c1, 2 as c2"
         )
 
+        table = SqlaTable(
+            schema=CTAS_SCHEMA_NAME, table_name="test_table", database=examples_db
+        )
+        db.session.add(table)
+        db.session.commit()
+
         data = self.run_sql(
             f"SELECT * FROM {CTAS_SCHEMA_NAME}.test_table", "3", username="SchemaUser"
         )
@@ -304,6 +310,7 @@ class TestSqlLab(SupersetTestCase):
         get_example_database().get_sqla_engine().execute(
             f"DROP TABLE IF EXISTS {CTAS_SCHEMA_NAME}.test_table"
         )
+        db.session.delete(table)
         db.session.commit()
 
     def test_queries_endpoint(self):


### PR DESCRIPTION
### SUMMARY

The schema level restrictions are not working properly in SQL Lab, when the default schema is used. Some DB Engines allow users to execute a query without specifying the Schema, in which default Schema will be queried.

In the permission check, we're assigning the schema from two sources: the query itself, or if it's not present, the schema selected on the left hand side in SQL Lab.
It's the second scenario that's not properly checked, because, if the user has schema permission for the one selected, and if the query can be executed in the engine without specifying the schema explicitly, then the permission check will allow said execution, since there's a permission for the schema.

This PR alters the order of checks, so that we validate that the default schema actually contains the table we're trying to query, and then check the permission on said datasource.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://user-images.githubusercontent.com/17252075/172245754-0186181c-5bbb-46cd-8ae5-c104e0d6d965.mov

After:

https://user-images.githubusercontent.com/17252075/172245791-cda848a5-aa53-41ea-a53a-477e0b5a3269.mov

### TESTING INSTRUCTIONS
1. Create a new user role with the following permissions:

* can read on SavedQuery
* can write on SavedQuery
* can read on Database
* can read on Query
* can sqllab on Superset
* can sqllab history on Superset
* can sqllab viz on Superset
* can sql json on Superset
* can sqllab table viz on Superset
* can validate sql json on Superset
* can activate on TabStateView
* can get on TabStateView
* can put on TabStateView
* can delete query on TabStateView
* can post on TabStateView
* can delete on TabStateView
* menu access on SQL Lab
* menu access on SQL Editor
* schema access on [examples].[information_schema]

2. Create a new user and assign the above role to it.
3. Log in with that user.
4. Go to SQL Lab
5. Select `examples` as database and `information_schema` as schema

Execute these two queries:
```SQL
select * from birth_names
```

```SQL
select * from public.birth_names
```

Ensure both fail with a forbidden error.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
