### PR TITLE
docs(featureflags): add GENERIC_CHART_AXES flag

### DIFF
--- a/RESOURCES/FEATURE_FLAGS.md
+++ b/RESOURCES/FEATURE_FLAGS.md
@@ -56,6 +56,7 @@ These features flags are **safe for production** and have been tested.
 - SQL_VALIDATORS_BY_ENGINE [(docs)](https://superset.apache.org/docs/installation/sql-templating)
 - SQLLAB_BACKEND_PERSISTENCE
 - THUMBNAILS [(docs)](https://superset.apache.org/docs/installation/cache)
+- GENERIC_CHART_AXES
 
 ## Deprecated Flags
 These features flags currently default to True and **will be removed in a future major release**. For this current release you can turn them off by setting your config to False, but it is advised to remove or set these flags in your local configuration to **True** so that you do not experience any unexpected changes in a future release.

--- a/RESOURCES/FEATURE_FLAGS.md
+++ b/RESOURCES/FEATURE_FLAGS.md
@@ -43,6 +43,7 @@ These features are **finished** but currently being tested. They are usable, but
 - GLOBAL_ASYNC_QUERIES [(docs)](https://github.com/apache/superset/blob/master/CONTRIBUTING.md#async-chart-queries)
 - VERSIONED_EXPORT
 - ENABLE_JAVASCRIPT_CONTROLS
+- GENERIC_CHART_AXES
 
 ## Stable
 These features flags are **safe for production** and have been tested.
@@ -56,7 +57,6 @@ These features flags are **safe for production** and have been tested.
 - SQL_VALIDATORS_BY_ENGINE [(docs)](https://superset.apache.org/docs/installation/sql-templating)
 - SQLLAB_BACKEND_PERSISTENCE
 - THUMBNAILS [(docs)](https://superset.apache.org/docs/installation/cache)
-- GENERIC_CHART_AXES
 
 ## Deprecated Flags
 These features flags currently default to True and **will be removed in a future major release**. For this current release you can turn them off by setting your config to False, but it is advised to remove or set these flags in your local configuration to **True** so that you do not experience any unexpected changes in a future release.


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

I found that GENERIC_CHART_AXES flag exists via superset config file, but GENERIC_CHART_AXES is not described in the document.(This feature was applied via https://github.com/apache/superset/pull/17917)
This would be helpful for the superset user reading only documents.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
