### PR TITLE
fix: alert & reports active toggle optimistic update

### DIFF
--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -316,11 +316,13 @@ export function useSingleViewResource<D extends object = any>(
   );
 
   const updateResource = useCallback(
-    (resourceID: number, resource: D, hideToast = false) => {
+    (resourceID: number, resource: D, hideToast = false, setLoading = true) => {
       // Set loading state
-      updateState({
-        loading: true,
-      });
+      if (setLoading) {
+        updateState({
+          loading: true,
+        });
+      }
 
       return SupersetClient.put({
         endpoint: `/api/v1/${resourceName}/${resourceID}`,
@@ -354,11 +356,14 @@ export function useSingleViewResource<D extends object = any>(
           }),
         )
         .finally(() => {
-          updateState({ loading: false });
+          if (setLoading) {
+            updateState({ loading: false });
+          }
         });
     },
     [handleErrorMsg, resourceName, resourceLabel],
   );
+
   const clearError = () =>
     updateState({
       error: null,


### PR DESCRIPTION
### SUMMARY

For the alert and reports, the active toggle could lag and give the user the impression nothing is happening.
This PR just uses an optimistic update instead, and revert the change if the API fails.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://user-images.githubusercontent.com/17252075/173914874-b585db66-5975-4039-817e-fb92eeb16cb6.mov

After:

https://user-images.githubusercontent.com/17252075/173914186-9e65add3-2193-4809-93b3-adf65eea86f6.mov

### TESTING INSTRUCTIONS

1. go to the alerts page
2. toggle the alert on and off

The expected result is that the user sees the toggle pretty quickly.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
