### PR TITLE
fix(explore): Re-enable Explore re-render on Save As

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/link.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/link.test.ts
@@ -28,7 +28,7 @@ import { HEALTH_POP_FORM_DATA_DEFAULTS } from './visualizations/shared.helper';
 const apiURL = (endpoint: string, queryObject: Record<string, unknown>) =>
   `${endpoint}?q=${rison.encode(queryObject)}`;
 
-describe.skip('Test explore links', () => {
+describe('Test explore links', () => {
   beforeEach(() => {
     cy.login();
     interceptChart({ legacy: true }).as('chartData');

--- a/superset-frontend/src/datasource/reducer.ts
+++ b/superset-frontend/src/datasource/reducer.ts
@@ -23,10 +23,14 @@ import {
   DatasourcesActionType,
 } from 'src/datasource/actions';
 import { Dataset } from '@superset-ui/chart-controls';
+import {
+  HydrateExplore,
+  HYDRATE_EXPLORE,
+} from 'src/explore/actions/hydrateExplore';
 
 export default function datasourcesReducer(
   datasources: { [key: string]: Dataset } | undefined,
-  action: DatasourcesAction,
+  action: DatasourcesAction | HydrateExplore,
 ) {
   if (action.type === DatasourcesActionType.INIT_DATASOURCES) {
     return { ...action.datasources };
@@ -42,6 +46,9 @@ export default function datasourcesReducer(
       ...datasources,
       [getDatasourceUid(action.datasource)]: action.datasource,
     };
+  }
+  if (action.type === HYDRATE_EXPLORE) {
+    return { ...(action as HydrateExplore).data.datasources };
   }
   return datasources || {};
 }

--- a/superset-frontend/src/explore/actions/hydrateExplore.test.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.test.ts
@@ -64,6 +64,19 @@ test('creates hydrate action from initial data', () => {
             lastRendered: 0,
           },
         },
+        datasources: {
+          '8__table': {
+            column_format: {},
+            columns: [{ column_name: 'a' }],
+            datasource_name: '8__table',
+            description: null,
+            id: 8,
+            main_dttm_col: '',
+            metrics: [{ metric_name: 'first' }, { metric_name: 'second' }],
+            type: 'table',
+            verbose_map: {},
+          },
+        },
         saveModal: {
           dashboards: [],
           saveModalAlert: null,

--- a/superset-frontend/src/explore/actions/hydrateExplore.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.ts
@@ -35,7 +35,6 @@ import { getDatasourceUid } from 'src/utils/getDatasourceUid';
 import { getUrlParam } from 'src/utils/urlUtils';
 import { URL_PARAMS } from 'src/constants';
 import { findPermission } from 'src/utils/findPermission';
-import { initDatasources } from 'src/datasource/actions';
 
 export const HYDRATE_EXPLORE = 'HYDRATE_EXPLORE';
 export const hydrateExplore =
@@ -121,19 +120,16 @@ export const hydrateExplore =
       lastRendered: 0,
     };
 
-    dispatch(
-      initDatasources({
-        ...datasources,
-        [getDatasourceUid(initialDatasource)]: initialDatasource,
-      }),
-    );
-
     return dispatch({
       type: HYDRATE_EXPLORE,
       data: {
         charts: {
           ...charts,
           [chartKey]: chart,
+        },
+        datasources: {
+          ...datasources,
+          [getDatasourceUid(initialDatasource)]: initialDatasource,
         },
         saveModal: {
           dashboards: [],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The combination of #20498 and #20645 caused a regression in Explore logic such that when a chart is saved as a new chart, the chart wouldn't render once the modal was closed without clicking the "Update Chart" button.  This broke a Cypress test, `explore/link.test.ts` that's currently failing on master, but which wasn't picked up by CI before merge because CI on #20645 was run before #20498 had been merged and the two PRs didn't have any conflicts that would prompt GH to require a rebase.  This PR reverts a little bit of #20645, making the `HYDRATE_EXPLORE` Redux action once again update the `datasources` store key in the same step instead of in a different step.  I don't really understand why this change fixes the issue, but it seems like the Explore components only refresh as expected if `datasources` is updated as part of the `HYDRATE_EXPLORE` action.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:

https://user-images.githubusercontent.com/13007381/178867373-61856316-c0b5-434f-a62b-a91801da183e.mov

After:

https://user-images.githubusercontent.com/13007381/178867380-54804f8b-4f64-4d69-9f3a-a33e07133078.mov

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Check that saving a chart as a new chart causes the chart to render.
- Check that Cypress tests are now passing.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
