### PR TITLE
refactor: Deprecate ensure_user_is_set in favor of override_user

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1453,23 +1453,27 @@ def get_user_id() -> Optional[int]:
 
 
 @contextmanager
-def override_user(user: Optional[User]) -> Iterator[Any]:
+def override_user(user: Optional[User], force: bool = True) -> Iterator[Any]:
     """
-    Temporarily override the current user (if defined) per `flask.g`.
+    Temporarily override the current user per `flask.g` with the specified user.
 
     Sometimes, often in the context of async Celery tasks, it is useful to switch the
     current user (which may be undefined) to different one, execute some SQLAlchemy
-    tasks and then revert back to the original one.
+    tasks et al. and then revert back to the original one.
 
     :param user: The override user
+    :param force: Whether to override the current user if set
     """
 
     # pylint: disable=assigning-non-slot
     if hasattr(g, "user"):
-        current = g.user
-        g.user = user
-        yield
-        g.user = current
+        if force or g.user is None:
+            current = g.user
+            g.user = user
+            yield
+            g.user = current
+        else:
+            yield
     else:
         g.user = user
         yield

--- a/tests/integration_tests/access_tests.py
+++ b/tests/integration_tests/access_tests.py
@@ -562,34 +562,34 @@ def test_get_username(
     assert get_username() == username
 
 
-@pytest.mark.parametrize(
-    "username",
-    [
-        None,
-        "alpha",
-        "gamma",
-    ],
-)
+@pytest.mark.parametrize("username", [None, "alpha", "gamma"])
+@pytest.mark.parametrize("force", [False, True])
 def test_override_user(
     app_context: AppContext,
     mocker: MockFixture,
     username: str,
+    force: bool,
 ) -> None:
     mock_g = mocker.patch("superset.utils.core.g", spec={})
     admin = security_manager.find_user(username="admin")
     user = security_manager.find_user(username)
 
-    assert not hasattr(mock_g, "user")
-
-    with override_user(user):
+    with override_user(user, force):
         assert mock_g.user == user
 
     assert not hasattr(mock_g, "user")
+
+    mock_g.user = None
+
+    with override_user(user, force):
+        assert mock_g.user == user
+
+    assert mock_g.user is None
 
     mock_g.user = admin
 
-    with override_user(user):
-        assert mock_g.user == user
+    with override_user(user, force):
+        assert mock_g.user == user if force else admin
 
     assert mock_g.user == admin
 

--- a/tests/integration_tests/tasks/async_queries_tests.py
+++ b/tests/integration_tests/tasks/async_queries_tests.py
@@ -28,7 +28,6 @@ from superset.exceptions import SupersetException
 from superset.extensions import async_query_manager, security_manager
 from superset.tasks import async_queries
 from superset.tasks.async_queries import (
-    ensure_user_is_set,
     load_chart_data_into_cache,
     load_explore_json_into_cache,
 )
@@ -58,12 +57,7 @@ class TestAsyncQueries(SupersetTestCase):
             "errors": [],
         }
 
-        with mock.patch.object(
-            async_queries, "ensure_user_is_set"
-        ) as ensure_user_is_set:
-            load_chart_data_into_cache(job_metadata, query_context)
-
-        ensure_user_is_set.assert_called_once_with(user.id)
+        load_chart_data_into_cache(job_metadata, query_context)
         mock_set_form_data.assert_called_once_with(query_context)
         mock_update_job.assert_called_once_with(
             job_metadata, "done", result_url=mock.ANY
@@ -85,11 +79,7 @@ class TestAsyncQueries(SupersetTestCase):
             "errors": [],
         }
         with pytest.raises(ChartDataQueryFailedError):
-            with mock.patch.object(
-                async_queries, "ensure_user_is_set"
-            ) as ensure_user_is_set:
-                load_chart_data_into_cache(job_metadata, query_context)
-            ensure_user_is_set.assert_called_once_with(user.id)
+            load_chart_data_into_cache(job_metadata, query_context)
 
         mock_run_command.assert_called_once_with(cache=True)
         errors = [{"message": "Error: foo"}]
@@ -115,11 +105,11 @@ class TestAsyncQueries(SupersetTestCase):
         with pytest.raises(SoftTimeLimitExceeded):
             with mock.patch.object(
                 async_queries,
-                "ensure_user_is_set",
-            ) as ensure_user_is_set:
-                ensure_user_is_set.side_effect = SoftTimeLimitExceeded()
+                "set_form_data",
+            ) as set_form_data:
+                set_form_data.side_effect = SoftTimeLimitExceeded()
                 load_chart_data_into_cache(job_metadata, form_data)
-            ensure_user_is_set.assert_called_once_with(user.id, "error", errors=errors)
+            set_form_data.assert_called_once_with(form_data, "error", errors=errors)
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     @mock.patch.object(async_query_manager, "update_job")
@@ -145,12 +135,7 @@ class TestAsyncQueries(SupersetTestCase):
             "errors": [],
         }
 
-        with mock.patch.object(
-            async_queries, "ensure_user_is_set"
-        ) as ensure_user_is_set:
-            load_explore_json_into_cache(job_metadata, form_data)
-
-        ensure_user_is_set.assert_called_once_with(user.id)
+        load_explore_json_into_cache(job_metadata, form_data)
         mock_update_job.assert_called_once_with(
             job_metadata, "done", result_url=mock.ANY
         )
@@ -172,11 +157,7 @@ class TestAsyncQueries(SupersetTestCase):
         }
 
         with pytest.raises(SupersetException):
-            with mock.patch.object(
-                async_queries, "ensure_user_is_set"
-            ) as ensure_user_is_set:
-                load_explore_json_into_cache(job_metadata, form_data)
-            ensure_user_is_set.assert_called_once_with(user.id)
+            load_explore_json_into_cache(job_metadata, form_data)
 
         mock_set_form_data.assert_called_once_with(form_data)
         errors = ["The dataset associated with this chart no longer exists"]
@@ -202,49 +183,8 @@ class TestAsyncQueries(SupersetTestCase):
         with pytest.raises(SoftTimeLimitExceeded):
             with mock.patch.object(
                 async_queries,
-                "ensure_user_is_set",
-            ) as ensure_user_is_set:
-                ensure_user_is_set.side_effect = SoftTimeLimitExceeded()
+                "set_form_data",
+            ) as set_form_data:
+                set_form_data.side_effect = SoftTimeLimitExceeded()
                 load_explore_json_into_cache(job_metadata, form_data)
-            ensure_user_is_set.assert_called_once_with(user.id, "error", errors=errors)
-
-    def test_ensure_user_is_set(self):
-        g_user_is_set = hasattr(g, "user")
-        original_g_user = g.user if g_user_is_set else None
-
-        if g_user_is_set:
-            del g.user
-
-        self.assertFalse(hasattr(g, "user"))
-        ensure_user_is_set(1)
-        self.assertTrue(hasattr(g, "user"))
-        self.assertFalse(g.user.is_anonymous)
-        self.assertEqual(1, get_user_id())
-
-        del g.user
-
-        self.assertFalse(hasattr(g, "user"))
-        ensure_user_is_set(None)
-        self.assertTrue(hasattr(g, "user"))
-        self.assertTrue(g.user.is_anonymous)
-        self.assertEqual(None, get_user_id())
-
-        del g.user
-
-        g.user = security_manager.get_user_by_id(2)
-        self.assertEqual(2, get_user_id())
-
-        ensure_user_is_set(1)
-        self.assertTrue(hasattr(g, "user"))
-        self.assertFalse(g.user.is_anonymous)
-        self.assertEqual(2, get_user_id())
-
-        ensure_user_is_set(None)
-        self.assertTrue(hasattr(g, "user"))
-        self.assertFalse(g.user.is_anonymous)
-        self.assertEqual(2, get_user_id())
-
-        if g_user_is_set:
-            g.user = original_g_user
-        else:
-            del g.user
+            set_form_data.assert_called_once_with(form_data, "error", errors=errors)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

The `ensure_user_is_set` method shares similar logic to `override_user`. It has logic to only override the user if not set—which I gather is to ensure that it doesn't permanently change the user, however if no user was previously set, setting of a user will persist.

This PR updates the `override_user` logic to also include a `force` flag to only override if non-set enabling the `ensure_user_is_set` method to be removed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
