### PR TITLE
fix: Allow dataset owners to explore their datasets

### DIFF
--- a/superset/charts/filters.py
+++ b/superset/charts/filters.py
@@ -20,10 +20,10 @@ from flask_babel import lazy_gettext as _
 from sqlalchemy import and_, or_
 from sqlalchemy.orm.query import Query
 
-from superset import security_manager, db
+from superset import db, security_manager
+from superset.connectors.sqla import models
 from superset.connectors.sqla.models import SqlaTable
 from superset.models.slice import Slice
-from superset.connectors.sqla import models
 from superset.views.base import BaseFilter
 from superset.views.base_api import BaseFavoriteFilter
 

--- a/superset/charts/filters.py
+++ b/superset/charts/filters.py
@@ -20,9 +20,10 @@ from flask_babel import lazy_gettext as _
 from sqlalchemy import and_, or_
 from sqlalchemy.orm.query import Query
 
-from superset import security_manager
+from superset import security_manager, db
 from superset.connectors.sqla.models import SqlaTable
 from superset.models.slice import Slice
+from superset.connectors.sqla import models
 from superset.views.base import BaseFilter
 from superset.views.base_api import BaseFavoriteFilter
 
@@ -77,6 +78,18 @@ class ChartFilter(BaseFilter):  # pylint: disable=too-few-public-methods
             return query
         perms = security_manager.user_view_menu_names("datasource_access")
         schema_perms = security_manager.user_view_menu_names("schema_access")
+        owner_ids_query = (
+            db.session.query(models.SqlaTable.id)
+            .join(models.SqlaTable.owners)
+            .filter(
+                security_manager.user_model.id
+                == security_manager.user_model.get_user_id()
+            )
+        )
         return query.filter(
-            or_(self.model.perm.in_(perms), self.model.schema_perm.in_(schema_perms))
+            or_(
+                self.model.perm.in_(perms),
+                self.model.schema_perm.in_(schema_perms),
+                models.SqlaTable.id.in_(owner_ids_query),
+            )
         )

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1037,6 +1037,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         from superset.connectors.sqla.models import SqlaTable
         from superset.extensions import feature_flag_manager
         from superset.sql_parse import Table
+        from superset.views.utils import is_owner
 
         if database and table or query:
             if query:
@@ -1067,10 +1068,9 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
 
                     # Access to any datasource is suffice.
                     for datasource_ in datasources:
-                        if (
-                            self.can_access("datasource_access", datasource_.perm)
-                            or g.user in datasource_.owners
-                        ):
+                        if self.can_access(
+                            "datasource_access", datasource_.perm
+                        ) or is_owner(datasource, getattr(g, "user", None)):
                             break
                     else:
                         denied.add(table_)
@@ -1096,7 +1096,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             if not (
                 self.can_access_schema(datasource)
                 or self.can_access("datasource_access", datasource.perm or "")
-                or g.user in datasource.owners
+                or is_owner(datasource, getattr(g, "user", None))
                 or (
                     should_check_dashboard_access
                     and self.can_access_based_on_dashboard(datasource)

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1070,7 +1070,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                     for datasource_ in datasources:
                         if self.can_access(
                             "datasource_access", datasource_.perm
-                        ) or is_owner(datasource, getattr(g, "user", None)):
+                        ) or is_owner(datasource_, getattr(g, "user", None)):
                             break
                     else:
                         denied.add(table_)

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1067,7 +1067,10 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
 
                     # Access to any datasource is suffice.
                     for datasource_ in datasources:
-                        if self.can_access("datasource_access", datasource_.perm):
+                        if (
+                            self.can_access("datasource_access", datasource_.perm)
+                            or g.user in datasource_.owners
+                        ):
                             break
                     else:
                         denied.add(table_)
@@ -1093,6 +1096,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             if not (
                 self.can_access_schema(datasource)
                 or self.can_access("datasource_access", datasource.perm or "")
+                or g.user in datasource.owners
                 or (
                     should_check_dashboard_access
                     and self.can_access_based_on_dashboard(datasource)

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -32,7 +32,9 @@ from sqlalchemy.orm.exc import NoResultFound
 import superset.models.core as models
 from superset import app, dataframe, db, result_set, viz
 from superset.common.db_query_status import QueryStatus
+
 from superset.datasource.dao import DatasourceDAO
+from superset.connectors.sqla.models import SqlaTable
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import (
     CacheLoadError,
@@ -46,7 +48,6 @@ from superset.models.core import Database
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.models.sql_lab import Query
-from superset.superset.connectors.sqla.models import SqlaTable
 from superset.superset_typing import FormData
 from superset.utils.core import DatasourceType
 from superset.utils.decorators import stats_timing

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -32,9 +32,8 @@ from sqlalchemy.orm.exc import NoResultFound
 import superset.models.core as models
 from superset import app, dataframe, db, result_set, viz
 from superset.common.db_query_status import QueryStatus
-
-from superset.datasource.dao import DatasourceDAO
 from superset.connectors.sqla.models import SqlaTable
+from superset.datasource.dao import DatasourceDAO
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import (
     CacheLoadError,

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -46,6 +46,7 @@ from superset.models.core import Database
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.models.sql_lab import Query
+from superset.superset.connectors.sqla.models import SqlaTable
 from superset.superset_typing import FormData
 from superset.utils.core import DatasourceType
 from superset.utils.decorators import stats_timing
@@ -426,7 +427,7 @@ def is_slice_in_container(
     return False
 
 
-def is_owner(obj: Union[Dashboard, Slice], user: User) -> bool:
+def is_owner(obj: Union[Dashboard, Slice, SqlaTable], user: User) -> bool:
     """Check if user is owner of the slice"""
     return obj and user in obj.owners
 

--- a/tests/integration_tests/base_tests.py
+++ b/tests/integration_tests/base_tests.py
@@ -21,7 +21,7 @@ import imp
 import json
 from contextlib import contextmanager
 from typing import Any, Dict, Union, List, Optional
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, MagicMock
 
 import pandas as pd
 import pytest
@@ -252,7 +252,7 @@ class SupersetTestCase(TestCase):
 
     @staticmethod
     def get_datasource_mock() -> BaseDatasource:
-        datasource = Mock()
+        datasource = MagicMock()
         results = Mock()
         results.query = Mock()
         results.status = Mock()
@@ -266,6 +266,7 @@ class SupersetTestCase(TestCase):
         datasource.database = Mock()
         datasource.database.db_engine_spec = Mock()
         datasource.database.db_engine_spec.mutate_expression_label = lambda x: x
+        datasource.owners = MagicMock()
         return datasource
 
     def get_resp(

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -879,7 +879,10 @@ class TestSecurityManager(SupersetTestCase):
 
     @patch("superset.security.SupersetSecurityManager.can_access")
     @patch("superset.security.SupersetSecurityManager.can_access_schema")
-    def test_raise_for_access_datasource(self, mock_can_access_schema, mock_can_access):
+    @patch("superset.views.utils.is_owner")
+    def test_raise_for_access_datasource(
+        self, mock_can_access_schema, mock_can_access, mock_is_owner
+    ):
         datasource = self.get_datasource_mock()
 
         mock_can_access_schema.return_value = True
@@ -887,12 +890,14 @@ class TestSecurityManager(SupersetTestCase):
 
         mock_can_access.return_value = False
         mock_can_access_schema.return_value = False
+        mock_is_owner.return_value = False
 
         with self.assertRaises(SupersetSecurityException):
             security_manager.raise_for_access(datasource=datasource)
 
     @patch("superset.security.SupersetSecurityManager.can_access")
-    def test_raise_for_access_query(self, mock_can_access):
+    @patch("superset.views.utils.is_owner")
+    def test_raise_for_access_query(self, mock_can_access, mock_is_owner):
         query = Mock(
             database=get_example_database(), schema="bar", sql="SELECT * FROM foo"
         )
@@ -901,6 +906,7 @@ class TestSecurityManager(SupersetTestCase):
         security_manager.raise_for_access(query=query)
 
         mock_can_access.return_value = False
+        mock_is_owner.return_value = False
 
         with self.assertRaises(SupersetSecurityException):
             security_manager.raise_for_access(query=query)

--- a/tests/unit_tests/explore/utils_test.py
+++ b/tests/unit_tests/explore/utils_test.py
@@ -271,7 +271,7 @@ def test_query_has_access(mocker: MockFixture, app_context: AppContext) -> None:
     )
 
 
-def test_query_no_access(mocker: MockFixture, app_context: AppContext) -> None:
+def test_query_no_access(mocker: MockFixture, client, app_context: AppContext) -> None:
     from superset.connectors.sqla.models import SqlaTable
     from superset.explore.utils import check_datasource_access
     from superset.models.core import Database
@@ -282,7 +282,9 @@ def test_query_no_access(mocker: MockFixture, app_context: AppContext) -> None:
             query_find_by_id,
             return_value=Query(database=Database(), sql="select * from foo"),
         )
-        mocker.patch(query_datasources_by_name, return_value=[SqlaTable()])
+        table = SqlaTable()
+        table.owners = []
+        mocker.patch(query_datasources_by_name, return_value=[table])
         mocker.patch(is_user_admin, return_value=False)
         mocker.patch(is_owner, return_value=False)
         mocker.patch(can_access, return_value=False)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This fixes a missed codepath by @cccs-tom's fix to #19360 which was pointed out by @HeathLee. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
Try to explore a dataset which you own. You should now be able to.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #19360 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
