### PR TITLE
fix(bar-chart-v2): remove marker control from bar chart V2

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -45,8 +45,6 @@ import {
 const {
   contributionMode,
   logAxis,
-  markerEnabled,
-  markerSize,
   minorSplitLine,
   rowLimit,
   truncateYAxis,
@@ -341,38 +339,6 @@ const config: ControlPanelConfig = {
       controlSetRows: [
         ['color_scheme'],
         ...showValueSection,
-        [
-          {
-            name: 'markerEnabled',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Marker'),
-              renderTrigger: true,
-              default: markerEnabled,
-              description: t(
-                'Draw a marker on data points. Only applicable for line types.',
-              ),
-            },
-          },
-        ],
-        [
-          {
-            name: 'markerSize',
-            config: {
-              type: 'SliderControl',
-              label: t('Marker Size'),
-              renderTrigger: true,
-              min: 0,
-              max: 20,
-              default: markerSize,
-              description: t(
-                'Size of marker. Also applies to forecast observations.',
-              ),
-              visibility: ({ controls }: ControlPanelsContainerProps) =>
-                Boolean(controls?.markerEnabled?.value),
-            },
-          },
-        ],
         [
           {
             name: 'zoomable',


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The marker is not used in bar chart v2 (including timeseries), so we remove it.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
