### PR TITLE
fix: Add migration to add created_by_fk as explicit owner for charts and datasets

### DIFF
--- a/superset/migrations/versions/2022-07-05_15-48_409c7b420ab0_add_created_by_fk_as_owner.py
+++ b/superset/migrations/versions/2022-07-05_15-48_409c7b420ab0_add_created_by_fk_as_owner.py
@@ -1,0 +1,134 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add created_by_fk as owner
+
+Revision ID: 409c7b420ab0
+Revises: cdcf3d64daf4
+Create Date: 2022-07-05 15:48:06.029190
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "409c7b420ab0"
+down_revision = "cdcf3d64daf4"
+
+from alembic import op
+from sqlalchemy import and_, Column, insert, Integer
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
+
+Base = declarative_base()
+
+
+class Dataset(Base):
+    __tablename__ = "sl_datasets"
+
+    id = Column(Integer, primary_key=True)
+    created_by_fk = Column(Integer)
+
+
+class DatasetUser(Base):
+    __tablename__ = "sl_dataset_users"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer)
+    dataset_id = Column(Integer)
+
+
+class Slice(Base):
+    __tablename__ = "slices"
+
+    id = Column(Integer, primary_key=True)
+    created_by_fk = Column(Integer)
+
+
+class SliceUser(Base):
+    __tablename__ = "slice_user"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer)
+    slice_id = Column(Integer)
+
+
+class SqlaTable(Base):
+    __tablename__ = "tables"
+
+    id = Column(Integer, primary_key=True)
+    created_by_fk = Column(Integer)
+
+
+class SqlaTableUser(Base):
+    __tablename__ = "sqlatable_user"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer)
+    table_id = Column(Integer)
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    op.execute(
+        insert(DatasetUser).from_select(
+            ["user_id", "dataset_id"],
+            session.query(Dataset.created_by_fk, Dataset.id)
+            .outerjoin(
+                DatasetUser,
+                and_(
+                    DatasetUser.dataset_id == Dataset.id,
+                    DatasetUser.user_id == Dataset.created_by_fk,
+                ),
+            )
+            .filter(DatasetUser.dataset_id == None),
+        )
+    )
+
+    op.execute(
+        insert(SliceUser).from_select(
+            ["user_id", "slice_id"],
+            session.query(Slice.created_by_fk, Slice.id)
+            .outerjoin(
+                SliceUser,
+                and_(
+                    SliceUser.slice_id == Slice.id,
+                    SliceUser.user_id == Slice.created_by_fk,
+                ),
+            )
+            .filter(SliceUser.slice_id == None),
+        )
+    )
+
+    op.execute(
+        insert(SqlaTableUser).from_select(
+            ["user_id", "table_id"],
+            session.query(SqlaTable.created_by_fk, SqlaTable.id)
+            .outerjoin(
+                SqlaTableUser,
+                and_(
+                    SqlaTableUser.table_id == SqlaTable.id,
+                    SqlaTableUser.user_id == SqlaTable.created_by_fk,
+                ),
+            )
+            .filter(SqlaTableUser.table_id == None),
+        )
+    )
+
+
+def downgrade():
+    pass

--- a/superset/migrations/versions/2022-07-05_15-48_409c7b420ab0_add_created_by_fk_as_owner.py
+++ b/superset/migrations/versions/2022-07-05_15-48_409c7b420ab0_add_created_by_fk_as_owner.py
@@ -17,14 +17,14 @@
 """add created_by_fk as owner
 
 Revision ID: 409c7b420ab0
-Revises: cdcf3d64daf4
+Revises: a39867932713
 Create Date: 2022-07-05 15:48:06.029190
 
 """
 
 # revision identifiers, used by Alembic.
 revision = "409c7b420ab0"
-down_revision = "cdcf3d64daf4"
+down_revision = "a39867932713"
 
 from alembic import op
 from sqlalchemy import and_, Column, insert, Integer

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1534,20 +1534,8 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         if self.is_admin():
             return
 
-        # Set of wners that works across ORM models.
-        owners: List[User] = []
-
         orig_resource = db.session.query(resource.__class__).get(resource.id)
-
-        if orig_resource:
-            if hasattr(resource, "owners"):
-                owners += orig_resource.owners
-
-            if hasattr(resource, "owner"):
-                owners.append(orig_resource.owner)
-
-            if hasattr(resource, "created_by"):
-                owners.append(orig_resource.created_by)
+        owners = orig_resource.owners if hasattr(orig_resource, "owners") else []
 
         if g.user.is_anonymous or g.user not in owners:
             raise SupersetSecurityException(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

https://github.com/apache/superset/pull/19854 introduced frontend logic which would check that (for Alpha users) only owners can edit datasets. The issue is the definition of ownership between the frontend and backend differs. Specifically the frontend merely checks whether the user is listed as a owner—per the [owners](https://github.com/apache/superset/blob/master/superset/connectors/sqla/models.py#L694) relationship—whereas the backend uses the [check_ownership](https://github.com/apache/superset/blob/3483446c28113fb9eb1e8adb8978e305ff5e7c65/superset/views/base.py#L647-L691) method which checks (in addition to the `owner` and `owners` relationships) whether the user is the creator. This dichotomy means that creators who are not explicitly listed as owners are unable to edit their datasets.

Unwinding the logic surfaces additional observations regarding ownership for various assets, i.e., charts, dashboards, datasets, and reports:

1. The DAO logic correctly adds the creator as an explicit owner ([example](https://github.com/apache/superset/blob/master/superset/datasets/commands/create.py#L92-L93)) so this isn't an issue for any asset which was created via a DAO commend.
2. Prior to the DAO logic only dashboards contained [pre_add](https://github.com/apache/superset/blob/8e29ec5a6685867ffc035d20999c54c2abe36fb1/superset/views/dashboard/views.py#L96-L97) logic which added the creator as an explicit owner meaning that this issue only impacts historical charts and datasets.
3. The `check_ownership` method contained a check for an `owner` relationship however grepping the code per `git grep "\bowner = relationship\b"` yielded no matches, i.e., it served no purpose.

Given these insights this PR performs the following:

1. It adds a database migration to add all creators as owners (if not already listed) for both charts and datasets. Granted this may be a little presumptive, i.e., we may be re-adding someone as an "owner" who was previously removed, however there's no way to determine what the intent of the current database state is.
2. It updates the `check_ownership` method to remove checking the `owner` (obsolete) and `created_by` (addressed in the migration) fields.

Finally a few things worth noting:

1. The frontend likely should rely on an API call to check ownership to adhere to the DRY principle and ensure that the frontend and backend logic for ownership is consistent.
2. The backend SQLAlchemy `pre_add`, `pre_update`, etc. checks should likely be deprecated given the logic also resides in the DAO commands. This really muddies the code logic and makes it hard to grok how things work (or should work).
3. I'm not really sure why the DAO `validate` command also populates fields, i.e., adds owners. This seems somewhat contradictory and non-intuitive, i.e., validation shouldn't update the model. I gather it was likely for efficiency reasons, but I sense there is merit in rewriting the DAO logic to break up the validation and population phases.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Tested the migration and confirmed that, 

```sql
SELECT 
  s.id, 
  s.created_by_fk
FROM 
  slices s
LEFT OUTER JOIN 
  slice_user su
ON 
 s.id = su.slice_id AND 
 s.created_by_fk = su.user_id  
WHERE 
  su.slice_id IS NULL
```

,

```sql  
SELECT 
  sd.id, 
  sd.created_by_fk
FROM 
   sl_datasets sd
LEFT OUTER JOIN 
  sl_dataset_users sdu
ON 
 sd.id = sdu.dataset_id AND 
 sd.created_by_fk = sdu.user_id  
WHERE 
  sdu.dataset_id IS NULL
```

and

```sql  
SELECT 
  t.id, 
  t.created_by_fk
FROM 
  tables t
LEFT OUTER JOIN 
  sqlatable_user su
ON 
 t.id = su.table_id AND 
 t.created_by_fk = su.user_id  
WHERE 
  su.table_id IS NULL
```

returned no rows.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
