### PR TITLE
feat: setting limit value when Pie chart switches

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { t, validateNonEmpty } from '@superset-ui/core';
+import { ensureIsInt, t, validateNonEmpty } from '@superset-ui/core';
 import {
   ControlPanelConfig,
   ControlPanelsContainerProps,
@@ -257,6 +257,8 @@ const config: ControlPanelConfig = {
     ...formData,
     metric: formData.standardizedFormData.standardizedState.metrics[0],
     groupby: formData.standardizedFormData.standardizedState.columns,
+    row_limit:
+      ensureIsInt(formData.row_limit, 100) >= 100 ? 100 : formData.row_limit,
   }),
 };
 


### PR DESCRIPTION
### SUMMARY
Currently, when we use a `Pie chart` on a high cardinality column as a dimension, the `Pie chart` will be crashed.

Now we have a new [mechanism](https://github.com/apache/superset/pull/20010) to set `a new control value` for each control when the chart is switched.

In this PR, if the chart switch to the Pie and `row_limit` is greater than 100, the `row_limit` will be set to default value `100`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### After
https://user-images.githubusercontent.com/2016594/173818273-f7727cdb-c5f4-4b70-8abf-7578a84af70d.mov




### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
