### PR TITLE
fix(explore): datatable crash when dimension is empty

### DIFF
--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -314,9 +314,9 @@ export const useTableColumns = (
               const isOriginalTimeColumn =
                 originalFormattedTimeColumns.includes(key);
               return {
-                id: key,
+                // react-table requires a non-empty id, therefore we introduce a fallback value in case the key is empty
+                id: key || index,
                 accessor: row => row[key],
-                // When the key is empty, have to give a string of length greater than 0
                 Header:
                   colType === GenericDataType.TEMPORAL &&
                   typeof firstValue !== 'string' ? (


### PR DESCRIPTION
Fixes https://github.com/apache/superset/issues/20679

### SUMMARY

`react-table` wants every column to have a non-empty ID (or Header), else it will crash. So we simply use the current index as a fallback. From what I can see this has no side effects.

Previously fixed with https://github.com/apache/superset/pull/17303
Reintroduced with https://github.com/apache/superset/pull/18569

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: https://d.pr/i/KQMrPe
After: https://d.pr/i/2qWjaq

### TESTING INSTRUCTIONS

See https://github.com/apache/superset/issues/20679.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/20679