### PR TITLE
fix: superset-ui/core coverage

### DIFF
--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -47,7 +47,7 @@ module.exports = {
     'tmp/',
     'dist/',
   ],
-  coverageReporters: ['lcov', 'json-summary', 'html'],
+  coverageReporters: ['lcov', 'json-summary', 'html', 'text'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   snapshotSerializers: ['@emotion/jest/enzyme-serializer'],
   globals: {

--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -17,17 +17,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { ReactNode, ReactText, ReactElement } from 'react';
+import React, { ReactElement, ReactNode, ReactText } from 'react';
 import type {
   AdhocColumn,
   Column,
   DatasourceType,
   JsonValue,
   Metric,
-  QueryFormData,
-  QueryResponse,
-  QueryFormMetric,
   QueryFormColumn,
+  QueryFormData,
+  QueryFormMetric,
+  QueryResponse,
 } from '@superset-ui/core';
 import { sharedControls } from './shared-controls';
 import sharedControlComponents from './shared-controls/components';
@@ -436,4 +436,20 @@ export function isControlPanelSectionConfig(
   section: ControlPanelSectionConfig | null,
 ): section is ControlPanelSectionConfig {
   return section !== null;
+}
+
+export function isDataset(
+  datasource: Dataset | QueryResponse | null | undefined,
+): datasource is Dataset {
+  return !!datasource && 'columns' in datasource;
+}
+
+export function isQueryResponse(
+  datasource: Dataset | QueryResponse | null | undefined,
+): datasource is QueryResponse {
+  return (
+    !!datasource &&
+    ('results' in datasource ||
+      datasource?.type === ('query' as DatasourceType.Query))
+  );
 }

--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/columnChoices.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/columnChoices.ts
@@ -16,8 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { QueryResponse } from '@superset-ui/core';
-import { Dataset } from '../types';
+import { ensureIsArray, QueryResponse } from '@superset-ui/core';
+import { Dataset, isColumnMeta, isDataset, isQueryResponse } from '../types';
 
 /**
  * Convert Datasource columns to column choices
@@ -25,23 +25,24 @@ import { Dataset } from '../types';
 export default function columnChoices(
   datasource?: Dataset | QueryResponse | null,
 ): [string, string][] {
-  if (datasource?.columns[0]?.hasOwnProperty('column_name')) {
-    return (
-      (datasource as Dataset)?.columns
-        .map((col): [string, string] => [
-          col.column_name,
-          col.verbose_name || col.column_name,
-        ])
-        .sort((opt1, opt2) =>
-          opt1[1].toLowerCase() > opt2[1].toLowerCase() ? 1 : -1,
-        ) || []
-    );
+  if (isDataset(datasource) && isColumnMeta(datasource.columns[0])) {
+    return datasource.columns
+      .map((col): [string, string] => [
+        col.column_name,
+        col.verbose_name || col.column_name,
+      ])
+      .sort((opt1, opt2) =>
+        opt1[1].toLowerCase() > opt2[1].toLowerCase() ? 1 : -1,
+      );
   }
-  return (
-    (datasource as QueryResponse)?.columns
+
+  if (isQueryResponse(datasource)) {
+    return ensureIsArray(datasource.columns)
       .map((col): [string, string] => [col.name, col.name])
       .sort((opt1, opt2) =>
         opt1[1].toLowerCase() > opt2[1].toLowerCase() ? 1 : -1,
-      ) || []
-  );
+      );
+  }
+
+  return [];
 }

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/defineSavedMetrics.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/defineSavedMetrics.test.tsx
@@ -26,30 +26,31 @@ import { defineSavedMetrics } from '@superset-ui/chart-controls';
 
 describe('defineSavedMetrics', () => {
   it('defines saved metrics if source is a Dataset', () => {
-    expect(
-      defineSavedMetrics({
-        id: 1,
-        metrics: [
-          {
-            metric_name: 'COUNT(*) non-default-dataset-metric',
-            expression: 'COUNT(*) non-default-dataset-metric',
-          },
-        ],
-        type: DatasourceType.Table,
-        main_dttm_col: 'test',
-        time_grain_sqla: 'P1D',
-        columns: [],
-        verbose_map: {},
-        column_format: {},
-        datasource_name: 'my_datasource',
-        description: 'this is my datasource',
-      }),
-    ).toEqual([
+    const dataset = {
+      id: 1,
+      metrics: [
+        {
+          metric_name: 'COUNT(*) non-default-dataset-metric',
+          expression: 'COUNT(*) non-default-dataset-metric',
+        },
+      ],
+      type: DatasourceType.Table,
+      main_dttm_col: 'test',
+      time_grain_sqla: 'P1D',
+      columns: [],
+      verbose_map: {},
+      column_format: {},
+      datasource_name: 'my_datasource',
+      description: 'this is my datasource',
+    };
+    expect(defineSavedMetrics(dataset)).toEqual([
       {
         metric_name: 'COUNT(*) non-default-dataset-metric',
         expression: 'COUNT(*) non-default-dataset-metric',
       },
     ]);
+    // @ts-ignore
+    expect(defineSavedMetrics({ ...dataset, metrics: undefined })).toEqual([]);
   });
 
   it('returns default saved metrics if souce is a Query', () => {

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Dashboard.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Dashboard.ts
@@ -127,3 +127,5 @@ export type DashboardComponentMetadata = {
   nativeFilters: NativeFiltersState;
   dataMask: DataMaskStateWithId;
 };
+
+export default {};

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
@@ -363,14 +363,14 @@ export const testQuery: Query = {
       is_dttm: false,
     },
     {
-      name: 'Column 2',
-      type: DatasourceType.Query,
-      is_dttm: true,
-    },
-    {
       name: 'Column 3',
       type: DatasourceType.Query,
       is_dttm: false,
+    },
+    {
+      name: 'Column 2',
+      type: DatasourceType.Query,
+      is_dttm: true,
     },
   ],
 };

--- a/superset-frontend/packages/superset-ui-core/src/query/types/index.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/index.ts
@@ -27,6 +27,7 @@ export * from './QueryResponse';
 export * from './Time';
 export * from './AdvancedAnalytics';
 export * from './PostProcessing';
+export * from './Dashboard';
 
 export { default as __hack_reexport_Datasource } from './Datasource';
 export { default as __hack_reexport_Column } from './Column';
@@ -36,5 +37,6 @@ export { default as __hack_reexport_QueryResponse } from './QueryResponse';
 export { default as __hack_reexport_QueryFormData } from './QueryFormData';
 export { default as __hack_reexport_Time } from './Time';
 export { default as __hack_reexport_AdvancedAnalytics } from './AdvancedAnalytics';
+export { default as __hack_reexport_Dashboard } from './Dashboard';
 
 export default {};

--- a/superset-frontend/packages/superset-ui-core/test/query/types/Dashboard.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/types/Dashboard.test.ts
@@ -16,22 +16,32 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import {
+  isNativeFilter,
+  isFilterDivider,
+  Filter,
+  NativeFilterType,
+} from '@superset-ui/core';
 
-export * from './models';
-export * from './utils';
-export * from './types';
-export * from './translation';
-export * from './connection';
-export * from './dynamic-plugins';
-export * from './query';
-export * from './number-format';
-export * from './time-format';
-export * from './dimension';
-export * from './color';
-export * from './style';
-export * from './validator';
-export * from './chart';
-export * from './chart-composition';
-export * from './components';
-export * from './math-expression';
-export * from './ui-overrides';
+test('should do native filter type guard', () => {
+  const dummyFilter: Filter = {
+    cascadeParentIds: [],
+    defaultDataMask: {},
+    id: 'dummyID',
+    name: 'dummyName',
+    scope: { rootPath: [], excluded: [] },
+    filterType: 'dummyType',
+    targets: [{}],
+    controlValues: {},
+    type: NativeFilterType.NATIVE_FILTER,
+    description: 'dummyDesc',
+  };
+  expect(isNativeFilter(dummyFilter)).toBeTruthy();
+  expect(
+    isFilterDivider({
+      ...dummyFilter,
+      type: NativeFilterType.DIVIDER,
+      title: 'dummyTitle',
+    }),
+  ).toBeTruthy();
+});

--- a/superset-frontend/packages/superset-ui-core/test/ui-overrides/UiOverrideRegistry.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/ui-overrides/UiOverrideRegistry.test.ts
@@ -16,5 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { getUiOverrideRegistry } from '@superset-ui/core';
 
-export * from './types/Base';
+test('should get instance of getUiOverrideRegistry', () => {
+  expect(getUiOverrideRegistry().name).toBe('UiOverrideRegistry');
+});


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix `superset-ui/core` codes coverage and enabled coverage output in the terminal.

Test this PR by following command
```shell
cd superset-frontend
rm -rf coverage
npx jest --coverage --collectCoverageFrom='["packages/**/src/**/*.{js,ts}", "!packages/superset-ui-demo/**/*"]' packages
```

![image](https://user-images.githubusercontent.com/2016594/172807104-b1253fa5-cf9b-4541-9251-76fae959fae9.png)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A
### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
