### PR TITLE
feat: update blankstate for metrics columns popovers

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -45,7 +45,6 @@ import {
   POPOVER_INITIAL_HEIGHT,
   UNRESIZABLE_POPOVER_WIDTH,
 } from 'src/explore/constants';
-import { SetState } from 'immer/dist/internal';
 
 const StyledSelect = styled(Select)`
   .metric-option {

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -298,7 +298,7 @@ const ColumnSelectPopover = ({
               description={
                 isTemporal ? (
                   <>
-                   <span
+                    <span
                       role="button"
                       tabIndex={0}
                       onClick={() => {

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -18,6 +18,8 @@
  */
 /* eslint-disable camelcase */
 import React, {
+  Dispatch,
+  SetStateAction,
   useCallback,
   useEffect,
   useMemo,
@@ -43,6 +45,7 @@ import {
   POPOVER_INITIAL_HEIGHT,
   UNRESIZABLE_POPOVER_WIDTH,
 } from 'src/explore/constants';
+import { SetState } from 'immer/dist/internal';
 
 const StyledSelect = styled(Select)`
   .metric-option {
@@ -65,6 +68,7 @@ interface ColumnSelectPopoverProps {
   getCurrentTab: (tab: string) => void;
   label: string;
   isTemporal?: boolean;
+  setDatasetModal?: Dispatch<SetStateAction<boolean>>;
 }
 
 const getInitialColumnValues = (
@@ -302,7 +306,7 @@ const ColumnSelectPopover = ({
                       role="button"
                       tabIndex={0}
                       onClick={() => {
-                        setDatasetModal(true);
+                        if (setDatasetModal) setDatasetModal(true);
                         onClose();
                       }}
                     >
@@ -316,7 +320,7 @@ const ColumnSelectPopover = ({
                       role="button"
                       tabIndex={0}
                       onClick={() => {
-                        setDatasetModal(true);
+                        if (setDatasetModal) setDatasetModal(true);
                         onClose();
                       }}
                     >
@@ -343,7 +347,7 @@ const ColumnSelectPopover = ({
                       role="button"
                       tabIndex={0}
                       onClick={() => {
-                        setDatasetModal(true);
+                        if (setDatasetModal) setDatasetModal(true);
                         onClose();
                       }}
                     >

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -87,6 +87,7 @@ const ColumnSelectPopover = ({
   editedColumn,
   onChange,
   onClose,
+  setDatasetModal,
   setLabel,
   getCurrentTab,
   label,
@@ -295,11 +296,35 @@ const ColumnSelectPopover = ({
                   : t('No saved expressions found')
               }
               description={
-                isTemporal
-                  ? t('Create a dataset to mark a column as a time column')
-                  : t(
-                      'Add calculated columns to dataset in "Edit datasource" modal',
-                    )
+                isTemporal ? (
+                  <>
+                   <span
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => {
+                        setDatasetModal(true);
+                        onClose();
+                      }}
+                    >
+                      {t('Create a dataset')}
+                    </span>{' '}
+                    {t(' to mark a column as a time column')}
+                  </>
+                ) : (
+                  <>
+                    <span
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => {
+                        setDatasetModal(true);
+                        onClose();
+                      }}
+                    >
+                      {t('Create a dataset')}
+                    </span>{' '}
+                    {t(' to mark a column as a calculated column')}
+                  </>
+                )
               }
             />
           )}
@@ -309,9 +334,25 @@ const ColumnSelectPopover = ({
             <EmptyStateSmall
               image="empty.svg"
               title={t('No temporal columns found')}
-              description={t(
-                'Mark a column as temporal in "Edit datasource" modal',
-              )}
+              description={
+                datasource.type === 'dataset' ? (
+                  t('Mark a column as temporal in "Edit datasource" modal')
+                ) : (
+                  <>
+                    <span
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => {
+                        setDatasetModal(true);
+                        onClose();
+                      }}
+                    >
+                      {t('Create a dataset')}
+                    </span>{' '}
+                    {t(' to mark a column as a time column')}
+                  </>
+                )
+              }
             />
           ) : (
             <FormItem label={simpleColumnsLabel}>

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -24,6 +24,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { useSelector } from 'react-redux';
 import { AdhocColumn, t, styled, css } from '@superset-ui/core';
 import {
   ColumnMeta,
@@ -91,6 +92,8 @@ const ColumnSelectPopover = ({
   label,
   isTemporal,
 }: ColumnSelectPopoverProps) => {
+  // @ts-ignore
+  const datasource = useSelector(state => state.explore.datasource.type);
   const [initialLabel] = useState(label);
   const [initialAdhocColumn, initialCalculatedColumn, initialSimpleColumn] =
     getInitialColumnValues(editedColumn);
@@ -265,7 +268,7 @@ const ColumnSelectPopover = ({
                 }))}
               />
             </FormItem>
-          ) : (
+          ) : datasource === 'dataset' ? (
             <EmptyStateSmall
               image="empty.svg"
               title={
@@ -278,6 +281,22 @@ const ColumnSelectPopover = ({
                   ? t(
                       'Add calculated temporal columns to dataset in "Edit datasource" modal',
                     )
+                  : t(
+                      'Add calculated columns to dataset in "Edit datasource" modal',
+                    )
+              }
+            />
+          ) : (
+            <EmptyStateSmall
+              image="empty.svg"
+              title={
+                isTemporal
+                  ? t('No temporal columns found')
+                  : t('No saved expressions found')
+              }
+              description={
+                isTemporal
+                  ? t('Create a dataset to mark a column as a time column')
                   : t(
                       'Add calculated columns to dataset in "Edit datasource" modal',
                     )

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.tsx
@@ -25,10 +25,10 @@ import {
   isColumnMeta,
 } from '@superset-ui/chart-controls';
 import { ExplorePopoverContent } from 'src/explore/components/ExploreContentPopover';
+import { SaveDatasetModal } from 'src/SqlLab/components/SaveDatasetModal';
 import ColumnSelectPopover from './ColumnSelectPopover';
 import { DndColumnSelectPopoverTitle } from './DndColumnSelectPopoverTitle';
 import ControlPopover from '../ControlPopover/ControlPopover';
-import { SaveDatasetModal } from 'src/SqlLab/components/SaveDatasetModal';
 
 interface ColumnSelectPopoverTriggerProps {
   columns: ColumnMeta[];

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { AdhocColumn, t } from '@superset-ui/core';
 import {
   ColumnMeta,
@@ -27,6 +28,7 @@ import { ExplorePopoverContent } from 'src/explore/components/ExploreContentPopo
 import ColumnSelectPopover from './ColumnSelectPopover';
 import { DndColumnSelectPopoverTitle } from './DndColumnSelectPopoverTitle';
 import ControlPopover from '../ControlPopover/ControlPopover';
+import { SaveDatasetModal } from 'src/SqlLab/components/SaveDatasetModal';
 
 interface ColumnSelectPopoverTriggerProps {
   columns: ColumnMeta[];
@@ -52,10 +54,13 @@ const ColumnSelectPopoverTrigger = ({
   isTemporal,
   ...props
 }: ColumnSelectPopoverTriggerProps) => {
+  // @ts-ignore
+  const datasource = useSelector(state => state.explore.datasource);
   const [popoverLabel, setPopoverLabel] = useState(defaultPopoverLabel);
   const [popoverVisible, setPopoverVisible] = useState(false);
   const [isTitleEditDisabled, setIsTitleEditDisabled] = useState(true);
   const [hasCustomLabel, setHasCustomLabel] = useState(false);
+  const [showDatasetModal, setDatasetModal] = useState(false);
 
   let initialPopoverLabel = defaultPopoverLabel;
   if (editedColumn && isColumnMeta(editedColumn)) {
@@ -99,6 +104,7 @@ const ColumnSelectPopoverTrigger = ({
         <ColumnSelectPopover
           editedColumn={editedColumn}
           columns={columns}
+          setDatasetModal={setDatasetModal}
           onClose={handleClosePopover}
           onChange={onColumnEdit}
           label={popoverLabel}
@@ -137,17 +143,31 @@ const ColumnSelectPopoverTrigger = ({
   );
 
   return (
-    <ControlPopover
-      trigger="click"
-      content={overlayContent}
-      defaultVisible={visible}
-      visible={visible}
-      onVisibleChange={handleTogglePopover}
-      title={popoverTitle}
-      destroyTooltipOnHide
-    >
-      {children}
-    </ControlPopover>
+    <>
+      {showDatasetModal && (
+        <SaveDatasetModal
+          visible={showDatasetModal}
+          onHide={() => setDatasetModal(false)}
+          buttonTextOnSave={t('Save & Explore')}
+          buttonTextOnOverwrite={t('Overwrite & Explore')}
+          modalDescription={t(
+            'Save this query as a virtual dataset to continue exploring',
+          )}
+          datasource={datasource}
+        />
+      )}
+      <ControlPopover
+        trigger="click"
+        content={overlayContent}
+        defaultVisible={visible}
+        visible={visible}
+        onVisibleChange={handleTogglePopover}
+        title={popoverTitle}
+        destroyTooltipOnHide
+      >
+        {children}
+      </ControlPopover>
+    </>
   );
 };
 

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
@@ -99,12 +99,14 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
     this.onTabChange = this.onTabChange.bind(this);
     this.handleAceEditorRef = this.handleAceEditorRef.bind(this);
     this.refreshAceEditor = this.refreshAceEditor.bind(this);
+    this.handleDatasetModal = this.handleDatasetModal.bind(this);
 
     this.state = {
       adhocMetric: this.props.adhocMetric,
       savedMetric: this.props.savedMetric,
       width: POPOVER_INITIAL_WIDTH,
       height: POPOVER_INITIAL_HEIGHT,
+      showSaveDatasetModal: false,
     };
 
     document.addEventListener('mouseup', this.onMouseUp);
@@ -243,6 +245,10 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
     this.props.getCurrentTab(tab);
   }
 
+  handleDatasetModal(bool)  {
+    this.setState({ showSaveDatasetModal: bool})
+  }
+
   handleAceEditorRef(ref) {
     if (ref) {
       this.aceEditorRef = ref;
@@ -359,7 +365,7 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
         {showSaveDatasetModal && (  
           <SaveDatasetModal
             visible={showSaveDatasetModal}
-            onHide={this.toggleSaveDatasetModal}
+            onHide={this.handleDatasetModal}
             buttonTextOnSave={t('Save & Explore')}
             buttonTextOnOverwrite={t('Overwrite & Explore')}
             modalDescription={t(
@@ -407,8 +413,8 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
                 title={t('No saved metrics found')}
                 description={
                   <>
-                    <a href>Create a dataset {' '}</a>
-                    to add some metrics
+                    <a onClick={() => this.handleDatasetModal(true)}>{t('Create a dataset')} {' '}</a>
+                     {t('to add some metrics')}
                   </>
                 }
               />

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
@@ -355,7 +355,6 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
         data-test="metrics-edit-popover"
         {...popoverProps}
       >
-       
         <Tabs
           id="adhoc-metric-edit-tabs"
           data-test="adhoc-metric-edit-tabs"
@@ -380,8 +379,7 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
                   {...savedSelectProps}
                 />
               </FormItem>
-            ) : 
-            datasource.type === 'dataset' ? 
+            ) : datasource.type === 'dataset' ? (
               <EmptyStateSmall
                 image="empty.svg"
                 title={t('No saved metrics found')}
@@ -389,24 +387,27 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
                   'Add metrics to dataset in "Edit datasource" modal',
                 )}
               />
-                :
+            ) : (
               <EmptyStateSmall
                 image="empty.svg"
                 title={t('No saved metrics found')}
                 description={
                   <>
-                    <span 
+                    <span
                       tabIndex={0}
                       role="button"
-                      onClick={() => { 
-                      this.props.handleDatasetModal(true); 
-                      this.props.onClose();
-                    }}>{t('Create a dataset')} {' '}</span>
-                     {t('to add some metrics')}
+                      onClick={() => {
+                        this.props.handleDatasetModal(true);
+                        this.props.onClose();
+                      }}
+                    >
+                      {t('Create a dataset')}{' '}
+                    </span>
+                    {t('to add some metrics')}
                   </>
                 }
               />
-            }
+            )}
           </Tabs.TabPane>
           <Tabs.TabPane
             key={EXPRESSION_TYPES.SIMPLE}

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
@@ -281,8 +281,6 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
       datasource,
       ...popoverProps
     } = this.props;
-    console.log('datasource', datasource)
-    console.log('showsavedatesetmodal------->', this.state.showSaveDatasetModal)
     const { adhocMetric, savedMetric } = this.state;
     const keywords = sqlKeywords.concat(
       columns.map(column => ({
@@ -397,10 +395,13 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
                 title={t('No saved metrics found')}
                 description={
                   <>
-                    <a onClick={() => { 
+                    <span 
+                      tabIndex={0}
+                      role="button"
+                      onClick={() => { 
                       this.props.handleDatasetModal(true); 
                       this.props.onClose();
-                    }}>{t('Create a dataset')} {' '}</a>
+                    }}>{t('Create a dataset')} {' '}</span>
                      {t('to add some metrics')}
                   </>
                 }

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
@@ -281,6 +281,7 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
       datasource,
       ...popoverProps
     } = this.props;
+    console.log('datasource', datasource)
     const { adhocMetric, savedMetric } = this.state;
     const keywords = sqlKeywords.concat(
       columns.map(column => ({
@@ -355,6 +356,18 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
         data-test="metrics-edit-popover"
         {...popoverProps}
       >
+        {showSaveDatasetModal && (  
+          <SaveDatasetModal
+            visible={showSaveDatasetModal}
+            onHide={this.toggleSaveDatasetModal}
+            buttonTextOnSave={t('Save & Explore')}
+            buttonTextOnOverwrite={t('Overwrite & Explore')}
+            modalDescription={t(
+              'Save this query as a virtual dataset to continue exploring',
+            )}
+            datasource={datasource}
+          />
+        )}
         <Tabs
           id="adhoc-metric-edit-tabs"
           data-test="adhoc-metric-edit-tabs"
@@ -379,7 +392,8 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
                   {...savedSelectProps}
                 />
               </FormItem>
-            ) : (
+            ) : 
+            datasource.type === 'dataset' ? 
               <EmptyStateSmall
                 image="empty.svg"
                 title={t('No saved metrics found')}
@@ -387,7 +401,18 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
                   'Add metrics to dataset in "Edit datasource" modal',
                 )}
               />
-            )}
+                :
+              <EmptyStateSmall
+                image="empty.svg"
+                title={t('No saved metrics found')}
+                description={
+                  <>
+                    <a href>Create a dataset {' '}</a>
+                    to add some metrics
+                  </>
+                }
+              />
+            }
           </Tabs.TabPane>
           <Tabs.TabPane
             key={EXPRESSION_TYPES.SIMPLE}

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
@@ -99,14 +99,12 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
     this.onTabChange = this.onTabChange.bind(this);
     this.handleAceEditorRef = this.handleAceEditorRef.bind(this);
     this.refreshAceEditor = this.refreshAceEditor.bind(this);
-    this.handleDatasetModal = this.handleDatasetModal.bind(this);
 
     this.state = {
       adhocMetric: this.props.adhocMetric,
       savedMetric: this.props.savedMetric,
       width: POPOVER_INITIAL_WIDTH,
       height: POPOVER_INITIAL_HEIGHT,
-      showSaveDatasetModal: false,
     };
 
     document.addEventListener('mouseup', this.onMouseUp);
@@ -245,10 +243,6 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
     this.props.getCurrentTab(tab);
   }
 
-  handleDatasetModal(bool)  {
-    this.setState({ showSaveDatasetModal: bool})
-  }
-
   handleAceEditorRef(ref) {
     if (ref) {
       this.aceEditorRef = ref;
@@ -288,6 +282,7 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
       ...popoverProps
     } = this.props;
     console.log('datasource', datasource)
+    console.log('showsavedatesetmodal------->', this.state.showSaveDatasetModal)
     const { adhocMetric, savedMetric } = this.state;
     const keywords = sqlKeywords.concat(
       columns.map(column => ({
@@ -362,18 +357,7 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
         data-test="metrics-edit-popover"
         {...popoverProps}
       >
-        {showSaveDatasetModal && (  
-          <SaveDatasetModal
-            visible={showSaveDatasetModal}
-            onHide={this.handleDatasetModal}
-            buttonTextOnSave={t('Save & Explore')}
-            buttonTextOnOverwrite={t('Overwrite & Explore')}
-            modalDescription={t(
-              'Save this query as a virtual dataset to continue exploring',
-            )}
-            datasource={datasource}
-          />
-        )}
+       
         <Tabs
           id="adhoc-metric-edit-tabs"
           data-test="adhoc-metric-edit-tabs"
@@ -413,7 +397,10 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
                 title={t('No saved metrics found')}
                 description={
                   <>
-                    <a onClick={() => this.handleDatasetModal(true)}>{t('Create a dataset')} {' '}</a>
+                    <a onClick={() => { 
+                      this.props.handleDatasetModal(true); 
+                      this.props.onClose();
+                    }}>{t('Create a dataset')} {' '}</a>
                      {t('to add some metrics')}
                   </>
                 }

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
@@ -34,7 +34,7 @@ export type AdhocMetricPopoverTriggerProps = {
   columns: { column_name: string; type: string }[];
   savedMetricsOptions: savedMetricType[];
   savedMetric: savedMetricType;
-  datasource?: Datasource;
+  datasource: Datasource;
   children: ReactNode;
   isControlledComponent?: boolean;
   visible?: boolean;
@@ -49,6 +49,7 @@ export type AdhocMetricPopoverTriggerState = {
   currentLabel: string;
   labelModified: boolean;
   isTitleEditDisabled: boolean;
+  showSaveDatasetModal: boolean;
 };
 
 class AdhocMetricPopoverTrigger extends React.PureComponent<
@@ -122,7 +123,7 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
     this.forceUpdate();
   }
 
-  handleDatasetModal(bool) {
+  handleDatasetModal(bool: boolean) {
     this.setState({ showSaveDatasetModal: bool });
   }
 

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
@@ -17,9 +17,10 @@
  * under the License.
  */
 import React, { ReactNode } from 'react';
-import { Datasource, Metric } from '@superset-ui/core';
+import { Datasource, Metric, t } from '@superset-ui/core';
 import AdhocMetricEditPopoverTitle from 'src/explore/components/controls/MetricControl/AdhocMetricEditPopoverTitle';
 import { ExplorePopoverContent } from 'src/explore/components/ExploreContentPopover';
+import { SaveDatasetModal } from 'src/SqlLab/components/SaveDatasetModal';
 import AdhocMetricEditPopover, {
   SAVED_TAB_KEY,
 } from './AdhocMetricEditPopover';
@@ -63,6 +64,7 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
     this.getCurrentTab = this.getCurrentTab.bind(this);
     this.getCurrentLabel = this.getCurrentLabel.bind(this);
     this.onChange = this.onChange.bind(this);
+    this.handleDatasetModal = this.handleDatasetModal.bind(this);
 
     this.state = {
       adhocMetric: props.adhocMetric,
@@ -74,6 +76,7 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
       currentLabel: '',
       labelModified: false,
       isTitleEditDisabled: false,
+      showSaveDatasetModal: false,
     };
   }
 
@@ -117,6 +120,10 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
 
   onPopoverResize() {
     this.forceUpdate();
+  }
+
+  handleDatasetModal(bool) {
+    this.setState({ showSaveDatasetModal: bool });
   }
 
   closePopover() {
@@ -205,6 +212,7 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
           savedMetricsOptions={savedMetricsOptions}
           savedMetric={savedMetric}
           datasource={datasource}
+          handleDatasetModal={this.handleDatasetModal}
           onResize={this.onPopoverResize}
           onClose={closePopover}
           onChange={this.onChange}
@@ -223,18 +231,32 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
     );
 
     return (
-      <ControlPopover
-        placement="right"
-        trigger="click"
-        content={overlayContent}
-        defaultVisible={visible}
-        visible={visible}
-        onVisibleChange={togglePopover}
-        title={popoverTitle}
-        destroyTooltipOnHide
-      >
-        {this.props.children}
-      </ControlPopover>
+      <>
+        {this.state.showSaveDatasetModal && (
+          <SaveDatasetModal
+            visible={this.state.showSaveDatasetModal}
+            onHide={() => this.handleDatasetModal(false)}
+            buttonTextOnSave={t('Save & Explore')}
+            buttonTextOnOverwrite={t('Overwrite & Explore')}
+            modalDescription={t(
+              'Save this query as a virtual dataset to continue exploring',
+            )}
+            datasource={datasource}
+          />
+        )}
+        <ControlPopover
+          placement="right"
+          trigger="click"
+          content={overlayContent}
+          defaultVisible={visible}
+          visible={visible}
+          onVisibleChange={togglePopover}
+          title={popoverTitle}
+          destroyTooltipOnHide
+        >
+          {this.props.children}
+        </ControlPopover>
+      </>
     );
   }
 }

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
@@ -21,6 +21,7 @@ import { Datasource, Metric, t } from '@superset-ui/core';
 import AdhocMetricEditPopoverTitle from 'src/explore/components/controls/MetricControl/AdhocMetricEditPopoverTitle';
 import { ExplorePopoverContent } from 'src/explore/components/ExploreContentPopover';
 import { SaveDatasetModal } from 'src/SqlLab/components/SaveDatasetModal';
+import { ExploreDatasource } from 'src/SqlLab/types';
 import AdhocMetricEditPopover, {
   SAVED_TAB_KEY,
 } from './AdhocMetricEditPopover';
@@ -34,7 +35,7 @@ export type AdhocMetricPopoverTriggerProps = {
   columns: { column_name: string; type: string }[];
   savedMetricsOptions: savedMetricType[];
   savedMetric: savedMetricType;
-  datasource: Datasource;
+  datasource: ExploreDatasource;
   children: ReactNode;
   isControlledComponent?: boolean;
   visible?: boolean;

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { ReactNode } from 'react';
-import { Datasource, Metric, t } from '@superset-ui/core';
+import { Metric, t } from '@superset-ui/core';
 import AdhocMetricEditPopoverTitle from 'src/explore/components/controls/MetricControl/AdhocMetricEditPopoverTitle';
 import { ExplorePopoverContent } from 'src/explore/components/ExploreContentPopover';
 import { SaveDatasetModal } from 'src/SqlLab/components/SaveDatasetModal';


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This pr updates the blank state to the metrics and columns controls and add a cta for user to save dataset if they using query to power chart.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

after

https://user-images.githubusercontent.com/17326228/176115344-819988bc-a6f6-4bf8-ae8a-0bff4ee2004f.mov



### TESTING INSTRUCTIONS
Must use a query to power chart in order to test this pr. Create a query from sqllab and then create chart. Check metrics and columns controls and check for updated blank state.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
