### PR TITLE
fix(charts): Scrollbar after removing an annotation

### DIFF
--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/index.jsx
@@ -26,7 +26,9 @@ import AsyncEsmComponent from 'src/components/AsyncEsmComponent';
 import { getChartKey } from 'src/explore/exploreUtils';
 import { runAnnotationQuery } from 'src/components/Chart/chartAction';
 import CustomListItem from 'src/explore/components/controls/CustomListItem';
-import ControlPopover from '../ControlPopover/ControlPopover';
+import ControlPopover, {
+  getSectionContainerElement,
+} from '../ControlPopover/ControlPopover';
 
 const AnnotationLayer = AsyncEsmComponent(
   () => import('./AnnotationLayer'),
@@ -114,6 +116,11 @@ class AnnotationLayerControl extends React.PureComponent {
 
   removeAnnotationLayer(annotation) {
     const annotations = this.props.value.filter(anno => anno !== annotation);
+    // So scrollbar doesnt get stuck on hidden
+    const element = getSectionContainerElement();
+    if (element) {
+      element.style.setProperty('overflow-y', 'auto', 'important');
+    }
     this.props.onChange(annotations);
   }
 

--- a/superset-frontend/src/explore/components/controls/ControlPopover/ControlPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/ControlPopover/ControlPopover.tsx
@@ -24,7 +24,7 @@ import Popover, {
 } from 'src/components/Popover';
 
 const sectionContainerId = 'controlSections';
-const getSectionContainerElement = () =>
+export const getSectionContainerElement = () =>
   document.getElementById(sectionContainerId)?.lastElementChild as HTMLElement;
 
 const getElementYVisibilityRatioOnContainer = (node: HTMLElement) => {


### PR DESCRIPTION
### SUMMARY
`ControlPopover` is in charge of handling the scroll status, however, after we remove an annotation, its ControlPopover is not longer available thus the scroll status stays hidden. We need reset it to be auto so the scroll bar shows

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![error](https://user-images.githubusercontent.com/38889534/179192800-705ee7b7-3a69-4580-a6dc-fc332a69cb0a.gif)

After:
![test](https://user-images.githubusercontent.com/38889534/179192847-44deb234-a65a-4d1d-b17f-0a8a541a1273.gif)

### TESTING INSTRUCTIONS
1. open mix-time series chart in explore
2. add annotation
3. remove annotation
4. Expected results: Scrollbar is still showing in the control panel section after you remove the annotation

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
