### PR TITLE
chore(rls): Remove passing global username

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1135,7 +1135,6 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
     def get_sqla_row_level_filters(
         self,
         template_processor: BaseTemplateProcessor,
-        username: Optional[str] = None,
     ) -> List[TextClause]:
         """
         Return the appropriate row level security filters for this table and the
@@ -1143,14 +1142,12 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
         Flask global namespace.
 
         :param template_processor: The template processor to apply to the filters.
-        :param username: Optional username if there's no user in the Flask global
-        namespace.
         :returns: A list of SQL clauses to be ANDed together.
         """
         all_filters: List[TextClause] = []
         filter_groups: Dict[Union[int, str], List[TextClause]] = defaultdict(list)
         try:
-            for filter_ in security_manager.get_rls_filters(self, username):
+            for filter_ in security_manager.get_rls_filters(self):
                 clause = self.text(
                     f"({template_processor.process_template(filter_.clause)})"
                 )

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1151,7 +1151,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         :param table: The table to check against
         :returns: A list of filters
         """
-        
+
         if not (hasattr(g, "user") and g.user is not None):
             return []
 

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1151,9 +1151,8 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         :param table: The table to check against
         :returns: A list of filters
         """
-        if hasattr(g, "user"):
-            user = g.user
-        else:
+        
+        if not (hasattr(g, "user") and g.user is not None):      
             return []
 
         # pylint: disable=import-outside-toplevel
@@ -1163,7 +1162,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             RowLevelSecurityFilter,
         )
 
-        user_roles = [role.id for role in self.get_user_roles(user)]
+        user_roles = [role.id for role in self.get_user_roles(g.user)]
         regular_filter_roles = (
             self.get_session()
             .query(RLSFilterRoles.c.rls_filter_id)

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1152,7 +1152,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         :returns: A list of filters
         """
         
-        if not (hasattr(g, "user") and g.user is not None):      
+        if not (hasattr(g, "user") and g.user is not None):
             return []
 
         # pylint: disable=import-outside-toplevel

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1143,15 +1143,12 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             ]
         return []
 
-    def get_rls_filters(
-        self,
-        table: "BaseDatasource",
-    ) -> List[SqlaQuery]:
+    def get_rls_filters(self, table: "BaseDatasource") -> List[SqlaQuery]:
         """
         Retrieves the appropriate row level security filters for the current user and
         the passed table.
 
-        :param BaseDatasource table: The table to check against.
+        :param table: The table to check against
         :returns: A list of filters
         """
         if hasattr(g, "user"):

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1146,21 +1146,16 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
     def get_rls_filters(
         self,
         table: "BaseDatasource",
-        username: Optional[str] = None,
     ) -> List[SqlaQuery]:
         """
         Retrieves the appropriate row level security filters for the current user and
         the passed table.
 
         :param BaseDatasource table: The table to check against.
-        :param Optional[str] username: Optional username if there's no user in the Flask
-        global namespace.
         :returns: A list of filters
         """
         if hasattr(g, "user"):
             user = g.user
-        elif username:
-            user = self.find_user(username=username)
         else:
             return []
 

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -208,7 +208,6 @@ def execute_sql_statement(  # pylint: disable=too-many-arguments,too-many-statem
                     parsed_query._parsed[0],  # pylint: disable=protected-access
                     database.id,
                     query.schema,
-                    username=get_username(),
                 )
             )
         )

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -553,7 +553,6 @@ def get_rls_for_table(
     candidate: Token,
     database_id: int,
     default_schema: Optional[str],
-    username: Optional[str] = None,
 ) -> Optional[TokenList]:
     """
     Given a table name, return any associated RLS predicates.
@@ -586,7 +585,7 @@ def get_rls_for_table(
     template_processor = dataset.get_template_processor()
     predicate = " AND ".join(
         str(filter_)
-        for filter_ in dataset.get_sqla_row_level_filters(template_processor, username)
+        for filter_ in dataset.get_sqla_row_level_filters(template_processor)
     )
     if not predicate:
         return None
@@ -601,7 +600,6 @@ def insert_rls(
     token_list: TokenList,
     database_id: int,
     default_schema: Optional[str],
-    username: Optional[str] = None,
 ) -> TokenList:
     """
     Update a statement inplace applying any associated RLS predicates.
@@ -623,7 +621,7 @@ def insert_rls(
         elif state == InsertRLSState.SEEN_SOURCE and (
             isinstance(token, Identifier) or token.ttype == Keyword
         ):
-            rls = get_rls_for_table(token, database_id, default_schema, username)
+            rls = get_rls_for_table(token, database_id, default_schema)
             if rls:
                 state = InsertRLSState.FOUND_TABLE
 

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -1409,7 +1409,6 @@ def test_insert_rls(
         candidate: Token,
         database_id: int,
         default_schema: str,
-        username: Optional[str] = None,
     ) -> Optional[TokenList]:
         """
         Return the RLS ``condition`` if ``candidate`` matches ``table``.


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

I'm not well versed in the row level security logic, but it seems there's functionality of the form,

```python
if hasattr(g, "user"):
    user = g.user
elif username:
    user = self.find_user(username=username)
else: 
    return []
```

to obtain the user associated with the RLS check. The issue is the optional `username`—which is used to set the user if no current user exists—was only specified once via `get_username()` which makes the the above logic behave like, 

```python
user = self.find_user(username=g.user.username if g.user else None)
```

which can be then refactored as,

```python
user = g.user if hasattr(g, "user") else None
```

which makes the `elif` clause unnecessarily as it's captured in the `if` clause. Furthermore that `g.user` and `self.find_user(...)` can return `None` and so the `else` should also replaced with the short circuit logic in essence returning if and only if there is isn't a user defined.

Said logic was added in https://github.com/apache/superset/pull/19999 but was likely made obsolete by https://github.com/apache/superset/pull/19914.

This PR removes the optional `username` argument throughout the RLS code path.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
