### PR TITLE
fix: Respecting max/min opacities, and adding tests.

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
@@ -41,13 +41,16 @@ export const getOpacity = (
   if (extremeValue === cutoffPoint) {
     return maxOpacity;
   }
-  else return Math.min(maxOpacity, round(
-    Math.abs(
-      ((maxOpacity - minOpacity) / (extremeValue - cutoffPoint)) *
-        (value - cutoffPoint),
-    ) + minOpacity,
-    2,
-  ));
+  return Math.min(
+    maxOpacity,
+    round(
+      Math.abs(
+        ((maxOpacity - minOpacity) / (extremeValue - cutoffPoint)) *
+          (value - cutoffPoint),
+      ) + minOpacity,
+      2,
+    ),
+  );
 };
 
 export const getColorFunction = (

--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
@@ -49,8 +49,7 @@ export const getOpacity = (
     2,
   );
 
-  if (result > maxOpacity) return maxOpacity;
-  return result;
+  return Math.min(result, maxOpacity);
 };
 
 export const getColorFunction = (

--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
@@ -49,7 +49,8 @@ export const getOpacity = (
     2,
   );
 
-  return result > maxOpacity ? maxOpacity : result;
+  if (result > maxOpacity) return maxOpacity;
+  return result;
 };
 
 export const getColorFunction = (

--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
@@ -49,10 +49,6 @@ export const getOpacity = (
     2,
   );
 
-  if (result < minOpacity) {
-    return minOpacity;
-  }
-
   return result > maxOpacity ? maxOpacity : result;
 };
 

--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
@@ -41,15 +41,13 @@ export const getOpacity = (
   if (extremeValue === cutoffPoint) {
     return maxOpacity;
   }
-  const result = round(
+  else return Math.min(maxOpacity, round(
     Math.abs(
       ((maxOpacity - minOpacity) / (extremeValue - cutoffPoint)) *
         (value - cutoffPoint),
     ) + minOpacity,
     2,
-  );
-
-  return Math.min(result, maxOpacity);
+  ));
 };
 
 export const getColorFunction = (

--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
@@ -37,16 +37,24 @@ export const getOpacity = (
   extremeValue: number,
   minOpacity = MIN_OPACITY_BOUNDED,
   maxOpacity = MAX_OPACITY,
-) =>
-  extremeValue === cutoffPoint
-    ? maxOpacity
-    : round(
-        Math.abs(
-          ((maxOpacity - minOpacity) / (extremeValue - cutoffPoint)) *
-            (value - cutoffPoint),
-        ) + minOpacity,
-        2,
-      );
+) => {
+  if (extremeValue === cutoffPoint) {
+    return maxOpacity;
+  }
+  const result = round(
+    Math.abs(
+      ((maxOpacity - minOpacity) / (extremeValue - cutoffPoint)) *
+        (value - cutoffPoint),
+    ) + minOpacity,
+    2,
+  );
+
+  if (result < minOpacity) {
+    return minOpacity;
+  }
+
+  return result > maxOpacity ? maxOpacity : result;
+};
 
 export const getColorFunction = (
   {

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
@@ -51,7 +51,7 @@ describe('getOpacity', () => {
     expect(getOpacity(100, 100, 100, 0, 0.8)).toEqual(0.8);
     expect(getOpacity(100, 100, 50, 0, 1)).toEqual(0);
     expect(getOpacity(999, 100, 50, 0, 1)).toEqual(1);
-    expect(getOpacity(-999, 100, 50, 0, 1)).toEqual(0.05);
+    expect(getOpacity(100, 100, 50, 0.99, 1)).toEqual(0.99);
   });
 });
 

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
@@ -50,6 +50,8 @@ describe('getOpacity', () => {
     expect(getOpacity(100, 100, 50)).toEqual(0.05);
     expect(getOpacity(100, 100, 100, 0, 0.8)).toEqual(0.8);
     expect(getOpacity(100, 100, 50, 0, 1)).toEqual(0);
+    expect(getOpacity(999, 100, 50, 0, 1)).toEqual(1);
+    expect(getOpacity(-999, 100, 50, 0, 1)).toEqual(0.05);
   });
 });
 

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
@@ -52,6 +52,7 @@ describe('getOpacity', () => {
     expect(getOpacity(100, 100, 50, 0, 1)).toEqual(0);
     expect(getOpacity(999, 100, 50, 0, 1)).toEqual(1);
     expect(getOpacity(100, 100, 50, 0.99, 1)).toEqual(0.99);
+    expect(getOpacity(99, 100, 50, 0, 1)).toEqual(0.02);
   });
 });
 

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
@@ -52,7 +52,6 @@ describe('getOpacity', () => {
     expect(getOpacity(100, 100, 50, 0, 1)).toEqual(0);
     expect(getOpacity(999, 100, 50, 0, 1)).toEqual(1);
     expect(getOpacity(100, 100, 50, 0.99, 1)).toEqual(0.99);
-    expect(getOpacity(99.9, 100, 50, 0.05, 1)).toEqual(0.05);
   });
 });
 

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
@@ -52,6 +52,7 @@ describe('getOpacity', () => {
     expect(getOpacity(100, 100, 50, 0, 1)).toEqual(0);
     expect(getOpacity(999, 100, 50, 0, 1)).toEqual(1);
     expect(getOpacity(100, 100, 50, 0.99, 1)).toEqual(0.99);
+    expect(getOpacity(99.9, 100, 50, 0.05, 1)).toEqual(0.05);
   });
 });
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
There was an error where calculated opacities could be over 1, or below 0. This code will only allow the opacity to go to the configured maximum or minimum. 

Hat tip to @michael-s-molina for the detective work here :)

<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="1043" alt="image" src="https://user-images.githubusercontent.com/812905/176567066-948cc732-ac7c-4db4-8323-00c24e84f5b3.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Unit tests included!

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
