### PR TITLE
feat: safer insert RLS

### DIFF
--- a/superset/connectors/sqla/utils.py
+++ b/superset/connectors/sqla/utils.py
@@ -38,7 +38,7 @@ from superset.exceptions import (
 )
 from superset.models.core import Database
 from superset.result_set import SupersetResultSet
-from superset.sql_parse import has_table_query, insert_rls_in_predicate, ParsedQuery
+from superset.sql_parse import ParsedQuery
 from superset.superset_typing import ResultSetColumnType
 
 if TYPE_CHECKING:
@@ -151,41 +151,6 @@ def get_columns_description(
             return result_set.columns
     except Exception as ex:
         raise SupersetGenericDBErrorException(message=str(ex)) from ex
-
-
-def validate_adhoc_subquery(
-    sql: str,
-    database_id: int,
-    default_schema: str,
-) -> str:
-    """
-    Check if adhoc SQL contains sub-queries or nested sub-queries with table.
-
-    If sub-queries are allowed, the adhoc SQL is modified to insert any applicable RLS
-    predicates to it.
-
-    :param sql: adhoc sql expression
-    :raise SupersetSecurityException if sql contains sub-queries or
-    nested sub-queries with table
-    """
-    # pylint: disable=import-outside-toplevel
-    from superset import is_feature_enabled
-
-    statements = []
-    for statement in sqlparse.parse(sql):
-        if has_table_query(statement):
-            if not is_feature_enabled("ALLOW_ADHOC_SUBQUERY"):
-                raise SupersetSecurityException(
-                    SupersetError(
-                        error_type=SupersetErrorType.ADHOC_SUBQUERY_NOT_ALLOWED_ERROR,
-                        message=_("Custom SQL fields cannot contain sub-queries."),
-                        level=ErrorLevel.ERROR,
-                    )
-                )
-            statement = insert_rls_in_predicate(statement, database_id, default_schema)
-        statements.append(statement)
-
-    return ";\n".join(str(statement) for statement in statements)
 
 
 @lru_cache(maxsize=LRU_CACHE_MAX_SIZE)

--- a/superset/connectors/sqla/utils.py
+++ b/superset/connectors/sqla/utils.py
@@ -38,7 +38,7 @@ from superset.exceptions import (
 )
 from superset.models.core import Database
 from superset.result_set import SupersetResultSet
-from superset.sql_parse import ParsedQuery
+from superset.sql_parse import has_table_query, insert_rls_in_predicate, ParsedQuery
 from superset.superset_typing import ResultSetColumnType
 
 if TYPE_CHECKING:
@@ -151,6 +151,41 @@ def get_columns_description(
             return result_set.columns
     except Exception as ex:
         raise SupersetGenericDBErrorException(message=str(ex)) from ex
+
+
+def validate_adhoc_subquery(
+    sql: str,
+    database_id: int,
+    default_schema: str,
+) -> str:
+    """
+    Check if adhoc SQL contains sub-queries or nested sub-queries with table.
+
+    If sub-queries are allowed, the adhoc SQL is modified to insert any applicable RLS
+    predicates to it.
+
+    :param sql: adhoc sql expression
+    :raise SupersetSecurityException if sql contains sub-queries or
+    nested sub-queries with table
+    """
+    # pylint: disable=import-outside-toplevel
+    from superset import is_feature_enabled
+
+    statements = []
+    for statement in sqlparse.parse(sql):
+        if has_table_query(statement):
+            if not is_feature_enabled("ALLOW_ADHOC_SUBQUERY"):
+                raise SupersetSecurityException(
+                    SupersetError(
+                        error_type=SupersetErrorType.ADHOC_SUBQUERY_NOT_ALLOWED_ERROR,
+                        message=_("Custom SQL fields cannot contain sub-queries."),
+                        level=ErrorLevel.ERROR,
+                    )
+                )
+            statement = insert_rls_in_predicate(statement, database_id, default_schema)
+        statements.append(statement)
+
+    return ";\n".join(str(statement) for statement in statements)
 
 
 @lru_cache(maxsize=LRU_CACHE_MAX_SIZE)

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -901,43 +901,6 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
             sql = f"{cte}\n{sql}"
         return sql
 
-    @staticmethod
-    def validate_adhoc_subquery(
-        sql: str,
-        database_id: int,
-        default_schema: str,
-    ) -> str:
-        """
-        Check if adhoc SQL contains sub-queries or nested sub-queries with table.
-
-        If sub-queries are allowed, the adhoc SQL is modified to insert any applicable RLS
-        predicates to it.
-
-        :param sql: adhoc sql expression
-        :raise SupersetSecurityException if sql contains sub-queries or
-        nested sub-queries with table
-        """
-
-        statements = []
-        for statement in sqlparse.parse(sql):
-            if has_table_query(statement):
-                if not is_feature_enabled("ALLOW_ADHOC_SUBQUERY"):
-                    raise SupersetSecurityException(
-                        SupersetError(
-                            error_type=SupersetErrorType.ADHOC_SUBQUERY_NOT_ALLOWED_ERROR,
-                            message=_("Custom SQL fields cannot contain sub-queries."),
-                            level=ErrorLevel.ERROR,
-                        )
-                    )
-                statement = insert_rls_in_predicate(
-                    statement,
-                    database_id,
-                    default_schema,
-                )
-            statements.append(statement)
-
-        return ";\n".join(str(statement) for statement in statements)
-
     def get_query_str_extended(
         self, query_obj: QueryObjectDict, mutate: bool = True
     ) -> QueryStringExtended:

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -68,7 +68,12 @@ from superset.exceptions import (
 )
 from superset.extensions import feature_flag_manager
 from superset.jinja_context import BaseTemplateProcessor
-from superset.sql_parse import has_table_query, insert_rls, ParsedQuery, sanitize_clause
+from superset.sql_parse import (
+    has_table_query,
+    insert_rls_in_predicate,
+    ParsedQuery,
+    sanitize_clause,
+)
 from superset.superset_typing import (
     AdhocMetric,
     Column as ColumnTyping,
@@ -128,7 +133,7 @@ def validate_adhoc_subquery(
                         level=ErrorLevel.ERROR,
                     )
                 )
-            statement = insert_rls(statement, database_id, default_schema)
+            statement = insert_rls_in_predicate(statement, database_id, default_schema)
         statements.append(statement)
 
     return ";\n".join(str(statement) for statement in statements)
@@ -895,6 +900,43 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         if cte:
             sql = f"{cte}\n{sql}"
         return sql
+
+    @staticmethod
+    def validate_adhoc_subquery(
+        sql: str,
+        database_id: int,
+        default_schema: str,
+    ) -> str:
+        """
+        Check if adhoc SQL contains sub-queries or nested sub-queries with table.
+
+        If sub-queries are allowed, the adhoc SQL is modified to insert any applicable RLS
+        predicates to it.
+
+        :param sql: adhoc sql expression
+        :raise SupersetSecurityException if sql contains sub-queries or
+        nested sub-queries with table
+        """
+
+        statements = []
+        for statement in sqlparse.parse(sql):
+            if has_table_query(statement):
+                if not is_feature_enabled("ALLOW_ADHOC_SUBQUERY"):
+                    raise SupersetSecurityException(
+                        SupersetError(
+                            error_type=SupersetErrorType.ADHOC_SUBQUERY_NOT_ALLOWED_ERROR,
+                            message=_("Custom SQL fields cannot contain sub-queries."),
+                            level=ErrorLevel.ERROR,
+                        )
+                    )
+                statement = insert_rls_in_predicate(
+                    statement,
+                    database_id,
+                    default_schema,
+                )
+            statements.append(statement)
+
+        return ";\n".join(str(statement) for statement in statements)
 
     def get_query_str_extended(
         self, query_obj: QueryObjectDict, mutate: bool = True

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -196,7 +196,7 @@ def get_sql_results(  # pylint: disable=too-many-arguments
                 return handle_query_error(ex, query, session)
 
 
-def execute_sql_statement(  # pylint: disable=too-many-arguments
+def execute_sql_statement(  # pylint: disable=too-many-arguments, too-many-locals
     sql_statement: str,
     query: Query,
     session: Session,

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -48,7 +48,12 @@ from superset.extensions import celery_app
 from superset.models.core import Database
 from superset.models.sql_lab import Query
 from superset.result_set import SupersetResultSet
-from superset.sql_parse import CtasMethod, insert_rls, ParsedQuery
+from superset.sql_parse import (
+    CtasMethod,
+    insert_rls_as_subquery,
+    insert_rls_in_predicate,
+    ParsedQuery,
+)
 from superset.sqllab.limiting_factor import LimitingFactor
 from superset.sqllab.utils import write_ipc_buffer
 from superset.utils.celery import session_scope
@@ -205,6 +210,16 @@ def execute_sql_statement(  # pylint: disable=too-many-arguments
 
     parsed_query = ParsedQuery(sql_statement)
     if is_feature_enabled("RLS_IN_SQLLAB"):
+        # There are two ways to insert RLS: either replacing the table with a subquery
+        # that has the RLS, or appending the RLS to the ``WHERE`` clause. The former is
+        # safer, but not supported in all databases.
+        insert_rls = (
+            insert_rls_as_subquery
+            if database.db_engine_spec.allows_subqueries
+            and database.db_engine_spec.allows_alias_in_select
+            else insert_rls_in_predicate
+        )
+
         # Insert any applicable RLS predicates
         parsed_query = ParsedQuery(
             str(

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -775,7 +775,6 @@ def insert_rls_in_predicate(
     rls: Optional[TokenList] = None
     state = InsertRLSState.SCANNING
     for token in token_list.tokens:
-
         # Recurse into child token list
         if isinstance(token, TokenList):
             i = token_list.tokens.index(token)

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -44,6 +44,7 @@ from sqlparse.tokens import (
     Punctuation,
     String,
     Whitespace,
+    Wildcard,
 )
 from sqlparse.utils import imt
 
@@ -660,18 +661,29 @@ def get_rls_for_table(
         return None
 
     rls = sqlparse.parse(predicate)[0]
-    add_table_name(rls, str(dataset))
+    add_table_name(rls, table.table)
 
     return rls
 
 
-def insert_rls(
+def insert_rls_as_subquery(
     token_list: TokenList,
     database_id: int,
     default_schema: Optional[str],
 ) -> TokenList:
     """
     Update a statement inplace applying any associated RLS predicates.
+
+    The RLS predicate is applied as subquery replacing the original table:
+
+        before: SELECT * FROM some_table WHERE 1=1
+        after:  SELECT * FROM (
+                  SELECT * FROM some_table WHERE some_table.id=42
+                ) AS some_table
+                WHERE 1=1
+
+    This method is safer than ``insert_rls_in_predicate``, but doesn't work in all
+    databases.
     """
     rls: Optional[TokenList] = None
     state = InsertRLSState.SCANNING
@@ -679,7 +691,99 @@ def insert_rls(
         # Recurse into child token list
         if isinstance(token, TokenList):
             i = token_list.tokens.index(token)
-            token_list.tokens[i] = insert_rls(token, database_id, default_schema)
+            token_list.tokens[i] = insert_rls_as_subquery(
+                token,
+                database_id,
+                default_schema,
+            )
+
+        # Found a source keyword (FROM/JOIN)
+        if imt(token, m=[(Keyword, "FROM"), (Keyword, "JOIN")]):
+            state = InsertRLSState.SEEN_SOURCE
+
+        # Found identifier/keyword after FROM/JOIN, test for table
+        elif state == InsertRLSState.SEEN_SOURCE and (
+            isinstance(token, Identifier) or token.ttype == Keyword
+        ):
+            rls = get_rls_for_table(token, database_id, default_schema)
+            if rls:
+                # replace table with subquery
+                subquery_alias = (
+                    token.tokens[-1].value
+                    if isinstance(token, Identifier)
+                    else token.value
+                )
+                i = token_list.tokens.index(token)
+
+                # strip alias from table name
+                if isinstance(token, Identifier) and token.has_alias():
+                    whitespace_index = token.token_next_by(t=Whitespace)[0]
+                    token.tokens = token.tokens[:whitespace_index]
+
+                token_list.tokens[i] = Identifier(
+                    [
+                        Parenthesis(
+                            [
+                                Token(Punctuation, "("),
+                                Token(DML, "SELECT"),
+                                Token(Whitespace, " "),
+                                Token(Wildcard, "*"),
+                                Token(Whitespace, " "),
+                                Token(Keyword, "FROM"),
+                                Token(Whitespace, " "),
+                                token,
+                                Token(Whitespace, " "),
+                                Where(
+                                    [
+                                        Token(Keyword, "WHERE"),
+                                        Token(Whitespace, " "),
+                                        rls,
+                                    ]
+                                ),
+                                Token(Punctuation, ")"),
+                            ]
+                        ),
+                        Token(Whitespace, " "),
+                        Token(Keyword, "AS"),
+                        Token(Whitespace, " "),
+                        Identifier([Token(Name, subquery_alias)]),
+                    ]
+                )
+                state = InsertRLSState.SCANNING
+
+        # Found nothing, leaving source
+        elif state == InsertRLSState.SEEN_SOURCE and token.ttype != Whitespace:
+            state = InsertRLSState.SCANNING
+
+    return token_list
+
+
+def insert_rls_in_predicate(
+    token_list: TokenList,
+    database_id: int,
+    default_schema: Optional[str],
+) -> TokenList:
+    """
+    Update a statement inplace applying any associated RLS predicates.
+
+    The RLS predicate is ``AND``ed to any existing predicates:
+
+        before: SELECT * FROM some_table WHERE 1=1
+        after:  SELECT * FROM some_table WHERE ( 1=1) AND some_table.id=42
+
+    """
+    rls: Optional[TokenList] = None
+    state = InsertRLSState.SCANNING
+    for token in token_list.tokens:
+
+        # Recurse into child token list
+        if isinstance(token, TokenList):
+            i = token_list.tokens.index(token)
+            token_list.tokens[i] = insert_rls_in_predicate(
+                token,
+                database_id,
+                default_schema,
+            )
 
         # Found a source keyword (FROM/JOIN)
         if imt(token, m=[(Keyword, "FROM"), (Keyword, "JOIN")]):

--- a/tests/unit_tests/sql_lab_test.py
+++ b/tests/unit_tests/sql_lab_test.py
@@ -87,7 +87,7 @@ def test_execute_sql_statement_with_rls(
     cursor = mocker.MagicMock()
     SupersetResultSet = mocker.patch("superset.sql_lab.SupersetResultSet")
     mocker.patch(
-        "superset.sql_lab.insert_rls",
+        "superset.sql_lab.insert_rls_as_subquery",
         return_value=sqlparse.parse("SELECT * FROM sales WHERE organization_id=42")[0],
     )
     mocker.patch("superset.sql_lab.is_feature_enabled", return_value=True)
@@ -112,12 +112,12 @@ def test_execute_sql_statement_with_rls(
     SupersetResultSet.assert_called_with([(42,)], cursor.description, db_engine_spec)
 
 
-def test_sql_lab_insert_rls(
+def test_sql_lab_insert_rls_as_subquery(
     mocker: MockerFixture,
     session: Session,
 ) -> None:
     """
-    Integration test for `insert_rls`.
+    Integration test for `insert_rls_as_subquery`.
     """
     from flask_appbuilder.security.sqla.models import Role, User
 
@@ -213,4 +213,7 @@ def test_sql_lab_insert_rls(
 |  2 |   8 |
 |  3 |   9 |""".strip()
     )
-    assert query.executed_sql == "SELECT c FROM t WHERE (t.c > 5)\nLIMIT 6"
+    assert (
+        query.executed_sql
+        == "SELECT c FROM (SELECT * FROM t WHERE (t.c > 5)) AS t\nLIMIT 6"
+    )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

We currently have a feature flag `RLS_IN_SQLLAB` that, when enabled, applies any relevant RLS rules to the SQL executed in SQL Lab. The current approach parses the SQL and extracts all tables being queried. If any of those tables have RLS rules associated with them the parse tree is modified inplace, appending the RLS predicate to the associated `WHERE` clause or creating a new one if needed.

@mistercrunch suggested an approach that is more bulletproof: replacing the table reference (eg, `my_table`) with a subquery that contains the RLS (`SELECT * FROM my_table WHERE rls`). This can be done conditionally on databases that support subqueries. I implemented that solution in this PR.

Note that this method is probably still not bulletproof. We're still using `sqlparse` to find table references, and this has been error-prone in the past. For example, we had problems where the identifier "RAW" was not detected properly because `sqlparse` considers it a reserved keyword, since it doesn't have separate lists of keywords for each dialect.

This PR and the original implementation are both conservative in cases like these, trying to figure out if a keyword is actually and identifier, and the unit tests cover such cases. But we should consider this feature experimental, and warn users that there are risks associated with using it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Added unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
