### PR TITLE
fix(reports): Confirmation message after deleting reports

### DIFF
--- a/superset-frontend/src/reports/actions/reports.js
+++ b/superset-frontend/src/reports/actions/reports.js
@@ -23,6 +23,7 @@ import {
   addDangerToast,
   addSuccessToast,
 } from 'src/components/MessageToasts/actions';
+import { isEmpty } from 'lodash';
 
 export const SET_REPORT = 'SET_REPORT';
 export function setReport(report, resourceId, creationMethod, filterField) {
@@ -76,7 +77,7 @@ export function fetchUISpecificReport({
 const structureFetchAction = (dispatch, getState) => {
   const state = getState();
   const { user, dashboardInfo, charts, explore } = state;
-  if (dashboardInfo) {
+  if (!isEmpty(dashboardInfo)) {
     dispatch(
       fetchUISpecificReport({
         userId: user.userId,
@@ -89,7 +90,7 @@ const structureFetchAction = (dispatch, getState) => {
     const [chartArr] = Object.keys(charts);
     dispatch(
       fetchUISpecificReport({
-        userId: explore.user.userId,
+        userId: explore.user?.userId || user?.userId,
         filterField: 'chart_id',
         creationMethod: 'charts',
         resourceId: charts[chartArr].id,


### PR DESCRIPTION
### SUMMARY
After deleting a report users would get stuck on with the modal open even after the report was actually deleted. It was caused because the resourceId was undefined when refreshing the data, so, we must use the chart info instead so the resourceId is not `undefined`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
![error](https://user-images.githubusercontent.com/38889534/179573588-1fb46351-f1f9-4c1d-8990-676be2c69873.gif)

AFTER:
![test](https://user-images.githubusercontent.com/38889534/179573692-2cff0988-060a-4472-9401-1fe020fac529.gif)


### TESTING INSTRUCTIONS
1. open a chart in explore and create report
2. go to the manage report from 3 dot menu on top right in explore
3. DELETE chart report

Expected Results:
1. The modal closes after you click `DELETE` and the toast shows the success message
2. The report is deleted

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
