### PR TITLE
feat(explore): Apply denormalization to tier 2 charts form data

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx
@@ -72,7 +72,7 @@ export const dndColumnsControl: typeof dndGroupByControl = {
 
 export const dndSeries: typeof dndGroupByControl = {
   ...dndGroupByControl,
-  label: t('Dimensions'),
+  label: t('Dimension'),
   multi: false,
   default: null,
   description: t(

--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/getStandardizedControls.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/getStandardizedControls.ts
@@ -43,6 +43,10 @@ class StandardizedControlsManager {
     return this.controls.metrics.shift();
   }
 
+  shiftColumn() {
+    return this.controls.columns.shift();
+  }
+
   popAllMetrics() {
     return this.controls.metrics.splice(0, this.controls.metrics.length);
   }

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts
@@ -191,6 +191,10 @@ const config: ControlPanelConfig = {
       label: t('Number Format'),
     },
   },
+  denormalizeFormData: formData => ({
+    ...formData,
+    metrics: formData.standardizedFormData.standardizedState.metrics,
+  }),
 };
 
 export default config;

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts
@@ -22,6 +22,7 @@ import {
   D3_FORMAT_DOCS,
   D3_TIME_FORMAT_OPTIONS,
   formatSelectOptions,
+  getStandardizedControls,
   sections,
 } from '@superset-ui/chart-controls';
 
@@ -191,9 +192,9 @@ const config: ControlPanelConfig = {
       label: t('Number Format'),
     },
   },
-  denormalizeFormData: formData => ({
+  formDataOverrides: formData => ({
     ...formData,
-    metrics: formData.standardizedFormData.standardizedState.metrics,
+    metrics: getStandardizedControls().popAllMetrics(),
   }),
 };
 

--- a/superset-frontend/plugins/legacy-plugin-chart-chord/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-chord/src/controlPanel.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, validateNonEmpty } from '@superset-ui/core';
+import { ensureIsArray, t, validateNonEmpty } from '@superset-ui/core';
 import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
 
 const config: ControlPanelConfig = {
@@ -68,6 +68,17 @@ const config: ControlPanelConfig = {
       validators: [validateNonEmpty],
       description: t('Choose a target'),
     },
+  },
+  denormalizeFormData: formData => {
+    const groupby =
+      formData.standardizedFormData.standardizedState.columns.filter(
+        col => !ensureIsArray(formData.columns).includes(col),
+      );
+    return {
+      ...formData,
+      metric: formData.standardizedFormData.standardizedState.metrics[0],
+      groupby,
+    };
   },
 };
 

--- a/superset-frontend/plugins/legacy-plugin-chart-chord/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-chord/src/controlPanel.ts
@@ -17,7 +17,11 @@
  * under the License.
  */
 import { ensureIsArray, t, validateNonEmpty } from '@superset-ui/core';
-import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
+import {
+  ControlPanelConfig,
+  getStandardizedControls,
+  sections,
+} from '@superset-ui/chart-controls';
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
@@ -69,15 +73,14 @@ const config: ControlPanelConfig = {
       description: t('Choose a target'),
     },
   },
-  denormalizeFormData: formData => {
-    const groupby =
-      formData.standardizedFormData.standardizedState.columns.filter(
-        col => !ensureIsArray(formData.columns).includes(col),
-      );
+  formDataOverrides: formData => {
+    const groupby = getStandardizedControls()
+      .popAllColumns()
+      .filter(col => !ensureIsArray(formData.columns).includes(col));
     return {
       ...formData,
-      metric: formData.standardizedFormData.standardizedState.metrics[0],
       groupby,
+      metric: getStandardizedControls().shiftMetric(),
     };
   },
 };

--- a/superset-frontend/plugins/legacy-plugin-chart-country-map/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-country-map/src/controlPanel.ts
@@ -88,6 +88,11 @@ const config: ControlPanelConfig = {
       renderTrigger: false,
     },
   },
+  denormalizeFormData: formData => ({
+    ...formData,
+    metric: formData.standardizedFormData.standardizedState.metrics[0],
+    entity: formData.standardizedFormData.standardizedState.columns[0],
+  }),
 };
 
 export default config;

--- a/superset-frontend/plugins/legacy-plugin-chart-country-map/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-country-map/src/controlPanel.ts
@@ -22,6 +22,7 @@ import {
   D3_FORMAT_OPTIONS,
   D3_FORMAT_DOCS,
   sections,
+  getStandardizedControls,
 } from '@superset-ui/chart-controls';
 import { countryOptions } from './countries';
 
@@ -88,10 +89,10 @@ const config: ControlPanelConfig = {
       renderTrigger: false,
     },
   },
-  denormalizeFormData: formData => ({
+  formDataOverrides: formData => ({
     ...formData,
-    metric: formData.standardizedFormData.standardizedState.metrics[0],
-    entity: formData.standardizedFormData.standardizedState.columns[0],
+    entity: getStandardizedControls().shiftColumn(),
+    metric: getStandardizedControls().shiftMetric(),
   }),
 };
 

--- a/superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts
@@ -329,6 +329,10 @@ const config: ControlPanelConfig = {
       label: t('Value Format'),
     },
   },
+  denormalizeFormData: formData => ({
+    ...formData,
+    metric: formData.standardizedFormData.standardizedState.metrics[0],
+  }),
 };
 
 export default config;

--- a/superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts
@@ -30,6 +30,7 @@ import {
   formatSelectOptionsForRange,
   sections,
   dndEntity,
+  getStandardizedControls,
 } from '@superset-ui/chart-controls';
 
 const sortAxisChoices = [
@@ -329,9 +330,9 @@ const config: ControlPanelConfig = {
       label: t('Value Format'),
     },
   },
-  denormalizeFormData: formData => ({
+  formDataOverrides: formData => ({
     ...formData,
-    metric: formData.standardizedFormData.standardizedState.metrics[0],
+    metric: getStandardizedControls().shiftMetric(),
   }),
 };
 

--- a/superset-frontend/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts
@@ -29,6 +29,7 @@ import {
   formatSelectOptions,
   sections,
   dndColumnsControl,
+  getStandardizedControls,
 } from '@superset-ui/chart-controls';
 
 const allColumns = {
@@ -160,9 +161,9 @@ const config: ControlPanelConfig = {
       ],
     },
   ],
-  denormalizeFormData: formData => ({
+  formDataOverrides: formData => ({
     ...formData,
-    groupby: formData.standardizedFormData.standardizedState.columns,
+    groupby: getStandardizedControls().popAllColumns(),
   }),
 };
 export default config;

--- a/superset-frontend/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts
@@ -160,5 +160,9 @@ const config: ControlPanelConfig = {
       ],
     },
   ],
+  denormalizeFormData: formData => ({
+    ...formData,
+    groupby: formData.standardizedFormData.standardizedState.columns,
+  }),
 };
 export default config;

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bubble/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bubble/controlPanel.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t } from '@superset-ui/core';
+import { ensureIsArray, t } from '@superset-ui/core';
 import {
   ControlPanelConfig,
   formatSelectOptions,
@@ -127,6 +127,16 @@ const config: ControlPanelConfig = {
     color_scheme: {
       renderTrigger: false,
     },
+  },
+  denormalizeFormData: formData => {
+    const entity =
+      formData.standardizedFormData.standardizedState.columns.filter(
+        col => !ensureIsArray(formData.series).includes(col),
+      )[0];
+    return {
+      ...formData,
+      entity,
+    };
   },
 };
 

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bubble/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bubble/controlPanel.ts
@@ -16,12 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ensureIsArray, t } from '@superset-ui/core';
+import { t } from '@superset-ui/core';
 import {
   ControlPanelConfig,
   formatSelectOptions,
   D3_FORMAT_OPTIONS,
   sections,
+  getStandardizedControls,
 } from '@superset-ui/chart-controls';
 import {
   showLegend,
@@ -128,16 +129,11 @@ const config: ControlPanelConfig = {
       renderTrigger: false,
     },
   },
-  denormalizeFormData: formData => {
-    const entity =
-      formData.standardizedFormData.standardizedState.columns.filter(
-        col => !ensureIsArray(formData.series).includes(col),
-      )[0];
-    return {
-      ...formData,
-      entity,
-    };
-  },
+  formDataOverrides: formData => ({
+    ...formData,
+    series: getStandardizedControls().shiftColumn(),
+    entity: getStandardizedControls().shiftColumn(),
+  }),
 };
 
 export default config;

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Compare/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Compare/controlPanel.ts
@@ -62,6 +62,11 @@ const config: ControlPanelConfig = {
     timeSeriesSection[1],
     sections.annotations,
   ],
+  denormalizeFormData: formData => ({
+    ...formData,
+    metrics: formData.standardizedFormData.standardizedState.metrics,
+    groupby: formData.standardizedFormData.standardizedState.columns,
+  }),
 };
 
 export default config;

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Compare/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Compare/controlPanel.ts
@@ -17,7 +17,11 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
-import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
+import {
+  ControlPanelConfig,
+  getStandardizedControls,
+  sections,
+} from '@superset-ui/chart-controls';
 import {
   xAxisLabel,
   yAxisLabel,
@@ -62,10 +66,10 @@ const config: ControlPanelConfig = {
     timeSeriesSection[1],
     sections.annotations,
   ],
-  denormalizeFormData: formData => ({
+  formDataOverrides: formData => ({
     ...formData,
-    metrics: formData.standardizedFormData.standardizedState.metrics,
-    groupby: formData.standardizedFormData.standardizedState.columns,
+    groupby: getStandardizedControls().popAllColumns(),
+    metrics: getStandardizedControls().popAllMetrics(),
   }),
 };
 

--- a/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controlPanel.tsx
@@ -19,6 +19,7 @@
 import {
   ControlPanelConfig,
   emitFilterControl,
+  getStandardizedControls,
   sections,
 } from '@superset-ui/chart-controls';
 import { addLocaleData, t } from '@superset-ui/core';
@@ -78,10 +79,10 @@ const config: ControlPanelConfig = {
       ],
     },
   ],
-  denormalizeFormData: formData => ({
+  formDataOverrides: formData => ({
     ...formData,
-    metrics: formData.standardizedFormData.standardizedState.metrics,
-    groupby: formData.standardizedFormData.standardizedState.columns,
+    groupby: getStandardizedControls().popAllColumns(),
+    metrics: getStandardizedControls().popAllMetrics(),
   }),
 };
 

--- a/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controlPanel.tsx
@@ -78,6 +78,11 @@ const config: ControlPanelConfig = {
       ],
     },
   ],
+  denormalizeFormData: formData => ({
+    ...formData,
+    metrics: formData.standardizedFormData.standardizedState.metrics,
+    groupby: formData.standardizedFormData.standardizedState.columns,
+  }),
 };
 
 export default config;


### PR DESCRIPTION
### SUMMARY
This PR enables following charts to use the standardized form data feature:

- Bubble chart
- Calendar heatmap
- Chord diagram
- Timeseries percent change
- Country map
- Handlebars
- Heatmap
- Histogram

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
Make sure that when you're switching between charts listed above and tier 1 charts (all echarts, table, pivot table, line chart) the metrics and dimensions are persisted and auto-populated.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
