### PR TITLE
fix: Unable to export multiple Dashboards with the same name

### DIFF
--- a/superset/dashboards/commands/export.py
+++ b/superset/dashboards/commands/export.py
@@ -112,7 +112,7 @@ class ExportDashboardsCommand(ExportModelsCommand):
         model: Dashboard, export_related: bool = True
     ) -> Iterator[Tuple[str, str]]:
         dashboard_slug = secure_filename(model.dashboard_title)
-        file_name = f"dashboards/{dashboard_slug}.yaml"
+        file_name = f"dashboards/{dashboard_slug}_{model.id}.yaml"
 
         payload = model.export_to_dict(
             recursive=False,

--- a/tests/integration_tests/dashboards/commands_tests.py
+++ b/tests/integration_tests/dashboards/commands_tests.py
@@ -68,7 +68,7 @@ class TestExportDashboardsCommand(SupersetTestCase):
 
         expected_paths = {
             "metadata.yaml",
-            "dashboards/World_Banks_Data.yaml",
+            f"dashboards/World_Banks_Data_{example_dashboard.id}.yaml",
             "datasets/examples/wb_health_population.yaml",
             "databases/examples.yaml",
         }
@@ -77,7 +77,9 @@ class TestExportDashboardsCommand(SupersetTestCase):
             expected_paths.add(f"charts/{chart_slug}_{chart.id}.yaml")
         assert expected_paths == set(contents.keys())
 
-        metadata = yaml.safe_load(contents["dashboards/World_Banks_Data.yaml"])
+        metadata = yaml.safe_load(
+            contents[f"dashboards/World_Banks_Data_{example_dashboard.id}.yaml"]
+        )
 
         # remove chart UUIDs from metadata so we can compare
         for chart_info in metadata["position"].values():
@@ -269,7 +271,9 @@ class TestExportDashboardsCommand(SupersetTestCase):
         command = ExportDashboardsCommand([example_dashboard.id])
         contents = dict(command.run())
 
-        metadata = yaml.safe_load(contents["dashboards/World_Banks_Data.yaml"])
+        metadata = yaml.safe_load(
+            contents[f"dashboards/World_Banks_Data_{example_dashboard.id}.yaml"]
+        )
         assert list(metadata.keys()) == [
             "dashboard_title",
             "description",
@@ -284,7 +288,7 @@ class TestExportDashboardsCommand(SupersetTestCase):
     @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
     @patch("superset.dashboards.commands.export.suffix")
     def test_append_charts(self, mock_suffix):
-        """Test that oprhaned charts are added to the dashbaord position"""
+        """Test that orphaned charts are added to the dashboard position"""
         # return deterministic IDs
         mock_suffix.side_effect = (str(i) for i in itertools.count(1))
 
@@ -435,7 +439,7 @@ class TestExportDashboardsCommand(SupersetTestCase):
 
         expected_paths = {
             "metadata.yaml",
-            "dashboards/World_Banks_Data.yaml",
+            f"dashboards/World_Banks_Data_{example_dashboard.id}.yaml",
         }
         assert expected_paths == set(contents.keys())
 


### PR DESCRIPTION
### SUMMARY

Users can export multiple Dashboards in a single ZIP.
However, selecting two Dashboards with the same name won’t work properly - only one is included on the export file.

This PR follows the same approach taken for the charts, and adds the dashboard id at the end of the file name.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Example:

<img width="315" alt="Screen Shot 2022-06-14 at 15 55 37" src="https://user-images.githubusercontent.com/17252075/173667402-1852be3c-f1bc-4e65-bba2-c95d3baf0606.png">


### TESTING INSTRUCTIONS

1. Navigate to **Dashboards**.
2. Click on **+ DASHBOARD**.
3. Name your dashboard - for example, `Export Test`.
4. Click on **SAVE**.
5. Navigate back to **Dashboards**.
6. Click on **+ DASHBOARD**.
7. Use the same title for this Dashboard.
8. Click on **SAVE**.
9. Navigate back to **Dashboards**.
10. Click on **BULK SELECT**.
11. Select both Dashboards.
12. Click on **EXPORT**.

Ensure two files are created under dashboards folder.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
