### PR TITLE
chore: add apache header for 2.0 changelog

### DIFF
--- a/RELEASING/release-notes-2-0/changelog.md
+++ b/RELEASING/release-notes-2-0/changelog.md
@@ -1,5 +1,26 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
 ### 2.0 (Thu Jun 23 05:39:46 2022 -0600)
+
 **Database Migrations**
+
 - [#20385](https://github.com/apache/superset/pull/20385) fix(migration): Ensure key_value LargeBinary is encoded as a MEDIUMBLOB as opposed to BLOB for MySQL (@john-bodley)
 - [#20449](https://github.com/apache/superset/pull/20449) fix: RLS new db migration downgrade fails on SQLite (@dpgaspar)
 - [#20284](https://github.com/apache/superset/pull/20284) chore(migrations): Renaming migration files so that they're easier to keep track of (@craig-rueda)


### PR DESCRIPTION
CI is currently throwing errors. 

<img width="960" alt="image" src="https://user-images.githubusercontent.com/335541/179125792-3bbd86e5-072c-45d8-ad52-6e943fe9c4fb.png">

Although it's not blocking merges, would be nice to not have to see the ❌ .