### PR TITLE
fix: getting default value in run-server.sh

### DIFF
--- a/docker/run-server.sh
+++ b/docker/run-server.sh
@@ -28,8 +28,8 @@ gunicorn \
     --threads ${SERVER_THREADS_AMOUNT:-20} \
     --timeout ${GUNICORN_TIMEOUT:-60} \
     --keep-alive ${GUNICORN_KEEPALIVE:-2} \
-    --max-requests ${WORKER_MAX_REQUESTS:0} \
-    --max-requests-jitter ${WORKER_MAX_REQUESTS_JITTER:0} \
+    --max-requests ${WORKER_MAX_REQUESTS:-0} \
+    --max-requests-jitter ${WORKER_MAX_REQUESTS_JITTER:-0} \
     --limit-request-line ${SERVER_LIMIT_REQUEST_LINE:-0} \
     --limit-request-field_size ${SERVER_LIMIT_REQUEST_FIELD_SIZE:-0} \
     "${FLASK_APP}"


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The recent [feature](https://github.com/apache/superset/pull/20733) introduced an approach to work around memory leaks. 

getting default value should be [${parameter:-word}](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html) instead of [${parameter:word}](https://github.com/apache/superset/pull/20733/files). 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
