### PR TITLE
fix(db): set slices.query_context to MEDIUMTEXT for mysql

### DIFF
--- a/superset/migrations/versions/2022-07-19_15-16_a39867932713_query_context_to_mediumtext.py
+++ b/superset/migrations/versions/2022-07-19_15-16_a39867932713_query_context_to_mediumtext.py
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""query_context_to_mediumtext
+
+Revision ID: a39867932713
+Revises: 06e1e70058c7
+Create Date: 2022-07-19 15:16:06.091961
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "a39867932713"
+down_revision = "06e1e70058c7"
+
+from alembic import op
+from sqlalchemy.dialects.mysql.base import MySQLDialect
+
+
+def upgrade():
+    if isinstance(op.get_bind().dialect, MySQLDialect):
+        # If the columns are already MEDIUMTEXT, this is a no-op
+        op.execute("ALTER TABLE slices MODIFY params MEDIUMTEXT")
+        op.execute("ALTER TABLE slices MODIFY query_context MEDIUMTEXT")
+
+
+def downgrade():
+    # It's Okay to keep these columns as MEDIUMTEXT
+    # Since some oraganizations may have already manually changed the type
+    # and downgrade may loose data so we don't do it.
+    pass


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Follow up for https://github.com/apache/superset/pull/20761, changing `Slice.query_context` and `Slice.params` to `MEDIUMTEXT` for MySQL databases. Ideally this should be ran before #20359 and #20346 but that would mean rebasing the existing migrations, which could be problematic for users who already ran both migrations.

We'll just accept the risk that some MySQL users may lose `query_context` data if they didn't manually run this column type change before #20359 and #20346...

On Airbnb's Superset instance with about 350k slices, this migration completes in about 50 seconds.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
