### PR TITLE
fix(explore): Adhoc columns don't display correctly

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.tsx
@@ -68,7 +68,7 @@ export const getColumnTooltipNode = (
   labelRef?: React.RefObject<any>,
 ): ReactNode => {
   if (
-    !column.verbose_name &&
+    (!column.column_name || !column.verbose_name) &&
     !column.description &&
     !isLabelTruncated(labelRef)
   ) {
@@ -77,7 +77,9 @@ export const getColumnTooltipNode = (
 
   return (
     <>
-      <TooltipSection label={t('Column name')} text={column.column_name} />
+      {column.column_name && (
+        <TooltipSection label={t('Column name')} text={column.column_name} />
+      )}
       {column.verbose_name && (
         <TooltipSection label={t('Label')} text={column.verbose_name} />
       )}

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Column.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Column.ts
@@ -18,6 +18,7 @@
  * under the License.
  */
 
+import { isDefined } from '@superset-ui/core';
 import { GenericDataType } from './QueryResponse';
 import { QueryFormColumn } from './QueryFormData';
 
@@ -61,7 +62,7 @@ export function isAdhocColumn(column?: any): column is AdhocColumn {
     typeof column !== 'string' &&
     column?.sqlExpression !== undefined &&
     column?.label !== undefined &&
-    column?.expressionType === 'SQL'
+    (!isDefined(column?.expressionType) || column?.expressionType === 'SQL')
   );
 }
 

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Column.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Column.ts
@@ -18,7 +18,6 @@
  * under the License.
  */
 
-import { isDefined } from '@superset-ui/core';
 import { GenericDataType } from './QueryResponse';
 import { QueryFormColumn } from './QueryFormData';
 
@@ -62,7 +61,7 @@ export function isAdhocColumn(column?: any): column is AdhocColumn {
     typeof column !== 'string' &&
     column?.sqlExpression !== undefined &&
     column?.label !== undefined &&
-    (!isDefined(column?.expressionType) || column?.expressionType === 'SQL')
+    (column?.expressionType === undefined || column?.expressionType === 'SQL')
   );
 }
 

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -121,7 +121,7 @@ const ColumnSelectPopover = ({
 
   const onSqlExpressionChange = useCallback(
     sqlExpression => {
-      setAdhocColumn({ label, sqlExpression } as AdhocColumn);
+      setAdhocColumn({ label, sqlExpression, expressionType: 'SQL' });
       setSelectedSimpleColumn(undefined);
       setSelectedCalculatedColumn(undefined);
     },

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.test.tsx
@@ -51,12 +51,12 @@ test('renders adhoc column', () => {
       {...defaultProps}
       value={{
         sqlExpression: 'Count *',
-        label: 'adhoc metric',
+        label: 'adhoc column',
         expressionType: 'SQL',
       }}
     />,
     { useDnd: true },
   );
-  expect(screen.getByText('adhoc metric')).toBeVisible();
+  expect(screen.getByText('adhoc column')).toBeVisible();
   expect(screen.getByLabelText('calculator')).toBeVisible();
 });

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.test.tsx
@@ -27,7 +27,9 @@ const defaultProps: DndColumnSelectProps = {
   type: 'DndColumnSelect',
   name: 'Filter',
   onChange: jest.fn(),
-  options: { string: { column_name: 'Column A' } },
+  options: {
+    string: { column_name: 'Column A' },
+  },
   actions: { setControlValue: jest.fn() },
 };
 
@@ -41,4 +43,20 @@ test('renders with value', () => {
     useDnd: true,
   });
   expect(screen.getByText('Column A')).toBeInTheDocument();
+});
+
+test('renders adhoc column', () => {
+  render(
+    <DndColumnSelect
+      {...defaultProps}
+      value={{
+        sqlExpression: 'Count *',
+        label: 'adhoc metric',
+        expressionType: 'SQL',
+      }}
+    />,
+    { useDnd: true },
+  );
+  expect(screen.getByText('adhoc metric')).toBeVisible();
+  expect(screen.getByLabelText('calculator')).toBeVisible();
 });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fix adhoc columns not displaying properly. When user added an adhoc column the label was blank and on click an empty popover was showing up instead of prefilled with custom sql.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="333" alt="image" src="https://user-images.githubusercontent.com/15073128/180207710-f4678de1-0f5f-480e-921f-3131d9aea188.png">

After:
<img width="331" alt="image" src="https://user-images.githubusercontent.com/15073128/180207623-d825d169-4805-4473-a446-63749391ddab.png">


### TESTING INSTRUCTIONS
1. Add an adhoc column
2. Verify that it displays correctly
3. Click on the column to edit
4. Verify that popover opens on Custom SQL tab with column's sql expression prefilled

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
