### PR TITLE
docs: fix link for Apache Superset source code

### DIFF
--- a/docs/docs/intro.mdx
+++ b/docs/docs/intro.mdx
@@ -13,7 +13,7 @@ geospatial charts.
 
 Here are a **few different ways you can get started with Superset**:
 
-- Download the [source from Apache Foundation's website](https://dist.apache.org/repos/dist/release/superset/1.4.1/)
+- Download the [source from Apache Foundation's website](https://dist.apache.org/repos/dist/release/superset/)
 - Download the latest Superset version from [Pypi here](https://pypi.org/project/apache-superset/)
 - Setup Superset locally with one command
   using [Docker Compose](installation/installing-superset-using-docker-compose)


### PR DESCRIPTION
### SUMMARY
Currently our docs on https://superset.apache.org/docs/intro/ have a broken link to superset source code on Apache.
It links specifically to 1.4.1 version that is no longer present

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
