### PR TITLE
fix: Create Chart opening in new tab

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -256,7 +256,7 @@ export default class ResultSet extends React.PureComponent<
                     // const qid = this.props?.query?.results?.query_id;
                     // if (qid) {
                     //   // This will open explore using the query as datasource
-                    //   window.location.href = `/explore/?dataset_type=query&dataset_id=${qid}`;
+                    //   window.open(`/explore/?dataset_type=query&dataset_id=${qid}`, '_blank', 'noreferrer');
                     // } else {
                     //   this.setState({ showSaveDatasetModal: true });
                     // }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This adds to the functionality of the new flow for using a query as a datasource. When that feature is live we want create chart to be open in a new tab. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
https://user-images.githubusercontent.com/48933336/179849503-ecd99662-7842-4d09-bdf4-629d3c66f435.mov

### TESTIN


G INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
