### PR TITLE
fix: Re-add filter-box time granularity/column

### DIFF
--- a/superset-frontend/src/visualizations/FilterBox/controlPanel.jsx
+++ b/superset-frontend/src/visualizations/FilterBox/controlPanel.jsx
@@ -66,6 +66,28 @@ export default {
             },
           },
         ],
+        [
+          {
+            name: 'show_sqla_time_granularity',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Show time grain dropdown'),
+              default: false,
+              description: t('Check to include time grain dropdown'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'show_sqla_time_column',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Show time column'),
+              default: false,
+              description: t('Check to include time column dropdown'),
+            },
+          },
+        ],
         ['adhoc_filters'],
       ],
     },


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR fixes a regression in https://github.com/apache/superset/pull/19770 which accidentally removed several SQL controls from the filter-box visualization.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE

<img width="1115" alt="Screen Shot 2022-06-23 at 11 46 34 AM" src="https://user-images.githubusercontent.com/4567245/175375358-23b9466a-a27c-4452-af27-d2398e45e813.png">

#### AFTER

<img width="1117" alt="Screen Shot 2022-06-23 at 11 48 31 AM" src="https://user-images.githubusercontent.com/4567245/175375384-97259c6e-17a1-4f73-a4b8-150e09ecadf8.png">

### TESTING INSTRUCTIONS

Tested locally and verified (per the screenshots) that the missing SQL controls were re-added.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
