### PR TITLE
feat(handlebars plugin): adding handlebars helpers for common math/formatting operations

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -24983,6 +24983,12 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.9.tgz",
       "integrity": "sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q=="
     },
+    "node_modules/currencyformatter.js": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/currencyformatter.js/-/currencyformatter.js-1.0.5.tgz",
+      "integrity": "sha1-+MbZRdzmtn70j0dRaGEajZXJx14=",
+      "peer": true
+    },
     "node_modules/cyclist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
@@ -55371,7 +55377,8 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "handlebars": "^4.7.7"
+        "handlebars": "^4.7.7",
+        "just-handlebars-helpers": "^1.0.19"
       },
       "devDependencies": {
         "@types/jest": "^26.0.0",
@@ -55388,6 +55395,23 @@
         "react-ace": "^9.4.4",
         "react-dom": "^16.13.1"
       }
+    },
+    "plugins/plugin-chart-handlebars/node_modules/just-handlebars-helpers": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/just-handlebars-helpers/-/just-handlebars-helpers-1.0.19.tgz",
+      "integrity": "sha512-E+0eUn5xKfBAoU6mF3QbGZ939PZDw7RYI6AMTpRQtesRH2lZXjXaOqHzJ2nbHnDVmxNQM453sXFnMpd/uaLkKg==",
+      "peerDependencies": {
+        "currencyformatter.js": ">= 1.0.4 < 2",
+        "handlebars": ">= 3.*",
+        "moment": ">= 2.22.0 < 3",
+        "sprintf-js": ">= 1.1.1 < 2"
+      }
+    },
+    "plugins/plugin-chart-handlebars/node_modules/sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+      "peer": true
     },
     "plugins/plugin-chart-pivot-table": {
       "name": "@superset-ui/plugin-chart-pivot-table",
@@ -68176,7 +68200,22 @@
         "@types/jest": "^26.0.0",
         "@types/lodash": "^4.14.149",
         "handlebars": "^4.7.7",
-        "jest": "^26.0.1"
+        "jest": "^26.0.1",
+        "just-handlebars-helpers": "*"
+      },
+      "dependencies": {
+        "just-handlebars-helpers": {
+          "version": "1.0.19",
+          "resolved": "https://registry.npmjs.org/just-handlebars-helpers/-/just-handlebars-helpers-1.0.19.tgz",
+          "integrity": "sha512-E+0eUn5xKfBAoU6mF3QbGZ939PZDw7RYI6AMTpRQtesRH2lZXjXaOqHzJ2nbHnDVmxNQM453sXFnMpd/uaLkKg==",
+          "requires": {}
+        },
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+          "peer": true
+        }
       }
     },
     "@superset-ui/plugin-chart-pivot-table": {
@@ -75265,6 +75304,12 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.9.tgz",
       "integrity": "sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q=="
+    },
+    "currencyformatter.js": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/currencyformatter.js/-/currencyformatter.js-1.0.5.tgz",
+      "integrity": "sha1-+MbZRdzmtn70j0dRaGEajZXJx14=",
+      "peer": true
     },
     "cyclist": {
       "version": "1.0.1",

--- a/superset-frontend/plugins/plugin-chart-handlebars/package.json
+++ b/superset-frontend/plugins/plugin-chart-handlebars/package.json
@@ -26,7 +26,8 @@
     "access": "public"
   },
   "dependencies": {
-    "handlebars": "^4.7.7"
+    "handlebars": "^4.7.7",
+    "just-handlebars-helpers": "^1.0.19"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
@@ -39,8 +40,8 @@
     "react-dom": "^16.13.1"
   },
   "devDependencies": {
-    "@types/lodash": "^4.14.149",
     "@types/jest": "^26.0.0",
+    "@types/lodash": "^4.14.149",
     "jest": "^26.0.1"
   }
 }

--- a/superset-frontend/plugins/plugin-chart-handlebars/src/components/Handlebars/HandlebarsViewer.tsx
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/components/Handlebars/HandlebarsViewer.tsx
@@ -21,6 +21,7 @@ import Handlebars from 'handlebars';
 import moment from 'moment';
 import React, { useMemo, useState } from 'react';
 import { isPlainObject } from 'lodash';
+import Helpers from 'just-handlebars-helpers';
 
 export interface HandlebarsViewerProps {
   templateSource: string;
@@ -73,3 +74,5 @@ Handlebars.registerHelper('stringify', (obj: any, obj2: any) => {
     throw Error('Please call with an object. Example: `stringify myObj`');
   return isPlainObject(obj) ? JSON.stringify(obj) : String(obj);
 });
+
+Helpers.registerHelpers(Handlebars);

--- a/superset-frontend/plugins/plugin-chart-handlebars/types/external.d.ts
+++ b/superset-frontend/plugins/plugin-chart-handlebars/types/external.d.ts
@@ -20,3 +20,5 @@ declare module '*.png' {
   const value: any;
   export default value;
 }
+
+declare module 'just-handlebars-helpers';


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds the `just-handlebars-helpers` [module](https://github.com/leapfrogtechnology/just-handlebars-helpers) to further expand the capabilities of the Handlebars viz plugin, allowing you to do common math operations and such in your templating

Hat tip to @villebro who did the _real_ legwork on this long ago... I'm just making sure it gets into the codebase for all to enjoy :)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - but the world is your oyster :)

### TESTING INSTRUCTIONS
Just give it a whirl! On the ephemeral environment of this PR, or by building something fun on your own. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
