### PR TITLE
fix: Faulty datetime parser regex

### DIFF
--- a/superset-frontend/src/explore/components/controls/DateFilterControl/utils/dateParser.ts
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/utils/dateParser.ts
@@ -35,7 +35,7 @@ import { SEVEN_DAYS_AGO, MIDNIGHT, MOMENT_FORMAT } from './constants';
  * @see: https://www.w3.org/TR/NOTE-datetime
  */
 const iso8601 = String.raw`\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?(?:(?:[+-]\d\d:\d\d)|Z)?`;
-const datetimeConstant = String.raw`TODAY|NOW`;
+const datetimeConstant = String.raw`(?:TODAY|NOW)`;
 const grainValue = String.raw`[+-]?[1-9][0-9]*`;
 const grain = String.raw`YEAR|QUARTER|MONTH|WEEK|DAY|HOUR|MINUTE|SECOND`;
 const CUSTOM_RANGE_EXPRESSION = RegExp(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
As it currently stands, the regex for the datetime parser will incorrectly recognize things like "todayblahblah" and "snow" as datetime constants.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
Try running "snow" through the dateTime parser before the changes. It should give erroneous results. After this change, it should behave as expected. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
