### PR TITLE
fix(databases): Display for credentials input

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
@@ -509,7 +509,7 @@ export const CredentialInfoForm = styled.div`
 
   .input-container {
     .input-upload {
-      display: none;
+      display: none !important;
     }
     .input-upload-current {
       display: flex;


### PR DESCRIPTION
### SUMMARY
- Since our DatabaseConnectionForm is wrapped in a AntD Form now, we need to ensure our custom design is applied in the upload input instead of AntD default one for file input type=file.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
![error](https://user-images.githubusercontent.com/38889534/177763160-d73720ed-6e43-4fbd-8ecd-f1c385989278.gif)

AFTER:
![test](https://user-images.githubusercontent.com/38889534/177763212-d412f0af-963d-4779-a8be-225df3249ca0.gif)


### TESTING INSTRUCTIONS
1. Visit the "Databases" page, hit the "+database+ button
2. Select "Google Bigquery" db
3. Upload JSON file
4. Expected Result: The input field (`UPLOAD CREDENTIALS`) is hidden and only the button is visible.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
