### PR TITLE
fix: Fixes the instructions to publish to PyPI

### DIFF
--- a/RELEASING/README.md
+++ b/RELEASING/README.md
@@ -458,10 +458,13 @@ while requesting access to push packages.
 
 ```bash
 twine upload dist/apache-superset-${SUPERSET_VERSION}.tar.gz
-
-# Set your username to token
-# Set your password to the token value, including the pypi- prefix
 ```
+
+Set your username to `__token__`
+
+Set your password to the token value, including the `pypi-` prefix
+
+More information on https://pypi.org/help/#apitoken
 
 ### Announcing
 


### PR DESCRIPTION
### SUMMARY
Fixes the instructions to publish to [PyPI](https://pypi.org/).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
