### PR TITLE
fix(plugin-chart-echarts): layout broken when resizing

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -92,11 +92,10 @@ function Echart(
     previousSelection.current = currentSelection;
   }, [currentSelection]);
 
-  useEffect(() => {
-    if (chartRef.current) {
-      chartRef.current.resize({ width, height });
-    }
-  }, [width, height]);
+  // Ensure that each render and resize is idempotent
+  if (chartRef.current) {
+    chartRef.current.resize({ width, height });
+  }
 
   return <Styles ref={divRef} height={height} width={width} />;
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -22,6 +22,8 @@ import React, {
   useMemo,
   forwardRef,
   useImperativeHandle,
+  useLayoutEffect,
+  useCallback,
 } from 'react';
 import { styled } from '@superset-ui/core';
 import { ECharts, init } from 'echarts';
@@ -92,10 +94,23 @@ function Echart(
     previousSelection.current = currentSelection;
   }, [currentSelection]);
 
-  // Ensure that each render and resize is idempotent
-  if (chartRef.current) {
-    chartRef.current.resize({ width, height });
-  }
+  const handleSizeChange = useCallback(
+    ({ width, height }: { width: number; height: number }) => {
+      if (chartRef.current) {
+        chartRef.current.resize({ width, height });
+      }
+    },
+    [],
+  );
+
+  // did mount
+  useEffect(() => {
+    handleSizeChange({ width, height });
+  }, []);
+
+  useLayoutEffect(() => {
+    handleSizeChange({ width, height });
+  }, [width, height, handleSizeChange]);
 
   return <Styles ref={divRef} height={height} width={width} />;
 }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The essence of this problem is the inconsistency between the width and height of the parent container and the actual echart resize. Since our outer layer is based on `useResizeDetector` to debounce the width and height change, there is a probability of inconsistency, so we do not put `useEffect` here to ensure that resize and render execution are idempotent.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### before

https://user-images.githubusercontent.com/11830681/179942307-6802c033-a164-4acf-8ad1-5c810e36927e.mov


### after

https://user-images.githubusercontent.com/11830681/179941959-f0580456-584d-4c26-953f-b6e8cda2d4cf.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
