### PR TITLE
fix: Adding extra metrics issue after chart configuration

### DIFF
--- a/superset-frontend/src/explore/reducers/exploreReducer.js
+++ b/superset-frontend/src/explore/reducers/exploreReducer.js
@@ -141,8 +141,8 @@ export default function exploreReducer(state = {}, action) {
       if (controlName === 'metrics' && old_metrics_data && new_column_config) {
         value.forEach((item, index) => {
           if (
-            item.label !== old_metrics_data[index].label &&
-            !!new_column_config[old_metrics_data[index].label]
+            item?.label !== old_metrics_data[index]?.label &&
+            !!new_column_config[old_metrics_data[index]?.label]
           ) {
             new_column_config[item.label] =
               new_column_config[old_metrics_data[index].label];


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
If we set the alignment on some columns, then start adding new metrics, the metrics throw an error and things break.

<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
 
<img width="619" alt="image (2)" src="https://user-images.githubusercontent.com/39701522/174126116-7817e53f-64a6-4664-8d4c-4f1e56aa48b6.png">

AFTER:
[[DEV] Explore - birth_names - 16 June 2022 - Watch Video](https://www.loom.com/share/99ae4c8bbceb43f2bea601836bf43d35)
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Create a Table Chart aggregating data.
2. Add some Columns and Metrics.
3. Execute your Chart.
4. Save it.
5. Try to add/remove Metrics from it.
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
