### PR TITLE
chore: Add eslint rule to ensure correct sections order in control panel

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -73,6 +73,7 @@ module.exports = {
     'file-progress',
     'theme-colors',
     'translation-vars',
+    'control-panel',
   ],
   overrides: [
     {
@@ -206,6 +207,17 @@ module.exports = {
         'theme-colors/no-literal-colors': 0,
         'translation-vars/no-template-vars': 0,
         'no-restricted-imports': 0,
+      },
+    },
+    {
+      files: [
+        'plugins/**/controlPanel.tsx',
+        'plugins/**/controlPanel.jsx',
+        'plugins/**/controlPanel.ts',
+        'plugins/**/controlPanel.js',
+      ],
+      rules: {
+        'control-panel/ensure-sections-order': 'error',
       },
     },
   ],

--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -217,7 +217,7 @@ module.exports = {
         'plugins/**/controlPanel.js',
       ],
       rules: {
-        'control-panel/ensure-sections-order': 'error',
+        'control-panel/ensure-sections-order': 'warn',
       },
     },
   ],

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -223,6 +223,7 @@
         "eslint-config-airbnb": "^18.2.1",
         "eslint-config-prettier": "^7.1.0",
         "eslint-import-resolver-typescript": "^2.5.0",
+        "eslint-plugin-control-panel": "file:tools/eslint-plugin-control-panel",
         "eslint-plugin-cypress": "^2.11.2",
         "eslint-plugin-file-progress": "^1.2.0",
         "eslint-plugin-import": "^2.24.2",
@@ -27597,6 +27598,10 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/eslint-plugin-control-panel": {
+      "resolved": "tools/eslint-plugin-control-panel",
+      "link": true
     },
     "node_modules/eslint-plugin-cypress": {
       "version": "2.11.2",
@@ -55630,6 +55635,18 @@
       "version": "0.0.1",
       "extraneous": true
     },
+    "tools/eslint-plugin-control-panel": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^16.9.1",
+        "npm": "^7.5.4"
+      },
+      "peerDependencies": {
+        "eslint": ">=0.8.0"
+      }
+    },
     "tools/eslint-plugin-theme-colors": {
       "version": "1.0.0",
       "dev": true,
@@ -77619,6 +77636,10 @@
           }
         }
       }
+    },
+    "eslint-plugin-control-panel": {
+      "version": "file:tools/eslint-plugin-control-panel",
+      "requires": {}
     },
     "eslint-plugin-cypress": {
       "version": "2.11.2",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -296,6 +296,7 @@
     "eslint-plugin-testing-library": "^3.10.1",
     "eslint-plugin-theme-colors": "file:tools/eslint-plugin-theme-colors",
     "eslint-plugin-translation-vars": "file:tools/eslint-plugin-translation-vars",
+    "eslint-plugin-control-panel": "file:tools/eslint-plugin-control-panel",
     "exports-loader": "^0.7.0",
     "fetch-mock": "^7.7.3",
     "fork-ts-checker-webpack-plugin": "^6.3.3",

--- a/superset-frontend/tools/eslint-plugin-control-panel/ensure-section-order.test.js
+++ b/superset-frontend/tools/eslint-plugin-control-panel/ensure-section-order.test.js
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @fileoverview Test rule to warn about incorrect order of sections in control panel
+ * @author Apache
+ */
+
+const { RuleTester } = require('eslint');
+const plugin = require('.');
+const {
+  fullControlPanel,
+  controlPanelWithNoTimeSection,
+  controlPanelWithNoFilterAndSettingsSection,
+  fullControlPanelWithTableSection,
+  controlPanelWithNoChartSection,
+  controlPanelWithFilterBeforeTime,
+  controlPanelWithSettingsFirst,
+} = require('./fixtures');
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+});
+const rule = plugin.rules['ensure-sections-order'];
+
+const errors = [
+  {
+    type: 'ExportDefaultDeclaration',
+  },
+];
+
+ruleTester.run('ensure-sections-order', rule, {
+  valid: [
+    fullControlPanel,
+    controlPanelWithNoTimeSection,
+    controlPanelWithNoFilterAndSettingsSection,
+    fullControlPanelWithTableSection,
+  ],
+  invalid: [
+    controlPanelWithNoChartSection,
+    controlPanelWithFilterBeforeTime,
+    controlPanelWithSettingsFirst,
+  ].map(invalidTestCase => ({ ...invalidTestCase, errors })),
+});

--- a/superset-frontend/tools/eslint-plugin-control-panel/ensure-section-order.test.js
+++ b/superset-frontend/tools/eslint-plugin-control-panel/ensure-section-order.test.js
@@ -29,6 +29,8 @@ const {
   controlPanelWithNoTimeSection,
   controlPanelWithNoFilterAndSettingsSection,
   fullControlPanelWithTableSection,
+  controlPanelWithConfigAsVariable,
+  controlPanelWithExportAsDefault,
   controlPanelWithNoChartSection,
   controlPanelWithFilterBeforeTime,
   controlPanelWithSettingsFirst,
@@ -55,6 +57,8 @@ ruleTester.run('ensure-sections-order', rule, {
     controlPanelWithNoTimeSection,
     controlPanelWithNoFilterAndSettingsSection,
     fullControlPanelWithTableSection,
+    controlPanelWithConfigAsVariable,
+    controlPanelWithExportAsDefault,
   ],
   invalid: [
     controlPanelWithNoChartSection,

--- a/superset-frontend/tools/eslint-plugin-control-panel/fixtures.js
+++ b/superset-frontend/tools/eslint-plugin-control-panel/fixtures.js
@@ -152,6 +152,64 @@ const fullControlPanelWithTableSection = {
   };`,
 };
 
+const controlPanelWithConfigAsVariable = {
+  code: `
+  const config = {
+    controlPanelSections: [
+      {
+        label: t('Chart'),
+        controlSetRows: [['metric']],
+      },
+      {
+        label: t('Time'),
+        controlSetRows: [['granularity']],
+      },
+      {
+        label: 'Some other section 1',
+        controlSetRows: [['control']],
+      },
+      {
+        label: 'Some other section 2',
+        controlSetRows: [['control']],
+      },
+      {
+        label: 'Some other section 3',
+        controlSetRows: [['control']],
+      },
+    ],
+  };
+  export default config;`,
+};
+
+const controlPanelWithExportAsDefault = {
+  code: `
+  const config = {
+    controlPanelSections: [
+      {
+        label: t('Chart'),
+        controlSetRows: [['metric']],
+      },
+      {
+        label: t('Time'),
+        controlSetRows: [['granularity']],
+      },
+      {
+        label: 'Some other section 1',
+        controlSetRows: [['control']],
+      },
+      {
+        label: 'Some other section 2',
+        controlSetRows: [['control']],
+      },
+      {
+        label: 'Some other section 3',
+        controlSetRows: [['control']],
+      },
+    ],
+  };
+  export { config as default };`,
+};
+
 // ----------------------
 // INVALID CONTROL PANELS
 // ----------------------
@@ -268,6 +326,8 @@ module.exports = {
   controlPanelWithNoTimeSection,
   controlPanelWithNoFilterAndSettingsSection,
   fullControlPanelWithTableSection,
+  controlPanelWithConfigAsVariable,
+  controlPanelWithExportAsDefault,
   controlPanelWithNoChartSection,
   controlPanelWithFilterBeforeTime,
   controlPanelWithSettingsFirst,

--- a/superset-frontend/tools/eslint-plugin-control-panel/fixtures.js
+++ b/superset-frontend/tools/eslint-plugin-control-panel/fixtures.js
@@ -1,0 +1,274 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// --------------------
+// VALID CONTROL PANELS
+// --------------------
+const fullControlPanel = {
+  code: `
+  export default {
+    controlPanelSections: [
+      {
+        label: t('Chart'),
+        controlSetRows: [['metric']],
+      },
+      {
+        label: t('Time'),
+        controlSetRows: [['granularity']],
+      },
+      {
+        label: 'Some other section 1',
+        controlSetRows: [['control']],
+      },
+      {
+        label: 'Filter',
+        controlSetRows: [['adhoc_filters']],
+      },
+      {
+        label: 'Some other section 2',
+        controlSetRows: [['control']],
+      },
+      {
+        label: t('Advanced query settings'),
+        controlSetRows: [['control']],
+      },
+      {
+        label: 'Some other section 3',
+        controlSetRows: [['control']],
+      },
+    ],
+  };`,
+};
+
+const controlPanelWithNoTimeSection = {
+  code: `
+  export default {
+    controlPanelSections: [
+      {
+        label: t('Chart'),
+        controlSetRows: [['metric']],
+      },
+      {
+        label: 'Some other section 1',
+        controlSetRows: [['control']],
+      },
+      {
+        label: 'Filter',
+        controlSetRows: [['adhoc_filters']],
+      },
+      {
+        label: 'Some other section 2',
+        controlSetRows: [['control']],
+      },
+      {
+        label: t('Chart settings'),
+        controlSetRows: [['control']],
+      },
+      {
+        label: 'Some other section 3',
+        controlSetRows: [['control']],
+      },
+    ],
+  };`,
+};
+
+const controlPanelWithNoFilterAndSettingsSection = {
+  code: `
+  export default {
+    controlPanelSections: [
+      {
+        label: t('Chart'),
+        controlSetRows: [['metric']],
+      },
+      {
+        label: t('Time'),
+        controlSetRows: [['granularity']],
+      },
+      {
+        label: 'Some other section 1',
+        controlSetRows: [['control']],
+      },
+      {
+        label: 'Some other section 2',
+        controlSetRows: [['control']],
+      },
+      {
+        label: 'Some other section 3',
+        controlSetRows: [['control']],
+      },
+    ],
+  };`,
+};
+
+const fullControlPanelWithTableSection = {
+  code: `
+  export default {
+    controlPanelSections: [
+      {
+        label: t('Table'),
+        controlSetRows: [['metric']],
+      },
+      {
+        label: t('Time'),
+        controlSetRows: [['granularity']],
+      },
+      {
+        label: 'Some other section 1',
+        controlSetRows: [['control']],
+      },
+      {
+        label: 'Filter',
+        controlSetRows: [['adhoc_filters']],
+      },
+      {
+        label: 'Some other section 2',
+        controlSetRows: [['control']],
+      },
+      {
+        label: t('Advanced query settings'),
+        controlSetRows: [['control']],
+      },
+      {
+        label: 'Some other section 3',
+        controlSetRows: [['control']],
+      },
+    ],
+  };`,
+};
+
+// ----------------------
+// INVALID CONTROL PANELS
+// ----------------------
+const controlPanelWithNoChartSection = {
+  code: `
+  export default {
+    controlPanelSections: [
+      {
+        label: t('Query'),
+        controlSetRows: [['metric']],
+      },
+      {
+        label: t('Time'),
+        controlSetRows: [['granularity']],
+      },
+      {
+        label: 'Some other section 1',
+        controlSetRows: [['control']],
+      },
+      {
+        label: 'Filter',
+        controlSetRows: [['adhoc_filters']],
+      },
+      {
+        label: 'Some other section 2',
+        controlSetRows: [['control']],
+      },
+      {
+        label: t('Advanced query settings'),
+        controlSetRows: [['control']],
+      },
+      {
+        label: 'Some other section 3',
+        controlSetRows: [['control']],
+      },
+    ],
+  };`,
+};
+
+const controlPanelWithFilterBeforeTime = {
+  code: `
+  export default {
+    controlPanelSections: [
+      {
+        label: t('Chart'),
+        controlSetRows: [['metric']],
+      },
+      {
+        label: 'Filter',
+        controlSetRows: [['adhoc_filters']],
+      },
+      {
+        label: t('Time'),
+        controlSetRows: [['granularity']],
+      },
+      {
+        label: 'Some other section 1',
+        controlSetRows: [['control']],
+      },
+      {
+        label: 'Some other section 2',
+        controlSetRows: [['control']],
+      },
+      {
+        label: t('Advanced query settings'),
+        controlSetRows: [['control']],
+      },
+      {
+        label: 'Some other section 3',
+        controlSetRows: [['control']],
+      },
+    ],
+  };`,
+};
+
+const controlPanelWithSettingsFirst = {
+  code: `
+  export default {
+    controlPanelSections: [
+      {
+        label: t('Chart settings'),
+        controlSetRows: [['control']],
+      },
+      {
+        label: t('Chart'),
+        controlSetRows: [['metric']],
+      },
+      {
+        label: 'Filter',
+        controlSetRows: [['adhoc_filters']],
+      },
+      {
+        label: t('Time'),
+        controlSetRows: [['granularity']],
+      },
+      {
+        label: 'Some other section 1',
+        controlSetRows: [['control']],
+      },
+      {
+        label: 'Some other section 2',
+        controlSetRows: [['control']],
+      },
+      {
+        label: 'Some other section 3',
+        controlSetRows: [['control']],
+      },
+    ],
+  };`,
+};
+
+module.exports = {
+  fullControlPanel,
+  controlPanelWithNoTimeSection,
+  controlPanelWithNoFilterAndSettingsSection,
+  fullControlPanelWithTableSection,
+  controlPanelWithNoChartSection,
+  controlPanelWithFilterBeforeTime,
+  controlPanelWithSettingsFirst,
+};

--- a/superset-frontend/tools/eslint-plugin-control-panel/index.js
+++ b/superset-frontend/tools/eslint-plugin-control-panel/index.js
@@ -29,7 +29,7 @@
 // The section order is still in development, might be a subject to changes
 const EXPECTED_SECTIONS_ORDER = [
   {
-    name: /^Chart|Table|Map$/i,
+    name: /^(Chart|Table|Map)$/i,
     isOptional: false,
     isPositionFixed: true,
     stringifiedName: 'Chart, Table or Map',
@@ -44,21 +44,47 @@ const EXPECTED_SECTIONS_ORDER = [
   },
 ];
 
-const errorMessage = `The order of control panel sections is not correct. The expected section order is: \n${EXPECTED_SECTIONS_ORDER.map(
-  section =>
-    `${section.stringifiedName || section.name}${
-      section.isOptional ? ' (optional)' : ''
-    }`,
-).join('\n')}`;
+const getErrorMessage = faultySection =>
+  `\nThe order of control panel sections is not correct. The expected section order is: \n${EXPECTED_SECTIONS_ORDER.map(
+    section =>
+      `${section.stringifiedName || section.name}${
+        section.isOptional ? ' (optional)' : ''
+      }`,
+  ).join('\n')} \n\nSection ${
+    faultySection.stringifiedName || faultySection.name
+  } is in wrong place${faultySection.isOptional ? '.' : ' or missing.'}`;
+
+function getControlPanelAsObjectExpression(context, node) {
+  if (node.declaration?.type === 'ObjectExpression') {
+    return node.declaration;
+  }
+  let identifierNode;
+  if (node.declaration?.type === 'Identifier') {
+    identifierNode = node.declaration;
+  } else if (node.type === 'ExportNamedDeclaration') {
+    identifierNode = node.specifiers?.find(
+      specifier => specifier.exported?.name === 'default',
+    )?.local;
+  }
+  if (identifierNode?.type === 'Identifier') {
+    const variableDef = context.getScope().set.get(identifierNode.name)
+      ?.defs?.[0];
+    if (
+      variableDef?.type === 'Variable' &&
+      variableDef?.node?.type === 'VariableDeclarator' &&
+      variableDef?.node?.init?.type === 'ObjectExpression'
+    ) {
+      return variableDef.node.init;
+    }
+  }
+  return null;
+}
 
 function getSectionLabels(node) {
-  if (
-    node.declaration?.type !== 'ObjectExpression' ||
-    !Array.isArray(node.declaration.properties)
-  ) {
+  if (!Array.isArray(node.properties)) {
     return [];
   }
-  const controlPanelSections = node.declaration.properties.find(
+  const controlPanelSections = node.properties.find(
     property => property.key.name === 'controlPanelSections',
   );
   if (
@@ -69,8 +95,8 @@ function getSectionLabels(node) {
   }
   return controlPanelSections.value.elements.reduce((acc, element) => {
     const labelNode = element.properties?.find(
-      property => property.key.name === 'label',
-    ).value;
+      property => property.key?.name === 'label',
+    )?.value;
     // labelNode is CallExpression if translation is used, otherwise Literal
     if (
       labelNode?.type === 'CallExpression' &&
@@ -85,15 +111,15 @@ function getSectionLabels(node) {
   }, []);
 }
 
-function isOrderCorrect(sectionLabels) {
-  return EXPECTED_SECTIONS_ORDER.every((section, index) => {
+function findSectionInWrongOrder(sectionLabels) {
+  return EXPECTED_SECTIONS_ORDER.find((section, index) => {
     // false if not optional section is missing
     if (!sectionLabels.some(label => label.match(section.name))) {
-      return section.isOptional;
+      return !section.isOptional;
     }
     // false if section has incorrect index
     if (section.isPositionFixed) {
-      return sectionLabels[index].match(section.name);
+      return !sectionLabels[index].match(section.name);
     }
     const sectionIndex = sectionLabels.findIndex(label =>
       label.match(section.name),
@@ -101,9 +127,9 @@ function isOrderCorrect(sectionLabels) {
     // false if order of sections is incorrect
     return sectionLabels
       .slice(0, sectionIndex)
-      .every(
+      .some(
         prevSection =>
-          sectionLabels.findIndex(label => label.match(prevSection.name)) <
+          sectionLabels.findIndex(label => label.match(prevSection.name)) >=
           sectionIndex,
       );
   });
@@ -115,16 +141,24 @@ module.exports = {
     'ensure-sections-order': {
       create(context) {
         function handler(node) {
-          const sectionLabels = getSectionLabels(node);
-          if (sectionLabels.length > 0 && !isOrderCorrect(sectionLabels)) {
-            context.report({
-              node,
-              message: errorMessage,
-            });
+          const controlPanelObject = getControlPanelAsObjectExpression(
+            context,
+            node,
+          );
+          if (controlPanelObject) {
+            const sectionLabels = getSectionLabels(controlPanelObject);
+            const sectionInWrongOrder = findSectionInWrongOrder(sectionLabels);
+            if (sectionInWrongOrder) {
+              context.report({
+                node,
+                message: getErrorMessage(sectionInWrongOrder),
+              });
+            }
           }
         }
         return {
           ExportDefaultDeclaration: handler,
+          ExportNamedDeclaration: handler,
         };
       },
     },

--- a/superset-frontend/tools/eslint-plugin-control-panel/index.js
+++ b/superset-frontend/tools/eslint-plugin-control-panel/index.js
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @fileoverview Rule to warn about incorrect order of sections in control panel
+ * @author Apache
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+// The section order is still in development, might be a subject to changes
+const EXPECTED_SECTIONS_ORDER = [
+  {
+    name: /^Chart|Table|Map$/i,
+    isOptional: false,
+    isPositionFixed: true,
+    stringifiedName: 'Chart, Table or Map',
+  },
+  { name: 'Time', isOptional: true, isPositionFixed: true },
+  { name: 'Filter', isOptional: true, isPositionFixed: false },
+  {
+    name: /Settings/i,
+    isOptional: true,
+    isPositionFixed: false,
+    stringifiedName: 'Settings or alike',
+  },
+];
+
+const errorMessage = `The order of control panel sections is not correct. The expected section order is: \n${EXPECTED_SECTIONS_ORDER.map(
+  section =>
+    `${section.stringifiedName || section.name}${
+      section.isOptional ? ' (optional)' : ''
+    }`,
+).join('\n')}`;
+
+function getSectionLabels(node) {
+  if (
+    node.declaration?.type !== 'ObjectExpression' ||
+    !Array.isArray(node.declaration.properties)
+  ) {
+    return [];
+  }
+  const controlPanelSections = node.declaration.properties.find(
+    property => property.key.name === 'controlPanelSections',
+  );
+  if (
+    !controlPanelSections ||
+    controlPanelSections.value?.type !== 'ArrayExpression'
+  ) {
+    return [];
+  }
+  return controlPanelSections.value.elements.reduce((acc, element) => {
+    const labelNode = element.properties?.find(
+      property => property.key.name === 'label',
+    ).value;
+    // labelNode is CallExpression if translation is used, otherwise Literal
+    if (
+      labelNode?.type === 'CallExpression' &&
+      labelNode?.callee.name === 't' &&
+      labelNode?.arguments.length === 1
+    ) {
+      acc.push(labelNode.arguments[0].value);
+    } else if (labelNode?.type === 'Literal') {
+      acc.push(labelNode.value);
+    }
+    return acc;
+  }, []);
+}
+
+function isOrderCorrect(sectionLabels) {
+  return EXPECTED_SECTIONS_ORDER.every((section, index) => {
+    // false if not optional section is missing
+    if (!sectionLabels.some(label => label.match(section.name))) {
+      return section.isOptional;
+    }
+    // false if section has incorrect index
+    if (section.isPositionFixed) {
+      return sectionLabels[index].match(section.name);
+    }
+    const sectionIndex = sectionLabels.findIndex(label =>
+      label.match(section.name),
+    );
+    // false if order of sections is incorrect
+    return sectionLabels
+      .slice(0, sectionIndex)
+      .every(
+        prevSection =>
+          sectionLabels.findIndex(label => label.match(prevSection.name)) <
+          sectionIndex,
+      );
+  });
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  rules: {
+    'ensure-sections-order': {
+      create(context) {
+        function handler(node) {
+          const sectionLabels = getSectionLabels(node);
+          if (sectionLabels.length > 0 && !isOrderCorrect(sectionLabels)) {
+            context.report({
+              node,
+              message: errorMessage,
+            });
+          }
+        }
+        return {
+          ExportDefaultDeclaration: handler,
+        };
+      },
+    },
+  },
+};

--- a/superset-frontend/tools/eslint-plugin-control-panel/package.json
+++ b/superset-frontend/tools/eslint-plugin-control-panel/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "eslint-plugin-control-panel",
+  "version": "1.0.0",
+  "description": "Warns about incorrect order of sections in control panel",
+  "main": "index.js",
+  "keywords": [],
+  "license": "Apache-2.0",
+  "author": "Apache",
+  "dependencies": {},
+  "peerDependencies": {
+    "eslint": ">=0.8.0"
+  },
+  "engines": {
+    "node": "^16.9.1",
+    "npm": "^7.5.4"
+  }
+}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Ensure that control panel sections are in order:
1. Chart
2. Time
3. Filter
4. Settings

This should be merged after control panels of tier 1 and tier 2 charts are rearranged

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="615" alt="image" src="https://user-images.githubusercontent.com/15073128/173082687-39d74d10-70d5-41cc-8d16-12b701b6475a.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
