### PR TITLE
fix(fbprophet): Fix weekly frequencies

### DIFF
--- a/superset/utils/pandas_postprocessing/utils.py
+++ b/superset/utils/pandas_postprocessing/utils.py
@@ -86,10 +86,10 @@ PROPHET_TIME_GRAIN_MAP = {
     "P1M": "M",
     "P3M": "Q",
     "P1Y": "A",
-    "1969-12-28T00:00:00Z/P1W": "W",
-    "1969-12-29T00:00:00Z/P1W": "W",
-    "P1W/1970-01-03T00:00:00Z": "W",
-    "P1W/1970-01-04T00:00:00Z": "W",
+    "1969-12-28T00:00:00Z/P1W": "W-SUN",
+    "1969-12-29T00:00:00Z/P1W": "W-MON",
+    "P1W/1970-01-03T00:00:00Z": "W-SAT",
+    "P1W/1970-01-04T00:00:00Z": "W-SUN",
 }
 
 RESAMPLE_METHOD = ("asfreq", "bfill", "ffill", "linear", "median", "mean", "sum")

--- a/tests/unit_tests/pandas_postprocessing/test_prophet.py
+++ b/tests/unit_tests/pandas_postprocessing/test_prophet.py
@@ -17,6 +17,7 @@
 from datetime import datetime
 from importlib.util import find_spec
 
+import pandas as pd
 import pytest
 
 from superset.exceptions import InvalidPostProcessingError
@@ -49,6 +50,66 @@ def test_prophet_valid():
     assert df[DTTM_ALIAS].iloc[0].to_pydatetime() == datetime(2018, 12, 31)
     assert df[DTTM_ALIAS].iloc[-1].to_pydatetime() == datetime(2022, 5, 31)
     assert len(df) == 9
+
+    df = prophet(
+        df=pd.DataFrame(
+            {
+                "__timestamp": [datetime(2022, 1, 2), datetime(2022, 1, 9)],
+                "x": [1, 1],
+            }
+        ),
+        time_grain="P1W",
+        periods=1,
+        confidence_interval=0.9,
+    )
+
+    assert df[DTTM_ALIAS].iloc[-1].to_pydatetime() == datetime(2022, 1, 16)
+    assert len(df) == 3
+
+    df = prophet(
+        df=pd.DataFrame(
+            {
+                "__timestamp": [datetime(2022, 1, 2), datetime(2022, 1, 9)],
+                "x": [1, 1],
+            }
+        ),
+        time_grain="1969-12-28T00:00:00Z/P1W",
+        periods=1,
+        confidence_interval=0.9,
+    )
+
+    assert df[DTTM_ALIAS].iloc[-1].to_pydatetime() == datetime(2022, 1, 16)
+    assert len(df) == 3
+
+    df = prophet(
+        df=pd.DataFrame(
+            {
+                "__timestamp": [datetime(2022, 1, 3), datetime(2022, 1, 10)],
+                "x": [1, 1],
+            }
+        ),
+        time_grain="1969-12-29T00:00:00Z/P1W",
+        periods=1,
+        confidence_interval=0.9,
+    )
+
+    assert df[DTTM_ALIAS].iloc[-1].to_pydatetime() == datetime(2022, 1, 17)
+    assert len(df) == 3
+
+    df = prophet(
+        df=pd.DataFrame(
+            {
+                "__timestamp": [datetime(2022, 1, 8), datetime(2022, 1, 15)],
+                "x": [1, 1],
+            }
+        ),
+        time_grain="P1W/1970-01-03T00:00:00Z",
+        periods=1,
+        confidence_interval=0.9,
+    )
+
+    assert df[DTTM_ALIAS].iloc[-1].to_pydatetime() == datetime(2022, 1, 22)
+    assert len(df) == 3
 
 
 def test_prophet_valid_zero_periods():


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

The `fbprophet` packages uses [`pandas.date_range`](https://pandas.pydata.org/docs/reference/api/pandas.date_range.html) per [here](https://github.com/facebook/prophet/blob/10310ceb2da05837a198db6714d658a1e0a32478/python/prophet/forecaster.py#L1567-L1570) for defining the forecast window where the frequency is defined via an [offset alias](https://pandas.pydata.org/docs/user_guide/timeseries.html#timeseries-offset-aliases).

Previously the mapping was wrong, i.e., [these weeks](https://github.com/apache/superset/blob/master/superset/db_engine_specs/base.py#L112-L115) which use different days of the weeks as anchors (alongside the direction of the anchor, i.e., starting vs. ending) previously all mapped to `W` which is the same as `W-SUN` and thus weekly forecasts did not adhere to the correct periodicity defined in the fitted data.

The fix is merely to use the [anchored offsets](https://pandas.pydata.org/docs/user_guide/timeseries.html#anchored-offsets). Pandas doesn't do a great job in specifying whether it's the week starting or week ending on Sunday say for `W-SUN`, however it's irrelevant for our needs, i.e., for both "Week starting Sunday" and "Week ending Sunday" the data provided by Superset to `fbprohet` has been bucketed appropriately and anchored on a Sunday and thus all `fbprohet` needs to know is Sundays (`W-SUN`) defines the weekly periodicity.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Tested locally and updated unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
