### PR TITLE
fix(dashboard): add toast if JSON metadata is invalid

### DIFF
--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -59,6 +59,7 @@ type PropertiesModalProps = {
   setColorSchemeAndUnsavedChanges?: () => void;
   onSubmit?: (params: Record<string, any>) => void;
   addSuccessToast: (message: string) => void;
+  addDangerToast: (message: string) => void;
   onlyApply?: boolean;
 };
 
@@ -80,6 +81,7 @@ type DashboardInfo = {
 
 const PropertiesModal = ({
   addSuccessToast,
+  addDangerToast,
   colorScheme: currentColorScheme,
   dashboardId,
   dashboardInfo: currentDashboardInfo,
@@ -294,7 +296,12 @@ const PropertiesModal = ({
 
     // color scheme in json metadata has precedence over selection
     if (currentJsonMetadata?.length) {
-      const metadata = JSON.parse(currentJsonMetadata);
+      let metadata;
+      try {
+        metadata = JSON.parse(currentJsonMetadata);
+      } catch (error) {
+        addDangerToast(t('JSON metadata is invalid!'));
+      }
       currentColorScheme = metadata?.color_scheme || colorScheme;
       colorNamespace = metadata?.color_namespace || '';
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When the json metadata of the dashboard is not legal, the user clicks the save button without any response and no other prompt, this PR adds toast to inform the user.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### before

https://user-images.githubusercontent.com/11830681/180412795-4eae920a-6ce2-4d55-b209-98baedb42448.mov


### after

https://user-images.githubusercontent.com/11830681/180412783-b5464423-d9a6-42ea-acea-c10a8116d545.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
