### PR TITLE
feat(sql lab): Save Dataset Modal Autocomplete should display list when overwritting

### DIFF
--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
@@ -50,7 +50,7 @@ describe('SaveDatasetModal RTL', () => {
     render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
 
     const overwriteRadioBtn = screen.getByRole('radio', {
-      name: /overwrite existing select or type dataset name/i,
+      name: /overwrite existing/i,
     });
     const fieldLabel = screen.getByText(/overwrite existing/i);
     const inputField = screen.getByRole('combobox');

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -51,7 +51,6 @@ import { postFormData } from 'src/explore/exploreUtils/formData';
 import { URL_PARAMS } from 'src/constants';
 import { SelectValue } from 'antd/lib/select';
 import { isEmpty } from 'lodash';
-import { OptionsTypePage } from 'src/components/Select/Select';
 
 interface SaveDatasetModalProps {
   visible: boolean;
@@ -370,7 +369,6 @@ export const SaveDatasetModal: FunctionComponent<SaveDatasetModalProps> = ({
                     value={selectedDatasetToOverwrite}
                     filterOption={filterAutocompleteOption}
                     disabled={newOrOverwrite !== 2}
-                    // @ts-ignore
                     getPopupContainer={() => document.body}
                   />
                 </div>

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -161,9 +161,9 @@ export const SaveDatasetModal: FunctionComponent<SaveDatasetModalProps> = ({
         datasetToOverwrite.owners.map((o: DatasetOwner) => o.id),
         true,
       ),
-      postFormData(datasetToOverwrite.datasetId, 'table', {
+      postFormData(datasetToOverwrite.datasetid, 'table', {
         ...EXPLORE_CHART_DEFAULT,
-        datasource: `${datasetToOverwrite.datasetId}__table`,
+        datasource: `${datasetToOverwrite.datasetid}__table`,
         ...(defaultVizType === 'table' && {
           all_columns: query.results.selected_columns.map(
             column => column.name,

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -186,45 +186,36 @@ export const SaveDatasetModal: FunctionComponent<SaveDatasetModalProps> = ({
   const loadDatasetOverwriteOptions = useCallback(
     async (input = '') => {
       const { userId } = user;
-      if (userId) {
-        const queryParams = rison.encode({
-          filters: [
-            {
-              col: 'table_name',
-              opr: 'ct',
-              value: input,
-            },
-            {
-              col: 'owners',
-              opr: 'rel_m_m',
-              value: userId,
-            },
-          ],
-          order_column: 'changed_on_delta_humanized',
-          order_direction: 'desc',
-        });
-
-        return SupersetClient.get({
-          endpoint: `/api/v1/dataset?q=${queryParams}`,
-        }).then(response => ({
-          data: response.json.result.map(
-            (r: {
-              table_name: string;
-              id: number;
-              owners: [DatasetOwner];
-            }) => ({
-              value: r.table_name,
-              label: r.table_name,
-              datasetid: r.id,
-              owners: r.owners,
-            }),
-          ),
-          totalCount: response.json.count,
-        }));
-      }
-      return new Promise<OptionsTypePage>(resolve => {
-        resolve({ data: [], totalCount: 0 });
+      const queryParams = rison.encode({
+        filters: [
+          {
+            col: 'table_name',
+            opr: 'ct',
+            value: input,
+          },
+          {
+            col: 'owners',
+            opr: 'rel_m_m',
+            value: userId,
+          },
+        ],
+        order_column: 'changed_on_delta_humanized',
+        order_direction: 'desc',
       });
+
+      return SupersetClient.get({
+        endpoint: `/api/v1/dataset?q=${queryParams}`,
+      }).then(response => ({
+        data: response.json.result.map(
+          (r: { table_name: string; id: number; owners: [DatasetOwner] }) => ({
+            value: r.table_name,
+            label: r.table_name,
+            datasetid: r.id,
+            owners: r.owners,
+          }),
+        ),
+        totalCount: response.json.count,
+      }));
     },
     [user],
   );

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -372,7 +372,6 @@ export const SaveDatasetModal: FunctionComponent<SaveDatasetModalProps> = ({
                     disabled={newOrOverwrite !== 2}
                     // @ts-ignore
                     getPopupContainer={() => document.body}
-                    // @ts-ignore
                   />
                 </div>
               </div>

--- a/superset-frontend/src/components/Select/Select.test.tsx
+++ b/superset-frontend/src/components/Select/Select.test.tsx
@@ -829,6 +829,28 @@ test('async - requests the options again after clearing the cache', async () => 
   expect(mock).toHaveBeenCalledTimes(2);
 });
 
+test('async - triggers getPopupContainer if passed', async () => {
+  const getPopupContainer = jest.fn(() => null);
+  render(
+    <div>
+      <Select
+        {...defaultProps}
+        options={loadOptions}
+        getPopupContainer={getPopupContainer}
+      />
+    </div>,
+  );
+  await open();
+  expect(getPopupContainer).toHaveBeenCalled();
+});
+
+test('static - triggers getPopupContainer if passed', async () => {
+  const getPopupContainer = jest.fn(() => null);
+  render(<Select {...defaultProps} getPopupContainer={getPopupContainer} />);
+  await open();
+  expect(getPopupContainer).toHaveBeenCalled();
+});
+
 /*
  TODO: Add tests that require scroll interaction. Needs further investigation.
  - Fetches more data when scrolling and more data is available

--- a/superset-frontend/src/components/Select/Select.test.tsx
+++ b/superset-frontend/src/components/Select/Select.test.tsx
@@ -830,7 +830,7 @@ test('async - requests the options again after clearing the cache', async () => 
 });
 
 test('async - triggers getPopupContainer if passed', async () => {
-  const getPopupContainer = jest.fn(() => null);
+  const getPopupContainer = jest.fn();
   render(
     <div>
       <Select
@@ -845,7 +845,7 @@ test('async - triggers getPopupContainer if passed', async () => {
 });
 
 test('static - triggers getPopupContainer if passed', async () => {
-  const getPopupContainer = jest.fn(() => null);
+  const getPopupContainer = jest.fn();
   render(<Select {...defaultProps} getPopupContainer={getPopupContainer} />);
   await open();
   expect(getPopupContainer).toHaveBeenCalled();

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -165,6 +165,11 @@ export interface SelectProps extends PickedSelectProps {
    * Will not apply to predefined `options` array when users are not searching.
    */
   sortComparator?: typeof DEFAULT_SORT_COMPARATOR;
+  /**
+   * Customize who the container node is.
+   * Parent node by default.
+   */
+  getPopupContainer?: (triggerNode?: any) => any;
 }
 
 const StyledContainer = styled.div`
@@ -316,6 +321,7 @@ const Select = (
     sortComparator = DEFAULT_SORT_COMPARATOR,
     tokenSeparators,
     value,
+    getPopupContainer,
     ...props
   }: SelectProps,
   ref: RefObject<SelectRef>,
@@ -701,7 +707,9 @@ const Select = (
         dropdownRender={dropdownRender}
         filterOption={handleFilterOption}
         filterSort={sortComparatorWithSearch}
-        getPopupContainer={triggerNode => triggerNode.parentNode}
+        getPopupContainer={
+          getPopupContainer || (triggerNode => triggerNode.parentNode)
+        }
         labelInValue={isAsync || labelInValue}
         maxTagCount={MAX_TAG_COUNT}
         mode={mappedMode}

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -67,6 +67,7 @@ type PickedSelectProps = Pick<
   | 'showSearch'
   | 'tokenSeparators'
   | 'value'
+  | 'getPopupContainer'
 >;
 
 export type OptionsType = Exclude<AntdSelectAllProps['options'], undefined>;
@@ -165,11 +166,6 @@ export interface SelectProps extends PickedSelectProps {
    * Will not apply to predefined `options` array when users are not searching.
    */
   sortComparator?: typeof DEFAULT_SORT_COMPARATOR;
-  /**
-   * Customize who the container node is.
-   * Parent node by default.
-   */
-  getPopupContainer?: (triggerNode?: any) => any;
 }
 
 const StyledContainer = styled.div`

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
@@ -199,7 +199,7 @@ test('Click on Save as dataset', () => {
     name: /save as new undefined/i,
   });
   const overwriteRadioBtn = screen.getByRole('radio', {
-    name: /overwrite existing select or type dataset name/i,
+    name: /overwrite existing/i,
   });
   expect(saveRadioBtn).toBeVisible();
   expect(overwriteRadioBtn).toBeVisible();

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
@@ -201,8 +201,10 @@ test('Click on Save as dataset', () => {
   const overwriteRadioBtn = screen.getByRole('radio', {
     name: /overwrite existing/i,
   });
+  const dropdownField = screen.getByText(/select or type dataset name/i);
   expect(saveRadioBtn).toBeVisible();
   expect(overwriteRadioBtn).toBeVisible();
   expect(screen.getByRole('button', { name: /save/i })).toBeVisible();
   expect(screen.getByRole('button', { name: /close/i })).toBeVisible();
+  expect(dropdownField).toBeVisible();
 });

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -307,8 +307,9 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
           disabled={isDisabled}
           getPopupContainer={
             showOverflow
-              ? () => parentRef?.current
-              : (trigger: HTMLElement) => trigger?.parentNode
+              ? () => (parentRef?.current as HTMLElement) || document.body
+              : (trigger: HTMLElement) =>
+                  (trigger?.parentNode as HTMLElement) || document.body
           }
           showSearch={showSearch}
           mode={multiSelect ? 'multiple' : 'single'}


### PR DESCRIPTION
### SUMMARY
- Use our Select component as substitute of the Autocomplete one so options are loaded without the user having to trigger a search and also we are more consistent with the rest of the app
- Changing `datasetId` to lowercase so when custom props get into the DOM we don't get warning related to invalid formatting
- We extracted the dropdown out of the radio because it causes invalid click handling when an option is selected
- Add getPopupContainer as prop for Select component

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![error](https://user-images.githubusercontent.com/38889534/176030821-46987de3-e0f3-4dab-b53f-6394d1a873ee.gif)

After:
![test](https://user-images.githubusercontent.com/38889534/176031049-ba1c56bb-bdc9-465b-86f0-a61c5b508dca.gif)


### TESTING INSTRUCTIONS
1. In SQL Editor, enter valid query
2. Result tab should show
3. Click on Explore in Result tab
4. Select overwrite existing and save & explore
5. User should be able to see a list of virtual datasets to choose from to overwrite without typing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
