### PR TITLE
fix: annotation broken

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/sections/annotationsAndLayers.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/sections/annotationsAndLayers.tsx
@@ -34,7 +34,7 @@ export const annotationsAndLayersControls: ControlPanelSectionConfig = {
           label: '',
           default: annotationLayers,
           description: t('Annotation Layers'),
-          renderTrigger: true,
+          renderTrigger: false,
         },
       },
     ],

--- a/superset-frontend/packages/superset-ui-core/src/query/types/AnnotationLayer.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/AnnotationLayer.ts
@@ -178,9 +178,9 @@ export function isTimeseriesAnnotationResult(
 }
 
 export function isRecordAnnotationResult(
-  result: AnnotationResult,
+  result: any,
 ): result is RecordAnnotationResult {
-  return 'columns' in result && 'records' in result;
+  return Array.isArray(result?.columns) && Array.isArray(result?.records);
 }
 
 export type AnnotationData = { [key: string]: AnnotationResult };

--- a/superset-frontend/packages/superset-ui-core/src/query/types/QueryResponse.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/QueryResponse.ts
@@ -47,7 +47,7 @@ export interface ChartDataResponseResult {
   /**
    * Data for the annotation layer.
    */
-  annotation_data: AnnotationData[] | null;
+  annotation_data: AnnotationData | null;
   cache_key: string | null;
   cache_timeout: number | null;
   cached_dttm: string | null;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -48,7 +48,10 @@ import {
   getColtypesMapping,
   getLegendProps,
 } from '../utils/series';
-import { extractAnnotationLabels } from '../utils/annotation';
+import {
+  extractAnnotationLabels,
+  getAnnotationData,
+} from '../utils/annotation';
 import {
   extractForecastSeriesContext,
   extractForecastValuesFromTooltipParams,
@@ -81,11 +84,11 @@ export default function transformProps(
     filterState,
     datasource,
     theme,
-    annotationData = {},
   } = chartProps;
   const { verboseMap = {} } = datasource;
   const data1 = (queriesData[0].data || []) as TimeseriesDataRecord[];
   const data2 = (queriesData[1].data || []) as TimeseriesDataRecord[];
+  const annotationData = getAnnotationData(chartProps);
 
   const {
     area,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 /* eslint-disable camelcase */
+import { isEmpty } from 'lodash';
 import {
   AnnotationLayer,
   CategoricalColorNamespace,
@@ -31,6 +32,7 @@ import {
   isTimeseriesAnnotationLayer,
   TimeseriesChartDataResponseResult,
   t,
+  AnnotationData,
 } from '@superset-ui/core';
 import { isDerivedSeries } from '@superset-ui/chart-controls';
 import { EChartsCoreOption, SeriesOption } from 'echarts';
@@ -81,6 +83,16 @@ import {
   TIMEGRAIN_TO_TIMESTAMP,
 } from '../constants';
 
+function getAnnotationData(
+  chartProps: EchartsTimeseriesChartProps,
+): AnnotationData {
+  const data = chartProps?.queriesData[0]?.annotation_data as AnnotationData;
+  if (!isEmpty(data)) {
+    return data;
+  }
+  return {};
+}
+
 export default function transformProps(
   chartProps: EchartsTimeseriesChartProps,
 ): TimeseriesChartTransformedProps {
@@ -93,12 +105,12 @@ export default function transformProps(
     queriesData,
     datasource,
     theme,
-    annotationData = {},
   } = chartProps;
   const { verboseMap = {} } = datasource;
   const [queryData] = queriesData;
   const { data = [] } = queryData as TimeseriesChartDataResponseResult;
   const dataTypes = getColtypesMapping(queryData);
+  const annotationData = getAnnotationData(chartProps);
 
   const {
     area,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 /* eslint-disable camelcase */
-import { isEmpty } from 'lodash';
 import {
   AnnotationLayer,
   CategoricalColorNamespace,
@@ -32,7 +31,6 @@ import {
   isTimeseriesAnnotationLayer,
   TimeseriesChartDataResponseResult,
   t,
-  AnnotationData,
 } from '@superset-ui/core';
 import { isDerivedSeries } from '@superset-ui/chart-controls';
 import { EChartsCoreOption, SeriesOption } from 'echarts';
@@ -57,7 +55,10 @@ import {
   extractDataTotalValues,
   extractShowValueIndexes,
 } from '../utils/series';
-import { extractAnnotationLabels } from '../utils/annotation';
+import {
+  extractAnnotationLabels,
+  getAnnotationData,
+} from '../utils/annotation';
 import {
   extractForecastSeriesContext,
   extractForecastSeriesContexts,
@@ -82,16 +83,6 @@ import {
   TIMESERIES_CONSTANTS,
   TIMEGRAIN_TO_TIMESTAMP,
 } from '../constants';
-
-function getAnnotationData(
-  chartProps: EchartsTimeseriesChartProps,
-): AnnotationData {
-  const data = chartProps?.queriesData[0]?.annotation_data as AnnotationData;
-  if (!isEmpty(data)) {
-    return data;
-  }
-  return {};
-}
 
 export default function transformProps(
   chartProps: EchartsTimeseriesChartProps,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/annotation.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/annotation.ts
@@ -17,6 +17,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { isEmpty } from 'lodash';
+
 import {
   Annotation,
   AnnotationData,
@@ -30,6 +32,8 @@ import {
   isTimeseriesAnnotationResult,
   TimeseriesDataRecord,
 } from '@superset-ui/core';
+import { EchartsTimeseriesChartProps } from '../types';
+import { EchartsMixedTimeseriesProps } from '../MixedTimeseries/types';
 
 export function evalFormula(
   formula: FormulaAnnotationLayer,
@@ -129,4 +133,14 @@ export function extractAnnotationLabels(
     });
 
   return formulaAnnotationLabels.concat(timeseriesAnnotationLabels);
+}
+
+export function getAnnotationData(
+  chartProps: EchartsTimeseriesChartProps | EchartsMixedTimeseriesProps,
+): AnnotationData {
+  const data = chartProps?.queriesData[0]?.annotation_data as AnnotationData;
+  if (!isEmpty(data)) {
+    return data;
+  }
+  return {};
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -174,60 +174,62 @@ describe('EchartsTimeseries transformProps', () => {
       titleColumn: '',
       value: 3,
     };
+    const annotationData = {
+      'My Event': {
+        columns: [
+          'start_dttm',
+          'end_dttm',
+          'short_descr',
+          'long_descr',
+          'json_metadata',
+        ],
+        records: [
+          {
+            start_dttm: 0,
+            end_dttm: 1000,
+            short_descr: '',
+            long_descr: '',
+            json_metadata: null,
+          },
+        ],
+      },
+      'My Interval': {
+        columns: ['start', 'end', 'title'],
+        records: [
+          {
+            start: 2000,
+            end: 3000,
+            title: 'My Title',
+          },
+        ],
+      },
+      'My Timeseries': [
+        {
+          key: 'My Line',
+          values: [
+            {
+              x: 10000,
+              y: 11000,
+            },
+            {
+              x: 20000,
+              y: 21000,
+            },
+          ],
+        },
+      ],
+    };
     const chartProps = new ChartProps({
       ...chartPropsConfig,
       formData: {
         ...formData,
         annotationLayers: [event, interval, timeseries],
       },
-      annotationData: {
-        'My Event': {
-          columns: [
-            'start_dttm',
-            'end_dttm',
-            'short_descr',
-            'long_descr',
-            'json_metadata',
-          ],
-          records: [
-            {
-              start_dttm: 0,
-              end_dttm: 1000,
-              short_descr: '',
-              long_descr: '',
-              json_metadata: null,
-            },
-          ],
-        },
-        'My Interval': {
-          columns: ['start', 'end', 'title'],
-          records: [
-            {
-              start: 2000,
-              end: 3000,
-              title: 'My Title',
-            },
-          ],
-        },
-        'My Timeseries': [
-          {
-            key: 'My Line',
-            values: [
-              {
-                x: 10000,
-                y: 11000,
-              },
-              {
-                x: 20000,
-                y: 21000,
-              },
-            ],
-          },
-        ],
-      },
+      annotationData,
       queriesData: [
         {
           ...queriesData[0],
+          annotation_data: annotationData,
         },
       ],
     });


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, the annotation on the time series chart has been broken.

![image](https://user-images.githubusercontent.com/2016594/177984698-192459b6-7842-445a-bae5-1fbad7b42c62.png)

1. This error is from the TypeScript [type guard function](https://github.com/apache/superset/blob/e33164024a17bb7e6de9d40b9fc60996dc9406fc/superset-frontend/packages/superset-ui-core/src/query/types/AnnotationLayer.ts#L183).
2. The annotation on the master branch doesn't apply annotation_data from the query response.

After these fixes it turns out that the Apply button is not working again, which I think should be fixed in a seprated PR. Also, the annnotation layer logic is very difficult to maintain, I would suggest investing more time in rewriting the current codes.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### After

https://user-images.githubusercontent.com/2016594/177987046-22838736-7cde-452a-afd2-26177bf7f74d.mov




#### Before
![image](https://user-images.githubusercontent.com/2016594/177986549-5a267c13-58d1-442a-8d39-e251ab0cf105.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
