### PR TITLE
fix(embedded): Ensure guest token is passed to log endpoint

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/connection/SupersetClient.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/SupersetClient.ts
@@ -44,6 +44,7 @@ const SupersetClient: SupersetClientInterface = {
   get: request => getInstance().get(request),
   init: force => getInstance().init(force),
   isAuthenticated: () => getInstance().isAuthenticated(),
+  getGuestToken: () => getInstance().getGuestToken(),
   post: request => getInstance().post(request),
   postForm: (...args) => getInstance().postForm(...args),
   put: request => getInstance().put(request),

--- a/superset-frontend/packages/superset-ui-core/src/connection/SupersetClientClass.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/SupersetClientClass.ts
@@ -158,6 +158,10 @@ export default class SupersetClientClass {
     return this.csrfToken !== null && this.csrfToken !== undefined;
   }
 
+  getGuestToken() {
+    return this.guestToken;
+  }
+
   async get<T extends ParseMethod = 'json'>(
     requestConfig: RequestConfig & { parseMethod?: T },
   ) {

--- a/superset-frontend/packages/superset-ui-core/src/connection/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/types.ts
@@ -152,6 +152,7 @@ export interface SupersetClientInterface
     | 'init'
     | 'isAuthenticated'
     | 'reAuthenticate'
+    | 'getGuestToken'
   > {
   configure: (config?: ClientConfig) => SupersetClientInterface;
   reset: () => void;

--- a/superset-frontend/src/middleware/loggerMiddleware.js
+++ b/superset-frontend/src/middleware/loggerMiddleware.js
@@ -44,6 +44,10 @@ const sendBeacon = events => {
   if (navigator.sendBeacon) {
     const formData = new FormData();
     formData.append('events', safeStringify(events));
+    if (SupersetClient.getGuestToken()) {
+      // if we have a guest token, we need to send it for auth via the form
+      formData.append('guest_token', SupersetClient.getGuestToken());
+    }
     navigator.sendBeacon(endpoint, formData);
   } else {
     SupersetClient.post({


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently when using embedding a dashboard, calls to the `/log/` endpoint return a 401 response. This is because `navigator.sendBeacon` was not sending the guest token used for authentication in the way that `SupersetClient` does.

This PR will ensure the guest token is included so that event logging works for embedded dashboards. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Embed a dashboard 
2. Perform actions that trigger calls to `/log/`
3. See that these calls succeed with a 200 response

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
