### PR TITLE
feat: Reuse Dashboard redux data in Explore

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/utils/isDefined.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/isDefined.ts
@@ -17,6 +17,6 @@
  * under the License.
  */
 
-export default function isDefined(x: unknown) {
+export default function isDefined<T>(x: T): x is NonNullable<T> {
   return x !== null && x !== undefined;
 }

--- a/superset-frontend/src/components/EditableTitle/index.tsx
+++ b/superset-frontend/src/components/EditableTitle/index.tsx
@@ -221,7 +221,7 @@ export default function EditableTitle({
     // don't actually want an input in this case
     titleComponent = url ? (
       <Link
-        to={url}
+        to={{ pathname: url, state: { fromDashboard: true } }}
         data-test="editable-title-input"
         css={(theme: SupersetTheme) => css`
           color: ${theme.colors.grayscale.dark1};

--- a/superset-frontend/src/dashboard/actions/hydrate.js
+++ b/superset-frontend/src/dashboard/actions/hydrate.js
@@ -152,9 +152,13 @@ export const hydrateDashboard =
         datasource: slice.form_data.datasource,
         description: slice.description,
         description_markeddown: slice.description_markeddown,
-        owners: slice.owners,
+        owners: slice.owners.map(owner => owner.id),
         modified: slice.modified,
         changed_on: new Date(slice.changed_on).getTime(),
+        is_managed_externally: slice.is_managed_externally,
+        query_context: slice.query_context,
+        certified_by: slice.certified_by,
+        certification_details: slice.certification_details,
       };
 
       sliceIds.add(key);

--- a/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
@@ -41,7 +41,7 @@ import { getSliceHeaderTooltip } from 'src/dashboard/util/getSliceHeaderTooltip'
 import { DashboardPageIdContext } from 'src/dashboard/containers/DashboardPage';
 import { clearDataMask } from 'src/dataMask/actions';
 
-type SliceHeaderProps = SliceHeaderControlsProps & {
+type SliceHeaderProps = Omit<SliceHeaderControlsProps, 'exploreUrl'> & {
   innerRef?: string;
   updateSliceName?: (arg0: string) => void;
   editMode?: boolean;

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -310,7 +310,12 @@ class SliceHeaderControls extends React.PureComponent<
 
         {this.props.supersetCanExplore && (
           <Menu.Item key={MENU_KEYS.EXPLORE_CHART}>
-            <Link to={this.props.exploreUrl}>
+            <Link
+              to={{
+                pathname: this.props.exploreUrl,
+                state: { fromDashboard: true },
+              }}
+            >
               <Tooltip
                 title={getSliceHeaderTooltip(this.props.slice.slice_name)}
               >
@@ -359,7 +364,11 @@ class SliceHeaderControls extends React.PureComponent<
                 <Button
                   buttonStyle="secondary"
                   buttonSize="small"
-                  onClick={() => this.props.history.push(this.props.exploreUrl)}
+                  onClick={() =>
+                    this.props.history.push(this.props.exploreUrl, {
+                      fromDashboard: true,
+                    })
+                  }
                 >
                   {t('Edit chart')}
                 </Button>

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -19,17 +19,11 @@
 import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  styled,
-  t,
-  logging,
-  isFeatureEnabled,
-  FeatureFlag,
-} from '@superset-ui/core';
+import { styled } from '@superset-ui/core';
 import { isEqual } from 'lodash';
 import { withRouter } from 'react-router-dom';
 
-import { exportChart, mountExploreUrl } from 'src/explore/exploreUtils';
+import { exportChart } from 'src/explore/exploreUtils';
 import ChartContainer from 'src/components/Chart/ChartContainer';
 import {
   LOG_ACTIONS_CHANGE_DASHBOARD_FILTER,
@@ -39,8 +33,6 @@ import {
 } from 'src/logger/LogUtils';
 import { areObjectsEqual } from 'src/reduxUtils';
 import { FILTER_BOX_MIGRATION_STATES } from 'src/explore/constants';
-import { postFormData } from 'src/explore/exploreUtils/formData';
-import { URL_PARAMS } from 'src/constants';
 
 import SliceHeader from '../SliceHeader';
 import MissingChart from '../MissingChart';
@@ -285,39 +277,6 @@ class Chart extends React.Component {
     });
   };
 
-  onExploreChart = async clickEvent => {
-    const isOpenInNewTab =
-      clickEvent.shiftKey || clickEvent.ctrlKey || clickEvent.metaKey;
-    try {
-      const lastTabId = window.localStorage.getItem('last_tab_id');
-      const nextTabId = lastTabId
-        ? String(Number.parseInt(lastTabId, 10) + 1)
-        : undefined;
-      const key = await postFormData(
-        this.props.datasource.id,
-        this.props.datasource.type,
-        this.props.formData,
-        this.props.slice.slice_id,
-        nextTabId,
-      );
-      const url = mountExploreUrl(null, {
-        [URL_PARAMS.formDataKey.name]: key,
-        [URL_PARAMS.sliceId.name]: this.props.slice.slice_id,
-      });
-      if (
-        isFeatureEnabled(FeatureFlag.DASHBOARD_EDIT_CHART_IN_NEW_TAB) ||
-        isOpenInNewTab
-      ) {
-        window.open(url, '_blank', 'noreferrer');
-      } else {
-        this.props.history.push(url);
-      }
-    } catch (error) {
-      logging.error(error);
-      this.props.addDangerToast(t('An error occurred while opening Explore'));
-    }
-  };
-
   exportCSV(isFullCSV = false) {
     this.props.logEvent(LOG_ACTIONS_EXPORT_CSV_DASHBOARD_CHART, {
       slice_id: this.props.slice.slice_id,
@@ -431,7 +390,6 @@ class Chart extends React.Component {
           editMode={editMode}
           annotationQuery={chart.annotationQuery}
           logExploreChart={this.logExploreChart}
-          onExploreChart={this.onExploreChart}
           exportCSV={this.exportCSV}
           exportFullCSV={this.exportFullCSV}
           updateSliceName={updateSliceName}

--- a/superset-frontend/src/explore/actions/hydrateExplore.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.ts
@@ -55,12 +55,11 @@ export const hydrateExplore =
     if (dashboardId) {
       initialFormData.dashboardId = dashboardId;
     }
-    const initialDatasource = dataset;
 
     const initialExploreState = {
       form_data: initialFormData,
       slice: initialSlice,
-      datasource: initialDatasource,
+      datasource: dataset,
     };
     const initialControls = getControlsState(
       initialExploreState,
@@ -79,7 +78,7 @@ export const hydrateExplore =
       isStarred: false,
       triggerRender: false,
       // duplicate datasource in exploreState - it's needed by getControlsState
-      datasource: initialDatasource,
+      datasource: dataset,
       // Initial control state will skip `control.mapStateToProps`
       // because `bootstrapData.controls` is undefined.
       controls: initialControls,
@@ -129,7 +128,7 @@ export const hydrateExplore =
         },
         datasources: {
           ...datasources,
-          [getDatasourceUid(initialDatasource)]: initialDatasource,
+          [getDatasourceUid(dataset)]: dataset,
         },
         saveModal: {
           dashboards: [],

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -121,6 +121,7 @@ description_markeddown_description = "Sanitized HTML version of the chart descri
 owners_name_description = "Name of an owner of the chart."
 certified_by_description = "Person or group that has certified this chart"
 certification_details_description = "Details of the certification"
+is_managed_externally_description = "If the chart is managed outside externally"
 
 #
 # OpenAPI method specification overrides
@@ -148,6 +149,10 @@ openapi_spec_methods_override = {
 }
 
 
+class UserSchema(Schema):
+    id = fields.Int()
+
+
 class ChartEntityResponseSchema(Schema):
     """
     Schema for a chart object
@@ -165,6 +170,11 @@ class ChartEntityResponseSchema(Schema):
     slice_url = fields.String(description=slice_url_description)
     certified_by = fields.String(description=certified_by_description)
     certification_details = fields.String(description=certification_details_description)
+    is_managed_externally = fields.Boolean(
+        description=is_managed_externally_description
+    )
+    owners = fields.List(fields.Nested(UserSchema))
+    query_context = fields.String(description=query_context_description)
 
 
 class ChartPostSchema(Schema):


### PR DESCRIPTION
### SUMMARY
Reopen https://github.com/apache/superset/pull/20668

Currently when user open Explore, we always send a request to `/v1/explore` endpoint, which assembles Explore initial data - slice, form_data and datasource.
When user goes to Explore from Dashboard (by clicking "Edit chart" or chart title), most of the data needed to assemble Explore should already be available in Redux store.
This PR implements using data from Dashboard Redux store to initialize Explore without calling `/v1/explore` endpoint.

If user opens Explore from Dashboard, check if slice, formData, datasourceId and datasourceType are available. If they are, fetch datasource metadata and hydrate Explore using slice, formData and datasource.
If they are not available, call `/v1/explore` and hydrate Explore.

We can't reuse datasource from Dashboard. Datasources metadata on Dashboard is trimmed so that datasource contains only columns and metrics used by charts on that dashboard. In Explore we need to be able to access all columns and metrics, which means we must fetch those from API.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Go to dashboard
2. Click "Edit chart"
3. Verify that Explore has opened correctly and that we did not call `/v1/explore/` endpoint
4. Enter Explore from any other entry point (for example Charts list or Welcome page)
5. Verify that we do call `/v1/explore`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
