### PR TITLE
docs: update elasticsearch.mdx

### DIFF
--- a/docs/docs/databases/elasticsearch.mdx
+++ b/docs/docs/databases/elasticsearch.mdx
@@ -66,3 +66,11 @@ you need to use the `CAST` function,but this function does not support our `time
 After elasticsearch7.8, you can use the `DATETIME_PARSE` function to solve this problem.
 The DATETIME_PARSE function is to support our `time_zone` setting, and here you need to fill in your elasticsearch version number in the Other > VERSION setting.
 the superset will use the `DATETIME_PARSE` function for conversion.
+
+**Disable SSL Verification**
+
+To disable SSL verification, add the following to the **SQLALCHEMY URI** field:
+
+```
+elasticsearch+https://{user}:{password}@{host}:9200/?verify_certs=False
+```


### PR DESCRIPTION
Documentation for Elasticsearch Driver: disable ssl verification

### SUMMARY
Configuration to get rid of "urllib3.exceptions.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate in certificate chain (_ssl.c:1131)"


### TESTING INSTRUCTIONS
If using an https connection to Elasticsearch requiring a certificate, add a new database connection without ssl_verify=false and check logs:
urllib3.exceptions.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate in certificate chain (_ssl.c:1131)"

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
