### PR TITLE
fix: Published Dashboard without charts don't show up for non admin users

### DIFF
--- a/superset/dashboards/filters.py
+++ b/superset/dashboards/filters.py
@@ -111,7 +111,7 @@ class DashboardAccessFilter(BaseFilter):  # pylint: disable=too-few-public-metho
 
         datasource_perm_query = (
             db.session.query(Dashboard.id)
-            .join(Dashboard.slices)
+            .join(Dashboard.slices, isouter=True)
             .filter(
                 and_(
                     Dashboard.published.is_(True),

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -494,7 +494,7 @@ class InsertRLSState(str, Enum):
 
 def has_table_query(token_list: TokenList) -> bool:
     """
-    Return if a stament has a query reading from a table.
+    Return if a statement has a query reading from a table.
 
         >>> has_table_query(sqlparse.parse("COUNT(*)")[0])
         False


### PR DESCRIPTION
### SUMMARY

Dashboards created & published that do not contain charts (most common ones, only with markdown content) don't show up in the dashboard list for non admin users.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://user-images.githubusercontent.com/17252075/177771777-44dc9f37-497a-4e8b-a70c-e6c15bc2f779.mov

After:

https://user-images.githubusercontent.com/17252075/177771822-d4f668a4-0349-4b11-8399-00a999019038.mov

### TESTING INSTRUCTIONS

1. Create a dashboard with only markdown content.
2. Publish the dashboard.

The published dashboard should appear in the dashboard list for Alpha users.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
