### PR TITLE
fix: handle tstzrange PostgreSQL column type

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -87,6 +87,7 @@ from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.sql.type_api import Variant
 from sqlalchemy.types import TEXT, TypeDecorator, TypeEngine
 from typing_extensions import TypedDict, TypeGuard
+import psycopg2
 
 from superset.constants import (
     EXTRA_FORM_DATA_APPEND_KEYS,
@@ -580,6 +581,10 @@ def json_iso_dttm_ser(obj: Any, pessimistic: bool = False) -> str:
         return val
     if isinstance(obj, (datetime, date, pd.Timestamp)):
         obj = obj.isoformat()
+    elif isinstance(obj, psycopg2._range.DateTimeTZRange):
+        obj_lower = obj.lower.isoformat() if obj.lower is not None else None
+        obj_upper = obj.upper.isoformat() if obj.upper is not None else None
+        obj = "{}|{}".format(obj_lower, obj_upper)
     else:
         if pessimistic:
             return "Unserializable [{}]".format(type(obj))


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Addresses the issue #19995 .

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

![image-20220509-124927](https://user-images.githubusercontent.com/89710/174809918-90367c1f-7e3c-4d77-abe4-bfdf2a243724.png)



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Use Superset to connect to a PostgreSQL database with a column of type `tstzrange`. Then, on "SQL Lab" -> "SQL Editor" try to query the database on data from the table that has the `tstzrange` column type.

The bug shows the error message stating it is unable to serialize the data. This PR creates a representation for that column type.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: #19995 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
