### PR TITLE
fix(viz): BigQuery time grain 'minute'/'second' throws an error

### DIFF
--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -123,8 +123,12 @@ class BigQueryEngineSpec(BaseEngineSpec):
 
     _time_grain_expressions = {
         None: "{col}",
-        "PT1S": "{func}({col}, SECOND)",
-        "PT1M": "{func}({col}, MINUTE)",
+        "PT1S": "CAST(TIMESTAMP_SECONDS("
+        "UNIX_SECONDS(CAST({col} AS TIMESTAMP))"
+        ") AS {type})",
+        "PT1M": "CAST(TIMESTAMP_SECONDS("
+        "60 * DIV(UNIX_SECONDS(CAST({col} AS TIMESTAMP)), 60)"
+        ") AS {type})",
         "PT5M": "CAST(TIMESTAMP_SECONDS("
         "5*60 * DIV(UNIX_SECONDS(CAST({col} AS TIMESTAMP)), 5*60)"
         ") AS {type})",


### PR DESCRIPTION
### SUMMARY

The time grain for minute and second is throwing an error.
For BigQuery, the `DATE_TRUNC` function does not support MINUTE and SECOND as param.
This PR changes the calculation to support these time grain options.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Error:
<img width="1056" alt="Screen Shot 2022-06-10 at 18 31 29" src="https://user-images.githubusercontent.com/17252075/173153899-bf3336d9-99e7-4a0b-a7ac-fb8cbdae7d85.png">

### TESTING INSTRUCTIONS
1. Create a Time-series table 
2. Mark a DATE column as temporal
3. Select that column as the time column
4. Set the time grain to Minute or Second

Ensure the query executes as expected.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
