### PR TITLE
fix: table viz sort icon bottom aligned

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -449,7 +449,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
               data-column-name={col.id}
               css={{
                 display: 'inline-flex',
-                alignItems: 'center',
+                alignItems: 'flex-end',
               }}
             >
               <span data-column-name={col.id}>{label}</span>


### PR DESCRIPTION
### SUMMARY

Bottom aligning the sort icon looks better for multi line column names

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

<img width="1061" alt="Screen Shot 2022-06-21 at 04 20 49" src="https://user-images.githubusercontent.com/17252075/174740090-16edc699-356c-4384-b9fa-cb2a20138b23.png">

After:

<img width="1070" alt="Screen Shot 2022-06-21 at 04 16 12" src="https://user-images.githubusercontent.com/17252075/174739816-3be12f5d-4fc4-4e54-8a9d-6c708f0f3704.png">

### TESTING INSTRUCTIONS

Create a table visualization with many many columns, enough that the title of one of them breaks to more than one line.
Ensure the sorting icon bottom aligns.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
