### PR TITLE
feat(vizgallery): Double-click viz type to submit form

### DIFF
--- a/superset-frontend/src/addSlice/AddSliceContainer.test.tsx
+++ b/superset-frontend/src/addSlice/AddSliceContainer.test.tsx
@@ -111,6 +111,27 @@ test('renders an enabled button if datasource and viz type are selected', async 
   ).toHaveLength(0);
 });
 
+test('double-click viz type does nothing if no datasource is selected', async () => {
+  const wrapper = await getWrapper();
+  wrapper.instance().gotoSlice = jest.fn();
+  wrapper.update();
+  wrapper.instance().onVizTypeDoubleClick();
+  expect(wrapper.instance().gotoSlice).not.toBeCalled();
+});
+
+test('double-click viz type submits if datasource is selected', async () => {
+  const wrapper = await getWrapper();
+  wrapper.instance().gotoSlice = jest.fn();
+  wrapper.update();
+  wrapper.setState({
+    datasource,
+    visType: 'table',
+  });
+
+  wrapper.instance().onVizTypeDoubleClick();
+  expect(wrapper.instance().gotoSlice).toBeCalled();
+});
+
 test('formats Explore url', async () => {
   const wrapper = await getWrapper();
   wrapper.setState({

--- a/superset-frontend/src/addSlice/AddSliceContainer.tsx
+++ b/superset-frontend/src/addSlice/AddSliceContainer.tsx
@@ -221,6 +221,7 @@ export default class AddSliceContainer extends React.PureComponent<
     this.gotoSlice = this.gotoSlice.bind(this);
     this.newLabel = this.newLabel.bind(this);
     this.loadDatasources = this.loadDatasources.bind(this);
+    this.onVizTypeDoubleClick = this.onVizTypeDoubleClick.bind(this);
   }
 
   exploreUrl() {
@@ -249,6 +250,12 @@ export default class AddSliceContainer extends React.PureComponent<
 
   isBtnDisabled() {
     return !(this.state.datasource?.value && this.state.visType);
+  }
+
+  onVizTypeDoubleClick() {
+    if (!this.isBtnDisabled()) {
+      this.gotoSlice();
+    }
   }
 
   newLabel(item: Dataset) {
@@ -368,6 +375,7 @@ export default class AddSliceContainer extends React.PureComponent<
                 <VizTypeGallery
                   className="viz-gallery"
                   onChange={this.changeVisType}
+                  onDoubleClick={this.onVizTypeDoubleClick}
                   selectedViz={this.state.visType}
                 />
               </StyledStepDescription>

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.tsx
@@ -266,4 +266,22 @@ describe('VizTypeControl', () => {
       within(visualizations).queryByText('Pie Chart'),
     ).not.toBeInTheDocument();
   });
+
+  it('Submit on viz type double-click', () => {
+    renderWrapper();
+    userEvent.click(screen.getByRole('button', { name: 'ballot All charts' }));
+    const visualizations = screen.getByTestId(getTestId('viz-row'));
+    userEvent.click(
+      within(visualizations).getByText('Time-series Bar Chart v2'),
+    );
+
+    expect(defaultProps.onChange).not.toBeCalled();
+    userEvent.dblClick(
+      within(visualizations).getByText('Time-series Line Chart'),
+    );
+
+    expect(defaultProps.onChange).toHaveBeenCalledWith(
+      'echarts_timeseries_line',
+    );
+  });
 });

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -47,6 +47,7 @@ import scrollIntoView from 'scroll-into-view-if-needed';
 
 interface VizTypeGalleryProps {
   onChange: (vizType: string | null) => void;
+  onDoubleClick: () => void;
   selectedViz: string | null;
   className?: string;
 }
@@ -380,12 +381,14 @@ interface ThumbnailProps {
   entry: VizEntry;
   selectedViz: string | null;
   setSelectedViz: (viz: string) => void;
+  onDoubleClick: () => void;
 }
 
 const Thumbnail: React.FC<ThumbnailProps> = ({
   entry,
   selectedViz,
   setSelectedViz,
+  onDoubleClick,
 }) => {
   const theme = useTheme();
   const { key, value: type } = entry;
@@ -400,6 +403,7 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
       tabIndex={0}
       className={isSelected ? 'selected' : ''}
       onClick={() => setSelectedViz(key)}
+      onDoubleClick={onDoubleClick}
       data-test="viztype-selector-container"
     >
       <img
@@ -429,6 +433,7 @@ interface ThumbnailGalleryProps {
   vizEntries: VizEntry[];
   selectedViz: string | null;
   setSelectedViz: (viz: string) => void;
+  onDoubleClick: () => void;
 }
 
 /** A list of viz thumbnails, used within the viz picker modal */
@@ -487,7 +492,7 @@ const doesVizMatchSelector = (viz: ChartMetadata, selector: string) =>
   (viz.tags || []).indexOf(selector) > -1;
 
 export default function VizTypeGallery(props: VizTypeGalleryProps) {
-  const { selectedViz, onChange, className } = props;
+  const { selectedViz, onChange, onDoubleClick, className } = props;
   const { mountedPluginMetadata } = usePluginContext();
   const searchInputRef = useRef<HTMLInputElement>();
   const [searchInputValue, setSearchInputValue] = useState('');
@@ -793,6 +798,7 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
           vizEntries={getVizEntriesToDisplay()}
           selectedViz={selectedViz}
           setSelectedViz={onChange}
+          onDoubleClick={onDoubleClick}
         />
       </RightPane>
 

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/index.tsx
@@ -140,6 +140,7 @@ const VizTypeControl = ({
           key={modalKey}
           selectedViz={selectedViz}
           onChange={setSelectedViz}
+          onDoubleClick={onSubmit}
         />
       </UnpaddedModal>
     </>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR streamlines the process of creating a chart or changing a chart's visualization type by allowing the user to double-click a visualization type in the viz type gallery to automatically submit the form.  On the AddSlice page, this only works if the user has already selected a dataset.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Visit `/chart/add`.
2. Without selecting a dataset, double-click on a viz type.  Ensure that nothing happens other than that viz type being selected in the gallery.
3. Select a dataset, then double-click on a different viz type.  Ensure that the form automatically submits, redirecting to Explore with the dataset and new viz type selected.
4. On Explore, click "View all charts" in the "Vizualization type" control to open the "Select a visualization type" modal.
5. Double-click on a new viz type and ensure that the modal disappears and the new viz type is active.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
