### PR TITLE
fix: context issues in custom authentication implementation

### DIFF
--- a/superset/app.py
+++ b/superset/app.py
@@ -29,14 +29,15 @@ def create_app() -> Flask:
     app = SupersetApp(__name__)
 
     try:
-        # Allow user to override our config completely
-        config_module = os.environ.get("SUPERSET_CONFIG", "superset.config")
-        app.config.from_object(config_module)
+        with app.app_context():
+                # Allow user to override our config completely
+                config_module = os.environ.get("SUPERSET_CONFIG", "superset.config")
+                app.config.from_object(config_module)
 
-        app_initializer = app.config.get("APP_INITIALIZER", SupersetAppInitializer)(app)
-        app_initializer.init_app()
+                app_initializer = app.config.get("APP_INITIALIZER", SupersetAppInitializer)(app)
+                app_initializer.init_app()
 
-        return app
+                return app
 
     # Make sure that bootstrap errors ALWAYS get logged
     except Exception as ex:


### PR DESCRIPTION
To pass flask context to superset.config and then to custom security so that flask functions can be used like app.<func_name>

### SUMMARY
When we use custom security for Authentication  - we may need flask context to perform few tasks. Like app.before_request() will need context to work otherwise will end up in error - 
RuntimeError: Working outside of application context.


### TESTING INSTRUCTIONS
This is for custom authentication scenarios which may not be required for everyone. So testing should focus that this change is not breaking existing authentication/login.
