### PR TITLE
chore: rename "uiOverrideRegistry" -> "extensionsRegistry"

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/ui-overrides/ExtensionsRegistry.ts
+++ b/superset-frontend/packages/superset-ui-core/src/ui-overrides/ExtensionsRegistry.ts
@@ -44,7 +44,7 @@ export type Extensions = Partial<{
 
 /**
  * A registry containing extensions which can alter Superset's UI at specific points defined by Superset.
- * See SIP-87: 
+ * See SIP-87: https://github.com/apache/superset/issues/20615
  */
 class ExtensionsRegistry extends TypedRegistry<Extensions> {
   name = 'ExtensionsRegistry';

--- a/superset-frontend/packages/superset-ui-core/src/ui-overrides/ExtensionsRegistry.ts
+++ b/superset-frontend/packages/superset-ui-core/src/ui-overrides/ExtensionsRegistry.ts
@@ -22,13 +22,13 @@ import { TypedRegistry } from '../models';
 import { makeSingleton } from '../utils';
 
 /**
- * A function (or component) which returns text (or marked-up text)
- * This != React.ComponentType. Use that when you want a react component.
+ * A function which returns text (or marked-up text)
+ * If what you want is a react component, don't use this. Use React.ComponentType instead.
  */
 type ReturningDisplayable<P = void> = (props: P) => string | React.ReactElement;
 
 /**
- * This type defines all the UI override options which replace elements of Superset's default UI.
+ * This type defines all available extensions of Superset's default UI.
  * Namespace the keys here to follow the form of 'some_domain.functonality.item'.
  * Take care to name your keys well, as the name describes what this extension point's role is in Superset.
  *
@@ -53,5 +53,5 @@ class ExtensionsRegistry extends TypedRegistry<Extensions> {
 export const getExtensionsRegistry = makeSingleton(ExtensionsRegistry, {});
 
 // Exporting this under the old name for backwards compatibility.
-// After the SIP-87 vote passes it should be safe to remove this.
+// After downstream folks have migrated to `getExtensionsRegistry`, we should remove this.
 export const getUiOverrideRegistry = getExtensionsRegistry;

--- a/superset-frontend/packages/superset-ui-core/src/ui-overrides/ExtensionsRegistry.ts
+++ b/superset-frontend/packages/superset-ui-core/src/ui-overrides/ExtensionsRegistry.ts
@@ -47,7 +47,7 @@ export type Extensions = Partial<{
  * See SIP-87: 
  */
 class ExtensionsRegistry extends TypedRegistry<Extensions> {
-  name = 'UiOverrideRegistry';
+  name = 'ExtensionsRegistry';
 }
 
 export const getExtensionsRegistry = makeSingleton(ExtensionsRegistry, {});

--- a/superset-frontend/packages/superset-ui-core/src/ui-overrides/ExtensionsRegistry.ts
+++ b/superset-frontend/packages/superset-ui-core/src/ui-overrides/ExtensionsRegistry.ts
@@ -21,28 +21,37 @@ import React from 'react';
 import { TypedRegistry } from '../models';
 import { makeSingleton } from '../utils';
 
-/** A function (or component) which returns text (or marked-up text) */
-type UiGeneratorText<P = void> = (props: P) => string | React.ReactElement;
+/**
+ * A function (or component) which returns text (or marked-up text)
+ * This != React.ComponentType. Use that when you want a react component.
+ */
+type ReturningDisplayable<P = void> = (props: P) => string | React.ReactElement;
 
 /**
  * This type defines all the UI override options which replace elements of Superset's default UI.
- * Idea with the keys here is generally to namespace following the form of 'domain.functonality.item'
+ * Namespace the keys here to follow the form of 'some_domain.functonality.item'.
+ * Take care to name your keys well, as the name describes what this extension point's role is in Superset.
  *
  * When defining a new option here, take care to keep any parameters to functions (or components) minimal.
  * Any removal or alteration to a parameter will be considered a breaking change.
  */
-export type UiOverrides = Partial<{
-  'embedded.documentation.description': UiGeneratorText;
+export type Extensions = Partial<{
+  'embedded.documentation.description': ReturningDisplayable;
   'embedded.documentation.url': string;
   'navbar.right': React.ComponentType;
   'welcome.banner': React.ComponentType;
 }>;
 
 /**
- * A registry containing UI customizations to replace elements of Superset's default UI.
+ * A registry containing extensions which can alter Superset's UI at specific points defined by Superset.
+ * See SIP-87: 
  */
-class UiOverrideRegistry extends TypedRegistry<UiOverrides> {
+class ExtensionsRegistry extends TypedRegistry<Extensions> {
   name = 'UiOverrideRegistry';
 }
 
-export const getUiOverrideRegistry = makeSingleton(UiOverrideRegistry, {});
+export const getExtensionsRegistry = makeSingleton(ExtensionsRegistry, {});
+
+// Exporting this under the old name for backwards compatibility.
+// After the SIP-87 vote passes it should be safe to remove this.
+export const getUiOverrideRegistry = getExtensionsRegistry;

--- a/superset-frontend/packages/superset-ui-core/src/ui-overrides/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/ui-overrides/index.tsx
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-export * from './UiOverrideRegistry';
+export * from './ExtensionsRegistry';

--- a/superset-frontend/packages/superset-ui-core/test/ui-overrides/ExtensionsRegistry.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/ui-overrides/ExtensionsRegistry.test.ts
@@ -19,5 +19,5 @@
 import { getExtensionsRegistry } from '@superset-ui/core';
 
 test('should get instance of getExtensionsRegistry', () => {
-  expect(getExtensionsRegistry().name).toBe('UiOverrideRegistry');
+  expect(getExtensionsRegistry().name).toBe('ExtensionsRegistry');
 });

--- a/superset-frontend/packages/superset-ui-core/test/ui-overrides/UiOverrideRegistry.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/ui-overrides/UiOverrideRegistry.test.ts
@@ -16,8 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { getUiOverrideRegistry } from '@superset-ui/core';
+import { getExtensionsRegistry } from '@superset-ui/core';
 
-test('should get instance of getUiOverrideRegistry', () => {
-  expect(getUiOverrideRegistry().name).toBe('UiOverrideRegistry');
+test('should get instance of getExtensionsRegistry', () => {
+  expect(getExtensionsRegistry().name).toBe('UiOverrideRegistry');
 });

--- a/superset-frontend/src/dashboard/components/DashboardEmbedControls.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardEmbedControls.tsx
@@ -22,7 +22,7 @@ import {
   styled,
   SupersetApiError,
   t,
-  getUiOverrideRegistry,
+  getExtensionsRegistry,
 } from '@superset-ui/core';
 import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
 import Modal from 'src/components/Modal';
@@ -33,7 +33,7 @@ import { useToasts } from 'src/components/MessageToasts/withToasts';
 import { FormItem } from 'src/components/Form';
 import { EmbeddedDashboard } from '../types';
 
-const uiOverrideRegistry = getUiOverrideRegistry();
+const extensionsRegistry = getExtensionsRegistry();
 
 type Props = {
   dashboardId: string;
@@ -148,11 +148,11 @@ export const DashboardEmbedControls = ({ dashboardId, onHide }: Props) => {
     return <Loading />;
   }
 
-  const docsDescription = uiOverrideRegistry.get(
+  const docsDescription = extensionsRegistry.get(
     'embedded.documentation.description',
   );
   const docsUrl =
-    uiOverrideRegistry.get('embedded.documentation.url') ??
+    extensionsRegistry.get('embedded.documentation.url') ??
     'https://www.npmjs.com/package/@superset-ui/embedded-sdk';
 
   return (

--- a/superset-frontend/src/views/CRUD/welcome/Welcome.test.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/Welcome.test.tsx
@@ -28,7 +28,7 @@ import Welcome from 'src/views/CRUD/welcome/Welcome';
 import { ReactWrapper } from 'enzyme';
 import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
 import { render, screen } from 'spec/helpers/testing-library';
-import { getUiOverrideRegistry } from '@superset-ui/core';
+import { getExtensionsRegistry } from '@superset-ui/core';
 import setupExtensions from 'src/setup/setupExtensions';
 
 const mockStore = configureStore([thunk]);
@@ -184,9 +184,9 @@ describe('Welcome page with toggle switch', () => {
 });
 
 test('should render an extension component if one is supplied', () => {
-  const uiOverrideRegistry = getUiOverrideRegistry();
+  const extensionsRegistry = getExtensionsRegistry();
 
-  uiOverrideRegistry.set('welcome.banner', () => (
+  extensionsRegistry.set('welcome.banner', () => (
     <>welcome.banner extension component</>
   ));
 

--- a/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useEffect, useState } from 'react';
-import { styled, t, getUiOverrideRegistry } from '@superset-ui/core';
+import { styled, t, getExtensionsRegistry } from '@superset-ui/core';
 import Collapse from 'src/components/Collapse';
 import { User } from 'src/types/bootstrapTypes';
 import { reject } from 'lodash';
@@ -46,7 +46,7 @@ import ChartTable from './ChartTable';
 import SavedQueries from './SavedQueries';
 import DashboardTable from './DashboardTable';
 
-const uiOverrideRegistry = getUiOverrideRegistry();
+const extensionsRegistry = getExtensionsRegistry();
 
 interface WelcomeProps {
   user: User;
@@ -179,7 +179,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
     setItem(LocalStorageKeys.homepage_collapse_state, state);
   };
 
-  const WelcomeTopExtension = uiOverrideRegistry.get('welcome.banner');
+  const WelcomeTopExtension = extensionsRegistry.get('welcome.banner');
 
   useEffect(() => {
     const activeTab = getItem(LocalStorageKeys.homepage_activity_filter, null);

--- a/superset-frontend/src/views/components/Menu.test.tsx
+++ b/superset-frontend/src/views/components/Menu.test.tsx
@@ -22,7 +22,7 @@ import fetchMock from 'fetch-mock';
 import { render, screen } from 'spec/helpers/testing-library';
 import setupExtensions from 'src/setup/setupExtensions';
 import userEvent from '@testing-library/user-event';
-import { getUiOverrideRegistry } from '@superset-ui/core';
+import { getExtensionsRegistry } from '@superset-ui/core';
 import { Menu } from './Menu';
 
 const dropdownItems = [
@@ -486,9 +486,9 @@ test('should render without QueryParamProvider', () => {
 });
 
 test('should render an extension component if one is supplied', () => {
-  const uiOverrideRegistry = getUiOverrideRegistry();
+  const extensionsRegistry = getExtensionsRegistry();
 
-  uiOverrideRegistry.set('navbar.right', () => (
+  extensionsRegistry.set('navbar.right', () => (
     <>navbar.right extension component</>
   ));
 

--- a/superset-frontend/src/views/components/RightMenu.tsx
+++ b/superset-frontend/src/views/components/RightMenu.tsx
@@ -28,7 +28,7 @@ import {
   css,
   SupersetTheme,
   SupersetClient,
-  getUiOverrideRegistry,
+  getExtensionsRegistry,
 } from '@superset-ui/core';
 import { MainNav as Menu } from 'src/components/Menu';
 import { Tooltip } from 'src/components/Tooltip';
@@ -47,7 +47,7 @@ import {
 } from './types';
 import { MenuObjectProps } from './Menu';
 
-const uiOverrideRegistry = getUiOverrideRegistry();
+const extensionsRegistry = getExtensionsRegistry();
 
 const versionInfoStyles = (theme: SupersetTheme) => css`
   padding: ${theme.gridUnit * 1.5}px ${theme.gridUnit * 4}px
@@ -258,7 +258,7 @@ const RightMenu = ({
     }
     return null;
   };
-  const RightMenuExtension = uiOverrideRegistry.get('navbar.right');
+  const RightMenuExtension = extensionsRegistry.get('navbar.right');
 
   const handleDatabaseAdd = () => setQuery({ databaseAdded: true });
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Renaming `uiOverrideRegistry` to the better name `extensionsRegistry`.

Kept the old name around for backwards compatibility. It should be removed later.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
