### PR TITLE
fix(docker): Make Gunicorn max_requests and max_requests_jitter adjustable 

### DIFF
--- a/docker/run-server.sh
+++ b/docker/run-server.sh
@@ -28,6 +28,8 @@ gunicorn \
     --threads ${SERVER_THREADS_AMOUNT:-20} \
     --timeout ${GUNICORN_TIMEOUT:-60} \
     --keep-alive ${GUNICORN_KEEPALIVE:-2} \
+    --max-requests ${WORKER_MAX_REQUESTS:0} \
+    --max-requests-jitter ${WORKER_MAX_REQUESTS_JITTER:0} \
     --limit-request-line ${SERVER_LIMIT_REQUEST_LINE:-0} \
     --limit-request-field_size ${SERVER_LIMIT_REQUEST_FIELD_SIZE:-0} \
     "${FLASK_APP}"


### PR DESCRIPTION
### SUMMARY
This PR allows to adjust Gunicorn max_requests and max_requests_jitter which allows to restart the Gunicorn worker process periodically.

This is a simple method to help limit the damage of memory leaks like one reported in [15132](https://github.com/apache/superset/issues/15132). 

For more details, Please refer to: https://docs.gunicorn.org/en/stable/settings.html#max-requests

Default values are set to zero to match gunicorn's default i.e. automatic worker restarts are disabled by default.

Note: This change is non-disruptive, no end user will be impacted unless they turn on settings.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

![memory1](https://user-images.githubusercontent.com/57723564/179397545-c5a16b87-6588-44a8-aad0-5c15618299cc.png)


### TESTING INSTRUCTIONS

Set the values like: 
gunicorn --max-requests 1024 --max-requests-jitter 100 ....

### ADDITIONAL INFORMATION
- [x] Has associated issue: [15132](https://github.com/apache/superset/issues/15132)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
