### PR TITLE
chore(deps): pinning pyjwt to 2.4.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -199,7 +199,7 @@ pyarrow==5.0.0
     # via apache-superset
 pycparser==2.20
     # via cffi
-pyjwt==2.2.0
+pyjwt==2.4.0
     # via
     #   apache-superset
     #   flask-appbuilder

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
         "python-geohash",
         "pyarrow>=5.0.0, <6.0",
         "pyyaml>=5.4",
-        "PyJWT>=2.0.0, <2.4.0",
+        "PyJWT>=2.4.0",
         "redis",
         "selenium>=3.141.0",
         "simplejson>=3.15.0",

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
         "python-geohash",
         "pyarrow>=5.0.0, <6.0",
         "pyyaml>=5.4",
-        "PyJWT>=2.4.0",
+        "PyJWT>=2.4.0", <3.0,
         "redis",
         "selenium>=3.141.0",
         "simplejson>=3.15.0",

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
         "python-geohash",
         "pyarrow>=5.0.0, <6.0",
         "pyyaml>=5.4",
-        "PyJWT>=2.4.0", <3.0,
+        "PyJWT>=2.4.0, <3.0",
         "redis",
         "selenium>=3.141.0",
         "simplejson>=3.15.0",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Missed a spot with https://github.com/apache/superset/pull/20287 where we were still using a lower version of pyjwt. 
Here is the change log for version [2.4.0](https://pyjwt.readthedocs.io/en/latest/changelog.html#v2-4-0) that we are moving to.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
