### PR TITLE
feat: Split long error message into 2 parts for user experience

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -902,15 +902,6 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         return utils.error_msg_from_exception(ex)
 
     @classmethod
-    def _reformat_error_message(cls, message: str) -> Tuple[str, str]:
-        """Reformat error message for user experience"""
-        splitted_message = re.split("\n+", message, 1)
-        if len(splitted_message) > 1:
-            return splitted_message[0], splitted_message[1]
-
-        return splitted_message[0], ""
-
-    @classmethod
     def extract_errors(
         cls, ex: Exception, context: Optional[Dict[str, Any]] = None
     ) -> List[SupersetError]:
@@ -922,24 +913,19 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
             if match:
                 params = {**context, **match.groupdict()}
                 extra["engine_name"] = cls.engine_name
-                message, more_message = cls._reformat_error_message(message % params)
                 return [
                     SupersetError(
                         error_type=error_type,
-                        message=message,
-                        more_message=more_message,
+                        message=message % params,
                         level=ErrorLevel.ERROR,
                         extra=extra,
                     )
                 ]
 
-        message, more_message = cls._reformat_error_message(raw_message)
-
         return [
             SupersetError(
                 error_type=SupersetErrorType.GENERIC_DB_ENGINE_ERROR,
-                message=message,
-                more_message=more_message,
+                message=cls._extract_error_message(ex),
                 level=ErrorLevel.ERROR,
                 extra={"engine_name": cls.engine_name},
             )

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -20,7 +20,6 @@ import logging
 import re
 from contextlib import closing
 from datetime import datetime
-from tokenize import String
 from typing import (
     Any,
     Callable,
@@ -65,7 +64,7 @@ from superset.models.sql_lab import Query
 from superset.sql_parse import ParsedQuery, Table
 from superset.superset_typing import ResultSetColumnType
 from superset.utils import core as utils
-from superset.utils.core import ColumnSpec, GenericDataType, get_username, split
+from superset.utils.core import ColumnSpec, GenericDataType, get_username
 from superset.utils.hashing import md5_sha_from_str
 from superset.utils.network import is_hostname_valid, is_port_open
 
@@ -906,7 +905,10 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     def _reformat_error_message(cls, message: str) -> Tuple[str, str]:
         """Reformat error message for user experience"""
         splitted_message = re.split("\n+", message, 1)
-        return splitted_message[0], splitted_message[1]
+        if len(splitted_message) > 1:
+            return splitted_message[0], splitted_message[1]
+
+        return splitted_message[0], ""
 
     @classmethod
     def extract_errors(

--- a/superset/errors.py
+++ b/superset/errors.py
@@ -201,7 +201,7 @@ class SupersetError:
     message: str
     error_type: SupersetErrorType
     level: ErrorLevel
-    more_message: Optional[str] = None
+    description: Optional[str] = None
     extra: Optional[Dict[str, Any]] = None
 
     def __post_init__(self) -> None:

--- a/superset/errors.py
+++ b/superset/errors.py
@@ -16,6 +16,7 @@
 # under the License.
 from dataclasses import dataclass
 from enum import Enum
+from optparse import Option
 from typing import Any, Dict, Optional
 
 from flask_babel import gettext as _
@@ -201,6 +202,7 @@ class SupersetError:
     message: str
     error_type: SupersetErrorType
     level: ErrorLevel
+    more_message: Optional[str] = None
     extra: Optional[Dict[str, Any]] = None
 
     def __post_init__(self) -> None:

--- a/superset/errors.py
+++ b/superset/errors.py
@@ -16,7 +16,6 @@
 # under the License.
 from dataclasses import dataclass
 from enum import Enum
-from optparse import Option
 from typing import Any, Dict, Optional
 
 from flask_babel import gettext as _

--- a/tests/integration_tests/sqllab_tests.py
+++ b/tests/integration_tests/sqllab_tests.py
@@ -136,6 +136,7 @@ class TestSqlLab(SupersetTestCase):
                     "message": "Only SELECT statements are allowed against this database.",
                     "error_type": SupersetErrorType.DML_NOT_ALLOWED_ERROR,
                     "level": ErrorLevel.ERROR,
+                    "description": None,
                     "extra": {
                         "issue_codes": [
                             {

--- a/tests/unit_tests/db_engine_specs/test_athena.py
+++ b/tests/unit_tests/db_engine_specs/test_athena.py
@@ -55,6 +55,7 @@ def test_extract_errors(app_context: AppContext) -> None:
     assert result == [
         SupersetError(
             message='Please check your query for syntax errors at or near "fromm". Then, try running your query again.',
+            more_message="",
             error_type=SupersetErrorType.SYNTAX_ERROR,
             level=ErrorLevel.ERROR,
             extra={

--- a/tests/unit_tests/db_engine_specs/test_mssql.py
+++ b/tests/unit_tests/db_engine_specs/test_mssql.py
@@ -296,6 +296,7 @@ Unable to connect: Adaptive Server is unavailable or does not exist (locahost)
         SupersetError(
             error_type=SupersetErrorType.CONNECTION_INVALID_HOSTNAME_ERROR,
             message='The hostname "locahost" cannot be resolved.',
+            more_message="",
             level=ErrorLevel.ERROR,
             extra={
                 "engine_name": "Microsoft SQL Server",

--- a/tests/unit_tests/db_engine_specs/test_snowflake.py
+++ b/tests/unit_tests/db_engine_specs/test_snowflake.py
@@ -62,6 +62,7 @@ def test_extract_errors(app_context: AppContext) -> None:
     assert result == [
         SupersetError(
             message="dumbBrick does not exist in this database.",
+            more_message="",
             error_type=SupersetErrorType.OBJECT_DOES_NOT_EXIST_ERROR,
             level=ErrorLevel.ERROR,
             extra={

--- a/tests/unit_tests/importexport/api_test.py
+++ b/tests/unit_tests/importexport/api_test.py
@@ -163,6 +163,7 @@ def test_import_assets_no_form_data(mocker: MockFixture, client: Any) -> None:
                 "message": "Request MIME type is not 'multipart/form-data'",
                 "error_type": "INVALID_PAYLOAD_FORMAT_ERROR",
                 "level": "error",
+                "more_message": "",
                 "extra": {
                     "issue_codes": [
                         {
@@ -236,6 +237,7 @@ def test_import_assets_no_contents(mocker: MockFixture, client: Any) -> None:
         "errors": [
             {
                 "message": "No valid import files were found",
+                "more_message": "",
                 "error_type": "GENERIC_COMMAND_ERROR",
                 "level": "warning",
                 "extra": {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

In some case, client get too long error message from BE, and this might cause overlaying error alert issue in FE. Bad User Experience.

This PR splits long error message into 2 parts, and returns `message` and `more_message` as an error.
In the frontend, we need updates to show `more_message` field in `show more` button clicking. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![image](https://user-images.githubusercontent.com/39701522/173873820-2296a865-f162-4627-af33-a270008a8ef1.png)

Expecting:
All message below JOB ID section will be hidden by `show more` button.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
