### PR TITLE
fix: controls validator glitch

### DIFF
--- a/superset-frontend/src/explore/controlUtils/standardizedFormData.ts
+++ b/superset-frontend/src/explore/controlUtils/standardizedFormData.ts
@@ -187,6 +187,7 @@ export class StandardizedFormData {
      * 4. attach `standardizedFormData` to the initial form_data
      * 5. call formDataOverrides to transform initial form_data if the plugin was defined
      * 6. use final form_data to generate controlsState
+     * 7. to refresh validator message
      * */
     const latestFormData = this.getLatestFormData(targetVizType);
     const publicFormData = {};
@@ -204,6 +205,10 @@ export class StandardizedFormData {
       ...getFormDataFromControls(targetControlsState),
       standardizedFormData: this.serialize(),
     };
+    let rv = {
+      formData: targetFormData,
+      controlsState: targetControlsState,
+    };
 
     const controlPanel = getChartControlPanelRegistry().get(targetVizType);
     if (controlPanel?.formDataOverrides) {
@@ -216,16 +221,17 @@ export class StandardizedFormData {
         },
       };
       getStandardizedControls().clear();
-
-      return {
+      rv = {
         formData: transformed,
         controlsState: getControlsState(exploreState, transformed),
       };
     }
 
-    return {
-      formData: targetFormData,
-      controlsState: targetControlsState,
-    };
+    // refresh validator message
+    rv.controlsState = getControlsState(
+      { ...exploreState, controls: rv.controlsState },
+      rv.formData,
+    );
+    return rv;
   }
 }


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There is a glitch when switching viz from `big number` to `table`, the validator error message can not work correctly in Table. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### Before
![image](https://user-images.githubusercontent.com/2016594/177547904-42801031-272f-4f0b-b1b4-2e38ed367b99.png)

#### After

https://user-images.githubusercontent.com/2016594/177548386-00beb330-08f9-458a-99e8-b049f4e98ea1.mov



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
