### PR TITLE
fix: A newly connected database doesn't appear in the databases list if user connected database using the 'plus' button

### DIFF
--- a/superset-frontend/src/views/components/Menu.test.tsx
+++ b/superset-frontend/src/views/components/Menu.test.tsx
@@ -476,3 +476,9 @@ test('should hide create button without proper roles', () => {
   render(<Menu {...mockedProps} />, { useRedux: true, useQueryParams: true });
   expect(screen.queryByTestId('new-dropdown')).not.toBeInTheDocument();
 });
+
+test('should render without QueryParamProvider', () => {
+  useSelectorMock.mockReturnValue({ roles: [] });
+  render(<Menu {...mockedProps} />, { useRedux: true });
+  expect(screen.queryByTestId('new-dropdown')).not.toBeInTheDocument();
+});

--- a/superset-frontend/src/views/components/MenuRight.tsx
+++ b/superset-frontend/src/views/components/MenuRight.tsx
@@ -446,6 +446,11 @@ const RightMenuWithQueryWrapper: React.FC<RightMenuProps> = props => {
   return <RightMenu setQuery={setQuery} {...props} />;
 };
 
+// Query param manipulation requires that, during the setup, the
+// QueryParamProvider is present and configured.
+// Superset still has multiple entry points, and not all of them have
+// the same setup, and critically, not all of them have the QueryParamProvider.
+// This wrapper ensures the RightMenu renders regardless of the provider being present.
 class RightMenuErrorWrapper extends React.PureComponent<RightMenuProps> {
   state = {
     hasError: false,

--- a/superset-frontend/src/views/components/MenuRight.tsx
+++ b/superset-frontend/src/views/components/MenuRight.tsx
@@ -88,17 +88,16 @@ const RightMenu = ({
   settings,
   navbarRight,
   isFrontendRoute,
-}: RightMenuProps) => {
+  setQuery,
+}: RightMenuProps & {
+  setQuery: ({ databaseAdded }: { databaseAdded: boolean }) => void;
+}) => {
   const user = useSelector<any, UserWithPermissionsAndRoles>(
     state => state.user,
   );
   const dashboardId = useSelector<RootState, number | undefined>(
     state => state.dashboardInfo?.id,
   );
-
-  const [, setQuery] = useQueryParams({
-    databaseAdded: BooleanParam,
-  });
 
   const { roles } = user;
   const {
@@ -439,4 +438,38 @@ const RightMenu = ({
   );
 };
 
-export default RightMenu;
+const RightMenuWithQueryWrapper: React.FC<RightMenuProps> = props => {
+  const [, setQuery] = useQueryParams({
+    databaseAdded: BooleanParam,
+  });
+
+  return <RightMenu setQuery={setQuery} {...props} />;
+};
+
+class RightMenuErrorWrapper extends React.PureComponent<RightMenuProps> {
+  state = {
+    hasError: false,
+  };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  noop = () => {};
+
+  render() {
+    if (this.state.hasError) {
+      return <RightMenu setQuery={this.noop} {...this.props} />;
+    }
+
+    return this.props.children;
+  }
+}
+
+const RightMenuWrapper: React.FC<RightMenuProps> = props => (
+  <RightMenuErrorWrapper {...props}>
+    <RightMenuWithQueryWrapper {...props} />
+  </RightMenuErrorWrapper>
+);
+
+export default RightMenuWrapper;


### PR DESCRIPTION
### SUMMARY

The RightMenu currently uses the `useQueryParam` hook that needs a Provider to wrap it (much like the redux store provider, theme provider, etc).

Currently, we have more that one entry point (App.tsx/js) and they don't have the same structure.
Long term solution is to unify these into a single entry point, or at least, have the same provider structure for commonly used tools.

This PR enables the useQueryParam in said component if the router is available, and otherwise ignores it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
--

### TESTING INSTRUCTIONS
Ensure that, adding a database from the + menu works.
Ensure the explore loads correctly.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
