### PR TITLE
fix: Use cache_manager.cache rather than cache_manager.data_cache for caching table metadata

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -511,7 +511,7 @@ class Database(
 
     @cache_util.memoized_func(
         key="db:{self.id}:schema:None:table_list",
-        cache=cache_manager.data_cache,
+        cache=cache_manager.cache,
     )
     def get_all_table_names_in_database(  # pylint: disable=unused-argument
         self,
@@ -531,7 +531,7 @@ class Database(
 
     @cache_util.memoized_func(
         key="db:{self.id}:schema:None:view_list",
-        cache=cache_manager.data_cache,
+        cache=cache_manager.cache,
     )
     def get_all_view_names_in_database(  # pylint: disable=unused-argument
         self,
@@ -551,7 +551,7 @@ class Database(
 
     @cache_util.memoized_func(
         key="db:{self.id}:schema:{schema}:table_list",
-        cache=cache_manager.data_cache,
+        cache=cache_manager.cache,
     )
     def get_all_table_names_in_schema(  # pylint: disable=unused-argument
         self,
@@ -582,7 +582,7 @@ class Database(
 
     @cache_util.memoized_func(
         key="db:{self.id}:schema:{schema}:view_list",
-        cache=cache_manager.data_cache,
+        cache=cache_manager.cache,
     )
     def get_all_view_names_in_schema(  # pylint: disable=unused-argument
         self,
@@ -613,7 +613,7 @@ class Database(
 
     @cache_util.memoized_func(
         key="db:{self.id}:schema_list",
-        cache=cache_manager.data_cache,
+        cache=cache_manager.cache,
     )
     def get_all_schema_names(  # pylint: disable=unused-argument
         self,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

The `cache_manager.cache`—the original catch-all cache which likely should be renames to `cache_manager.metadata_cache`—should be used for caching the table/view metadata as opposed to the `cache_manager.data_cache` which is used to cache non-metadata data.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
