### PR TITLE
fix(chart): Time Column configuration doesn't accept Custom SQL

### DIFF
--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -1223,14 +1223,14 @@
             "type": "array"
           },
           "granularity": {
-            "description": "Name of temporal column used for time filtering. For legacy Druid datasources this defines the time grain.",
+            "description": "Name of temporal column or SQL expression used for time filtering. For legacy Druid datasources this defines the time grain.",
             "nullable": true,
-            "type": "string"
+            "type": ["string", "object"]
           },
           "granularity_sqla": {
-            "description": "Name of temporal column used for time filtering for SQL datasources. This field is deprecated, use `granularity` instead.",
+            "description": "Name of temporal column or SQL expression used for time filtering for SQL datasources. This field is deprecated, use `granularity` instead.",
             "nullable": true,
-            "type": "string"
+            "type": ["string", "object"]
           },
           "groupby": {
             "description": "Columns by which to group the query. This field is deprecated, use `columns` instead.",

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -1002,12 +1002,12 @@ class ChartDataQueryObjectSchema(Schema):
         allow_none=True,
     )
     filters = fields.List(fields.Nested(ChartDataFilterSchema), allow_none=True)
-    granularity = fields.String(
+    granularity = fields.Raw(
         description="Name of temporal column used for time filtering. For legacy Druid "
         "datasources this defines the time grain.",
         allow_none=True,
     )
-    granularity_sqla = fields.String(
+    granularity_sqla = fields.Raw(
         description="Name of temporal column used for time filtering for SQL "
         "datasources. This field is deprecated, use `granularity` "
         "instead.",

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1210,14 +1210,15 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
     def get_dttm_time_filter(
         self, col: ColumnClause, start_dttm: DateTime, end_dttm: DateTime
     ) -> ColumnElement:
-        range = []
+        l = []
         if start_dttm:
-            range.append(col >= self.text(self.default_dttm_sql_literal(start_dttm)))
+            l.append(col >= self.text(self.default_dttm_sql_literal(start_dttm)))
         if end_dttm:
-            range.append(col < self.text(self.default_dttm_sql_literal(end_dttm)))
-        return and_(*range)
+            l.append(col < self.text(self.default_dttm_sql_literal(end_dttm)))
+        return and_(*l)
 
-    def default_dttm_sql_literal(self, dttm: DateTime) -> str:
+    @staticmethod
+    def default_dttm_sql_literal(dttm: DateTime) -> str:
         # TODO(john-bodley): SIP-15 will explicitly require a type conversion.
         return f"""'{dttm.strftime("%Y-%m-%d %H:%M:%S.%f")}'"""
 

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1253,7 +1253,7 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
     ) -> SqlaQuery:
         """Querying any sqla table from this common interface"""
         # For backward compatibility
-        if granularity not in self.dttm_cols and type(granularity) is str:
+        if granularity not in self.dttm_cols and isinstance(granularity, str):
             granularity = self.main_dttm_col
 
         extras = extras or {}
@@ -1384,10 +1384,10 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
         columns = [col for col in columns if col != utils.DTTM_ALIAS]
 
         dttm_col = (
-            columns_by_name.get(granularity) if type(granularity) is str else None
+            columns_by_name.get(granularity) if isinstance(granularity, str) else None
         )
         dttm_expr = None
-        if type(granularity) is dict and granularity.get("sqlExpression"):
+        if isinstance(granularity, dict) and granularity.get("sqlExpression"):
             expression = _process_sql_expression(
                 expression=granularity.get("sqlExpression"),
                 database_id=self.database_id,
@@ -1443,7 +1443,7 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
             metrics_exprs = []
 
         if granularity:
-            if type(granularity) is str and (
+            if isinstance(granularity, str) and (
                 granularity not in columns_by_name or not dttm_col
             ):
                 raise QueryObjectValidationError(


### PR DESCRIPTION
### SUMMARY

Superset allows you to add custom SQL to the Time Column configuration on Charts through the UI.
However, that feature is not implemented in the API, and instead throws a wrongly formatted request error.

This PR adds support for custom SQL to the time column configuration.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://user-images.githubusercontent.com/17252075/172587258-c3ad6292-610c-4990-a479-fd69f90e6742.mov

After:

https://user-images.githubusercontent.com/17252075/172587324-4a284025-42a5-4808-bf1e-38074dde018f.mov

### TESTING INSTRUCTIONS
1. Create a new Chart using the `Vehicle Sales` Dataset.
2. On the **METRIC** configuration, set `COUNT(*)`.
3. On the **TIME COLUMN** configuration, switch to the **CUSTOM SQL** tab and set `date_trunc('week', order_date)::date - 1`. 
4. Remove any **TIME GRAIN** if set.
5. Click on **RUN**.

The query should run and return data properly.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
