### PR TITLE
fix: Removes psycopg2 as a required dependency

### DIFF
--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -289,6 +289,7 @@ class PostgresEngineSpec(PostgresBaseEngineSpec, BasicParametersMixin):
 
     @classmethod
     def get_datatype(cls, type_code: Any) -> Optional[str]:
+        # pylint: disable=import-outside-toplevel
         from psycopg2.extensions import binary_types, string_types
 
         types = binary_types.copy()

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -21,7 +21,6 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Pattern, Tuple, TYPE_CHECKING
 
 from flask_babel import gettext as __
-from psycopg2.extensions import binary_types, string_types
 from sqlalchemy.dialects.postgresql import ARRAY, DOUBLE_PRECISION, ENUM, JSON
 from sqlalchemy.dialects.postgresql.base import PGInspector
 from sqlalchemy.types import String
@@ -290,6 +289,8 @@ class PostgresEngineSpec(PostgresBaseEngineSpec, BasicParametersMixin):
 
     @classmethod
     def get_datatype(cls, type_code: Any) -> Optional[str]:
+        from psycopg2.extensions import binary_types, string_types
+
         types = binary_types.copy()
         types.update(string_types)
         if type_code in types:


### PR DESCRIPTION
### SUMMARY
Removes `psycopg2` as a required dependency in `superset/db_engine_specs/postgres.py`

### TESTING INSTRUCTIONS
1 - Execute all tests
2 - All tests should pass

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
