### PR TITLE
feat: Reuse Dashboard redux data in Explore

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/utils/isDefined.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/isDefined.ts
@@ -17,6 +17,6 @@
  * under the License.
  */
 
-export default function isDefined(x: unknown) {
+export default function isDefined<T>(x: T): x is NonNullable<T> {
   return x !== null && x !== undefined;
 }

--- a/superset-frontend/src/dashboard/actions/hydrate.js
+++ b/superset-frontend/src/dashboard/actions/hydrate.js
@@ -150,9 +150,13 @@ export const hydrateDashboard =
         datasource: slice.form_data.datasource,
         description: slice.description,
         description_markeddown: slice.description_markeddown,
-        owners: slice.owners,
+        owners: slice.owners.map(owner => owner.id),
         modified: slice.modified,
         changed_on: new Date(slice.changed_on).getTime(),
+        is_managed_externally: slice.is_managed_externally,
+        query_context: slice.query_context,
+        certified_by: slice.certified_by,
+        certification_details: slice.certification_details,
       };
 
       sliceIds.add(key);

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -302,7 +302,7 @@ class Chart extends React.Component {
       ) {
         window.open(url, '_blank', 'noreferrer');
       } else {
-        this.props.history.push(url);
+        this.props.history.push(url, { dashboardId: this.props.dashboardId });
       }
     } catch (error) {
       logging.error(error);

--- a/superset-frontend/src/explore/actions/hydrateExplore.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.ts
@@ -56,7 +56,7 @@ export const hydrateExplore =
       initialFormData.dashboardId = dashboardId;
     }
     const initialDatasource =
-      datasources?.[initialFormData.datasource] ?? dataset;
+      dataset ?? datasources?.[initialFormData.datasource];
 
     const initialExploreState = {
       form_data: initialFormData,

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -121,6 +121,7 @@ description_markeddown_description = "Sanitized HTML version of the chart descri
 owners_name_description = "Name of an owner of the chart."
 certified_by_description = "Person or group that has certified this chart"
 certification_details_description = "Details of the certification"
+is_managed_externally_description = "If the chart is managed outside externally"
 
 #
 # OpenAPI method specification overrides
@@ -148,6 +149,10 @@ openapi_spec_methods_override = {
 }
 
 
+class UserSchema(Schema):
+    id = fields.Int()
+
+
 class ChartEntityResponseSchema(Schema):
     """
     Schema for a chart object
@@ -165,6 +170,11 @@ class ChartEntityResponseSchema(Schema):
     slice_url = fields.String(description=slice_url_description)
     certified_by = fields.String(description=certified_by_description)
     certification_details = fields.String(description=certification_details_description)
+    is_managed_externally = fields.Boolean(
+        description=is_managed_externally_description
+    )
+    owners = fields.List(fields.Nested(UserSchema))
+    query_context = fields.String(description=query_context_description)
 
 
 class ChartPostSchema(Schema):


### PR DESCRIPTION

### SUMMARY
Currently when user open Explore, we always send a request to `/v1/explore` endpoint, which assembles Explore initial data - slice, form_data and datasource.
When user goes to Explore from Dashboard (by clicking "Edit chart" or char title), most of the data needed to assemble Explore should already be available in Redux store.
This PR implements using data from Dashboard Redux store to initialize Explore without calling `/v1/explore` endpoint.

If user opens Explore from Dashboard, check if slice, formData, datasourceId and datasourceType are available. If they are, fetch datasource metadata and hydrate Explore using slice, formData and datasource.
If they are not available, call `/v1/explore` and hydrate Explore.

We can't reuse datasource from Dashboard. Datasources metadata on Dashboard is trimmed so that datasource contains only columns and metrics used by charts on that dashboard. In Explore we need to be able to access all columns and metrics, which means we must fetch those from API.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Go to dashboard
2. Click "Edit chart"
3. Verify that Explore has opened correctly and that we did not call `/v1/explore/` endpoint
4. Enter Explore from any other entry point (for example Charts list or Welcome page)
5. Verify that we do call `/v1/explore`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
