### PR TITLE
fix(chart): Time Series set showMaxLabel as null for time xAxis

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -35,7 +35,6 @@ import {
 import { isDerivedSeries } from '@superset-ui/chart-controls';
 import { EChartsCoreOption, SeriesOption } from 'echarts';
 import { ZRLineType } from 'echarts/types/src/util/types';
-import { merge } from 'lodash';
 import {
   EchartsTimeseriesChartProps,
   EchartsTimeseriesFormData,
@@ -342,7 +341,7 @@ export default function transformProps(
      * Not including this in the initial declaration above so if echarts changes the default
      * behavior for other axist types we won't unintentionally override it
      */
-    xAxis = merge(xAxis, { axisLabel: { showMaxLabel: null } });
+    xAxis.axisLabel.showLabel = null;
   }
 
   let yAxis: any = {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -35,12 +35,14 @@ import {
 import { isDerivedSeries } from '@superset-ui/chart-controls';
 import { EChartsCoreOption, SeriesOption } from 'echarts';
 import { ZRLineType } from 'echarts/types/src/util/types';
+import { merge } from 'lodash';
 import {
   EchartsTimeseriesChartProps,
   EchartsTimeseriesFormData,
   EchartsTimeseriesSeriesType,
   TimeseriesChartTransformedProps,
   OrientationType,
+  AxisType,
 } from './types';
 import { DEFAULT_FORM_DATA } from './constants';
 import { ForecastSeriesEnum, ForecastValue } from '../types';
@@ -329,13 +331,23 @@ export default function transformProps(
       rotate: xAxisLabelRotation,
     },
     minInterval:
-      xAxisType === 'time' && timeGrainSqla
+      xAxisType === AxisType.time && timeGrainSqla
         ? TIMEGRAIN_TO_TIMESTAMP[timeGrainSqla]
         : 0,
   };
+
+  if (xAxisType === AxisType.time) {
+    /**
+     * Overriding default behavior (false) for time axis regardless of the granilarity.
+     * Not including this in the initial declaration above so if echarts changes the default
+     * behavior for other axist types we won't unintentionally override it
+     */
+    xAxis = merge(xAxis, { axisLabel: { showMaxLabel: null } });
+  }
+
   let yAxis: any = {
     ...defaultYAxis,
-    type: logAxis ? 'log' : 'value',
+    type: logAxis ? AxisType.log : AxisType.value,
     min,
     max,
     minorTick: { show: true },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -341,7 +341,7 @@ export default function transformProps(
      * Not including this in the initial declaration above so if echarts changes the default
      * behavior for other axist types we won't unintentionally override it
      */
-    xAxis.axisLabel.showLabel = null;
+    xAxis.axisLabel.showMaxLabel = null;
   }
 
   let yAxis: any = {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -94,3 +94,10 @@ export interface EchartsTimeseriesChartProps
 
 export type TimeseriesChartTransformedProps =
   EChartTransformedProps<EchartsTimeseriesFormData>;
+
+export enum AxisType {
+  category = 'category',
+  value = 'value',
+  time = 'time',
+  log = 'log',
+}


### PR DESCRIPTION
### SUMMARY
- Apache Echarts has `showMaxLabel` option set to `false` by default for time axis (https://github.com/apache/echarts/blob/master/src/coord/axisDefault.ts#L178), so we need to override it for our time series charts in order to not be fixed with hidden and instead let the library determine whether to show the label of the max tick
- Add AxisType enum so we stop comparing agains raw strings when checking xAxis type

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
![error](https://user-images.githubusercontent.com/38889534/177609650-947e9ff0-2005-426a-9aa8-558623ef7404.gif)

AFTER:
![test](https://user-images.githubusercontent.com/38889534/177610754-3e12270a-b91a-4a58-b6ef-57870937e5a3.gif)


### TESTING INSTRUCTIONS
1. Go to a time series line chart with monthly data from the example datasets
2. Chose month time grain
3. Expected results: last month should show on X axis

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
