### PR TITLE
feat(explore): Dataset Panel Options when Source = Query II

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/types/Datasource.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Datasource.ts
@@ -54,4 +54,10 @@ export const DEFAULT_METRICS = [
   },
 ];
 
+export const isValidDatasourceType = (datasource: DatasourceType) =>
+  datasource === DatasourceType.Dataset ||
+  datasource === DatasourceType.SlTable ||
+  datasource === DatasourceType.SavedQuery ||
+  datasource === DatasourceType.Query;
+
 export default {};

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Datasource.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Datasource.ts
@@ -54,10 +54,4 @@ export const DEFAULT_METRICS = [
   },
 ];
 
-export const isValidDatasourceType = (datasource: DatasourceType) =>
-  datasource === DatasourceType.Dataset ||
-  datasource === DatasourceType.SlTable ||
-  datasource === DatasourceType.SavedQuery ||
-  datasource === DatasourceType.Query;
-
 export default {};

--- a/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { css, styled, t, DatasourceType } from '@superset-ui/core';
+import { css, styled, t, isValidDatasourceType } from '@superset-ui/core';
 import {
   ControlConfig,
   Dataset,
@@ -307,12 +307,6 @@ export default function DataSourcePanel({
     return true;
   };
 
-  const isValidDatasourceType =
-    datasource.type === DatasourceType.Dataset ||
-    datasource.type === DatasourceType.SlTable ||
-    datasource.type === DatasourceType.SavedQuery ||
-    datasource.type === DatasourceType.Query;
-
   const mainBody = useMemo(
     () => (
       <>
@@ -327,7 +321,7 @@ export default function DataSourcePanel({
           placeholder={t('Search Metrics & Columns')}
         />
         <div className="field-selections">
-          {isValidDatasourceType && showInfoboxCheck() && (
+          {isValidDatasourceType(datasource.type) && showInfoboxCheck() && (
             <StyledInfoboxWrapper>
               <Alert
                 closable

--- a/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { css, styled, t, isValidDatasourceType } from '@superset-ui/core';
+import { css, styled, t, DatasourceType } from '@superset-ui/core';
 import {
   ControlConfig,
   Dataset,
@@ -321,7 +321,7 @@ export default function DataSourcePanel({
           placeholder={t('Search Metrics & Columns')}
         />
         <div className="field-selections">
-          {isValidDatasourceType(datasource.type) && showInfoboxCheck() && (
+          {datasource.type === DatasourceType.Query && showInfoboxCheck() && (
             <StyledInfoboxWrapper>
               <Alert
                 closable

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -19,7 +19,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { t, styled, withTheme, DatasourceType } from '@superset-ui/core';
+import { t, styled, withTheme, isValidDatasourceType } from '@superset-ui/core';
 import { getUrlParam } from 'src/utils/urlUtils';
 
 import { AntdDropdown } from 'src/components';
@@ -270,12 +270,6 @@ class DatasourceControl extends React.PureComponent {
       </Menu>
     );
 
-    const datasourceTypeCheck =
-      datasource.type === DatasourceType.Dataset ||
-      datasource.type === DatasourceType.SlTable ||
-      datasource.type === DatasourceType.SavedQuery ||
-      datasource.type === DatasourceType.Query;
-
     const { health_check_message: healthCheckMessage } = datasource;
 
     let extra = {};
@@ -309,7 +303,9 @@ class DatasourceControl extends React.PureComponent {
           )}
           <AntdDropdown
             overlay={
-              datasourceTypeCheck ? defaultDatasourceMenu : queryDatasourceMenu
+              isValidDatasourceType(datasource.type)
+                ? queryDatasourceMenu
+                : defaultDatasourceMenu
             }
             trigger={['click']}
             data-test="datasource-menu"

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -19,7 +19,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { t, styled, withTheme } from '@superset-ui/core';
+import { t, styled, withTheme, DatasourceType } from '@superset-ui/core';
 import { getUrlParam } from 'src/utils/urlUtils';
 
 import { AntdDropdown } from 'src/components';
@@ -30,6 +30,7 @@ import {
   ChangeDatasourceModal,
   DatasourceModal,
 } from 'src/components/Datasource';
+import { SaveDatasetModal } from 'src/SqlLab/components/SaveDatasetModal';
 import { postForm } from 'src/explore/exploreUtils';
 import Button from 'src/components/Button';
 import ErrorAlert from 'src/components/ErrorMessage/ErrorAlert';
@@ -112,6 +113,8 @@ const Styles = styled.div`
 const CHANGE_DATASET = 'change_dataset';
 const VIEW_IN_SQL_LAB = 'view_in_sql_lab';
 const EDIT_DATASET = 'edit_dataset';
+const QUERY_PREVIEW = 'query_preview';
+const SAVE_AS_DATASET = 'save_as_dataset';
 
 class DatasourceControl extends React.PureComponent {
   constructor(props) {
@@ -126,6 +129,7 @@ class DatasourceControl extends React.PureComponent {
     this.toggleEditDatasourceModal = this.toggleEditDatasourceModal.bind(this);
     this.toggleShowDatasource = this.toggleShowDatasource.bind(this);
     this.handleMenuItemClick = this.handleMenuItemClick.bind(this);
+    this.toggleSaveDatasetModal = this.toggleSaveDatasetModal.bind(this);
   }
 
   onDatasourceSave(datasource) {
@@ -166,25 +170,51 @@ class DatasourceControl extends React.PureComponent {
     }));
   }
 
+  toggleSaveDatasetModal() {
+    this.setState(({ showSaveDatasetModal }) => ({
+      showSaveDatasetModal: !showSaveDatasetModal,
+    }));
+  }
+
   handleMenuItemClick({ key }) {
-    if (key === CHANGE_DATASET) {
-      this.toggleChangeDatasourceModal();
-    }
-    if (key === EDIT_DATASET) {
-      this.toggleEditDatasourceModal();
-    }
-    if (key === VIEW_IN_SQL_LAB) {
-      const { datasource } = this.props;
-      const payload = {
-        datasourceKey: `${datasource.id}__${datasource.type}`,
-        sql: datasource.sql,
-      };
-      postForm('/superset/sqllab/', payload);
+    switch (key) {
+      case CHANGE_DATASET:
+        this.toggleChangeDatasourceModal();
+        break;
+
+      case EDIT_DATASET:
+        this.toggleEditDatasourceModal();
+        break;
+
+      case VIEW_IN_SQL_LAB:
+        {
+          const { datasource } = this.props;
+          const payload = {
+            datasourceKey: `${datasource.id}__${datasource.type}`,
+            sql: datasource.sql,
+          };
+          postForm('/superset/sqllab/', payload);
+        }
+        break;
+
+      case QUERY_PREVIEW:
+        break;
+
+      case SAVE_AS_DATASET:
+        this.toggleSaveDatasetModal();
+        break;
+
+      default:
+        break;
     }
   }
 
   render() {
-    const { showChangeDatasourceModal, showEditDatasourceModal } = this.state;
+    const {
+      showChangeDatasourceModal,
+      showEditDatasourceModal,
+      showSaveDatasetModal,
+    } = this.state;
     const { datasource, onChange, theme } = this.props;
     const isMissingDatasource = datasource.id == null;
     let isMissingParams = false;
@@ -204,7 +234,7 @@ class DatasourceControl extends React.PureComponent {
 
     const editText = t('Edit dataset');
 
-    const datasourceMenu = (
+    const defaultDatasourceMenu = (
       <Menu onClick={this.handleMenuItemClick}>
         {this.props.isEditable && (
           <Menu.Item
@@ -231,6 +261,20 @@ class DatasourceControl extends React.PureComponent {
         )}
       </Menu>
     );
+
+    const queryDatasourceMenu = (
+      <Menu onClick={this.handleMenuItemClick}>
+        <Menu.Item key={QUERY_PREVIEW}>{t('Query preview')}</Menu.Item>
+        <Menu.Item key={VIEW_IN_SQL_LAB}>{t('View in SQL Lab')}</Menu.Item>
+        <Menu.Item key={SAVE_AS_DATASET}>{t('Save as dataset')}</Menu.Item>
+      </Menu>
+    );
+
+    const datasourceTypeCheck =
+      datasource.type === DatasourceType.Dataset ||
+      datasource.type === DatasourceType.SlTable ||
+      datasource.type === DatasourceType.SavedQuery ||
+      datasource.type === DatasourceType.Query;
 
     const { health_check_message: healthCheckMessage } = datasource;
 
@@ -264,7 +308,9 @@ class DatasourceControl extends React.PureComponent {
             <WarningIconWithTooltip warningMarkdown={extra.warning_markdown} />
           )}
           <AntdDropdown
-            overlay={datasourceMenu}
+            overlay={
+              datasourceTypeCheck ? defaultDatasourceMenu : queryDatasourceMenu
+            }
             trigger={['click']}
             data-test="datasource-menu"
           >
@@ -337,6 +383,18 @@ class DatasourceControl extends React.PureComponent {
             onHide={this.toggleChangeDatasourceModal}
             show={showChangeDatasourceModal}
             onChange={onChange}
+          />
+        )}
+        {showSaveDatasetModal && (
+          <SaveDatasetModal
+            visible={showSaveDatasetModal}
+            onHide={this.toggleSaveDatasetModal}
+            buttonTextOnSave={t('Save & Explore')}
+            buttonTextOnOverwrite={t('Overwrite & Explore')}
+            modalDescription={t(
+              'Save this query as a virtual dataset to continue exploring',
+            )}
+            datasource={datasource}
           />
         )}
       </Styles>

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -19,7 +19,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { t, styled, withTheme, isValidDatasourceType } from '@superset-ui/core';
+import { t, styled, withTheme, DatasourceType } from '@superset-ui/core';
 import { getUrlParam } from 'src/utils/urlUtils';
 
 import { AntdDropdown } from 'src/components';
@@ -303,7 +303,7 @@ class DatasourceControl extends React.PureComponent {
           )}
           <AntdDropdown
             overlay={
-              isValidDatasourceType(datasource.type)
+              datasource.type === DatasourceType.Query
                 ? queryDatasourceMenu
                 : defaultDatasourceMenu
             }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This adds a different dataset panel dropdown when a chart's datasource is a query.


### SCREENSHOTS / ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="695" alt="queryDatasourcePanel" src="https://user-images.githubusercontent.com/55605634/169922171-4ff59a63-8d69-4b44-8351-44611c76e967.png">
<img width="1339" alt="queryDatasourceSaveDatasetModal" src="https://user-images.githubusercontent.com/55605634/169922178-cacf88c2-d6ac-4cfc-857a-b34465812f0e.png">

![queryDatasetPanel](https://user-images.githubusercontent.com/55605634/169922192-b754d665-d936-4967-9f08-617575e24695.gif)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Open a chart with a query datasource type
- Click the thee dots next to the chart name to reveal the dataset options dropdown
- Observe that the options are now "Query preview", "View in SQL Lab", and "Save as dataset"
- Click "View in SQL Lab" to be taken to SQL Lab
- Click "Save as dataset" and observe the save dataset modal

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
