### PR TITLE
fix: Redirects old Explore URLs to the new ones

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -752,6 +752,9 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             "This API endpoint is deprecated and will be removed in version 3.0.0",
             self.__class__.__name__,
         )
+        if request.method == "GET":
+            return redirect(request.url.replace("/superset/explore", "/explore"))
+
         initial_form_data = {}
 
         form_data_key = request.args.get("form_data_key")


### PR DESCRIPTION
### SUMMARY
To preserve bookmarked URLs this PR redirects old Explore URLs in the format `/superset/explore` to the new one without the `/superset` prefix. This only affects `GET` operations. We only preserved the `POST` operation in case anyone is using it for something. In any case, this endpoint will be deleted in 3.0 as the warning clearly states.

Follow-up of https://github.com/apache/superset/pull/20572

### TESTING INSTRUCTIONS
Check if old Explore URLs are redirected to the new ones with all parameters preserved.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
