### PR TITLE
fix: cache warmup unable to login (#9597, #18933)

### DIFF
--- a/docs/docs/installation/cache.mdx
+++ b/docs/docs/installation/cache.mdx
@@ -46,6 +46,8 @@ Superset has a Celery task that will periodically warm up the cache based on dif
 To use it, add the following to the `CELERYBEAT_SCHEDULE` section in `config.py`:
 
 ```python
+SUPERSET_CACHE_WARMUP_USER = "user_with_permission_to_dashboards"
+
 CELERYBEAT_SCHEDULE = {
     'cache-warmup-hourly': {
         'task': 'cache-warmup',

--- a/superset/config.py
+++ b/superset/config.py
@@ -541,6 +541,9 @@ THUMBNAIL_CACHE_CONFIG: CacheConfig = {
     "CACHE_NO_NULL_WARNING": True,
 }
 
+# Cache warmup user
+SUPERSET_CACHE_WARMUP_USER = "admin"
+
 # Time before selenium times out after trying to locate an element on the page and wait
 # for that element to load for a screenshot.
 SCREENSHOT_LOCATE_WAIT = int(timedelta(seconds=10).total_seconds())

--- a/superset/utils/screenshots.py
+++ b/superset/utils/screenshots.py
@@ -47,9 +47,11 @@ class BaseScreenshot:
         self.url = url
         self.screenshot: Optional[bytes] = None
 
-    def driver(self, window_size: Optional[WindowSize] = None) -> WebDriverProxy:
+    def driver(
+        self, window_size: Optional[WindowSize] = None, user: "User" = None
+    ) -> WebDriverProxy:
         window_size = window_size or self.window_size
-        return WebDriverProxy(self.driver_type, window_size)
+        return WebDriverProxy(self.driver_type, window_size, user)
 
     def cache_key(
         self,
@@ -70,8 +72,8 @@ class BaseScreenshot:
     def get_screenshot(
         self, user: "User", window_size: Optional[WindowSize] = None
     ) -> Optional[bytes]:
-        driver = self.driver(window_size)
-        self.screenshot = driver.get_screenshot(self.url, self.element, user)
+        driver = self.driver(window_size, user)
+        self.screenshot = driver.get_screenshot(self.url, self.element)
         return self.screenshot
 
     def get(

--- a/tests/integration_tests/strategy_tests.py
+++ b/tests/integration_tests/strategy_tests.py
@@ -16,38 +16,22 @@
 # under the License.
 # isort:skip_file
 """Unit tests for Superset cache warmup"""
-import datetime
-import json
-from unittest.mock import MagicMock
-from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
-    load_birth_names_data,
-)
-
-from sqlalchemy import String, Date, Float
-
 import pytest
-import pandas as pd
-
-from superset.models.slice import Slice
-from superset.utils.database import get_example_database
 
 from superset import db
 
 from superset.models.core import Log
 from superset.models.tags import get_tag, ObjectTypes, TaggedObject, TagTypes
+from tests.integration_tests.fixtures.birth_names_dashboard import (
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
+)
 from superset.tasks.cache import (
     DashboardTagsStrategy,
-    get_form_data,
     TopNDashboardsStrategy,
 )
 
 from .base_tests import SupersetTestCase
-from .dashboard_utils import create_dashboard, create_slice, create_table_metadata
-from .fixtures.unicode_dashboard import (
-    load_unicode_dashboard_with_slice,
-    load_unicode_data,
-)
 
 URL_PREFIX = "http://0.0.0.0:8081"
 
@@ -69,128 +53,6 @@ mock_positions = {
 
 
 class TestCacheWarmUp(SupersetTestCase):
-    def test_get_form_data_chart_only(self):
-        chart_id = 1
-        result = get_form_data(chart_id, None)
-        expected = {"slice_id": chart_id}
-        self.assertEqual(result, expected)
-
-    def test_get_form_data_no_dashboard_metadata(self):
-        chart_id = 1
-        dashboard = MagicMock()
-        dashboard.json_metadata = None
-        dashboard.position_json = json.dumps(mock_positions)
-        result = get_form_data(chart_id, dashboard)
-        expected = {"slice_id": chart_id}
-        self.assertEqual(result, expected)
-
-    def test_get_form_data_immune_slice(self):
-        chart_id = 1
-        filter_box_id = 2
-        dashboard = MagicMock()
-        dashboard.position_json = json.dumps(mock_positions)
-        dashboard.json_metadata = json.dumps(
-            {
-                "filter_scopes": {
-                    str(filter_box_id): {
-                        "name": {"scope": ["ROOT_ID"], "immune": [chart_id]}
-                    }
-                },
-                "default_filters": json.dumps(
-                    {str(filter_box_id): {"name": ["Alice", "Bob"]}}
-                ),
-            }
-        )
-        result = get_form_data(chart_id, dashboard)
-        expected = {"slice_id": chart_id}
-        self.assertEqual(result, expected)
-
-    def test_get_form_data_no_default_filters(self):
-        chart_id = 1
-        dashboard = MagicMock()
-        dashboard.json_metadata = json.dumps({})
-        dashboard.position_json = json.dumps(mock_positions)
-        result = get_form_data(chart_id, dashboard)
-        expected = {"slice_id": chart_id}
-        self.assertEqual(result, expected)
-
-    def test_get_form_data_immune_fields(self):
-        chart_id = 1
-        filter_box_id = 2
-        dashboard = MagicMock()
-        dashboard.position_json = json.dumps(mock_positions)
-        dashboard.json_metadata = json.dumps(
-            {
-                "default_filters": json.dumps(
-                    {
-                        str(filter_box_id): {
-                            "name": ["Alice", "Bob"],
-                            "__time_range": "100 years ago : today",
-                        }
-                    }
-                ),
-                "filter_scopes": {
-                    str(filter_box_id): {
-                        "__time_range": {"scope": ["ROOT_ID"], "immune": [chart_id]}
-                    }
-                },
-            }
-        )
-        result = get_form_data(chart_id, dashboard)
-        expected = {
-            "slice_id": chart_id,
-            "extra_filters": [{"col": "name", "op": "in", "val": ["Alice", "Bob"]}],
-        }
-        self.assertEqual(result, expected)
-
-    def test_get_form_data_no_extra_filters(self):
-        chart_id = 1
-        filter_box_id = 2
-        dashboard = MagicMock()
-        dashboard.position_json = json.dumps(mock_positions)
-        dashboard.json_metadata = json.dumps(
-            {
-                "default_filters": json.dumps(
-                    {str(filter_box_id): {"__time_range": "100 years ago : today"}}
-                ),
-                "filter_scopes": {
-                    str(filter_box_id): {
-                        "__time_range": {"scope": ["ROOT_ID"], "immune": [chart_id]}
-                    }
-                },
-            }
-        )
-        result = get_form_data(chart_id, dashboard)
-        expected = {"slice_id": chart_id}
-        self.assertEqual(result, expected)
-
-    def test_get_form_data(self):
-        chart_id = 1
-        filter_box_id = 2
-        dashboard = MagicMock()
-        dashboard.position_json = json.dumps(mock_positions)
-        dashboard.json_metadata = json.dumps(
-            {
-                "default_filters": json.dumps(
-                    {
-                        str(filter_box_id): {
-                            "name": ["Alice", "Bob"],
-                            "__time_range": "100 years ago : today",
-                        }
-                    }
-                )
-            }
-        )
-        result = get_form_data(chart_id, dashboard)
-        expected = {
-            "slice_id": chart_id,
-            "extra_filters": [
-                {"col": "name", "op": "in", "val": ["Alice", "Bob"]},
-                {"col": "__time_range", "op": "==", "val": "100 years ago : today"},
-            ],
-        }
-        self.assertEqual(result, expected)
-
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_top_n_dashboards_strategy(self):
         # create a top visited dashboard
@@ -201,8 +63,8 @@ class TestCacheWarmUp(SupersetTestCase):
             self.client.get(f"/superset/dashboard/{dash.id}/")
 
         strategy = TopNDashboardsStrategy(1)
-        result = sorted(strategy.get_urls())
-        expected = sorted([f"{URL_PREFIX}{slc.url}" for slc in dash.slices])
+        result = strategy.get_urls()
+        expected = [f"{URL_PREFIX}{dash.url}"]
         self.assertEqual(result, expected)
 
     def reset_tag(self, tag):
@@ -212,9 +74,7 @@ class TestCacheWarmUp(SupersetTestCase):
                 db.session.delete(o)
             db.session.commit()
 
-    @pytest.mark.usefixtures(
-        "load_unicode_dashboard_with_slice", "load_birth_names_dashboard_with_slices"
-    )
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_dashboard_tags(self):
         tag1 = get_tag("tag1", db.session, TagTypes.custom)
         # delete first to make test idempotent
@@ -228,7 +88,7 @@ class TestCacheWarmUp(SupersetTestCase):
         # tag dashboard 'births' with `tag1`
         tag1 = get_tag("tag1", db.session, TagTypes.custom)
         dash = self.get_dash_by_slug("births")
-        tag1_urls = sorted([f"{URL_PREFIX}{slc.url}" for slc in dash.slices])
+        tag1_urls = [f"{URL_PREFIX}{dash.url}"]
         tagged_object = TaggedObject(
             tag_id=tag1.id, object_id=dash.id, object_type=ObjectTypes.dashboard
         )
@@ -243,24 +103,4 @@ class TestCacheWarmUp(SupersetTestCase):
 
         result = sorted(strategy.get_urls())
         expected = []
-        self.assertEqual(result, expected)
-
-        # tag first slice
-        dash = self.get_dash_by_slug("unicode-test")
-        slc = dash.slices[0]
-        tag2_urls = [f"{URL_PREFIX}{slc.url}"]
-        object_id = slc.id
-        tagged_object = TaggedObject(
-            tag_id=tag2.id, object_id=object_id, object_type=ObjectTypes.chart
-        )
-        db.session.add(tagged_object)
-        db.session.commit()
-
-        result = sorted(strategy.get_urls())
-        self.assertEqual(result, tag2_urls)
-
-        strategy = DashboardTagsStrategy(["tag1", "tag2"])
-
-        result = sorted(strategy.get_urls())
-        expected = sorted(tag1_urls + tag2_urls)
         self.assertEqual(result, expected)

--- a/tests/integration_tests/thumbnails_tests.py
+++ b/tests/integration_tests/thumbnails_tests.py
@@ -69,37 +69,37 @@ class TestWebDriverProxy(SupersetTestCase):
     def test_screenshot_selenium_headstart(
         self, mock_sleep, mock_webdriver, mock_webdriver_wait
     ):
-        webdriver = WebDriverProxy("firefox")
         user = security_manager.get_user_by_username(
             app.config["THUMBNAIL_SELENIUM_USER"]
         )
+        webdriver = WebDriverProxy("firefox", user=user)
         url = get_url_path("Superset.slice", slice_id=1, standalone="true")
         app.config["SCREENSHOT_SELENIUM_HEADSTART"] = 5
-        webdriver.get_screenshot(url, "chart-container", user=user)
+        webdriver.get_screenshot(url, "chart-container")
         assert mock_sleep.call_args_list[0] == call(5)
 
     @patch("superset.utils.webdriver.WebDriverWait")
     @patch("superset.utils.webdriver.firefox")
     def test_screenshot_selenium_locate_wait(self, mock_webdriver, mock_webdriver_wait):
         app.config["SCREENSHOT_LOCATE_WAIT"] = 15
-        webdriver = WebDriverProxy("firefox")
         user = security_manager.get_user_by_username(
             app.config["THUMBNAIL_SELENIUM_USER"]
         )
+        webdriver = WebDriverProxy("firefox", user=user)
         url = get_url_path("Superset.slice", slice_id=1, standalone="true")
-        webdriver.get_screenshot(url, "chart-container", user=user)
+        webdriver.get_screenshot(url, "chart-container")
         assert mock_webdriver_wait.call_args_list[0] == call(ANY, 15)
 
     @patch("superset.utils.webdriver.WebDriverWait")
     @patch("superset.utils.webdriver.firefox")
     def test_screenshot_selenium_load_wait(self, mock_webdriver, mock_webdriver_wait):
         app.config["SCREENSHOT_LOAD_WAIT"] = 15
-        webdriver = WebDriverProxy("firefox")
         user = security_manager.get_user_by_username(
             app.config["THUMBNAIL_SELENIUM_USER"]
         )
+        webdriver = WebDriverProxy("firefox", user=user)
         url = get_url_path("Superset.slice", slice_id=1, standalone="true")
-        webdriver.get_screenshot(url, "chart-container", user=user)
+        webdriver.get_screenshot(url, "chart-container")
         assert mock_webdriver_wait.call_args_list[1] == call(ANY, 15)
 
     @patch("superset.utils.webdriver.WebDriverWait")
@@ -108,13 +108,13 @@ class TestWebDriverProxy(SupersetTestCase):
     def test_screenshot_selenium_animation_wait(
         self, mock_sleep, mock_webdriver, mock_webdriver_wait
     ):
-        webdriver = WebDriverProxy("firefox")
         user = security_manager.get_user_by_username(
             app.config["THUMBNAIL_SELENIUM_USER"]
         )
+        webdriver = WebDriverProxy("firefox", user=user)
         url = get_url_path("Superset.slice", slice_id=1, standalone="true")
         app.config["SCREENSHOT_SELENIUM_ANIMATION_WAIT"] = 4
-        webdriver.get_screenshot(url, "chart-container", user=user)
+        webdriver.get_screenshot(url, "chart-container")
         assert mock_sleep.call_args_list[1] == call(4)
 
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently cache warmup feature is unusable due to #9597 & #18933
This implement intend to fix it by following changes:
- Use security_manager.find_user to find a user credential
- Use WebDriverProxy to perform warmups
  - In Superset, front-end tend to send multiple api with complex filter and many options, which is difficult to replay via simple request apis. In order to reduce the probability to cache the wrong slices or with wrong parameters, we use web driver to simulate a user's real behavior.
- Refine WebDriverProxy to support multiple operations without re-initialize web driver
- Cache toward dashboard instead of slices, because slices cache aren't always able to use in dashboards

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
