### PR TITLE
feat(dashboard): make permalinks stable

### DIFF
--- a/superset/key_value/commands/upsert.py
+++ b/superset/key_value/commands/upsert.py
@@ -63,7 +63,7 @@ class UpsertKeyValueCommand(BaseCommand):
         self.value = value
         self.expires_on = expires_on
 
-    def run(self) -> Optional[Key]:
+    def run(self) -> Key:
         try:
             return self.upsert()
         except SQLAlchemyError as ex:
@@ -74,7 +74,7 @@ class UpsertKeyValueCommand(BaseCommand):
     def validate(self) -> None:
         pass
 
-    def upsert(self) -> Optional[Key]:
+    def upsert(self) -> Key:
         filter_ = get_filter(self.resource, self.key)
         entry: KeyValueEntry = (
             db.session.query(KeyValueEntry)

--- a/superset/key_value/utils.py
+++ b/superset/key_value/utils.py
@@ -18,14 +18,15 @@ from __future__ import annotations
 
 from hashlib import md5
 from secrets import token_urlsafe
-from typing import Union
-from uuid import UUID
+from typing import Any, Union
+from uuid import UUID, uuid3
 
 import hashids
 from flask_babel import gettext as _
 
 from superset.key_value.exceptions import KeyValueParseKeyError
 from superset.key_value.types import KeyValueFilter, KeyValueResource
+from superset.utils.core import json_dumps_w_dates
 
 HASHIDS_MIN_LENGTH = 11
 
@@ -63,3 +64,9 @@ def get_uuid_namespace(seed: str) -> UUID:
     md5_obj = md5()
     md5_obj.update(seed.encode("utf-8"))
     return UUID(md5_obj.hexdigest())
+
+
+def get_deterministic_uuid(namespace: str, payload: Any) -> UUID:
+    """Get a deterministic UUID (uuid3) from a salt and a JSON-serializable payload."""
+    payload_str = json_dumps_w_dates(payload, sort_keys=True)
+    return uuid3(get_uuid_namespace(namespace), payload_str)

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -608,8 +608,9 @@ def json_int_dttm_ser(obj: Any) -> float:
     return obj
 
 
-def json_dumps_w_dates(payload: Dict[Any, Any]) -> str:
-    return json.dumps(payload, default=json_int_dttm_ser)
+def json_dumps_w_dates(payload: Dict[Any, Any], sort_keys: bool = False) -> str:
+    """Dumps payload to JSON with Datetime objects properly converted"""
+    return json.dumps(payload, default=json_int_dttm_ser, sort_keys=sort_keys)
 
 
 def error_msg_from_exception(ex: Exception) -> str:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Make dashboard permalink API always return the same key if the request payload is the same---i.e., for a given dashboard state, a user should always get a stable permalink when they request one.

This is a required change for #20552 and #19354 as we don't want to generate a new permalink each time a dashboard report is executed.

The Explore permalink should probably do the same, but this PR only changes the behavior for dashboard permalink just in case it causes any problems.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A. This is a pure backend change. There should be no visible changes to users.

### TESTING INSTRUCTIONS

1. Copy a permalink for dashboard---you can do it in the "..." menu on the dashboard page, or in charts or tabs.
   <img width="575" alt="image" src="https://user-images.githubusercontent.com/335541/177657369-ffa725fa-fed4-4328-9877-4edc9a314b8b.png">

3. The link should always be the same no matter how many times you click on the trigger button/link

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
