### PR TITLE
fix: using sqla session to persist permission view

### DIFF
--- a/superset/connectors/sqla/utils.py
+++ b/superset/connectors/sqla/utils.py
@@ -213,7 +213,7 @@ def find_cached_objects_in_session(
         return iter([])
     uuids = uuids or []
     try:
-        items = set(session)
+        items = list(session)
     except ObjectDeletedError:
         logger.warning("ObjectDeletedError", exc_info=True)
         return iter(())

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -990,17 +990,17 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             if not permission:
                 permission = self.permission_model(name=permission_name)
                 self.get_session.add(permission)
-                self.get_session.commit()
+                self.get_session.merge(permission)
             if not view_menu:
                 view_menu = self.viewmenu_model(name=view_menu_name)
                 self.get_session.add(view_menu)
-                self.get_session.commit()
+                self.get_session.merge(view_menu)
             if not pv and permission and view_menu:
                 pv = self.permissionview_model(
                     permission=permission, view_menu=view_menu
                 )
                 self.get_session.add(pv)
-                self.get_session.commit()
+                self.get_session.merge(pv)
 
     def raise_for_access(
         # pylint: disable=too-many-arguments,too-many-locals

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -973,8 +973,8 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             if permission and view_menu:
                 pv = (
                     self.get_session.query(self.permissionview_model)
-                        .filter_by(permission=permission, view_menu=view_menu)
-                        .first()
+                    .filter_by(permission=permission, view_menu=view_menu)
+                    .first()
                 )
 
             if not permission:

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -946,15 +946,25 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         except DatasetInvalidPermissionEvaluationException:
             logger.warning("Dataset has no database refusing to set permission")
             return
+        link_table = target.__table__
         if target.perm != target_get_perm:
+            connection.execute(
+                link_table.update()
+                .where(link_table.c.id == target.id)
+                .values(perm=target_get_perm)
+            )
             target.perm = target_get_perm
-            self.get_session.merge(target)
+
         if (
             hasattr(target, "schema_perm")
             and target.schema_perm != target.get_schema_perm()
         ):
+            connection.execute(
+                link_table.update()
+                .where(link_table.c.id == target.id)
+                .values(schema_perm=target.get_schema_perm())
+            )
             target.schema_perm = target.get_schema_perm()
-            self.get_session.merge(target)
 
         pvm_names = []
         if target.__tablename__ in {"dbs", "clusters"}:

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -989,19 +989,15 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
 
             if not permission:
                 permission = self.permission_model(name=permission_name)
-                # self.get_session.add(permission)
                 self.get_session.add(permission)
             if not view_menu:
                 view_menu = self.viewmenu_model(name=view_menu_name)
-                # self.get_session.add(view_menu)
                 self.get_session.add(view_menu)
 
             if not pv and permission and view_menu:
                 pv = self.permissionview_model(
                     permission=permission, view_menu=view_menu
                 )
-                # self.get_session.add(pv)
-                logger.info(permission, view_menu)
                 self.get_session.add(pv)
 
     def raise_for_access(

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -989,18 +989,20 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
 
             if not permission:
                 permission = self.permission_model(name=permission_name)
+                # self.get_session.add(permission)
                 self.get_session.add(permission)
-                self.get_session.merge(permission)
             if not view_menu:
                 view_menu = self.viewmenu_model(name=view_menu_name)
+                # self.get_session.add(view_menu)
                 self.get_session.add(view_menu)
-                self.get_session.merge(view_menu)
+
             if not pv and permission and view_menu:
                 pv = self.permissionview_model(
                     permission=permission, view_menu=view_menu
                 )
+                # self.get_session.add(pv)
+                logger.info(permission, view_menu)
                 self.get_session.add(pv)
-                self.get_session.merge(pv)
 
     def raise_for_access(
         # pylint: disable=too-many-arguments,too-many-locals

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -990,15 +990,17 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             if not permission:
                 permission = self.permission_model(name=permission_name)
                 self.get_session.add(permission)
+                self.get_session.commit()
             if not view_menu:
                 view_menu = self.viewmenu_model(name=view_menu_name)
                 self.get_session.add(view_menu)
-
+                self.get_session.commit()
             if not pv and permission and view_menu:
                 pv = self.permissionview_model(
                     permission=permission, view_menu=view_menu
                 )
                 self.get_session.add(pv)
+                self.get_session.commit()
 
     def raise_for_access(
         # pylint: disable=too-many-arguments,too-many-locals


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
1. In security manager, set_perm, instead of using connection to update perm directly, we should use sqla session.
2. This will enable proper callback function to be triggered for PermissionView object

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
