### PR TITLE
fix(migration): Ensure key_value LargeBinary is encoded as a MEDIUMBLOB as opposed to BLOB for MySQL

### DIFF
--- a/superset/key_value/models.py
+++ b/superset/key_value/models.py
@@ -28,7 +28,7 @@ class KeyValueEntry(Model, AuditMixinNullable, ImportExportMixin):
     __tablename__ = "key_value"
     id = Column(Integer, primary_key=True)
     resource = Column(String(32), nullable=False)
-    value = Column(LargeBinary(), nullable=False)
+    value = Column(LargeBinary(length=2**24 - 1), nullable=False)
     created_on = Column(DateTime, nullable=True)
     created_by_fk = Column(Integer, ForeignKey("ab_user.id"), nullable=True)
     changed_on = Column(DateTime, nullable=True)

--- a/superset/migrations/versions/2022-06-14_15-28_e09b4ae78457_resize_key_value_blob.py
+++ b/superset/migrations/versions/2022-06-14_15-28_e09b4ae78457_resize_key_value_blob.py
@@ -26,8 +26,8 @@ Create Date: 2022-06-14 15:28:42.746349
 revision = "e09b4ae78457"
 down_revision = "e786798587de"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/2022-06-14_15-28_e09b4ae78457_resize_key_value_blob.py
+++ b/superset/migrations/versions/2022-06-14_15-28_e09b4ae78457_resize_key_value_blob.py
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Resize key_value blob
+
+Revision ID: e09b4ae78457
+Revises: e786798587de
+Create Date: 2022-06-14 15:28:42.746349
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "e09b4ae78457"
+down_revision = "e786798587de"
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    with op.batch_alter_table("key_value", schema=None) as batch_op:
+        batch_op.alter_column(
+            "value",
+            existing_nullable=False,
+            existing_type=sa.LargeBinary(),
+            type_=sa.LargeBinary(length=2**24 - 1),
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("key_value", schema=None) as batch_op:
+        batch_op.alter_column(
+            "value",
+            existing_nullable=False,
+            existing_type=sa.LargeBinary(length=2**24 - 1),
+            type_=sa.LargeBinary(),
+        )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

At Airbnb we use MySQL for Superset's metadata database where the SQLAlchemy LargeBinary type—which is used for the `key_value.value` column—is encoded as a `BLOB` which can handle up to 64 KiB of data. This isn't sufficient for storing large form-data blobs and thus this PR adds a migration which encodes the column as a `MEDIUMBLOB` which can handle up to 16 MiB of data.

The solution uses the suggestion [here](https://stackoverflow.com/a/43791881), note 16 MiB is equivalent to 2^24 - 1 bytes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
