### PR TITLE
feat: Create Chart onClick Functionality

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -221,6 +221,7 @@ export default class ResultSet extends React.PureComponent<
 
   async createExploreResultsOnClick() {
     const { results } = this.props.query;
+
     if (results.query_id) {
       const key = await postFormData(results.query_id, 'table', {
         ...EXPLORE_CHART_DEFAULT,
@@ -248,7 +249,7 @@ export default class ResultSet extends React.PureComponent<
       // Added compute logic to stop user from being able to Save & Explore
       const { showSaveDatasetModal } = this.state;
       const { query } = this.props;
-      console.log('this is query', query);
+
       const datasource: ISaveableDatasource = {
         columns: query.results.columns as ISimpleColumn[],
         name: query?.tab || 'Untitled',
@@ -275,8 +276,11 @@ export default class ResultSet extends React.PureComponent<
               this.props.database?.allows_virtual_table_explore && (
                 <ExploreResultsButton
                   database={this.props.database}
-                  onClick={this.createExploreResultsOnClick}
+                  onClick={() => this.setState({ showSaveDatasetModal: true })}
                 />
+                // In order to use the new workflow for a query powered chart, replace the
+                // above function with:
+                // onClick={this.createExploreResultsOnClick}
               )}
             {this.props.csv && (
               <Button buttonSize="small" href={`/superset/csv/${query.id}`}>

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -223,9 +223,9 @@ export default class ResultSet extends React.PureComponent<
     const { results } = this.props.query;
 
     if (results.query_id) {
-      const key = await postFormData(results.query_id, 'table', {
+      const key = await postFormData(results.query_id, 'query', {
         ...EXPLORE_CHART_DEFAULT,
-        datasource: `${results.query_id}__table`,
+        datasource: `${results.query_id}__query`,
         ...{
           all_columns: results.columns.map(column => column.name),
         },

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -29,6 +29,9 @@ import {
   SaveDatasetModal,
 } from 'src/SqlLab/components/SaveDatasetModal';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
+import { EXPLORE_CHART_DEFAULT } from 'src/SqlLab/types';
+import { mountExploreUrl } from 'src/explore/exploreUtils';
+import { postFormData } from 'src/explore/exploreUtils/formData';
 import ProgressBar from 'src/components/ProgressBar';
 import Loading from 'src/components/Loading';
 import FilterableTable, {
@@ -41,6 +44,7 @@ import ExploreCtasResultsButton from '../ExploreCtasResultsButton';
 import ExploreResultsButton from '../ExploreResultsButton';
 import HighlightedSql from '../HighlightedSql';
 import QueryStateLabel from '../QueryStateLabel';
+import { URL_PARAMS } from 'src/constants';
 
 enum LIMITING_FACTOR {
   QUERY = 'QUERY',
@@ -134,6 +138,8 @@ export default class ResultSet extends React.PureComponent<
     this.reFetchQueryResults = this.reFetchQueryResults.bind(this);
     this.toggleExploreResultsButton =
       this.toggleExploreResultsButton.bind(this);
+    this.createExploreResultsOnClick =
+      this.createExploreResultsOnClick.bind(this);
   }
 
   async componentDidMount() {
@@ -213,6 +219,25 @@ export default class ResultSet extends React.PureComponent<
     }
   }
 
+  async createExploreResultsOnClick() {
+    const { results } = this.props.query;
+    if (results.query_id) {
+      const key = await postFormData(results.query_id, 'table', {
+        ...EXPLORE_CHART_DEFAULT,
+        datasource: `${results.query_id}__table`,
+        ...{
+          all_columns: results.columns.map(column => column.name),
+        },
+      });
+      const url = mountExploreUrl(null, {
+        [URL_PARAMS.formDataKey.name]: key,
+      });
+      window.open(url, '_blank', 'noreferrer');
+    } else {
+      this.setState({ showSaveDatasetModal: true });
+    }
+  }
+
   renderControls() {
     if (this.props.search || this.props.visualize || this.props.csv) {
       let { data } = this.props.query.results;
@@ -223,7 +248,7 @@ export default class ResultSet extends React.PureComponent<
       // Added compute logic to stop user from being able to Save & Explore
       const { showSaveDatasetModal } = this.state;
       const { query } = this.props;
-
+      console.log('this is query', query);
       const datasource: ISaveableDatasource = {
         columns: query.results.columns as ISimpleColumn[],
         name: query?.tab || 'Untitled',
@@ -250,18 +275,7 @@ export default class ResultSet extends React.PureComponent<
               this.props.database?.allows_virtual_table_explore && (
                 <ExploreResultsButton
                   database={this.props.database}
-                  onClick={() => {
-                    // There is currently redux / state issue where sometimes a query will have serverId
-                    // and other times it will not.  We need this attribute consistently for this to work
-                    // const qid = this.props?.query?.results?.query_id;
-                    // if (qid) {
-                    //   // This will open explore using the query as datasource
-                    //   window.location.href = `/explore/?dataset_type=query&dataset_id=${qid}`;
-                    // } else {
-                    //   this.setState({ showSaveDatasetModal: true });
-                    // }
-                    this.setState({ showSaveDatasetModal: true });
-                  }}
+                  onClick={this.createExploreResultsOnClick}
                 />
               )}
             {this.props.csv && (

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -38,13 +38,14 @@ import FilterableTable, {
   MAX_COLUMNS_FOR_TABLE,
 } from 'src/components/FilterableTable';
 import CopyToClipboard from 'src/components/CopyToClipboard';
+import { addDangerToast } from 'src/components/MessageToasts/actions';
 import { prepareCopyToClipboardTabularData } from 'src/utils/common';
 import { CtasEnum } from 'src/SqlLab/actions/sqlLab';
+import { URL_PARAMS } from 'src/constants';
 import ExploreCtasResultsButton from '../ExploreCtasResultsButton';
 import ExploreResultsButton from '../ExploreResultsButton';
 import HighlightedSql from '../HighlightedSql';
 import QueryStateLabel from '../QueryStateLabel';
-import { URL_PARAMS } from 'src/constants';
 
 enum LIMITING_FACTOR {
   QUERY = 'QUERY',
@@ -138,8 +139,6 @@ export default class ResultSet extends React.PureComponent<
     this.reFetchQueryResults = this.reFetchQueryResults.bind(this);
     this.toggleExploreResultsButton =
       this.toggleExploreResultsButton.bind(this);
-    this.createExploreResultsOnClick =
-      this.createExploreResultsOnClick.bind(this);
   }
 
   async componentDidMount() {
@@ -219,10 +218,10 @@ export default class ResultSet extends React.PureComponent<
     }
   }
 
-  async createExploreResultsOnClick() {
+  createExploreResultsOnClick = async () => {
     const { results } = this.props.query;
 
-    if (results.query_id) {
+    if (results?.query_id) {
       const key = await postFormData(results.query_id, 'query', {
         ...EXPLORE_CHART_DEFAULT,
         datasource: `${results.query_id}__query`,
@@ -235,9 +234,9 @@ export default class ResultSet extends React.PureComponent<
       });
       window.open(url, '_blank', 'noreferrer');
     } else {
-      this.setState({ showSaveDatasetModal: true });
+      addDangerToast(t('Unable to create chart without a query id.'));
     }
-  }
+  };
 
   renderControls() {
     if (this.props.search || this.props.visualize || this.props.csv) {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This changes the functionality of the create chart button to be in line with the new feature of a query powered chart. Essentially when the create chart button is now clicked the user will have a new tab open with a table chart using all their current data. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

https://user-images.githubusercontent.com/48933336/180262255-7d78988c-578a-444b-8ac0-2922bc842875.mov




### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
