### PR TITLE
fix: Error when saving datasource from Explore

### DIFF
--- a/superset-frontend/src/explore/actions/exploreActions.ts
+++ b/superset-frontend/src/explore/actions/exploreActions.ts
@@ -142,6 +142,14 @@ export function setForceQuery(force: boolean) {
   };
 }
 
+export const SAVE_DATASOURCE = 'SAVE_DATASOURCE';
+export function saveDatasource(datasource: Dataset) {
+  return function (dispatch: Dispatch) {
+    dispatch(setDatasource(datasource));
+    dispatch({ type: SAVE_DATASOURCE, datasource });
+  };
+}
+
 export function changeDatasource(newDatasource: Dataset) {
   return function (dispatch: Dispatch, getState: () => ExplorePageState) {
     const {

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -170,7 +170,7 @@ class DatasourceControl extends React.PureComponent {
   }
 
   onDatasourceSave = datasource => {
-    this.props.actions.setDatasource(datasource);
+    this.props.actions.saveDatasource(datasource);
     const timeCol = this.props.form_data?.granularity_sqla;
     const { columns } = this.props.datasource;
     const firstDttmCol = columns.find(column => column.is_dttm);

--- a/superset-frontend/src/explore/reducers/exploreReducer.js
+++ b/superset-frontend/src/explore/reducers/exploreReducer.js
@@ -50,6 +50,19 @@ export default function exploreReducer(state = {}, action) {
         isDatasourceMetaLoading: true,
       };
     },
+    [actions.SAVE_DATASOURCE]() {
+      return {
+        ...state,
+        datasource: action.datasource,
+        controls: {
+          ...state.controls,
+          datasource: {
+            ...state.controls.datasource,
+            datasource: action.datasource,
+          },
+        },
+      };
+    },
     [actions.UPDATE_FORM_DATA_BY_DATASOURCE]() {
       const newFormData = { ...state.form_data };
       const { prevDatasource, newDatasource } = action;


### PR DESCRIPTION
### SUMMARY
Fixes an error when saving the datasource from Explore.

Follow-up of https://github.com/apache/superset/pull/20645

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/70410625/179556783-8ebde0db-9f49-4608-a703-e45e8995969f.mov

https://user-images.githubusercontent.com/70410625/179556850-b6870030-6801-4bc8-9d0e-be32f14a37fb.mov

### TESTING INSTRUCTIONS
Check the videos for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
