### PR TITLE
fix: set allow `filter_select` for Query objects in Explore

### DIFF
--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
@@ -359,7 +359,7 @@ const AdhocFilterEditPopoverSimpleTabContent: React.FC<Props> = props => {
       const col = props.adhocFilter.subject;
       const having = props.adhocFilter.clause === CLAUSES.HAVING;
 
-      if (col && datasource && datasource.filter_select && !having) {
+      if (col && datasource?.filter_select !== false && !having) {
         const controller = new AbortController();
         const { signal } = controller;
         if (loadingComparatorSuggestions) {

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
@@ -359,7 +359,7 @@ const AdhocFilterEditPopoverSimpleTabContent: React.FC<Props> = props => {
       const col = props.adhocFilter.subject;
       const having = props.adhocFilter.clause === CLAUSES.HAVING;
 
-      if (col && datasource?.filter_select !== false && !having) {
+      if (col && datasource && datasource.filter_select && !having) {
         const controller = new AbortController();
         const { signal } = controller;
         if (loadingComparatorSuggestions) {

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1189,6 +1189,38 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
 
         return or_(*groups)
 
+    def values_for_column(self, column_name: str, limit: int = 10000) -> List[Any]:
+        """Runs query against sqla to retrieve some
+        sample values for the given column.
+        """
+        cols = {}
+        for col in self.columns:
+            if isinstance(col, dict):
+                cols[col.get("column_name")] = col
+            else:
+                cols[col.column_name] = col
+
+        target_col = cols[column_name]
+        tp = None  # self.get_template_processor()
+        tbl, cte = self.get_from_clause(tp)
+
+        if isinstance(target_col, dict):
+            sql_column = sa.column(target_col.get("name"))
+        else:
+            sql_column = target_col
+
+        qry = sa.select([sql_column]).select_from(tbl).distinct()
+        if limit:
+            qry = qry.limit(limit)
+
+        engine = self.database.get_sqla_engine()
+        sql = qry.compile(engine, compile_kwargs={"literal_binds": True})
+        sql = self._apply_cte(sql, cte)
+        sql = self.mutate_query_from_config(sql)
+
+        df = pd.read_sql_query(sql=sql, con=engine)
+        return df[column_name].to_list()
+
     def get_sqla_query(  # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
         self,
         apply_fetch_values_predicate: bool = False,

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1201,7 +1201,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                 cols[col.column_name] = col
 
         target_col = cols[column_name]
-        tp = None  # self.get_template_processor()
+        tp = None  # todo(hughhhh): add back self.get_template_processor()
         tbl, cte = self.get_from_clause(tp)
 
         if isinstance(target_col, dict):

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -212,6 +212,7 @@ class Query(Model, ExtraJSONMixin, ExploreMixin):  # pylint: disable=abstract-me
     @property
     def data(self) -> Dict[str, Any]:
         return {
+            "filter_select": True,
             "name": self.tab_name,
             "columns": self.columns,
             "metrics": [],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Allow filter select dropdown to execute `select distinct {col} from {table}` to make it easier for users to know what values are available to filter when in explore.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
