### PR TITLE
feat(python): add purge Event logger database

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -73,6 +73,7 @@ if TYPE_CHECKING:
 # Realtime stats logger, a StatsD implementation exists
 STATS_LOGGER = DummyStatsLogger()
 EVENT_LOGGER = DBEventLogger()
+EVENT_LOGGER_PURGE = 365
 
 SUPERSET_LOG_VIEW = True
 


### PR DESCRIPTION
### SUMMARY
An example to add purge for Event Logger in Database, because today Logs tables is not purged and grow to infinity.

Is not perfect, ! :warning: warning this PR can slow down Superset Interface if you have a lot of element in logs table.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/78090694/177745190-366ba70f-120b-4cbb-beae-657f26398ba8.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
