### PR TITLE
chore: Change Button background color from primary.dark1 to primary.base

### DIFF
--- a/superset-frontend/src/components/Button/index.tsx
+++ b/superset-frontend/src/components/Button/index.tsx
@@ -119,8 +119,8 @@ export default function Button(props: ButtonProps) {
   let borderColorDisabled = 'transparent';
 
   if (buttonStyle === 'primary') {
-    backgroundColor = primary.dark1;
-    backgroundColorHover = mix(0.1, grayscale.light5, primary.dark1);
+    backgroundColor = primary.base;
+    backgroundColorHover = primary.dark1;
     backgroundColorActive = mix(0.2, grayscale.dark2, primary.dark1);
     color = grayscale.light5;
     colorHover = color;

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -225,7 +225,7 @@ const SelectorLabel = styled.button`
     }
 
     &.selected {
-      background-color: ${theme.colors.primary.dark1};
+      background-color: ${theme.colors.primary.base};
       color: ${theme.colors.primary.light5};
 
       svg {


### PR DESCRIPTION

### SUMMARY
Change primary Button background color from `primary.dark1` to `primary.base` to make it consistent with the designs. Also, change background color from `primary.dark1` to `primary.base` of the active label in viz gallery to make it consistent with the button.

CC @kasiazjc 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="201" alt="image" src="https://user-images.githubusercontent.com/15073128/180783724-9bb34be9-1a17-4253-974b-663470cdb97d.png">

After:
<img width="196" alt="image" src="https://user-images.githubusercontent.com/15073128/180783612-89262912-c094-4761-91f9-17338cd38930.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
