### PR TITLE
fix: suppress translation warning in jest

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -16970,9 +16970,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ=="
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
+      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.1",
@@ -54322,6 +54322,7 @@
         "@types/fetch-mock": "^7.3.3",
         "@types/lodash": "^4.14.149",
         "@types/math-expression-evaluator": "^1.2.1",
+        "@types/node": "^18.0.0",
         "@types/prop-types": "^15.7.2",
         "@types/rison": "0.0.6",
         "@types/seedrandom": "^2.4.28",
@@ -67442,6 +67443,7 @@
         "@types/fetch-mock": "^7.3.3",
         "@types/lodash": "^4.14.149",
         "@types/math-expression-evaluator": "^1.2.1",
+        "@types/node": "^18.0.0",
         "@types/prop-types": "^15.7.2",
         "@types/rison": "0.0.6",
         "@types/seedrandom": "^2.4.28",
@@ -69036,9 +69038,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ=="
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
+      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA=="
     },
     "@types/node-fetch": {
       "version": "2.6.1",

--- a/superset-frontend/packages/superset-ui-core/package.json
+++ b/superset-frontend/packages/superset-ui-core/package.json
@@ -40,6 +40,7 @@
     "@types/d3-time-format": "^2.1.0",
     "@types/lodash": "^4.14.149",
     "@types/math-expression-evaluator": "^1.2.1",
+    "@types/node": "^18.0.0",
     "@types/rison": "0.0.6",
     "@types/seedrandom": "^2.4.28",
     "@types/fetch-mock": "^7.3.3",

--- a/superset-frontend/packages/superset-ui-core/src/translation/Translator.ts
+++ b/superset-frontend/packages/superset-ui-core/src/translation/Translator.ts
@@ -56,7 +56,7 @@ export default class Translator {
    */
   addTranslation(key: string, texts: ReadonlyArray<string>) {
     const translations = this.i18n.options.locale_data.superset;
-    if (key in translations) {
+    if (process?.env?.NODE_ENV !== 'test' && key in translations) {
       logging.warn(`Duplicate translation key "${key}", will override.`);
     }
     translations[key] = texts;

--- a/superset-frontend/packages/superset-ui-core/src/translation/Translator.ts
+++ b/superset-frontend/packages/superset-ui-core/src/translation/Translator.ts
@@ -56,7 +56,7 @@ export default class Translator {
    */
   addTranslation(key: string, texts: ReadonlyArray<string>) {
     const translations = this.i18n.options.locale_data.superset;
-    if (process?.env?.NODE_ENV !== 'test' && key in translations) {
+    if (process.env.WEBPACK_MODE !== 'test' && key in translations) {
       logging.warn(`Duplicate translation key "${key}", will override.`);
     }
     translations[key] = texts;

--- a/superset-frontend/packages/superset-ui-core/test/translation/Translator.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/translation/Translator.test.ts
@@ -41,12 +41,12 @@ describe('Translator', () => {
     spy.mockImplementation((info: any) => {
       throw new Error(info);
     });
-    process.env.NODE_ENV = 'production';
+    process.env.WEBPACK_MODE = 'production';
   });
 
   afterAll(() => {
     spy.mockRestore();
-    process.env.NODE_ENV = 'test';
+    process.env.WEBPACK_MODE = 'test';
   });
 
   describe('new Translator(config)', () => {

--- a/superset-frontend/packages/superset-ui-core/test/translation/Translator.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/translation/Translator.test.ts
@@ -41,10 +41,12 @@ describe('Translator', () => {
     spy.mockImplementation((info: any) => {
       throw new Error(info);
     });
+    process.env.NODE_ENV = 'production';
   });
 
   afterAll(() => {
     spy.mockRestore();
+    process.env.NODE_ENV = 'test';
   });
 
   describe('new Translator(config)', () => {

--- a/superset-frontend/spec/helpers/shim.ts
+++ b/superset-frontend/spec/helpers/shim.ts
@@ -81,3 +81,5 @@ setupSupersetClient();
 jest.mock('src/hooks/useTabId', () => ({
   useTabId: () => 1,
 }));
+
+process.env.WEBPACK_MODE = 'test';

--- a/superset-frontend/tsconfig.json
+++ b/superset-frontend/tsconfig.json
@@ -29,7 +29,8 @@
     "types": [
       "@emotion/react/types/css-prop",
       "jest",
-      "@testing-library/jest-dom"
+      "@testing-library/jest-dom",
+      "@types/node"
     ],
 
     /* Emit */


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Suppress the "Duplicate translation" warning message in jest processor. test this PR by
```
npx jest src/explore/controlUtils/standardizedFormData.test.tsx
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### After
![image](https://user-images.githubusercontent.com/2016594/173994241-db6ef57b-7039-4b53-ab10-030bbaa2cdf0.png)



#### Before
![image](https://user-images.githubusercontent.com/2016594/173994339-e37df691-d151-42cb-8bb7-6f9b32dbb481.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
