### PR TITLE
fix: unexpected commit causes pytest failure

### DIFF
--- a/superset/utils/database.py
+++ b/superset/utils/database.py
@@ -39,10 +39,7 @@ def get_or_create_db(
     from superset.models import core as models
 
     database = (
-        db.session.query(models.Database)
-        .filter_by(database_name=database_name)
-        .autoflush(False)
-        .first()
+        db.session.query(models.Database).filter_by(database_name=database_name).first()
     )
 
     # databases with a fixed UUID
@@ -56,8 +53,11 @@ def get_or_create_db(
             database_name=database_name, uuid=uuids.get(database_name)
         )
         db.session.add(database)
+        database.set_sqlalchemy_uri(sqlalchemy_uri)
+        db.session.commit()
 
-    if database:
+    # todo: it's a bad idea to do an update in a get/create function
+    if database and database.sqlalchemy_uri_decrypted != sqlalchemy_uri:
         database.set_sqlalchemy_uri(sqlalchemy_uri)
         db.session.commit()
 

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -472,6 +472,8 @@ class TestDatabaseModel(SupersetTestCase):
         assert VIRTUAL_TABLE_STRING_TYPES[backend].match(cols["mycase"].type)
         assert cols["expr"].expression == "case when 1 then 1 else 0 end"
 
+        db.session.delete(table)
+
     @patch("superset.models.core.Database.db_engine_spec", BigQueryEngineSpec)
     def test_labels_expected_on_mutated_query(self):
         query_obj = {

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -472,8 +472,6 @@ class TestDatabaseModel(SupersetTestCase):
         assert VIRTUAL_TABLE_STRING_TYPES[backend].match(cols["mycase"].type)
         assert cols["expr"].expression == "case when 1 then 1 else 0 end"
 
-        db.session.delete(table)
-
     @patch("superset.models.core.Database.db_engine_spec", BigQueryEngineSpec)
     def test_labels_expected_on_mutated_query(self):
         query_obj = {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The latest SQLAlchemy [upgrade](https://github.com/apache/superset/pull/19890) seems to be changing the autoflush rule, the full background at [here](https://github.com/apache/superset/pull/20780#issuecomment-1190344225). It causes `test_fetch_metadata_for_updated_virtual_table` failure. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Pure backend changes, so no screenshot.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
should pass following command in local and passes CI.
```
pytest --disable-warnings -s tests/integration_tests/sqla_models_tests.py -k test_fetch_metadata_for_updated_virtual_table
```


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
