### PR TITLE
chore: rename drop missing columns to show empty columns

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/pivotOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/pivotOperator.ts
@@ -44,7 +44,7 @@ export const pivotOperator: PostProcessingFactory<PostProcessingPivot> = (
         aggregates: Object.fromEntries(
           metricLabels.map(metric => [metric, { operator: 'mean' }]),
         ),
-        drop_missing_columns: !!formData?.drop_missing_columns,
+        drop_missing_columns: !formData?.show_empty_columns,
       },
     };
   }

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/timeComparePivotOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/timeComparePivotOperator.ts
@@ -46,7 +46,7 @@ export const timeComparePivotOperator: PostProcessingFactory<PostProcessingPivot
         options: {
           index,
           columns: ensureIsArray(queryObject.columns).map(getColumnLabel),
-          drop_missing_columns: !!formData?.drop_missing_columns,
+          drop_missing_columns: !formData?.show_empty_columns,
           aggregates,
         },
       };

--- a/superset-frontend/packages/superset-ui-chart-controls/src/sections/echartsTimeSeriesQuery.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/sections/echartsTimeSeriesQuery.tsx
@@ -55,6 +55,6 @@ export const echartsTimeSeriesQuery: ControlPanelSectionConfig = {
     ['order_desc'],
     ['row_limit'],
     ['truncate_metric'],
-    ['drop_missing_columns'],
+    ['show_empty_columns'],
   ],
 };

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -542,11 +542,11 @@ const truncate_metric: SharedControlConfig<'CheckboxControl'> = {
   description: t('Whether to truncate metrics'),
 };
 
-const drop_missing_columns: SharedControlConfig<'CheckboxControl'> = {
+const show_empty_columns: SharedControlConfig<'CheckboxControl'> = {
   type: 'CheckboxControl',
-  label: t('Drop Missing Columns'),
-  default: false,
-  description: t('Drop a column if all values are null'),
+  label: t('Show empty columns'),
+  default: true,
+  description: t('Show empty columns'),
 };
 
 const x_axis: SharedControlConfig<'SelectControl', ColumnMeta> = {
@@ -594,7 +594,7 @@ const sharedControls = {
   legacy_order_by: enableExploreDnd ? dnd_sort_by : sort_by,
   truncate_metric,
   x_axis: enableExploreDnd ? dnd_x_axis : x_axis,
-  drop_missing_columns,
+  show_empty_columns,
 };
 
 export { sharedControls, dndEntity, dndColumnsControl };

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/pivotOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/pivotOperator.test.ts
@@ -28,6 +28,7 @@ const formData: SqlaFormData = {
   granularity: 'month',
   datasource: 'foo',
   viz_type: 'table',
+  show_empty_columns: true,
 };
 const queryObject: QueryObject = {
   metrics: [

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/timeComparePivotOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/timeComparePivotOperator.test.ts
@@ -31,6 +31,7 @@ const formData: SqlaFormData = {
   granularity: 'month',
   datasource: 'foo',
   viz_type: 'table',
+  show_empty_columns: true,
 };
 const queryObject: QueryObject = {
   metrics: [

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/buildQuery.test.ts
@@ -48,6 +48,7 @@ const formDataMixedChart = {
   order_desc: true,
   emit_filter: true,
   truncate_metric: true,
+  show_empty_columns: true,
   //   -- query b
   groupby_b: [],
   metrics_b: ['count'],
@@ -64,6 +65,7 @@ const formDataMixedChart = {
   order_desc_b: false,
   emit_filter_b: undefined,
   truncate_metric_b: true,
+  show_empty_columns_b: true,
   // chart configs
   show_value: false,
   show_valueB: undefined,


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
rename the control from "drop missing columns" to "show empty columns", thanks for the heads up from @stephenLYZ.

Default value is true.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![image](https://user-images.githubusercontent.com/2016594/177243693-696d6a4d-da79-4d0c-8727-2d944ea2fadc.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
