### PR TITLE
feat: only show active user for chart/dashboard/datasource owner drop…

### DIFF
--- a/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
@@ -540,10 +540,12 @@ function OwnersSelector({ datasource, onChange }) {
     return SupersetClient.get({
       endpoint: `/api/v1/dataset/related/owners?q=${query}`,
     }).then(response => ({
-      data: response.json.result.map(item => ({
-        value: item.value,
-        label: item.text,
-      })),
+      data: response.json.result
+        .filter(item => item.extra.active)
+        .map(item => ({
+          value: item.value,
+          label: item.text,
+        })),
       totalCount: response.json.count,
     }));
   }, []);

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -133,6 +133,7 @@ const PropertiesModal = ({
         endpoint: `/api/v1/dashboard/related/${accessType}?q=${query}`,
       }).then(response => ({
         data: response.json.result
+          // @ts-ignore
           .filter(item => item.extra.active)
           .map((item: { value: number; text: string }) => ({
             value: item.value,

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -132,12 +132,12 @@ const PropertiesModal = ({
       return SupersetClient.get({
         endpoint: `/api/v1/dashboard/related/${accessType}?q=${query}`,
       }).then(response => ({
-        data: response.json.result.map(
-          (item: { value: number; text: string }) => ({
+        data: response.json.result
+          .filter(item => item.extra.active)
+          .map((item: { value: number; text: string }) => ({
             value: item.value,
             label: item.text,
-          }),
-        ),
+          })),
         totalCount: response.json.count,
       }));
     },

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -133,8 +133,7 @@ const PropertiesModal = ({
         endpoint: `/api/v1/dashboard/related/${accessType}?q=${query}`,
       }).then(response => ({
         data: response.json.result
-          // @ts-ignore
-          .filter(item => item.extra.active)
+          .filter((item: { extra: { active: boolean } }) => item.extra.active)
           .map((item: { value: number; text: string }) => ({
             value: item.value,
             label: item.text,

--- a/superset-frontend/src/explore/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/index.tsx
@@ -108,6 +108,7 @@ function PropertiesModal({
           endpoint: `/api/v1/chart/related/owners?q=${query}`,
         }).then(response => ({
           data: response.json.result
+            // @ts-ignore
             .filter(item => item.extra.active)
             .map((item: { value: number; text: string }) => ({
               value: item.value,

--- a/superset-frontend/src/explore/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/index.tsx
@@ -107,12 +107,12 @@ function PropertiesModal({
         return SupersetClient.get({
           endpoint: `/api/v1/chart/related/owners?q=${query}`,
         }).then(response => ({
-          data: response.json.result.map(
-            (item: { value: number; text: string }) => ({
+          data: response.json.result
+            .filter(item => item.extra.active)
+            .map((item: { value: number; text: string }) => ({
               value: item.value,
               label: item.text,
-            }),
-          ),
+            })),
           totalCount: response.json.count,
         }));
       },

--- a/superset-frontend/src/explore/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/index.tsx
@@ -108,8 +108,7 @@ function PropertiesModal({
           endpoint: `/api/v1/chart/related/owners?q=${query}`,
         }).then(response => ({
           data: response.json.result
-            // @ts-ignore
-            .filter(item => item.extra.active)
+            .filter((item: { extra: { active: boolean } }) => item.extra.active)
             .map((item: { value: number; text: string }) => ({
               value: item.value,
               label: item.text,

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -223,6 +223,15 @@ class BaseSupersetModelRestApi(ModelRestApi):
         }
     """
 
+    extra_fields_rel_fields: Dict[str, List[str]] = {"owners": ["email", "active"]}
+    """
+    Declare extra fields for the representation of the Model object::
+
+        extra_fields_rel_fields = {
+            "<RELATED_FIELD>": "[<RELATED_OBJECT_FIELD_1>, <RELATED_OBJECT_FIELD_2>]"
+        }
+    """
+
     allowed_distinct_fields: Set[str] = set()
 
     add_columns: List[str]
@@ -317,6 +326,17 @@ class BaseSupersetModelRestApi(ModelRestApi):
                 return getattr(model, model_column_name)
         return str(model)
 
+    def _get_extra_field_for_model(
+        self, model: Model, column_name: str
+    ) -> Dict[str, str]:
+        ret = {}
+        if column_name in self.extra_fields_rel_fields:
+            model_column_names = self.extra_fields_rel_fields.get(column_name)
+            if model_column_names:
+                for key in model_column_names:
+                    ret[key] = getattr(model, key)
+        return ret
+
     def _get_result_from_rows(
         self, datamodel: SQLAInterface, rows: List[Model], column_name: str
     ) -> List[Dict[str, Any]]:
@@ -324,6 +344,7 @@ class BaseSupersetModelRestApi(ModelRestApi):
             {
                 "value": datamodel.get_pk_value(row),
                 "text": self._get_text_for_model(row, column_name),
+                "extra": self._get_extra_field_for_model(row, column_name),
             }
             for row in rows
         ]

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -56,6 +56,7 @@ get_related_schema = {
 class RelatedResultResponseSchema(Schema):
     value = fields.Integer(description="The related item identifier")
     text = fields.String(description="The related item string representation")
+    extra = fields.Dict(description="The extra metadata for related item")
 
 
 class RelatedResponseSchema(Schema):

--- a/tests/integration_tests/base_api_tests.py
+++ b/tests/integration_tests/base_api_tests.py
@@ -264,10 +264,26 @@ class ApiOwnersTestCaseMixin:
         assert 4 == response["count"]
         sorted_results = sorted(response["result"], key=lambda value: value["text"])
         expected_results = [
-            {"text": "gamma user", "value": 2},
-            {"text": "gamma2 user", "value": 3},
-            {"text": "gamma_no_csv user", "value": 6},
-            {"text": "gamma_sqllab user", "value": 4},
+            {
+                "extra": {"active": True, "email": "gamma@fab.org"},
+                "text": "gamma user",
+                "value": 2,
+            },
+            {
+                "extra": {"active": True, "email": "gamma2@fab.org"},
+                "text": "gamma2 user",
+                "value": 3,
+            },
+            {
+                "extra": {"active": True, "email": "gamma_no_csv@fab.org"},
+                "text": "gamma_no_csv user",
+                "value": 6,
+            },
+            {
+                "extra": {"active": True, "email": "gamma_sqllab@fab.org"},
+                "text": "gamma_sqllab user",
+                "value": 4,
+            },
         ]
         # TODO Check me
         assert expected_results == sorted_results
@@ -286,8 +302,16 @@ class ApiOwnersTestCaseMixin:
         assert 2 == response["count"]
         sorted_results = sorted(response["result"], key=lambda value: value["text"])
         expected_results = [
-            {"text": "gamma user", "value": 2},
-            {"text": "gamma_sqllab user", "value": 4},
+            {
+                "extra": {"active": True, "email": "gamma@fab.org"},
+                "text": "gamma user",
+                "value": 2,
+            },
+            {
+                "extra": {"active": True, "email": "gamma_sqllab@fab.org"},
+                "text": "gamma_sqllab user",
+                "value": 4,
+            },
         ]
         assert expected_results == sorted_results
 
@@ -305,8 +329,16 @@ class ApiOwnersTestCaseMixin:
         assert 2 == response["count"]
         sorted_results = sorted(response["result"], key=lambda value: value["text"])
         expected_results = [
-            {"text": "gamma user", "value": 2},
-            {"text": "gamma_sqllab user", "value": 4},
+            {
+                "extra": {"active": True, "email": "gamma@fab.org"},
+                "text": "gamma user",
+                "value": 2,
+            },
+            {
+                "extra": {"active": True, "email": "gamma_sqllab@fab.org"},
+                "text": "gamma_sqllab user",
+                "value": 4,
+            },
         ]
         assert expected_results == sorted_results
 

--- a/tests/integration_tests/queries/saved_queries/api_tests.py
+++ b/tests/integration_tests/queries/saved_queries/api_tests.py
@@ -445,7 +445,8 @@ class TestSavedQueryApi(SupersetTestCase):
         expected_result = {
             "count": len(databases),
             "result": [
-                {"extra": {}, "text": str(database), "value": database.id} for database in databases
+                {"extra": {}, "text": str(database), "value": database.id}
+                for database in databases
             ],
         }
 

--- a/tests/integration_tests/queries/saved_queries/api_tests.py
+++ b/tests/integration_tests/queries/saved_queries/api_tests.py
@@ -445,7 +445,7 @@ class TestSavedQueryApi(SupersetTestCase):
         expected_result = {
             "count": len(databases),
             "result": [
-                {"text": str(database), "value": database.id} for database in databases
+                {"extra": {}, "text": str(database), "value": database.id} for database in databases
             ],
         }
 


### PR DESCRIPTION
…down

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
1. Don't show inactive user in the owner dropdown list for dashboard/chart/dataset by leveraging the extra fields returned from API

### AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="1375" alt="Screen Shot 2022-09-01 at 10 24 09 AM" src="https://user-images.githubusercontent.com/5824221/187976120-9630303f-066f-456b-82df-0120e4d0b2e7.png">
<img width="1371" alt="Screen Shot 2022-09-01 at 10 25 58 AM" src="https://user-images.githubusercontent.com/5824221/187976125-e1ed18fa-a64a-4d4f-bae4-f7ee9d260ad9.png">
<img width="1404" alt="Screen Shot 2022-09-01 at 10 27 22 AM" src="https://user-images.githubusercontent.com/5824221/187976128-353034a1-c4f4-44f6-a471-82e058e98753.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
