### PR TITLE
fix(sqllab):clickhouse result no column header

### DIFF
--- a/superset/db_engine_specs/clickhouse.py
+++ b/superset/db_engine_specs/clickhouse.py
@@ -120,3 +120,19 @@ class ClickHouseEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method
 
         # otherwise, return no function names to prevent errors
         return []
+
+    FORMAT_SUFFIX = "FORMAT TabSeparatedWithNamesAndTypes"
+
+    @classmethod
+    def execute(  # pylint: disable=unused-argument
+        cls,
+        cursor: Any,
+        query: str,
+        **kwargs: Any,
+    ) -> None:
+
+        raw_sql_big = query.upper()
+        if "FORMAT" in raw_sql_big and "INSERT" not in raw_sql_big:
+            query = f"{query} {cls.FORMAT_SUFFIX}"
+
+        super().execute(cursor, query, **kwargs)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
version : superset 1.5.0
python : 3.8
connect db：clickhouse + **http**（8123）


if you run any clickhouse sql  with "**format**" keyword， returned results have no column headers，the first row of results will be the column header。

![image](https://user-images.githubusercontent.com/16257260/172777464-d5868669-e8db-41f1-830b-2e28583c13eb.png)

In this case, if the first column has a null value, an error will be thrown directly。

After troubleshooting, the problem lies in the referenced package clickhouse_sqlalchemy/drivers/http/connector.py:112 
![image](https://user-images.githubusercontent.com/16257260/172778065-01de0c6d-fbd6-433a-a6b5-1f99a9f465fd.png)

Therefore, the SQL with format keyword needs to add format parameters “FORMAT TabSeparatedWithNamesAndTypes” manually


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before
![image](https://user-images.githubusercontent.com/16257260/172776043-c9655f92-7a1d-464d-b62b-814ead8f0900.png)

after
![image](https://user-images.githubusercontent.com/16257260/172775964-84e4380b-deb1-46c2-a671-fd78e519b1d2.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1、run any clickhouse sql with "format" keyword. like 
`select subtractDays(toDateTime(formatDateTime(now(),'%Y-%m-%d 00:00:00')),2) as t`



### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
        Fixes #19253 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
