### PR TITLE
fix: core coverage and add a coverage step in workflow

### DIFF
--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -51,6 +51,11 @@ jobs:
         if: steps.check.outcome == 'failure'
         working-directory: ./superset-frontend
         run: npm run plugins:build-storybook
+      - name: superset-ui/core coverage
+        if: steps.check.outcome == 'failure'
+        working-directory: ./superset-frontend
+        run: |
+          npm run core:cover
       - name: unit tests
         if: steps.check.outcome == 'failure'
         working-directory: ./superset-frontend

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Datasource.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Datasource.ts
@@ -53,7 +53,4 @@ export const DEFAULT_METRICS: Metric[] = [
   },
 ];
 
-export const isValidDatasourceType = (datasource: DatasourceType) =>
-  Object.values(DatasourceType).includes(datasource);
-
 export default {};

--- a/superset-frontend/packages/superset-ui-core/test/query/types/Datasource.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/types/Datasource.test.ts
@@ -16,18 +16,22 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { DatasourceKey } from '@superset-ui/core';
+import { DatasourceType, DEFAULT_METRICS } from '@superset-ui/core';
 
-describe('DatasourceKey', () => {
-  it('should handle table data sources', () => {
-    const datasourceKey = new DatasourceKey('5__table');
-    expect(datasourceKey.toString()).toBe('5__table');
-    expect(datasourceKey.toObject()).toEqual({ id: 5, type: 'table' });
-  });
+test('DEFAULT_METRICS', () => {
+  expect(DEFAULT_METRICS).toEqual([
+    {
+      metric_name: 'COUNT(*)',
+      expression: 'COUNT(*)',
+    },
+  ]);
+});
 
-  it('should handle query data sources', () => {
-    const datasourceKey = new DatasourceKey('5__query');
-    expect(datasourceKey.toString()).toBe('5__query');
-    expect(datasourceKey.toObject()).toEqual({ id: 5, type: 'query' });
-  });
+test('DatasourceType', () => {
+  expect(Object.keys(DatasourceType).length).toBe(5);
+  expect(DatasourceType.Table).toBe('table');
+  expect(DatasourceType.Query).toBe('query');
+  expect(DatasourceType.Dataset).toBe('dataset');
+  expect(DatasourceType.SlTable).toBe('sl_table');
+  expect(DatasourceType.SavedQuery).toBe('saved_query');
 });


### PR DESCRIPTION
### SUMMARY
bring 100% code coverage to the `superset-ui/core`. this PR should wait for [this to merge](https://github.com/apache/superset/pull/20769).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
