### PR TITLE
fix: should raise exception when apply a categorical axis

### DIFF
--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -322,6 +322,16 @@ class QueryContextProcessor:
                 #  multi-dimensional charts
                 granularity = query_object.granularity
                 index = granularity if granularity in df.columns else DTTM_ALIAS
+                if not pd.api.types.is_datetime64_any_dtype(
+                    offset_metrics_df.get(index)
+                ):
+                    raise QueryObjectValidationError(
+                        _(
+                            "A time column must be specified "
+                            "when using a Time Comparison."
+                        )
+                    )
+
                 offset_metrics_df[index] = offset_metrics_df[index] - DateOffset(
                     **normalize_time_delta(offset)
                 )


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Raise a specified error when using categorical x-axis and time comparison.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### After
![image](https://user-images.githubusercontent.com/2016594/174779709-1e7ea110-05fa-46a7-8776-4ca765b32a17.png)

#### Before
![image](https://user-images.githubusercontent.com/2016594/174779824-eae27ea4-2dd8-4359-9ccc-d2acd9a715e8.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
