### PR TITLE
chore: move isAdhocColumn from controls to core

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -437,12 +437,6 @@ export function isSavedExpression(
   );
 }
 
-export function isAdhocColumn(
-  column: AdhocColumn | ColumnMeta,
-): column is AdhocColumn {
-  return 'label' in column && 'sqlExpression' in column;
-}
-
 export function isControlPanelSectionConfig(
   section: ControlPanelSectionConfig | null,
 ): section is ControlPanelSectionConfig {

--- a/superset-frontend/packages/superset-ui-chart-controls/test/types.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/types.test.ts
@@ -20,7 +20,6 @@ import { AdhocColumn } from '@superset-ui/core';
 import {
   ColumnMeta,
   ControlPanelSectionConfig,
-  isAdhocColumn,
   isColumnMeta,
   isControlPanelSectionConfig,
   isSavedExpression,
@@ -51,14 +50,6 @@ test('isColumnMeta returns false for AdhocColumn', () => {
 
 test('isColumnMeta returns true for ColumnMeta', () => {
   expect(isColumnMeta(COLUMN_META)).toEqual(true);
-});
-
-test('isAdhocColumn returns true for AdhocColumn', () => {
-  expect(isAdhocColumn(ADHOC_COLUMN)).toEqual(true);
-});
-
-test('isAdhocColumn returns false for ColumnMeta', () => {
-  expect(isAdhocColumn(COLUMN_META)).toEqual(false);
 });
 
 test('isSavedExpression returns false for AdhocColumn', () => {

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/getStandardizedControls.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/getStandardizedControls.test.ts
@@ -62,10 +62,12 @@ test('getStandardizedControls', () => {
     metrics: [],
     columns: ['gender', 'gender'],
   });
-  expect(getStandardizedControls().popAllColumns()).toEqual([
-    'gender',
-    'gender',
-  ]);
+  expect(getStandardizedControls().shiftColumn()).toEqual('gender');
+  expect(getStandardizedControls().controls).toEqual({
+    metrics: [],
+    columns: ['gender'],
+  });
+  expect(getStandardizedControls().popAllColumns()).toEqual(['gender']);
   expect(getStandardizedControls().controls).toEqual({
     metrics: [],
     columns: [],

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Column.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Column.ts
@@ -52,8 +52,6 @@ export interface Column {
   python_date_format?: string | null;
 }
 
-export default {};
-
 export function isPhysicalColumn(column?: any): column is PhysicalColumn {
   return typeof column === 'string';
 }
@@ -62,6 +60,7 @@ export function isAdhocColumn(column?: any): column is AdhocColumn {
   return (
     typeof column !== 'string' &&
     column?.sqlExpression !== undefined &&
+    column?.label !== undefined &&
     column?.expressionType === 'SQL'
   );
 }
@@ -69,3 +68,5 @@ export function isAdhocColumn(column?: any): column is AdhocColumn {
 export function isQueryFormColumn(column: any): column is QueryFormColumn {
   return isPhysicalColumn(column) || isAdhocColumn(column);
 }
+
+export default {};

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Metric.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Metric.ts
@@ -72,8 +72,6 @@ export interface Metric {
   warning_text?: Maybe<string>;
 }
 
-export default {};
-
 export function isSavedMetric(metric: any): metric is SavedMetric {
   return typeof metric === 'string';
 }
@@ -93,3 +91,5 @@ export function isQueryFormMetric(metric: any): metric is QueryFormMetric {
     isAdhocMetricSQL(metric)
   );
 }
+
+export default {};

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -27,8 +27,8 @@ import {
   NumberFormatter,
   styled,
   useTheme,
+  isAdhocColumn,
 } from '@superset-ui/core';
-import { isAdhocColumn } from '@superset-ui/chart-controls';
 import { PivotTable, sortAs, aggregatorTemplates } from './react-pivottable';
 import {
   FilterType,

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -24,12 +24,8 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { AdhocColumn, t, styled, css } from '@superset-ui/core';
-import {
-  ColumnMeta,
-  isAdhocColumn,
-  isSavedExpression,
-} from '@superset-ui/chart-controls';
+import { AdhocColumn, isAdhocColumn, t, styled, css } from '@superset-ui/core';
+import { ColumnMeta, isSavedExpression } from '@superset-ui/chart-controls';
 import Tabs from 'src/components/Tabs';
 import Button from 'src/components/Button';
 import { Select } from 'src/components';

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.tsx
@@ -17,12 +17,8 @@
  * under the License.
  */
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { AdhocColumn, t } from '@superset-ui/core';
-import {
-  ColumnMeta,
-  isAdhocColumn,
-  isColumnMeta,
-} from '@superset-ui/chart-controls';
+import { AdhocColumn, t, isAdhocColumn } from '@superset-ui/core';
+import { ColumnMeta, isColumnMeta } from '@superset-ui/chart-controls';
 import { ExplorePopoverContent } from 'src/explore/components/ExploreContentPopover';
 import ColumnSelectPopover from './ColumnSelectPopover';
 import { DndColumnSelectPopoverTitle } from './DndColumnSelectPopoverTitle';

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/OptionWrapper.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/OptionWrapper.tsx
@@ -30,8 +30,8 @@ import {
 } from 'src/explore/components/controls/DndColumnSelectControl/types';
 import { Tooltip } from 'src/components/Tooltip';
 import { StyledColumnOption } from 'src/explore/components/optionRenderers';
-import { styled } from '@superset-ui/core';
-import { ColumnMeta, isAdhocColumn } from '@superset-ui/chart-controls';
+import { styled, isAdhocColumn } from '@superset-ui/core';
+import { ColumnMeta } from '@superset-ui/chart-controls';
 import Option from './Option';
 
 export const OptionLabel = styled.div`


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
move isAdhocColumn from `@superset-ui/controls` to `@superset-ui/core`, no functional changes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/a

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
