### PR TITLE
fix: Revert "feat: Reuse Dashboard redux data in Explore (#20668)"

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/utils/isDefined.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/isDefined.ts
@@ -17,6 +17,6 @@
  * under the License.
  */
 
-export default function isDefined<T>(x: T): x is NonNullable<T> {
+export default function isDefined(x: unknown) {
   return x !== null && x !== undefined;
 }

--- a/superset-frontend/src/dashboard/actions/hydrate.js
+++ b/superset-frontend/src/dashboard/actions/hydrate.js
@@ -150,13 +150,9 @@ export const hydrateDashboard =
         datasource: slice.form_data.datasource,
         description: slice.description,
         description_markeddown: slice.description_markeddown,
-        owners: slice.owners.map(owner => owner.id),
+        owners: slice.owners,
         modified: slice.modified,
         changed_on: new Date(slice.changed_on).getTime(),
-        is_managed_externally: slice.is_managed_externally,
-        query_context: slice.query_context,
-        certified_by: slice.certified_by,
-        certification_details: slice.certification_details,
       };
 
       sliceIds.add(key);

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -302,7 +302,7 @@ class Chart extends React.Component {
       ) {
         window.open(url, '_blank', 'noreferrer');
       } else {
-        this.props.history.push(url, { dashboardId: this.props.dashboardId });
+        this.props.history.push(url);
       }
     } catch (error) {
       logging.error(error);

--- a/superset-frontend/src/explore/ExplorePage.tsx
+++ b/superset-frontend/src/explore/ExplorePage.tsx
@@ -16,13 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useCallback, useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { isDefined, makeApi, SupersetClient, t } from '@superset-ui/core';
-import { useLocation } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { makeApi, t } from '@superset-ui/core';
 import Loading from 'src/components/Loading';
-import pick from 'lodash/pick';
-import { Dataset } from '@superset-ui/chart-controls';
 import { getParsedExploreURLParams } from './exploreUtils/getParsedExploreURLParams';
 import { hydrateExplore } from './actions/hydrateExplore';
 import ExploreViewContainer from './components/ExploreViewContainer';
@@ -30,10 +27,6 @@ import { ExploreResponsePayload } from './types';
 import { fallbackExploreInitialData } from './fixtures';
 import { addDangerToast } from '../components/MessageToasts/actions';
 import { isNullish } from '../utils/common';
-import { getUrlParam } from '../utils/urlUtils';
-import { URL_PARAMS } from '../constants';
-import { RootState } from '../dashboard/types';
-import { Slice } from '../types/Chart';
 
 const loadErrorMessage = t('Failed to load chart data.');
 
@@ -45,58 +38,12 @@ const fetchExploreData = () => {
   })(exploreUrlParams);
 };
 
-const useExploreInitialData = (
-  shouldUseDashboardData: boolean,
-  sliceId: string | null,
-) => {
-  const slice = useSelector<RootState, Slice | null>(({ sliceEntities }) =>
-    isDefined(sliceId) ? sliceEntities?.slices?.[sliceId] : null,
-  );
-  const formData = slice?.form_data;
-  const { id: datasourceId, type: datasourceType } = useSelector<
-    RootState,
-    { id: number | undefined; type: string | undefined }
-  >(({ datasources }) =>
-    formData?.datasource
-      ? pick(datasources[formData.datasource], ['id', 'type'])
-      : { id: undefined, type: undefined },
-  );
-  return useCallback(() => {
-    if (
-      !shouldUseDashboardData ||
-      !isDefined(slice) ||
-      !isDefined(formData) ||
-      !isDefined(datasourceId) ||
-      !isDefined(datasourceType)
-    ) {
-      return fetchExploreData();
-    }
-    return SupersetClient.get({
-      endpoint: `/datasource/get/${datasourceType}/${datasourceId}/`,
-    }).then(({ json }) => ({
-      result: {
-        slice,
-        form_data: formData,
-        dataset: json as Dataset,
-        message: '',
-      },
-    }));
-    /* eslint-disable react-hooks/exhaustive-deps */
-  }, []);
-};
-
 const ExplorePage = () => {
   const [isLoaded, setIsLoaded] = useState(false);
   const dispatch = useDispatch();
-  const location = useLocation<{ dashboardId?: number }>();
-
-  const getExploreInitialData = useExploreInitialData(
-    isDefined(location.state?.dashboardId),
-    getUrlParam(URL_PARAMS.sliceId),
-  );
 
   useEffect(() => {
-    getExploreInitialData()
+    fetchExploreData()
       .then(({ result }) => {
         if (isNullish(result.dataset?.id) && isNullish(result.dataset?.uid)) {
           dispatch(hydrateExplore(fallbackExploreInitialData));

--- a/superset-frontend/src/explore/actions/hydrateExplore.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.ts
@@ -56,7 +56,7 @@ export const hydrateExplore =
       initialFormData.dashboardId = dashboardId;
     }
     const initialDatasource =
-      dataset ?? datasources?.[initialFormData.datasource];
+      datasources?.[initialFormData.datasource] ?? dataset;
 
     const initialExploreState = {
       form_data: initialFormData,

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -121,7 +121,6 @@ description_markeddown_description = "Sanitized HTML version of the chart descri
 owners_name_description = "Name of an owner of the chart."
 certified_by_description = "Person or group that has certified this chart"
 certification_details_description = "Details of the certification"
-is_managed_externally_description = "If the chart is managed outside externally"
 
 #
 # OpenAPI method specification overrides
@@ -149,10 +148,6 @@ openapi_spec_methods_override = {
 }
 
 
-class UserSchema(Schema):
-    id = fields.Int()
-
-
 class ChartEntityResponseSchema(Schema):
     """
     Schema for a chart object
@@ -170,11 +165,6 @@ class ChartEntityResponseSchema(Schema):
     slice_url = fields.String(description=slice_url_description)
     certified_by = fields.String(description=certified_by_description)
     certification_details = fields.String(description=certification_details_description)
-    is_managed_externally = fields.Boolean(
-        description=is_managed_externally_description
-    )
-    owners = fields.List(fields.Nested(UserSchema))
-    query_context = fields.String(description=query_context_description)
 
 
 class ChartPostSchema(Schema):


### PR DESCRIPTION

### SUMMARY
This PR reverts https://github.com/apache/superset/pull/20668.
When user applies native filters and then clicked "Edit chart", the native filters are not added to adhoc filters in Explore.
This problem will disappear when we refactor the way that we transition from Dashboard to Explore (coming in a few days)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
