### PR TITLE
fix(dashboard): Native filter on the dashboard with multiple tabs is displayed as out of scope

### DIFF
--- a/superset-frontend/src/dashboard/containers/DashboardPage.tsx
+++ b/superset-frontend/src/dashboard/containers/DashboardPage.tsx
@@ -186,7 +186,9 @@ export const DashboardPage: FC<PageProps> = ({ idOrSlug }: PageProps) => {
       const isOldRison = getUrlParam(URL_PARAMS.nativeFilters);
 
       let dataMask = nativeFilterKeyValue || {};
-      let activeTabs: string[] | undefined = [];
+      // activeTabs is initialized with undefined so that it doesn't override
+      // the currently stored value when hydrating
+      let activeTabs: string[] | undefined;
       if (permalinkKey) {
         const permalinkValue = await getPermalinkValue(permalinkKey);
         if (permalinkValue) {


### PR DESCRIPTION
### SUMMARY

There's a race condition when hydrating the dashboard that's causing the native filters to be treated as out of scope.
The original issue was found and fixed by #17084 by ensuring the hydration happened before the active tabs were set.

However, this #19983 caused a regression by passing to the hydration function an empty array for the active tabs, causing it to override what's already in the state. The state could already have the tabs set cause the function that calls the hydration is under an async callback, un thus could be slower.

By passing undefined as the active tabs (the normal scenario), the issue is solved.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://user-images.githubusercontent.com/17252075/178627163-7fe7a8ff-c2d6-4bb8-9e1c-23e1f32ee80c.mov

After:

https://user-images.githubusercontent.com/17252075/178627188-42c84e52-259a-4e17-bca2-02800f919356.mov

### TESTING INSTRUCTIONS

1. Create 2 charts
2. Create a dashboard with 2 tabs
3. Add 1st chart to 1st tab, 2nd chart to 2nd tab
4. Create a native filter (e.g. value filter), save the changes and revisit the dashboard
5. Pay attention to the native filter

Note that the issue happens on revisit, the first time around it works.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
