### PR TITLE
test: Improve & un-skip flaky Cypress test

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
@@ -127,10 +127,16 @@ describe('Test datatable', () => {
     cy.get('[data-test="row-count-label"]').contains('26 rows');
     cy.get('.ant-empty-description').should('not.exist');
   });
-  it.skip('Datapane loads view samples', () => {
-    cy.contains('Samples').click();
-    cy.get('[data-test="row-count-label"]').contains('1k rows');
-    cy.get('.ant-empty-description').should('not.exist');
+  it('Datapane loads view samples', () => {
+    cy.intercept('/api/v1/dataset/*/samples?force=false').as('Samples');
+    cy.contains('Samples')
+      .click()
+      .then(() => {
+        cy.wait('@Samples');
+        cy.get('.ant-tabs-tab-active').contains('Samples');
+        cy.get('[data-test="row-count-label"]').contains('1k rows');
+        cy.get('.ant-empty-description').should('not.exist');
+      });
   });
 });
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds some resilience to the flaky Cypress test skipped in #20417 (thanks @adam-stasiak!) and un-skips it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Check CI and perhaps try running Cypress locally to make sure tests pass.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
