### PR TITLE
fix: Custom sql issue in table viz with raw records

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1379,15 +1379,23 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
                 select_exprs.append(outer)
         elif columns:
             for selected in columns:
-                selected = validate_adhoc_subquery(
-                    selected,
+                selected_query = (
+                    selected["sqlExpression"]
+                    if "sqlExpression" in selected
+                    else selected
+                )
+                label_expected = selected["label"] if "label" in selected else selected
+                selected_query = validate_adhoc_subquery(
+                    selected_query,
                     self.database_id,
                     self.schema,
                 )
                 select_exprs.append(
-                    columns_by_name[selected].get_sqla_col()
-                    if selected in columns_by_name
-                    else self.make_sqla_column_compatible(literal_column(selected))
+                    columns_by_name[selected_query].get_sqla_col()
+                    if selected_query in columns_by_name
+                    else self.make_sqla_column_compatible(
+                        literal_column(selected_query), label_expected
+                    )
                 )
             metrics_exprs = []
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This issue was happened because in backend, when we validate sql, we got wrong sql string from columns.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

AFTER:
[Best JSON Viewer and JSON Beautifier Online - 22 June 2022 - Watch Video](https://www.loom.com/share/a90e2c84acd541438cd2f1b6106b9cf6)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Create a Table with Raw Records as the type
2. Drag in a metric
3. Add a column using Custom SQL
4. You can try adding a constant or just type out any column name

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
