### PR TITLE
feat: save dataset savemodal

### DIFF
--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -56,6 +56,7 @@ import { getFormDataFromControls } from 'src/explore/controlUtils';
 import * as exploreActions from 'src/explore/actions/exploreActions';
 import * as saveModalActions from 'src/explore/actions/saveModalActions';
 import { useTabId } from 'src/hooks/useTabId';
+import withToasts from 'src/components/MessageToasts/withToasts';
 import ExploreChartPanel from '../ExploreChartPanel';
 import ConnectedControlPanelsContainer from '../ControlPanelsContainer';
 import SaveModal from '../SaveModal';
@@ -386,6 +387,11 @@ function ExploreViewContainer(props) {
     );
     if (!hasError) {
       props.actions.triggerQuery(true, props.chart.id);
+    }
+    const toShowToast = getItem(LocalStorageKeys.datasetname_set_successful);
+    if (toShowToast) {
+      props.addSuccessToast('Chart saved');
+      setItem(LocalStorageKeys.datasetname_set_successful, false);
     }
   }, []);
 
@@ -767,4 +773,4 @@ function mapDispatchToProps(dispatch) {
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(ExploreViewContainer);
+)(withToasts(ExploreViewContainer));

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -387,7 +387,7 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
                 tooltip={t('A reusable dataset will be saved with your chart.')}
                 placement="right"
               />
-          <Input
+              <Input
                 name="dataset_name"
                 type="text"
                 placeholder="Dataset Name"
@@ -395,7 +395,7 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
                 onChange={this.handleDatasetNameChange}
                 data-test="new-dataset-name"
               />{' '}
-             </FormItem>
+            </FormItem>
           ) : null}
           <FormItem
             label={t('Add to dashboard')}

--- a/superset-frontend/src/utils/localStorageHelpers.ts
+++ b/superset-frontend/src/utils/localStorageHelpers.ts
@@ -40,6 +40,7 @@ export enum LocalStorageKeys {
   homepage_dashboard_filter = 'homepage_dashboard_filter',
   homepage_collapse_state = 'homepage_collapse_state',
   homepage_activity_filter = 'homepage_activity_filter',
+  datasetname_set_successful = 'datasetname_set_successful',
   /** END LEGACY LOCAL STORAGE KEYS */
 
   /**
@@ -64,6 +65,7 @@ export type LocalStorageValues = {
   homepage_chart_filter: TableTabTypes;
   homepage_dashboard_filter: TableTabTypes;
   homepage_collapse_state: string[];
+  datasetname_set_successful: boolean;
   homepage_activity_filter: SetTabType | null;
   sqllab__is_autocomplete_enabled: boolean;
   explore__data_table_original_formatted_time_columns: Record<string, string[]>;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This pr allows for the dataset to be saved in the save datasetmodal in explore when dataset is type query.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
write a query in sqllab and create a chart. Go to save and save the chart and dataset.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
