### PR TITLE
fix: change buttons to be only save and overwrite

### DIFF
--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -437,8 +437,8 @@ class DatasourceControl extends React.PureComponent {
           <SaveDatasetModal
             visible={showSaveDatasetModal}
             onHide={this.toggleSaveDatasetModal}
-            buttonTextOnSave={t('Save & Explore')}
-            buttonTextOnOverwrite={t('Overwrite & Explore')}
+            buttonTextOnSave={t('Save')}
+            buttonTextOnOverwrite={t('Overwrite')}
             modalDescription={t(
               'Save this query as a virtual dataset to continue exploring',
             )}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Change the naming of the save dataset modal buttons when in explore:

![Screen Shot 2022-07-25 at 1 08 01 PM](https://user-images.githubusercontent.com/27827808/180835173-34b1e27e-960b-46d2-8c1c-5c7ab06d0891.png)

![Screen Shot 2022-07-25 at 1 07 51 PM](https://user-images.githubusercontent.com/27827808/180835180-6791cfdb-b482-472c-b360-9b0b419cb3a3.png)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
