### PR TITLE
feat: add 'dashboard.nav.right' extension to registry

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/ui-overrides/ExtensionsRegistry.ts
+++ b/superset-frontend/packages/superset-ui-core/src/ui-overrides/ExtensionsRegistry.ts
@@ -38,6 +38,7 @@ type ReturningDisplayable<P = void> = (props: P) => string | React.ReactElement;
 export type Extensions = Partial<{
   'embedded.documentation.description': ReturningDisplayable;
   'embedded.documentation.url': string;
+  'dashboard.nav.right': React.ComponentType;
   'navbar.right': React.ComponentType;
   'welcome.banner': React.ComponentType;
 }>;

--- a/superset-frontend/src/dashboard/components/Header/Header.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/Header.test.tsx
@@ -20,6 +20,8 @@ import React from 'react';
 import { render, screen, fireEvent } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
+import { getExtensionsRegistry } from '@superset-ui/core';
+import setupExtensions from 'src/setup/setupExtensions';
 import { HeaderProps } from './types';
 import Header from '.';
 
@@ -326,4 +328,18 @@ test('should refresh the charts', async () => {
   await openActionsDropdown();
   userEvent.click(screen.getByText('Refresh dashboard'));
   expect(mockedProps.onRefresh).toHaveBeenCalledTimes(1);
+});
+
+test('should render an extension component if one is supplied', () => {
+  const extensionsRegistry = getExtensionsRegistry();
+  extensionsRegistry.set('dashboard.nav.right', () => (
+    <>dashboard.nav.right extension component</>
+  ));
+  setupExtensions();
+
+  const mockedProps = createProps();
+  setup(mockedProps);
+  expect(
+    screen.getByText('dashboard.nav.right extension component'),
+  ).toBeInTheDocument();
 });

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -20,7 +20,13 @@
 import moment from 'moment';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { styled, css, t, getSharedLabelColor } from '@superset-ui/core';
+import {
+  styled,
+  css,
+  t,
+  getSharedLabelColor,
+  getUiOverrideRegistry,
+} from '@superset-ui/core';
 import { Global } from '@emotion/react';
 import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 import {
@@ -52,6 +58,8 @@ import { options as PeriodicRefreshOptions } from 'src/dashboard/components/Refr
 import { FILTER_BOX_MIGRATION_STATES } from 'src/explore/constants';
 import { PageHeaderWithActions } from 'src/components/PageHeaderWithActions';
 import { DashboardEmbedModal } from '../DashboardEmbedControls';
+
+const uiOverrideRegistry = getUiOverrideRegistry();
 
 const propTypes = {
   addSuccessToast: PropTypes.func.isRequired,
@@ -483,6 +491,8 @@ class Header extends React.PureComponent {
       dashboardTitleChanged(updates.title);
     };
 
+    const NavExtension = uiOverrideRegistry.get('dashboard.nav.right');
+
     return (
       <div
         css={headerContainerStyle}
@@ -601,6 +611,7 @@ class Header extends React.PureComponent {
                 />
               ) : (
                 <div css={actionButtonsStyle}>
+                  {NavExtension && <NavExtension />}
                   {userCanEdit && (
                     <Button
                       buttonStyle="secondary"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Adds a extension point to the right side of the dashboard nav

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
