### PR TITLE
fix(plugin-chart-pivot-table): color weight of Conditional formatting metrics not work

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import memoizeOne from 'memoize-one';
-import { DataRecord } from '@superset-ui/core';
+import { addAlpha, DataRecord } from '@superset-ui/core';
 import {
   ColorFormatters,
   COMPARATOR,
@@ -27,9 +27,6 @@ import {
 
 export const round = (num: number, precision = 0) =>
   Number(`${Math.round(Number(`${num}e+${precision}`))}e-${precision}`);
-
-export const rgbToRgba = (rgb: string, alpha: number) =>
-  rgb.replace(/rgb/i, 'rgba').replace(/\)/i, `,${alpha})`);
 
 const MIN_OPACITY_BOUNDED = 0.05;
 const MIN_OPACITY_UNBOUNDED = 0;
@@ -174,7 +171,7 @@ export const getColorFunction = (
     const compareResult = comparatorFunction(value, columnValues);
     if (compareResult === false) return undefined;
     const { cutoffValue, extremeValue } = compareResult;
-    return rgbToRgba(
+    return addAlpha(
       colorScheme,
       getOpacity(value, cutoffValue, extremeValue, minOpacity, maxOpacity),
     );

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
@@ -20,7 +20,6 @@ import { configure } from '@superset-ui/core';
 import {
   COMPARATOR,
   getOpacity,
-  rgbToRgba,
   round,
   getColorFormatters,
   getColorFunction,
@@ -51,12 +50,6 @@ describe('getOpacity', () => {
     expect(getOpacity(100, 100, 50)).toEqual(0.05);
     expect(getOpacity(100, 100, 100, 0, 0.8)).toEqual(0.8);
     expect(getOpacity(100, 100, 50, 0, 1)).toEqual(0);
-  });
-});
-
-describe('rgba', () => {
-  it('returns correct rgba value', () => {
-    expect(rgbToRgba('rgb(255,0,0)', 0.5)).toEqual('rgba(255,0,0,0.5)');
   });
 });
 

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
@@ -59,13 +59,13 @@ describe('getColorFunction()', () => {
       {
         operator: COMPARATOR.GREATER_THAN,
         targetValue: 50,
-        colorScheme: 'rgb(255,0,0)',
+        colorScheme: '#FF0000',
         column: 'count',
       },
       countValues,
     );
     expect(colorFunction(50)).toBeUndefined();
-    expect(colorFunction(100)).toEqual('rgba(255,0,0,1)');
+    expect(colorFunction(100)).toEqual('#FF0000FF');
   });
 
   it('getColorFunction LESS_THAN', () => {
@@ -73,13 +73,13 @@ describe('getColorFunction()', () => {
       {
         operator: COMPARATOR.LESS_THAN,
         targetValue: 100,
-        colorScheme: 'rgb(255,0,0)',
+        colorScheme: '#FF0000',
         column: 'count',
       },
       countValues,
     );
     expect(colorFunction(100)).toBeUndefined();
-    expect(colorFunction(50)).toEqual('rgba(255,0,0,1)');
+    expect(colorFunction(50)).toEqual('#FF0000FF');
   });
 
   it('getColorFunction GREATER_OR_EQUAL', () => {
@@ -87,13 +87,13 @@ describe('getColorFunction()', () => {
       {
         operator: COMPARATOR.GREATER_OR_EQUAL,
         targetValue: 50,
-        colorScheme: 'rgb(255,0,0)',
+        colorScheme: '#FF0000',
         column: 'count',
       },
       countValues,
     );
-    expect(colorFunction(50)).toEqual('rgba(255,0,0,0.05)');
-    expect(colorFunction(100)).toEqual('rgba(255,0,0,1)');
+    expect(colorFunction(50)).toEqual('#FF00000D');
+    expect(colorFunction(100)).toEqual('#FF0000FF');
     expect(colorFunction(0)).toBeUndefined();
   });
 
@@ -102,13 +102,13 @@ describe('getColorFunction()', () => {
       {
         operator: COMPARATOR.LESS_OR_EQUAL,
         targetValue: 100,
-        colorScheme: 'rgb(255,0,0)',
+        colorScheme: '#FF0000',
         column: 'count',
       },
       countValues,
     );
-    expect(colorFunction(50)).toEqual('rgba(255,0,0,1)');
-    expect(colorFunction(100)).toEqual('rgba(255,0,0,0.05)');
+    expect(colorFunction(50)).toEqual('#FF0000FF');
+    expect(colorFunction(100)).toEqual('#FF00000D');
     expect(colorFunction(150)).toBeUndefined();
   });
 
@@ -117,13 +117,13 @@ describe('getColorFunction()', () => {
       {
         operator: COMPARATOR.EQUAL,
         targetValue: 100,
-        colorScheme: 'rgb(255,0,0)',
+        colorScheme: '#FF0000',
         column: 'count',
       },
       countValues,
     );
     expect(colorFunction(50)).toBeUndefined();
-    expect(colorFunction(100)).toEqual('rgba(255,0,0,1)');
+    expect(colorFunction(100)).toEqual('#FF0000FF');
   });
 
   it('getColorFunction NOT_EQUAL', () => {
@@ -131,27 +131,27 @@ describe('getColorFunction()', () => {
       {
         operator: COMPARATOR.NOT_EQUAL,
         targetValue: 60,
-        colorScheme: 'rgb(255,0,0)',
+        colorScheme: '#FF0000',
         column: 'count',
       },
       countValues,
     );
     expect(colorFunction(60)).toBeUndefined();
-    expect(colorFunction(100)).toEqual('rgba(255,0,0,1)');
-    expect(colorFunction(50)).toEqual('rgba(255,0,0,0.29)');
+    expect(colorFunction(100)).toEqual('#FF0000FF');
+    expect(colorFunction(50)).toEqual('#FF00004A');
 
     colorFunction = getColorFunction(
       {
         operator: COMPARATOR.NOT_EQUAL,
         targetValue: 90,
-        colorScheme: 'rgb(255,0,0)',
+        colorScheme: '#FF0000',
         column: 'count',
       },
       countValues,
     );
     expect(colorFunction(90)).toBeUndefined();
-    expect(colorFunction(100)).toEqual('rgba(255,0,0,0.29)');
-    expect(colorFunction(50)).toEqual('rgba(255,0,0,1)');
+    expect(colorFunction(100)).toEqual('#FF00004A');
+    expect(colorFunction(50)).toEqual('#FF0000FF');
   });
 
   it('getColorFunction BETWEEN', () => {
@@ -160,13 +160,13 @@ describe('getColorFunction()', () => {
         operator: COMPARATOR.BETWEEN,
         targetValueLeft: 75,
         targetValueRight: 125,
-        colorScheme: 'rgb(255,0,0)',
+        colorScheme: '#FF0000',
         column: 'count',
       },
       countValues,
     );
     expect(colorFunction(50)).toBeUndefined();
-    expect(colorFunction(100)).toEqual('rgba(255,0,0,0.53)');
+    expect(colorFunction(100)).toEqual('#FF000087');
   });
 
   it('getColorFunction BETWEEN_OR_EQUAL', () => {
@@ -175,13 +175,13 @@ describe('getColorFunction()', () => {
         operator: COMPARATOR.BETWEEN_OR_EQUAL,
         targetValueLeft: 50,
         targetValueRight: 100,
-        colorScheme: 'rgb(255,0,0)',
+        colorScheme: '#FF0000',
         column: 'count',
       },
       countValues,
     );
-    expect(colorFunction(50)).toEqual('rgba(255,0,0,0.05)');
-    expect(colorFunction(100)).toEqual('rgba(255,0,0,1)');
+    expect(colorFunction(50)).toEqual('#FF00000D');
+    expect(colorFunction(100)).toEqual('#FF0000FF');
     expect(colorFunction(150)).toBeUndefined();
   });
 
@@ -191,12 +191,12 @@ describe('getColorFunction()', () => {
         operator: COMPARATOR.BETWEEN_OR_LEFT_EQUAL,
         targetValueLeft: 50,
         targetValueRight: 100,
-        colorScheme: 'rgb(255,0,0)',
+        colorScheme: '#FF0000',
         column: 'count',
       },
       countValues,
     );
-    expect(colorFunction(50)).toEqual('rgba(255,0,0,0.05)');
+    expect(colorFunction(50)).toEqual('#FF00000D');
     expect(colorFunction(100)).toBeUndefined();
   });
 
@@ -206,13 +206,13 @@ describe('getColorFunction()', () => {
         operator: COMPARATOR.BETWEEN_OR_RIGHT_EQUAL,
         targetValueLeft: 50,
         targetValueRight: 100,
-        colorScheme: 'rgb(255,0,0)',
+        colorScheme: '#FF0000',
         column: 'count',
       },
       countValues,
     );
     expect(colorFunction(50)).toBeUndefined();
-    expect(colorFunction(100)).toEqual('rgba(255,0,0,1)');
+    expect(colorFunction(100)).toEqual('#FF0000FF');
   });
 
   it('getColorFunction GREATER_THAN with target value undefined', () => {
@@ -220,7 +220,7 @@ describe('getColorFunction()', () => {
       {
         operator: COMPARATOR.GREATER_THAN,
         targetValue: undefined,
-        colorScheme: 'rgb(255,0,0)',
+        colorScheme: '#FF0000',
         column: 'count',
       },
       countValues,
@@ -235,7 +235,7 @@ describe('getColorFunction()', () => {
         operator: COMPARATOR.BETWEEN,
         targetValueLeft: undefined,
         targetValueRight: 100,
-        colorScheme: 'rgb(255,0,0)',
+        colorScheme: '#FF0000',
         column: 'count',
       },
       countValues,
@@ -250,7 +250,7 @@ describe('getColorFunction()', () => {
         operator: COMPARATOR.BETWEEN,
         targetValueLeft: 50,
         targetValueRight: undefined,
-        colorScheme: 'rgb(255,0,0)',
+        colorScheme: '#FF0000',
         column: 'count',
       },
       countValues,
@@ -265,7 +265,7 @@ describe('getColorFunction()', () => {
         // @ts-ignore
         operator: 'unsupported operator',
         targetValue: 50,
-        colorScheme: 'rgb(255,0,0)',
+        colorScheme: '#FF0000',
         column: 'count',
       },
       countValues,
@@ -278,15 +278,15 @@ describe('getColorFunction()', () => {
     const colorFunction = getColorFunction(
       {
         operator: COMPARATOR.NONE,
-        colorScheme: 'rgb(255,0,0)',
+        colorScheme: '#FF0000',
         column: 'count',
       },
       countValues,
     );
     expect(colorFunction(20)).toEqual(undefined);
-    expect(colorFunction(50)).toEqual('rgba(255,0,0,0)');
-    expect(colorFunction(75)).toEqual('rgba(255,0,0,0.5)');
-    expect(colorFunction(100)).toEqual('rgba(255,0,0,1)');
+    expect(colorFunction(50)).toEqual('#FF000000');
+    expect(colorFunction(75)).toEqual('#FF000080');
+    expect(colorFunction(100)).toEqual('#FF0000FF');
     expect(colorFunction(120)).toEqual(undefined);
   });
 
@@ -295,7 +295,7 @@ describe('getColorFunction()', () => {
       {
         operator: undefined,
         targetValue: 150,
-        colorScheme: 'rgb(255,0,0)',
+        colorScheme: '#FF0000',
         column: 'count',
       },
       countValues,
@@ -325,26 +325,26 @@ describe('getColorFormatters()', () => {
       {
         operator: COMPARATOR.GREATER_THAN,
         targetValue: 50,
-        colorScheme: 'rgb(255,0,0)',
+        colorScheme: '#FF0000',
         column: 'count',
       },
       {
         operator: COMPARATOR.LESS_THAN,
         targetValue: 300,
-        colorScheme: 'rgb(255,0,0)',
+        colorScheme: '#FF0000',
         column: 'sum',
       },
       {
         operator: COMPARATOR.BETWEEN,
         targetValueLeft: 75,
         targetValueRight: 125,
-        colorScheme: 'rgb(255,0,0)',
+        colorScheme: '#FF0000',
         column: 'count',
       },
       {
         operator: COMPARATOR.GREATER_THAN,
         targetValue: 150,
-        colorScheme: 'rgb(255,0,0)',
+        colorScheme: '#FF0000',
         column: undefined,
       },
     ];
@@ -352,20 +352,14 @@ describe('getColorFormatters()', () => {
     expect(colorFormatters.length).toEqual(3);
 
     expect(colorFormatters[0].column).toEqual('count');
-    expect(colorFormatters[0].getColorFromValue(100)).toEqual(
-      'rgba(255,0,0,1)',
-    );
+    expect(colorFormatters[0].getColorFromValue(100)).toEqual('#FF0000FF');
 
     expect(colorFormatters[1].column).toEqual('sum');
-    expect(colorFormatters[1].getColorFromValue(200)).toEqual(
-      'rgba(255,0,0,1)',
-    );
+    expect(colorFormatters[1].getColorFromValue(200)).toEqual('#FF0000FF');
     expect(colorFormatters[1].getColorFromValue(400)).toBeUndefined();
 
     expect(colorFormatters[2].column).toEqual('count');
-    expect(colorFormatters[2].getColorFromValue(100)).toEqual(
-      'rgba(255,0,0,0.53)',
-    );
+    expect(colorFormatters[2].getColorFromValue(100)).toEqual('#FF000087');
   });
 
   it('undefined column config', () => {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Since our color scheme uses hex values, the previous way of RGB is not working, so we fix it here.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### before
<img width="792" alt="image" src="https://user-images.githubusercontent.com/11830681/173874746-f37e08ac-1e8d-4ba2-908f-91e5ecb81c95.png">

### after
<img width="881" alt="image" src="https://user-images.githubusercontent.com/11830681/173874593-883e80bd-6505-495e-a487-0cad717dfe76.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/20391
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
