### PR TITLE
chore: Set table viz default row limit to 1000

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -316,6 +316,7 @@ const config: ControlPanelConfig = {
           {
             name: 'row_limit',
             override: {
+              default: 1000,
               visibility: ({ controls }: ControlPanelsContainerProps) =>
                 !controls?.server_pagination?.value,
             },


### PR DESCRIPTION
### SUMMARY

Table viz default of row limit `10000` is too high and rough on the browser - 1000 is a better default.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
--

### TESTING INSTRUCTIONS

Create a new table chart and ensure the default limit is set at `1000`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
