### PR TITLE
fix: query execution time is not fully displayed in bubble icon

### DIFF
--- a/superset-frontend/src/components/Timer/index.tsx
+++ b/superset-frontend/src/components/Timer/index.tsx
@@ -31,7 +31,6 @@ export interface TimerProps {
 
 const TimerLabel = styled(Label)`
   text-align: left;
-  width: 91px;
 `;
 
 export default function Timer({


### PR DESCRIPTION
### SUMMARY

The query execution time is fully displayed in the green bubble is cut off.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

<img width="1289" alt="old" src="https://user-images.githubusercontent.com/17252075/173421530-0e17b122-6f43-416d-ab2c-95700882b0ba.png">
<img width="1728" alt="old2" src="https://user-images.githubusercontent.com/17252075/173421535-95fd4e16-d7ff-4d6c-aa88-454987743d36.png">

After:

<img width="1293" alt="Screen Shot 2022-06-13 at 15 28 09" src="https://user-images.githubusercontent.com/17252075/173421590-7c1e1137-0f4d-4bdc-a449-f9d815318a3e.png">
<img width="1728" alt="Screen Shot 2022-06-13 at 15 30 07" src="https://user-images.githubusercontent.com/17252075/173421596-20b1dc4a-82cf-4c51-837f-ef564734fc2d.png">

### TESTING INSTRUCTIONS

1. Open SQL lab
2. Run any query
3. Pay attention to the query execution time (in bubble icon)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
