### PR TITLE
fix: X Axis should be called Y Axis when using the Bar Chart V2 on Horizontal mode

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/constants.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/constants.tsx
@@ -25,7 +25,16 @@ import {
 import { ControlPanelState, ControlState } from '../types';
 
 export const xAxisControlConfig = {
-  label: t('X-axis'),
+  label: (state: ControlPanelState) => {
+    if (
+      isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) &&
+      state?.form_data?.orientation === 'horizontal'
+    ) {
+      return t('Y-axis');
+    }
+
+    return t('X-axis');
+  },
   default: (
     control: ControlState,
     controlPanel: Partial<ControlPanelState>,
@@ -43,6 +52,15 @@ export const xAxisControlConfig = {
     return null;
   },
   multi: false,
-  description: t('Dimension to use on x-axis.'),
+  description: (state: ControlPanelState) => {
+    if (
+      isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) &&
+      state?.form_data?.orientation === 'horizontal'
+    ) {
+      return t('Dimension to use on y-axis.');
+    }
+
+    return t('Dimension to use on x-axis.');
+  },
   validators: [validateNonEmpty],
 };

--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -204,8 +204,22 @@ export interface BaseControlConfig<
   V = JsonValue,
 > extends AnyDict {
   type: T;
-  label?: ReactNode;
-  description?: ReactNode;
+  label?:
+    | ReactNode
+    | ((
+        state: ControlPanelState,
+        controlState: ControlState,
+        // TODO: add strict `chartState` typing (see superset-frontend/src/explore/types)
+        chartState?: AnyDict,
+      ) => ReactNode);
+  description?:
+    | ReactNode
+    | ((
+        state: ControlPanelState,
+        controlState: ControlState,
+        // TODO: add strict `chartState` typing (see superset-frontend/src/explore/types)
+        chartState?: AnyDict,
+      ) => ReactNode);
   default?: V;
   renderTrigger?: boolean;
   validators?: ControlValueValidator<T, O, V>[];

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -329,7 +329,12 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
           undefined),
       name,
     };
-    const { validationErrors, ...restProps } = controlData as ControlState & {
+    const {
+      validationErrors,
+      label: baseLabel,
+      description: baseDescription,
+      ...restProps
+    } = controlData as ControlState & {
       validationErrors?: any[];
     };
 
@@ -337,10 +342,22 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
       ? visibility.call(config, props, controlData)
       : undefined;
 
+    const label =
+      typeof baseLabel === 'function'
+        ? baseLabel(exploreState, controls[name], chart)
+        : baseLabel;
+
+    const description =
+      typeof baseDescription === 'function'
+        ? baseDescription(exploreState, controls[name], chart)
+        : baseDescription;
+
     return (
       <Control
         key={`control-${name}`}
         name={name}
+        label={label}
+        description={description}
         validationErrors={validationErrors}
         actions={props.actions}
         isVisible={isVisible}

--- a/superset/translations/nl/LC_MESSAGES/messages.json
+++ b/superset/translations/nl/LC_MESSAGES/messages.json
@@ -2454,6 +2454,8 @@
       ],
       "X-axis": [""],
       "Dimension to use on x-axis.": [""],
+      "Y-axis": [""],
+      "Dimension to use on y-axis.": [""],
       "Percentage threshold": [""],
       "Minimum threshold in percentage points for showing labels.": [""],
       "Rich tooltip": [""],


### PR DESCRIPTION
### SUMMARY

If the feature flag `GENERIC_CHART_AXES` is enabled, the **Time-Series Bar Char v2** becomes **Bar Chart v2** and has a field named **X-Axis**. However, if the Bar Chart is configured on horizontal mode, the X-Axis should be re-named to Y-Axis.

This PR expands the type for the control label & description to be computed, and then does so for the above scenario.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://user-images.githubusercontent.com/17252075/178072360-bd11ef82-8773-4e2d-939b-ddbcd265c9a7.mov

After:

https://user-images.githubusercontent.com/17252075/178069240-784e800c-ed6d-466e-b808-5481e79c05ea.mov

### TESTING INSTRUCTIONS

1. Enable the `GENERIC_CHART_AXES` feature
2. Hover the **+ **icon > **Chart**.
3. Use the `Vehicle Sales` Dataset, and the **Bar Chart v2**.
4. Set `count(*)` on the **Metrics**, and `product_line` on the **X-Axis** field.
5. Navigate to the **CUSTOMIZE** tab.
6. Switch to the **HORIZONTAL** orientation.
7. Navigate back to the **DATA** tab.

Ensure the label changes accordingly.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
