### PR TITLE
fix: Show all columns from dataset when transitioning from dashboard to Explore

### DIFF
--- a/superset-frontend/src/explore/actions/hydrateExplore.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.ts
@@ -56,7 +56,7 @@ export const hydrateExplore =
       initialFormData.dashboardId = dashboardId;
     }
     const initialDatasource =
-      datasources?.[initialFormData.datasource] ?? dataset;
+      dataset ?? datasources?.[initialFormData.datasource];
 
     const initialExploreState = {
       form_data: initialFormData,


### PR DESCRIPTION
### SUMMARY
Due to the fact that dashboards use trimmed datasets (they only contain columns used by charts on that dashboard), we can't reuse them in Explore. This PR fixes that behaviour.

This PR is a "subset" of PR https://github.com/apache/superset/pull/20699 which fixes the same thing, but also introduces a code refactor. CI was failing on that PR, and since it's an urgent bug I decided to open a smaller PR to quickly fix the issue.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/15073128/178796194-234da0de-b867-4696-b387-8987c74ee518.png">

After:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/15073128/178796053-71909bb2-f68c-4298-a3b6-e6730bd41164.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
