### PR TITLE
fix: Changes the return type of get_permissions to be JSON friendly

### DIFF
--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -468,7 +468,7 @@ def check_datasource_perms(
     _self: Any,
     datasource_type: Optional[str] = None,
     datasource_id: Optional[int] = None,
-    **kwargs: Any,
+    **kwargs: Any
 ) -> None:
     """
     Check if user can access a cached response from explore_json.

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -116,9 +116,10 @@ def get_permissions(
             if permission[0] in ("datasource_access", "database_access"):
                 permissions[permission[0]].add(permission[1])
             roles[role.name].append([permission[0], permission[1]])
+    transformed_permissions = defaultdict(list)
     for perm in permissions:
-        permissions[perm] = list(permissions[perm])
-    return roles, permissions
+        transformed_permissions[perm] = list(permissions[perm])
+    return roles, transformed_permissions
 
 
 def get_viz(

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -103,7 +103,7 @@ def bootstrap_user_data(user: User, include_perms: bool = False) -> Dict[str, An
 
 def get_permissions(
     user: User,
-) -> Tuple[Dict[str, List[List[str]]], DefaultDict[str, Set[str]]]:
+) -> Tuple[Dict[str, List[List[str]]], DefaultDict[str, List[str]]]:
     if not user.roles:
         raise AttributeError("User object does not have roles")
 
@@ -116,7 +116,8 @@ def get_permissions(
             if permission[0] in ("datasource_access", "database_access"):
                 permissions[permission[0]].add(permission[1])
             roles[role.name].append([permission[0], permission[1]])
-
+    for perm in permissions:
+        permissions[perm] = list(permissions[perm])
     return roles, permissions
 
 
@@ -467,7 +468,7 @@ def check_datasource_perms(
     _self: Any,
     datasource_type: Optional[str] = None,
     datasource_id: Optional[int] = None,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> None:
     """
     Check if user can access a cached response from explore_json.

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -17,7 +17,7 @@
 import logging
 from collections import defaultdict
 from functools import wraps
-from typing import Any, Callable, DefaultDict, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, DefaultDict, Dict, List, Optional, Tuple, Union
 from urllib import parse
 
 import msgpack


### PR DESCRIPTION
### SUMMARY
Changes the return type of `superset/views/utils/get_permissions` to be JSON friendly. At Preset, we noticed a bunch of serialization errors because the permissions were returned as `Set` instead of `List`. 

Big thanks to @zephyring for investigating the issue.

### TESTING INSTRUCTIONS
Before merging, we'll deploy this fix to our test environments to make sure it fixes the issue.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
