### PR TITLE
fix(docker): Make Gunicorn Keepalive Adjustable

### DIFF
--- a/docker/run-server.sh
+++ b/docker/run-server.sh
@@ -27,6 +27,7 @@ gunicorn \
     --worker-class ${SERVER_WORKER_CLASS:-gthread} \
     --threads ${SERVER_THREADS_AMOUNT:-20} \
     --timeout ${GUNICORN_TIMEOUT:-60} \
+    --keep-alive ${GUNICORN_KEEPALIVE:-2} \
     --limit-request-line ${SERVER_LIMIT_REQUEST_LINE:-0} \
     --limit-request-field_size ${SERVER_LIMIT_REQUEST_FIELD_SIZE:-0} \
     "${FLASK_APP}"


### PR DESCRIPTION
### SUMMARY
This PR helps to solve [16742](https://github.com/apache/superset/issues/16742)

We were getting frequent 502 errors during loading of charts in dashboard forcing us to refresh the page.

This is how traffic flows in our Superset setup: AWS ALB --> Gunicorn --> Superset App
We are using official Superset docker image.

I modified timeout settings i.e. GUNICORN_TIMEOUT and SUPERSET_WEBSERVER_TIMEOUT but it didn't resolve the problem.
I have already increased SERVER_WORKER_AMOUNT to 8 and using default thread value of 20 but it didn't resolve the issue.
My ECS task cpu/memory are underutilized so scaling is not a cause of the problem.

Finally, I saw this blog which says solution is to keep Gunicorn --keep-alive more than alb idle timeout: https://www.tessian.com/blog/how-to-fix-http-502-errors/

Default value for --keep-alive is 2, please see https://docs.gunicorn.org/en/stable/settings.html#keepalive 

Even Gunicorn's official documentation here https://docs.gunicorn.org/en/stable/settings.html#keepalive says:
"Generally set in the 1-5 seconds range for servers with direct connection to the client (e.g. when you don’t have separate load balancer). When gunicorn is deployed behind a load balancer, it often makes sense to set this to a higher value."

But run-server.sh in official docker image doesn't has an option for setting Gunicorn's --keep-alive to a custom value.
So I have done improvements in run-server.sh to allow this customization keeping the default value as 2 taken from Gunicorn's default. 

I hope this helps people with similar setup as mine.

Note: This change is non-disruptive, no end user will be impacted unless they turn on settings.
You can also refer https://apache-superset.slack.com/archives/C014LS99C1K/p1653678959786229 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![133964881-01a3075a-1bf4-4079-ac99-85df6670c4b3](https://user-images.githubusercontent.com/57723564/173070040-70c12060-3286-479c-b70c-255c40e82eee.png)
![133964682-578da6b7-859b-4d61-93fc-eff21d6a0fd2](https://user-images.githubusercontent.com/57723564/173070074-f7d58f6e-47b4-440c-b47a-8e96801d7dd9.png)


### TESTING INSTRUCTIONS
Set GUNICORN_KEEPALIVE to more than alb timeout in your docker containers environment and see issue disappear.

![image](https://user-images.githubusercontent.com/57723564/173071490-4a15c2d8-8d2a-4fc9-93d3-cd5659995219.png)

![image](https://user-images.githubusercontent.com/57723564/173072111-6f37486f-4c91-4c0c-bae2-86c22a823ab2.png)


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
