### PR TITLE
fix: Re-add schema as a searchable field for the datasets v1 API

### DIFF
--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -204,7 +204,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         "sql": [DatasetIsNullOrEmptyFilter],
         "id": [DatasetCertifiedFilter],
     }
-    search_columns = ["id", "database", "owners", "sql", "table_name"]
+    search_columns = ["id", "database", "owners", "schema", "sql", "table_name"]
     filter_rel_fields = {"database": [["id", DatabaseFilter, lambda: []]]}
     allowed_rel_fields = {"database", "owners"}
     allowed_distinct_fields = {"schema"}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR fixes a regression introduced in https://github.com/apache/superset/pull/20136 where at Airbnb an existing `api/v1/dataset` GET request broke which was filtering on the `schema` name, i.e.,

```
{
  "message": "Filter column: schema not allowed to filter"
}
```

The fix is to include `schema` in the `search_columns`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Verified that the API request succeeded.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
