### PR TITLE
fix: Databricks views showing up as tables

### DIFF
--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -16,7 +16,9 @@
 # under the License.
 
 from datetime import datetime
-from typing import Any, Dict, Optional, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+from sqlalchemy.engine.reflection import Inspector
 
 from superset.constants import USER_AGENT
 from superset.db_engine_specs.base import BaseEngineSpec
@@ -87,3 +89,16 @@ class DatabricksNativeEngineSpec(DatabricksODBCEngineSpec):
         }
         extra.update(BaseEngineSpec.get_extra_params(database))
         return extra
+
+    @classmethod
+    def get_table_names(
+        cls,
+        database: "Database",
+        inspector: Inspector,
+        schema: Optional[str],
+    ) -> List[str]:
+        tables = set(super().get_table_names(database, inspector, schema))
+        views = set(cls.get_view_names(database, inspector, schema))
+        actual_tables = tables - views
+
+        return list(actual_tables)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The Databricks connector returns views as tables, so that they show up twice in SQL Lab:

<img width="416" alt="Screen Shot 2022-07-11 at 11 56 19 AM" src="https://user-images.githubusercontent.com/1534870/178346107-20c0cd79-2020-4d36-a9bd-2613d35b6cf4.png">

This PR fixes it by removing the views from the tables:

<img width="418" alt="Screen Shot 2022-07-11 at 11 54 48 AM" src="https://user-images.githubusercontent.com/1534870/178346150-f3a5a026-b221-4bf2-91a3-67121209eeec.png">

This is the same approach we do for Presto/Trino, BTW.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

See above.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
