### PR TITLE
fix(chart & table): Prevent the dates from wrapping in table chart

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -394,6 +394,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
                   colorPositiveNegative,
                 })
               : undefined)};
+            white-space: ${value instanceof Date ? 'nowrap' : undefined};
           `;
 
           const cellProps = {


### PR DESCRIPTION
### SUMMARY
[table viz] prevent dates from wrapping.

In the table viz type:
• date hyphen breaks! we need to either white-space: nowrap; or the non-breaking hyphen &amp;#8209;

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
![image](https://user-images.githubusercontent.com/47900232/173680054-931bd04c-96bc-4f08-b763-91d7fc0939d0.png)

AFTER:
![image](https://user-images.githubusercontent.com/47900232/173680112-b6dfa09b-e30b-49c9-83cc-e9196268ed0b.png)

### TESTING INSTRUCTIONS
1. Go to the Table chart
2. Make sure that it includes the date.
3. You can show that date is wrapping in table chart

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
