### PR TITLE
fix: Ensure main_dttm_col is adhered to for non-drag-and-drop

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -289,14 +289,14 @@ const granularity_sqla: SharedControlConfig<'SelectControl', ColumnMeta> = {
   mapStateToProps: state => {
     const props: Partial<SelectControlConfig<ColumnMeta | QueryColumn>> = {};
     const { datasource } = state;
-    if (datasource?.columns[0]?.hasOwnProperty('main_dttm_col')) {
+    if (datasource?.hasOwnProperty('main_dttm_col')) {
       const dataset = datasource as Dataset;
       props.options = dataset.columns.filter((c: ColumnMeta) => c.is_dttm);
       props.default = null;
       if (dataset.main_dttm_col) {
         props.default = dataset.main_dttm_col;
       } else if (props?.options) {
-        props.default = (props.options[0] as ColumnMeta).column_name;
+        props.default = (props.options[0] as ColumnMeta)?.column_name;
       }
     } else {
       const sortedQueryColumns = (datasource as QueryResponse)?.columns?.sort(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR fixes a regression introduced in https://github.com/apache/superset/pull/19855 where for non-drag-and-drop the `main_dttm_col` wasn't being adhered to when creating a new chart.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE

<img width="618" alt="Screen Shot 2022-07-14 at 7 20 53 PM" src="https://user-images.githubusercontent.com/4567245/179133835-e25c0976-bf21-4ce8-83e5-4a3104f27d64.png">

#### AFTER

<img width="619" alt="Screen Shot 2022-07-14 at 7 18 18 PM" src="https://user-images.githubusercontent.com/4567245/179133845-8dbc88ff-cd77-47ba-8efe-842ee5272cd7.png">


### TESTING INSTRUCTIONS

Tested locally.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
