### PR TITLE
fix: Revert #20408 (stacking negative values in echarts bar chart)

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -26520,12 +26520,12 @@
       }
     },
     "node_modules/echarts": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.3.3.tgz",
-      "integrity": "sha512-BRw2serInRwO5SIwRviZ6Xgm5Lb7irgz+sLiFMmy/HOaf4SQ+7oYqxKzRHAKp4xHQ05AuHw1xvoQWJjDQq/FGw==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.3.2.tgz",
+      "integrity": "sha512-LWCt7ohOKdJqyiBJ0OGBmE9szLdfA9sGcsMEi+GGoc6+Xo75C+BkcT/6NNGRHAWtnQl2fNow05AQjznpap28TQ==",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "5.3.2"
+        "zrender": "5.3.1"
       }
     },
     "node_modules/echarts/node_modules/tslib": {
@@ -54228,9 +54228,9 @@
       }
     },
     "node_modules/zrender": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.3.2.tgz",
-      "integrity": "sha512-8IiYdfwHj2rx0UeIGZGGU4WEVSDEdeVCaIg/fomejg1Xu6OifAL1GVzIPHg2D+MyUkbNgPWji90t0a8IDk+39w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.3.1.tgz",
+      "integrity": "sha512-7olqIjy0gWfznKr6vgfnGBk7y4UtdMvdwFmK92vVQsQeDPyzkHW1OlrLEKg6GHz1W5ePf0FeN1q2vkl/HFqhXw==",
       "dependencies": {
         "tslib": "2.3.0"
       }
@@ -55356,7 +55356,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "d3-array": "^1.2.0",
-        "echarts": "^5.3.3",
+        "echarts": "^5.3.2",
         "lodash": "^4.17.15",
         "moment": "^2.26.0"
       },
@@ -68169,7 +68169,7 @@
       "version": "file:plugins/plugin-chart-echarts",
       "requires": {
         "d3-array": "^1.2.0",
-        "echarts": "^5.3.3",
+        "echarts": "^5.3.2",
         "lodash": "^4.17.15",
         "moment": "^2.26.0"
       }
@@ -76557,12 +76557,12 @@
       }
     },
     "echarts": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.3.3.tgz",
-      "integrity": "sha512-BRw2serInRwO5SIwRviZ6Xgm5Lb7irgz+sLiFMmy/HOaf4SQ+7oYqxKzRHAKp4xHQ05AuHw1xvoQWJjDQq/FGw==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.3.2.tgz",
+      "integrity": "sha512-LWCt7ohOKdJqyiBJ0OGBmE9szLdfA9sGcsMEi+GGoc6+Xo75C+BkcT/6NNGRHAWtnQl2fNow05AQjznpap28TQ==",
       "requires": {
         "tslib": "2.3.0",
-        "zrender": "5.3.2"
+        "zrender": "5.3.1"
       },
       "dependencies": {
         "tslib": {
@@ -97997,9 +97997,9 @@
       }
     },
     "zrender": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.3.2.tgz",
-      "integrity": "sha512-8IiYdfwHj2rx0UeIGZGGU4WEVSDEdeVCaIg/fomejg1Xu6OifAL1GVzIPHg2D+MyUkbNgPWji90t0a8IDk+39w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.3.1.tgz",
+      "integrity": "sha512-7olqIjy0gWfznKr6vgfnGBk7y4UtdMvdwFmK92vVQsQeDPyzkHW1OlrLEKg6GHz1W5ePf0FeN1q2vkl/HFqhXw==",
       "requires": {
         "tslib": "2.3.0"
       },

--- a/superset-frontend/plugins/plugin-chart-echarts/package.json
+++ b/superset-frontend/plugins/plugin-chart-echarts/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "d3-array": "^1.2.0",
-    "echarts": "^5.3.3",
+    "echarts": "^5.3.2",
     "lodash": "^4.17.15",
     "moment": "^2.26.0"
   },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -204,7 +204,6 @@ export function transformSeries(
       ? seriesType
       : undefined,
     stack: stackId,
-    stackStrategy: 'all',
     lineStyle,
     areaStyle:
       area || forecastSeries.type === ForecastSeriesEnum.ForecastUpper


### PR DESCRIPTION

This reverts commit c959d92dd17499e3fb7a0f4f02f3781516f3d3e6.

The PR being reverted bumped echarts and changes the stacking method to allow proper stacking of negative values (cool!). However, if a dataset happens to display `null` values as bar segments, clicking on the legend causes the chart display to become VERY erratic in terms of what's displayed/hidden in the stacked bars - things disappear completely!

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/812905/176741409-6d0aaffe-4af4-4e10-802e-2f1ae591d1f0.mp4

After: coming soon... but it works, trust me ;)

<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Create a dataset with this query
```sql
SELECT TO_DATE('2011-01-01', 'yyyy-MM-dd') as d, 1 as city, 1 as count
union all SELECt TO_DATE('2011-01-01', 'yyyy-MM-dd'), 1, 1
union all SELECt TO_DATE('2011-01-01', 'yyyy-MM-dd'), 1, null
union all SELECt TO_DATE('2011-01-01', 'yyyy-MM-dd'), 2, 1
union all SELECt TO_DATE('2011-01-01', 'yyyy-MM-dd'), 2, null
union all SELECt TO_DATE('2012-01-01', 'yyyy-MM-dd'), 2, null
union all SELECt TO_DATE('2013-01-01', 'yyyy-MM-dd'), 2, null
union all SELECt TO_DATE('2013-01-01', 'yyyy-MM-dd'), 2, 1
```
...then make Timeseries Bar Chart V2 as shown in the GIF. Click around on the labels and see if you see all the right bars at all times.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [x] Removes existing feature or API
