### PR TITLE
refactor: Improve performance regression introduced in #20473

### DIFF
--- a/superset/datasets/dao.py
+++ b/superset/datasets/dao.py
@@ -154,10 +154,10 @@ class DatasetDAO(BaseDAO):  # pylint: disable=too-many-public-methods
         """
 
         if "columns" in properties:
-            cls.update_columns(model, properties.pop("columns"))
+            cls.update_columns(model, properties.pop("columns"), commit=commit)
 
         if "metrics" in properties:
-            cls.update_metrics(model, properties.pop("metrics"))
+            cls.update_metrics(model, properties.pop("metrics"), commit=commit)
 
         return super().update(model, properties, commit=commit)
 
@@ -166,6 +166,7 @@ class DatasetDAO(BaseDAO):  # pylint: disable=too-many-public-methods
         cls,
         model: SqlaTable,
         property_columns: List[Dict[str, Any]],
+        commit: bool = True,
     ) -> None:
         """
         Creates/updates and/or deletes a list of columns, based on a
@@ -198,11 +199,15 @@ class DatasetDAO(BaseDAO):  # pylint: disable=too-many-public-methods
         for id_ in {obj.id for obj in model.columns} - seen:
             DatasetDAO.delete_column(column_by_id[id_], commit=False)
 
+        if commit:
+            db.session.commit()
+
     @classmethod
     def update_metrics(
         cls,
         model: SqlaTable,
         property_metrics: List[Dict[str, Any]],
+        commit: bool = True,
     ) -> None:
         """
         Creates/updates and/or deletes a list of metrics, based on a
@@ -234,6 +239,9 @@ class DatasetDAO(BaseDAO):  # pylint: disable=too-many-public-methods
 
         for id_ in {obj.id for obj in model.metrics} - seen:
             DatasetDAO.delete_column(metric_by_id[id_], commit=False)
+
+        if commit:
+            db.session.commit()
 
     @classmethod
     def find_dataset_column(

--- a/superset/datasets/dao.py
+++ b/superset/datasets/dao.py
@@ -154,10 +154,10 @@ class DatasetDAO(BaseDAO):  # pylint: disable=too-many-public-methods
         """
 
         if "columns" in properties:
-            properties["columns"] = cls.update_columns(model, properties["columns"])
+            cls.update_columns(model, properties.pop("columns"))
 
         if "metrics" in properties:
-            properties["metrics"] = cls.update_metrics(model, properties["metrics"])
+            cls.update_metrics(model, properties.pop("metrics"))
 
         return super().update(model, properties, commit=commit)
 
@@ -166,7 +166,7 @@ class DatasetDAO(BaseDAO):  # pylint: disable=too-many-public-methods
         cls,
         model: SqlaTable,
         property_columns: List[Dict[str, Any]],
-    ) -> List[TableColumn]:
+    ) -> None:
         """
         Creates/updates and/or deletes a list of columns, based on a
         list of Dict.
@@ -178,33 +178,32 @@ class DatasetDAO(BaseDAO):  # pylint: disable=too-many-public-methods
         """
 
         column_by_id = {column.id: column for column in model.columns}
-        columns = []
+        seen = set()
 
         for properties in property_columns:
             if "id" in properties:
-                columns.append(
-                    DatasetDAO.update_column(
-                        column_by_id[properties["id"]],
-                        properties,
-                        commit=False,
-                    )
+                seen.add(properties["id"])
+
+                DatasetDAO.update_column(
+                    column_by_id[properties["id"]],
+                    properties,
+                    commit=False,
                 )
             else:
+                DatasetDAO.create_column(
+                    {**properties, "table_id": model.id},
+                    commit=False,
+                )
 
-                # Note for new columns the primary key is undefined sans a commit/flush.
-                columns.append(DatasetDAO.create_column(properties, commit=False))
-
-        for id_ in {obj.id for obj in model.columns} - {obj.id for obj in columns}:
+        for id_ in {obj.id for obj in model.columns} - seen:
             DatasetDAO.delete_column(column_by_id[id_], commit=False)
-
-        return columns
 
     @classmethod
     def update_metrics(
         cls,
         model: SqlaTable,
         property_metrics: List[Dict[str, Any]],
-    ) -> List[SqlMetric]:
+    ) -> None:
         """
         Creates/updates and/or deletes a list of metrics, based on a
         list of Dict.
@@ -216,26 +215,25 @@ class DatasetDAO(BaseDAO):  # pylint: disable=too-many-public-methods
         """
 
         metric_by_id = {metric.id: metric for metric in model.metrics}
-        metrics = []
+        seen = set()
 
         for properties in property_metrics:
             if "id" in properties:
-                metrics.append(
-                    DatasetDAO.update_metric(
-                        metric_by_id[properties["id"]],
-                        properties,
-                        commit=False,
-                    )
+                seen.add(properties["id"])
+
+                DatasetDAO.update_metric(
+                    metric_by_id[properties["id"]],
+                    properties,
+                    commit=False,
                 )
             else:
+                DatasetDAO.create_metric(
+                    {**properties, "table_id": model.id},
+                    commit=False,
+                )
 
-                # Note for new metrics the primary key is undefined sans a commit/flush.
-                metrics.append(DatasetDAO.create_metric(properties, commit=False))
-
-        for id_ in {obj.id for obj in model.metrics} - {obj.id for obj in metrics}:
+        for id_ in {obj.id for obj in model.metrics} - seen:
             DatasetDAO.delete_column(metric_by_id[id_], commit=False)
-
-        return metrics
 
     @classmethod
     def find_dataset_column(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR resolves a performance regression introduced in https://github.com/apache/superset/pull/20473. Previously only the new columns/metrics where returned via the `update_columns` and `update_metrics` methods respectively—which were defined as properties of the dataset and then bound to the table via the DAO [update](https://github.com/apache/superset/blob/master/superset/dao/base.py#L155-L172). I also re-introduced the commit to both methods as one likely would expect these methods to commit rather than waiting for the `update` commit. Note the previous optimization exists, i.e., the commit occurs at the end rather than for each create, update, or delete.

In https://github.com/apache/superset/pull/20473 both new and existing columns were returned which added unnecessary overhead. Furthermore I'm not sure how complex a SQLAlchemy ORM model update with relationships is,  i.e., where it tries to re-update all the columns and metrics, but given we already have dedicated methods to "update" columns/metrics—actually create, update, and delete—it seems simpler/clearer to bind new columns/metrics to the parent table on create and exclude all columns/metrics when updating the dataset model, i.e., previously it wasn't overly clear from the code—without digging—why the `update_columns` and `update_metrics`  were returning a subset of entities.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
