### PR TITLE
fix: PrestoEngineSpec._show_columns return type

### DIFF
--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -442,8 +442,7 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
         full_table = quote(table_name)
         if schema:
             full_table = "{}.{}".format(quote(schema), full_table)
-        columns = inspector.bind.execute("SHOW COLUMNS FROM {}".format(full_table))
-        return columns
+        return inspector.bind.execute(f"SHOW COLUMNS FROM {full_table}").fetchall()
 
     column_type_mappings = (
         (

--- a/tests/integration_tests/db_engine_specs/presto_tests.py
+++ b/tests/integration_tests/db_engine_specs/presto_tests.py
@@ -84,7 +84,7 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
         inspector.engine.dialect.identifier_preparer.quote_identifier = mock.Mock()
         row = mock.Mock()
         row.Column, row.Type, row.Null = column
-        inspector.bind.execute = mock.Mock(return_value=[row])
+        inspector.bind.execute.return_value.fetchall = mock.Mock(return_value=[row])
         results = PrestoEngineSpec.get_columns(inspector, "", "")
         self.assertEqual(len(expected_results), len(results))
         for expected_result, result in zip(expected_results, results):
@@ -744,25 +744,29 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
         inspector.engine.dialect.identifier_preparer.quote_identifier = (
             lambda x: f'"{x}"'
         )
-        mock_execute = mock.MagicMock(return_value=["a", "b"])
-        inspector.bind.execute = mock_execute
+        inspector.bind.execute.return_value.fetchall = mock.MagicMock(
+            return_value=["a", "b"]
+        )
         table_name = "table_name"
         result = PrestoEngineSpec._show_columns(inspector, table_name, None)
         assert result == ["a", "b"]
-        mock_execute.assert_called_once_with(f'SHOW COLUMNS FROM "{table_name}"')
+        inspector.bind.execute.assert_called_once_with(
+            f'SHOW COLUMNS FROM "{table_name}"'
+        )
 
     def test_show_columns_with_schema(self):
         inspector = mock.MagicMock()
         inspector.engine.dialect.identifier_preparer.quote_identifier = (
             lambda x: f'"{x}"'
         )
-        mock_execute = mock.MagicMock(return_value=["a", "b"])
-        inspector.bind.execute = mock_execute
+        inspector.bind.execute.return_value.fetchall = mock.MagicMock(
+            return_value=["a", "b"]
+        )
         table_name = "table_name"
         schema = "schema"
         result = PrestoEngineSpec._show_columns(inspector, table_name, schema)
         assert result == ["a", "b"]
-        mock_execute.assert_called_once_with(
+        inspector.bind.execute.assert_called_once_with(
             f'SHOW COLUMNS FROM "{schema}"."{table_name}"'
         )
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

The `PrestoEngineSpec._show_columns` method stated it returned a `List[RowProxy]` type however it actually returned a `ResultProxy`, i.e., per the SQLAlchemy [documentation](https://docs.sqlalchemy.org/en/13/core/connections.html),

> The [RowProxy](https://docs.sqlalchemy.org/en/13/core/connections.html?highlight=rowproxy#sqlalchemy.engine.RowProxy) object is retrieved from a database result, from the [ResultProxy](https://docs.sqlalchemy.org/en/13/core/connections.html?highlight=rowproxy#sqlalchemy.engine.ResultProxy) object using methods like [ResultProxy.fetchall()](https://docs.sqlalchemy.org/en/13/core/connections.html?highlight=rowproxy#sqlalchemy.engine.ResultProxy.fetchall).

From a coding perspective this wasn't problematic as the output is later processed via, 

```python
for column in PrestoEngineSpec._show_columns(...):
 ....
```

and though the `ResultProxy` supports iteration (per the DB API), it does not support pickling (and thus caching) whereas the `RowProxy` does (it's acts somewhat akin to a Python `tuple`). This was resulting in an issue at Airbnb where we actually override and cache the `PrestoEngineSpec._show_columns` using a user lock to help reduce the number of queries we send to Presto.

The fix is merely to augment the method to return a `List[RowProxy]` as promised rather than a `ResultProxy`. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
