### PR TITLE
chore(explore): Update chart save to use API endpoints

### DIFF
--- a/superset-frontend/src/constants.ts
+++ b/superset-frontend/src/constants.ts
@@ -99,6 +99,10 @@ export const URL_PARAMS = {
     name: 'show_database_modal',
     type: 'boolean',
   },
+  saveAction: {
+    name: 'save_action',
+    type: 'string',
+  },
 } as const;
 
 export const RESERVED_CHART_URL_PARAMS: string[] = [

--- a/superset-frontend/src/explore/ExplorePage.tsx
+++ b/superset-frontend/src/explore/ExplorePage.tsx
@@ -16,50 +16,58 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { useLocation } from 'react-router-dom';
 import { makeApi, t } from '@superset-ui/core';
 import Loading from 'src/components/Loading';
+import { addDangerToast } from 'src/components/MessageToasts/actions';
+import { isNullish } from 'src/utils/common';
+import { getUrlParam } from 'src/utils/urlUtils';
+import { URL_PARAMS } from 'src/constants';
 import { getParsedExploreURLParams } from './exploreUtils/getParsedExploreURLParams';
 import { hydrateExplore } from './actions/hydrateExplore';
 import ExploreViewContainer from './components/ExploreViewContainer';
 import { ExploreResponsePayload } from './types';
 import { fallbackExploreInitialData } from './fixtures';
-import { addDangerToast } from '../components/MessageToasts/actions';
-import { isNullish } from '../utils/common';
 
 const loadErrorMessage = t('Failed to load chart data.');
 
-const fetchExploreData = () => {
-  const exploreUrlParams = getParsedExploreURLParams();
-  return makeApi<{}, ExploreResponsePayload>({
+const fetchExploreData = (exploreUrlParams: URLSearchParams) =>
+  makeApi<{}, ExploreResponsePayload>({
     method: 'GET',
     endpoint: 'api/v1/explore/',
   })(exploreUrlParams);
-};
 
 const ExplorePage = () => {
   const [isLoaded, setIsLoaded] = useState(false);
+  const isExploreInitialized = useRef(false);
   const dispatch = useDispatch();
+  const location = useLocation();
 
   useEffect(() => {
-    fetchExploreData()
-      .then(({ result }) => {
-        if (isNullish(result.dataset?.id) && isNullish(result.dataset?.uid)) {
+    const exploreUrlParams = getParsedExploreURLParams(location);
+    const isSaveAction = !!getUrlParam(URL_PARAMS.saveAction);
+    if (!isExploreInitialized.current || isSaveAction) {
+      fetchExploreData(exploreUrlParams)
+        .then(({ result }) => {
+          if (isNullish(result.dataset?.id) && isNullish(result.dataset?.uid)) {
+            dispatch(hydrateExplore(fallbackExploreInitialData));
+            dispatch(addDangerToast(loadErrorMessage));
+          } else {
+            dispatch(hydrateExplore(result));
+          }
+        })
+        .catch(() => {
           dispatch(hydrateExplore(fallbackExploreInitialData));
           dispatch(addDangerToast(loadErrorMessage));
-        } else {
-          dispatch(hydrateExplore(result));
-        }
-      })
-      .catch(() => {
-        dispatch(hydrateExplore(fallbackExploreInitialData));
-        dispatch(addDangerToast(loadErrorMessage));
-      })
-      .finally(() => {
-        setIsLoaded(true);
-      });
-  }, [dispatch]);
+        })
+        .finally(() => {
+          setIsLoaded(true);
+          isExploreInitialized.current = true;
+        });
+    }
+  }, [dispatch, location]);
 
   if (!isLoaded) {
     return <Loading />;

--- a/superset-frontend/src/explore/actions/hydrateExplore.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.ts
@@ -89,6 +89,7 @@ export const hydrateExplore =
       controlsTransferred: [],
       standalone: getUrlParam(URL_PARAMS.standalone),
       force: getUrlParam(URL_PARAMS.force),
+      sliceDashboards: initialFormData.dashboards,
     };
 
     // apply initial mapStateToProps for all controls, must execute AFTER

--- a/superset-frontend/src/explore/actions/saveModalActions.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.js
@@ -61,7 +61,7 @@ export function removeSaveModalAlert() {
   return { type: REMOVE_SAVE_MODAL_ALERT };
 }
 
-export const getSlicePayload = (sliceName, formData) => {
+export const getSlicePayload = (sliceName, formData, owners) => {
   const [datasourceId, datasourceType] = formData.datasource.split('__');
   const payload = {
     params: JSON.stringify(formData),
@@ -70,6 +70,7 @@ export const getSlicePayload = (sliceName, formData) => {
     datasource_id: parseInt(datasourceId, 10),
     datasource_type: datasourceType,
     dashboards: formData.dashboards,
+    owners,
     query_context: JSON.stringify(
       buildV1ChartDataPayload({
         formData,
@@ -104,12 +105,13 @@ const addDashboardSuccessToast = (addedToDashboard, sliceName) => {
 
 //  Update existing slice
 export const updateSlice =
-  (sliceId, sliceName, formData, addedToDashboard) => async dispatch => {
+  ({ slice_id: sliceId, owners }, sliceName, formData, addedToDashboard) =>
+  async dispatch => {
     try {
       const response = await SupersetClient.put({
         endpoint: `/api/v1/chart/${sliceId}`,
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(getSlicePayload(sliceName, formData)),
+        body: JSON.stringify(getSlicePayload(sliceName, formData, owners)),
       });
 
       dispatch(saveSliceSuccess());

--- a/superset-frontend/src/explore/actions/saveModalActions.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.js
@@ -85,22 +85,41 @@ export const getSlicePayload = (sliceName, formData, owners) => {
   return payload;
 };
 
-const addDashboardSuccessToast = (addedToDashboard, sliceName) => {
+const addToasts = (isNewSlice, sliceName, addedToDashboard) => {
+  const toasts = [];
+  if (isNewSlice) {
+    toasts.push(
+      addSuccessToast(`${t('Chart')} [${sliceName}] ${t('has been saved')}`),
+    );
+  } else {
+    toasts.push(
+      addSuccessToast(
+        `${t('Chart')} [${sliceName}] ${t('has been overwritten')}`,
+      ),
+    );
+  }
+
   if (addedToDashboard) {
     if (addedToDashboard.new) {
-      addSuccessToast(
-        `${t('Dashboard')} [${addedToDashboard.title}] ${t(
-          'just got created and chart',
-        )} [${sliceName}] ${t('was added to it')}`,
+      toasts.push(
+        addSuccessToast(
+          `${t('Dashboard')} [${addedToDashboard.title}] ${t(
+            'just got created and chart',
+          )} [${sliceName}] ${t('was added to it')}`,
+        ),
       );
     } else {
-      addSuccessToast(
-        `${t('Chart')} [${sliceName}] ${t('was added to dashboard')} [${
-          addedToDashboard.title
-        }]`,
+      toasts.push(
+        addSuccessToast(
+          `${t('Chart')} [${sliceName}] ${t('was added to dashboard')} [${
+            addedToDashboard.title
+          }]`,
+        ),
       );
     }
   }
+
+  return toasts;
 };
 
 //  Update existing slice
@@ -115,11 +134,7 @@ export const updateSlice =
       });
 
       dispatch(saveSliceSuccess());
-      addSuccessToast(
-        `${t('Chart')} [${sliceName}] ${t('has been overwritten')}`,
-      );
-
-      addDashboardSuccessToast(addedToDashboard, sliceName);
+      addToasts(false, sliceName, addedToDashboard).map(dispatch);
       return response.json;
     } catch (error) {
       dispatch(saveSliceFailed());
@@ -138,8 +153,7 @@ export const createSlice =
       });
 
       dispatch(saveSliceSuccess());
-      addSuccessToast(`${t('Chart')} [${sliceName}] ${t('has been saved')}`);
-      addDashboardSuccessToast(addedToDashboard, sliceName);
+      addToasts(true, sliceName, addedToDashboard).map(dispatch);
       return response.json;
     } catch (error) {
       dispatch(saveSliceFailed());

--- a/superset-frontend/src/explore/actions/saveModalActions.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.js
@@ -88,14 +88,10 @@ export const getSlicePayload = (sliceName, formData, owners) => {
 const addToasts = (isNewSlice, sliceName, addedToDashboard) => {
   const toasts = [];
   if (isNewSlice) {
-    toasts.push(
-      addSuccessToast(`${t('Chart')} [${sliceName}] ${t('has been saved')}`),
-    );
+    toasts.push(addSuccessToast(t('Chart [%s] has been saved', sliceName)));
   } else {
     toasts.push(
-      addSuccessToast(
-        `${t('Chart')} [${sliceName}] ${t('has been overwritten')}`,
-      ),
+      addSuccessToast(t('Chart [%s] has been overwritten', sliceName)),
     );
   }
 
@@ -103,17 +99,21 @@ const addToasts = (isNewSlice, sliceName, addedToDashboard) => {
     if (addedToDashboard.new) {
       toasts.push(
         addSuccessToast(
-          `${t('Dashboard')} [${addedToDashboard.title}] ${t(
-            'just got created and chart',
-          )} [${sliceName}] ${t('was added to it')}`,
+          t(
+            'Dashboard [%s] just got created and chart [%s] was added to it',
+            addedToDashboard.title,
+            sliceName,
+          ),
         ),
       );
     } else {
       toasts.push(
         addSuccessToast(
-          `${t('Chart')} [${sliceName}] ${t('was added to dashboard')} [${
-            addedToDashboard.title
-          }]`,
+          t(
+            'Chart [%s] was added to dashboard [%s]',
+            sliceName,
+            addedToDashboard.title,
+          ),
         ),
       );
     }

--- a/superset-frontend/src/explore/actions/saveModalActions.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.js
@@ -140,8 +140,7 @@ export const updateSlice =
     try {
       const response = await SupersetClient.put({
         endpoint: `/api/v1/chart/${sliceId}`,
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(getSlicePayload(sliceName, formData, owners)),
+        jsonPayload: getSlicePayload(sliceName, formData, owners),
       });
 
       dispatch(saveSliceSuccess());
@@ -159,8 +158,7 @@ export const createSlice =
     try {
       const response = await SupersetClient.post({
         endpoint: `/api/v1/chart/`,
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(getSlicePayload(sliceName, formData)),
+        jsonPayload: getSlicePayload(sliceName, formData),
       });
 
       dispatch(saveSliceSuccess());
@@ -177,8 +175,7 @@ export const createDashboard = dashboardName => async dispatch => {
   try {
     const response = await SupersetClient.post({
       endpoint: `/api/v1/dashboard/`,
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ dashboard_title: dashboardName }),
+      jsonPayload: { dashboard_title: dashboardName },
     });
 
     return response.json;

--- a/superset-frontend/src/explore/actions/saveModalActions.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.js
@@ -61,7 +61,18 @@ export function removeSaveModalAlert() {
   return { type: REMOVE_SAVE_MODAL_ALERT };
 }
 
-export const getSlicePayload = (sliceName, formData, owners) => {
+export const getSlicePayload = (
+  sliceName,
+  formDataWithNativeFilters,
+  owners,
+) => {
+  const formData = {
+    ...formDataWithNativeFilters,
+    adhoc_filters: formDataWithNativeFilters.adhoc_filters?.filter(
+      f => !f.isExtra,
+    ),
+  };
+
   const [datasourceId, datasourceType] = formData.datasource.split('__');
   const payload = {
     params: JSON.stringify(formData),

--- a/superset-frontend/src/explore/actions/saveModalActions.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.js
@@ -107,11 +107,13 @@ export const updateSlice = (sliceId, sliceName, formData) => async dispatch => {
 export const createSlice = (sliceName, formData) => async dispatch => {
   let response;
   try {
-    response = await SupersetClient.post({
-      endpoint: `/api/v1/chart/`,
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(getSlicePayload(sliceName, formData)),
-    });
+    response = (
+      await SupersetClient.post({
+        endpoint: `/api/v1/chart/`,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(getSlicePayload(sliceName, formData)),
+      })
+    ).json;
   } catch (error) {
     dispatch(saveSliceFailed());
     throw error;

--- a/superset-frontend/src/explore/actions/saveModalActions.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.js
@@ -61,7 +61,7 @@ export function removeSaveModalAlert() {
   return { type: REMOVE_SAVE_MODAL_ALERT };
 }
 
-const getSlicePayload = (sliceName, formData) => {
+export const getSlicePayload = (sliceName, formData) => {
   const [datasourceId, datasourceType] = formData.datasource.split('__');
   const payload = {
     params: JSON.stringify(formData),
@@ -88,15 +88,15 @@ const addDashboardSuccessToast = (addedToDashboard, sliceName) => {
   if (addedToDashboard) {
     if (addedToDashboard.new) {
       addSuccessToast(
-        `${t('Chart')} [${sliceName}] ${t('was added to dashboard')} [${
-          addedToDashboard.title
-        }]`,
+        `${t('Dashboard')} [${addedToDashboard.title}] ${t(
+          'just got created and chart',
+        )} [${sliceName}] ${t('was added to it')}`,
       );
     } else {
       addSuccessToast(
-        `${t('Dashboard')} ${addedToDashboard.title}] ${t(
-          'just got created and chart',
-        )} [${sliceName}] ${t('was added to it')}`,
+        `${t('Chart')} [${sliceName}] ${t('was added to dashboard')} [${
+          addedToDashboard.title
+        }]`,
       );
     }
   }
@@ -136,7 +136,7 @@ export const createSlice =
       });
 
       dispatch(saveSliceSuccess());
-      addSuccessToast(`${t('Chart')} ${sliceName} ${t('has been saved')}`);
+      addSuccessToast(`${t('Chart')} [${sliceName}] ${t('has been saved')}`);
       addDashboardSuccessToast(addedToDashboard, sliceName);
       return response.json;
     } catch (error) {

--- a/superset-frontend/src/explore/actions/saveModalActions.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.js
@@ -67,7 +67,7 @@ const getSlicePayload = (sliceName, formData) => {
     params: JSON.stringify(formData),
     slice_name: sliceName,
     viz_type: formData.viz_type,
-    datasource_id: +datasourceId,
+    datasource_id: parseInt(datasourceId, 10),
     datasource_type: datasourceType,
     dashboards: formData.dashboards,
     query_context: JSON.stringify(
@@ -105,84 +105,72 @@ const addDashboardSuccessToast = (addedToDashboard, sliceName) => {
 //  Update existing slice
 export const updateSlice =
   (sliceId, sliceName, formData, addedToDashboard) => async dispatch => {
-    let response;
     try {
-      response = (
-        await SupersetClient.put({
-          endpoint: `/api/v1/chart/${sliceId}`,
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(getSlicePayload(sliceName, formData)),
-        })
-      ).json;
+      const response = await SupersetClient.put({
+        endpoint: `/api/v1/chart/${sliceId}`,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(getSlicePayload(sliceName, formData)),
+      });
+
+      dispatch(saveSliceSuccess());
+      addSuccessToast(
+        `${t('Chart')} [${sliceName}] ${t('has been overwritten')}`,
+      );
+
+      addDashboardSuccessToast(addedToDashboard, sliceName);
+      return response.json;
     } catch (error) {
       dispatch(saveSliceFailed());
       throw error;
     }
-
-    dispatch(saveSliceSuccess());
-    addSuccessToast(
-      `${t('Chart')} [${sliceName}] ${t('has been overwritten')}`,
-    );
-
-    addDashboardSuccessToast(addedToDashboard, sliceName);
-    return response;
   };
 
 //  Create new slice
 export const createSlice =
   (sliceName, formData, addedToDashboard) => async dispatch => {
-    let response;
     try {
-      response = (
-        await SupersetClient.post({
-          endpoint: `/api/v1/chart/`,
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(getSlicePayload(sliceName, formData)),
-        })
-      ).json;
+      const response = await SupersetClient.post({
+        endpoint: `/api/v1/chart/`,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(getSlicePayload(sliceName, formData)),
+      });
+
+      dispatch(saveSliceSuccess());
+      addSuccessToast(`${t('Chart')} ${sliceName} ${t('has been saved')}`);
+      addDashboardSuccessToast(addedToDashboard, sliceName);
+      return response.json;
     } catch (error) {
       dispatch(saveSliceFailed());
       throw error;
     }
-
-    dispatch(saveSliceSuccess());
-    addSuccessToast(`${t('Chart')} ${sliceName} ${t('has been saved')}`);
-    addDashboardSuccessToast(addedToDashboard, sliceName);
-    return response;
   };
 
 //  Create new dashboard
 export const createDashboard = dashboardName => async dispatch => {
-  let response;
   try {
-    response = (
-      await SupersetClient.post({
-        endpoint: `/api/v1/dashboard/`,
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ dashboard_title: dashboardName }),
-      })
-    ).json;
+    const response = await SupersetClient.post({
+      endpoint: `/api/v1/dashboard/`,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ dashboard_title: dashboardName }),
+    });
+
+    return response.json;
   } catch (error) {
     dispatch(saveSliceFailed());
     throw error;
   }
-
-  return response;
 };
 
 //  Get existing dashboard from ID
 export const getDashboard = dashboardId => async dispatch => {
-  let response;
   try {
-    response = (
-      await SupersetClient.get({
-        endpoint: `/api/v1/dashboard/${dashboardId}`,
-      })
-    ).json;
+    const response = await SupersetClient.get({
+      endpoint: `/api/v1/dashboard/${dashboardId}`,
+    });
+
+    return response.json;
   } catch (error) {
     dispatch(saveSliceFailed());
     throw error;
   }
-
-  return response;
 };

--- a/superset-frontend/src/explore/actions/saveModalActions.test.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.test.js
@@ -100,7 +100,12 @@ test('updateSlice handles success', async () => {
   fetchMock.reset();
   fetchMock.put(updateSliceEndpoint, sliceResponsePayload);
   const dispatch = sinon.spy();
-  const slice = await updateSlice(sliceId, sliceName, formData)(dispatch);
+  const slice = await updateSlice(
+    { slice_id: sliceId },
+    sliceName,
+    formData,
+  )(dispatch);
+
   expect(fetchMock.calls(updateSliceEndpoint)).toHaveLength(1);
   expect(dispatch.callCount).toBe(1);
   expect(dispatch.getCall(0).args[0].type).toBe(SAVE_SLICE_SUCCESS);
@@ -119,7 +124,7 @@ test('updateSlice handles failure', async () => {
   const dispatch = sinon.spy();
   let caughtError;
   try {
-    await updateSlice(sliceId, sliceName, formData)(dispatch);
+    await updateSlice({ slice_id: sliceId }, sliceName, formData)(dispatch);
   } catch (error) {
     caughtError = error;
   }
@@ -255,7 +260,7 @@ test('updateSlice with add to new dashboard handles success', async () => {
   fetchMock.reset();
   fetchMock.put(updateSliceEndpoint, sliceResponsePayload);
   const dispatch = sinon.spy();
-  const slice = await updateSlice(sliceId, sliceName, formData, {
+  const slice = await updateSlice({ slice_id: sliceId }, sliceName, formData, {
     new: true,
     title: dashboardName,
   })(dispatch);
@@ -281,7 +286,7 @@ test('updateSlice with add to existing dashboard handles success', async () => {
   fetchMock.reset();
   fetchMock.put(updateSliceEndpoint, sliceResponsePayload);
   const dispatch = sinon.spy();
-  const slice = await updateSlice(sliceId, sliceName, formData, {
+  const slice = await updateSlice({ slice_id: sliceId }, sliceName, formData, {
     new: false,
     title: dashboardName,
   })(dispatch);

--- a/superset-frontend/src/explore/actions/saveModalActions.test.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.test.js
@@ -19,11 +19,22 @@
 
 import sinon from 'sinon';
 import fetchMock from 'fetch-mock';
+import { addSuccessToast } from 'src/components/MessageToasts/actions';
 import {
+  createDashboard,
+  createSlice,
   fetchDashboards,
   FETCH_DASHBOARDS_FAILED,
   FETCH_DASHBOARDS_SUCCEEDED,
+  getDashboard,
+  SAVE_SLICE_FAILED,
+  SAVE_SLICE_SUCCESS,
+  updateSlice,
 } from './saveModalActions';
+
+/**
+ * Tests fetchDashboards action
+ */
 
 const userId = 1;
 const fetchDashboardsEndpoint = `glob:*/dashboardasync/api/read?_flt_0_owners=${1}`;
@@ -32,46 +43,261 @@ const mockDashboardData = {
   result: [{ id: 'id', dashboard_title: 'dashboard title' }],
 };
 
-test('fetchDashboards makes the correct fetch request', () => {
-  fetchMock.restore();
+test('fetchDashboards handles success', async () => {
+  fetchMock.reset();
   fetchMock.get(fetchDashboardsEndpoint, mockDashboardData);
   const dispatch = sinon.spy();
-  return fetchDashboards(userId)(dispatch).then(() => {
-    expect(fetchMock.calls(fetchDashboardsEndpoint)).toHaveLength(1);
-
-    return Promise.resolve();
-  });
+  await fetchDashboards(userId)(dispatch);
+  expect(fetchMock.calls(fetchDashboardsEndpoint)).toHaveLength(1);
+  expect(dispatch.callCount).toBe(1);
+  expect(dispatch.getCall(0).args[0].type).toBe(FETCH_DASHBOARDS_SUCCEEDED);
 });
 
-test('fetchDashboards calls correct actions on success', () => {
-  fetchMock.restore();
-  fetchMock.get(fetchDashboardsEndpoint, mockDashboardData);
+test('fetchDashboards handles failure', async () => {
+  fetchMock.reset();
+  fetchMock.get(fetchDashboardsEndpoint, { throws: 'error' });
   const dispatch = sinon.spy();
-  return fetchDashboards(userId)(dispatch).then(() => {
-    expect(dispatch.callCount).toBe(1);
-    expect(dispatch.getCall(0).args[0].type).toBe(FETCH_DASHBOARDS_SUCCEEDED);
-
-    return Promise.resolve();
-  });
+  await fetchDashboards(userId)(dispatch);
+  expect(fetchMock.calls(fetchDashboardsEndpoint)).toHaveLength(4); // 3 retries
+  expect(dispatch.callCount).toBe(1);
+  expect(dispatch.getCall(0).args[0].type).toBe(FETCH_DASHBOARDS_FAILED);
 });
 
-test('fetchDashboards calls correct actions on error', () => {
-  fetchMock.restore();
-  fetchMock.get(
-    fetchDashboardsEndpoint,
-    { throws: 'error' },
-    { overwriteRoutes: true },
+const sliceId = 10;
+const sliceName = 'New chart';
+const vizType = 'sample_viz_type';
+const datasourceId = 11;
+const datasourceType = 'sample_datasource_type';
+const dashboards = [12, 13];
+const queryContext = { sampleKey: 'sampleValue' };
+const formData = {
+  viz_type: vizType,
+  datasource: `${datasourceId}__${datasourceType}`,
+  dashboards,
+};
+
+const sliceResponsePayload = {
+  id: 10,
+};
+
+const sampleError = new Error('sampleError');
+
+jest.mock('../exploreUtils', () => ({
+  buildV1ChartDataPayload: jest.fn(() => queryContext),
+}));
+
+jest.mock('src/components/MessageToasts/actions', () => ({
+  addSuccessToast: jest.fn(),
+}));
+
+/**
+ * Tests updateSlice action
+ */
+
+const updateSliceEndpoint = `glob:*/api/v1/chart/${sliceId}`;
+test('updateSlice handles success', async () => {
+  addSuccessToast.mockClear();
+  fetchMock.reset();
+  fetchMock.put(updateSliceEndpoint, sliceResponsePayload);
+  const dispatch = sinon.spy();
+  const slice = await updateSlice(sliceId, sliceName, formData)(dispatch);
+  expect(fetchMock.calls(updateSliceEndpoint)).toHaveLength(1);
+  expect(dispatch.callCount).toBe(1);
+  expect(dispatch.getCall(0).args[0].type).toBe(SAVE_SLICE_SUCCESS);
+  expect(addSuccessToast).toHaveBeenNthCalledWith(
+    1,
+    'Chart [New chart] has been overwritten',
   );
 
+  expect(slice).toEqual(sliceResponsePayload);
+});
+
+test('updateSlice handles failure', async () => {
+  addSuccessToast.mockClear();
+  fetchMock.reset();
+  fetchMock.put(updateSliceEndpoint, { throws: sampleError });
   const dispatch = sinon.spy();
-  return fetchDashboards(userId)(dispatch).then(() => {
-    expect(dispatch.callCount).toBe(1);
-    expect(dispatch.getCall(0).args[0].type).toBe(FETCH_DASHBOARDS_FAILED);
+  let caughtError;
+  try {
+    await updateSlice(sliceId, sliceName, formData)(dispatch);
+  } catch (error) {
+    caughtError = error;
+  }
 
-    fetchMock.get(fetchDashboardsEndpoint, mockDashboardData, {
-      overwriteRoutes: true,
-    });
+  expect(caughtError).toEqual(sampleError);
+  expect(fetchMock.calls(updateSliceEndpoint)).toHaveLength(4);
+  expect(dispatch.callCount).toBe(1);
+  expect(dispatch.getCall(0).args[0].type).toBe(SAVE_SLICE_FAILED);
+  expect(addSuccessToast).not.toHaveBeenCalled();
+});
 
-    return Promise.resolve();
-  });
+/**
+ * Tests createSlice action
+ */
+
+const createSliceEndpoint = `glob:*/api/v1/chart/`;
+test('createSlice handles success', async () => {
+  addSuccessToast.mockClear();
+  fetchMock.reset();
+  fetchMock.post(createSliceEndpoint, sliceResponsePayload);
+  const dispatch = sinon.spy();
+  const slice = await createSlice(sliceName, formData)(dispatch);
+  expect(fetchMock.calls(createSliceEndpoint)).toHaveLength(1);
+  expect(dispatch.callCount).toBe(1);
+  expect(dispatch.getCall(0).args[0].type).toBe(SAVE_SLICE_SUCCESS);
+  expect(addSuccessToast).toHaveBeenNthCalledWith(
+    1,
+    'Chart [New chart] has been saved',
+  );
+
+  expect(slice).toEqual(sliceResponsePayload);
+});
+
+test('createSlice handles failure', async () => {
+  addSuccessToast.mockClear();
+  fetchMock.reset();
+  fetchMock.post(createSliceEndpoint, { throws: sampleError });
+  const dispatch = sinon.spy();
+  let caughtError;
+  try {
+    await createSlice(sliceName, formData)(dispatch);
+  } catch (error) {
+    caughtError = error;
+  }
+
+  expect(caughtError).toEqual(sampleError);
+  expect(fetchMock.calls(createSliceEndpoint)).toHaveLength(4);
+  expect(dispatch.callCount).toBe(1);
+  expect(dispatch.getCall(0).args[0].type).toBe(SAVE_SLICE_FAILED);
+  expect(addSuccessToast).not.toHaveBeenCalled();
+});
+
+const dashboardId = 14;
+const dashboardName = 'New dashboard';
+const dashboardResponsePayload = {
+  id: 14,
+};
+
+/**
+ * Tests createDashboard action
+ */
+
+const createDashboardEndpoint = `glob:*/api/v1/dashboard/`;
+test('createDashboard handles success', async () => {
+  addSuccessToast.mockClear();
+  fetchMock.reset();
+  fetchMock.post(createDashboardEndpoint, dashboardResponsePayload);
+  const dispatch = sinon.spy();
+  const dashboard = await createDashboard(dashboardName)(dispatch);
+  expect(fetchMock.calls(createDashboardEndpoint)).toHaveLength(1);
+  expect(dispatch.callCount).toBe(0);
+  expect(addSuccessToast).not.toHaveBeenCalled();
+  expect(dashboard).toEqual(dashboardResponsePayload);
+});
+
+test('createDashboard handles failure', async () => {
+  addSuccessToast.mockClear();
+  fetchMock.reset();
+  fetchMock.post(createDashboardEndpoint, { throws: sampleError });
+  const dispatch = sinon.spy();
+  let caughtError;
+  try {
+    await createDashboard(dashboardName)(dispatch);
+  } catch (error) {
+    caughtError = error;
+  }
+
+  expect(caughtError).toEqual(sampleError);
+  expect(fetchMock.calls(createDashboardEndpoint)).toHaveLength(4);
+  expect(dispatch.callCount).toBe(1);
+  expect(dispatch.getCall(0).args[0].type).toBe(SAVE_SLICE_FAILED);
+  expect(addSuccessToast).not.toHaveBeenCalled();
+});
+
+/**
+ * Tests getDashboard action
+ */
+
+const getDashboardEndpoint = `glob:*/api/v1/dashboard/${dashboardId}`;
+test('getDashboard handles success', async () => {
+  addSuccessToast.mockClear();
+  fetchMock.reset();
+  fetchMock.get(getDashboardEndpoint, dashboardResponsePayload);
+  const dispatch = sinon.spy();
+  const dashboard = await getDashboard(dashboardId)(dispatch);
+  expect(fetchMock.calls(getDashboardEndpoint)).toHaveLength(1);
+  expect(dispatch.callCount).toBe(0);
+  expect(addSuccessToast).not.toHaveBeenCalled();
+  expect(dashboard).toEqual(dashboardResponsePayload);
+});
+
+test('getDashboard handles failure', async () => {
+  addSuccessToast.mockClear();
+  fetchMock.reset();
+  fetchMock.get(getDashboardEndpoint, { throws: sampleError });
+  const dispatch = sinon.spy();
+  let caughtError;
+  try {
+    await getDashboard(dashboardId)(dispatch);
+  } catch (error) {
+    caughtError = error;
+  }
+
+  expect(caughtError).toEqual(sampleError);
+  expect(fetchMock.calls(getDashboardEndpoint)).toHaveLength(4);
+  expect(dispatch.callCount).toBe(1);
+  expect(dispatch.getCall(0).args[0].type).toBe(SAVE_SLICE_FAILED);
+  expect(addSuccessToast).not.toHaveBeenCalled();
+});
+
+test('updateSlice with add to new dashboard handles success', async () => {
+  addSuccessToast.mockClear();
+  fetchMock.reset();
+  fetchMock.put(updateSliceEndpoint, sliceResponsePayload);
+  const dispatch = sinon.spy();
+  const slice = await updateSlice(sliceId, sliceName, formData, {
+    new: true,
+    title: dashboardName,
+  })(dispatch);
+
+  expect(fetchMock.calls(updateSliceEndpoint)).toHaveLength(1);
+  expect(dispatch.callCount).toBe(1);
+  expect(dispatch.getCall(0).args[0].type).toBe(SAVE_SLICE_SUCCESS);
+  expect(addSuccessToast).toHaveBeenNthCalledWith(
+    1,
+    'Chart [New chart] has been overwritten',
+  );
+
+  expect(addSuccessToast).toHaveBeenNthCalledWith(
+    2,
+    'Dashboard [New dashboard] just got created and chart [New chart] was added to it',
+  );
+
+  expect(slice).toEqual(sliceResponsePayload);
+});
+
+test('updateSlice with add to existing dashboard handles success', async () => {
+  addSuccessToast.mockClear();
+  fetchMock.reset();
+  fetchMock.put(updateSliceEndpoint, sliceResponsePayload);
+  const dispatch = sinon.spy();
+  const slice = await updateSlice(sliceId, sliceName, formData, {
+    new: false,
+    title: dashboardName,
+  })(dispatch);
+
+  expect(fetchMock.calls(updateSliceEndpoint)).toHaveLength(1);
+  expect(dispatch.callCount).toBe(1);
+  expect(dispatch.getCall(0).args[0].type).toBe(SAVE_SLICE_SUCCESS);
+  expect(addSuccessToast).toHaveBeenNthCalledWith(
+    1,
+    'Chart [New chart] has been overwritten',
+  );
+
+  expect(addSuccessToast).toHaveBeenNthCalledWith(
+    2,
+    'Chart [New chart] was added to dashboard [New dashboard]',
+  );
+
+  expect(slice).toEqual(sliceResponsePayload);
 });

--- a/superset-frontend/src/explore/actions/saveModalActions.test.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.test.js
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import sinon from 'sinon';
+import fetchMock from 'fetch-mock';
+import {
+  fetchDashboards,
+  FETCH_DASHBOARDS_FAILED,
+  FETCH_DASHBOARDS_SUCCEEDED,
+} from './saveModalActions';
+
+const userId = 1;
+const fetchDashboardsEndpoint = `glob:*/dashboardasync/api/read?_flt_0_owners=${1}`;
+const mockDashboardData = {
+  pks: ['id'],
+  result: [{ id: 'id', dashboard_title: 'dashboard title' }],
+};
+
+test('fetchDashboards makes the correct fetch request', () => {
+  fetchMock.restore();
+  fetchMock.get(fetchDashboardsEndpoint, mockDashboardData);
+  const dispatch = sinon.spy();
+  return fetchDashboards(userId)(dispatch).then(() => {
+    expect(fetchMock.calls(fetchDashboardsEndpoint)).toHaveLength(1);
+
+    return Promise.resolve();
+  });
+});
+
+test('fetchDashboards calls correct actions on success', () => {
+  fetchMock.restore();
+  fetchMock.get(fetchDashboardsEndpoint, mockDashboardData);
+  const dispatch = sinon.spy();
+  return fetchDashboards(userId)(dispatch).then(() => {
+    expect(dispatch.callCount).toBe(1);
+    expect(dispatch.getCall(0).args[0].type).toBe(FETCH_DASHBOARDS_SUCCEEDED);
+
+    return Promise.resolve();
+  });
+});
+
+test('fetchDashboards calls correct actions on error', () => {
+  fetchMock.restore();
+  fetchMock.get(
+    fetchDashboardsEndpoint,
+    { throws: 'error' },
+    { overwriteRoutes: true },
+  );
+
+  const dispatch = sinon.spy();
+  return fetchDashboards(userId)(dispatch).then(() => {
+    expect(dispatch.callCount).toBe(1);
+    expect(dispatch.getCall(0).args[0].type).toBe(FETCH_DASHBOARDS_FAILED);
+
+    fetchMock.get(fetchDashboardsEndpoint, mockDashboardData, {
+      overwriteRoutes: true,
+    });
+
+    return Promise.resolve();
+  });
+});

--- a/superset-frontend/src/explore/actions/saveModalActions.test.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.test.js
@@ -19,7 +19,7 @@
 
 import sinon from 'sinon';
 import fetchMock from 'fetch-mock';
-import { addSuccessToast } from 'src/components/MessageToasts/actions';
+import { ADD_TOAST } from 'src/components/MessageToasts/actions';
 import {
   createDashboard,
   createSlice,
@@ -86,17 +86,12 @@ jest.mock('../exploreUtils', () => ({
   buildV1ChartDataPayload: jest.fn(() => queryContext),
 }));
 
-jest.mock('src/components/MessageToasts/actions', () => ({
-  addSuccessToast: jest.fn(),
-}));
-
 /**
  * Tests updateSlice action
  */
 
 const updateSliceEndpoint = `glob:*/api/v1/chart/${sliceId}`;
 test('updateSlice handles success', async () => {
-  addSuccessToast.mockClear();
   fetchMock.reset();
   fetchMock.put(updateSliceEndpoint, sliceResponsePayload);
   const dispatch = sinon.spy();
@@ -107,10 +102,11 @@ test('updateSlice handles success', async () => {
   )(dispatch);
 
   expect(fetchMock.calls(updateSliceEndpoint)).toHaveLength(1);
-  expect(dispatch.callCount).toBe(1);
+  expect(dispatch.callCount).toBe(2);
   expect(dispatch.getCall(0).args[0].type).toBe(SAVE_SLICE_SUCCESS);
-  expect(addSuccessToast).toHaveBeenNthCalledWith(
-    1,
+  expect(dispatch.getCall(1).args[0].type).toBe(ADD_TOAST);
+  expect(dispatch.getCall(1).args[0].payload.toastType).toBe('SUCCESS_TOAST');
+  expect(dispatch.getCall(1).args[0].payload.text).toBe(
     'Chart [New chart] has been overwritten',
   );
 
@@ -118,7 +114,6 @@ test('updateSlice handles success', async () => {
 });
 
 test('updateSlice handles failure', async () => {
-  addSuccessToast.mockClear();
   fetchMock.reset();
   fetchMock.put(updateSliceEndpoint, { throws: sampleError });
   const dispatch = sinon.spy();
@@ -133,7 +128,6 @@ test('updateSlice handles failure', async () => {
   expect(fetchMock.calls(updateSliceEndpoint)).toHaveLength(4);
   expect(dispatch.callCount).toBe(1);
   expect(dispatch.getCall(0).args[0].type).toBe(SAVE_SLICE_FAILED);
-  expect(addSuccessToast).not.toHaveBeenCalled();
 });
 
 /**
@@ -142,16 +136,16 @@ test('updateSlice handles failure', async () => {
 
 const createSliceEndpoint = `glob:*/api/v1/chart/`;
 test('createSlice handles success', async () => {
-  addSuccessToast.mockClear();
   fetchMock.reset();
   fetchMock.post(createSliceEndpoint, sliceResponsePayload);
   const dispatch = sinon.spy();
   const slice = await createSlice(sliceName, formData)(dispatch);
   expect(fetchMock.calls(createSliceEndpoint)).toHaveLength(1);
-  expect(dispatch.callCount).toBe(1);
+  expect(dispatch.callCount).toBe(2);
   expect(dispatch.getCall(0).args[0].type).toBe(SAVE_SLICE_SUCCESS);
-  expect(addSuccessToast).toHaveBeenNthCalledWith(
-    1,
+  expect(dispatch.getCall(1).args[0].type).toBe(ADD_TOAST);
+  expect(dispatch.getCall(1).args[0].payload.toastType).toBe('SUCCESS_TOAST');
+  expect(dispatch.getCall(1).args[0].payload.text).toBe(
     'Chart [New chart] has been saved',
   );
 
@@ -159,7 +153,6 @@ test('createSlice handles success', async () => {
 });
 
 test('createSlice handles failure', async () => {
-  addSuccessToast.mockClear();
   fetchMock.reset();
   fetchMock.post(createSliceEndpoint, { throws: sampleError });
   const dispatch = sinon.spy();
@@ -174,7 +167,6 @@ test('createSlice handles failure', async () => {
   expect(fetchMock.calls(createSliceEndpoint)).toHaveLength(4);
   expect(dispatch.callCount).toBe(1);
   expect(dispatch.getCall(0).args[0].type).toBe(SAVE_SLICE_FAILED);
-  expect(addSuccessToast).not.toHaveBeenCalled();
 });
 
 const dashboardId = 14;
@@ -189,19 +181,16 @@ const dashboardResponsePayload = {
 
 const createDashboardEndpoint = `glob:*/api/v1/dashboard/`;
 test('createDashboard handles success', async () => {
-  addSuccessToast.mockClear();
   fetchMock.reset();
   fetchMock.post(createDashboardEndpoint, dashboardResponsePayload);
   const dispatch = sinon.spy();
   const dashboard = await createDashboard(dashboardName)(dispatch);
   expect(fetchMock.calls(createDashboardEndpoint)).toHaveLength(1);
   expect(dispatch.callCount).toBe(0);
-  expect(addSuccessToast).not.toHaveBeenCalled();
   expect(dashboard).toEqual(dashboardResponsePayload);
 });
 
 test('createDashboard handles failure', async () => {
-  addSuccessToast.mockClear();
   fetchMock.reset();
   fetchMock.post(createDashboardEndpoint, { throws: sampleError });
   const dispatch = sinon.spy();
@@ -216,7 +205,6 @@ test('createDashboard handles failure', async () => {
   expect(fetchMock.calls(createDashboardEndpoint)).toHaveLength(4);
   expect(dispatch.callCount).toBe(1);
   expect(dispatch.getCall(0).args[0].type).toBe(SAVE_SLICE_FAILED);
-  expect(addSuccessToast).not.toHaveBeenCalled();
 });
 
 /**
@@ -225,19 +213,16 @@ test('createDashboard handles failure', async () => {
 
 const getDashboardEndpoint = `glob:*/api/v1/dashboard/${dashboardId}`;
 test('getDashboard handles success', async () => {
-  addSuccessToast.mockClear();
   fetchMock.reset();
   fetchMock.get(getDashboardEndpoint, dashboardResponsePayload);
   const dispatch = sinon.spy();
   const dashboard = await getDashboard(dashboardId)(dispatch);
   expect(fetchMock.calls(getDashboardEndpoint)).toHaveLength(1);
   expect(dispatch.callCount).toBe(0);
-  expect(addSuccessToast).not.toHaveBeenCalled();
   expect(dashboard).toEqual(dashboardResponsePayload);
 });
 
 test('getDashboard handles failure', async () => {
-  addSuccessToast.mockClear();
   fetchMock.reset();
   fetchMock.get(getDashboardEndpoint, { throws: sampleError });
   const dispatch = sinon.spy();
@@ -252,11 +237,9 @@ test('getDashboard handles failure', async () => {
   expect(fetchMock.calls(getDashboardEndpoint)).toHaveLength(4);
   expect(dispatch.callCount).toBe(1);
   expect(dispatch.getCall(0).args[0].type).toBe(SAVE_SLICE_FAILED);
-  expect(addSuccessToast).not.toHaveBeenCalled();
 });
 
 test('updateSlice with add to new dashboard handles success', async () => {
-  addSuccessToast.mockClear();
   fetchMock.reset();
   fetchMock.put(updateSliceEndpoint, sliceResponsePayload);
   const dispatch = sinon.spy();
@@ -266,15 +249,16 @@ test('updateSlice with add to new dashboard handles success', async () => {
   })(dispatch);
 
   expect(fetchMock.calls(updateSliceEndpoint)).toHaveLength(1);
-  expect(dispatch.callCount).toBe(1);
+  expect(dispatch.callCount).toBe(3);
   expect(dispatch.getCall(0).args[0].type).toBe(SAVE_SLICE_SUCCESS);
-  expect(addSuccessToast).toHaveBeenNthCalledWith(
-    1,
+  expect(dispatch.getCall(1).args[0].type).toBe(ADD_TOAST);
+  expect(dispatch.getCall(1).args[0].payload.toastType).toBe('SUCCESS_TOAST');
+  expect(dispatch.getCall(1).args[0].payload.text).toBe(
     'Chart [New chart] has been overwritten',
   );
-
-  expect(addSuccessToast).toHaveBeenNthCalledWith(
-    2,
+  expect(dispatch.getCall(2).args[0].type).toBe(ADD_TOAST);
+  expect(dispatch.getCall(2).args[0].payload.toastType).toBe('SUCCESS_TOAST');
+  expect(dispatch.getCall(2).args[0].payload.text).toBe(
     'Dashboard [New dashboard] just got created and chart [New chart] was added to it',
   );
 
@@ -282,7 +266,6 @@ test('updateSlice with add to new dashboard handles success', async () => {
 });
 
 test('updateSlice with add to existing dashboard handles success', async () => {
-  addSuccessToast.mockClear();
   fetchMock.reset();
   fetchMock.put(updateSliceEndpoint, sliceResponsePayload);
   const dispatch = sinon.spy();
@@ -292,15 +275,16 @@ test('updateSlice with add to existing dashboard handles success', async () => {
   })(dispatch);
 
   expect(fetchMock.calls(updateSliceEndpoint)).toHaveLength(1);
-  expect(dispatch.callCount).toBe(1);
+  expect(dispatch.callCount).toBe(3);
   expect(dispatch.getCall(0).args[0].type).toBe(SAVE_SLICE_SUCCESS);
-  expect(addSuccessToast).toHaveBeenNthCalledWith(
-    1,
+  expect(dispatch.getCall(1).args[0].type).toBe(ADD_TOAST);
+  expect(dispatch.getCall(1).args[0].payload.toastType).toBe('SUCCESS_TOAST');
+  expect(dispatch.getCall(1).args[0].payload.text).toBe(
     'Chart [New chart] has been overwritten',
   );
-
-  expect(addSuccessToast).toHaveBeenNthCalledWith(
-    2,
+  expect(dispatch.getCall(2).args[0].type).toBe(ADD_TOAST);
+  expect(dispatch.getCall(2).args[0].payload.toastType).toBe('SUCCESS_TOAST');
+  expect(dispatch.getCall(2).args[0].payload.text).toBe(
     'Chart [New chart] was added to dashboard [New dashboard]',
   );
 

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -586,6 +586,7 @@ function ExploreViewContainer(props) {
             form_data={props.form_data}
             sliceName={props.sliceName}
             dashboardId={props.dashboardId}
+            sliceDashboards={props.exploreState.form_data.dashboards ?? []}
           />
         )}
         <Resizable

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -594,7 +594,7 @@ function ExploreViewContainer(props) {
             form_data={props.form_data}
             sliceName={props.sliceName}
             dashboardId={props.dashboardId}
-            sliceDashboards={props.exploreState.form_data.dashboards ?? []}
+            sliceDashboards={props.exploreState.sliceDashboards ?? []}
           />
         )}
         <Resizable

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -464,6 +464,14 @@ function ExploreViewContainer(props) {
     return false;
   }, [lastQueriedControls, props.controls]);
 
+  const saveAction = getUrlParam(URL_PARAMS.saveAction);
+  useChangeEffect(saveAction, () => {
+    if (['saveas', 'overwrite'].includes(saveAction)) {
+      onQuery();
+      addHistory({ isReplace: true });
+    }
+  });
+
   useEffect(() => {
     if (props.ownState !== undefined) {
       onQuery();

--- a/superset-frontend/src/explore/components/SaveModal.test.jsx
+++ b/superset-frontend/src/explore/components/SaveModal.test.jsx
@@ -31,6 +31,7 @@ import fetchMock from 'fetch-mock';
 
 import * as saveModalActions from 'src/explore/actions/saveModalActions';
 import SaveModal, { StyledModal } from 'src/explore/components/SaveModal';
+import { BrowserRouter } from 'react-router-dom';
 
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
@@ -85,7 +86,16 @@ beforeAll(() => fetchMock.get(fetchDashboardsEndpoint, mockDashboardData));
 afterAll(() => fetchMock.restore());
 
 const getWrapper = () =>
-  shallow(<SaveModal {...defaultProps} store={store} />)
+  shallow(
+    <BrowserRouter>
+      <SaveModal {...defaultProps} store={store} />
+    </BrowserRouter>,
+  )
+    .dive()
+    .dive()
+    .dive()
+    .dive()
+    .dive()
     .dive()
     .dive();
 

--- a/superset-frontend/src/explore/components/SaveModal.test.jsx
+++ b/superset-frontend/src/explore/components/SaveModal.test.jsx
@@ -29,322 +29,162 @@ import Button from 'src/components/Button';
 import sinon from 'sinon';
 import fetchMock from 'fetch-mock';
 
-import * as exploreUtils from 'src/explore/exploreUtils';
 import * as saveModalActions from 'src/explore/actions/saveModalActions';
 import SaveModal, { StyledModal } from 'src/explore/components/SaveModal';
 
-describe('SaveModal', () => {
-  const middlewares = [thunk];
-  const mockStore = configureStore(middlewares);
-  const initialState = {
-    chart: {},
-    saveModal: {
-      dashboards: [],
+const middlewares = [thunk];
+const mockStore = configureStore(middlewares);
+const initialState = {
+  chart: {},
+  saveModal: {
+    dashboards: [],
+  },
+  explore: {
+    datasource: {},
+    slice: {
+      slice_id: 1,
+      slice_name: 'title',
+      owners: [1],
     },
-    explore: {
-      datasource: {},
-      slice: {
-        slice_id: 1,
-        slice_name: 'title',
-        owners: [1],
-      },
-      alert: null,
-    },
-    user: {
-      userId: 1,
-    },
-  };
-  const store = mockStore(initialState);
+    alert: null,
+  },
+  user: {
+    userId: 1,
+  },
+};
 
-  const defaultProps = {
-    onHide: () => ({}),
-    actions: bindActionCreators(saveModalActions, arg => {
-      if (typeof arg === 'function') {
-        return arg(jest.fn);
-      }
-      return arg;
-    }),
-    form_data: { datasource: '107__table', url_params: { foo: 'bar' } },
-  };
-  const mockEvent = {
-    target: {
-      value: 'mock event target',
-    },
-    value: 10,
-  };
+const store = mockStore(initialState);
 
-  const mockDashboardData = {
-    pks: ['id'],
-    result: [{ id: 'id', dashboard_title: 'dashboard title' }],
-  };
+const defaultProps = {
+  onHide: () => ({}),
+  actions: bindActionCreators(saveModalActions, arg => {
+    if (typeof arg === 'function') {
+      return arg(jest.fn);
+    }
+    return arg;
+  }),
+  form_data: { datasource: '107__table', url_params: { foo: 'bar' } },
+};
 
-  const saveEndpoint = `glob:*/dashboardasync/api/read?_flt_0_owners=${1}`;
+const mockEvent = {
+  target: {
+    value: 'mock event target',
+  },
+  value: 10,
+};
 
-  beforeAll(() => fetchMock.get(saveEndpoint, mockDashboardData));
+const mockDashboardData = {
+  pks: ['id'],
+  result: [{ id: 'id', dashboard_title: 'dashboard title' }],
+};
 
-  afterAll(() => fetchMock.restore());
+const fetchDashboardsEndpoint = `glob:*/dashboardasync/api/read?_flt_0_owners=${1}`;
 
-  const getWrapper = () =>
-    shallow(<SaveModal {...defaultProps} store={store} />)
-      .dive()
-      .dive();
+beforeAll(() => fetchMock.get(fetchDashboardsEndpoint, mockDashboardData));
 
-  it('renders a Modal with the right set of components', () => {
-    const wrapper = getWrapper();
-    expect(wrapper.find(StyledModal)).toExist();
-    expect(wrapper.find(Radio)).toHaveLength(2);
+afterAll(() => fetchMock.restore());
 
-    const footerWrapper = shallow(wrapper.find(StyledModal).props().footer);
+const getWrapper = () =>
+  shallow(<SaveModal {...defaultProps} store={store} />)
+    .dive()
+    .dive();
 
-    expect(footerWrapper.find(Button)).toHaveLength(3);
+test('renders a Modal with the right set of components', () => {
+  const wrapper = getWrapper();
+  expect(wrapper.find(StyledModal)).toExist();
+  expect(wrapper.find(Radio)).toHaveLength(2);
+
+  const footerWrapper = shallow(wrapper.find(StyledModal).props().footer);
+
+  expect(footerWrapper.find(Button)).toHaveLength(3);
+});
+
+test('renders the right footer buttons when existing dashboard selected', () => {
+  const wrapper = getWrapper();
+  const footerWrapper = shallow(wrapper.find(StyledModal).props().footer);
+  const saveAndGoDash = footerWrapper
+    .find('#btn_modal_save_goto_dash')
+    .getElement();
+  const save = footerWrapper.find('#btn_modal_save').getElement();
+  expect(save.props.children).toBe('Save');
+  expect(saveAndGoDash.props.children).toBe('Save & go to dashboard');
+});
+
+test('renders the right footer buttons when new dashboard selected', () => {
+  const wrapper = getWrapper();
+  wrapper.setState({
+    saveToDashboardId: null,
+    newDashboardName: 'Test new dashboard',
   });
+  const footerWrapper = shallow(wrapper.find(StyledModal).props().footer);
+  const saveAndGoDash = footerWrapper
+    .find('#btn_modal_save_goto_dash')
+    .getElement();
+  const save = footerWrapper.find('#btn_modal_save').getElement();
+  expect(save.props.children).toBe('Save to new dashboard');
+  expect(saveAndGoDash.props.children).toBe('Save & go to new dashboard');
+});
 
-  it('renders the right footer buttons when an existing dashboard', () => {
-    const wrapper = getWrapper();
-    const footerWrapper = shallow(wrapper.find(StyledModal).props().footer);
-    const saveAndGoDash = footerWrapper
-      .find('#btn_modal_save_goto_dash')
-      .getElement();
-    const save = footerWrapper.find('#btn_modal_save').getElement();
-    expect(save.props.children).toBe('Save');
-    expect(saveAndGoDash.props.children).toBe('Save & go to dashboard');
-  });
+test('disables overwrite option for new slice', () => {
+  const wrapper = getWrapper();
+  wrapper.setProps({ slice: null });
+  expect(wrapper.find('#overwrite-radio').prop('disabled')).toBe(true);
+});
 
-  it('renders the right footer buttons when a new dashboard', () => {
-    const wrapper = getWrapper();
-    wrapper.setState({
-      saveToDashboardId: null,
-      newDashboardName: 'Test new dashboard',
-    });
-    const footerWrapper = shallow(wrapper.find(StyledModal).props().footer);
-    const saveAndGoDash = footerWrapper
-      .find('#btn_modal_save_goto_dash')
-      .getElement();
-    const save = footerWrapper.find('#btn_modal_save').getElement();
-    expect(save.props.children).toBe('Save to new dashboard');
-    expect(saveAndGoDash.props.children).toBe('Save & go to new dashboard');
-  });
+test('disables overwrite option for non-owner', () => {
+  const wrapperForNonOwner = getWrapper();
+  wrapperForNonOwner.setProps({ userId: 2 });
+  const overwriteRadio = wrapperForNonOwner.find('#overwrite-radio');
+  expect(overwriteRadio).toHaveLength(1);
+  expect(overwriteRadio.prop('disabled')).toBe(true);
+});
 
-  it('overwrite radio button is disabled for new slice', () => {
-    const wrapper = getWrapper();
-    wrapper.setProps({ slice: null });
-    expect(wrapper.find('#overwrite-radio').prop('disabled')).toBe(true);
-  });
+test('sets action when saving as new slice', () => {
+  const wrapperForNewSlice = getWrapper();
+  wrapperForNewSlice.setProps({ can_overwrite: false });
+  wrapperForNewSlice.instance().changeAction('saveas');
+  const saveasRadio = wrapperForNewSlice.find('#saveas-radio');
+  saveasRadio.simulate('click');
+  expect(wrapperForNewSlice.state().action).toBe('saveas');
+});
 
-  it('disable overwrite option for non-owner', () => {
-    const wrapperForNonOwner = getWrapper();
-    wrapperForNonOwner.setProps({ userId: 2 });
-    const overwriteRadio = wrapperForNonOwner.find('#overwrite-radio');
-    expect(overwriteRadio).toHaveLength(1);
-    expect(overwriteRadio.prop('disabled')).toBe(true);
-  });
+test('sets action when overwriting slice', () => {
+  const wrapperForOverwrite = getWrapper();
+  const overwriteRadio = wrapperForOverwrite.find('#overwrite-radio');
+  overwriteRadio.simulate('click');
+  expect(wrapperForOverwrite.state().action).toBe('overwrite');
+});
 
-  it('saves a new slice', () => {
-    const wrapperForNewSlice = getWrapper();
-    wrapperForNewSlice.setProps({ can_overwrite: false });
-    wrapperForNewSlice.instance().changeAction('saveas');
-    const saveasRadio = wrapperForNewSlice.find('#saveas-radio');
-    saveasRadio.simulate('click');
-    expect(wrapperForNewSlice.state().action).toBe('saveas');
-  });
+test('fetches dashboards on component mount', () => {
+  sinon.spy(defaultProps.actions, 'fetchDashboards');
+  mount(
+    <Provider store={store}>
+      <SaveModal {...defaultProps} />
+    </Provider>,
+  );
+  expect(defaultProps.actions.fetchDashboards.calledOnce).toBe(true);
 
-  it('overwrite a slice', () => {
-    const wrapperForOverwrite = getWrapper();
-    const overwriteRadio = wrapperForOverwrite.find('#overwrite-radio');
-    overwriteRadio.simulate('click');
-    expect(wrapperForOverwrite.state().action).toBe('overwrite');
-  });
+  defaultProps.actions.fetchDashboards.restore();
+});
 
-  it('componentDidMount', () => {
-    sinon.spy(defaultProps.actions, 'fetchDashboards');
-    mount(
-      <Provider store={store}>
-        <SaveModal {...defaultProps} />
-      </Provider>,
-    );
-    expect(defaultProps.actions.fetchDashboards.calledOnce).toBe(true);
+test('updates slice name and selected dashboard', () => {
+  const wrapper = getWrapper();
+  const dashboardId = mockEvent.value;
 
-    defaultProps.actions.fetchDashboards.restore();
-  });
+  wrapper.instance().onSliceNameChange(mockEvent);
+  expect(wrapper.state().newSliceName).toBe(mockEvent.target.value);
 
-  it('onChange', () => {
-    const wrapper = getWrapper();
-    const dashboardId = mockEvent.value;
+  wrapper.instance().onDashboardSelectChange(dashboardId);
+  expect(wrapper.state().saveToDashboardId).toBe(dashboardId);
+});
 
-    wrapper.instance().onSliceNameChange(mockEvent);
-    expect(wrapper.state().newSliceName).toBe(mockEvent.target.value);
+test('removes alert', () => {
+  sinon.spy(defaultProps.actions, 'removeSaveModalAlert');
+  const wrapper = getWrapper();
+  wrapper.setProps({ alert: 'old alert' });
 
-    wrapper.instance().onDashboardSelectChange(dashboardId);
-    expect(wrapper.state().saveToDashboardId).toBe(dashboardId);
-  });
-
-  describe('saveOrOverwrite', () => {
-    beforeEach(() => {
-      sinon.stub(exploreUtils, 'getExploreUrl').callsFake(() => 'mockURL');
-
-      sinon.stub(defaultProps.actions, 'saveSlice').callsFake(() =>
-        Promise.resolve({
-          dashboard_url: 'http://localhost/mock_dashboard/',
-          slice: { slice_url: '/mock_slice/' },
-        }),
-      );
-    });
-
-    afterEach(() => {
-      exploreUtils.getExploreUrl.restore();
-      defaultProps.actions.saveSlice.restore();
-    });
-
-    it('should save slice without url_params in form_data', () => {
-      const wrapper = getWrapper();
-      wrapper.instance().saveOrOverwrite(true);
-      const { args } = defaultProps.actions.saveSlice.getCall(0);
-      expect(args[0]).toEqual({ datasource: '107__table' });
-    });
-
-    it('existing dashboard', () => {
-      const wrapper = getWrapper();
-      const saveToDashboardId = 100;
-
-      wrapper.setState({ saveToDashboardId });
-      wrapper.instance().saveOrOverwrite(true);
-      const { args } = defaultProps.actions.saveSlice.getCall(0);
-      expect(args[1].save_to_dashboard_id).toBe(saveToDashboardId);
-    });
-
-    it('new dashboard', () => {
-      const wrapper = getWrapper();
-      const newDashboardName = 'new dashboard name';
-
-      wrapper.setState({ newDashboardName });
-      wrapper.instance().saveOrOverwrite(true);
-      const { args } = defaultProps.actions.saveSlice.getCall(0);
-      expect(args[1].new_dashboard_name).toBe(newDashboardName);
-    });
-
-    describe('should always reload or redirect', () => {
-      const originalLocation = window.location;
-      delete window.location;
-      window.location = { assign: jest.fn() };
-      const stub = sinon.stub(window.location, 'assign');
-
-      afterAll(() => {
-        delete window.location;
-        window.location = originalLocation;
-      });
-
-      let wrapper;
-
-      beforeEach(() => {
-        stub.resetHistory();
-        wrapper = getWrapper();
-      });
-
-      it('Save & go to dashboard', () =>
-        new Promise(done => {
-          wrapper.instance().saveOrOverwrite(true);
-          defaultProps.actions.saveSlice().then(() => {
-            expect(window.location.assign.callCount).toEqual(1);
-            expect(window.location.assign.getCall(0).args[0]).toEqual(
-              'http://localhost/mock_dashboard/?foo=bar',
-            );
-            done();
-          });
-        }));
-
-      it('saveas new slice', () =>
-        new Promise(done => {
-          wrapper.setState({
-            action: 'saveas',
-            newSliceName: 'new slice name',
-          });
-          wrapper.instance().saveOrOverwrite(false);
-          defaultProps.actions.saveSlice().then(() => {
-            expect(window.location.assign.callCount).toEqual(1);
-            expect(window.location.assign.getCall(0).args[0]).toEqual(
-              '/mock_slice/?foo=bar',
-            );
-            done();
-          });
-        }));
-
-      it('overwrite original slice', () =>
-        new Promise(done => {
-          wrapper.setState({ action: 'overwrite' });
-          wrapper.instance().saveOrOverwrite(false);
-          defaultProps.actions.saveSlice().then(() => {
-            expect(window.location.assign.callCount).toEqual(1);
-            expect(window.location.assign.getCall(0).args[0]).toEqual(
-              '/mock_slice/?foo=bar',
-            );
-            done();
-          });
-        }));
-    });
-  });
-
-  describe('fetchDashboards', () => {
-    let dispatch;
-    let actionThunk;
-    const userID = 1;
-
-    beforeEach(() => {
-      fetchMock.resetHistory();
-      dispatch = sinon.spy();
-    });
-
-    const makeRequest = () => {
-      actionThunk = saveModalActions.fetchDashboards(userID);
-      return actionThunk(dispatch);
-    };
-
-    it('makes the fetch request', () =>
-      makeRequest().then(() => {
-        expect(fetchMock.calls(saveEndpoint)).toHaveLength(1);
-
-        return Promise.resolve();
-      }));
-
-    it('calls correct actions on success', () =>
-      makeRequest().then(() => {
-        expect(dispatch.callCount).toBe(1);
-        expect(dispatch.getCall(0).args[0].type).toBe(
-          saveModalActions.FETCH_DASHBOARDS_SUCCEEDED,
-        );
-
-        return Promise.resolve();
-      }));
-
-    it('calls correct actions on error', () => {
-      fetchMock.get(
-        saveEndpoint,
-        { throws: 'error' },
-        { overwriteRoutes: true },
-      );
-
-      return makeRequest().then(() => {
-        expect(dispatch.callCount).toBe(1);
-        expect(dispatch.getCall(0).args[0].type).toBe(
-          saveModalActions.FETCH_DASHBOARDS_FAILED,
-        );
-
-        fetchMock.get(saveEndpoint, mockDashboardData, {
-          overwriteRoutes: true,
-        });
-
-        return Promise.resolve();
-      });
-    });
-  });
-
-  it('removeAlert', () => {
-    sinon.spy(defaultProps.actions, 'removeSaveModalAlert');
-    const wrapper = getWrapper();
-    wrapper.setProps({ alert: 'old alert' });
-
-    wrapper.instance().removeAlert();
-    expect(defaultProps.actions.removeSaveModalAlert.callCount).toBe(1);
-    expect(wrapper.state().alert).toBeNull();
-    defaultProps.actions.removeSaveModalAlert.restore();
-  });
+  wrapper.instance().removeAlert();
+  expect(defaultProps.actions.removeSaveModalAlert.callCount).toBe(1);
+  expect(wrapper.state().alert).toBeNull();
+  defaultProps.actions.removeSaveModalAlert.restore();
 });

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -137,7 +137,12 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
     let promise = Promise.resolve();
 
     //  Create or retrieve dashboard
-    type DashboardGetResponse = { id: number; url: string };
+    type DashboardGetResponse = {
+      id: number;
+      url: string;
+      dashboard_title: string;
+    };
+
     let dashboard: DashboardGetResponse | null = null;
     if (this.state.newDashboardName || this.state.saveToDashboardId) {
       let saveToDashboardId = this.state.saveToDashboardId || null;
@@ -168,11 +173,26 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
           this.props.slice?.slice_id,
           this.state.newSliceName,
           formData,
+          dashboard
+            ? {
+                title: dashboard.dashboard_title,
+                new: !this.state.saveToDashboardId,
+              }
+            : null,
         ),
       );
     } else {
       promise = promise.then(() =>
-        this.props.actions.createSlice(this.state.newSliceName, formData),
+        this.props.actions.createSlice(
+          this.state.newSliceName,
+          formData,
+          dashboard
+            ? {
+                title: dashboard.dashboard_title,
+                new: !this.state.saveToDashboardId,
+              }
+            : null,
+        ),
       );
     }
 

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -29,7 +29,6 @@ import Button from 'src/components/Button';
 import { Select } from 'src/components';
 import { SelectValue } from 'antd/lib/select';
 import { connect } from 'react-redux';
-import { getExploreUrl } from '../exploreUtils';
 
 // Session storage key for recent dashboard
 const SK_DASHBOARD_ID = 'save_chart_recent_dashboard';
@@ -132,6 +131,7 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
   saveOrOverwrite(gotodash: boolean) {
     this.setState({ alert: null });
     this.props.actions.removeSaveModalAlert();
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { url_params, ...formData } = this.props.form_data || {};
 
     let promise = Promise.resolve();
@@ -176,7 +176,7 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
       );
     }
 
-    promise.then(() => {
+    promise.then((slice => {
       //  Update recent dashboard
       if (dashboard) {
         sessionStorage.setItem(SK_DASHBOARD_ID, `${dashboard.id}`);
@@ -185,14 +185,13 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
       }
 
       // Go to new slice url or dashboard url
-      let url = gotodash ? dashboard?.url : getExploreUrl({ formData });
-      if (url_params) {
-        const prefix = url.includes('?') ? '&' : '?';
-        url = `${url}${prefix}${new URLSearchParams(url_params).toString()}`;
-      }
+      const url =
+        gotodash && dashboard
+          ? dashboard.url
+          : `${window.location.pathname}?form_data={"slice_id": ${slice.id}}`;
 
       window.location.assign(url);
-    });
+    }) as (slice: any) => void);
 
     this.props.onHide();
   }

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -209,9 +209,16 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
       // Go to new dashboard url
       if (gotodash && dashboard) {
         this.props.history.push(dashboard.url);
-      } else {
-        window.location.assign(`/explore/?slice_id=${value.id}`);
+        return;
       }
+
+      const searchParams = new URLSearchParams(this.props.location.search);
+      searchParams.set('save_action', this.state.action);
+      searchParams.delete('form_data_key');
+      if (this.state.action === 'saveas') {
+        searchParams.set('slice_id', value.id.toString());
+      }
+      this.props.history.replace(`/explore/?${searchParams.toString()}`);
     }) as (value: any) => void);
 
     this.props.onHide();

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -46,6 +46,7 @@ interface SaveModalProps extends RouteComponentProps {
   slice?: Record<string, any>;
   datasource?: Record<string, any>;
   dashboardId: '' | number | null;
+  sliceDashboards: number[];
 }
 
 type ActionType = 'overwrite' | 'saveas';
@@ -161,7 +162,7 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
         .then(() => this.props.actions.getDashboard(saveToDashboardId))
         .then((response: { result: DashboardGetResponse }) => {
           dashboard = response.result;
-          const dashboards = new Set<number>(formData.dashboards);
+          const dashboards = new Set<number>(this.props.sliceDashboards);
           dashboards.add(dashboard.id);
           formData.dashboards = Array.from(dashboards);
         });

--- a/superset-frontend/src/explore/exploreUtils/getParsedExploreURLParams.ts
+++ b/superset-frontend/src/explore/exploreUtils/getParsedExploreURLParams.ts
@@ -17,6 +17,11 @@
  * under the License.
  */
 
+export interface Location {
+  search: string;
+  pathname: string;
+}
+
 // mapping { url_param: v1_explore_request_param }
 const EXPLORE_URL_SEARCH_PARAMS = {
   form_data: {
@@ -70,8 +75,8 @@ const EXPLORE_URL_PATH_PARAMS = {
 
 // search params can be placed in form_data object
 // we need to "flatten" the search params to use them with /v1/explore endpoint
-const getParsedExploreURLSearchParams = () => {
-  const urlSearchParams = new URLSearchParams(window.location.search);
+const getParsedExploreURLSearchParams = (search: string) => {
+  const urlSearchParams = new URLSearchParams(search);
   return Object.keys(EXPLORE_URL_SEARCH_PARAMS).reduce((acc, currentParam) => {
     const paramValue = urlSearchParams.get(currentParam);
     if (paramValue === null) {
@@ -96,21 +101,23 @@ const getParsedExploreURLSearchParams = () => {
 };
 
 // path params need to be transformed to search params to use them with /v1/explore endpoint
-const getParsedExploreURLPathParams = () =>
+const getParsedExploreURLPathParams = (pathname: string) =>
   Object.keys(EXPLORE_URL_PATH_PARAMS).reduce((acc, currentParam) => {
     const re = new RegExp(`/(${currentParam})/(\\w+)`);
-    const pathGroups = window.location.pathname.match(re);
+    const pathGroups = pathname.match(re);
     if (pathGroups && pathGroups[2]) {
       return { ...acc, [EXPLORE_URL_PATH_PARAMS[currentParam]]: pathGroups[2] };
     }
     return acc;
   }, {});
 
-export const getParsedExploreURLParams = () =>
+export const getParsedExploreURLParams = (
+  location: Location = window.location,
+) =>
   new URLSearchParams(
     Object.entries({
-      ...getParsedExploreURLSearchParams(),
-      ...getParsedExploreURLPathParams(),
+      ...getParsedExploreURLSearchParams(location.search),
+      ...getParsedExploreURLPathParams(location.pathname),
     })
       .map(entry => entry.join('='))
       .join('&'),


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When a user saves a chart in Explore, the client sends one `POST /explore` request, then the server creates/updates the chart and optionally adds it to a new/existing dashboard as indicated.  This PR updates Explore's `SaveModal` to instead use v1 API endpoints to accomplish the same.  Here's the updated sequence of API calls:
- If user is creating a new dashboard: `POST /api/v1/dashboard/`
- If user is adding to a new dashboard: `PUT /api/v1/dashboard/{dashboard_id}`
- If user is saving as a new chart: `POST /api/v1/chart/`
  - If adding to new/existing dashboard: `{ dashboards: [..., dashboard_id] }`
- If user is overwriting an existing chart: `PUT /api/v1/chart/{chart_id}`
  - If adding to new/existing dashboard: `{ dashboards: [..., dashboardId] }`

In addition, this PR makes the Save and Save and Go to Dashboard buttons no longer trigger a page refresh.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Try performing the following tasks with and without proposed update and ensure that interface and user experience are identical (with the exception of there no longer being page refreshes):
- Create new chart from scratch, save as new chart, don't add to dashboard
- Create new chart from scratch, save as new chart, add to existing dashboard
- Create new chart from scratch, save as new chart, add to new dashboard
- Edit existing chart, overwrite existing chart, don't add to dashboard
- Edit existing chart, overwrite existing chart, add to existing dashboard
- Edit existing chart, overwrite existing chart, add to new dashboard
- Edit existing chart, save as new chart, don't add to dashboard
- Edit existing chart, save as new chart, add to existing dashboard
- Edit existing chart, save as new chart, add to new dashboard

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
