### PR TITLE
feat: add pyproject.toml file to project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 40.6.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 [build-system]
 requires = ["setuptools >= 40.6.0", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
### SUMMARY
It is best pratice [PEP-517](https://peps.python.org/pep-0517/)/[PEP-518](https://peps.python.org/pep-0518/) to add a `pyproject.toml` file defining the pip package build requirements. See as well: [What the heck is pyproject.toml?](https://snarky.ca/what-the-heck-is-pyproject-toml/).


### TESTING INSTRUCTIONS
Clone the repo and go to its root directory. Run the following shell commands:

``` bash
python3 -m venv .env
.env/bin/pip install --upgrade pip
.env/bin/pip install .
```
