### PR TITLE
fix(csv): Do not coerce persisted data integer columns to float

### DIFF
--- a/superset/utils/csv.py
+++ b/superset/utils/csv.py
@@ -65,6 +65,7 @@ def escape_value(value: str) -> str:
 
 
 def df_to_escaped_csv(df: pd.DataFrame, **kwargs: Any) -> Any:
+    escape_values = lambda v: escape_value(v) if isinstance(v, str) else v
 
     # Escape csv headers
     df = df.rename(columns=escape_values)

--- a/superset/utils/csv.py
+++ b/superset/utils/csv.py
@@ -65,7 +65,6 @@ def escape_value(value: str) -> str:
 
 
 def df_to_escaped_csv(df: pd.DataFrame, **kwargs: Any) -> Any:
-    escape_values = lambda v: escape_value(v) if isinstance(v, str) else v
 
     # Escape csv headers
     df = df.rename(columns=escape_values)

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2502,8 +2502,13 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             obj = _deserialize_results_payload(
                 payload, query, cast(bool, results_backend_use_msgpack)
             )
-            columns = [c['name'] for c in obj['columns']]
-            df = pd.DataFrame(data=obj["data"], dtype=object, columns=columns)
+
+            df = pd.DataFrame(
+                data=obj["data"], 
+                dtype=object, 
+                columns=[c["name"] for c in obj["columns"]],
+            )
+            
             logger.info("Using pandas to convert to CSV")
         else:
             logger.info("Running a query to turn into CSV")

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2502,7 +2502,8 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             obj = _deserialize_results_payload(
                 payload, query, cast(bool, results_backend_use_msgpack)
             )
-            df = pd.DataFrame(data=obj["data"], dtype=object)
+            columns = [c['name'] for c in obj['columns']]
+            df = pd.DataFrame(data=obj["data"], dtype=object, columns=columns)
             logger.info("Using pandas to convert to CSV")
         else:
             logger.info("Running a query to turn into CSV")

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2502,8 +2502,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             obj = _deserialize_results_payload(
                 payload, query, cast(bool, results_backend_use_msgpack)
             )
-            columns = [c["name"] for c in obj["columns"]]
-            df = pd.DataFrame.from_records(obj["data"], columns=columns)
+            df = pd.DataFrame(data=obj["data"], dtype=object)
             logger.info("Using pandas to convert to CSV")
         else:
             logger.info("Running a query to turn into CSV")

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2504,11 +2504,11 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             )
 
             df = pd.DataFrame(
-                data=obj["data"], 
-                dtype=object, 
+                data=obj["data"],
+                dtype=object,
                 columns=[c["name"] for c in obj["columns"]],
             )
-            
+
             logger.info("Using pandas to convert to CSV")
         else:
             logger.info("Running a query to turn into CSV")


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Regrettably https://github.com/apache/superset/pull/20151 wasn't suffice is the result set was stored prior to downloading the CSV file. More specifically Pandas coerces an integer array with `None` to a float—likely because of the Numpy coercion, i.e., 

```python
>>> pd.DataFrame.from_records([{"foo": 1}, {"foo": None}])
   foo
0  1.0
1  NaN
```

The fix is to explicitly define the dtype, using the standard DataFrame constructor, i.e., 

```python
>>> pd.DataFrame(data=[{"foo": 1}, {"foo": None}], dtype=object)
    foo
0     1
1  None
```

Long term we should probably replace quirky Pandas with PyArrow globally.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
