### PR TITLE
refactor: Remove obsolete HiveEngineSpec.fetch_logs method

### DIFF
--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -149,7 +149,6 @@ class HiveEngineSpec(PrestoEngineSpec):
         hive.TCLIService = patched_TCLIService
         hive.constants = patched_constants
         hive.ttypes = patched_ttypes
-        hive.Cursor.fetch_logs = fetch_logs
 
     @classmethod
     def fetch_data(cls, cursor: Any, limit: int | None = None) -> list[tuple[Any, ...]]:
@@ -361,7 +360,8 @@ class HiveEngineSpec(PrestoEngineSpec):
                 break
 
             try:
-                log = cursor.fetch_logs() or ""
+                logs = cursor.fetch_logs()
+                log = "\n".join(logs) if logs else ""
             except Exception:  # pylint: disable=broad-except
                 logger.warning("Call to GetLog() failed")
                 log = ""
@@ -632,50 +632,3 @@ class HiveEngineSpec(PrestoEngineSpec):
             cursor.execute(sql)
             results = cursor.fetchall()
             return {row[0] for row in results}
-
-
-# TODO: contribute back to pyhive.
-def fetch_logs(  # pylint: disable=protected-access
-    self: Cursor,
-    _max_rows: int = 1024,
-    orientation: TFetchOrientation | None = None,
-) -> str:
-    """Mocked. Retrieve the logs produced by the execution of the query.
-    Can be called multiple times to fetch the logs produced after
-    the previous call.
-    :returns: list<str>
-    :raises: ``ProgrammingError`` when no query has been started
-    .. note::
-        This is not a part of DB-API.
-    """
-    # pylint: disable=import-outside-toplevel
-    from pyhive import hive
-    from TCLIService import ttypes
-    from thrift import Thrift
-
-    orientation = orientation or ttypes.TFetchOrientation.FETCH_NEXT
-    try:
-        req = ttypes.TGetLogReq(operationHandle=self._operationHandle)
-        logs = self._connection.client.GetLog(req).log
-        return logs
-    # raised if Hive is used
-    except (ttypes.TApplicationException, Thrift.TApplicationException) as ex:
-        if self._state == self._STATE_NONE:
-            raise hive.ProgrammingError("No query yet") from ex
-        logs = []
-        while True:
-            req = ttypes.TFetchResultsReq(
-                operationHandle=self._operationHandle,
-                orientation=ttypes.TFetchOrientation.FETCH_NEXT,
-                maxRows=self.arraysize,
-                fetchType=1,  # 0: results, 1: logs
-            )
-            response = self._connection.client.FetchResults(req)
-            hive._check_status(response)
-            assert not response.results.rows, "expected data in columnar format"
-            assert len(response.results.columns) == 1, response.results.columns
-            new_logs = hive._unwrap_column(response.results.columns[0])
-            logs += new_logs
-            if not new_logs:
-                break
-        return "\n".join(logs)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

PyHive now contains the [fetch_log](https://github.com/dropbox/PyHive/blob/b21c507a24ed2f2b0cf15b0b6abb1c43f31d3ee0/pyhive/hive.py#L509-L544) method which makes the `HiveEngineSpec.fetch_logs()` method obsolete—per the comment it mentioned it should be contributed back to PyHive.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
