### PR TITLE
chore(explore): update Explore icons and icon colors

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/visualizations/line.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/visualizations/line.test.ts
@@ -40,7 +40,10 @@ describe('Visualization > Line', () => {
     cy.get('.panel-body').contains(
       `Add required control values to preview chart`,
     );
-    cy.get('.text-danger').contains('Metrics');
+    cy.get('[data-test="metrics-header"]').contains('Metrics');
+    cy.get('[data-test="metrics-header"] [data-test="error-tooltip"]').should(
+      'exist',
+    );
 
     cy.get('[data-test=metrics]')
       .contains('Drop columns/metrics here or click')
@@ -55,7 +58,11 @@ describe('Visualization > Line', () => {
       .type('sum{enter}');
     cy.get('[data-test="AdhocMetricEdit#save"]').contains('Save').click();
 
-    cy.get('.text-danger').should('not.exist');
+    cy.get('[data-test="metrics-header"]').contains('Metrics');
+    cy.get('[data-test="metrics-header"] [data-test="error-tooltip"]').should(
+      'not.exist',
+    );
+
     cy.get('.ant-alert-warning').should('not.exist');
   });
 

--- a/superset-frontend/src/explore/components/ControlHeader.tsx
+++ b/superset-frontend/src/explore/components/ControlHeader.tsx
@@ -152,7 +152,7 @@ const ControlHeader: FC<ControlHeaderProps> = ({
             </span>
           )}
           {validationErrors?.length > 0 && (
-            <span>
+            <span data-test="error-tooltip">
               <Tooltip
                 id="error-tooltip"
                 placement="top"

--- a/superset-frontend/src/explore/components/ControlHeader.tsx
+++ b/superset-frontend/src/explore/components/ControlHeader.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { FC, ReactNode } from 'react';
+import React, { FC, ReactNode, useMemo, useRef } from 'react';
 import { t, css, useTheme, SupersetTheme } from '@superset-ui/core';
 import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
 import { Tooltip } from 'src/components/Tooltip';
@@ -59,6 +59,18 @@ const ControlHeader: FC<ControlHeaderProps> = ({
   danger,
 }) => {
   const { gridUnit, colors } = useTheme();
+  const hasHadNoErrors = useRef(false);
+  const labelColor = useMemo(() => {
+    if (!validationErrors.length) {
+      hasHadNoErrors.current = true;
+    }
+
+    return hasHadNoErrors.current
+      ? validationErrors.length
+        ? colors.error.base
+        : 'unset'
+      : colors.info.dark1;
+  }, [colors.error.base, colors.info.dark1, validationErrors.length]);
 
   if (!label) {
     return null;
@@ -105,8 +117,6 @@ const ControlHeader: FC<ControlHeaderProps> = ({
     );
   };
 
-  const labelClass = validationErrors?.length > 0 ? 'text-info' : '';
-
   return (
     <div className="ControlHeader" data-test={`${name}-header`}>
       <div className="pull-left">
@@ -123,8 +133,7 @@ const ControlHeader: FC<ControlHeaderProps> = ({
             role="button"
             tabIndex={0}
             onClick={onClick}
-            className={labelClass}
-            style={{ cursor: onClick ? 'pointer' : '' }}
+            style={{ cursor: onClick ? 'pointer' : '', color: labelColor }}
           >
             {label}
           </span>{' '}
@@ -149,9 +158,7 @@ const ControlHeader: FC<ControlHeaderProps> = ({
                 placement="top"
                 title={validationErrors?.join(' ')}
               >
-                <ExclamationCircleOutlined
-                  style={{ color: colors.info.base }}
-                />
+                <ExclamationCircleOutlined style={{ color: labelColor }} />
               </Tooltip>{' '}
             </span>
           )}

--- a/superset-frontend/src/explore/components/ControlHeader.tsx
+++ b/superset-frontend/src/explore/components/ControlHeader.tsx
@@ -22,6 +22,10 @@ import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
 import { Tooltip } from 'src/components/Tooltip';
 import { FormLabel } from 'src/components/Form';
 import Icons from 'src/components/Icons';
+import {
+  ExclamationCircleOutlined,
+  InfoCircleOutlined,
+} from '@ant-design/icons';
 
 type ValidationError = string;
 
@@ -78,12 +82,13 @@ const ControlHeader: FC<ControlHeaderProps> = ({
       >
         {description && (
           <span>
-            <InfoTooltipWithTrigger
-              label={t('description')}
-              tooltip={description}
+            <Tooltip
+              id={`${t('description')}-tooltip`}
+              title={description}
               placement="top"
-              onClick={tooltipOnClick}
-            />{' '}
+            >
+              <InfoCircleOutlined onClick={tooltipOnClick} />
+            </Tooltip>{' '}
           </span>
         )}
         {renderTrigger && (
@@ -100,7 +105,7 @@ const ControlHeader: FC<ControlHeaderProps> = ({
     );
   };
 
-  const labelClass = validationErrors?.length > 0 ? 'text-danger' : '';
+  const labelClass = validationErrors?.length > 0 ? 'text-info' : '';
 
   return (
     <div className="ControlHeader" data-test={`${name}-header`}>
@@ -144,7 +149,9 @@ const ControlHeader: FC<ControlHeaderProps> = ({
                 placement="top"
                 title={validationErrors?.join(' ')}
               >
-                <Icons.ErrorSolid iconColor={colors.error.base} iconSize="s" />
+                <ExclamationCircleOutlined
+                  style={{ color: colors.info.base }}
+                />
               </Tooltip>{' '}
             </span>
           )}

--- a/superset-frontend/src/explore/components/ControlHeader.tsx
+++ b/superset-frontend/src/explore/components/ControlHeader.tsx
@@ -22,10 +22,6 @@ import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
 import { Tooltip } from 'src/components/Tooltip';
 import { FormLabel } from 'src/components/Form';
 import Icons from 'src/components/Icons';
-import {
-  ExclamationCircleOutlined,
-  InfoCircleOutlined,
-} from '@ant-design/icons';
 
 type ValidationError = string;
 
@@ -43,6 +39,16 @@ export type ControlHeaderProps = {
   warning?: string;
   danger?: string;
 };
+
+const iconStyles = css`
+  &.anticon {
+    font-size: unset;
+    .anticon {
+      line-height: unset;
+      vertical-align: unset;
+    }
+  }
+`;
 
 const ControlHeader: FC<ControlHeaderProps> = ({
   name,
@@ -103,7 +109,10 @@ const ControlHeader: FC<ControlHeaderProps> = ({
               title={description}
               placement="top"
             >
-              <InfoCircleOutlined onClick={tooltipOnClick} />
+              <Icons.InfoCircleOutlined
+                css={iconStyles}
+                onClick={tooltipOnClick}
+              />
             </Tooltip>{' '}
           </span>
         )}
@@ -162,7 +171,12 @@ const ControlHeader: FC<ControlHeaderProps> = ({
                 placement="top"
                 title={validationErrors?.join(' ')}
               >
-                <ExclamationCircleOutlined style={{ color: labelColor }} />
+                <Icons.ExclamationCircleOutlined
+                  css={css`
+                    ${iconStyles}
+                    color: ${labelColor};
+                  `}
+                />
               </Tooltip>{' '}
             </span>
           )}

--- a/superset-frontend/src/explore/components/ControlHeader.tsx
+++ b/superset-frontend/src/explore/components/ControlHeader.tsx
@@ -65,11 +65,15 @@ const ControlHeader: FC<ControlHeaderProps> = ({
       hasHadNoErrors.current = true;
     }
 
-    return hasHadNoErrors.current
-      ? validationErrors.length
-        ? colors.error.base
-        : 'unset'
-      : colors.alert.base;
+    if (hasHadNoErrors.current) {
+      if (validationErrors.length) {
+        return colors.error.base;
+      }
+
+      return 'unset';
+    }
+
+    return colors.alert.base;
   }, [colors.error.base, colors.alert.base, validationErrors.length]);
 
   if (!label) {

--- a/superset-frontend/src/explore/components/ControlHeader.tsx
+++ b/superset-frontend/src/explore/components/ControlHeader.tsx
@@ -69,8 +69,8 @@ const ControlHeader: FC<ControlHeaderProps> = ({
       ? validationErrors.length
         ? colors.error.base
         : 'unset'
-      : colors.info.dark1;
-  }, [colors.error.base, colors.info.dark1, validationErrors.length]);
+      : colors.alert.base;
+  }, [colors.error.base, colors.alert.base, validationErrors.length]);
 
   if (!label) {
     return null;
@@ -133,7 +133,7 @@ const ControlHeader: FC<ControlHeaderProps> = ({
             role="button"
             tabIndex={0}
             onClick={onClick}
-            style={{ cursor: onClick ? 'pointer' : '', color: labelColor }}
+            style={{ cursor: onClick ? 'pointer' : '' }}
           >
             {label}
           </span>{' '}

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -56,13 +56,10 @@ import { getSectionsToRender } from 'src/explore/controlUtils';
 import { ExploreActions } from 'src/explore/actions/exploreActions';
 import { ChartState, ExplorePageState } from 'src/explore/types';
 import { Tooltip } from 'src/components/Tooltip';
+import Icons from 'src/components/Icons';
 
 import { rgba } from 'emotion-rgba';
 import { kebabCase } from 'lodash';
-import {
-  ExclamationCircleOutlined,
-  InfoCircleOutlined,
-} from '@ant-design/icons';
 import ControlRow from './ControlRow';
 import Control from './Control';
 import { ExploreAlert } from './ExploreAlert';
@@ -89,6 +86,16 @@ export type ExpandedControlPanelSectionConfig = Omit<
 > & {
   controlSetRows: ExpandedControlItem[][];
 };
+
+const iconStyles = css`
+  &.anticon {
+    font-size: unset;
+    .anticon {
+      line-height: unset;
+      vertical-align: unset;
+    }
+  }
+`;
 
 const actionButtonsContainerStyles = (theme: SupersetTheme) => css`
   display: flex;
@@ -437,7 +444,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
         </span>{' '}
         {description && (
           <Tooltip id={sectionId} title={description}>
-            <InfoCircleOutlined />
+            <Icons.InfoCircleOutlined css={iconStyles} />
           </Tooltip>
         )}
         {hasErrors && (
@@ -445,7 +452,12 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
             id={`${kebabCase('validation-errors')}-tooltip`}
             title="This section contains validation errors"
           >
-            <InfoCircleOutlined style={{ color: errorColor }} />
+            <Icons.InfoCircleOutlined
+              css={css`
+                ${iconStyles}
+                color: ${errorColor};
+              `}
+            />
           </Tooltip>
         )}
       </span>
@@ -576,7 +588,12 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
               placement="right"
               title={props.errorMessage}
             >
-              <ExclamationCircleOutlined style={{ color: errorColor }} />
+              <Icons.ExclamationCircleOutlined
+                css={css`
+                  ${iconStyles}
+                  color: ${errorColor};
+                `}
+              />
             </Tooltip>
           </span>
         )}

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -35,6 +35,7 @@ import {
   DatasourceType,
   css,
   SupersetTheme,
+  useTheme,
 } from '@superset-ui/core';
 import {
   ControlPanelSectionConfig,
@@ -42,7 +43,6 @@ import {
   CustomControlItem,
   Dataset,
   ExpandedControlItem,
-  InfoTooltipWithTrigger,
   sections,
 } from '@superset-ui/chart-controls';
 
@@ -58,6 +58,11 @@ import { ChartState, ExplorePageState } from 'src/explore/types';
 import { Tooltip } from 'src/components/Tooltip';
 
 import { rgba } from 'emotion-rgba';
+import { kebabCase } from 'lodash';
+import {
+  ExclamationCircleOutlined,
+  InfoCircleOutlined,
+} from '@ant-design/icons';
 import ControlRow from './ControlRow';
 import Control from './Control';
 import { ExploreAlert } from './ExploreAlert';
@@ -236,6 +241,7 @@ function getState(
 }
 
 export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
+  const { colors } = useTheme();
   const pluginContext = useContext(PluginContext);
 
   const prevState = usePrevious(props.exploreState);
@@ -405,15 +411,17 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
           {label}
         </span>{' '}
         {description && (
-          // label is only used in tooltip id (should probably call this prop `id`)
-          <InfoTooltipWithTrigger label={sectionId} tooltip={description} />
+          <Tooltip id={sectionId} title={description}>
+            <InfoCircleOutlined />
+          </Tooltip>
         )}
         {hasErrors && (
-          <InfoTooltipWithTrigger
-            label="validation-errors"
-            bsStyle="danger"
-            tooltip="This section contains validation errors"
-          />
+          <Tooltip
+            id={`${kebabCase('validation-errors')}-tooltip`}
+            title="This section contains validation errors"
+          >
+            <InfoCircleOutlined style={{ color: colors.info.base }} />
+          </Tooltip>
         )}
       </span>
     );
@@ -521,7 +529,6 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
         {props.errorMessage && (
           <span
             css={(theme: SupersetTheme) => css`
-              font-size: ${theme.typography.sizes.xs}px;
               margin-left: ${theme.gridUnit * 2}px;
             `}
           >
@@ -531,13 +538,13 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
               placement="right"
               title={props.errorMessage}
             >
-              <i className="fa fa-exclamation-circle text-danger fa-lg" />
+              <ExclamationCircleOutlined style={{ color: colors.info.base }} />
             </Tooltip>
           </span>
         )}
       </>
     ),
-    [props.errorMessage],
+    [colors.info.base, props.errorMessage],
   );
 
   const controlPanelRegistry = getChartControlPanelRegistry();

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -423,7 +423,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
 
     const errorColor = sectionHasHadNoErrors.current[sectionId]
       ? colors.error.base
-      : colors.info.dark1;
+      : colors.alert.base;
 
     const PanelHeader = () => (
       <span data-test="collapsible-control-panel-header">
@@ -559,7 +559,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
 
     const errorColor = dataTabHasHadNoErrors.current
       ? colors.error.base
-      : colors.info.dark1;
+      : colors.alert.base;
 
     return (
       <>
@@ -584,7 +584,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
     );
   }, [
     colors.error.base,
-    colors.info.dark1,
+    colors.alert.base,
     dataTabHasHadNoErrors,
     props.errorMessage,
   ]);


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR changes the info and error icons on the Explore screen to AntD icons, and makes the validation error color ~blue~ **yellow** instead of red if required fields aren't filled because the user just created a new chart or selected a new viz type.  If the user clears required fields that were previously filled, the validation color is still red. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:

https://user-images.githubusercontent.com/13007381/177659825-c566af4f-ca4e-4473-bf90-06bd8642fb23.mov

After:

https://user-images.githubusercontent.com/13007381/179296184-4eb75034-c393-4d0b-a3aa-add985f59758.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Confirm that when creating a new chart, validation errors from missing fields are ~blue~ **yellow** instead of red.
- Confirm that when changing the viz type, validation errors from missing fields are also ~blue~ **yellow** instead of red.
- Confirm that new info and error icons are visible, and that no old-style info or error icons are left on the Explore screen that I missed.
- Confirm that other than the above changes, the UI for Explore looks the same as before.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
