### PR TITLE
fix: change permissions on action

### DIFF
--- a/.github/workflows/welcome-new-users.yml
+++ b/.github/workflows/welcome-new-users.yml
@@ -8,7 +8,7 @@ jobs:
   welcome:
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      pull-requests: write
 
     steps:
       - name: Welcome Message


### PR DESCRIPTION
The permissions on the new welcome message were only on issue instead of PR and it was failing the action.  This changes the permission to pr.


### TESTING INSTRUCTIONS
I tested this with a github action runner, but unfortunately, the same permissions don't apply in test, so it will need to be run live to see if this fixes the issue. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
