### PR TITLE
fix(database-modal): Refresh Data when importing

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -979,9 +979,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       passwords,
       confirmedOverwrite,
     );
-    if (dbId) {
-      if (onDatabaseAdd) onDatabaseAdd();
-    }
+    if (dbId) onDatabaseAdd?.();
   };
 
   const passwordNeededField = () => {

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -788,6 +788,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
             onClick={() => setDatabaseModel(database.name)}
             buttonText={database.name}
             icon={dbImages?.[database.engine]}
+            key={`${database.name}`}
           />
         ))}
     </div>
@@ -973,11 +974,14 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
     ]);
 
     if (!(info.file.originFileObj instanceof File)) return;
-    await importResource(
+    const dbId = await importResource(
       info.file.originFileObj,
       passwords,
       confirmedOverwrite,
     );
+    if (dbId) {
+      if (onDatabaseAdd) onDatabaseAdd();
+    }
   };
 
   const passwordNeededField = () => {


### PR DESCRIPTION
### SUMMARY
- Add missing invocation to onDatabaseAdd after importing DB from file so the table refreshes
- Add keys to our IconButtons so we avoid having warnings when the list is rendered

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![error](https://user-images.githubusercontent.com/38889534/176210873-a5c96e17-84cb-4520-bbb9-4db9c21c7f7e.gif)

After:
![test](https://user-images.githubusercontent.com/38889534/176211419-cd2cfadb-d008-4aff-a8a0-627f3d2f525d.gif)


### TESTING INSTRUCTIONS
1. Visit the "Databases" page and hit the "+Database+ button
2. Click on "Import database from file" and select a database
3. Check the list of databases so it renders the new DB without need for manual page reload


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
