### PR TITLE
chore(explore): Visual updates to explore datasource panel

### DIFF
--- a/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
@@ -307,12 +307,6 @@ export default function DataSourcePanel({
     return true;
   };
 
-  const isValidDatasourceType =
-    datasource.type === DatasourceType.Dataset ||
-    datasource.type === DatasourceType.SlTable ||
-    datasource.type === DatasourceType.SavedQuery ||
-    datasource.type === DatasourceType.Query;
-
   const mainBody = useMemo(
     () => (
       <>
@@ -327,7 +321,7 @@ export default function DataSourcePanel({
           placeholder={t('Search Metrics & Columns')}
         />
         <div className="field-selections">
-          {isValidDatasourceType && showInfoboxCheck() && (
+          {datasource.type === DatasourceType.Query && showInfoboxCheck() && (
             <StyledInfoboxWrapper>
               <Alert
                 closable

--- a/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
@@ -307,6 +307,8 @@ export default function DataSourcePanel({
     return true;
   };
 
+  const dataSourceIsQuery = datasource?.type === DatasourceType.Query;
+
   const mainBody = useMemo(
     () => (
       <>
@@ -321,7 +323,7 @@ export default function DataSourcePanel({
           placeholder={t('Search Metrics & Columns')}
         />
         <div className="field-selections">
-          {datasource.type === DatasourceType.Query && showInfoboxCheck() && (
+          {dataSourceIsQuery && showInfoboxCheck() && (
             <StyledInfoboxWrapper>
               <Alert
                 closable
@@ -434,19 +436,22 @@ export default function DataSourcePanel({
       search,
       showAllColumns,
       showAllMetrics,
+      dataSourceIsQuery,
       shouldForceUpdate,
     ],
   );
 
   return (
     <DatasourceContainer>
-      <SaveDatasetModal
-        visible={showSaveDatasetModal}
-        onHide={() => setShowSaveDatasetModal(false)}
-        buttonTextOnSave={t('Save')}
-        buttonTextOnOverwrite={t('Overwrite')}
-        datasource={datasource}
-      />
+      {dataSourceIsQuery && (
+        <SaveDatasetModal
+          visible={showSaveDatasetModal}
+          onHide={() => setShowSaveDatasetModal(false)}
+          buttonTextOnSave={t('Save')}
+          buttonTextOnOverwrite={t('Overwrite')}
+          datasource={datasource}
+        />
+      )}
       <Control {...datasourceControl} name="datasource" actions={actions} />
       {datasource.id != null && mainBody}
     </DatasourceContainer>

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -126,10 +126,10 @@ const ExplorePanelContainer = styled.div`
       position: relative;
       display: flex;
       flex-direction: row;
-      padding: 0 ${theme.gridUnit * 4}px;
+      padding: 0 ${theme.gridUnit * 2}px 0 ${theme.gridUnit * 4}px;
       justify-content: space-between;
       .horizontal-text {
-        font-size: ${theme.typography.sizes.s}px;
+        font-size: ${theme.typography.sizes.m}px;
       }
     }
     .no-show {
@@ -145,7 +145,7 @@ const ExplorePanelContainer = styled.div`
       padding: ${theme.gridUnit * 2}px;
       width: ${theme.gridUnit * 8}px;
     }
-    .callpase-icon > svg {
+    .collapse-icon > svg {
       color: ${theme.colors.primary.base};
     }
   `};
@@ -603,7 +603,7 @@ function ExploreViewContainer(props) {
           }
         >
           <div className="title-container">
-            <span className="horizontal-text">{t('Dataset')}</span>
+            <span className="horizontal-text">{t('Chart Source')}</span>
             <span
               role="button"
               tabIndex={0}
@@ -642,11 +642,6 @@ function ExploreViewContainer(props) {
                 />
               </Tooltip>
             </span>
-            <Icons.DatasetPhysical
-              css={{ marginTop: theme.gridUnit * 2 }}
-              iconSize="l"
-              iconColor={theme.colors.grayscale.base}
-            />
           </div>
         ) : null}
         <Resizable

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.jsx
@@ -20,13 +20,13 @@ import React from 'react';
 import sinon from 'sinon';
 import configureStore from 'redux-mock-store';
 import { mount, shallow } from 'enzyme';
-import { supersetTheme, ThemeProvider } from '@superset-ui/core';
+import { supersetTheme, ThemeProvider, DatasourceType } from '@superset-ui/core';
 import { Menu } from 'src/components/Menu';
 import {
   DatasourceModal,
   ChangeDatasourceModal,
 } from 'src/components/Datasource';
-import DatasourceControl from 'src/explore/components/controls/DatasourceControl';
+import DatasourceControl, { getDatasourceTitle } from 'src/explore/components/controls/DatasourceControl';
 import Icons from 'src/components/Icons';
 import { Tooltip } from 'src/components/Tooltip';
 
@@ -143,4 +143,30 @@ describe('DatasourceControl', () => {
       defaultProps.datasource.health_check_message,
     );
   });
+
+  it('Gets Datasource Title', () => {
+    const sql = 'This is the sql';
+    const name = 'this is a name';
+    const emptyResult = '';
+    const queryDatasource1 = {type: DatasourceType.Query, sql: sql};
+    let displayText = getDatasourceTitle(queryDatasource1);
+    expect(displayText).toBe(sql);
+    const queryDatasource2 = {type: DatasourceType.Query, sql: null};
+    displayText = getDatasourceTitle(queryDatasource2);
+    expect(displayText).toBe(emptyResult);
+    const queryDatasource3 = {type: 'random type', name: name};
+    displayText = getDatasourceTitle(queryDatasource3);
+    expect(displayText).toBe(name);
+    const queryDatasource4 = {type: 'random type'};
+    displayText = getDatasourceTitle(queryDatasource4);
+    expect(displayText).toBe(emptyResult);
+    displayText = getDatasourceTitle();
+    expect(displayText).toBe(emptyResult);
+    displayText = getDatasourceTitle(null);
+    expect(displayText).toBe(emptyResult);
+    displayText = getDatasourceTitle('I should not be a string');
+    expect(displayText).toBe(emptyResult);
+    displayText = getDatasourceTitle([]);
+    expect(displayText).toBe(emptyResult);
+  })
 });

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -244,7 +244,7 @@ class DatasourceControl extends React.PureComponent {
     return (
       <Styles data-test="datasource-control" className="DatasourceControl">
         <div className="data-container">
-          {isValidDatasourceType ? (
+          {!isValidDatasourceType ? (
             <Icons.ConsoleSqlOutlined className="datasource-svg" />
           ) : (
             <Icons.DatasetPhysical className="datasource-svg" />

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -113,6 +113,47 @@ const CHANGE_DATASET = 'change_dataset';
 const VIEW_IN_SQL_LAB = 'view_in_sql_lab';
 const EDIT_DATASET = 'edit_dataset';
 
+// If the string is longer than this value's number characters we add
+// a tooltip for user can see the full name by hovering over the visually truncated string in UI
+const VISIBLE_TITLE_LENGTH = 25;
+
+
+// Assign icon for each DatasourceType.  If no icon assingment is found in the lookup, no icon will render
+export const datasourceIconLookup = {
+    [DatasourceType.Query]: <Icons.ConsoleSqlOutlined className="datasource-svg" />,
+    [DatasourceType.Table]: <Icons.DatasetPhysical className="datasource-svg" />,
+  }
+
+// Render title for datasource with tooltip only if text is longer than VISIBLE_TITLE_LENGTH
+export const renderDatasourceTitle = displayString =>
+    displayString.length > VISIBLE_TITLE_LENGTH ? (
+      // Add a tooltip only for long names that will be visually truncated
+      <Tooltip title={displayString}>
+        <span className="title-select">{displayString}</span>
+      </Tooltip>
+    ) : (
+      <span title={displayString} className="title-select">
+        {displayString}
+      </span>
+    );
+
+// Different data source types use different attributes for the display title
+export const getDatasourceTitle = datasource => {
+    let text = '';
+    const dataSourceType = datasource?.type;
+    if (dataSourceType) {
+      switch (dataSourceType) {
+        case DatasourceType.Query:
+          text = datasource?.sql ?? '';
+          break;
+        default:
+          text = datasource?.name ?? '';
+          break;
+      }
+    }
+    return text;
+  };
+
 class DatasourceControl extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -186,7 +227,7 @@ class DatasourceControl extends React.PureComponent {
   render() {
     const { showChangeDatasourceModal, showEditDatasourceModal } = this.state;
     const { datasource, onChange, theme } = this.props;
-    const isMissingDatasource = datasource.id == null;
+    const isMissingDatasource = datasource?.id?.length > 0 ? false : true;
     let isMissingParams = false;
     if (isMissingDatasource) {
       const datasourceId = getUrlParam(URL_PARAMS.datasourceId);
@@ -241,34 +282,13 @@ class DatasourceControl extends React.PureComponent {
       } catch {} // eslint-disable-line no-empty
     }
 
+    const titleText = getDatasourceTitle(datasource) ;
+
     return (
       <Styles data-test="datasource-control" className="DatasourceControl">
         <div className="data-container">
-          {datasource.type === DatasourceType.Query ? (
-            <Icons.ConsoleSqlOutlined className="datasource-svg" />
-          ) : (
-            <Icons.DatasetPhysical className="datasource-svg" />
-          )}
-          {datasource.type === DatasourceType.Query ? (
-            /* Add a tooltip only for long dataset names */
-            !isMissingDatasource && datasource.sql.length > 25 ? (
-              <Tooltip title={datasource.sql}>
-                <span className="title-select">{datasource.sql}</span>
-              </Tooltip>
-            ) : (
-              <span title={datasource.sql} className="title-select">
-                {datasource.sql}
-              </span>
-            )
-          ) : !isMissingDatasource && datasource.name.length > 25 ? (
-            <Tooltip title={datasource.name}>
-              <span className="title-select">{datasource.name}</span>
-            </Tooltip>
-          ) : (
-            <span title={datasource.name} className="title-select">
-              {datasource.name}
-            </span>
-          )}
+          {datasourceIconLookup[datasource?.type]}
+          {renderDatasourceTitle(titleText)}
           {healthCheckMessage && (
             <Tooltip title={healthCheckMessage}>
               <Icons.AlertSolid iconColor={theme.colors.warning.base} />

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -244,7 +244,7 @@ class DatasourceControl extends React.PureComponent {
     return (
       <Styles data-test="datasource-control" className="DatasourceControl">
         <div className="data-container">
-          {!isValidDatasourceType ? (
+          {isValidDatasourceType ? (
             <Icons.ConsoleSqlOutlined className="datasource-svg" />
           ) : (
             <Icons.DatasetPhysical className="datasource-svg" />

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -19,7 +19,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { t, styled, withTheme } from '@superset-ui/core';
+import { t, styled, withTheme, isValidDatasourceType } from '@superset-ui/core';
 import { getUrlParam } from 'src/utils/urlUtils';
 
 import { AntdDropdown } from 'src/components';
@@ -97,7 +97,7 @@ const Styles = styled.div`
     white-space: nowrap;
     overflow: hidden;
   }
-  .dataset-svg {
+  .datasource-svg {
     margin-right: ${({ theme }) => 2 * theme.gridUnit}px;
     flex: none;
   }
@@ -244,9 +244,23 @@ class DatasourceControl extends React.PureComponent {
     return (
       <Styles data-test="datasource-control" className="DatasourceControl">
         <div className="data-container">
-          <Icons.DatasetPhysical className="dataset-svg" />
-          {/* Add a tooltip only for long dataset names */}
-          {!isMissingDatasource && datasource.name.length > 25 ? (
+          {isValidDatasourceType ? (
+            <Icons.ConsoleSqlOutlined className="datasource-svg" />
+          ) : (
+            <Icons.DatasetPhysical className="datasource-svg" />
+          )}
+          {isValidDatasourceType ? (
+            /* Add a tooltip only for long dataset names */
+            !isMissingDatasource && datasource.sql.length > 25 ? (
+              <Tooltip title={datasource.sql}>
+                <span className="title-select">{datasource.sql}</span>
+              </Tooltip>
+            ) : (
+              <span title={datasource.sql} className="title-select">
+                {datasource.sql}
+              </span>
+            )
+          ) : !isMissingDatasource && datasource.name.length > 25 ? (
             <Tooltip title={datasource.name}>
               <span className="title-select">{datasource.name}</span>
             </Tooltip>
@@ -268,12 +282,10 @@ class DatasourceControl extends React.PureComponent {
             trigger={['click']}
             data-test="datasource-menu"
           >
-            <Tooltip title={t('More dataset related options')}>
-              <Icons.MoreVert
-                className="datasource-modal-trigger"
-                data-test="datasource-menu-trigger"
-              />
-            </Tooltip>
+            <Icons.MoreVert
+              className="datasource-modal-trigger"
+              data-test="datasource-menu-trigger"
+            />
           </AntdDropdown>
         </div>
         {/* missing dataset */}

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -19,7 +19,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { t, styled, withTheme, isValidDatasourceType } from '@superset-ui/core';
+import { t, styled, withTheme, DatasourceType } from '@superset-ui/core';
 import { getUrlParam } from 'src/utils/urlUtils';
 
 import { AntdDropdown } from 'src/components';
@@ -244,12 +244,12 @@ class DatasourceControl extends React.PureComponent {
     return (
       <Styles data-test="datasource-control" className="DatasourceControl">
         <div className="data-container">
-          {isValidDatasourceType ? (
+          {datasource.type === DatasourceType.Query ? (
             <Icons.ConsoleSqlOutlined className="datasource-svg" />
           ) : (
             <Icons.DatasetPhysical className="datasource-svg" />
           )}
-          {isValidDatasourceType ? (
+          {datasource.type === DatasourceType.Query ? (
             /* Add a tooltip only for long dataset names */
             !isMissingDatasource && datasource.sql.length > 25 ? (
               <Tooltip title={datasource.sql}>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Made the following visual updates to the explore datasource panel:
- Changed "Dataset" to "Chart Source"
  - Increased font size to 14px
- Removed "More dataset related options" tooltip
- Moved inner collapse icon to the right by 8px
- Removed outer dataset icon when panel is collapsed
- Changed icon to ConsoleSqlOutlined when chart source is a Query
- User sees beginning of SQL query when chart source is a Query

### SCREENSHOTS
<!--- Skip this if not applicable -->
#### When chart source is a Query:
<img width="353" alt="panelUpdateAfter" src="https://user-images.githubusercontent.com/55605634/172693294-4eba9916-a054-4e3f-a67a-c63d9cfc681f.png">

#### When chart source is not a Query:
<img width="353" alt="panelUpdateAfter2" src="https://user-images.githubusercontent.com/55605634/172693307-3100cd44-c3e2-41a3-ac90-1bfaec9e52eb.png">

#### Collapsed panel (no longer has an icon):
<img width="353" alt="panelUpdateAfter3" src="https://user-images.githubusercontent.com/55605634/172693318-4ad4bdeb-6f04-4410-9e8f-ca3a6335a274.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Go to explore by opening any chart
- Observe the visual updates

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
