### PR TITLE
fix: Fix chart title truncating when Chrome is zoomed out

### DIFF
--- a/superset-frontend/src/components/DynamicEditableTitle/index.tsx
+++ b/superset-frontend/src/components/DynamicEditableTitle/index.tsx
@@ -197,7 +197,7 @@ export const DynamicEditableTitle = ({
               ${inputWidth &&
               inputWidth > 0 &&
               css`
-                width: ${inputWidth}px;
+                width: ${inputWidth + 1}px;
               `}
             `}
           />


### PR DESCRIPTION
### SUMMARY
When user zoomed out the browser (could repro only in Chrome, Safari and Firefox worked fine), titles of some charts would truncate. That's because for some reason (probably browser bug) the input container decreased it's width by 0.01px.
Also, confirmed that it's always just 0.01px, so this PR simply adds 1px to the input container as a failsafe.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="492" alt="image" src="https://user-images.githubusercontent.com/15073128/180797200-591ab270-8505-4ecb-ad32-3a155bc9f031.png">

After:
<img width="559" alt="image" src="https://user-images.githubusercontent.com/15073128/180796474-3b10989a-0d64-4051-be88-adcad5d6d397.png">


### TESTING INSTRUCTIONS
1. Open Explore, zoom out Chrome (with cmd -)
2. Verify that title is not truncated (unless it should be because there's actually too little space of course)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
