### PR TITLE
fix: reuse existing row on dual write if available

### DIFF
--- a/tests/unit_tests/datasets/commands/importers/v1/import_test.py
+++ b/tests/unit_tests/datasets/commands/importers/v1/import_test.py
@@ -137,6 +137,129 @@ def test_import_dataset(app_context: None, session: Session) -> None:
     assert sqla_table.database.id == database.id
 
 
+def test_import_dataset_duplicate_column(app_context: None, session: Session) -> None:
+    """
+    Test importing a dataset with a column that already exists.
+    """
+    from superset.columns.models import Column as NewColumn
+    from superset.connectors.sqla.models import SqlaTable, TableColumn
+    from superset.datasets.commands.importers.v1.utils import import_dataset
+    from superset.models.core import Database
+
+    engine = session.get_bind()
+    SqlaTable.metadata.create_all(engine)  # pylint: disable=no-member
+
+    dataset_uuid = uuid.uuid4()
+
+    database = Database(database_name="my_database", sqlalchemy_uri="sqlite://")
+
+    session.add(database)
+    session.flush()
+
+    dataset = SqlaTable(
+        uuid=dataset_uuid, table_name="existing_dataset", database_id=database.id
+    )
+    column = TableColumn(column_name="existing_column")
+    session.add(dataset)
+    session.add(column)
+    session.flush()
+
+    config = {
+        "table_name": dataset.table_name,
+        "main_dttm_col": "ds",
+        "description": "This is the description",
+        "default_endpoint": None,
+        "offset": -8,
+        "cache_timeout": 3600,
+        "schema": "my_schema",
+        "sql": None,
+        "params": {
+            "remote_id": 64,
+            "database_name": "examples",
+            "import_time": 1606677834,
+        },
+        "template_params": {
+            "answer": "42",
+        },
+        "filter_select_enabled": True,
+        "fetch_values_predicate": "foo IN (1, 2)",
+        "extra": {"warning_markdown": "*WARNING*"},
+        "uuid": dataset_uuid,
+        "metrics": [
+            {
+                "metric_name": "cnt",
+                "verbose_name": None,
+                "metric_type": None,
+                "expression": "COUNT(*)",
+                "description": None,
+                "d3format": None,
+                "extra": {"warning_markdown": None},
+                "warning_text": None,
+            }
+        ],
+        "columns": [
+            {
+                "column_name": column.column_name,
+                "verbose_name": None,
+                "is_dttm": None,
+                "is_active": None,
+                "type": "INTEGER",
+                "groupby": None,
+                "filterable": None,
+                "expression": "revenue-expenses",
+                "description": None,
+                "python_date_format": None,
+                "extra": {
+                    "certified_by": "User",
+                },
+            }
+        ],
+        "database_uuid": database.uuid,
+        "database_id": database.id,
+    }
+
+    sqla_table = import_dataset(session, config, overwrite=True)
+    assert sqla_table.table_name == dataset.table_name
+    assert sqla_table.main_dttm_col == "ds"
+    assert sqla_table.description == "This is the description"
+    assert sqla_table.default_endpoint is None
+    assert sqla_table.offset == -8
+    assert sqla_table.cache_timeout == 3600
+    assert sqla_table.schema == "my_schema"
+    assert sqla_table.sql is None
+    assert sqla_table.params == json.dumps(
+        {"remote_id": 64, "database_name": "examples", "import_time": 1606677834}
+    )
+    assert sqla_table.template_params == json.dumps({"answer": "42"})
+    assert sqla_table.filter_select_enabled is True
+    assert sqla_table.fetch_values_predicate == "foo IN (1, 2)"
+    assert sqla_table.extra == '{"warning_markdown": "*WARNING*"}'
+    assert sqla_table.uuid == dataset_uuid
+    assert len(sqla_table.metrics) == 1
+    assert sqla_table.metrics[0].metric_name == "cnt"
+    assert sqla_table.metrics[0].verbose_name is None
+    assert sqla_table.metrics[0].metric_type is None
+    assert sqla_table.metrics[0].expression == "COUNT(*)"
+    assert sqla_table.metrics[0].description is None
+    assert sqla_table.metrics[0].d3format is None
+    assert sqla_table.metrics[0].extra == '{"warning_markdown": null}'
+    assert sqla_table.metrics[0].warning_text is None
+    assert len(sqla_table.columns) == 1
+    assert sqla_table.columns[0].column_name == column.column_name
+    assert sqla_table.columns[0].verbose_name is None
+    assert sqla_table.columns[0].is_dttm is False
+    assert sqla_table.columns[0].is_active is True
+    assert sqla_table.columns[0].type == "INTEGER"
+    assert sqla_table.columns[0].groupby is True
+    assert sqla_table.columns[0].filterable is True
+    assert sqla_table.columns[0].expression == "revenue-expenses"
+    assert sqla_table.columns[0].description is None
+    assert sqla_table.columns[0].python_date_format is None
+    assert sqla_table.columns[0].extra == '{"certified_by": "User"}'
+    assert sqla_table.database.uuid == database.uuid
+    assert sqla_table.database.id == database.id
+
+
 def test_import_column_extra_is_string(app_context: None, session: Session) -> None:
     """
     Test importing a dataset when the column extra is a string.


### PR DESCRIPTION
### SUMMARY
We're seeing some integrity errors 
```
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "sl_columns_pkey"
DETAIL:  Key (id)=(x) already exists.
```

on import. 
To avoid  a duplicate primary key violation, I'm copying the existing row from the database instead of copying just the id and trying to use Sqlalchemy to merge the data since the add/merge functionality isn't in this module.

### TESTING INSTRUCTIONS
This is an intermittent error and difficult to reproduce but happens for some people on import. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
