### PR TITLE
feat: add Spark Sql DB engine spec and support Spark 3.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -165,6 +165,7 @@ setup(
         "snowflake": [
             "snowflake-sqlalchemy==1.2.4"
         ],  # PINNED! 1.2.5 introduced breaking changes requiring sqlalchemy>=1.4.0
+        "spark": ["pyhive[hive]>=0.6.5", "tableschema", "thrift>=0.11.0, <1.0.0"],
         "teradata": ["teradatasql>=16.20.0.23"],
         "thumbnails": ["Pillow>=9.0.1, <10.0.0"],
         "vertica": ["sqlalchemy-vertica-python>=0.5.9, < 0.6"],

--- a/superset/config.py
+++ b/superset/config.py
@@ -179,6 +179,7 @@ SQLALCHEMY_TRACK_MODIFICATIONS = False
 # Use a strong complex alphanumeric string and use a tool to help you generate
 # a sufficiently random sequence, ex: openssl rand -base64 42"
 SECRET_KEY = CHANGE_ME_SECRET_KEY
+SECRET_KEY = '\2\1thisismyscretkey\1\2\e\y\y\h'
 
 # The SQLAlchemy connection string.
 SQLALCHEMY_DATABASE_URI = "sqlite:///" + os.path.join(DATA_DIR, "superset.db")

--- a/superset/config.py
+++ b/superset/config.py
@@ -179,7 +179,6 @@ SQLALCHEMY_TRACK_MODIFICATIONS = False
 # Use a strong complex alphanumeric string and use a tool to help you generate
 # a sufficiently random sequence, ex: openssl rand -base64 42"
 SECRET_KEY = CHANGE_ME_SECRET_KEY
-SECRET_KEY = '\2\1thisismyscretkey\1\2\e\y\y\h'
 
 # The SQLAlchemy connection string.
 SQLALCHEMY_DATABASE_URI = "sqlite:///" + os.path.join(DATA_DIR, "superset.db")

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -40,7 +40,7 @@ time_grain_expressions = {
 }
 
 
-class DatabricksHiveEngineSpec(HiveEngineSpec):
+class DatabricksHiveEngineSpec(SparkEngineSpec):
     engine = "databricks"
     engine_name = "Databricks Interactive Cluster"
     driver = "pyhive"

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -19,13 +19,34 @@ from datetime import datetime
 from typing import Any, Dict, Optional
 
 from superset.db_engine_specs.base import BaseEngineSpec
-from superset.db_engine_specs.spark import SparkEngineSpec
+from superset.db_engine_specs.hive import HiveEngineSpec
 
-class DatabricksHiveEngineSpec(SparkEngineSpec):
+time_grain_expressions = {
+    None: "{col}",
+    "PT1S": "date_trunc('second', {col})",
+    "PT1M": "date_trunc('minute', {col})",
+    "PT1H": "date_trunc('hour', {col})",
+    "P1D": "date_trunc('day', {col})",
+    "P1W": "date_trunc('week', {col})",
+    "P1M": "date_trunc('month', {col})",
+    "P3M": "date_trunc('quarter', {col})",
+    "P1Y": "date_trunc('year', {col})",
+    "P1W/1970-01-03T00:00:00Z": (
+        "date_trunc('week', {col} + interval '1 day') + interval '5 days'"
+    ),
+    "1969-12-28T00:00:00Z/P1W": (
+        "date_trunc('week', {col} + interval '1 day') - interval '1 day'"
+    ),
+}
+
+
+class DatabricksHiveEngineSpec(HiveEngineSpec):
     engine = "databricks"
     engine_name = "Databricks Interactive Cluster"
     driver = "pyhive"
     _show_functions_column = "function"
+
+    _time_grain_expressions = time_grain_expressions
 
 
 class DatabricksODBCEngineSpec(BaseEngineSpec):
@@ -33,17 +54,17 @@ class DatabricksODBCEngineSpec(BaseEngineSpec):
     engine_name = "Databricks SQL Endpoint"
     driver = "pyodbc"
 
-    _time_grain_expressions = SparkEngineSpec._time_grain_expressions
+    _time_grain_expressions = time_grain_expressions
 
     @classmethod
     def convert_dttm(
         cls, target_type: str, dttm: datetime, db_extra: Optional[Dict[str, Any]] = None
     ) -> Optional[str]:
-        return SparkEngineSpec.convert_dttm(target_type, dttm, db_extra=db_extra)
+        return HiveEngineSpec.convert_dttm(target_type, dttm, db_extra=db_extra)
 
     @classmethod
     def epoch_to_dttm(cls) -> str:
-        return SparkEngineSpec.epoch_to_dttm()
+        return HiveEngineSpec.epoch_to_dttm()
 
 
 class DatabricksNativeEngineSpec(DatabricksODBCEngineSpec):

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -13,32 +13,13 @@
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
-# under the License.o
+# under the License.
 
 from datetime import datetime
 from typing import Any, Dict, Optional
 
 from superset.db_engine_specs.base import BaseEngineSpec
-from superset.db_engine_specs.hive import HiveEngineSpec
-
-time_grain_expressions = {
-    None: "{col}",
-    "PT1S": "date_trunc('second', {col})",
-    "PT1M": "date_trunc('minute', {col})",
-    "PT1H": "date_trunc('hour', {col})",
-    "P1D": "date_trunc('day', {col})",
-    "P1W": "date_trunc('week', {col})",
-    "P1M": "date_trunc('month', {col})",
-    "P3M": "date_trunc('quarter', {col})",
-    "P1Y": "date_trunc('year', {col})",
-    "P1W/1970-01-03T00:00:00Z": (
-        "date_trunc('week', {col} + interval '1 day') + interval '5 days'"
-    ),
-    "1969-12-28T00:00:00Z/P1W": (
-        "date_trunc('week', {col} + interval '1 day') - interval '1 day'"
-    ),
-}
-
+from superset.db_engine_specs.spark import SparkEngineSpec
 
 class DatabricksHiveEngineSpec(SparkEngineSpec):
     engine = "databricks"
@@ -46,25 +27,23 @@ class DatabricksHiveEngineSpec(SparkEngineSpec):
     driver = "pyhive"
     _show_functions_column = "function"
 
-    _time_grain_expressions = time_grain_expressions
-
 
 class DatabricksODBCEngineSpec(BaseEngineSpec):
     engine = "databricks"
     engine_name = "Databricks SQL Endpoint"
     driver = "pyodbc"
 
-    _time_grain_expressions = time_grain_expressions
+    _time_grain_expressions = SparkEngineSpec._time_grain_expressions
 
     @classmethod
     def convert_dttm(
         cls, target_type: str, dttm: datetime, db_extra: Optional[Dict[str, Any]] = None
     ) -> Optional[str]:
-        return HiveEngineSpec.convert_dttm(target_type, dttm, db_extra=db_extra)
+        return SparkEngineSpec.convert_dttm(target_type, dttm, db_extra=db_extra)
 
     @classmethod
     def epoch_to_dttm(cls) -> str:
-        return HiveEngineSpec.epoch_to_dttm()
+        return SparkEngineSpec.epoch_to_dttm()
 
 
 class DatabricksNativeEngineSpec(DatabricksODBCEngineSpec):

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -580,14 +580,4 @@ class HiveEngineSpec(PrestoEngineSpec):
         """
 
         return True
-
-
-class SparkEngineSpec(HiveEngineSpec):
-
-    engine_name = "Apache Spark SQL"
-
-
-class Spark3EngineSpec(HiveEngineSpec):
-
-    engine_name = "Apache Spark3 SQL"
     

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -585,3 +585,9 @@ class HiveEngineSpec(PrestoEngineSpec):
 class SparkEngineSpec(HiveEngineSpec):
 
     engine_name = "Apache Spark SQL"
+
+
+class Spark3EngineSpec(HiveEngineSpec):
+
+    engine_name = "Apache Spark3 SQL"
+    

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -580,4 +580,3 @@ class HiveEngineSpec(PrestoEngineSpec):
         """
 
         return True
-    

--- a/superset/db_engine_specs/spark.py
+++ b/superset/db_engine_specs/spark.py
@@ -13,7 +13,7 @@
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
-# under the License.o
+# under the License.
 
 from superset.db_engine_specs.hive import HiveEngineSpec
 

--- a/superset/db_engine_specs/spark.py
+++ b/superset/db_engine_specs/spark.py
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.o
+
+from superset.db_engine_specs.hive import HiveEngineSpec
+
+time_grain_expressions = {
+        None: "{col}",
+        "PT1S": "date_trunc('second', {col})",
+        "PT1M": "date_trunc('minute', {col})",
+        "PT1H": "date_trunc('hour', {col})",
+        "P1D": "date_trunc('day', {col})",
+        "P1W": "date_trunc('week', {col})",
+        "P1M": "date_trunc('month', {col})",
+        "P3M": "date_trunc('quarter', {col})",
+        "P1Y": "date_trunc('year', {col})",
+        "P1W/1970-01-03T00:00:00Z": (
+            "date_trunc('week', {col} + interval '1 day') + interval '5 days'"
+        ),
+        "1969-12-28T00:00:00Z/P1W": (
+            "date_trunc('week', {col} + interval '1 day') - interval '1 day'"
+        ),
+    }
+
+class SparkEngineSpec(HiveEngineSpec):
+    _time_grain_expressions = time_grain_expressions
+    engine_name = "Apache Spark SQL"

--- a/superset/db_engine_specs/spark.py
+++ b/superset/db_engine_specs/spark.py
@@ -18,22 +18,23 @@
 from superset.db_engine_specs.hive import HiveEngineSpec
 
 time_grain_expressions = {
-        None: "{col}",
-        "PT1S": "date_trunc('second', {col})",
-        "PT1M": "date_trunc('minute', {col})",
-        "PT1H": "date_trunc('hour', {col})",
-        "P1D": "date_trunc('day', {col})",
-        "P1W": "date_trunc('week', {col})",
-        "P1M": "date_trunc('month', {col})",
-        "P3M": "date_trunc('quarter', {col})",
-        "P1Y": "date_trunc('year', {col})",
-        "P1W/1970-01-03T00:00:00Z": (
+    None: "{col}",
+    "PT1S": "date_trunc('second', {col})",
+    "PT1M": "date_trunc('minute', {col})",
+    "PT1H": "date_trunc('hour', {col})",
+    "P1D": "date_trunc('day', {col})",
+    "P1W": "date_trunc('week', {col})",
+    "P1M": "date_trunc('month', {col})",
+    "P3M": "date_trunc('quarter', {col})",
+    "P1Y": "date_trunc('year', {col})",
+    "P1W/1970-01-03T00:00:00Z": (
             "date_trunc('week', {col} + interval '1 day') + interval '5 days'"
-        ),
-        "1969-12-28T00:00:00Z/P1W": (
-            "date_trunc('week', {col} + interval '1 day') - interval '1 day'"
-        ),
-    }
+    ),
+    "1969-12-28T00:00:00Z/P1W": (
+        "date_trunc('week', {col} + interval '1 day') - interval '1 day'"
+    ),
+}
+
 
 class SparkEngineSpec(HiveEngineSpec):
     _time_grain_expressions = time_grain_expressions

--- a/superset/db_engine_specs/spark.py
+++ b/superset/db_engine_specs/spark.py
@@ -28,7 +28,7 @@ time_grain_expressions = {
     "P3M": "date_trunc('quarter', {col})",
     "P1Y": "date_trunc('year', {col})",
     "P1W/1970-01-03T00:00:00Z": (
-            "date_trunc('week', {col} + interval '1 day') + interval '5 days'"
+        "date_trunc('week', {col} + interval '1 day') + interval '5 days'"
     ),
     "1969-12-28T00:00:00Z/P1W": (
         "date_trunc('week', {col} + interval '1 day') - interval '1 day'"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Move spark engine spec in `hive.py` to a new file: `spark.py` and support Spark 3.x DateFormat; 

1. As tools like Kyuubi are gradually maturing, spark SQL has greater advantages than hive, and pyhive can not meet some of the features of spark SQL. I think it would be better to take spark SQL Engine spec alone; It is also convenient to provide better Kyuubi or spark server support in the future;
2. Spark3.0 remove date format string[apache/superset/pull/18690], DatabricksEngineSpec have fixed it: <https://issues.apache.org/jira/browse/SPARK-31892> but Spark SQL engine is not, so i simply fix it;

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![image](https://user-images.githubusercontent.com/51081799/174930155-050bbb37-8c1d-48cb-86f6-98e72d1036d3.png)
![image](https://user-images.githubusercontent.com/51081799/174935191-bcc9b55e-0678-4295-ab26-085beb9c3f98.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
connect and query see screenshots;
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
