### PR TITLE
fix(dashboard): Fix missing metadata on draggable dashboard edit chart cards

### DIFF
--- a/superset-frontend/src/dashboard/actions/sliceEntities.js
+++ b/superset-frontend/src/dashboard/actions/sliceEntities.js
@@ -75,10 +75,7 @@ export function fetchSlices(
         'url',
         'viz_type',
       ],
-      filters: [
-        { col: 'owners', opr: 'rel_m_m', value: userId },
-        ...additional_filters,
-      ],
+      filters: [...additional_filters],
       page_size: FETCH_SLICES_PAGE_SIZE,
       order_column:
         sortColumn === 'changed_on' ? 'changed_on_delta_humanized' : sortColumn,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, when editing a dashboard, any charts that are already in the dashboard when the Edit button is clicked but are not owned by the current user appear in the sidebar of draggable charts missing metadata.  This is due to a two-step process for downloading charts:
- Charts in the dashboard are added to the Redux store's `sliceEntities.slices` object  when the dashboard is loaded, but are missing the metadata necessary to correctly render as draggable cards.
- When the edit button is clicked, all charts owned by the current user are downloaded with necessary metadata and merged into the `sliceEntities.slices` store object.  Because some charts added to the dashboard might not be owned by the current user, the `sliceEntities.slices` entries for those charts are not updated with the necessary metadata.
This PR removes the filter from the 2nd request that limits it to charts owned by the current user, so all charts are now correctly downloaded and merged into the store object.

**Note: I'm opening this PR under the assumption that this filter was present for no good reason.  If there's a reason that you should only be able to add charts that you own to a dashboard, let me know and I'll find another solution.**

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![Before](https://user-images.githubusercontent.com/13007381/178610807-d8819dea-e902-4b89-87eb-1c42804b301a.png)

After:
![After](https://user-images.githubusercontent.com/13007381/178610835-151d3bce-6b62-467e-a27d-e08f13ef5d2d.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Confirm that metadata now appears for charts that were added to the dashboard previously but that you don't own.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
