### PR TITLE
feat(SqlLab): Change Save Dataset Button to Split Save Query Button

### DIFF
--- a/superset-frontend/src/SqlLab/components/RunQueryActionButton/index.tsx
+++ b/superset-frontend/src/SqlLab/components/RunQueryActionButton/index.tsx
@@ -20,13 +20,11 @@ import React, { useMemo } from 'react';
 import { t, styled, useTheme } from '@superset-ui/core';
 
 import { Menu } from 'src/components/Menu';
-import Button, { ButtonProps } from 'src/components/Button';
+import Button from 'src/components/Button';
 import Icons from 'src/components/Icons';
-import {
-  DropdownButton,
-  DropdownButtonProps,
-} from 'src/components/DropdownButton';
+import { DropdownButton } from 'src/components/DropdownButton';
 import { detectOS } from 'src/utils/common';
+import { QueryButtonProps } from 'src/SqlLab/types';
 
 interface Props {
   allowAsync: boolean;
@@ -37,8 +35,6 @@ interface Props {
   sql: string;
   overlayCreateAsMenu: typeof Menu | null;
 }
-
-type QueryButtonProps = DropdownButtonProps | ButtonProps;
 
 const buildText = (
   shouldShowStopButton: boolean,
@@ -80,7 +76,7 @@ const StyledButton = styled.span`
     }
     span[name='caret-down'] {
       display: flex;
-      margin-right: ${({ theme }) => theme.gridUnit * -2}px;
+      margin-left: ${({ theme }) => theme.gridUnit * 1}px;
     }
   }
 `;

--- a/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/SaveDatasetActionButton.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/SaveDatasetActionButton.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { render, screen } from 'spec/helpers/testing-library';
+import userEvent from '@testing-library/user-event';
+import { Menu } from 'src/components/Menu';
+import SaveDatasetActionButton from 'src/SqlLab/components/SaveDatasetActionButton';
+
+const overlayMenu = (
+  <Menu>
+    <Menu.Item>Save dataset</Menu.Item>
+  </Menu>
+);
+
+describe('SaveDatasetActionButton', () => {
+  it('renders a split save button', () => {
+    render(
+      <SaveDatasetActionButton
+        toggleSave={() => {}}
+        overlayMenu={overlayMenu}
+      />,
+    );
+
+    const saveBtn = screen.getByRole('button', { name: /save/i });
+    const caretBtn = screen.getByRole('button', { name: /caret-down/i });
+
+    expect(saveBtn).toBeVisible();
+    expect(caretBtn).toBeVisible();
+  });
+
+  it('renders a "save dataset" dropdown menu item when user clicks caret button', () => {
+    render(
+      <SaveDatasetActionButton
+        toggleSave={() => {}}
+        overlayMenu={overlayMenu}
+      />,
+    );
+
+    const caretBtn = screen.getByRole('button', { name: /caret-down/i });
+    userEvent.click(caretBtn);
+
+    const saveDatasetMenuItem = screen.getByText(/save dataset/i);
+
+    expect(saveDatasetMenuItem).toBeInTheDocument();
+  });
+});

--- a/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/index.tsx
@@ -21,7 +21,7 @@ import { t, styled, useTheme } from '@superset-ui/core';
 import Icons from 'src/components/Icons';
 import { DropdownButton } from 'src/components/DropdownButton';
 import Button from 'src/components/Button';
-import { QueryButtonProps } from 'src/SqlLab/types';
+import { DropdownButtonProps } from 'antd/lib/dropdown';
 
 interface Props {
   toggleSave: () => void;
@@ -34,10 +34,12 @@ export default function SaveDatasetActionButton({
 }: Props) {
   const theme = useTheme();
 
-  const ButtonComponentStyles = styled.div`
-    .ant-btn-group button.ant-btn {
+  const ButtonComponentStyles = styled(
+    DropdownButton as React.FC<DropdownButtonProps>,
+  )`
+    button.ant-btn.ant-btn-default {
       &:first-of-type {
-        width: 64px;
+        width: ${theme.gridUnit * 16}px;
       }
       background-color: ${theme.colors.primary.light4};
       color: ${theme.colors.primary.dark1};
@@ -54,29 +56,27 @@ export default function SaveDatasetActionButton({
     }
   `;
 
-  const ButtonComponent: React.FC<QueryButtonProps> = overlayMenu
-    ? (DropdownButton as React.FC)
-    : Button;
-
-  return (
-    <ButtonComponentStyles>
-      <ButtonComponent
-        onClick={toggleSave}
-        {...(overlayMenu
-          ? {
-              overlay: overlayMenu,
-              icon: (
-                <Icons.CaretDown
-                  iconColor={theme.colors.grayscale.light5}
-                  name="caret-down"
-                />
-              ),
-              trigger: 'click',
-            }
-          : { buttonStyle: 'primary', css: { width: theme.gridUnit * 25 } })}
-      >
-        {t('Save')}
-      </ButtonComponent>
+  return overlayMenu ? (
+    <ButtonComponentStyles
+      onClick={toggleSave}
+      overlay={overlayMenu}
+      icon={
+        <Icons.CaretDown
+          iconColor={theme.colors.grayscale.light5}
+          name="caret-down"
+        />
+      }
+      trigger={['click']}
+    >
+      {t('Save')}
     </ButtonComponentStyles>
+  ) : (
+    <Button
+      onClick={toggleSave}
+      buttonStyle="primary"
+      css={{ width: theme.gridUnit * 25 }}
+    >
+      {t('Save')}
+    </Button>
   );
 }

--- a/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/index.tsx
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { t, styled, useTheme } from '@superset-ui/core';
+import Icons from 'src/components/Icons';
+import { DropdownButton } from 'src/components/DropdownButton';
+import Button from 'src/components/Button';
+import { QueryButtonProps } from 'src/SqlLab/types';
+
+interface Props {
+  toggleSave: () => void;
+  overlayMenu: JSX.Element | null;
+}
+
+export default function SaveDatasetActionButton({
+  toggleSave,
+  overlayMenu,
+}: Props) {
+  const theme = useTheme();
+
+  const ButtonComponentStyles = styled.div`
+    .ant-btn-group button.ant-btn {
+      &:first-of-type {
+        width: 64px;
+      }
+      background-color: ${theme.colors.primary.light4};
+      color: ${theme.colors.primary.dark1};
+      &:nth-child(2) {
+        &:before,
+        &:hover:before {
+          border-left: 1px solid ${theme.colors.primary.dark2};
+        }
+      }
+    }
+    span[name='caret-down'] {
+      margin-left: ${theme.gridUnit * 1}px;
+      color: ${theme.colors.primary.dark2};
+    }
+  `;
+
+  const ButtonComponent: React.FC<QueryButtonProps> = overlayMenu
+    ? (DropdownButton as React.FC)
+    : Button;
+
+  return (
+    <ButtonComponentStyles>
+      <ButtonComponent
+        onClick={toggleSave}
+        {...(overlayMenu
+          ? {
+              overlay: overlayMenu,
+              icon: (
+                <Icons.CaretDown
+                  iconColor={theme.colors.grayscale.light5}
+                  name="caret-down"
+                />
+              ),
+              trigger: 'click',
+            }
+          : { buttonStyle: 'primary', css: { width: theme.gridUnit * 25 } })}
+      >
+        {t('Save')}
+      </ButtonComponent>
+    </ButtonComponentStyles>
+  );
+}

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -209,7 +209,7 @@ export const SaveDatasetModal: FunctionComponent<SaveDatasetModalProps> = ({
       return;
     }
 
-    const selectedColumns = query.results.selected_columns || [];
+    const selectedColumns = query?.results?.selected_columns || [];
 
     // The filters param is only used to test jinja templates.
     // Remove the special filters entry from the templateParams

--- a/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
@@ -19,7 +19,7 @@
 import React, { useState, useEffect } from 'react';
 import { Row, Col } from 'src/components';
 import { Input, TextArea } from 'src/components/Input';
-import { t, styled, useTheme } from '@superset-ui/core';
+import { t, styled } from '@superset-ui/core';
 import Button from 'src/components/Button';
 import { Menu } from 'src/components/Menu';
 import { Form, FormItem } from 'src/components/Form';
@@ -62,6 +62,18 @@ type QueryPayload = {
   title: string;
 };
 
+const Styles = styled.span`
+  span[role='img'] {
+    display: flex;
+    margin: 0;
+    color: ${({ theme }) => theme.colors.grayscale.base};
+    svg {
+      vertical-align: -${({ theme }) => theme.gridUnit * 1.25}px;
+      margin: 0;
+    }
+  }
+`;
+
 export default function SaveQuery({
   query,
   defaultLabel = t('Undefined'),
@@ -77,20 +89,7 @@ export default function SaveQuery({
   const [showSave, setShowSave] = useState<boolean>(false);
   const [showSaveDatasetModal, setShowSaveDatasetModal] = useState(false);
   const isSaved = !!query.remoteId;
-  const theme = useTheme();
   const canExploreDatabase = !!database?.allows_virtual_table_explore;
-
-  const Styles = styled.span`
-    span[role='img'] {
-      display: flex;
-      margin: 0;
-      color: ${theme.colors.grayscale.base};
-      svg {
-        vertical-align: -${theme.gridUnit * 1.25}px;
-        margin: 0;
-      }
-    }
-  `;
 
   const overlayMenu = (
     <Menu>
@@ -107,14 +106,10 @@ export default function SaveQuery({
   });
 
   useEffect(() => {
-    if (!isSaved) {
-      setLabel(defaultLabel);
-    }
+    if (!isSaved) setLabel(defaultLabel);
   }, [defaultLabel]);
 
-  const close = () => {
-    setShowSave(false);
-  };
+  const close = () => setShowSave(false);
 
   const onSaveWrapper = () => {
     onSave(queryPayload());
@@ -134,9 +129,7 @@ export default function SaveQuery({
     setDescription(e.target.value);
   };
 
-  const toggleSave = () => {
-    setShowSave(!showSave);
-  };
+  const toggleSave = () => setShowSave(!showSave);
 
   const renderModalBody = () => (
     <Form layout="vertical">

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -726,6 +726,7 @@ class SqlEditor extends React.PureComponent {
               onSave={this.saveQuery}
               onUpdate={this.props.actions.updateSavedQuery}
               saveQueryWarning={this.props.saveQueryWarning}
+              database={this.props.database}
             />
           </span>
           <span>

--- a/superset-frontend/src/SqlLab/types.ts
+++ b/superset-frontend/src/SqlLab/types.ts
@@ -22,8 +22,11 @@ import { ToastType } from 'src/components/MessageToasts/types';
 import { Dataset } from '@superset-ui/chart-controls';
 import { Query, QueryResponse } from '@superset-ui/core';
 import { ExploreRootState } from 'src/explore/types';
+import { DropdownButtonProps } from 'src/components/DropdownButton';
+import { ButtonProps } from 'src/components/Button';
 
 export type ExploreDatasource = Dataset | QueryResponse;
+export type QueryButtonProps = DropdownButtonProps | ButtonProps;
 
 export interface QueryEditor {
   dbId?: number;

--- a/superset-frontend/src/components/DropdownButton/index.tsx
+++ b/superset-frontend/src/components/DropdownButton/index.tsx
@@ -52,10 +52,9 @@ const StyledDropdownButton = styled.div`
           border-left: 1px solid ${({ theme }) => theme.colors.grayscale.light5};
           content: '';
           display: block;
-          height: 23px;
+          height: ${({ theme }) => theme.gridUnit * 8}px;
           margin: 0;
           position: absolute;
-          top: ${({ theme }) => theme.gridUnit * 0.75}px;
           width: ${({ theme }) => theme.gridUnit * 0.25}px;
         }
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This changes the current save query button into a split save button if the database has "Allow this database to be explored" enabled. When the user clicks the caret section of the button, they can now save the query as a dataset.

`Bonus`: In order to create this button, I conveniently needed to fix the styling on the "Run" query split button. The split line now goes all the way through the button and the caret is centered.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### BEFORE:
![saveButtonBefore](https://user-images.githubusercontent.com/55605634/176063560-492b124a-40ce-4aaf-8745-691ddfa271ef.png)
![runButtonBefore](https://user-images.githubusercontent.com/55605634/176329868-20285ba0-16be-41ad-89fc-eb7dd6aba913.png)

#### AFTER:
![splitSaveButtonAfter](https://user-images.githubusercontent.com/55605634/176063585-59e7074d-cec6-4bd3-b26e-276fd5a1a090.png)
![saveButtonAfter](https://user-images.githubusercontent.com/55605634/176063591-55dafb31-a843-4052-8372-a10bb9d0526a.png)
![runButtonAfter](https://user-images.githubusercontent.com/55605634/176067479-c5ba02bc-834a-4d0b-8e01-3b1eb0787c65.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- From SqlLab, open a query for a database that has "Allow this database to be explored" enabled.
  - Observe the new split save button
    - Click the "Save" section of the button to see the save query modal
    - Click the caret `v` section of the button, then click "Save dataset" to see the save dataset modal
    - Both of these modals should be fully functional
- From SqlLab, open a query for a database that does NOT have "Allow this database to be explored" enabled.
  - Observe that the save button is a normal button, not split
    - Clicking this button should show the save query modal

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
