### PR TITLE
fix: "Refresh Dashboard" only refreshes active tab

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -162,6 +162,14 @@ class Chart extends React.Component {
       return true;
     }
 
+    // allow chart to update if the status changed and the previous status was loading.
+    if (
+      this.props?.chart?.chartStatus !== nextProps?.chart?.chartStatus &&
+      this.props?.chart?.chartStatus === 'loading'
+    ) {
+      return true;
+    }
+
     // allow chart update/re-render only if visible:
     // under selected tab or no tab layout
     if (nextProps.isComponentVisible) {


### PR DESCRIPTION
### SUMMARY

On a tabbed dashboard, “refresh dashboard” only refreshes the active tab.
Due to performance, charts are not rerendered if their visibility changes, so when switching tabs, you'll get the old values back.

This PR allows the rerendering of the chart if the status changed from the loading status.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://user-images.githubusercontent.com/17252075/178557703-b60e4bb3-0e76-44b9-92e7-6f88f3d5b253.mov

After:

https://user-images.githubusercontent.com/17252075/178558754-bba34095-0f29-4ce5-94ce-54c136e029ba.mov

### TESTING INSTRUCTIONS

1. Create a dataset from SQL lab that can easily be changed `Select 1 as "Test"`
2. Save the chart created from that SQL.
3. Create a Dashboard with 2 tabs
4. Add any chart to the first tab and the one created in 2 to the second tab.

When you load the dashboard and open the tab from the first time, it should show the value correctly.

5. Make sure you visit both tabs, then go back to the first one
6. Change the dataset to `Select 2 as "Test"`
7. Refresh the dashboard
8. Go to the second tab

The chart should display the updated data.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
