### PR TITLE
fix: Ensure consistent rollback logic for failed SQL operations

### DIFF
--- a/superset/annotation_layers/annotations/dao.py
+++ b/superset/annotation_layers/annotations/dao.py
@@ -40,8 +40,7 @@ class AnnotationDAO(BaseDAO):
             if commit:
                 db.session.commit()
         except SQLAlchemyError as ex:
-            if commit:
-                db.session.rollback()
+            db.session.rollback()
             raise DAODeleteFailedError() from ex
 
     @staticmethod

--- a/superset/annotation_layers/dao.py
+++ b/superset/annotation_layers/dao.py
@@ -42,8 +42,7 @@ class AnnotationLayerDAO(BaseDAO):
             if commit:
                 db.session.commit()
         except SQLAlchemyError as ex:
-            if commit:
-                db.session.rollback()
+            db.session.rollback()
             raise DAODeleteFailedError() from ex
 
     @staticmethod

--- a/superset/charts/dao.py
+++ b/superset/charts/dao.py
@@ -54,8 +54,7 @@ class ChartDAO(BaseDAO):
             if commit:
                 db.session.commit()
         except SQLAlchemyError as ex:
-            if commit:
-                db.session.rollback()
+            db.session.rollback()
             raise ex
 
     @staticmethod

--- a/superset/dashboards/dao.py
+++ b/superset/dashboards/dao.py
@@ -169,8 +169,7 @@ class DashboardDAO(BaseDAO):
             if commit:
                 db.session.commit()
         except SQLAlchemyError as ex:
-            if commit:
-                db.session.rollback()
+            db.session.rollback()
             raise ex
 
     @staticmethod

--- a/superset/queries/saved_queries/dao.py
+++ b/superset/queries/saved_queries/dao.py
@@ -42,6 +42,5 @@ class SavedQueryDAO(BaseDAO):
             if commit:
                 db.session.commit()
         except SQLAlchemyError as ex:
-            if commit:
-                db.session.rollback()
+            db.session.rollback()
             raise DAODeleteFailedError() from ex

--- a/superset/reports/dao.py
+++ b/superset/reports/dao.py
@@ -111,8 +111,7 @@ class ReportScheduleDAO(BaseDAO):
             if commit:
                 db.session.commit()
         except SQLAlchemyError as ex:
-            if commit:
-                db.session.rollback()
+            db.session.rollback()
             raise DAODeleteFailedError(str(ex)) from ex
 
     @staticmethod
@@ -324,6 +323,5 @@ class ReportScheduleDAO(BaseDAO):
                 session.commit()
             return row_count
         except SQLAlchemyError as ex:
-            if commit:
-                session.rollback()
+            session.rollback()
             raise DAODeleteFailedError(str(ex)) from ex


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR ensures we consistently handle rollbacks when an error occurs. Throughout the code there's inconsistent logic of the form:

```python
try:    
    if commit:
        db.session.commit()
except SQLAlchemyError as ex:
    db.session.rollback()
```

as well as:

```python
try:    
    if commit:
        db.session.commit()
except SQLAlchemyError as ex:
    if commit:
        db.session.rollback()
```

This PR—by way of `git grep -B 1 rollback`—removes the unnecessary `if commit` checkout before a rollback because we want to rollback any operation which failed—pre commit—in the transaction regardless of whether we're planning to commit, i.e., save the state. 

Regarding commits per [here](https://www.geeksforgeeks.org/difference-between-commit-and-rollback-in-sql/) it's worth noting that once committed a rollback is not viable.

> The transaction can not undo changes after COMMIT execution.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
