### PR TITLE
fix(docker): Fixing broken node build

### DIFF
--- a/docker/docker-frontend.sh
+++ b/docker/docker-frontend.sh
@@ -17,8 +17,11 @@
 #
 set -e
 
+# Packages needed for puppeteer:
+apt update
+apt install -y chromium
+
 cd /app/superset-frontend
-npm install -g npm@7
 npm install -f --no-optional --global webpack webpack-cli
 npm install -f --no-optional
 


### PR DESCRIPTION
### SUMMARY
The node container used to build local assets in `docker compose up` was failing to run `npm install` due to a missing dependency. This PR fixes this issue by adding the dependency that's required.