### PR TITLE
feat(dashboard): Add Drill to Detail modal w/ chart menu + right-click support

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
@@ -32,26 +32,33 @@ import { PostProcessingRule } from './PostProcessing';
 import { JsonObject } from '../../connection';
 import { TimeGranularity } from '../../time-format';
 
-export type QueryObjectFilterClause = {
+export type BaseQueryObjectFilterClause = {
   col: QueryFormColumn;
   grain?: TimeGranularity;
   isExtra?: boolean;
-} & (
-  | {
-      op: BinaryOperator;
-      val: string | number | boolean | null | Date;
-      formattedVal?: string;
-    }
-  | {
-      op: SetOperator;
-      val: (string | number | boolean | null | Date)[];
-      formattedVal?: string[];
-    }
-  | {
-      op: UnaryOperator;
-      formattedVal?: string;
-    }
-);
+};
+
+export type BinaryQueryObjectFilterClause = BaseQueryObjectFilterClause & {
+  op: BinaryOperator;
+  val: string | number | boolean | null | Date;
+  formattedVal?: string;
+};
+
+export type SetQueryObjectFilterClause = BaseQueryObjectFilterClause & {
+  op: SetOperator;
+  val: (string | number | boolean | null | Date)[];
+  formattedVal?: string[];
+};
+
+export type UnaryQueryObjectFilterClause = BaseQueryObjectFilterClause & {
+  op: UnaryOperator;
+  formattedVal?: string;
+};
+
+export type QueryObjectFilterClause =
+  | BinaryQueryObjectFilterClause
+  | SetQueryObjectFilterClause
+  | UnaryQueryObjectFilterClause;
 
 export type QueryObjectExtras = Partial<{
   /** HAVING condition for Druid */
@@ -401,5 +408,9 @@ export enum ContributionType {
   Row = 'row',
   Column = 'column',
 }
+
+export type DatasourceSamplesQuery = {
+  filters?: QueryObjectFilterClause[];
+};
 
 export default {};

--- a/superset-frontend/src/components/Chart/ChartRenderer.jsx
+++ b/superset-frontend/src/components/Chart/ChartRenderer.jsx
@@ -30,6 +30,7 @@ import {
 import { Logger, LOG_ACTIONS_RENDER_CHART } from 'src/logger/LogUtils';
 import { EmptyStateBig, EmptyStateSmall } from 'src/components/EmptyState';
 import ChartContextMenu from './ChartContextMenu';
+import DrillDetailModal from './DrillDetailModal';
 
 const propTypes = {
   annotationData: PropTypes.object,
@@ -83,6 +84,7 @@ class ChartRenderer extends React.Component {
     super(props);
     this.state = {
       inContextMenu: false,
+      drillDetailFilters: null,
     };
     this.hasQueryResponseChange = false;
 
@@ -202,10 +204,7 @@ class ChartRenderer extends React.Component {
   }
 
   handleContextMenuSelected(filters) {
-    const extraFilters = this.props.formData.extra_form_data?.filters || [];
-    // eslint-disable-next-line no-alert
-    alert(JSON.stringify(filters.concat(extraFilters)));
-    this.setState({ inContextMenu: false });
+    this.setState({ inContextMenu: false, drillDetailFilters: filters });
   }
 
   handleContextMenuClosed() {
@@ -289,12 +288,19 @@ class ChartRenderer extends React.Component {
     return (
       <div>
         {this.props.source === 'dashboard' && (
-          <ChartContextMenu
-            ref={this.contextMenuRef}
-            id={chartId}
-            onSelection={this.handleContextMenuSelected}
-            onClose={this.handleContextMenuClosed}
-          />
+          <>
+            <ChartContextMenu
+              ref={this.contextMenuRef}
+              id={chartId}
+              onSelection={this.handleContextMenuSelected}
+              onClose={this.handleContextMenuClosed}
+            />
+            <DrillDetailModal
+              chartId={chartId}
+              initialFilters={this.state.drillDetailFilters}
+              formData={currentFormData}
+            />
+          </>
         )}
         <SuperChart
           disableErrorBoundary

--- a/superset-frontend/src/components/Chart/DrillDetailModal.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetailModal.tsx
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { useSelector } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import {
+  BinaryQueryObjectFilterClause,
+  QueryFormData,
+  t,
+} from '@superset-ui/core';
+import DrillDetailPane from 'src/dashboard/components/DrillDetailPane';
+import { DashboardPageIdContext } from 'src/dashboard/containers/DashboardPage';
+import { Slice } from 'src/types/Chart';
+import Modal from '../Modal';
+import Button from '../Button';
+
+const DrillDetailModal: React.FC<{
+  chartId: number;
+  initialFilters?: BinaryQueryObjectFilterClause[];
+  formData: QueryFormData;
+}> = ({ chartId, initialFilters, formData }) => {
+  const [showModal, setShowModal] = useState(false);
+  const openModal = useCallback(() => setShowModal(true), []);
+  const closeModal = useCallback(() => setShowModal(false), []);
+  const history = useHistory();
+  const dashboardPageId = useContext(DashboardPageIdContext);
+  const { slice_name: chartName } = useSelector(
+    (state: { sliceEntities: { slices: Record<number, Slice> } }) =>
+      state.sliceEntities.slices[chartId],
+  );
+
+  const exploreUrl = useMemo(
+    () => `/explore/?dashboard_page_id=${dashboardPageId}&slice_id=${chartId}`,
+    [chartId, dashboardPageId],
+  );
+
+  const exploreChart = useCallback(() => {
+    history.push(exploreUrl);
+  }, [exploreUrl, history]);
+
+  //  Trigger modal open when initial filters change
+  useEffect(() => {
+    if (initialFilters) {
+      openModal();
+    }
+  }, [initialFilters, openModal]);
+
+  return (
+    <Modal
+      show={showModal}
+      onHide={closeModal}
+      title={t('Drill to detail: %s', chartName)}
+      footer={
+        <>
+          <Button
+            buttonStyle="secondary"
+            buttonSize="small"
+            onClick={exploreChart}
+          >
+            {t('Edit chart')}
+          </Button>
+          <Button buttonStyle="primary" buttonSize="small" onClick={closeModal}>
+            {t('Close')}
+          </Button>
+        </>
+      }
+      responsive
+      resizable
+      draggable
+      destroyOnClose
+    >
+      <DrillDetailPane formData={formData} initialFilters={initialFilters} />
+    </Modal>
+  );
+};
+
+export default DrillDetailModal;

--- a/superset-frontend/src/components/Chart/DrillDetailModal.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetailModal.tsx
@@ -28,8 +28,10 @@ import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import {
   BinaryQueryObjectFilterClause,
+  css,
   QueryFormData,
   t,
+  useTheme,
 } from '@superset-ui/core';
 import DrillDetailPane from 'src/dashboard/components/DrillDetailPane';
 import { DashboardPageIdContext } from 'src/dashboard/containers/DashboardPage';
@@ -46,6 +48,7 @@ const DrillDetailModal: React.FC<{
   const openModal = useCallback(() => setShowModal(true), []);
   const closeModal = useCallback(() => setShowModal(false), []);
   const history = useHistory();
+  const theme = useTheme();
   const dashboardPageId = useContext(DashboardPageIdContext);
   const { slice_name: chartName } = useSelector(
     (state: { sliceEntities: { slices: Record<number, Slice> } }) =>
@@ -70,6 +73,12 @@ const DrillDetailModal: React.FC<{
 
   return (
     <Modal
+      css={css`
+        .ant-modal-body {
+          display: flex;
+          flex-direction: column;
+        }
+      `}
       show={showModal}
       onHide={closeModal}
       title={t('Drill to detail: %s', chartName)}
@@ -89,6 +98,14 @@ const DrillDetailModal: React.FC<{
       }
       responsive
       resizable
+      resizableConfig={{
+        minHeight: theme.gridUnit * 128,
+        minWidth: theme.gridUnit * 128,
+        defaultSize: {
+          width: 'auto',
+          height: '75vh',
+        },
+      }}
       draggable
       destroyOnClose
     >

--- a/superset-frontend/src/components/Chart/chartAction.js
+++ b/superset-frontend/src/components/Chart/chartAction.js
@@ -603,8 +603,13 @@ export const getDatasourceSamples = async (
   datasourceId,
   force,
   jsonPayload,
+  pagination,
 ) => {
-  const endpoint = `/datasource/samples?force=${force}&datasource_type=${datasourceType}&datasource_id=${datasourceId}`;
+  let endpoint = `/datasource/samples?force=${force}&datasource_type=${datasourceType}&datasource_id=${datasourceId}`;
+  if (pagination) {
+    endpoint += `&page=${pagination.page}&per_page=${pagination.perPage}`;
+  }
+
   try {
     const response = await SupersetClient.post({ endpoint, jsonPayload });
     return response.json.result;

--- a/superset-frontend/src/components/Chart/chartAction.js
+++ b/superset-frontend/src/components/Chart/chartAction.js
@@ -19,7 +19,7 @@
 /* eslint no-undef: 'error' */
 /* eslint no-param-reassign: ["error", { "props": false }] */
 import moment from 'moment';
-import { t, SupersetClient } from '@superset-ui/core';
+import { t, SupersetClient, isDefined } from '@superset-ui/core';
 import { getControlsState } from 'src/explore/store';
 import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 import {
@@ -603,15 +603,27 @@ export const getDatasourceSamples = async (
   datasourceId,
   force,
   jsonPayload,
-  pagination,
+  perPage,
+  page,
 ) => {
-  let endpoint = `/datasource/samples?force=${force}&datasource_type=${datasourceType}&datasource_id=${datasourceId}`;
-  if (pagination) {
-    endpoint += `&page=${pagination.page}&per_page=${pagination.perPage}`;
-  }
-
   try {
-    const response = await SupersetClient.post({ endpoint, jsonPayload });
+    const searchParams = {
+      force,
+      datasource_type: datasourceType,
+      datasource_id: datasourceId,
+    };
+
+    if (isDefined(perPage) && isDefined(page)) {
+      searchParams.per_page = perPage;
+      searchParams.page = page;
+    }
+
+    const response = await SupersetClient.post({
+      endpoint: '/datasource/samples',
+      jsonPayload,
+      searchParams,
+    });
+
     return response.json.result;
   } catch (err) {
     const clientError = await getClientErrorObject(err);

--- a/superset-frontend/src/dashboard/components/DrillDetailPane/DrillDetailPane.tsx
+++ b/superset-frontend/src/dashboard/components/DrillDetailPane/DrillDetailPane.tsx
@@ -122,7 +122,7 @@ export default function DrillDetailPane({
       getDatasourceSamples(
         datasourceType,
         datasourceId,
-        true,
+        false,
         jsonPayload,
         PAGE_SIZE,
         pageIndex + 1,

--- a/superset-frontend/src/dashboard/components/DrillDetailPane/DrillDetailPane.tsx
+++ b/superset-frontend/src/dashboard/components/DrillDetailPane/DrillDetailPane.tsx
@@ -126,8 +126,8 @@ export default function DrillDetailPane({
         datasourceId,
         true,
         jsonPayload,
-        pageIndex + 1,
         PAGE_SIZE,
+        pageIndex + 1,
       )
         .then(response => {
           setResultsPages(

--- a/superset-frontend/src/dashboard/components/DrillDetailPane/DrillDetailPane.tsx
+++ b/superset-frontend/src/dashboard/components/DrillDetailPane/DrillDetailPane.tsx
@@ -1,0 +1,239 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, {
+  useState,
+  useEffect,
+  useMemo,
+  useCallback,
+  useRef,
+} from 'react';
+import {
+  BinaryQueryObjectFilterClause,
+  css,
+  ensureIsArray,
+  GenericDataType,
+  t,
+  useTheme,
+} from '@superset-ui/core';
+import Loading from 'src/components/Loading';
+import { EmptyStateMedium } from 'src/components/EmptyState';
+import TableView, { EmptyWrapperType } from 'src/components/TableView';
+import { useTableColumns } from 'src/explore/components/DataTableControl';
+import { getDatasourceSamples } from 'src/components/Chart/chartAction';
+import TableControls from './TableControls';
+
+type ResultsPage = {
+  total: number;
+  data: Record<string, any>[];
+  colNames: string[];
+  colTypes: GenericDataType[];
+};
+
+const PAGE_SIZE = 50;
+const MAX_CACHED_PAGES = 5;
+
+export default function DrillDetailPane({
+  datasource,
+  initialFilters,
+}: {
+  datasource: string;
+  initialFilters?: BinaryQueryObjectFilterClause[];
+}) {
+  const theme = useTheme();
+  const [pageIndex, setPageIndex] = useState(0);
+  const lastPageIndex = useRef(pageIndex);
+  const [filters, setFilters] = useState(initialFilters || []);
+  const [isLoading, setIsLoading] = useState(false);
+  const [responseError, setResponseError] = useState('');
+  const [resultsPages, setResultsPages] = useState<Map<number, ResultsPage>>(
+    new Map(),
+  );
+
+  //  Get string identifier for dataset
+  const [datasourceId, datasourceType] = useMemo(
+    () => datasource.split('__'),
+    [datasource],
+  );
+
+  //  Get page of results
+  const resultsPage = useMemo(() => {
+    const nextResultsPage = resultsPages.get(pageIndex);
+    if (nextResultsPage) {
+      lastPageIndex.current = pageIndex;
+      return nextResultsPage;
+    }
+
+    return resultsPages.get(lastPageIndex.current);
+  }, [pageIndex, resultsPages]);
+
+  //  Clear cache and reset page index if filters change
+  useEffect(() => {
+    setResultsPages(new Map());
+    setPageIndex(0);
+  }, [filters]);
+
+  //  Update cache order if page in cache
+  useEffect(() => {
+    if (
+      resultsPages.has(pageIndex) &&
+      [...resultsPages.keys()].at(-1) !== pageIndex
+    ) {
+      const nextResultsPages = new Map(resultsPages);
+      nextResultsPages.delete(pageIndex);
+      setResultsPages(
+        nextResultsPages.set(
+          pageIndex,
+          resultsPages.get(pageIndex) as ResultsPage,
+        ),
+      );
+    }
+  }, [pageIndex, resultsPages]);
+
+  //  Download page of results & trim cache if page not in cache
+  useEffect(() => {
+    if (!resultsPages.has(pageIndex)) {
+      setIsLoading(true);
+      getDatasourceSamples(
+        datasourceType,
+        datasourceId,
+        true,
+        filters.length ? { filters } : null,
+        { page: pageIndex + 1, perPage: PAGE_SIZE },
+      )
+        .then(response => {
+          setResultsPages(
+            new Map([
+              ...[...resultsPages.entries()].slice(-MAX_CACHED_PAGES + 1),
+              [
+                pageIndex,
+                {
+                  total: response.total_count,
+                  data: response.data,
+                  colNames: ensureIsArray(response.colnames),
+                  colTypes: ensureIsArray(response.coltypes),
+                },
+              ],
+            ]),
+          );
+          setResponseError('');
+        })
+        .catch(error => {
+          setResponseError(`${error.name}: ${error.message}`);
+        })
+        .finally(() => {
+          setIsLoading(false);
+        });
+    }
+  }, [datasourceId, datasourceType, filters, pageIndex, resultsPages]);
+
+  // this is to preserve the order of the columns, even if there are integer values,
+  // while also only grabbing the first column's keys
+  const columns = useTableColumns(
+    resultsPage?.colNames,
+    resultsPage?.colTypes,
+    resultsPage?.data,
+    datasource,
+  );
+
+  const sortDisabledColumns = columns.map(column => ({
+    ...column,
+    disableSortBy: true,
+  }));
+
+  //  Update page index on pagination click
+  const onServerPagination = useCallback(({ pageIndex }) => {
+    setPageIndex(pageIndex);
+  }, []);
+
+  //  Clear cache on reload button click
+  const handleReload = useCallback(() => {
+    setResultsPages(new Map());
+  }, []);
+
+  //  Render error if page download failed
+  if (responseError) {
+    return (
+      <pre
+        css={css`
+          margin-top: ${theme.gridUnit * 4}px;
+        `}
+      >
+        {responseError}
+      </pre>
+    );
+  }
+
+  //  Render loading if first page hasn't loaded
+  if (!resultsPages.size) {
+    return (
+      <div
+        css={css`
+          height: ${theme.gridUnit * 25}px;
+        `}
+      >
+        <Loading />
+      </div>
+    );
+  }
+
+  //  Render empty state if no results are returned for page
+  if (resultsPage?.total === 0) {
+    const title = t('No rows were returned for this dataset');
+    return <EmptyStateMedium image="document.svg" title={title} />;
+  }
+
+  //  Render chart if at least one page has successfully loaded
+  return (
+    <div
+      css={css`
+        display: flex;
+        flex-direction: column;
+      `}
+    >
+      <TableControls
+        filters={filters}
+        setFilters={setFilters}
+        totalCount={resultsPage?.total}
+        onReload={handleReload}
+      />
+      <TableView
+        columns={sortDisabledColumns}
+        data={resultsPage?.data || []}
+        pageSize={PAGE_SIZE}
+        totalCount={resultsPage?.total}
+        serverPagination
+        initialPageIndex={pageIndex}
+        onServerPagination={onServerPagination}
+        loading={isLoading}
+        noDataText={t('No results')}
+        emptyWrapperType={EmptyWrapperType.Small}
+        className="table-condensed"
+        isPaginationSticky
+        showRowCount={false}
+        small
+        css={css`
+          min-height: 0;
+          overflow: scroll;
+          height: ${theme.gridUnit * 128}px;
+        `}
+      />
+    </div>
+  );
+}

--- a/superset-frontend/src/dashboard/components/DrillDetailPane/DrillDetailPane.tsx
+++ b/superset-frontend/src/dashboard/components/DrillDetailPane/DrillDetailPane.tsx
@@ -52,18 +52,16 @@ type ResultsPage = {
 const PAGE_SIZE = 50;
 
 export default function DrillDetailPane({
-  datasource,
-  queryFormData,
-  drillFilters,
+  formData,
+  initialFilters,
 }: {
-  datasource: string;
-  queryFormData?: QueryFormData;
-  drillFilters?: BinaryQueryObjectFilterClause[];
+  formData: QueryFormData;
+  initialFilters?: BinaryQueryObjectFilterClause[];
 }) {
   const theme = useTheme();
   const [pageIndex, setPageIndex] = useState(0);
   const lastPageIndex = useRef(pageIndex);
-  const [filters, setFilters] = useState(drillFilters || []);
+  const [filters, setFilters] = useState(initialFilters || []);
   const [isLoading, setIsLoading] = useState(false);
   const [responseError, setResponseError] = useState('');
   const [resultsPages, setResultsPages] = useState<Map<number, ResultsPage>>(
@@ -77,8 +75,8 @@ export default function DrillDetailPane({
 
   //  Extract datasource ID/type from string ID
   const [datasourceId, datasourceType] = useMemo(
-    () => datasource.split('__'),
-    [datasource],
+    () => formData.datasource.split('__'),
+    [formData.datasource],
   );
 
   //  Get page of results
@@ -120,7 +118,7 @@ export default function DrillDetailPane({
   useEffect(() => {
     if (!resultsPages.has(pageIndex)) {
       setIsLoading(true);
-      const jsonPayload = getDrillPayload(queryFormData, drillFilters);
+      const jsonPayload = getDrillPayload(formData, filters);
       getDatasourceSamples(
         datasourceType,
         datasourceId,
@@ -157,9 +155,9 @@ export default function DrillDetailPane({
     cachePageLimit,
     datasourceId,
     datasourceType,
-    drillFilters,
+    filters,
+    formData,
     pageIndex,
-    queryFormData,
     resultsPages,
   ]);
 
@@ -169,7 +167,7 @@ export default function DrillDetailPane({
     resultsPage?.colNames,
     resultsPage?.colTypes,
     resultsPage?.data,
-    datasource,
+    formData.datasource,
   );
 
   const sortDisabledColumns = columns.map(column => ({

--- a/superset-frontend/src/dashboard/components/DrillDetailPane/DrillDetailPane.tsx
+++ b/superset-frontend/src/dashboard/components/DrillDetailPane/DrillDetailPane.tsx
@@ -117,6 +117,7 @@ export default function DrillDetailPane({
   //  Clear cache on reload button click
   const handleReload = useCallback(() => {
     setResultsPages(new Map());
+    setPageIndex(0);
   }, []);
 
   //  Clear cache and reset page index if filters change

--- a/superset-frontend/src/dashboard/components/DrillDetailPane/DrillDetailPane.tsx
+++ b/superset-frontend/src/dashboard/components/DrillDetailPane/DrillDetailPane.tsx
@@ -190,13 +190,19 @@ export default function DrillDetailPane({
   //  Render error if page download failed
   if (responseError) {
     return (
-      <pre
+      <div
         css={css`
-          margin-top: ${theme.gridUnit * 4}px;
+          height: ${theme.gridUnit * 128}px;
         `}
       >
-        {responseError}
-      </pre>
+        <pre
+          css={css`
+            margin-top: ${theme.gridUnit * 4}px;
+          `}
+        >
+          {responseError}
+        </pre>
+      </div>
     );
   }
 
@@ -205,7 +211,7 @@ export default function DrillDetailPane({
     return (
       <div
         css={css`
-          height: ${theme.gridUnit * 25}px;
+          height: ${theme.gridUnit * 128}px;
         `}
       >
         <Loading />
@@ -216,7 +222,15 @@ export default function DrillDetailPane({
   //  Render empty state if no results are returned for page
   if (resultsPage?.total === 0) {
     const title = t('No rows were returned for this dataset');
-    return <EmptyStateMedium image="document.svg" title={title} />;
+    return (
+      <div
+        css={css`
+          height: ${theme.gridUnit * 128}px;
+        `}
+      >
+        <EmptyStateMedium image="document.svg" title={title} />
+      </div>
+    );
   }
 
   //  Render chart if at least one page has successfully loaded
@@ -225,6 +239,7 @@ export default function DrillDetailPane({
       css={css`
         display: flex;
         flex-direction: column;
+        height: ${theme.gridUnit * 128}px;
       `}
     >
       <TableControls
@@ -251,7 +266,6 @@ export default function DrillDetailPane({
         css={css`
           min-height: 0;
           overflow: scroll;
-          height: ${theme.gridUnit * 128}px;
         `}
       />
     </div>

--- a/superset-frontend/src/dashboard/components/DrillDetailPane/DrillDetailPane.tsx
+++ b/superset-frontend/src/dashboard/components/DrillDetailPane/DrillDetailPane.tsx
@@ -121,10 +121,14 @@ export default function DrillDetailPane({
     if (!resultsPages.has(pageIndex)) {
       setIsLoading(true);
       const jsonPayload = getDrillPayload(queryFormData, drillFilters);
-      getDatasourceSamples(datasourceType, datasourceId, true, jsonPayload, {
-        page: pageIndex + 1,
-        perPage: PAGE_SIZE,
-      })
+      getDatasourceSamples(
+        datasourceType,
+        datasourceId,
+        true,
+        jsonPayload,
+        pageIndex + 1,
+        PAGE_SIZE,
+      )
         .then(response => {
           setResultsPages(
             new Map([

--- a/superset-frontend/src/dashboard/components/DrillDetailPane/DrillDetailPane.tsx
+++ b/superset-frontend/src/dashboard/components/DrillDetailPane/DrillDetailPane.tsx
@@ -116,12 +116,14 @@ export default function DrillDetailPane({
 
   //  Clear cache on reload button click
   const handleReload = useCallback(() => {
+    setResponseError('');
     setResultsPages(new Map());
     setPageIndex(0);
   }, []);
 
   //  Clear cache and reset page index if filters change
   useEffect(() => {
+    setResponseError('');
     setResultsPages(new Map());
     setPageIndex(0);
   }, [filters]);
@@ -145,7 +147,7 @@ export default function DrillDetailPane({
 
   //  Download page of results & trim cache if page not in cache
   useEffect(() => {
-    if (!isLoading && !resultsPages.has(pageIndex)) {
+    if (!responseError && !isLoading && !resultsPages.has(pageIndex)) {
       setIsLoading(true);
       const jsonPayload = getDrillPayload(formData, filters);
       const cachePageLimit = Math.ceil(SAMPLES_ROW_LIMIT / PAGE_SIZE);
@@ -189,6 +191,7 @@ export default function DrillDetailPane({
     formData,
     isLoading,
     pageIndex,
+    responseError,
     resultsPages,
   ]);
 

--- a/superset-frontend/src/dashboard/components/DrillDetailPane/DrillDetailPane.tsx
+++ b/superset-frontend/src/dashboard/components/DrillDetailPane/DrillDetailPane.tsx
@@ -233,21 +233,17 @@ export default function DrillDetailPane({
         showRowCount={false}
         small
         css={css`
-          min-height: 0;
-          overflow: scroll;
+          overflow: auto;
+          .table {
+            margin-bottom: 0;
+          }
         `}
       />
     );
   }
 
   return (
-    <div
-      css={css`
-        display: flex;
-        flex-direction: column;
-        height: ${theme.gridUnit * 128}px;
-      `}
-    >
+    <>
       <TableControls
         filters={filters}
         setFilters={setFilters}
@@ -256,6 +252,6 @@ export default function DrillDetailPane({
         onReload={handleReload}
       />
       {tableContent}
-    </div>
+    </>
   );
 }

--- a/superset-frontend/src/dashboard/components/DrillDetailPane/TableControls.tsx
+++ b/superset-frontend/src/dashboard/components/DrillDetailPane/TableControls.tsx
@@ -1,0 +1,134 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useCallback, useMemo } from 'react';
+import { Tag } from 'antd';
+import {
+  BinaryQueryObjectFilterClause,
+  css,
+  isAdhocColumn,
+  t,
+  useTheme,
+} from '@superset-ui/core';
+import RowCountLabel from 'src/explore/components/RowCountLabel';
+import Icons from 'src/components/Icons';
+
+export default function TableControls({
+  filters,
+  setFilters,
+  totalCount,
+  onReload,
+}: {
+  filters: BinaryQueryObjectFilterClause[];
+  setFilters: (filters: BinaryQueryObjectFilterClause[]) => void;
+  totalCount?: number;
+  loading?: boolean;
+  onReload: () => void;
+}) {
+  const theme = useTheme();
+  const filterMap: Record<string, BinaryQueryObjectFilterClause> = useMemo(
+    () =>
+      Object.assign(
+        {},
+        ...filters.map(filter => ({
+          [isAdhocColumn(filter.col)
+            ? (filter.col.label as string)
+            : filter.col]: filter,
+        })),
+      ),
+    [filters],
+  );
+
+  const removeFilter = useCallback(
+    colName => {
+      const updatedFilterMap = { ...filterMap };
+      delete updatedFilterMap[colName];
+      setFilters([...Object.values(updatedFilterMap)]);
+    },
+    [filterMap, setFilters],
+  );
+
+  const filterTags = useMemo(
+    () =>
+      Object.entries(filterMap)
+        .map(([colName, { val }]) => ({ colName, val }))
+        .sort((a, b) => a.colName.localeCompare(b.colName)),
+    [filterMap],
+  );
+
+  return (
+    <div
+      css={css`
+        display: flex;
+        justify-content: space-between;
+        padding: ${theme.gridUnit / 2}px 0;
+      `}
+    >
+      <div
+        css={css`
+          display: flex;
+          flex-wrap: wrap;
+          margin-bottom: -${theme.gridUnit * 4}px;
+        `}
+      >
+        {filterTags.map(({ colName, val }) => (
+          <Tag
+            closable
+            onClose={removeFilter.bind(null, colName)}
+            key={colName}
+            css={css`
+              height: ${theme.gridUnit * 6}px;
+              display: flex;
+              align-items: center;
+              padding: ${theme.gridUnit / 2}px ${theme.gridUnit * 2}px;
+              margin-right: ${theme.gridUnit * 4}px;
+              margin-bottom: ${theme.gridUnit * 4}px;
+              line-height: 1.2;
+            `}
+          >
+            <span
+              css={css`
+                margin-right: ${theme.gridUnit}px;
+              `}
+            >
+              {colName}
+            </span>
+            <strong>{val}</strong>
+          </Tag>
+        ))}
+      </div>
+      <div
+        css={css`
+          display: flex;
+          align-items: center;
+          height: min-content;
+        `}
+      >
+        <RowCountLabel rowcount={totalCount} />
+        <Icons.ReloadOutlined
+          iconColor={theme.colors.grayscale.light1}
+          iconSize="l"
+          aria-label={t('Reload')}
+          role="button"
+          onClick={onReload}
+        />
+      </div>
+    </div>
+  );
+}

--- a/superset-frontend/src/dashboard/components/DrillDetailPane/TableControls.tsx
+++ b/superset-frontend/src/dashboard/components/DrillDetailPane/TableControls.tsx
@@ -33,12 +33,13 @@ export default function TableControls({
   filters,
   setFilters,
   totalCount,
+  loading,
   onReload,
 }: {
   filters: BinaryQueryObjectFilterClause[];
   setFilters: (filters: BinaryQueryObjectFilterClause[]) => void;
   totalCount?: number;
-  loading?: boolean;
+  loading: boolean;
   onReload: () => void;
 }) {
   const theme = useTheme();
@@ -120,7 +121,7 @@ export default function TableControls({
           height: min-content;
         `}
       >
-        <RowCountLabel rowcount={totalCount} />
+        <RowCountLabel loading={loading && !totalCount} rowcount={totalCount} />
         <Icons.ReloadOutlined
           iconColor={theme.colors.grayscale.light1}
           iconSize="l"

--- a/superset-frontend/src/dashboard/components/DrillDetailPane/TableControls.tsx
+++ b/superset-frontend/src/dashboard/components/DrillDetailPane/TableControls.tsx
@@ -68,7 +68,10 @@ export default function TableControls({
   const filterTags = useMemo(
     () =>
       Object.entries(filterMap)
-        .map(([colName, { val }]) => ({ colName, val }))
+        .map(([colName, { val, formattedVal }]) => ({
+          colName,
+          val: formattedVal ?? val,
+        }))
         .sort((a, b) => a.colName.localeCompare(b.colName)),
     [filterMap],
   );

--- a/superset-frontend/src/dashboard/components/DrillDetailPane/index.ts
+++ b/superset-frontend/src/dashboard/components/DrillDetailPane/index.ts
@@ -17,6 +17,4 @@
  * under the License.
  */
 
-import DrillDetailPane from './DrillDetailPane';
-
-export default DrillDetailPane;
+export { default } from './DrillDetailPane';

--- a/superset-frontend/src/dashboard/components/DrillDetailPane/index.ts
+++ b/superset-frontend/src/dashboard/components/DrillDetailPane/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import DrillDetailPane from './DrillDetailPane';
+
+export default DrillDetailPane;

--- a/superset-frontend/src/dashboard/components/DrillDetailPane/utils.ts
+++ b/superset-frontend/src/dashboard/components/DrillDetailPane/utils.ts
@@ -35,7 +35,7 @@ export function getDrillPayload(
   const extras = omit(queryObject.extras, 'having');
   const filters = [
     ...ensureIsArray(queryObject.filters),
-    ...ensureIsArray(drillFilters),
+    ...ensureIsArray(drillFilters).map(f => omit(f, 'formattedVal')),
   ];
   return {
     granularity: queryObject.granularity,

--- a/superset-frontend/src/dashboard/components/DrillDetailPane/utils.ts
+++ b/superset-frontend/src/dashboard/components/DrillDetailPane/utils.ts
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { omit } from 'lodash';
+import {
+  ensureIsArray,
+  QueryFormData,
+  BinaryQueryObjectFilterClause,
+  buildQueryObject,
+} from '@superset-ui/core';
+
+export function getDrillPayload(
+  queryFormData?: QueryFormData,
+  drillFilters?: BinaryQueryObjectFilterClause[],
+) {
+  if (!queryFormData) {
+    return undefined;
+  }
+  const queryObject = buildQueryObject(queryFormData);
+  const extras = omit(queryObject.extras, 'having');
+  const filters = [
+    ...ensureIsArray(queryObject.filters),
+    ...ensureIsArray(drillFilters),
+  ];
+  return {
+    granularity: queryObject.granularity,
+    time_range: queryObject.time_range,
+    filters,
+    extras,
+  };
+}

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -448,12 +448,7 @@ class SliceHeaderControls extends React.PureComponent<
                   </span>
                 }
                 modalTitle={t('Drill to detail: %s', slice.slice_name)}
-                modalBody={
-                  <DrillDetailPane
-                    datasource={this.props.slice.datasource}
-                    queryFormData={this.props.formData}
-                  />
-                }
+                modalBody={<DrillDetailPane formData={this.props.formData} />}
               />
             </Menu.Item>
           )}

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -16,8 +16,19 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { MouseEvent, Key } from 'react';
-import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
+import React, {
+  MouseEvent,
+  Key,
+  ReactChild,
+  useState,
+  useCallback,
+} from 'react';
+import {
+  Link,
+  RouteComponentProps,
+  useHistory,
+  withRouter,
+} from 'react-router-dom';
 import moment from 'moment';
 import {
   Behavior,
@@ -40,6 +51,8 @@ import ModalTrigger from 'src/components/ModalTrigger';
 import Button from 'src/components/Button';
 import ViewQueryModal from 'src/explore/components/controls/ViewQueryModal';
 import { ResultsPaneOnDashboard } from 'src/explore/components/DataTablesPane';
+import Modal from 'src/components/Modal';
+import DrillDetailPane from 'src/dashboard/components/DrillDetailPane';
 
 const MENU_KEYS = {
   CROSS_FILTER_SCOPING: 'cross_filter_scoping',
@@ -52,6 +65,7 @@ const MENU_KEYS = {
   TOGGLE_CHART_DESCRIPTION: 'toggle_chart_description',
   VIEW_QUERY: 'view_query',
   VIEW_RESULTS: 'view_results',
+  DRILL_TO_DETAIL: 'drill_to_detail',
 };
 
 const VerticalDotsContainer = styled.div`
@@ -97,6 +111,7 @@ export interface SliceHeaderControlsProps {
     slice_id: number;
     slice_description: string;
     form_data?: { emit_filter?: boolean };
+    datasource: string;
   };
 
   componentId: string;
@@ -139,6 +154,68 @@ const dropdownIconsStyles = css`
     vertical-align: 0;
   }
 `;
+
+const DashboardChartModalTrigger = ({
+  exploreUrl,
+  triggerNode,
+  modalTitle,
+  modalBody,
+}: {
+  exploreUrl: string;
+  triggerNode: ReactChild;
+  modalTitle: ReactChild;
+  modalBody: ReactChild;
+}) => {
+  const [showModal, setShowModal] = useState(false);
+  const openModal = useCallback(() => setShowModal(true), []);
+  const closeModal = useCallback(() => setShowModal(false), []);
+  const history = useHistory();
+  const exploreChart = () => history.push(exploreUrl);
+
+  return (
+    <>
+      <span
+        data-test="span-modal-trigger"
+        onClick={openModal}
+        role="button"
+        tabIndex={0}
+      >
+        {triggerNode}
+      </span>
+      {(() => (
+        <Modal
+          show={showModal}
+          onHide={closeModal}
+          title={modalTitle}
+          footer={
+            <>
+              <Button
+                buttonStyle="secondary"
+                buttonSize="small"
+                onClick={exploreChart}
+              >
+                {t('Edit chart')}
+              </Button>
+              <Button
+                buttonStyle="primary"
+                buttonSize="small"
+                onClick={closeModal}
+              >
+                {t('Close')}
+              </Button>
+            </>
+          }
+          responsive
+          resizable
+          draggable
+          destroyOnClose
+        >
+          {modalBody}
+        </Modal>
+      ))()}
+    </>
+  );
+};
 
 class SliceHeaderControls extends React.PureComponent<
   SliceHeaderControlsPropsWithRouter,
@@ -339,7 +416,8 @@ class SliceHeaderControls extends React.PureComponent<
 
         {this.props.supersetCanExplore && (
           <Menu.Item key={MENU_KEYS.VIEW_RESULTS}>
-            <ModalTrigger
+            <DashboardChartModalTrigger
+              exploreUrl={this.props.exploreUrl}
               triggerNode={
                 <span data-test="view-query-menu-item">
                   {t('View as table')}
@@ -355,18 +433,23 @@ class SliceHeaderControls extends React.PureComponent<
                   isVisible
                 />
               }
-              modalFooter={
-                <Button
-                  buttonStyle="secondary"
-                  buttonSize="small"
-                  onClick={() => this.props.history.push(this.props.exploreUrl)}
-                >
-                  {t('Edit chart')}
-                </Button>
+            />
+          </Menu.Item>
+        )}
+
+        {this.props.supersetCanExplore && (
+          <Menu.Item key={MENU_KEYS.DRILL_TO_DETAIL}>
+            <DashboardChartModalTrigger
+              exploreUrl={this.props.exploreUrl}
+              triggerNode={
+                <span data-test="view-query-menu-item">
+                  {t('Drill to detail')}
+                </span>
               }
-              draggable
-              resizable
-              responsive
+              modalTitle={t('Drill to detail: %s', slice.slice_name)}
+              modalBody={
+                <DrillDetailPane datasource={this.props.slice.datasource} />
+              }
             />
           </Menu.Item>
         )}

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -437,25 +437,26 @@ class SliceHeaderControls extends React.PureComponent<
           </Menu.Item>
         )}
 
-        {this.props.supersetCanExplore && (
-          <Menu.Item key={MENU_KEYS.DRILL_TO_DETAIL}>
-            <DashboardChartModalTrigger
-              exploreUrl={this.props.exploreUrl}
-              triggerNode={
-                <span data-test="view-query-menu-item">
-                  {t('Drill to detail')}
-                </span>
-              }
-              modalTitle={t('Drill to detail: %s', slice.slice_name)}
-              modalBody={
-                <DrillDetailPane
-                  datasource={this.props.slice.datasource}
-                  queryFormData={this.props.formData}
-                />
-              }
-            />
-          </Menu.Item>
-        )}
+        {isFeatureEnabled(FeatureFlag.DRILL_TO_DETAIL) &&
+          this.props.supersetCanExplore && (
+            <Menu.Item key={MENU_KEYS.DRILL_TO_DETAIL}>
+              <DashboardChartModalTrigger
+                exploreUrl={this.props.exploreUrl}
+                triggerNode={
+                  <span data-test="view-query-menu-item">
+                    {t('Drill to detail')}
+                  </span>
+                }
+                modalTitle={t('Drill to detail: %s', slice.slice_name)}
+                modalBody={
+                  <DrillDetailPane
+                    datasource={this.props.slice.datasource}
+                    queryFormData={this.props.formData}
+                  />
+                }
+              />
+            </Menu.Item>
+          )}
 
         {(slice.description || this.props.supersetCanExplore) && (
           <Menu.Divider />

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -448,7 +448,10 @@ class SliceHeaderControls extends React.PureComponent<
               }
               modalTitle={t('Drill to detail: %s', slice.slice_name)}
               modalBody={
-                <DrillDetailPane datasource={this.props.slice.datasource} />
+                <DrillDetailPane
+                  datasource={this.props.slice.datasource}
+                  queryFormData={this.props.formData}
+                />
               }
             />
           </Menu.Item>

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -37,6 +37,7 @@ import {
   QueryFormData,
   styled,
   t,
+  useTheme,
 } from '@superset-ui/core';
 import { Menu } from 'src/components/Menu';
 import { NoAnimationDropdown } from 'src/components/Dropdown';
@@ -171,6 +172,7 @@ const DashboardChartModalTrigger = ({
   const closeModal = useCallback(() => setShowModal(false), []);
   const history = useHistory();
   const exploreChart = () => history.push(exploreUrl);
+  const theme = useTheme();
 
   return (
     <>
@@ -184,6 +186,12 @@ const DashboardChartModalTrigger = ({
       </span>
       {(() => (
         <Modal
+          css={css`
+            .ant-modal-body {
+              display: flex;
+              flex-direction: column;
+            }
+          `}
           show={showModal}
           onHide={closeModal}
           title={modalTitle}
@@ -207,6 +215,14 @@ const DashboardChartModalTrigger = ({
           }
           responsive
           resizable
+          resizableConfig={{
+            minHeight: theme.gridUnit * 128,
+            minWidth: theme.gridUnit * 128,
+            defaultSize: {
+              width: 'auto',
+              height: '75vh',
+            },
+          }}
           draggable
           destroyOnClose
         >


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR introduces a drill-to-detail modal.  It adds a "Drill to detail" menu item to dashboard charts' contextual menus and also completes support for opening the modal by right-clicking on chart features.  The drill-to-detail modal allows users to inspect the data that is backing a chart from the dashboard that the chart is on, while optionally applying filters based on where in the chart was clicked.

More details:
- Unlike the Samples pane, the drill-to-detail modal content is server-paginated and allows paging through all rows of data.
- All columns of the dataset are displayed.
- Native dashboard filters, cross-filters, ad-hoc chart filters and time chart filters are transparently respected; only rows matching those filters are displayed in the modal table.
- The chart menu item and contextual menus appear when the `DRILL_TO_DETAIL` feature flag is enabled.
- Only ECharts (excluding Tree Chart) are currently supported for contextual menu access.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Menu item:
![localhost_9000_superset_dashboard_births__native_filters_key=7menIfx9h9P-xFkGBuKMFYlgho-hubMp7tZVmWyfTDwRyNH5UgdFt1pGo8-RJIw-](https://user-images.githubusercontent.com/13007381/183224639-1d268a97-b1c8-48fe-b042-822bba23e047.png)

Modal:
![localhost_9000_superset_dashboard_births__native_filters_key=7menIfx9h9P-xFkGBuKMFYlgho-hubMp7tZVmWyfTDwRyNH5UgdFt1pGo8-RJIw- (1)](https://user-images.githubusercontent.com/13007381/183224648-53fa05f4-c134-4dd2-8c4d-faf96fbc4d7e.png)

Modal w/ native filters:
![localhost_9000_superset_dashboard_births__native_filters_key=7menIfx9h9P-xFkGBuKMFYlgho-hubMp7tZVmWyfTDwRyNH5UgdFt1pGo8-RJIw- (2)](https://user-images.githubusercontent.com/13007381/183224625-67a21bcb-599a-42b3-b76b-7a9804d13aab.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Ensure no change to contextual menu without feature flag set
- With feature flag set, compare expected datasource results to drill to detail results in the following circumstances:
  - No filters from chart or dashboard context
  - Chart time filters
  - Chart ad-hoc filters
  - Dashboard native filters
  - Dashboard cross-filters
- Ensure that paginated results in modal work as expected in the following circumstances:
  - No results
  - One page of results
  - Multiple pages of results
  - Few columns
  - Lots of columns
- Check that right-clicking parts of charts opens the appropriate filters
  - See below for list of charts that are supported
  - Try "Drill to detail", "Drill by X" and "Drill by all" options
  - Try filtering by string values, number values, and date values
  - Try clearing filters

#### Charts supporting right-click:
- Big number
  - Right-click on number: Drill to detail
- Big number with Trendline
  - Right-click on number: Drill to detail
  - Right-click on point on trendline: Drill by {date}
- Box Plot
  - Right-click on box: Drill by {dimension}
- Funnel Chart
  - Right-click on funnel segment: Drill by {dimension}
- Gauge Chart
  - Right-click on gauge segment or needle: Drill by {dimension}
- Graph Chart
  - Right-click on edge: Drill by {dimension}
- Mixed Time-Series
  - Right-click on point on line: Drill by {dimension}, Drill by {timestamp}, Drill by all
- Pie Chart
  - Right-click on pie segment: Drill by {dimension}
- Radar Chart
  - Right-click on dimension point: Drill by {dimension}
- Time-series Chart
    - Time-series Line Chart
    - Time-series Area Chart
    - Time-series Bar Chart v2
    - Time-series Scatter Plot
    - Time-series Smooth Line
    - Time-series Stepped Line
    - For all of these: Right-click on point on line: Drill by {dimension}, Drill by {timestamp}, Drill by all
- Treemap v2
  - Right-click on dimension title (for multiple-dimension treemaps): Drill by {dimension}
  - Right-click on box: Drill by {dimension}, Drill by {addl dimension}, Drill by all

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags: `DRILL_TO_DETAIL` (`DASHBOARD_CROSS_FILTERS` optional to test cross-filter support)
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
