### PR TITLE
fix: Change dataset name affect data access role set to this dataset

### DIFF
--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -185,6 +185,7 @@ class TestRolePermission(SupersetTestCase):
         )
 
         # table name change
+        orig_table_perm = stored_table.perm
         stored_table.table_name = "tmp_perm_table_v2"
         session.commit()
         stored_table = (
@@ -192,6 +193,11 @@ class TestRolePermission(SupersetTestCase):
         )
         self.assertEqual(
             stored_table.perm, f"[examples].[tmp_perm_table_v2](id:{stored_table.id})"
+        )
+        self.assertIsNone(
+            security_manager.find_permission_view_menu(
+                "datasource_access", orig_table_perm
+            )
         )
         self.assertIsNotNone(
             security_manager.find_permission_view_menu(


### PR DESCRIPTION
### SUMMARY

When the user changes the name of a virtual dataset, any user that had specific access to said dataset will no longer be able to access it.

The issue is because the `set_perm` function is changing the table name but not the permission and view_model, thus, a new permission/view is created and the users keep pointing to the old one.

This PR ensures that, on name change, those records are also updated.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://user-images.githubusercontent.com/17252075/176782468-0c324cd4-5216-46aa-a633-4ebb8b0a25f3.mov

After:

https://user-images.githubusercontent.com/17252075/176782538-d19ab23b-7bbb-4a88-af30-5d4b523bf301.mov

### TESTING INSTRUCTIONS

1. Create a virtual dataset
2. Create a new role and grant access to the created dataset
3. Create a new user and assign the Gamma role, and the role created in 2.
4. Access the dataset list with that user
5. With the admin account, change the dataset table name
6. Ensure the user created in 3 can still see the dataset, now with the new name

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
