### PR TITLE
fix(20428): Address-Presto/Trino-Poll-Issue-Refactor

### DIFF
--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -949,11 +949,7 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
             sql = f"SHOW CREATE VIEW {schema}.{table}"
             try:
                 cls.execute(cursor, sql)
-                polled = cursor.poll()
 
-                while polled:
-                    time.sleep(0.2)
-                    polled = cursor.poll()
             except DatabaseError:  # not a VIEW
                 return None
             rows = cls.fetch_data(cursor, 1)

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
-import time
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 import simplejson as json
@@ -24,7 +23,6 @@ from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.url import URL
 from sqlalchemy.orm import Session
 
-from superset.common.db_query_status import QueryStatus
 from superset.databases.utils import make_url_safe
 from superset.db_engine_specs.base import BaseEngineSpec
 from superset.db_engine_specs.presto import PrestoEngineSpec


### PR DESCRIPTION
### SUMMARY

Change to modify `TrinoEngineSpec` inherit class `PrestoEngineSpec` to address bug when running against `presto-trino`.

Given issue:

```bash
Traceback (most recent call last):
  File "/app/superset/sql_lab.py", line 275, in execute_sql_statement
    db_engine_spec.handle_cursor(cursor, query, session)
  File "/app/superset/db_engine_specs/presto.py", line 970, in handle_cursor
    polled = cursor.poll()
AttributeError: 'Cursor' object has no attribute 'poll'
```

### Bug

Raised issue: https://github.com/apache/superset/issues/20428

Slack conversation: https://apache-superset.slack.com/archives/C015WAZL0KH/p1655449901353689

### Additional Info:

See quote:

[@S Thelin](https://apache-superset.slack.com/team/U03LFFH7N1X)
 I don’t believe we can provide query stats given the way the Trino client is configured. Statistics are updated when fetch is called per [here](https://github.com/trinodb/trino-python-client/blob/ca57138aa0cbeb337e4b032fefb1e88fe7d4a633/trino/client.py#L679-L683), however this also fetches results and we cannot advance the cursor in the handle_cursor method. There could be some trickery we could do, but I think it’s safer to simply fallback to the default method.
 
 @john-bodley 