### PR TITLE
docs: correction - dashboard export is JSON, not YAML

### DIFF
--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -734,7 +734,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         ---
         get:
           description: >-
-            Exports multiple Dashboards and downloads them as YAML files.
+            Exports multiple Dashboards and downloads them as JSON files.
           parameters:
           - in: query
             name: q


### PR DESCRIPTION
### SUMMARY
Single-word correction in the API docs.

### TESTING INSTRUCTIONS
Verify docs  for `/api/v1/dashboard/export/` on swagger page