### PR TITLE
docs: add Matomo tracking to docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -251,6 +251,7 @@ const config = {
         darkTheme: darkCodeTheme,
       },
     }),
+  scripts: ['/script/matomo.js'],
 };
 
 module.exports = config;

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -37,11 +37,14 @@ const config = {
   projectName: 'superset', // Usually your repo name.
   themes: ['@saucelabs/theme-github-codeblock'],
   plugins: [
-    ["docusaurus-plugin-less", {
-      lessOptions: {
-        javascriptEnabled: true,
-      }
-    }],
+    [
+      'docusaurus-plugin-less',
+      {
+        lessOptions: {
+          javascriptEnabled: true,
+        },
+      },
+    ],
     [
       '@docusaurus/plugin-client-redirects',
       {
@@ -229,8 +232,7 @@ const config = {
       },
       footer: {
         style: 'dark',
-        links: [
-        ],
+        links: [],
         copyright: `Copyright © ${new Date().getFullYear()},
         The <a href="https://www.apache.org/" target="_blank" rel="noreferrer">Apache Software Foundation</a>,
         Licensed under the Apache <a href="https://apache.org/licenses/LICENSE-2.0" target="_blank" rel="noreferrer">License</a>. <br/>

--- a/docs/static/script/matomo.js
+++ b/docs/static/script/matomo.js
@@ -1,0 +1,17 @@
+var _paq = (window._paq = window._paq || []);
+/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+/* We explicitly disable cookie tracking to avoid privacy issues */
+_paq.push(['disableCookies']);
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function () {
+  var u = 'https://analytics.apache.org/';
+  _paq.push(['setTrackerUrl', u + 'matomo.php']);
+  _paq.push(['setSiteId', '22']);
+  var d = document,
+    g = d.createElement('script'),
+    s = d.getElementsByTagName('script')[0];
+  g.async = true;
+  g.src = u + 'matomo.js';
+  s.parentNode.insertBefore(g, s);
+})();

--- a/docs/static/script/matomo.js
+++ b/docs/static/script/matomo.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 var _paq = (window._paq = window._paq || []);
 /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
 /* We explicitly disable cookie tracking to avoid privacy issues */


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
- Run Prettier on `docusaurus.config.js`
- Put Matomo tracking script in JS file and inject in `<head>` of each page using `scripts` key in `docusaurus.config.js`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Script in `<head>`:
<img width="832" alt="Screen Shot 2022-06-15 at 11 31 14 AM" src="https://user-images.githubusercontent.com/13007381/173889526-6776b2bb-b83a-4d90-8f23-13ec9a6564c5.png">

Ping sent:
<img width="867" alt="Screen Shot 2022-06-15 at 11 31 22 AM" src="https://user-images.githubusercontent.com/13007381/173889595-2b8b8f03-c99d-4b85-9efd-139af5cec622.png">


### TESTING INSTRUCTIONS
1. Run docs:
```shell
cd docs
yarn install
yarn start
```
2. Visit `http://localhost:3000` and check for `<script src="/script/matomo.js"></script>` in the `<head>` tag of the homepage and various other pages.  You can also check that the tracker's ping was sent to `analytics.apache.org`.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
