### PR TITLE
feat: Adds the /explore endpoint to the v1 API

### DIFF
--- a/superset/explore/api.py
+++ b/superset/explore/api.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
-from abc import ABC
 
 from flask import g, request, Response
 from flask_appbuilder.api import BaseApi, expose, protect, safe
@@ -36,7 +35,7 @@ from superset.temporary_cache.commands.exceptions import (
 logger = logging.getLogger(__name__)
 
 
-class ExploreRestApi(BaseApi, ABC):
+class ExploreRestApi(BaseApi):
     method_permission_name = MODEL_API_RW_METHOD_PERMISSION_MAP
     include_route_methods = {RouteMethod.GET}
     allow_browser_login = True

--- a/superset/explore/api.py
+++ b/superset/explore/api.py
@@ -19,12 +19,11 @@ from abc import ABC
 
 from flask import g, request, Response
 from flask_appbuilder.api import BaseApi, expose, protect, safe
-from flask_babel import lazy_gettext as _
 
 from superset.charts.commands.exceptions import ChartNotFoundError
 from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP, RouteMethod
-from superset.datasets.schemas import DatasetSchema
 from superset.explore.commands.get import GetExploreCommand
+from superset.explore.commands.parameters import CommandParameters
 from superset.explore.exceptions import DatasetAccessDeniedError, WrongEndpointError
 from superset.explore.permalink.exceptions import ExplorePermalinkGetFailedError
 from superset.explore.schemas import ExploreContextSchema
@@ -99,21 +98,15 @@ class ExploreRestApi(BaseApi, ABC):
               $ref: '#/components/responses/500'
         """
         try:
-            permalink_key = request.args.get("permalink_key")
-            form_data_key = request.args.get("form_data_key")
-            dataset_id = request.args.get("dataset_id")
-            dataset_type = request.args.get("dataset_type")
-            slice_id = request.args.get("slice_id")
-
-            result = GetExploreCommand(
+            params = CommandParameters(
                 actor=g.user,
-                permalink_key=permalink_key,
-                form_data_key=form_data_key,
-                dataset_id=dataset_id,
-                dataset_type=dataset_type,
-                slice_id=slice_id,
-            ).run()
-
+                permalink_key=request.args.get("permalink_key"),
+                form_data_key=request.args.get("form_data_key"),
+                dataset_id=request.args.get("dataset_id"),
+                dataset_type=request.args.get("dataset_type"),
+                slice_id=request.args.get("slice_id"),
+            )
+            result = GetExploreCommand(params).run()
             if not result:
                 return self.response_404()
             return self.response(200, result=result)

--- a/superset/explore/commands/__init__.py
+++ b/superset/explore/commands/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/superset/explore/commands/get.py
+++ b/superset/explore/commands/get.py
@@ -1,0 +1,172 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import logging
+from abc import ABC
+from typing import Any, cast, Dict, Optional
+
+import simplejson as json
+from flask import current_app as app
+from flask_appbuilder.security.sqla.models import User
+from flask_babel import gettext as __, lazy_gettext as _
+from sqlalchemy.exc import SQLAlchemyError
+
+from superset import db, security_manager
+from superset.commands.base import BaseCommand
+from superset.connectors.base.models import BaseDatasource
+from superset.connectors.connector_registry import ConnectorRegistry
+from superset.connectors.sqla.models import SqlaTable
+from superset.datasets.commands.exceptions import DatasetNotFoundError
+from superset.exceptions import SupersetException
+from superset.explore.exceptions import DatasetAccessDeniedError, WrongEndpointError
+from superset.explore.form_data.commands.get import GetFormDataCommand
+from superset.explore.form_data.commands.parameters import CommandParameters
+from superset.explore.permalink.commands.get import GetExplorePermalinkCommand
+from superset.explore.permalink.exceptions import ExplorePermalinkGetFailedError
+from superset.models.sql_lab import Query
+from superset.utils import core as utils
+from superset.views.utils import (
+    get_datasource_info,
+    get_form_data,
+    sanitize_datasource_data,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class GetExploreCommand(BaseCommand, ABC):
+    def __init__(
+        self,
+        actor: User,
+        permalink_key: Optional[str],
+        form_data_key: Optional[str],
+        dataset_id: Optional[int],
+        dataset_type: Optional[str],
+        slice_id: Optional[int],
+    ) -> None:
+        self._actor = actor
+        self._permalink_key = permalink_key
+        self._form_data_key = form_data_key
+        self._dataset_id = dataset_id
+        self._dataset_type = dataset_type
+        self._slice_id = slice_id
+
+    def run(self) -> Optional[Dict[str, Any]]:
+        initial_form_data = {}
+
+        if self._permalink_key is not None:
+            command = GetExplorePermalinkCommand(self._actor, self._permalink_key)
+            permalink_value = command.run()
+            if permalink_value:
+                state = permalink_value["state"]
+                initial_form_data = state["formData"]
+                url_params = state.get("urlParams")
+                if url_params:
+                    initial_form_data["url_params"] = dict(url_params)
+            else:
+                raise ExplorePermalinkGetFailedError()
+        elif self._form_data_key:
+            parameters = CommandParameters(actor=self._actor, key=self._form_data_key)
+            value = GetFormDataCommand(parameters).run()
+            initial_form_data = json.loads(value) if value else {}
+
+        message = None
+
+        if not initial_form_data:
+            if self._slice_id:
+                initial_form_data["slice_id"] = self._slice_id
+                if self._form_data_key:
+                    message = _(
+                        "Form data not found in cache, reverting to chart metadata."
+                    )
+            elif self._dataset_id:
+                initial_form_data["datasource"] = f"{self._dataset_id}__table"
+                if self._form_data_key:
+                    message = _(
+                        "Form data not found in cache, reverting to dataset metadata."
+                    )
+
+        form_data, slc = get_form_data(
+            use_slice_data=True, initial_form_data=initial_form_data
+        )
+        try:
+            self._dataset_id, self._dataset_type = get_datasource_info(
+                self._dataset_id, self._dataset_type, form_data
+            )
+        except SupersetException:
+            self._dataset_id = None
+            # fallback unkonw datasource to table type
+            self._dataset_type = SqlaTable.type
+
+        dataset: Optional[BaseDatasource] = None
+        if self._dataset_id is not None:
+            try:
+                dataset = ConnectorRegistry.get_datasource(
+                    cast(str, self._dataset_type), self._dataset_id, db.session
+                )
+            except DatasetNotFoundError:
+                pass
+        dataset_name = dataset.name if dataset else _("[Missing Dataset]")
+
+        if dataset:
+            if app.config["ENABLE_ACCESS_REQUEST"] and (
+                not security_manager.can_access_datasource(dataset)
+            ):
+                message = __(security_manager.get_datasource_access_error_msg(dataset))
+                raise DatasetAccessDeniedError(
+                    message=message,
+                    dataset_type=self._dataset_type,
+                    dataset_id=self._dataset_id,
+                )
+
+        viz_type = form_data.get("viz_type")
+        if not viz_type and dataset and dataset.default_endpoint:
+            raise WrongEndpointError(redirect=dataset.default_endpoint)
+
+        form_data["datasource"] = (
+            str(self._dataset_id) + "__" + cast(str, self._dataset_type)
+        )
+
+        # On explore, merge legacy and extra filters into the form data
+        utils.convert_legacy_filters_into_adhoc(form_data)
+        utils.merge_extra_filters(form_data)
+
+        dummy_dataset_data: Dict[str, Any] = {
+            "type": self._dataset_type,
+            "name": dataset_name,
+            "columns": [],
+            "metrics": [],
+            "database": {"id": 0, "backend": ""},
+        }
+        try:
+            dataset_data = dataset.data if dataset else dummy_dataset_data
+        except (SupersetException, SQLAlchemyError):
+            dataset_data = dummy_dataset_data
+
+        if dataset:
+            dataset_data["owners"] = dataset.owners_data
+            if isinstance(dataset, Query):
+                dataset_data["columns"] = dataset.columns
+
+        return {
+            "dataset": sanitize_datasource_data(dataset_data),
+            "form_data": form_data,
+            "slice": slc.data if slc else None,
+            "message": message,
+        }
+
+    def validate(self) -> None:
+        pass

--- a/superset/explore/commands/get.py
+++ b/superset/explore/commands/get.py
@@ -68,14 +68,13 @@ class GetExploreCommand(BaseCommand, ABC):
         if self._permalink_key is not None:
             command = GetExplorePermalinkCommand(self._actor, self._permalink_key)
             permalink_value = command.run()
-            if permalink_value:
-                state = permalink_value["state"]
-                initial_form_data = state["formData"]
-                url_params = state.get("urlParams")
-                if url_params:
-                    initial_form_data["url_params"] = dict(url_params)
-            else:
+            if not permalink_value:
                 raise ExplorePermalinkGetFailedError()
+            state = permalink_value["state"]
+            initial_form_data = state["formData"]
+            url_params = state.get("urlParams")
+            if url_params:
+                initial_form_data["url_params"] = dict(url_params)
         elif self._form_data_key:
             parameters = FormDataCommandParameters(
                 actor=self._actor, key=self._form_data_key

--- a/superset/explore/commands/get.py
+++ b/superset/explore/commands/get.py
@@ -26,9 +26,9 @@ from sqlalchemy.exc import SQLAlchemyError
 from superset import db, security_manager
 from superset.commands.base import BaseCommand
 from superset.connectors.base.models import BaseDatasource
-from superset.connectors.connector_registry import ConnectorRegistry
 from superset.connectors.sqla.models import SqlaTable
 from superset.datasets.commands.exceptions import DatasetNotFoundError
+from superset.datasource.dao import DatasourceDAO
 from superset.exceptions import SupersetException
 from superset.explore.commands.parameters import CommandParameters
 from superset.explore.exceptions import DatasetAccessDeniedError, WrongEndpointError
@@ -113,8 +113,8 @@ class GetExploreCommand(BaseCommand, ABC):
         dataset: Optional[BaseDatasource] = None
         if self._dataset_id is not None:
             try:
-                dataset = ConnectorRegistry.get_datasource(
-                    cast(str, self._dataset_type), self._dataset_id, db.session
+                dataset = DatasourceDAO.get_datasource(
+                    db.session, cast(str, self._dataset_type), self._dataset_id
                 )
             except DatasetNotFoundError:
                 pass

--- a/superset/explore/commands/parameters.py
+++ b/superset/explore/commands/parameters.py
@@ -14,22 +14,17 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from dataclasses import dataclass
 from typing import Optional
 
-from superset.commands.exceptions import CommandException, ForbiddenError
+from flask_appbuilder.security.sqla.models import User
 
 
-class DatasetAccessDeniedError(ForbiddenError):
-    def __init__(
-        self, message: str, dataset_id: Optional[int], dataset_type: Optional[str]
-    ) -> None:
-        self.message = message
-        self.dataset_id = dataset_id
-        self.dataset_type = dataset_type
-        super().__init__(self.message)
-
-
-class WrongEndpointError(CommandException):
-    def __init__(self, redirect: str) -> None:
-        self.redirect = redirect
-        super().__init__()
+@dataclass
+class CommandParameters:
+    actor: User
+    permalink_key: Optional[str]
+    form_data_key: Optional[str]
+    dataset_id: Optional[int]
+    dataset_type: Optional[str]
+    slice_id: Optional[int]

--- a/superset/explore/exceptions.py
+++ b/superset/explore/exceptions.py
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Optional
+
+from flask_babel import lazy_gettext as _
+
+from superset.commands.exceptions import CommandException, ForbiddenError
+
+
+class DatasetAccessDeniedError(ForbiddenError):
+    def __init__(
+        self, message: str, dataset_id: Optional[int], dataset_type: Optional[str]
+    ) -> None:
+        self.message = message
+        self.dataset_id = dataset_id
+        self.dataset_type = dataset_type
+        super().__init__(self.message)
+
+
+class WrongEndpointError(CommandException):
+    def __init__(self, redirect: str) -> None:
+        self.redirect = redirect
+        super().__init__()

--- a/superset/explore/form_data/api.py
+++ b/superset/explore/form_data/api.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
-from abc import ABC
 
 from flask import g, request, Response
 from flask_appbuilder.api import BaseApi, expose, protect, safe
@@ -38,7 +37,7 @@ from superset.views.base_api import requires_json
 logger = logging.getLogger(__name__)
 
 
-class ExploreFormDataRestApi(BaseApi, ABC):
+class ExploreFormDataRestApi(BaseApi):
     add_model_schema = FormDataPostSchema()
     edit_model_schema = FormDataPutSchema()
     method_permission_name = MODEL_API_RW_METHOD_PERMISSION_MAP

--- a/superset/explore/schemas.py
+++ b/superset/explore/schemas.py
@@ -1,0 +1,80 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+#  License ); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+#  AS IS  BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from marshmallow import fields, Schema
+
+
+class DatasetSchema(Schema):
+    cache_timeout = fields.Int()
+    column_formats = fields.Dict()
+    columns = fields.List(fields.Dict())
+    database = fields.Dict()
+    datasource_name = fields.Str()
+    default_endpoint = fields.Str()
+    description = fields.Str()
+    edit_url = fields.Str()
+    extra = fields.Dict()
+    fetch_values_predicate = fields.Str()
+    filter_select = fields.Bool()
+    filter_select_enabled = fields.Bool()
+    granularity_sqla = fields.List(fields.List(fields.Dict()))
+    health_check_message = fields.Str()
+    id = fields.Int()
+    is_sqllab_view = fields.Bool()
+    main_dttm_col = fields.Str()
+    metrics = fields.List(fields.Dict())
+    name = fields.Str()
+    offset = fields.Int()
+    order_by_choices = fields.List(fields.List(fields.Str()))
+    owners = fields.List(fields.Number)
+    params = fields.Dict()
+    perm = fields.Str()
+    schema = fields.Str()
+    select_star = fields.Str()
+    sql = fields.Str()
+    table_name = fields.Str()
+    template_params = fields.Dict()
+    time_grain_sqla = fields.List(fields.List(fields.Str()))
+    type = fields.Str()
+    uid = fields.Str()
+    verbose_map = fields.Dict()
+
+
+class SliceSchema(Schema):
+    cache_timeout = fields.Int()
+    certification_details = fields.Str()
+    certified_by = fields.Str()
+    changed_on = fields.Str()
+    changed_on_humanized = fields.Str()
+    datasource = fields.Str()
+    description = fields.Str()
+    description_markeddown = fields.Str()
+    edit_url = fields.Str()
+    form_data = fields.Dict()
+    is_managed_externally = fields.Bool()
+    modified = fields.Str()
+    owners = fields.List(fields.Number)
+    query_context = fields.Dict()
+    slice_id = fields.Int()
+    slice_name = fields.Str()
+    slice_url = fields.Str()
+
+
+class ExploreContextSchema(Schema):
+    form_data = fields.Dict()
+    dataset = fields.Nested(DatasetSchema)
+    slice = fields.Nested(SliceSchema)
+    message = fields.String()

--- a/superset/explore/schemas.py
+++ b/superset/explore/schemas.py
@@ -18,63 +18,97 @@ from marshmallow import fields, Schema
 
 
 class DatasetSchema(Schema):
-    cache_timeout = fields.Int()
-    column_formats = fields.Dict()
-    columns = fields.List(fields.Dict())
-    database = fields.Dict()
-    datasource_name = fields.Str()
-    default_endpoint = fields.Str()
-    description = fields.Str()
-    edit_url = fields.Str()
-    extra = fields.Dict()
-    fetch_values_predicate = fields.Str()
-    filter_select = fields.Bool()
-    filter_select_enabled = fields.Bool()
-    granularity_sqla = fields.List(fields.List(fields.Dict()))
-    health_check_message = fields.Str()
-    id = fields.Int()
-    is_sqllab_view = fields.Bool()
-    main_dttm_col = fields.Str()
-    metrics = fields.List(fields.Dict())
-    name = fields.Str()
-    offset = fields.Int()
-    order_by_choices = fields.List(fields.List(fields.Str()))
-    owners = fields.List(fields.Number)
-    params = fields.Dict()
-    perm = fields.Str()
-    schema = fields.Str()
-    select_star = fields.Str()
-    sql = fields.Str()
-    table_name = fields.Str()
-    template_params = fields.Dict()
-    time_grain_sqla = fields.List(fields.List(fields.Str()))
-    type = fields.Str()
-    uid = fields.Str()
-    verbose_map = fields.Dict()
+    cache_timeout = fields.Integer(
+        description="Duration (in seconds) of the caching timeout for this dataset."
+    )
+    column_formats = fields.Dict(description="Column formats.")
+    columns = fields.List(fields.Dict(), description="Columns metadata.")
+    database = fields.Dict(description="Database associated with the dataset.")
+    datasource_name = fields.String(description="Dataset name.")
+    default_endpoint = fields.String(description="Default endpoint for the dataset.")
+    description = fields.String(description="Dataset description.")
+    edit_url = fields.String(description="The URL for editing the dataset.")
+    extra = fields.Dict(
+        description="JSON string containing extra configuration elements."
+    )
+    fetch_values_predicate = fields.String(
+        description="Predicate used when fetching values from the dataset."
+    )
+    filter_select = fields.Bool(description="SELECT filter applied to the dataset.")
+    filter_select_enabled = fields.Bool(description="If the SELECT filter is enabled.")
+    granularity_sqla = fields.List(
+        fields.List(fields.Dict()),
+        description=(
+            "Name of temporal column used for time filtering for SQL datasources. "
+            "This field is deprecated, use `granularity` instead."
+        ),
+    )
+    health_check_message = fields.String(description="Health check message.")
+    id = fields.Integer(description="Dataset ID.")
+    is_sqllab_view = fields.Bool(description="If the dataset is a SQL Lab view.")
+    main_dttm_col = fields.String(description="The main temporal column.")
+    metrics = fields.List(fields.Dict(), description="Dataset metrics.")
+    name = fields.String(description="Dataset name.")
+    offset = fields.Integer(description="Dataset offset.")
+    order_by_choices = fields.List(
+        fields.List(fields.String()), description="List of order by columns."
+    )
+    owners = fields.List(fields.Integer(), description="List of owners identifiers")
+    params = fields.Dict(description="Extra params for the dataset.")
+    perm = fields.String(description="Permission expression.")
+    schema = fields.String(description="Dataset schema.")
+    select_star = fields.String(description="Select all clause.")
+    sql = fields.String(description="A SQL statement that defines the dataset.")
+    table_name = fields.String(
+        description="The name of the table associated with the dataset."
+    )
+    template_params = fields.Dict(description="Table template params.")
+    time_grain_sqla = fields.List(
+        fields.List(fields.String()),
+        description="List of temporal granularities supported by the dataset.",
+    )
+    type = fields.String(description="Dataset type.")
+    uid = fields.String(description="Dataset unique identifier.")
+    verbose_map = fields.Dict(description="Mapping from raw name to verbose name.")
 
 
 class SliceSchema(Schema):
-    cache_timeout = fields.Int()
-    certification_details = fields.Str()
-    certified_by = fields.Str()
-    changed_on = fields.Str()
-    changed_on_humanized = fields.Str()
-    datasource = fields.Str()
-    description = fields.Str()
-    description_markeddown = fields.Str()
-    edit_url = fields.Str()
-    form_data = fields.Dict()
-    is_managed_externally = fields.Bool()
-    modified = fields.Str()
-    owners = fields.List(fields.Number)
-    query_context = fields.Dict()
-    slice_id = fields.Int()
-    slice_name = fields.Str()
-    slice_url = fields.Str()
+    cache_timeout = fields.Integer(
+        description="Duration (in seconds) of the caching timeout for this chart."
+    )
+    certification_details = fields.String(description="Details of the certification.")
+    certified_by = fields.String(
+        description="Person or group that has certified this dashboard."
+    )
+    changed_on = fields.String(description="Timestamp of the last modification.")
+    changed_on_humanized = fields.String(
+        description="Timestamp of the last modification in human readable form."
+    )
+    datasource = fields.String(description="Datasource identifier.")
+    description = fields.String(description="Slice description.")
+    description_markeddown = fields.String(
+        description="Sanitized HTML version of the chart description."
+    )
+    edit_url = fields.String(description="The URL for editing the slice.")
+    form_data = fields.Dict(description="Form data associated with the slice.")
+    is_managed_externally = fields.Bool(
+        description="If the chart is managed outside externally."
+    )
+    modified = fields.String(description="Last modification in human readable form.")
+    owners = fields.List(fields.Integer(), description="Owners identifiers.")
+    query_context = fields.Dict(description="The context associated with the query.")
+    slice_id = fields.Integer(description="The slice ID.")
+    slice_name = fields.String(description="The slice name.")
+    slice_url = fields.String(description="The slice URL.")
 
 
 class ExploreContextSchema(Schema):
-    form_data = fields.Dict()
+    form_data = fields.Dict(
+        description=(
+            "Form data from the Explore controls used to form the "
+            "chart's data query."
+        )
+    )
     dataset = fields.Nested(DatasetSchema)
     slice = fields.Nested(SliceSchema)
-    message = fields.String()
+    message = fields.String(description="Any message related to the processed request.")

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -136,6 +136,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         from superset.datasets.metrics.api import DatasetMetricRestApi
         from superset.embedded.api import EmbeddedDashboardRestApi
         from superset.embedded.view import EmbeddedView
+        from superset.explore.api import ExploreRestApi
         from superset.explore.form_data.api import ExploreFormDataRestApi
         from superset.explore.permalink.api import ExplorePermalinkRestApi
         from superset.importexport.api import ImportExportRestApi
@@ -204,6 +205,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         appbuilder.add_api(DatasetColumnsRestApi)
         appbuilder.add_api(DatasetMetricRestApi)
         appbuilder.add_api(EmbeddedDashboardRestApi)
+        appbuilder.add_api(ExploreRestApi)
         appbuilder.add_api(ExploreFormDataRestApi)
         appbuilder.add_api(ExplorePermalinkRestApi)
         appbuilder.add_api(FilterSetRestApi)

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -749,6 +749,11 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         datasource_id: Optional[int] = None,
         key: Optional[str] = None,
     ) -> FlaskResponse:
+        logger.warning(
+            "%s.explore "
+            "This API endpoint is deprecated and will be removed in version 3.0.0",
+            self.__class__.__name__,
+        )
         initial_form_data = {}
 
         form_data_key = request.args.get("form_data_key")

--- a/tests/integration_tests/explore/api_tests.py
+++ b/tests/integration_tests/explore/api_tests.py
@@ -87,7 +87,7 @@ def assert_dataset(result, dataset_id):
     assert dataset["main_dttm_col"] == "year"
     assert dataset["sql"] == None
     assert dataset["type"] == "table"
-    assert dataset["uid"] == "1__table"
+    assert dataset["uid"] == f"{dataset_id}__table"
 
 
 # partially match the slice using the most important attributes
@@ -97,7 +97,7 @@ def assert_slice(result, chart_id):
     assert slice["is_managed_externally"] == False
     assert slice["slice_id"] == chart_id
     assert slice["slice_name"] == "World's Population"
-    assert slice["form_data"]["datasource"] == "1__table"
+    assert slice["form_data"]["datasource"] == f"{chart_id}__table"
     assert slice["form_data"]["viz_type"] == "big_number"
 
 
@@ -122,7 +122,7 @@ def test_get_from_cache(client, dataset):
     data = json.loads(resp.data.decode("utf-8"))
     result = data.get("result")
     assert_dataset(result, dataset.id)
-    assert result["form_data"]["datasource"] == "1__table"
+    assert result["form_data"]["datasource"] == f"{dataset.id}__table"
     assert result["form_data"]["test"] == "test value"
     assert result["message"] == None
     assert result["slice"] == None
@@ -139,7 +139,7 @@ def test_get_from_cache_unknown_key_chart_id(client, chart_id, dataset):
     result = data.get("result")
     assert_dataset(result, dataset.id)
     assert_slice(result, chart_id)
-    assert result["form_data"]["datasource"] == "1__table"
+    assert result["form_data"]["datasource"] == f"{dataset.id}__table"
     assert (
         result["message"]
         == "Form data not found in cache, reverting to chart metadata."
@@ -156,7 +156,7 @@ def test_get_from_cache_unknown_key_dataset(client, dataset):
     data = json.loads(resp.data.decode("utf-8"))
     result = data.get("result")
     assert_dataset(result, dataset.id)
-    assert result["form_data"]["datasource"] == "1__table"
+    assert result["form_data"]["datasource"] == f"{dataset.id}__table"
     assert (
         result["message"]
         == "Form data not found in cache, reverting to dataset metadata."
@@ -192,7 +192,7 @@ def test_get_from_permalink(client, chart_id, dataset):
     data = json.loads(resp.data.decode("utf-8"))
     result = data.get("result")
     assert_dataset(result, dataset.id)
-    assert result["form_data"]["datasource"] == "1__table"
+    assert result["form_data"]["datasource"] == f"{dataset.id}__table"
     assert result["form_data"]["test"] == "test value"
     assert result["message"] == None
     assert result["slice"] == None

--- a/tests/integration_tests/explore/api_tests.py
+++ b/tests/integration_tests/explore/api_tests.py
@@ -85,9 +85,7 @@ def assert_dataset(result, dataset_id):
     assert dataset["datasource_name"] == "wb_health_population"
     assert dataset["is_sqllab_view"] == False
     assert dataset["main_dttm_col"] == "year"
-    assert dataset["schema"] == "public"
     assert dataset["sql"] == None
-    assert dataset["table_name"] == "wb_health_population"
     assert dataset["type"] == "table"
     assert dataset["uid"] == "1__table"
 

--- a/tests/integration_tests/explore/api_tests.py
+++ b/tests/integration_tests/explore/api_tests.py
@@ -79,9 +79,9 @@ def cache(chart_id, admin_id, dataset):
 
 
 # partially match the dataset using the most important attributes
-def assert_dataset(result):
+def assert_dataset(result, dataset_id):
     dataset = result["dataset"]
-    assert dataset["id"] == 1
+    assert dataset["id"] == dataset_id
     assert dataset["datasource_name"] == "wb_health_population"
     assert dataset["is_sqllab_view"] == False
     assert dataset["main_dttm_col"] == "year"
@@ -123,14 +123,14 @@ def test_get_from_cache(client, dataset):
     assert resp.status_code == 200
     data = json.loads(resp.data.decode("utf-8"))
     result = data.get("result")
-    assert_dataset(result)
+    assert_dataset(result, dataset.id)
     assert result["form_data"]["datasource"] == "1__table"
     assert result["form_data"]["test"] == "test value"
     assert result["message"] == None
     assert result["slice"] == None
 
 
-def test_get_from_cache_unknown_key_chart_id(client, chart_id):
+def test_get_from_cache_unknown_key_chart_id(client, chart_id, dataset):
     login(client, "admin")
     unknown_key = "unknown_key"
     resp = client.get(
@@ -139,7 +139,7 @@ def test_get_from_cache_unknown_key_chart_id(client, chart_id):
     assert resp.status_code == 200
     data = json.loads(resp.data.decode("utf-8"))
     result = data.get("result")
-    assert_dataset(result)
+    assert_dataset(result, dataset.id)
     assert_slice(result, chart_id)
     assert result["form_data"]["datasource"] == "1__table"
     assert (
@@ -157,7 +157,7 @@ def test_get_from_cache_unknown_key_dataset(client, dataset):
     assert resp.status_code == 200
     data = json.loads(resp.data.decode("utf-8"))
     result = data.get("result")
-    assert_dataset(result)
+    assert_dataset(result, dataset.id)
     assert result["form_data"]["datasource"] == "1__table"
     assert (
         result["message"]
@@ -193,7 +193,7 @@ def test_get_from_permalink(client, chart_id, dataset):
     assert resp.status_code == 200
     data = json.loads(resp.data.decode("utf-8"))
     result = data.get("result")
-    assert_dataset(result)
+    assert_dataset(result, dataset.id)
     assert result["form_data"]["datasource"] == "1__table"
     assert result["form_data"]["test"] == "test value"
     assert result["message"] == None

--- a/tests/integration_tests/explore/api_tests.py
+++ b/tests/integration_tests/explore/api_tests.py
@@ -91,13 +91,13 @@ def assert_dataset(result, dataset_id):
 
 
 # partially match the slice using the most important attributes
-def assert_slice(result, chart_id):
+def assert_slice(result, chart_id, dataset_id):
     slice = result["slice"]
     assert slice["edit_url"] == f"/chart/edit/{chart_id}"
     assert slice["is_managed_externally"] == False
     assert slice["slice_id"] == chart_id
     assert slice["slice_name"] == "World's Population"
-    assert slice["form_data"]["datasource"] == f"{chart_id}__table"
+    assert slice["form_data"]["datasource"] == f"{dataset_id}__table"
     assert slice["form_data"]["viz_type"] == "big_number"
 
 
@@ -138,7 +138,7 @@ def test_get_from_cache_unknown_key_chart_id(client, chart_id, dataset):
     data = json.loads(resp.data.decode("utf-8"))
     result = data.get("result")
     assert_dataset(result, dataset.id)
-    assert_slice(result, chart_id)
+    assert_slice(result, chart_id, dataset.id)
     assert result["form_data"]["datasource"] == f"{dataset.id}__table"
     assert (
         result["message"]

--- a/tests/integration_tests/explore/api_tests.py
+++ b/tests/integration_tests/explore/api_tests.py
@@ -1,0 +1,230 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import json
+from unittest.mock import patch
+
+import pytest
+from flask_appbuilder.security.sqla.models import User
+from sqlalchemy.orm import Session
+
+from superset.connectors.sqla.models import SqlaTable
+from superset.explore.exceptions import DatasetAccessDeniedError, WrongEndpointError
+from superset.explore.form_data.commands.state import TemporaryExploreState
+from superset.extensions import cache_manager
+from superset.models.slice import Slice
+from tests.integration_tests.base_tests import login
+from tests.integration_tests.fixtures.client import client
+from tests.integration_tests.fixtures.world_bank_dashboard import (
+    load_world_bank_dashboard_with_slices,
+    load_world_bank_data,
+)
+from tests.integration_tests.test_app import app
+
+PERMALINK_KEY = "permalink_key"
+FORM_DATA_KEY = "form_data_key"
+FORM_DATA = {"test": "initial value"}
+RESULT = {
+    "dataset": {
+        "columns": [],
+        "database": {"backend": "", "id": 0, "parameters": {}},
+        "metrics": [],
+        "name": "[Missing Dataset]",
+        "type": "table",
+    },
+    "form_data": {
+        "adhoc_filters": [],
+        "applied_time_extras": {},
+        "datasource": "None__table",
+    },
+    "message": None,
+    "slice": None,
+}
+
+
+@pytest.fixture
+def chart_id(load_world_bank_dashboard_with_slices) -> int:
+    with app.app_context() as ctx:
+        session: Session = ctx.app.appbuilder.get_session
+        chart = session.query(Slice).filter_by(slice_name="World's Population").one()
+        return chart.id
+
+
+@pytest.fixture
+def admin_id() -> int:
+    with app.app_context() as ctx:
+        session: Session = ctx.app.appbuilder.get_session
+        admin = session.query(User).filter_by(username="admin").one()
+        return admin.id
+
+
+@pytest.fixture
+def dataset() -> int:
+    with app.app_context() as ctx:
+        session: Session = ctx.app.appbuilder.get_session
+        dataset = (
+            session.query(SqlaTable)
+            .filter_by(table_name="wb_health_population")
+            .first()
+        )
+        return dataset
+
+
+@pytest.fixture(autouse=True)
+def cache(chart_id, admin_id, dataset):
+    entry: TemporaryExploreState = {
+        "owner": admin_id,
+        "datasource_id": dataset.id,
+        "datasource_type": dataset.type,
+        "chart_id": chart_id,
+        "form_data": json.dumps(FORM_DATA),
+    }
+    cache_manager.explore_form_data_cache.set(FORM_DATA_KEY, entry)
+
+
+def test_no_params_provided(client):
+    login(client, "admin")
+    resp = client.get(f"api/v1/explore/")
+    assert resp.status_code == 200
+    data = json.loads(resp.data.decode("utf-8"))
+    result = data.get("result")
+    assert result["dataset"]["name"] == "[Missing Dataset]"
+    assert result["form_data"]["datasource"] == "None__table"
+    assert result["message"] == None
+    assert result["slice"] == None
+
+
+def test_get_from_cache(client, dataset):
+    login(client, "admin")
+    resp = client.get(
+        f"api/v1/explore/?form_data_key={FORM_DATA_KEY}&dataset_id={dataset.id}&dataset_type={dataset.type}"
+    )
+    assert resp.status_code == 200
+    data = json.loads(resp.data.decode("utf-8"))
+    result = data.get("result")
+    assert result["dataset"]["name"] == "wb_health_population"
+    assert result["form_data"]["datasource"] == "1__table"
+    assert result["form_data"]["test"] == "initial value"
+    assert result["message"] == None
+    assert result["slice"] == None
+
+
+def test_get_from_cache_unknown_key_chart_id(client, chart_id):
+    login(client, "admin")
+    unknown_key = "unknown_key"
+    resp = client.get(
+        f"api/v1/explore/?form_data_key={unknown_key}&slice_id={chart_id}"
+    )
+    assert resp.status_code == 200
+    data = json.loads(resp.data.decode("utf-8"))
+    result = data.get("result")
+    assert result["dataset"]["name"] == "wb_health_population"
+    assert result["form_data"]["datasource"] == "1__table"
+    assert (
+        result["message"]
+        == "Form data not found in cache, reverting to chart metadata."
+    )
+    assert result["slice"]["slice_id"] == 2
+    assert result["slice"]["slice_name"] == "World's Population"
+
+
+def test_get_from_cache_unknown_key_dataset(client, dataset):
+    login(client, "admin")
+    unknown_key = "unknown_key"
+    resp = client.get(
+        f"api/v1/explore/?form_data_key={unknown_key}&dataset_id={dataset.id}&dataset_type={dataset.type}"
+    )
+    assert resp.status_code == 200
+    data = json.loads(resp.data.decode("utf-8"))
+    result = data.get("result")
+    assert result["dataset"]["name"] == "wb_health_population"
+    assert result["form_data"]["datasource"] == "1__table"
+    assert (
+        result["message"]
+        == "Form data not found in cache, reverting to dataset metadata."
+    )
+    assert result["slice"] == None
+
+
+def test_get_from_cache_unknown_key_no_extra_parameters(client):
+    login(client, "admin")
+    unknown_key = "unknown_key"
+    resp = client.get(f"api/v1/explore/?form_data_key={unknown_key}")
+    assert resp.status_code == 200
+    data = json.loads(resp.data.decode("utf-8"))
+    result = data.get("result")
+    assert result["dataset"]["name"] == "[Missing Dataset]"
+    assert result["form_data"]["datasource"] == "None__table"
+    assert result["message"] == None
+    assert result["slice"] == None
+
+
+def test_get_from_permalink(client, chart_id, dataset):
+    login(client, "admin")
+    form_data = {
+        "chart_id": chart_id,
+        "datasource": f"{dataset.id}__{dataset.type}",
+        **FORM_DATA,
+    }
+    resp = client.post(f"api/v1/explore/permalink", json={"formData": form_data})
+    data = json.loads(resp.data.decode("utf-8"))
+    permalink_key = data["key"]
+    resp = client.get(f"api/v1/explore/?permalink_key={permalink_key}")
+    assert resp.status_code == 200
+    data = json.loads(resp.data.decode("utf-8"))
+    result = data.get("result")
+    assert result["dataset"]["name"] == "wb_health_population"
+    assert result["form_data"]["datasource"] == "1__table"
+    assert result["form_data"]["test"] == "initial value"
+    assert result["message"] == None
+    assert result["slice"] == None
+
+
+def test_get_from_permalink_unknown_key(client):
+    login(client, "admin")
+    unknown_key = "unknown_key"
+    resp = client.get(f"api/v1/explore/?permalink_key={unknown_key}")
+    assert resp.status_code == 404
+
+
+@patch("superset.security.SupersetSecurityManager.can_access_datasource")
+def test_get_dataset_access_denied(mock_can_access_datasource, client, dataset):
+    message = "Dataset access denied"
+    mock_can_access_datasource.side_effect = DatasetAccessDeniedError(
+        message=message, dataset_id=dataset.id, dataset_type=dataset.type
+    )
+    login(client, "admin")
+    resp = client.get(
+        f"api/v1/explore/?form_data_key={FORM_DATA_KEY}&dataset_id={dataset.id}&dataset_type={dataset.type}"
+    )
+    data = json.loads(resp.data.decode("utf-8"))
+    assert resp.status_code == 403
+    assert data["dataset_id"] == dataset.id
+    assert data["dataset_type"] == dataset.type
+    assert data["message"] == message
+
+
+@patch("superset.connectors.connector_registry.ConnectorRegistry.get_datasource")
+def test_wrong_endpoint(mock_get_datasource, client, dataset):
+    dataset.default_endpoint = "another_endpoint"
+    mock_get_datasource.return_value = dataset
+    login(client, "admin")
+    resp = client.get(
+        f"api/v1/explore/?dataset_id={dataset.id}&dataset_type={dataset.type}"
+    )
+    data = json.loads(resp.data.decode("utf-8"))
+    assert resp.status_code == 302
+    assert data["redirect"] == dataset.default_endpoint

--- a/tests/integration_tests/explore/api_tests.py
+++ b/tests/integration_tests/explore/api_tests.py
@@ -22,7 +22,7 @@ from flask_appbuilder.security.sqla.models import User
 from sqlalchemy.orm import Session
 
 from superset.connectors.sqla.models import SqlaTable
-from superset.explore.exceptions import DatasetAccessDeniedError, WrongEndpointError
+from superset.explore.exceptions import DatasetAccessDeniedError
 from superset.explore.form_data.commands.state import TemporaryExploreState
 from superset.extensions import cache_manager
 from superset.models.slice import Slice
@@ -35,7 +35,7 @@ from tests.integration_tests.fixtures.world_bank_dashboard import (
 from tests.integration_tests.test_app import app
 
 FORM_DATA_KEY = "form_data_key"
-FORM_DATA = {"test": "initial value"}
+FORM_DATA = {"test": "test value"}
 
 
 @pytest.fixture
@@ -84,8 +84,8 @@ def test_no_params_provided(client):
     assert resp.status_code == 200
     data = json.loads(resp.data.decode("utf-8"))
     result = data.get("result")
-    assert result["dataset"]["name"] == "[Missing Dataset]"
-    assert result["form_data"]["datasource"] == "None__table"
+    assert result["dataset"] != None
+    assert result["form_data"] != None
     assert result["message"] == None
     assert result["slice"] == None
 
@@ -98,9 +98,8 @@ def test_get_from_cache(client, dataset):
     assert resp.status_code == 200
     data = json.loads(resp.data.decode("utf-8"))
     result = data.get("result")
-    assert result["dataset"]["datasource_name"] == "wb_health_population"
-    assert result["form_data"]["datasource"] == "1__table"
-    assert result["form_data"]["test"] == "initial value"
+    assert result["dataset"] != None
+    assert result["form_data"]["test"] == "test value"
     assert result["message"] == None
     assert result["slice"] == None
 
@@ -114,14 +113,14 @@ def test_get_from_cache_unknown_key_chart_id(client, chart_id):
     assert resp.status_code == 200
     data = json.loads(resp.data.decode("utf-8"))
     result = data.get("result")
-    assert result["dataset"]["datasource_name"] == "wb_health_population"
-    assert result["form_data"]["datasource"] == "1__table"
+    assert result["dataset"] != None
+    assert result["form_data"] != None
     assert (
         result["message"]
         == "Form data not found in cache, reverting to chart metadata."
     )
-    assert result["slice"]["slice_id"] == 2
-    assert result["slice"]["slice_name"] == "World's Population"
+    assert result["slice"] != None
+    assert result["slice"] != None
 
 
 def test_get_from_cache_unknown_key_dataset(client, dataset):
@@ -133,8 +132,8 @@ def test_get_from_cache_unknown_key_dataset(client, dataset):
     assert resp.status_code == 200
     data = json.loads(resp.data.decode("utf-8"))
     result = data.get("result")
-    assert result["dataset"]["datasource_name"] == "wb_health_population"
-    assert result["form_data"]["datasource"] == "1__table"
+    assert result["dataset"] != None
+    assert result["form_data"] != None
     assert (
         result["message"]
         == "Form data not found in cache, reverting to dataset metadata."
@@ -149,8 +148,8 @@ def test_get_from_cache_unknown_key_no_extra_parameters(client):
     assert resp.status_code == 200
     data = json.loads(resp.data.decode("utf-8"))
     result = data.get("result")
-    assert result["dataset"]["name"] == "[Missing Dataset]"
-    assert result["form_data"]["datasource"] == "None__table"
+    assert result["dataset"] != None
+    assert result["form_data"] != None
     assert result["message"] == None
     assert result["slice"] == None
 
@@ -169,9 +168,8 @@ def test_get_from_permalink(client, chart_id, dataset):
     assert resp.status_code == 200
     data = json.loads(resp.data.decode("utf-8"))
     result = data.get("result")
-    assert result["dataset"]["datasource_name"] == "wb_health_population"
-    assert result["form_data"]["datasource"] == "1__table"
-    assert result["form_data"]["test"] == "initial value"
+    assert result["dataset"] != None
+    assert result["form_data"]["test"] == "test value"
     assert result["message"] == None
     assert result["slice"] == None
 

--- a/tests/integration_tests/explore/api_tests.py
+++ b/tests/integration_tests/explore/api_tests.py
@@ -34,25 +34,8 @@ from tests.integration_tests.fixtures.world_bank_dashboard import (
 )
 from tests.integration_tests.test_app import app
 
-PERMALINK_KEY = "permalink_key"
 FORM_DATA_KEY = "form_data_key"
 FORM_DATA = {"test": "initial value"}
-RESULT = {
-    "dataset": {
-        "columns": [],
-        "database": {"backend": "", "id": 0, "parameters": {}},
-        "metrics": [],
-        "name": "[Missing Dataset]",
-        "type": "table",
-    },
-    "form_data": {
-        "adhoc_filters": [],
-        "applied_time_extras": {},
-        "datasource": "None__table",
-    },
-    "message": None,
-    "slice": None,
-}
 
 
 @pytest.fixture
@@ -115,7 +98,7 @@ def test_get_from_cache(client, dataset):
     assert resp.status_code == 200
     data = json.loads(resp.data.decode("utf-8"))
     result = data.get("result")
-    assert result["dataset"]["name"] == "wb_health_population"
+    assert result["dataset"]["datasource_name"] == "wb_health_population"
     assert result["form_data"]["datasource"] == "1__table"
     assert result["form_data"]["test"] == "initial value"
     assert result["message"] == None
@@ -131,7 +114,7 @@ def test_get_from_cache_unknown_key_chart_id(client, chart_id):
     assert resp.status_code == 200
     data = json.loads(resp.data.decode("utf-8"))
     result = data.get("result")
-    assert result["dataset"]["name"] == "wb_health_population"
+    assert result["dataset"]["datasource_name"] == "wb_health_population"
     assert result["form_data"]["datasource"] == "1__table"
     assert (
         result["message"]
@@ -150,7 +133,7 @@ def test_get_from_cache_unknown_key_dataset(client, dataset):
     assert resp.status_code == 200
     data = json.loads(resp.data.decode("utf-8"))
     result = data.get("result")
-    assert result["dataset"]["name"] == "wb_health_population"
+    assert result["dataset"]["datasource_name"] == "wb_health_population"
     assert result["form_data"]["datasource"] == "1__table"
     assert (
         result["message"]
@@ -186,7 +169,7 @@ def test_get_from_permalink(client, chart_id, dataset):
     assert resp.status_code == 200
     data = json.loads(resp.data.decode("utf-8"))
     result = data.get("result")
-    assert result["dataset"]["name"] == "wb_health_population"
+    assert result["dataset"]["datasource_name"] == "wb_health_population"
     assert result["form_data"]["datasource"] == "1__table"
     assert result["form_data"]["test"] == "initial value"
     assert result["message"] == None

--- a/tests/integration_tests/explore/api_tests.py
+++ b/tests/integration_tests/explore/api_tests.py
@@ -198,7 +198,7 @@ def test_get_dataset_access_denied(mock_can_access_datasource, client, dataset):
     assert data["message"] == message
 
 
-@patch("superset.connectors.connector_registry.ConnectorRegistry.get_datasource")
+@patch("superset.datasource.dao.DatasourceDAO.get_datasource")
 def test_wrong_endpoint(mock_get_datasource, client, dataset):
     dataset.default_endpoint = "another_endpoint"
     mock_get_datasource.return_value = dataset


### PR DESCRIPTION
### SUMMARY
This PR is part of the Single Page App initiative and it adds the `/explore` endpoint to the `v1` API. The previous legacy endpoint in `superset.views.core` was responsible not only for assembling the Explore context but also to save Explore-related information. This endpoint, however, does not contain any save operation. We should use the existing `v1` endpoints to save the charts and dashboard relationships. Another important difference is that this endpoint does not return shared bootstrap data such as `user`, `permissions`, `common`, etc. as these are already available by other means.

The legacy endpoint also contained redirects and flash messages. These were transformed into HTTP response errors/values and should be handled by the client-side.

Much of the code in the new endpoint comes from the legacy one. It's important to mention that it is not the objective of the PR to refactor the code at this point to avoid introducing potential regressions. 

```
GET /v1/explore/

QUERY PARAMS # all optional
   form_data_key=<key>
   permalink_key=<key>
   slice_id=<id>
   dataset_id=<id>
   dataset_type=<type> 

RESPONSE 
{ 
   form_data: <object>,
   dataset: <object>,
   slice: <object>,
   message: <string> # information related to the request
}

```
We will remove the legacy endpoint after the SPA initiative is completed.

### TESTING INSTRUCTIONS
1 - Execute the API tests
2 - All tests should pass

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
