### PR TITLE
fix: Alpha are unable to perform a second modification to a Dataset when in Explore

### DIFF
--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -198,9 +198,9 @@ class DatasourceControl extends React.PureComponent {
 
     const isSqlSupported = datasource.type === 'table';
     const { user } = this.props;
-    const allowEdit =
-      datasource.owners.map(o => o.id).includes(user.userId) ||
-      datasource.owners.map(o => o.value).includes(user.userId);
+    const allowEdit = datasource.owners
+      .map(o => o.id || o.value)
+      .includes(user.userId);
     isUserAdmin(user);
 
     const editText = t('Edit dataset');

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -200,7 +200,8 @@ class DatasourceControl extends React.PureComponent {
     const { user } = this.props;
     const allowEdit =
       datasource.owners.map(o => o.id).includes(user.userId) ||
-      isUserAdmin(user);
+      datasource.owners.map(o => o.value).includes(user.userId);
+    isUserAdmin(user);
 
     const editText = t('Edit dataset');
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix issue when Alpha users want to make a secondary change in `Edit Dataset`. The issue lies with the API from `datasource/save` returning a different payload for datasource.owners. To handle we'll add an additional check for the key value to make sure the user will still be able to edit moving forward.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
