### PR TITLE
fix: enable admin to edit dataset in explore

### DIFF
--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
@@ -139,6 +139,27 @@ test('Click on Edit dataset', async () => {
   ).toBeInTheDocument();
 });
 
+test('Edit dataset should be disabled when user is not admin', async () => {
+  const props = createProps();
+  // @ts-expect-error
+  props.user.roles = {};
+  props.datasource.owners = [];
+  SupersetClientGet.mockImplementation(
+    async () => ({ json: { result: [] } } as any),
+  );
+
+  render(<DatasourceControl {...props} />, {
+    useRedux: true,
+  });
+
+  userEvent.click(screen.getByTestId('datasource-menu-trigger'));
+
+  expect(screen.getByTestId('edit-dataset')).toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
+});
+
 test('Click on View in SQL Lab', async () => {
   const props = createProps();
   const postFormSpy = jest.spyOn(SupersetClient, 'postForm');

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -236,9 +236,9 @@ class DatasourceControl extends React.PureComponent {
 
     const isSqlSupported = datasource.type === 'table';
     const { user } = this.props;
-    const allowEdit = datasource.owners
-      ?.map(o => o.id || o.value)
-      .includes(user.userId) || isUserAdmin(user);
+    const allowEdit =
+      datasource.owners?.map(o => o.id || o.value).includes(user.userId) ||
+      isUserAdmin(user);
 
     const editText = t('Edit dataset');
 

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -238,8 +238,7 @@ class DatasourceControl extends React.PureComponent {
     const { user } = this.props;
     const allowEdit = datasource.owners
       ?.map(o => o.id || o.value)
-      .includes(user.userId);
-    isUserAdmin(user);
+      .includes(user.userId) || isUserAdmin(user);
 
     const editText = t('Edit dataset');
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This pr fixes an issue where the dataset is not editable if user is admin in explore.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

after

https://user-images.githubusercontent.com/17326228/177460715-49060e55-c3da-4cc2-a21c-107f9d99779d.mov



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
