### PR TITLE
fix: Temporal X Axis values are not properly displayed if the time column has a custom label defined

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -173,7 +173,8 @@ export default function transformProps(
     Object.values(rawSeries).map(series => series.name as string),
   );
   const isAreaExpand = stack === AreaChartExtraControlsValue.Expand;
-  const xAxisDataType = dataTypes?.[xAxisCol];
+  const xAxisDataType = dataTypes?.[xAxisCol] ?? dataTypes?.[xAxisOrig];
+
   const xAxisType = getAxisType(xAxisDataType);
   const series: SeriesOption[] = [];
   const formatter = getNumberFormatter(


### PR DESCRIPTION
### SUMMARY

Defining a label to the time column on the dataset level breaks the axis values displayed on the chart, in case the `GENERIC_CHART_AXES` feature flag enabled.

The issue is that, by changing the label, we're failing to calculate the proper type of the x axis column, since the dataType mapping is done with the original axis value.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://user-images.githubusercontent.com/17252075/180376109-403d63c4-c293-4af1-9cab-008332480965.mov

After:

https://user-images.githubusercontent.com/17252075/180376182-c5403433-df9c-4e50-8cbe-c017bbf47b29.mov

### TESTING INSTRUCTIONS

1. Create a **Bar Chart v2** using the `Vehicle Sales` dataset.
2. Set **Month** as the granularity.
3. Set `order_date` as the X Axis.
4. Set `sum(price_each)` as the metric. 
5. Click on **CREATE CHART**.
6. Note that the months are properly displayed on the X Axis. 
7. Click on the three ellipses next to the dataset name > **Edit dataset**.
8. Navigate to the **COLUMNS** tab.
9. Expand the `order_date` column.
10. Set date as a label for this column.
11. Click on **SAVE**.
12. Click on **OK**.

Ensure **Months** are still properly displayed on the X Axis.
 
### ADDITIONAL INFORMATION
Fixes #20074
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
