### PR TITLE
chore: Updated copy in chart drop down to "View as table"

### DIFF
--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -334,7 +334,7 @@ class SliceHeaderControls extends React.PureComponent<
             <ModalTrigger
               triggerNode={
                 <span data-test="view-query-menu-item">
-                  {t('Drill to detail')}
+                  {t('View as table')}
                 </span>
               }
               modalTitle={t('Chart Data: %s', slice.slice_name)}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
It said Drill to detail, which was misleading; instead it should say View as table since its just the table that creates the chart and not additional details.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: 
![Screen Shot 2022-06-23 at 3 29 48 PM](https://user-images.githubusercontent.com/3453043/175405694-a2ee2b77-48ac-4803-b997-2fa9aaaa2cb9.png)

After:

### TESTING INSTRUCTIONS
Make sure it actually says the new copy. Test on ephem. env.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
