### PR TITLE
chore: move xaxis to superset-ui

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -67,6 +67,8 @@ import {
   ExtraControlProps,
   SelectControlConfig,
   Dataset,
+  ControlState,
+  ControlPanelState,
 } from '../types';
 import { ColumnOption } from '../components/ColumnOption';
 
@@ -544,6 +546,30 @@ const enableExploreDnd = isFeatureEnabled(
   FeatureFlag.ENABLE_EXPLORE_DRAG_AND_DROP,
 );
 
+const x_axis: SharedControlConfig = {
+  ...(enableExploreDnd ? dndGroupByControl : groupByControl),
+  label: t('X-axis'),
+  default: (
+    control: ControlState,
+    controlPanel: Partial<ControlPanelState>,
+  ) => {
+    // default to the chosen time column if x-axis is unset and the
+    // GENERIC_CHART_AXES feature flag is enabled
+    const { value } = control;
+    if (value) {
+      return value;
+    }
+    const timeColumn = controlPanel?.form_data?.granularity_sqla;
+    if (isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) && timeColumn) {
+      return timeColumn;
+    }
+    return null;
+  },
+  multi: false,
+  description: t('Dimension to use on x-axis.'),
+  validators: [validateNonEmpty],
+};
+
 const sharedControls = {
   metrics: enableExploreDnd ? dnd_adhoc_metrics : metrics,
   metric: enableExploreDnd ? dnd_adhoc_metric : metric,
@@ -579,6 +605,7 @@ const sharedControls = {
   series_limit_metric: enableExploreDnd ? dnd_sort_by : sort_by,
   legacy_order_by: enableExploreDnd ? dnd_sort_by : sort_by,
   truncate_metric,
+  x_axis,
 };
 
 export { sharedControls, dndEntity, dndColumnsControl };

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/types.ts
@@ -25,7 +25,8 @@ import {
   SetDataMaskHook,
 } from '@superset-ui/core';
 import { EChartsCoreOption } from 'echarts';
-import { EchartsTitleFormData, DEFAULT_TITLE_FORM_DATA } from '../types';
+import { EchartsTitleFormData } from '../types';
+import { DEFAULT_TITLE_FORM_DATA } from '../constants';
 
 export type BoxPlotQueryFormData = QueryFormData & {
   numberFormat?: string;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
@@ -35,7 +35,6 @@ import {
   EchartsFunnelLabelTypeType,
   FunnelChartTransformedProps,
 } from './types';
-import { DEFAULT_LEGEND_FORM_DATA } from '../types';
 import {
   extractGroupbyLabel,
   getChartPadding,
@@ -43,7 +42,7 @@ import {
   sanitizeHtml,
 } from '../utils/series';
 import { defaultGrid, defaultTooltip } from '../defaults';
-import { OpacityEnum } from '../constants';
+import { OpacityEnum, DEFAULT_LEGEND_FORM_DATA } from '../constants';
 
 const percentFormatter = getNumberFormatter(NumberFormats.PERCENT_2_POINT);
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/types.ts
@@ -25,12 +25,8 @@ import {
   QueryFormData,
   SetDataMaskHook,
 } from '@superset-ui/core';
-import {
-  DEFAULT_LEGEND_FORM_DATA,
-  EchartsLegendFormData,
-  LegendOrientation,
-  LegendType,
-} from '../types';
+import { EchartsLegendFormData, LegendOrientation, LegendType } from '../types';
+import { DEFAULT_LEGEND_FORM_DATA } from '../constants';
 
 export type EchartsFunnelFormData = QueryFormData &
   EchartsLegendFormData & {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Gauge/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Gauge/types.ts
@@ -22,7 +22,8 @@ import {
   QueryFormColumn,
   QueryFormData,
 } from '@superset-ui/core';
-import { DEFAULT_LEGEND_FORM_DATA, EChartTransformedProps } from '../types';
+import { EChartTransformedProps } from '../types';
+import { DEFAULT_LEGEND_FORM_DATA } from '../constants';
 
 export type AxisTickLineStyle = {
   width: number;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Graph/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Graph/types.ts
@@ -19,12 +19,8 @@
 import { QueryFormData } from '@superset-ui/core';
 import { GraphNodeItemOption } from 'echarts/types/src/chart/graph/GraphSeries';
 import { SeriesTooltipOption } from 'echarts/types/src/util/types';
-import {
-  DEFAULT_LEGEND_FORM_DATA,
-  EchartsLegendFormData,
-  LegendOrientation,
-  LegendType,
-} from '../types';
+import { EchartsLegendFormData, LegendOrientation, LegendType } from '../types';
+import { DEFAULT_LEGEND_FORM_DATA } from '../constants';
 
 export type EdgeSymbol = 'none' | 'circle' | 'arrow';
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -36,7 +36,7 @@ import {
 
 import { DEFAULT_FORM_DATA } from './types';
 import { EchartsTimeseriesSeriesType } from '../Timeseries/types';
-import { legendSection, richTooltipSection, xAxisControl } from '../controls';
+import { legendSection, richTooltipSection } from '../controls';
 
 const {
   area,
@@ -295,7 +295,7 @@ const config: ControlPanelConfig = {
       ? {
           label: t('Shared query fields'),
           expanded: true,
-          controlSetRows: [[xAxisControl]],
+          controlSetRows: [['x_axis']],
         }
       : null,
     createQuerySection(t('Query A'), ''),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
@@ -28,17 +28,17 @@ import {
   QueryFormColumn,
 } from '@superset-ui/core';
 import {
-  DEFAULT_LEGEND_FORM_DATA,
   EchartsLegendFormData,
   EchartsTitleFormData,
-  DEFAULT_TITLE_FORM_DATA,
   StackType,
-} from '../types';
-import {
-  DEFAULT_FORM_DATA as TIMESERIES_DEFAULTS,
   EchartsTimeseriesContributionType,
   EchartsTimeseriesSeriesType,
-} from '../Timeseries/types';
+} from '../types';
+import {
+  DEFAULT_LEGEND_FORM_DATA,
+  DEFAULT_TITLE_FORM_DATA,
+  DEFAULT_FORM_DATA as TIMESERIES_DEFAULTS,
+} from '../constants';
 
 export type EchartsMixedTimeseriesFormData = QueryFormData & {
   annotationLayers: AnnotationLayer[];

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
@@ -36,7 +36,7 @@ import {
   EchartsPieLabelType,
   PieChartTransformedProps,
 } from './types';
-import { DEFAULT_LEGEND_FORM_DATA } from '../types';
+import { DEFAULT_LEGEND_FORM_DATA, OpacityEnum } from '../constants';
 import {
   extractGroupbyLabel,
   getChartPadding,
@@ -45,7 +45,6 @@ import {
   sanitizeHtml,
 } from '../utils/series';
 import { defaultGrid, defaultTooltip } from '../defaults';
-import { OpacityEnum } from '../constants';
 import { convertInteger } from '../utils/convertInteger';
 
 const percentFormatter = getNumberFormatter(NumberFormats.PERCENT_2_POINT);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Pie/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Pie/types.ts
@@ -25,12 +25,8 @@ import {
   QueryFormData,
   SetDataMaskHook,
 } from '@superset-ui/core';
-import {
-  DEFAULT_LEGEND_FORM_DATA,
-  EchartsLegendFormData,
-  LegendOrientation,
-  LegendType,
-} from '../types';
+import { EchartsLegendFormData, LegendOrientation, LegendType } from '../types';
+import { DEFAULT_LEGEND_FORM_DATA } from '../constants';
 
 export type EchartsPieFormData = QueryFormData &
   EchartsLegendFormData & {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Radar/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Radar/transformProps.ts
@@ -36,7 +36,7 @@ import {
   EchartsRadarLabelType,
   RadarChartTransformedProps,
 } from './types';
-import { DEFAULT_LEGEND_FORM_DATA } from '../types';
+import { DEFAULT_LEGEND_FORM_DATA, OpacityEnum } from '../constants';
 import {
   extractGroupbyLabel,
   getChartPadding,
@@ -44,7 +44,6 @@ import {
   getLegendProps,
 } from '../utils/series';
 import { defaultGrid, defaultTooltip } from '../defaults';
-import { OpacityEnum } from '../constants';
 
 export function formatLabel({
   params,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Radar/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Radar/types.ts
@@ -27,12 +27,12 @@ import {
   SetDataMaskHook,
 } from '@superset-ui/core';
 import {
-  DEFAULT_LEGEND_FORM_DATA,
   EchartsLegendFormData,
   LabelPositionEnum,
   LegendOrientation,
   LegendType,
 } from '../types';
+import { DEFAULT_LEGEND_FORM_DATA } from '../constants';
 
 type RadarColumnConfig = Record<string, { radarMetricMaxValue?: number }>;
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
@@ -28,10 +28,10 @@ import {
 } from '@superset-ui/chart-controls';
 
 import {
-  DEFAULT_FORM_DATA,
   EchartsTimeseriesContributionType,
   EchartsTimeseriesSeriesType,
-} from '@superset-ui/plugin-chart-echarts';
+} from '../types';
+import { DEFAULT_FORM_DATA } from '../constants';
 import {
   legendSection,
   onlyTotalControl,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
@@ -31,7 +31,7 @@ import {
   DEFAULT_FORM_DATA,
   EchartsTimeseriesContributionType,
   EchartsTimeseriesSeriesType,
-} from '../types';
+} from '@superset-ui/plugin-chart-echarts';
 import {
   legendSection,
   onlyTotalControl,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { FeatureFlag, isFeatureEnabled, t } from '@superset-ui/core';
+import { t } from '@superset-ui/core';
 import {
   ControlPanelConfig,
   ControlPanelsContainerProps,
@@ -62,7 +62,7 @@ const config: ControlPanelConfig = {
       label: t('Query'),
       expanded: true,
       controlSetRows: [
-        isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) ? [xAxisControl] : [],
+        [xAxisControl],
         ['metrics'],
         ['groupby'],
         [

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -31,10 +31,10 @@ import {
 } from '@superset-ui/chart-controls';
 
 import {
-  DEFAULT_FORM_DATA,
   EchartsTimeseriesContributionType,
   OrientationType,
-} from '@superset-ui/plugin-chart-echarts';
+} from '../../types';
+import { DEFAULT_FORM_DATA } from '../../constants';
 import {
   legendSection,
   richTooltipSection,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -34,7 +34,7 @@ import {
   DEFAULT_FORM_DATA,
   EchartsTimeseriesContributionType,
   OrientationType,
-} from '../../types';
+} from '@superset-ui/plugin-chart-echarts';
 import {
   legendSection,
   richTooltipSection,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { FeatureFlag, isFeatureEnabled, t } from '@superset-ui/core';
+import { t } from '@superset-ui/core';
 import {
   ControlPanelConfig,
   ControlPanelsContainerProps,
@@ -269,7 +269,7 @@ const config: ControlPanelConfig = {
       label: t('Query'),
       expanded: true,
       controlSetRows: [
-        isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) ? [xAxisControl] : [],
+        [xAxisControl],
         ['metrics'],
         ['groupby'],
         [

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/index.ts
@@ -29,7 +29,7 @@ import {
   EchartsTimeseriesChartProps,
   EchartsTimeseriesFormData,
   EchartsTimeseriesSeriesType,
-} from '@superset-ui/plugin-chart-echarts';
+} from '../../types';
 import buildQuery from '../../buildQuery';
 import controlPanel from './controlPanel';
 import transformProps from '../../transformProps';

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/index.ts
@@ -25,15 +25,15 @@ import {
   isFeatureEnabled,
   t,
 } from '@superset-ui/core';
-import buildQuery from '../../buildQuery';
-import controlPanel from './controlPanel';
-import transformProps from '../../transformProps';
-import thumbnail from './images/thumbnail.png';
 import {
   EchartsTimeseriesChartProps,
   EchartsTimeseriesFormData,
   EchartsTimeseriesSeriesType,
 } from '@superset-ui/plugin-chart-echarts';
+import buildQuery from '../../buildQuery';
+import controlPanel from './controlPanel';
+import transformProps from '../../transformProps';
+import thumbnail from './images/thumbnail.png';
 import example1 from './images/Bar1.png';
 import example2 from './images/Bar2.png';
 import example3 from './images/Bar3.png';

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/index.ts
@@ -33,7 +33,7 @@ import {
   EchartsTimeseriesChartProps,
   EchartsTimeseriesFormData,
   EchartsTimeseriesSeriesType,
-} from '../../types';
+} from '@superset-ui/plugin-chart-echarts';
 import example1 from './images/Bar1.png';
 import example2 from './images/Bar2.png';
 import example3 from './images/Bar3.png';

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/controlPanel.tsx
@@ -22,26 +22,33 @@ import {
   ControlPanelConfig,
   ControlPanelsContainerProps,
   D3_TIME_FORMAT_DOCS,
-  emitFilterControl,
   sections,
   sharedControls,
+  emitFilterControl,
 } from '@superset-ui/chart-controls';
 
-import { DEFAULT_FORM_DATA, EchartsTimeseriesContributionType } from '../types';
+import {
+  DEFAULT_FORM_DATA,
+  EchartsTimeseriesContributionType,
+  EchartsTimeseriesSeriesType,
+} from '@superset-ui/plugin-chart-echarts';
 import {
   legendSection,
   richTooltipSection,
-  showValueSectionWithoutStack,
+  showValueSection,
   xAxisControl,
-} from '../../controls';
+} from '../../../controls';
 
 const {
+  area,
   contributionMode,
   logAxis,
   markerEnabled,
   markerSize,
   minorSplitLine,
+  opacity,
   rowLimit,
+  seriesType,
   truncateYAxis,
   yAxisBounds,
   zoomable,
@@ -91,7 +98,61 @@ const config: ControlPanelConfig = {
       expanded: true,
       controlSetRows: [
         ['color_scheme'],
-        ...showValueSectionWithoutStack,
+        [
+          {
+            name: 'seriesType',
+            config: {
+              type: 'SelectControl',
+              label: t('Series Style'),
+              renderTrigger: true,
+              default: seriesType,
+              choices: [
+                [EchartsTimeseriesSeriesType.Line, 'Line'],
+                [EchartsTimeseriesSeriesType.Scatter, 'Scatter'],
+                [EchartsTimeseriesSeriesType.Smooth, 'Smooth Line'],
+                [EchartsTimeseriesSeriesType.Bar, 'Bar'],
+                [EchartsTimeseriesSeriesType.Start, 'Step - start'],
+                [EchartsTimeseriesSeriesType.Middle, 'Step - middle'],
+                [EchartsTimeseriesSeriesType.End, 'Step - end'],
+              ],
+              description: t('Series chart type (line, bar etc)'),
+            },
+          },
+        ],
+        ...showValueSection,
+        [
+          {
+            name: 'area',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Area Chart'),
+              renderTrigger: true,
+              default: area,
+              description: t(
+                'Draw area under curves. Only applicable for line types.',
+              ),
+            },
+          },
+        ],
+        [
+          {
+            name: 'opacity',
+            config: {
+              type: 'SliderControl',
+              label: t('Area chart opacity'),
+              renderTrigger: true,
+              min: 0,
+              max: 1,
+              step: 0.1,
+              default: opacity,
+              description: t(
+                'Opacity of Area Chart. Also applies to confidence band.',
+              ),
+              visibility: ({ controls }: ControlPanelsContainerProps) =>
+                Boolean(controls?.area?.value),
+            },
+          },
+        ],
         [
           {
             name: 'markerEnabled',
@@ -170,11 +231,9 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        // eslint-disable-next-line react/jsx-key
         ...richTooltipSection,
         // eslint-disable-next-line react/jsx-key
         [<div className="section-header">{t('Y Axis')}</div>],
-
         ['y_axis_format'],
         [
           {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/controlPanel.tsx
@@ -28,10 +28,10 @@ import {
 } from '@superset-ui/chart-controls';
 
 import {
-  DEFAULT_FORM_DATA,
   EchartsTimeseriesContributionType,
   EchartsTimeseriesSeriesType,
-} from '@superset-ui/plugin-chart-echarts';
+} from '../../types';
+import { DEFAULT_FORM_DATA } from '../../constants';
 import {
   legendSection,
   richTooltipSection,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/index.ts
@@ -29,7 +29,7 @@ import {
   EchartsTimeseriesChartProps,
   EchartsTimeseriesFormData,
   EchartsTimeseriesSeriesType,
-} from '@superset-ui/plugin-chart-echarts';
+} from '../../types';
 import buildQuery from '../../buildQuery';
 import controlPanel from './controlPanel';
 import transformProps from '../../transformProps';

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/index.ts
@@ -25,15 +25,15 @@ import {
   isFeatureEnabled,
   t,
 } from '@superset-ui/core';
-import buildQuery from '../../buildQuery';
-import controlPanel from './controlPanel';
-import transformProps from '../../transformProps';
-import thumbnail from './images/thumbnail.png';
 import {
   EchartsTimeseriesChartProps,
   EchartsTimeseriesFormData,
   EchartsTimeseriesSeriesType,
 } from '@superset-ui/plugin-chart-echarts';
+import buildQuery from '../../buildQuery';
+import controlPanel from './controlPanel';
+import transformProps from '../../transformProps';
+import thumbnail from './images/thumbnail.png';
 import example1 from './images/Line1.png';
 import example2 from './images/Line2.png';
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/index.ts
@@ -26,14 +26,14 @@ import {
   t,
 } from '@superset-ui/core';
 import buildQuery from '../../buildQuery';
-import controlPanel from '../controlPanel';
+import controlPanel from './controlPanel';
 import transformProps from '../../transformProps';
 import thumbnail from './images/thumbnail.png';
 import {
   EchartsTimeseriesChartProps,
   EchartsTimeseriesFormData,
   EchartsTimeseriesSeriesType,
-} from '../../types';
+} from '@superset-ui/plugin-chart-echarts';
 import example1 from './images/Line1.png';
 import example2 from './images/Line2.png';
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { FeatureFlag, isFeatureEnabled, t } from '@superset-ui/core';
+import { t } from '@superset-ui/core';
 import {
   ControlPanelConfig,
   ControlPanelsContainerProps,
@@ -53,7 +53,7 @@ const config: ControlPanelConfig = {
       label: t('Query'),
       expanded: true,
       controlSetRows: [
-        isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) ? [xAxisControl] : [],
+        [xAxisControl],
         ['metrics'],
         ['groupby'],
         ['adhoc_filters'],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
@@ -27,7 +27,7 @@ import {
   sharedControls,
 } from '@superset-ui/chart-controls';
 
-import { DEFAULT_FORM_DATA } from '../../types';
+import { DEFAULT_FORM_DATA } from '@superset-ui/plugin-chart-echarts';
 import {
   legendSection,
   richTooltipSection,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
@@ -27,7 +27,7 @@ import {
   sharedControls,
 } from '@superset-ui/chart-controls';
 
-import { DEFAULT_FORM_DATA } from '@superset-ui/plugin-chart-echarts';
+import { DEFAULT_FORM_DATA } from '../../constants';
 import {
   legendSection,
   richTooltipSection,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/index.ts
@@ -29,7 +29,7 @@ import {
   EchartsTimeseriesChartProps,
   EchartsTimeseriesFormData,
   EchartsTimeseriesSeriesType,
-} from '@superset-ui/plugin-chart-echarts';
+} from '../../types';
 import buildQuery from '../../buildQuery';
 import controlPanel from './controlPanel';
 import transformProps from '../../transformProps';

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/index.ts
@@ -25,15 +25,15 @@ import {
   isFeatureEnabled,
   t,
 } from '@superset-ui/core';
-import buildQuery from '../../buildQuery';
-import controlPanel from './controlPanel';
-import transformProps from '../../transformProps';
-import thumbnail from './images/thumbnail.png';
 import {
   EchartsTimeseriesChartProps,
   EchartsTimeseriesFormData,
   EchartsTimeseriesSeriesType,
 } from '@superset-ui/plugin-chart-echarts';
+import buildQuery from '../../buildQuery';
+import controlPanel from './controlPanel';
+import transformProps from '../../transformProps';
+import thumbnail from './images/thumbnail.png';
 import example1 from './images/Scatter1.png';
 
 const scatterTransformProps = (chartProps: EchartsTimeseriesChartProps) =>

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/index.ts
@@ -33,7 +33,7 @@ import {
   EchartsTimeseriesChartProps,
   EchartsTimeseriesFormData,
   EchartsTimeseriesSeriesType,
-} from '../../types';
+} from '@superset-ui/plugin-chart-echarts';
 import example1 from './images/Scatter1.png';
 
 const scatterTransformProps = (chartProps: EchartsTimeseriesChartProps) =>

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/SmoothLine/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/SmoothLine/controlPanel.tsx
@@ -27,10 +27,8 @@ import {
   sharedControls,
 } from '@superset-ui/chart-controls';
 
-import {
-  DEFAULT_FORM_DATA,
-  EchartsTimeseriesContributionType,
-} from '@superset-ui/plugin-chart-echarts';
+import { EchartsTimeseriesContributionType } from '../../types';
+import { DEFAULT_FORM_DATA } from '../../constants';
 import {
   legendSection,
   richTooltipSection,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/SmoothLine/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/SmoothLine/controlPanel.tsx
@@ -22,33 +22,29 @@ import {
   ControlPanelConfig,
   ControlPanelsContainerProps,
   D3_TIME_FORMAT_DOCS,
+  emitFilterControl,
   sections,
   sharedControls,
-  emitFilterControl,
 } from '@superset-ui/chart-controls';
 
 import {
   DEFAULT_FORM_DATA,
   EchartsTimeseriesContributionType,
-  EchartsTimeseriesSeriesType,
-} from './types';
+} from '@superset-ui/plugin-chart-echarts';
 import {
   legendSection,
   richTooltipSection,
-  showValueSection,
+  showValueSectionWithoutStack,
   xAxisControl,
-} from '../controls';
+} from '../../../controls';
 
 const {
-  area,
   contributionMode,
   logAxis,
   markerEnabled,
   markerSize,
   minorSplitLine,
-  opacity,
   rowLimit,
-  seriesType,
   truncateYAxis,
   yAxisBounds,
   zoomable,
@@ -98,61 +94,7 @@ const config: ControlPanelConfig = {
       expanded: true,
       controlSetRows: [
         ['color_scheme'],
-        [
-          {
-            name: 'seriesType',
-            config: {
-              type: 'SelectControl',
-              label: t('Series Style'),
-              renderTrigger: true,
-              default: seriesType,
-              choices: [
-                [EchartsTimeseriesSeriesType.Line, 'Line'],
-                [EchartsTimeseriesSeriesType.Scatter, 'Scatter'],
-                [EchartsTimeseriesSeriesType.Smooth, 'Smooth Line'],
-                [EchartsTimeseriesSeriesType.Bar, 'Bar'],
-                [EchartsTimeseriesSeriesType.Start, 'Step - start'],
-                [EchartsTimeseriesSeriesType.Middle, 'Step - middle'],
-                [EchartsTimeseriesSeriesType.End, 'Step - end'],
-              ],
-              description: t('Series chart type (line, bar etc)'),
-            },
-          },
-        ],
-        ...showValueSection,
-        [
-          {
-            name: 'area',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Area Chart'),
-              renderTrigger: true,
-              default: area,
-              description: t(
-                'Draw area under curves. Only applicable for line types.',
-              ),
-            },
-          },
-        ],
-        [
-          {
-            name: 'opacity',
-            config: {
-              type: 'SliderControl',
-              label: t('Area chart opacity'),
-              renderTrigger: true,
-              min: 0,
-              max: 1,
-              step: 0.1,
-              default: opacity,
-              description: t(
-                'Opacity of Area Chart. Also applies to confidence band.',
-              ),
-              visibility: ({ controls }: ControlPanelsContainerProps) =>
-                Boolean(controls?.area?.value),
-            },
-          },
-        ],
+        ...showValueSectionWithoutStack,
         [
           {
             name: 'markerEnabled',
@@ -231,9 +173,11 @@ const config: ControlPanelConfig = {
             },
           },
         ],
+        // eslint-disable-next-line react/jsx-key
         ...richTooltipSection,
         // eslint-disable-next-line react/jsx-key
         [<div className="section-header">{t('Y Axis')}</div>],
+
         ['y_axis_format'],
         [
           {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/SmoothLine/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/SmoothLine/index.ts
@@ -29,7 +29,7 @@ import {
   EchartsTimeseriesChartProps,
   EchartsTimeseriesFormData,
   EchartsTimeseriesSeriesType,
-} from '@superset-ui/plugin-chart-echarts';
+} from '../../types';
 import buildQuery from '../../buildQuery';
 import controlPanel from './controlPanel';
 import transformProps from '../../transformProps';

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/SmoothLine/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/SmoothLine/index.ts
@@ -25,15 +25,15 @@ import {
   isFeatureEnabled,
   t,
 } from '@superset-ui/core';
-import buildQuery from '../../buildQuery';
-import controlPanel from './controlPanel';
-import transformProps from '../../transformProps';
-import thumbnail from './images/thumbnail.png';
 import {
   EchartsTimeseriesChartProps,
   EchartsTimeseriesFormData,
   EchartsTimeseriesSeriesType,
 } from '@superset-ui/plugin-chart-echarts';
+import buildQuery from '../../buildQuery';
+import controlPanel from './controlPanel';
+import transformProps from '../../transformProps';
+import thumbnail from './images/thumbnail.png';
 import example1 from './images/SmoothLine1.png';
 
 const smoothTransformProps = (chartProps: EchartsTimeseriesChartProps) =>

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/SmoothLine/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/SmoothLine/index.ts
@@ -26,14 +26,14 @@ import {
   t,
 } from '@superset-ui/core';
 import buildQuery from '../../buildQuery';
-import controlPanel from '../controlPanel';
+import controlPanel from './controlPanel';
 import transformProps from '../../transformProps';
 import thumbnail from './images/thumbnail.png';
 import {
   EchartsTimeseriesChartProps,
   EchartsTimeseriesFormData,
   EchartsTimeseriesSeriesType,
-} from '../../types';
+} from '@superset-ui/plugin-chart-echarts';
 import example1 from './images/SmoothLine1.png';
 
 const smoothTransformProps = (chartProps: EchartsTimeseriesChartProps) =>

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/controlPanel.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { FeatureFlag, isFeatureEnabled, t } from '@superset-ui/core';
+import { t } from '@superset-ui/core';
 import {
   ControlPanelConfig,
   ControlPanelsContainerProps,
@@ -54,7 +54,7 @@ const config: ControlPanelConfig = {
       label: t('Query'),
       expanded: true,
       controlSetRows: [
-        isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) ? [xAxisControl] : [],
+        [xAxisControl],
         ['metrics'],
         ['groupby'],
         [

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { FeatureFlag, isFeatureEnabled, t } from '@superset-ui/core';
+import { t } from '@superset-ui/core';
 import {
   ControlPanelConfig,
   ControlPanelsContainerProps,
@@ -60,7 +60,7 @@ const config: ControlPanelConfig = {
       label: t('Query'),
       expanded: true,
       controlSetRows: [
-        isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) ? [xAxisControl] : [],
+        [xAxisControl],
         ['metrics'],
         ['groupby'],
         [

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
@@ -28,10 +28,10 @@ import {
 } from '@superset-ui/chart-controls';
 
 import {
-  DEFAULT_FORM_DATA,
   EchartsTimeseriesContributionType,
   EchartsTimeseriesSeriesType,
-} from '@superset-ui/plugin-chart-echarts';
+} from '../../types';
+import { DEFAULT_FORM_DATA } from '../constants';
 import {
   legendSection,
   richTooltipSection,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
@@ -31,7 +31,7 @@ import {
   DEFAULT_FORM_DATA,
   EchartsTimeseriesContributionType,
   EchartsTimeseriesSeriesType,
-} from '../types';
+} from '@superset-ui/plugin-chart-echarts';
 import {
   legendSection,
   richTooltipSection,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/index.ts
@@ -32,7 +32,7 @@ import thumbnail from './images/thumbnail.png';
 import {
   EchartsTimeseriesChartProps,
   EchartsTimeseriesFormData,
-} from '../types';
+} from '@superset-ui/plugin-chart-echarts';
 import example1 from './images/Step1.png';
 import example2 from './images/Step2.png';
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/index.ts
@@ -25,14 +25,14 @@ import {
   isFeatureEnabled,
   t,
 } from '@superset-ui/core';
-import buildQuery from '../buildQuery';
-import controlPanel from './controlPanel';
-import transformProps from '../transformProps';
-import thumbnail from './images/thumbnail.png';
 import {
   EchartsTimeseriesChartProps,
   EchartsTimeseriesFormData,
 } from '@superset-ui/plugin-chart-echarts';
+import buildQuery from '../buildQuery';
+import controlPanel from './controlPanel';
+import transformProps from '../transformProps';
+import thumbnail from './images/thumbnail.png';
 import example1 from './images/Step1.png';
 import example2 from './images/Step2.png';
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/constants.ts
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { sections } from '@superset-ui/chart-controls';
+import {
+  OrientationType,
+  EchartsTimeseriesSeriesType,
+  EchartsTimeseriesFormData,
+} from './types';
+import {
+  DEFAULT_LEGEND_FORM_DATA,
+  DEFAULT_TITLE_FORM_DATA,
+} from '../constants';
+
+// @ts-ignore
+export const DEFAULT_FORM_DATA: EchartsTimeseriesFormData = {
+  ...DEFAULT_LEGEND_FORM_DATA,
+  ...DEFAULT_TITLE_FORM_DATA,
+  annotationLayers: sections.annotationLayers,
+  area: false,
+  forecastEnabled: sections.FORECAST_DEFAULT_DATA.forecastEnabled,
+  forecastInterval: sections.FORECAST_DEFAULT_DATA.forecastInterval,
+  forecastPeriods: sections.FORECAST_DEFAULT_DATA.forecastPeriods,
+  forecastSeasonalityDaily:
+    sections.FORECAST_DEFAULT_DATA.forecastSeasonalityDaily,
+  forecastSeasonalityWeekly:
+    sections.FORECAST_DEFAULT_DATA.forecastSeasonalityWeekly,
+  forecastSeasonalityYearly:
+    sections.FORECAST_DEFAULT_DATA.forecastSeasonalityYearly,
+  logAxis: false,
+  markerEnabled: false,
+  markerSize: 6,
+  minorSplitLine: false,
+  opacity: 0.2,
+  orderDesc: true,
+  rowLimit: 10000,
+  seriesType: EchartsTimeseriesSeriesType.Line,
+  stack: false,
+  tooltipTimeFormat: 'smart_date',
+  truncateYAxis: false,
+  yAxisBounds: [null, null],
+  zoomable: false,
+  richTooltip: true,
+  xAxisLabelRotation: 0,
+  emitFilter: false,
+  groupby: [],
+  showValue: false,
+  onlyTotal: false,
+  percentageThreshold: 0,
+  orientation: OrientationType.vertical,
+};

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { FeatureFlag, isFeatureEnabled, t } from '@superset-ui/core';
+import { t } from '@superset-ui/core';
 import {
   ControlPanelConfig,
   ControlPanelsContainerProps,
@@ -61,7 +61,7 @@ const config: ControlPanelConfig = {
       label: t('Query'),
       expanded: true,
       controlSetRows: [
-        isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) ? [xAxisControl] : [],
+        [xAxisControl],
         ['metrics'],
         ['groupby'],
         [

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/index.ts
@@ -26,7 +26,7 @@ import {
   t,
 } from '@superset-ui/core';
 import buildQuery from './buildQuery';
-import controlPanel from './controlPanel';
+import controlPanel from './Regular/Line/controlPanel';
 import transformProps from './transformProps';
 import thumbnail from './images/thumbnail.png';
 import {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -36,13 +36,13 @@ import { isDerivedSeries } from '@superset-ui/chart-controls';
 import { EChartsCoreOption, SeriesOption } from 'echarts';
 import { ZRLineType } from 'echarts/types/src/util/types';
 import {
-  DEFAULT_FORM_DATA,
   EchartsTimeseriesChartProps,
   EchartsTimeseriesFormData,
   EchartsTimeseriesSeriesType,
   TimeseriesChartTransformedProps,
   OrientationType,
 } from './types';
+import { DEFAULT_FORM_DATA } from './constants';
 import { ForecastSeriesEnum, ForecastValue } from '../types';
 import { parseYAxisBound } from '../utils/controls';
 import {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -24,13 +24,10 @@ import {
   QueryFormData,
   TimeGranularity,
 } from '@superset-ui/core';
-import { sections } from '@superset-ui/chart-controls';
 import {
-  DEFAULT_LEGEND_FORM_DATA,
   EchartsLegendFormData,
   EChartTransformedProps,
   EchartsTitleFormData,
-  DEFAULT_TITLE_FORM_DATA,
   StackType,
 } from '../types';
 
@@ -92,44 +89,6 @@ export type EchartsTimeseriesFormData = QueryFormData & {
   orientation?: OrientationType;
 } & EchartsLegendFormData &
   EchartsTitleFormData;
-
-// @ts-ignore
-export const DEFAULT_FORM_DATA: EchartsTimeseriesFormData = {
-  ...DEFAULT_LEGEND_FORM_DATA,
-  annotationLayers: sections.annotationLayers,
-  area: false,
-  forecastEnabled: sections.FORECAST_DEFAULT_DATA.forecastEnabled,
-  forecastInterval: sections.FORECAST_DEFAULT_DATA.forecastInterval,
-  forecastPeriods: sections.FORECAST_DEFAULT_DATA.forecastPeriods,
-  forecastSeasonalityDaily:
-    sections.FORECAST_DEFAULT_DATA.forecastSeasonalityDaily,
-  forecastSeasonalityWeekly:
-    sections.FORECAST_DEFAULT_DATA.forecastSeasonalityWeekly,
-  forecastSeasonalityYearly:
-    sections.FORECAST_DEFAULT_DATA.forecastSeasonalityYearly,
-  logAxis: false,
-  markerEnabled: false,
-  markerSize: 6,
-  minorSplitLine: false,
-  opacity: 0.2,
-  orderDesc: true,
-  rowLimit: 10000,
-  seriesType: EchartsTimeseriesSeriesType.Line,
-  stack: false,
-  tooltipTimeFormat: 'smart_date',
-  truncateYAxis: false,
-  yAxisBounds: [null, null],
-  zoomable: false,
-  richTooltip: true,
-  xAxisLabelRotation: 0,
-  emitFilter: false,
-  groupby: [],
-  showValue: false,
-  onlyTotal: false,
-  percentageThreshold: 0,
-  orientation: OrientationType.vertical,
-  ...DEFAULT_TITLE_FORM_DATA,
-};
 
 export interface EchartsTimeseriesChartProps
   extends ChartProps<EchartsTimeseriesFormData> {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
@@ -19,7 +19,13 @@
 
 import { JsonValue, t, TimeGranularity } from '@superset-ui/core';
 import { ReactNode } from 'react';
-import { LabelPositionEnum } from './types';
+import {
+  EchartsLegendFormData,
+  EchartsTitleFormData,
+  LabelPositionEnum,
+  LegendOrientation,
+  LegendType,
+} from './types';
 
 // eslint-disable-next-line import/prefer-default-export
 export const NULL_STRING = '<NULL>';
@@ -84,3 +90,20 @@ export const TIMEGRAIN_TO_TIMESTAMP = {
   [TimeGranularity.QUARTER]: 3600 * 1000 * 24 * 31 * 3,
   [TimeGranularity.YEAR]: 3600 * 1000 * 24 * 31 * 12,
 };
+
+export const DEFAULT_LEGEND_FORM_DATA: EchartsLegendFormData = {
+  legendMargin: null,
+  legendOrientation: LegendOrientation.Top,
+  legendType: LegendType.Scroll,
+  showLegend: true,
+};
+
+export const DEFAULT_TITLE_FORM_DATA: EchartsTitleFormData = {
+  xAxisTitle: '',
+  xAxisTitleMargin: 0,
+  yAxisTitle: '',
+  yAxisTitleMargin: 0,
+  yAxisTitlePosition: 'Top',
+};
+
+export { DEFAULT_FORM_DATA } from './Timeseries/constants';

--- a/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
@@ -24,8 +24,8 @@ import {
   ControlSetRow,
   sharedControls,
 } from '@superset-ui/chart-controls';
-import { DEFAULT_LEGEND_FORM_DATA } from './types';
-import { DEFAULT_FORM_DATA } from './Timeseries/types';
+import { DEFAULT_LEGEND_FORM_DATA } from './constants';
+import { DEFAULT_FORM_DATA } from './Timeseries/constants';
 
 const { legendMargin, legendOrientation, legendType, showLegend } =
   DEFAULT_LEGEND_FORM_DATA;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
@@ -17,18 +17,11 @@
  * under the License.
  */
 import React from 'react';
-import {
-  FeatureFlag,
-  isFeatureEnabled,
-  t,
-  validateNonEmpty,
-} from '@superset-ui/core';
+import { FeatureFlag, isFeatureEnabled, t } from '@superset-ui/core';
 import {
   ControlPanelsContainerProps,
-  ControlPanelState,
   ControlSetItem,
   ControlSetRow,
-  ControlState,
   sharedControls,
 } from '@superset-ui/chart-controls';
 import { DEFAULT_LEGEND_FORM_DATA } from './types';
@@ -145,32 +138,9 @@ export const onlyTotalControl: ControlSetItem = {
   },
 };
 
-export const xAxisControl: ControlSetItem = {
-  name: 'x_axis',
-  config: {
-    ...sharedControls.groupby,
-    label: t('X-axis'),
-    default: (
-      control: ControlState,
-      controlPanel: Partial<ControlPanelState>,
-    ) => {
-      // default to the chosen time column if x-axis is unset and the
-      // GENERIC_CHART_AXES feature flag is enabled
-      const { value } = control;
-      if (value) {
-        return value;
-      }
-      const timeColumn = controlPanel?.form_data?.granularity_sqla;
-      if (isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) && timeColumn) {
-        return timeColumn;
-      }
-      return null;
-    },
-    multi: false,
-    description: t('Dimension to use on x-axis.'),
-    validators: [validateNonEmpty],
-  },
-};
+export const xAxisControl = isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES)
+  ? 'x_axis'
+  : null;
 
 const percentageThresholdControl: ControlSetItem = {
   name: 'percentage_threshold',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/index.ts
@@ -45,7 +45,7 @@ export { default as TimeseriesTransformProps } from './Timeseries/transformProps
 export { default as TreeTransformProps } from './Tree/transformProps';
 export { default as TreemapTransformProps } from './Treemap/transformProps';
 
-export { DEFAULT_FORM_DATA as TimeseriesDefaultFormData } from './Timeseries/types';
+export { DEFAULT_FORM_DATA as TimeseriesDefaultFormData } from './Timeseries/constants';
 
 export * from './types';
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/types.ts
@@ -85,13 +85,6 @@ export type EchartsLegendFormData = {
   showLegend: boolean;
 };
 
-export const DEFAULT_LEGEND_FORM_DATA: EchartsLegendFormData = {
-  legendMargin: null,
-  legendOrientation: LegendOrientation.Top,
-  legendType: LegendType.Scroll,
-  showLegend: true,
-};
-
 export type EventHandlers = Record<string, { (props: any): void }>;
 
 export enum LabelPositionEnum {
@@ -131,14 +124,6 @@ export interface EchartsTitleFormData {
   yAxisTitleMargin: number;
   yAxisTitlePosition: string;
 }
-
-export const DEFAULT_TITLE_FORM_DATA: EchartsTitleFormData = {
-  xAxisTitle: '',
-  xAxisTitleMargin: 0,
-  yAxisTitle: '',
-  yAxisTitleMargin: 0,
-  yAxisTitlePosition: 'Top',
-};
 
 export type StackType = boolean | null | Partial<AreaChartExtraControlsValue>;
 

--- a/superset-frontend/plugins/plugin-chart-echarts/test/BoxPlot/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/BoxPlot/buildQuery.test.ts
@@ -20,7 +20,7 @@ import {
   isPostProcessingBoxplot,
   PostProcessingBoxplot,
 } from '@superset-ui/core';
-import { DEFAULT_TITLE_FORM_DATA } from '../../src/types';
+import { DEFAULT_TITLE_FORM_DATA } from '../../src/constants';
 import buildQuery from '../../src/BoxPlot/buildQuery';
 import { BoxPlotQueryFormData } from '../../src/BoxPlot/types';
 


### PR DESCRIPTION
### SUMMARY
In order to backward-compatible NVD3 chart,
1. move the x-axis controls to `superset-ui`. 
2. the `echarts plugins` move constants into `constats.ts` from 'type.ts`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
No functional changes.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
