### PR TITLE
fix(db): Show the only db install guide when the db is already installed and error is existed while importing file.

### DIFF
--- a/superset-frontend/src/components/ImportModal/ErrorAlert.tsx
+++ b/superset-frontend/src/components/ImportModal/ErrorAlert.tsx
@@ -31,10 +31,13 @@ export const DOCUMENTATION_LINK = supersetTextDocs
 
 export interface IProps {
   errorMessage: string;
-  dbInstall: boolean;
+  showDbInstallInstructions: boolean;
 }
 
-const ErrorAlert: FunctionComponent<IProps> = ({ errorMessage, dbInstall }) => (
+const ErrorAlert: FunctionComponent<IProps> = ({
+  errorMessage,
+  showDbInstallInstructions,
+}) => (
   <Alert
     closable={false}
     css={(theme: SupersetTheme) => antdWarningAlertStyles(theme)}
@@ -42,7 +45,7 @@ const ErrorAlert: FunctionComponent<IProps> = ({ errorMessage, dbInstall }) => (
     showIcon
     message={errorMessage}
     description={
-      dbInstall ? (
+      showDbInstallInstructions ? (
         <>
           <br />
           {t(

--- a/superset-frontend/src/components/ImportModal/ErrorAlert.tsx
+++ b/superset-frontend/src/components/ImportModal/ErrorAlert.tsx
@@ -31,9 +31,10 @@ export const DOCUMENTATION_LINK = supersetTextDocs
 
 export interface IProps {
   errorMessage: string;
+  dbInstall: boolean;
 }
 
-const ErrorAlert: FunctionComponent<IProps> = ({ errorMessage }) => (
+const ErrorAlert: FunctionComponent<IProps> = ({ errorMessage, dbInstall }) => (
   <Alert
     closable={false}
     css={(theme: SupersetTheme) => antdWarningAlertStyles(theme)}
@@ -41,21 +42,25 @@ const ErrorAlert: FunctionComponent<IProps> = ({ errorMessage }) => (
     showIcon
     message={errorMessage}
     description={
-      <>
-        <br />
-        {t(
-          'Database driver for importing maybe not installed. Visit the Superset documentation page for installation instructions:',
-        )}
-        <a
-          href={DOCUMENTATION_LINK}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="additional-fields-alert-description"
-        >
-          {t('here')}
-        </a>
-        .
-      </>
+      dbInstall ? (
+        <>
+          <br />
+          {t(
+            'Database driver for importing maybe not installed. Visit the Superset documentation page for installation instructions:',
+          )}
+          <a
+            href={DOCUMENTATION_LINK}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="additional-fields-alert-description"
+          >
+            {t('here')}
+          </a>
+          .
+        </>
+      ) : (
+        ''
+      )
     }
   />
 );

--- a/superset-frontend/src/components/ImportModal/index.tsx
+++ b/superset-frontend/src/components/ImportModal/index.tsx
@@ -303,7 +303,7 @@ const ImportModelsModal: FunctionComponent<ImportModelsModalProps> = ({
       {errorMessage && (
         <ErrorAlert
           errorMessage={errorMessage}
-          dbInstall={passwordFields.length > 0}
+          showDbInstallInstructions={passwordFields.length > 0}
         />
       )}
       {renderPasswordFields()}

--- a/superset-frontend/src/components/ImportModal/index.tsx
+++ b/superset-frontend/src/components/ImportModal/index.tsx
@@ -300,7 +300,12 @@ const ImportModelsModal: FunctionComponent<ImportModelsModalProps> = ({
           <Button loading={importingModel}>Select file</Button>
         </Upload>
       </StyledInputContainer>
-      {errorMessage && <ErrorAlert errorMessage={errorMessage} />}
+      {errorMessage && (
+        <ErrorAlert
+          errorMessage={errorMessage}
+          dbInstall={passwordFields.length > 0}
+        />
+      )}
       {renderPasswordFields()}
       {renderOverwriteConfirmation()}
     </Modal>


### PR DESCRIPTION
### SUMMARY
Add error message when user tries to import without having db driver installed

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
![image](https://user-images.githubusercontent.com/47900232/174669019-d70e5e73-782c-4d32-989d-cdf4effc8ea2.png)

AFTER:
![image](https://user-images.githubusercontent.com/47900232/174668722-d358e246-a6b0-49f2-bc97-dff74bef8658.png)

### TESTING INSTRUCTIONS

1. Import a file (dashboard, chart, dataset, database) that contains a database where the user doesn't have the database driver installed

2. Current behavior:
The db driver is installed and the error has nothing to do with the database, so the user getting this error text doesn't make sense.

3. Expected behavior:
User sees an error message when they don't have the db driver installed

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
