### PR TITLE
fix(sqllab): Save Dataset Modal Multiple overwrites

### DIFF
--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -19,7 +19,7 @@
 
 import React, { FunctionComponent, useCallback, useState } from 'react';
 import { Radio } from 'src/components/Radio';
-import { RadioChangeEvent, Select } from 'src/components';
+import { RadioChangeEvent, AsyncSelect } from 'src/components';
 import { Input } from 'src/components/Input';
 import StyledModal from 'src/components/Modal';
 import Button from 'src/components/Button';
@@ -158,7 +158,7 @@ export const SaveDatasetModal: FunctionComponent<SaveDatasetModalProps> = ({
             is_dttm: d.is_dttm,
           }),
         ),
-        datasetToOverwrite.owners.map((o: DatasetOwner) => o.id),
+        datasetToOverwrite.owners?.map((o: DatasetOwner) => o.id),
         true,
       ),
       postFormData(datasetToOverwrite.datasetid, 'table', {
@@ -178,7 +178,6 @@ export const SaveDatasetModal: FunctionComponent<SaveDatasetModalProps> = ({
     window.open(url, '_blank', 'noreferrer');
 
     setShouldOverwriteDataset(false);
-    setDatasetToOverwrite({});
     setDatasetName(getDefaultDatasetName());
   };
 
@@ -359,7 +358,7 @@ export const SaveDatasetModal: FunctionComponent<SaveDatasetModalProps> = ({
                   {t('Overwrite existing')}
                 </Radio>
                 <div className="sdm-autocomplete">
-                  <Select
+                  <AsyncSelect
                     allowClear
                     showSearch
                     placeholder={t('Select or type dataset name')}


### PR DESCRIPTION
### SUMMARY
- Stop clearing the selected dataset after overwriting so users can overwrite as many times as they see fit
- There's a new AsyncSelect we should use now

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
![error](https://user-images.githubusercontent.com/38889534/178586539-7841d642-ea1a-4414-876b-0948621fc335.gif)

AFTER:
![test](https://user-images.githubusercontent.com/38889534/178586500-a52aa748-6739-418f-b157-4b0454c6f29a.gif)


### TESTING INSTRUCTIONS
1. Go to "SQL Editor"
2. Edit SQL query
e.g. 
```
SELECT "YEAR",
       "MONTH",
       "DAY"
FROM public.flights
LIMIT 10
```
3. Run the query and then click the "Create Chart" button
4. Select the "Save as new" option and enter the name
5. Click the "Save & Explore" button
6. Repeat steps 1-3
7. Select the "Overwrite existing" and select recently created dataset
8. Click the "Save & Explore" and click the "Overwrite & Explore" button

Expected results:
1. A new tab must open with the chart
2. If you go back to the tab that has the dropdown open you can repeat as many times as you want step 8 from above



### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
