### PR TITLE
chore: Updates control panel font size in Explore

### DIFF
--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -381,7 +381,14 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
     );
     const PanelHeader = () => (
       <span data-test="collapsible-control-panel-header">
-        <span>{label}</span>{' '}
+        <span
+          css={(theme: SupersetTheme) => css`
+            font-size: ${theme.typography.sizes.m}px;
+            line-height: 1.3;
+          `}
+        >
+          {label}
+        </span>{' '}
         {description && (
           // label is only used in tooltip id (should probably call this prop `id`)
           <InfoTooltipWithTrigger label={sectionId} tooltip={description} />


### PR DESCRIPTION
### SUMMARY
Updates control panel font size in Explore. Changes the `font-size` to `14px` and `line-height` to `1.3` according to design specifications.

@kasiazjc 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1183" alt="Screen Shot 2022-06-27 at 11 48 45 AM" src="https://user-images.githubusercontent.com/70410625/175970447-c2032e93-89ca-429c-a118-545ff9e6555e.png">
<img width="1193" alt="Screen Shot 2022-06-27 at 11 48 05 AM" src="https://user-images.githubusercontent.com/70410625/175970498-fed6df9b-e729-461e-aaa4-adfb4833c700.png">

### TESTING INSTRUCTIONS
1 - Go to Explore
2 - Check the new font sizes

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
