### PR TITLE
fix(sql lab): Syntax errors should return with 422 status

### DIFF
--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -115,6 +115,14 @@ class SupersetErrorsException(SupersetException):
             self.status = status
 
 
+class SupersetSyntaxErrorException(SupersetErrorsException):
+    status = 422
+    error_type = SupersetErrorType.SYNTAX_ERROR
+
+    def __init__(self, errors: List[SupersetError]) -> None:
+        super().__init__(errors)
+
+
 class SupersetTimeoutException(SupersetErrorFromParamsException):
     status = 408
 


### PR DESCRIPTION
### SUMMARY

A syntax error in SQL Lab, like the following:

```sql
select * from "FCC 2018 Survey" where par_region = 'US' land
```

returns a 500 error.

This PR changes the status to a 422, to reflect it as an user error instead.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
-

### TESTING INSTRUCTIONS

Execute a query with a syntax error in SQL Lab and observe the response status. Should be 422

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
