### PR TITLE
fix: [explore][mixed time series chart] when user change size of view query window, query B part will disappear

### DIFF
--- a/superset-frontend/src/explore/components/controls/ViewQuery.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQuery.tsx
@@ -45,10 +45,12 @@ interface ViewQueryProps {
 
 const StyledSyntaxContainer = styled.div`
   height: 100%;
+  display: flex;
+  flex-direction: column;
 `;
 
 const StyledSyntaxHighlighter = styled(SyntaxHighlighter)`
-  height: calc(100% - 26px); // 100% - clipboard height
+  flex: 1;
 `;
 
 const ViewQuery: React.FC<ViewQueryProps> = props => {

--- a/superset-frontend/src/explore/components/controls/ViewQueryModal.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQueryModal.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useEffect, useState } from 'react';
-import { ensureIsArray, t } from '@superset-ui/core';
+import { styled, ensureIsArray, t } from '@superset-ui/core';
 import Loading from 'src/components/Loading';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 import { getChartDataRequest } from 'src/components/Chart/chartAction';
@@ -31,6 +31,12 @@ type Result = {
   query: string;
   language: string;
 };
+
+const ViewQueryModalContainer = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+`;
 
 const ViewQueryModal: React.FC<Props> = props => {
   const [result, setResult] = useState<Result[]>([]);
@@ -71,14 +77,15 @@ const ViewQueryModal: React.FC<Props> = props => {
   if (error) {
     return <pre>{error}</pre>;
   }
+
   return (
-    <>
+    <ViewQueryModalContainer>
       {result.map(item =>
         item.query ? (
           <ViewQuery sql={item.query} language={item.language || undefined} />
         ) : null,
       )}
-    </>
+    </ViewQueryModalContainer>
   );
 };
 


### PR DESCRIPTION
### SUMMARY

The mixed time series has more than one query.
When opening the "View Query" modal and resizing it, the second query dissapears.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://user-images.githubusercontent.com/17252075/179558250-1b9b9d84-32ad-434e-9b19-a14264aae3c0.mov

After:

https://user-images.githubusercontent.com/17252075/179557996-127619a8-c282-4d3e-9dbd-bf12994f60c1.mov

### TESTING INSTRUCTIONS

1. create new chart use vehicle sales data for mix time-series chart
2. select sum(sales) for metrics in query A, Max(sales) for query B
3. run query
4. go to view query, change the view query window to smaller size from bottom, then change it back to origin size 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
