### PR TITLE
fix: Ensure Presto database engine spec correctly handles Trino

### DIFF
--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -947,8 +947,6 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
         :param schema: Schema name
         :param table: Table (view) name
         """
-        # pylint: disable=import-outside-toplevel
-        from pyhive.exc import DatabaseError
 
         engine = cls.get_engine(database, schema)
         with closing(engine.raw_connection()) as conn:
@@ -956,11 +954,12 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
             sql = f"SHOW CREATE VIEW {schema}.{table}"
             try:
                 cls.execute(cursor, sql)
+                return cls.fetch_data(cursor, 1)[0][0]
 
-            except DatabaseError:  # not a VIEW
+            # TODO(john-bodley): Replace with sqlalchemy.exc.DBAPIError after 
+            # https://github.com/trinodb/trino-python-client/issues/199 is resolved.
+            except Exception:  # pylint: disable=broad-exception
                 return None
-            rows = cls.fetch_data(cursor, 1)
-        return rows[0][0]
 
     @classmethod
     def get_tracking_url(cls, cursor: "Cursor") -> Optional[str]:

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -913,21 +913,23 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
         indexes = database.get_indexes(table_name, schema_name)
         if indexes:
             cols = indexes[0].get("column_names", [])
-            full_table_name = table_name
-            if schema_name and "." not in table_name:
-                full_table_name = "{}.{}".format(schema_name, table_name)
-            pql = cls._partition_query(full_table_name, database)
-            col_names, latest_parts = cls.latest_partition(
-                table_name, schema_name, database, show_first=True
-            )
+            
+            if cols:
+                full_table_name = table_name
+                if schema_name and "." not in table_name:
+                    full_table_name = "{}.{}".format(schema_name, table_name)
+                pql = cls._partition_query(full_table_name, database)
+                col_names, latest_parts = cls.latest_partition(
+                    table_name, schema_name, database, show_first=True
+                )
 
-            if not latest_parts:
-                latest_parts = tuple([None] * len(col_names))
-            metadata["partitions"] = {
-                "cols": cols,
-                "latest": dict(zip(col_names, latest_parts)),
-                "partitionQuery": pql,
-            }
+                if not latest_parts:
+                    latest_parts = tuple([None] * len(col_names))
+                metadata["partitions"] = {
+                    "cols": cols,
+                    "latest": dict(zip(col_names, latest_parts)),
+                    "partitionQuery": pql,
+                }
 
         # flake8 is not matching `Optional[str]` to `Any` for some reason...
         metadata["view"] = cast(

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -913,7 +913,7 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
         indexes = database.get_indexes(table_name, schema_name)
         if indexes:
             cols = indexes[0].get("column_names", [])
-            
+
             if cols:
                 full_table_name = table_name
                 if schema_name and "." not in table_name:
@@ -958,9 +958,9 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
                 cls.execute(cursor, sql)
                 return cls.fetch_data(cursor, 1)[0][0]
 
-            # TODO(john-bodley): Replace with sqlalchemy.exc.DBAPIError after 
+            # TODO(john-bodley): Replace with sqlalchemy.exc.DBAPIError after
             # https://github.com/trinodb/trino-python-client/issues/199 is resolved.
-            except Exception:  # pylint: disable=broad-exception
+            except Exception:  # pylint: disable=broad-except
                 return None
 
     @classmethod

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Type, TYPE_CHECKING
 
 import simplejson as json
 from flask import current_app
@@ -25,6 +25,7 @@ from sqlalchemy.orm import Session
 
 from superset.databases.utils import make_url_safe
 from superset.db_engine_specs.base import BaseEngineSpec
+from superset.db_engine_specs.exceptions import SupersetDBAPIDatabaseError
 from superset.db_engine_specs.presto import PrestoEngineSpec
 from superset.models.sql_lab import Query
 from superset.utils import core as utils
@@ -44,6 +45,15 @@ class TrinoEngineSpec(PrestoEngineSpec):
     engine = "trino"
     engine_aliases = {"trinonative"}  # Required for backwards compatibility.
     engine_name = "Trino"
+
+    @classmethod
+    def get_dbapi_exception_mapping(cls) -> Dict[Type[Exception], Type[Exception]]:
+        # pylint: disable=import-outside-toplevel,import-error
+        from trino.exceptions import DatabaseError
+
+        return {
+            DatabaseError: SupersetDBAPIDatabaseError,
+        }
 
     @classmethod
     def update_impersonation_config(

--- a/tests/integration_tests/db_engine_specs/presto_tests.py
+++ b/tests/integration_tests/db_engine_specs/presto_tests.py
@@ -19,9 +19,11 @@ from unittest import mock, skipUnless
 
 import pandas as pd
 from sqlalchemy import types
+from sqlalchemy.exc import DatabaseError
 from sqlalchemy.sql import select
 
 from superset.db_engine_specs.presto import PrestoEngineSpec
+from superset.db_engine_specs.exceptions import SupersetDBAPIDatabaseError
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.sql_parse import ParsedQuery
 from superset.utils.core import DatasourceName, GenericDataType
@@ -895,9 +897,7 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
             PrestoEngineSpec.get_create_view(database, schema=schema, table=table)
 
     def test_get_create_view_database_error(self):
-        from pyhive.exc import DatabaseError
-
-        mock_execute = mock.MagicMock(side_effect=DatabaseError())
+        mock_execute = mock.MagicMock(side_effect=SupersetDBAPIDatabaseError())
         database = mock.MagicMock()
         database.get_sqla_engine.return_value.raw_connection.return_value.cursor.return_value.execute = (
             mock_execute


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR remedies a few issues with Trino—which extends the Presto database engine spec. Specifically it adds a few more safeguards when fetching extra metadata as part of the SQL Lab schema/table workflow.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
