### PR TITLE
fix: Bar stacking on v2 doesn't work if the x-axis is value type

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -193,10 +193,10 @@ export type TabOverride = 'data' | 'customize' | boolean;
  *    show a warning based on the value of another component. It's also possible to bind
  *    arbitrary data from the redux store to the component this way.
  * - tabOverride: set to 'data' if you want to force a renderTrigger to show up on the `Data`
-     tab, or 'customize' if you want it to show up on that tam. Otherwise sections with ALL
-     `renderTrigger: true` components will show up on the `Customize` tab.
+      tab, or 'customize' if you want it to show up on that tam. Otherwise sections with ALL
+      `renderTrigger: true` components will show up on the `Customize` tab.
  * - visibility: a function that uses control panel props to check whether a control should
- *    be visibile.
+ *    be visible. Return undefined if the result of the function call should not be used.
  */
 export interface BaseControlConfig<
   T extends ControlType = ControlType,
@@ -230,7 +230,7 @@ export interface BaseControlConfig<
   visibility?: (
     props: ControlPanelsContainerProps,
     controlData: AnyDict,
-  ) => boolean;
+  ) => boolean | undefined;
 }
 
 export interface ControlValueValidator<


### PR DESCRIPTION
### SUMMARY

When `GENERIC_CHART_AXES` is enabled, stacking on bar chart v2 is not working correctly in all cases.
The reason is that bar stacking is supported by echarts only for categorical types.
Source: https://github.com/apache/echarts/issues/15102

This PR hides that feature if the axis is not categorical.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://user-images.githubusercontent.com/17252075/176978590-653b4411-ed1a-4e1f-a0a9-d138b6091b29.mov

After:

https://user-images.githubusercontent.com/17252075/176978651-8ff74bd7-45f6-49d8-9641-11d635317692.mov

### TESTING INSTRUCTIONS
1. Enable `GENERIC_CHART_AXES`.
2. Create Bar v2 charts with different types in the x-types.

Ensure the stack option is only available for categorical types, and that it works as expected.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
