### PR TITLE
fix(dashboard): new created chart did not have high lighted effect when using the permalink of chart share in dashboard

### DIFF
--- a/superset-frontend/src/dashboard/actions/hydrate.js
+++ b/superset-frontend/src/dashboard/actions/hydrate.js
@@ -127,6 +127,8 @@ export const hydrateDashboard =
     const dashboardFilters = {};
     const slices = {};
     const sliceIds = new Set();
+    const slicesFromExploreCount = new Map();
+
     chartData.forEach(slice => {
       const key = slice.slice_id;
       const form_data = {
@@ -181,6 +183,10 @@ export const hydrateDashboard =
           },
           (newSlicesContainer.parents || []).slice(),
         );
+
+        const count = (slicesFromExploreCount.get(slice.slice_id) ?? 0) + 1;
+        chartHolder.id = `${CHART_TYPE}-explore-${slice.slice_id}-${count}`;
+        slicesFromExploreCount.set(slice.slice_id, count);
 
         layout[chartHolder.id] = chartHolder;
         newSlicesContainer.children.push(chartHolder.id);


### PR DESCRIPTION
### SUMMARY

If we create a new chart and add it to the dashboard, then generating a permalink for that char from said dashboard does not highlight it on load.

The issue is that, for these charts, they're not part of the dashboard per-se, and get added at the end (in new rows).
For that reason, we're generating the id for them on the fly, and thus, they're always different on load.
The permalink does not find the chart in question in that case.

This PR changes the id generation for these charts to always be the same.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://user-images.githubusercontent.com/17252075/174135328-e5ece0b8-1daf-422f-9b5a-f4db9de917fc.mov

After:

https://user-images.githubusercontent.com/17252075/174135407-fdb53fb6-cfe8-46cb-b80f-bde36dd3a330.mov

### TESTING INSTRUCTIONS

1. create a new chart and add to dashboard
2. click 3 dot menu of the chart and copy permalink
3. open chart permalink in browser and observe the chart

Ensure that the chart highlights.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
