### PR TITLE
feat: a simple LRUCache in frontend

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/utils/index.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/index.ts
@@ -26,6 +26,7 @@ export { default as makeSingleton } from './makeSingleton';
 export { default as promiseTimeout } from './promiseTimeout';
 export { default as logging } from './logging';
 export { default as removeDuplicates } from './removeDuplicates';
+export { lruCache } from './lruCache';
 export * from './featureFlags';
 export * from './random';
 export * from './typedMemo';

--- a/superset-frontend/packages/superset-ui-core/src/utils/lruCache.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/lruCache.ts
@@ -41,7 +41,6 @@ class LRUCache<T> {
       this.cache.set(key, tmp);
       return tmp;
     }
-
     return undefined;
   }
 

--- a/superset-frontend/packages/superset-ui-core/src/utils/lruCache.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/lruCache.ts
@@ -35,6 +35,11 @@ class LRUCache<T> {
   }
 
   public get(key: string): T | undefined {
+    // Prevent runtime errors
+    if (typeof key !== 'string') {
+      throw new TypeError('The LRUCache key must be string.');
+    }
+
     if (this.cache.has(key)) {
       const tmp = this.cache.get(key) as T;
       this.cache.delete(key);

--- a/superset-frontend/packages/superset-ui-core/src/utils/lruCache.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/lruCache.ts
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class LRUCache<T> {
+  private cache: Map<string, T>;
+
+  readonly capacity: number;
+
+  constructor(capacity: number) {
+    if (capacity < 1) {
+      throw new Error('The capacity in LRU must be greater than 0.');
+    }
+    this.capacity = capacity;
+    this.cache = new Map<string, T>();
+  }
+
+  public has(key: string): boolean {
+    return this.cache.has(key);
+  }
+
+  public get(key: string): T | undefined {
+    if (this.cache.has(key)) {
+      const tmp = this.cache.get(key) as T;
+      this.cache.delete(key);
+      this.cache.set(key, tmp);
+      return tmp;
+    }
+
+    return undefined;
+  }
+
+  public set(key: string, value: T) {
+    // Prevent runtime errors
+    if (typeof key !== 'string') {
+      throw new TypeError('The LRUCache key must be string.');
+    }
+    if (this.cache.size >= this.capacity) {
+      this.cache.delete(this.cache.keys().next().value);
+    }
+    this.cache.set(key, value);
+  }
+
+  public clear() {
+    this.cache.clear();
+  }
+
+  public get size() {
+    return this.cache.size;
+  }
+}
+
+export function lruCache<T>(capacity = 100) {
+  return new LRUCache<T>(capacity);
+}

--- a/superset-frontend/packages/superset-ui-core/test/utils/lruCache.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/lruCache.test.ts
@@ -19,41 +19,39 @@
 
 import { lruCache } from '@superset-ui/core';
 
-describe('simple LRUCache', () => {
-  test('initial LRU', () => {
-    expect(lruCache().capacity).toBe(100);
-    expect(lruCache(10).capacity).toBe(10);
-    expect(lruCache(10).size).toBe(0);
-    expect(() => lruCache(0)).toThrow(Error);
-  });
+test('initial LRU', () => {
+  expect(lruCache().capacity).toBe(100);
+  expect(lruCache(10).capacity).toBe(10);
+  expect(lruCache(10).size).toBe(0);
+  expect(() => lruCache(0)).toThrow(Error);
+});
 
-  test('LRU', () => {
-    const cache = lruCache<string>(3);
-    cache.set('1', 'a');
-    cache.set('2', 'b');
-    cache.set('3', 'c');
-    cache.set('4', 'd');
-    expect(cache.size).toBe(3);
-    expect(cache.has('1')).toBeFalsy();
-    expect(cache.get('1')).toBeUndefined();
-    cache.get('2');
-    cache.set('5', 'e');
-    expect(cache.has('2')).toBeTruthy();
-    expect(cache.has('3')).toBeFalsy();
-    // @ts-ignore
-    expect(() => cache.set(0)).toThrow(TypeError);
-    cache.clear();
-    expect(cache.size).toBe(0);
-    expect(cache.capacity).toBe(3);
-  });
+test('LRU operation', () => {
+  const cache = lruCache<string>(3);
+  cache.set('1', 'a');
+  cache.set('2', 'b');
+  cache.set('3', 'c');
+  cache.set('4', 'd');
+  expect(cache.size).toBe(3);
+  expect(cache.has('1')).toBeFalsy();
+  expect(cache.get('1')).toBeUndefined();
+  cache.get('2');
+  cache.set('5', 'e');
+  expect(cache.has('2')).toBeTruthy();
+  expect(cache.has('3')).toBeFalsy();
+  // @ts-ignore
+  expect(() => cache.set(0)).toThrow(TypeError);
+  cache.clear();
+  expect(cache.size).toBe(0);
+  expect(cache.capacity).toBe(3);
+});
 
-  test('null and undefined', () => {
-    const cache = lruCache();
-    cache.set('a', null);
-    cache.set('b', undefined);
-    expect(cache.has('a')).toBeTruthy();
-    expect(cache.has('b')).toBeTruthy();
-    expect(cache.get('a')).toBeNull();
-    expect(cache.get('b')).toBeUndefined();
-  });
+test('LRU handle null and undefined', () => {
+  const cache = lruCache();
+  cache.set('a', null);
+  cache.set('b', undefined);
+  expect(cache.has('a')).toBeTruthy();
+  expect(cache.has('b')).toBeTruthy();
+  expect(cache.get('a')).toBeNull();
+  expect(cache.get('b')).toBeUndefined();
 });

--- a/superset-frontend/packages/superset-ui-core/test/utils/lruCache.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/lruCache.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { lruCache } from '@superset-ui/core';
+
+describe('simple LRUCache', () => {
+  test('initial LRU', () => {
+    expect(lruCache().capacity).toBe(100);
+    expect(lruCache(10).capacity).toBe(10);
+    expect(lruCache(10).size).toBe(0);
+    expect(() => lruCache(0)).toThrow(Error);
+  });
+
+  test('LRU', () => {
+    const cache = lruCache<string>(3);
+    cache.set('1', 'a');
+    cache.set('2', 'b');
+    cache.set('3', 'c');
+    cache.set('4', 'd');
+    expect(cache.size).toBe(3);
+    expect(cache.has('1')).toBeFalsy();
+    expect(cache.get('1')).toBeUndefined();
+    cache.get('2');
+    cache.set('5', 'e');
+    expect(cache.has('2')).toBeTruthy();
+    expect(cache.has('3')).toBeFalsy();
+    // @ts-ignore
+    expect(() => cache.set(0)).toThrow(TypeError);
+    cache.clear();
+    expect(cache.size).toBe(0);
+    expect(cache.capacity).toBe(3);
+  });
+
+  test('null and undefined', () => {
+    const cache = lruCache();
+    cache.set('a', null);
+    cache.set('b', undefined);
+    expect(cache.has('a')).toBeTruthy();
+    expect(cache.has('b')).toBeTruthy();
+    expect(cache.get('a')).toBeNull();
+    expect(cache.get('b')).toBeUndefined();
+  });
+});

--- a/superset-frontend/packages/superset-ui-core/test/utils/lruCache.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/lruCache.test.ts
@@ -41,6 +41,7 @@ test('LRU operations', () => {
   expect(cache.has('3')).toBeFalsy();
   // @ts-expect-error
   expect(() => cache.set(0)).toThrow(TypeError);
+  // @ts-expect-error
   expect(() => cache.get(0)).toThrow(TypeError);
   expect(cache.size).toBe(3);
   cache.clear();

--- a/superset-frontend/packages/superset-ui-core/test/utils/lruCache.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/lruCache.test.ts
@@ -26,7 +26,7 @@ test('initial LRU', () => {
   expect(() => lruCache(0)).toThrow(Error);
 });
 
-test('LRU operation', () => {
+test('LRU operations', () => {
   const cache = lruCache<string>(3);
   cache.set('1', 'a');
   cache.set('2', 'b');
@@ -39,8 +39,10 @@ test('LRU operation', () => {
   cache.set('5', 'e');
   expect(cache.has('2')).toBeTruthy();
   expect(cache.has('3')).toBeFalsy();
-  // @ts-ignore
+  // @ts-expect-error
   expect(() => cache.set(0)).toThrow(TypeError);
+  expect(() => cache.get(0)).toThrow(TypeError);
+  expect(cache.size).toBe(3);
   cache.clear();
   expect(cache.size).toBe(0);
   expect(cache.capacity).toBe(3);


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
the [Drill to detail modal](https://github.com/apache/superset/pull/20728) needs a LRUCache to handle response data in the client, so making a simple LRUCache in superset-ui/core.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
passes all CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
