### PR TITLE
refactor: remove unused flatten function

### DIFF
--- a/.github/workflows/caches.js
+++ b/.github/workflows/caches.js
@@ -25,6 +25,8 @@ const assetsConfig = {
   path: [`${workspaceDirectory}/superset/static/assets`],
   hashFiles: [
     `${workspaceDirectory}/superset-frontend/src/**/*`,
+    `${workspaceDirectory}/superset-frontend/packages/**/*`,
+    `${workspaceDirectory}/superset-frontend/plugins/**/*`,
     `${workspaceDirectory}/superset-frontend/*.js`,
     `${workspaceDirectory}/superset-frontend/*.json`,
   ],

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/pivotOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/pivotOperator.ts
@@ -45,8 +45,6 @@ export const pivotOperator: PostProcessingFactory<PostProcessingPivot> = (
           metricLabels.map(metric => [metric, { operator: 'mean' }]),
         ),
         drop_missing_columns: false,
-        flatten_columns: false,
-        reset_index: false,
       },
     };
   }

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/timeComparePivotOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/timeComparePivotOperator.ts
@@ -47,8 +47,6 @@ export const timeComparePivotOperator: PostProcessingFactory<PostProcessingPivot
           index,
           columns: ensureIsArray(queryObject.columns).map(getColumnLabel),
           drop_missing_columns: false,
-          flatten_columns: false,
-          reset_index: false,
           aggregates,
         },
       };

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/pivotOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/pivotOperator.test.ts
@@ -80,8 +80,6 @@ test('pivot by __timestamp without groupby', () => {
         'sum(val)': { operator: 'mean' },
       },
       drop_missing_columns: false,
-      flatten_columns: false,
-      reset_index: false,
     },
   });
 });
@@ -103,8 +101,6 @@ test('pivot by __timestamp with groupby', () => {
         'sum(val)': { operator: 'mean' },
       },
       drop_missing_columns: false,
-      flatten_columns: false,
-      reset_index: false,
     },
   });
 });
@@ -131,8 +127,6 @@ test('pivot by x_axis with groupby', () => {
         'sum(val)': { operator: 'mean' },
       },
       drop_missing_columns: false,
-      flatten_columns: false,
-      reset_index: false,
     },
   });
 });
@@ -163,8 +157,6 @@ test('pivot by adhoc x_axis', () => {
         'sum(val)': { operator: 'mean' },
       },
       drop_missing_columns: false,
-      flatten_columns: false,
-      reset_index: false,
     },
   });
 });

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/timeCompareOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/timeCompareOperator.test.ts
@@ -51,8 +51,6 @@ const queryObject: QueryObject = {
           },
         },
         drop_missing_columns: false,
-        flatten_columns: false,
-        reset_index: false,
       },
     },
     {

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/timeComparePivotOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/timeComparePivotOperator.test.ts
@@ -93,8 +93,6 @@ test('should pivot on any type of timeCompare', () => {
           },
         },
         drop_missing_columns: false,
-        flatten_columns: false,
-        reset_index: false,
         columns: ['foo', 'bar'],
         index: ['__timestamp'],
       },
@@ -133,8 +131,6 @@ test('should pivot on x-axis', () => {
       drop_missing_columns: false,
       columns: ['foo', 'bar'],
       index: ['ds'],
-      flatten_columns: false,
-      reset_index: false,
     },
   });
 });
@@ -174,8 +170,6 @@ test('should pivot on adhoc x-axis', () => {
       drop_missing_columns: false,
       columns: ['foo', 'bar'],
       index: ['my_case_expr'],
-      flatten_columns: false,
-      reset_index: false,
     },
   });
 });

--- a/superset-frontend/packages/superset-ui-core/src/query/types/PostProcessing.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/PostProcessing.ts
@@ -111,12 +111,10 @@ interface _PostProcessingPivot {
     columns: string[];
     combine_value_with_metric?: boolean;
     drop_missing_columns?: boolean;
-    flatten_columns?: boolean;
     index: string[];
     marginal_distribution_name?: string;
     marginal_distributions?: boolean;
     metric_fill_value?: any;
-    reset_index?: boolean;
   };
 }
 export type PostProcessingPivot = _PostProcessingPivot | DefaultPostProcessing;

--- a/superset-frontend/packages/superset-ui-core/test/query/types/PostProcessing.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/types/PostProcessing.test.ts
@@ -110,8 +110,6 @@ const PIVOT_RULE: PostProcessingPivot = {
     index: ['foo'],
     columns: ['bar'],
     aggregates: AGGREGATES_OPTION,
-    flatten_columns: true,
-    reset_index: true,
   },
 };
 

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/buildQuery.test.ts
@@ -125,9 +125,7 @@ test('should compile query object A', () => {
           },
           columns: ['foo'],
           drop_missing_columns: false,
-          flatten_columns: false,
           index: ['__timestamp'],
-          reset_index: false,
         },
       },
       {
@@ -188,9 +186,7 @@ test('should compile query object B', () => {
           },
           columns: [],
           drop_missing_columns: false,
-          flatten_columns: false,
           index: ['__timestamp'],
-          reset_index: false,
         },
       },
       {
@@ -314,9 +310,7 @@ test('should compile query objects with x-axis', () => {
           },
           columns: ['foo'],
           drop_missing_columns: false,
-          flatten_columns: false,
           index: ['my_index'],
-          reset_index: false,
         },
       },
       {
@@ -354,9 +348,7 @@ test('should compile query objects with x-axis', () => {
             },
             columns: [],
             drop_missing_columns: false,
-            flatten_columns: false,
             index: ['my_index'],
-            reset_index: false,
           },
         },
         {

--- a/superset/utils/pandas_postprocessing/__init__.py
+++ b/superset/utils/pandas_postprocessing/__init__.py
@@ -33,7 +33,6 @@ from superset.utils.pandas_postprocessing.resample import resample
 from superset.utils.pandas_postprocessing.rolling import rolling
 from superset.utils.pandas_postprocessing.select import select
 from superset.utils.pandas_postprocessing.sort import sort
-from superset.utils.pandas_postprocessing.utils import _flatten_column_after_pivot
 
 __all__ = [
     "aggregate",
@@ -53,5 +52,4 @@ __all__ = [
     "select",
     "sort",
     "flatten",
-    "_flatten_column_after_pivot",
 ]

--- a/superset/utils/pandas_postprocessing/pivot.py
+++ b/superset/utils/pandas_postprocessing/pivot.py
@@ -22,7 +22,6 @@ from pandas import DataFrame
 from superset.constants import NULL_STRING, PandasAxis
 from superset.exceptions import InvalidPostProcessingError
 from superset.utils.pandas_postprocessing.utils import (
-    _flatten_column_after_pivot,
     _get_aggregate_funcs,
     validate_column_args,
 )
@@ -40,8 +39,6 @@ def pivot(  # pylint: disable=too-many-arguments,too-many-locals
     combine_value_with_metric: bool = False,
     marginal_distributions: Optional[bool] = None,
     marginal_distribution_name: Optional[str] = None,
-    flatten_columns: bool = True,
-    reset_index: bool = True,
 ) -> DataFrame:
     """
     Perform a pivot operation on a DataFrame.
@@ -61,8 +58,6 @@ def pivot(  # pylint: disable=too-many-arguments,too-many-locals
     :param marginal_distributions: Add totals for row/column. Default to False
     :param marginal_distribution_name: Name of row/column with marginal distribution.
            Default to 'All'.
-    :param flatten_columns: Convert column names to strings
-    :param reset_index: Convert index to column
     :return: A pivot table
     :raises InvalidPostProcessingError: If the request in incorrect
     """
@@ -114,12 +109,4 @@ def pivot(  # pylint: disable=too-many-arguments,too-many-locals
     if combine_value_with_metric:
         df = df.stack(0).unstack()
 
-    # Make index regular column
-    if flatten_columns:
-        df.columns = [
-            _flatten_column_after_pivot(col, aggregates) for col in df.columns
-        ]
-    # return index as regular column
-    if reset_index:
-        df.reset_index(level=0, inplace=True)
     return df

--- a/superset/utils/pandas_postprocessing/utils.py
+++ b/superset/utils/pandas_postprocessing/utils.py
@@ -97,30 +97,6 @@ RESAMPLE_METHOD = ("asfreq", "bfill", "ffill", "linear", "median", "mean", "sum"
 FLAT_COLUMN_SEPARATOR = ", "
 
 
-def _flatten_column_after_pivot(
-    column: Union[float, Timestamp, str, Tuple[str, ...]],
-    aggregates: Dict[str, Dict[str, Any]],
-) -> str:
-    """
-    Function for flattening column names into a single string. This step is necessary
-    to be able to properly serialize a DataFrame. If the column is a string, return
-    element unchanged. For multi-element columns, join column elements with a comma,
-    with the exception of pivots made with a single aggregate, in which case the
-    aggregate column name is omitted.
-
-    :param column: single element from `DataFrame.columns`
-    :param aggregates: aggregates
-    :return:
-    """
-    if not isinstance(column, tuple):
-        column = (column,)
-    if len(aggregates) == 1 and len(column) > 1:
-        # drop aggregate for single aggregate pivots with multiple groupings
-        # from column name (aggregates always come first in column name)
-        column = column[1:]
-    return FLAT_COLUMN_SEPARATOR.join([str(col) for col in column])
-
-
 def _is_multi_index_on_columns(df: DataFrame) -> bool:
     return isinstance(df.columns, pd.MultiIndex)
 

--- a/superset/utils/pandas_postprocessing/utils.py
+++ b/superset/utils/pandas_postprocessing/utils.py
@@ -15,12 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 from functools import partial
-from typing import Any, Callable, Dict, Tuple, Union
+from typing import Any, Callable, Dict
 
 import numpy as np
 import pandas as pd
 from flask_babel import gettext as _
-from pandas import DataFrame, NamedAgg, Timestamp
+from pandas import DataFrame, NamedAgg
 
 from superset.exceptions import InvalidPostProcessingError
 

--- a/tests/unit_tests/pandas_postprocessing/test_compare.py
+++ b/tests/unit_tests/pandas_postprocessing/test_compare.py
@@ -188,8 +188,6 @@ def test_compare_after_pivot():
             "sum_metric": {"operator": "sum"},
             "count_metric": {"operator": "sum"},
         },
-        flatten_columns=False,
-        reset_index=False,
     )
     """
                    count_metric    sum_metric

--- a/tests/unit_tests/pandas_postprocessing/test_cum.py
+++ b/tests/unit_tests/pandas_postprocessing/test_cum.py
@@ -83,8 +83,6 @@ def test_cum_after_pivot_with_single_metric():
         index=["dttm"],
         columns=["country"],
         aggregates={"sum_metric": {"operator": "sum"}},
-        flatten_columns=False,
-        reset_index=False,
     )
     """
                sum_metric
@@ -127,8 +125,6 @@ def test_cum_after_pivot_with_multiple_metrics():
             "sum_metric": {"operator": "sum"},
             "count_metric": {"operator": "sum"},
         },
-        flatten_columns=False,
-        reset_index=False,
     )
     """
                    count_metric    sum_metric

--- a/tests/unit_tests/pandas_postprocessing/test_resample.py
+++ b/tests/unit_tests/pandas_postprocessing/test_resample.py
@@ -110,8 +110,6 @@ def test_resample_after_pivot():
         aggregates={
             "val": {"operator": "sum"},
         },
-        flatten_columns=False,
-        reset_index=False,
     )
     """
                     val

--- a/tests/unit_tests/pandas_postprocessing/test_rolling.py
+++ b/tests/unit_tests/pandas_postprocessing/test_rolling.py
@@ -113,8 +113,6 @@ def test_rolling_should_empty_df():
         index=["dttm"],
         columns=["country"],
         aggregates={"sum_metric": {"operator": "sum"}},
-        flatten_columns=False,
-        reset_index=False,
     )
     rolling_df = pp.rolling(
         df=pivot_df,
@@ -132,8 +130,6 @@ def test_rolling_after_pivot_with_single_metric():
         index=["dttm"],
         columns=["country"],
         aggregates={"sum_metric": {"operator": "sum"}},
-        flatten_columns=False,
-        reset_index=False,
     )
     """
                    sum_metric
@@ -182,8 +178,6 @@ def test_rolling_after_pivot_with_multiple_metrics():
             "sum_metric": {"operator": "sum"},
             "count_metric": {"operator": "sum"},
         },
-        flatten_columns=False,
-        reset_index=False,
     )
     """
                count_metric    sum_metric


### PR DESCRIPTION
### SUMMARY
The flatten operation after `pivot operator` has been replaced with `flatten operator`, so removed unused codes.

the flatten operator is [here](https://github.com/apache/superset/blob/master/superset/utils/pandas_postprocessing/flatten.py)

No functionality should be impacted.
 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
