### PR TITLE
feat: apply standardized form data to tier 2 charts

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/src/controlPanel.ts
@@ -24,6 +24,7 @@ import {
   formatSelectOptions,
   sections,
   dndEntity,
+  getStandardizedControls,
 } from '@superset-ui/chart-controls';
 
 const allColumns = {
@@ -328,6 +329,10 @@ const config: ControlPanelConfig = {
       ),
     },
   },
+  formDataOverrides: formData => ({
+    ...formData,
+    groupby: getStandardizedControls().popAllColumns(),
+  }),
 };
 
 export default config;

--- a/superset-frontend/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx
@@ -25,6 +25,7 @@ import {
   D3_FORMAT_OPTIONS,
   D3_TIME_FORMAT_OPTIONS,
   formatSelectOptions,
+  getStandardizedControls,
   sections,
 } from '@superset-ui/chart-controls';
 import OptionDescription from './OptionDescription';
@@ -39,7 +40,8 @@ const config: ControlPanelConfig = {
         ['metrics'],
         ['adhoc_filters'],
         ['groupby'],
-        ['limit', 'timeseries_limit_metric'],
+        ['limit'],
+        ['timeseries_limit_metric'],
         ['order_desc'],
         [
           {
@@ -52,7 +54,7 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        ['row_limit', null],
+        ['row_limit'],
       ],
     },
     {
@@ -383,6 +385,11 @@ const config: ControlPanelConfig = {
       ],
     },
   ],
+  formDataOverrides: formData => ({
+    ...formData,
+    groupby: getStandardizedControls().popAllColumns(),
+    metrics: getStandardizedControls().popAllMetrics(),
+  }),
 };
 
 export default config;

--- a/superset-frontend/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx
@@ -25,6 +25,7 @@ import {
   D3_FORMAT_OPTIONS,
   D3_TIME_FORMAT_OPTIONS,
   sections,
+  getStandardizedControls,
 } from '@superset-ui/chart-controls';
 
 const config: ControlPanelConfig = {
@@ -266,6 +267,11 @@ const config: ControlPanelConfig = {
       ],
     },
   ],
+  formDataOverrides: formData => ({
+    ...formData,
+    groupby: getStandardizedControls().popAllColumns(),
+    metrics: getStandardizedControls().popAllMetrics(),
+  }),
 };
 
 export default config;

--- a/superset-frontend/plugins/legacy-plugin-chart-sankey/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-sankey/src/controlPanel.ts
@@ -17,7 +17,11 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
-import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
+import {
+  ControlPanelConfig,
+  getStandardizedControls,
+  sections,
+} from '@superset-ui/chart-controls';
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
@@ -67,6 +71,11 @@ const config: ControlPanelConfig = {
       controlSetRows: [['color_scheme']],
     },
   ],
+  formDataOverrides: formData => ({
+    ...formData,
+    groupby: getStandardizedControls().popAllColumns(),
+    metric: getStandardizedControls().shiftMetric(),
+  }),
 };
 
 export default config;

--- a/superset-frontend/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts
@@ -20,6 +20,7 @@ import { t } from '@superset-ui/core';
 import {
   ControlPanelConfig,
   ControlPanelsContainerProps,
+  getStandardizedControls,
   sections,
 } from '@superset-ui/chart-controls';
 
@@ -96,6 +97,12 @@ const config: ControlPanelConfig = {
       description: t('This defines the level of the hierarchy'),
     },
   },
+  formDataOverrides: formData => ({
+    ...formData,
+    groupby: getStandardizedControls().popAllColumns(),
+    metric: getStandardizedControls().shiftMetric(),
+    secondary_metric: getStandardizedControls().shiftMetric(),
+  }),
 };
 
 export default config;

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts
@@ -155,7 +155,8 @@ const config: ControlPanelConfig = {
   },
   formDataOverrides: formData => ({
     ...formData,
-    metrics: getStandardizedControls().popAllMetrics(),
+    entity: getStandardizedControls().shiftColumn(),
+    metric: getStandardizedControls().shiftMetric(),
   }),
 };
 

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bubble/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bubble/controlPanel.ts
@@ -133,6 +133,9 @@ const config: ControlPanelConfig = {
     ...formData,
     series: getStandardizedControls().shiftColumn(),
     entity: getStandardizedControls().shiftColumn(),
+    x: getStandardizedControls().shiftMetric(),
+    y: getStandardizedControls().shiftMetric(),
+    size: getStandardizedControls().shiftMetric(),
   }),
 };
 

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.ts
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.ts
@@ -17,7 +17,11 @@
  * under the License.
  */
 import { t, validateNonEmpty } from '@superset-ui/core';
-import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
+import {
+  ControlPanelConfig,
+  getStandardizedControls,
+  sections,
+} from '@superset-ui/chart-controls';
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
@@ -103,6 +107,11 @@ const config: ControlPanelConfig = {
       default: 100,
     },
   },
+  formDataOverrides: formData => ({
+    ...formData,
+    series: getStandardizedControls().shiftColumn(),
+    metric: getStandardizedControls().shiftMetric(),
+  }),
 };
 
 export default config;

--- a/superset-frontend/src/explore/controlUtils/standardizedFormData.test.ts
+++ b/superset-frontend/src/explore/controlUtils/standardizedFormData.test.ts
@@ -68,6 +68,9 @@ describe('should collect control values and create SFD', () => {
     metrics: ['m2'],
     metric_2: 'm3',
     size: 'm4',
+    x: 'm5',
+    y: 'm6',
+    secondary_metric: 'm7',
     // columns
     groupby: ['c1'],
     columns: ['c2'],
@@ -75,6 +78,7 @@ describe('should collect control values and create SFD', () => {
     groupbyRows: ['c4'],
     series: 'c5',
     entity: 'c6',
+    series_columns: ['c7'],
   };
   const publicControlsFormData = {
     // time section
@@ -171,7 +175,15 @@ describe('should collect control values and create SFD', () => {
       Object.entries(sharedKey).length,
     );
     const sfd = new StandardizedFormData(sourceMockFormData);
-    expect(sfd.serialize().controls.metrics).toEqual(['m1', 'm2', 'm3', 'm4']);
+    expect(sfd.serialize().controls.metrics).toEqual([
+      'm1',
+      'm2',
+      'm3',
+      'm4',
+      'm5',
+      'm6',
+      'm7',
+    ]);
     expect(sfd.serialize().controls.columns).toEqual([
       'c1',
       'c2',
@@ -179,6 +191,7 @@ describe('should collect control values and create SFD', () => {
       'c4',
       'c5',
       'c6',
+      'c7',
     ]);
   });
 
@@ -193,8 +206,24 @@ describe('should collect control values and create SFD', () => {
       expect(formData).toHaveProperty(key);
       expect(value).toEqual(publicControlsFormData[key]);
     });
-    expect(formData.columns).toEqual(['c1', 'c2', 'c3', 'c4', 'c5', 'c6']);
-    expect(formData.metrics).toEqual(['m1', 'm2', 'm3', 'm4']);
+    expect(formData.columns).toEqual([
+      'c1',
+      'c2',
+      'c3',
+      'c4',
+      'c5',
+      'c6',
+      'c7',
+    ]);
+    expect(formData.metrics).toEqual([
+      'm1',
+      'm2',
+      'm3',
+      'm4',
+      'm5',
+      'm6',
+      'm7',
+    ]);
   });
 
   test('should inherit standardizedFormData and memorizedFormData is LIFO', () => {

--- a/superset-frontend/src/explore/controlUtils/standardizedFormData.ts
+++ b/superset-frontend/src/explore/controlUtils/standardizedFormData.ts
@@ -38,6 +38,9 @@ export const sharedMetricsKey = [
   'metrics', // via sharedControls, array
   'metric_2', // via sharedControls, scalar
   'size', // via sharedControls, scalar
+  'x', // via sharedControls, scalar
+  'y', // via sharedControls, scalar
+  'secondary_metric', // via sharedControls, scalar
 ];
 export const sharedColumnsKey = [
   'groupby', // via sharedControls, array
@@ -46,6 +49,7 @@ export const sharedColumnsKey = [
   'groupbyRows', // via pivot table v2, array
   'entity', // via sharedControls, scalar
   'series', // via sharedControls, scalar
+  'series_columns', // via sharedControls, array
 ];
 
 export const publicControls = [

--- a/superset-frontend/src/visualizations/TimeTable/controlPanel.js
+++ b/superset-frontend/src/visualizations/TimeTable/controlPanel.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { t, validateNonEmpty } from '@superset-ui/core';
-import { sections } from '@superset-ui/chart-controls';
+import { getStandardizedControls, sections } from '@superset-ui/chart-controls';
 
 export default {
   controlPanelSections: [
@@ -65,4 +65,9 @@ export default {
       multiple: false,
     },
   },
+  formDataOverrides: formData => ({
+    ...formData,
+    groupby: getStandardizedControls().popAllColumns(),
+    metrics: getStandardizedControls().popAllMetrics(),
+  }),
 };


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Apply StandardizedFormData to the following charts

- Mapbox
- Partition chart
- Nightingale rose chart
- Sankey diagram
- Sunburst chart
- Timeseries table
- Word cloud


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
