### PR TITLE
fix: ensure column name in description is string

### DIFF
--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -101,10 +101,9 @@ class SupersetResultSet:
 
         if cursor_description:
             # get deduped list of column names
-            column_names = dedup([col[0] for col in cursor_description])
-
-            # ensure colum names are strings (see #20137)
-            column_names = [convert_to_string(name) for name in column_names]
+            column_names = dedup(
+                [convert_to_string(col[0]) for col in cursor_description]
+            )
 
             # fix cursor descriptor with the deduped names
             deduped_cursor_desc = [

--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -71,6 +71,19 @@ def destringify(obj: str) -> Any:
     return json.loads(obj)
 
 
+def convert_to_string(value: Any) -> str:
+    """
+    Used to ensure column names from the cursor description are strings.
+    """
+    if isinstance(value, str):
+        return value
+
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+
+    return str(value)
+
+
 class SupersetResultSet:
     def __init__(  # pylint: disable=too-many-locals
         self,
@@ -89,6 +102,9 @@ class SupersetResultSet:
         if cursor_description:
             # get deduped list of column names
             column_names = dedup([col[0] for col in cursor_description])
+
+            # ensure colum names are strings (see #20137)
+            column_names = [convert_to_string(name) for name in column_names]
 
             # fix cursor descriptor with the deduped names
             deduped_cursor_desc = [

--- a/superset/superset_typing.py
+++ b/superset/superset_typing.py
@@ -69,7 +69,13 @@ class ResultSetColumnType(TypedDict):
 
 CacheConfig = Dict[str, Any]
 DbapiDescriptionRow = Tuple[
-    str, str, Optional[str], Optional[str], Optional[int], Optional[int], bool
+    Union[str, bytes],
+    str,
+    Optional[str],
+    Optional[str],
+    Optional[int],
+    Optional[int],
+    bool,
 ]
 DbapiDescription = Union[List[DbapiDescriptionRow], Tuple[DbapiDescriptionRow, ...]]
 DbapiResult = Sequence[Union[List[Any], Tuple[Any, ...]]]

--- a/tests/unit_tests/result_set_test.py
+++ b/tests/unit_tests/result_set_test.py
@@ -1,0 +1,67 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# pylint: disable=import-outside-toplevel, unused-argument
+
+
+def test_column_names_as_bytes(app_context: None) -> None:
+    """
+    Test that we can handle column names as bytes.
+    """
+    from superset.db_engine_specs.redshift import RedshiftEngineSpec
+    from superset.result_set import SupersetResultSet
+
+    data = (
+        [
+            "2016-01-26",
+            392.002014,
+            397.765991,
+            390.575012,
+            392.153015,
+            392.153015,
+            58147000,
+        ],
+        [
+            "2016-01-27",
+            392.444,
+            396.842987,
+            391.782013,
+            394.971985,
+            394.971985,
+            47424400,
+        ],
+    )
+    description = [
+        (b"date", 1043, None, None, None, None, None),
+        (b"open", 701, None, None, None, None, None),
+        (b"high", 701, None, None, None, None, None),
+        (b"low", 701, None, None, None, None, None),
+        (b"close", 701, None, None, None, None, None),
+        (b"adj close", 701, None, None, None, None, None),
+        (b"volume", 20, None, None, None, None, None),
+    ]
+    result_set = SupersetResultSet(data, description, RedshiftEngineSpec)  # type: ignore
+
+    assert (
+        result_set.to_pandas_df().to_markdown()
+        == """
+|    | date       |    open |    high |     low |   close |   adj close |   volume |
+|---:|:-----------|--------:|--------:|--------:|--------:|------------:|---------:|
+|  0 | 2016-01-26 | 392.002 | 397.766 | 390.575 | 392.153 |     392.153 | 58147000 |
+|  1 | 2016-01-27 | 392.444 | 396.843 | 391.782 | 394.972 |     394.972 | 47424400 |
+    """.strip()
+    )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The `redshift_connector` driver returns column names as bytes in the  cursor description. I added some logic to handle them correctly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Added a test.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: https://github.com/apache/superset/issues/20137
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
