### PR TITLE
feat(SqlLab): Change Save Dataset Button to Split Save Query Button IV

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -112,7 +112,7 @@ const queryClientMapping = {
   id: 'remoteId',
   db_id: 'dbId',
   client_id: 'id',
-  label: 'title',
+  label: 'name',
 };
 const queryServerMapping = invert(queryClientMapping);
 
@@ -541,7 +541,7 @@ export function cloneQueryToNewTab(query, autorun) {
       qe => qe.id === tabHistory[tabHistory.length - 1],
     );
     const queryEditor = {
-      title: t('Copy of %s', sourceQueryEditor.title),
+      name: t('Copy of %s', sourceQueryEditor.name),
       dbId: query.dbId ? query.dbId : null,
       schema: query.schema ? query.schema : null,
       autorun,
@@ -629,7 +629,7 @@ export function switchQueryEditor(queryEditor, displayLimit) {
           const loadedQueryEditor = {
             id: json.id.toString(),
             loaded: true,
-            title: json.label,
+            name: json.label,
             sql: json.sql,
             selectedText: null,
             latestQueryId: json.latest_query?.id,
@@ -834,24 +834,22 @@ export function queryEditorSetAutorun(queryEditor, autorun) {
   };
 }
 
-export function queryEditorSetTitle(queryEditor, title) {
+export function queryEditorSetTitle(queryEditor, name) {
   return function (dispatch) {
     const sync = isFeatureEnabled(FeatureFlag.SQLLAB_BACKEND_PERSISTENCE)
       ? SupersetClient.put({
           endpoint: encodeURI(`/tabstateview/${queryEditor.id}`),
-          postPayload: { label: title },
+          postPayload: { label: name },
         })
       : Promise.resolve();
 
     return sync
-      .then(() =>
-        dispatch({ type: QUERY_EDITOR_SET_TITLE, queryEditor, title }),
-      )
+      .then(() => dispatch({ type: QUERY_EDITOR_SET_TITLE, queryEditor, name }))
       .catch(() =>
         dispatch(
           addDangerToast(
             t(
-              'An error occurred while setting the tab title. Please contact your administrator.',
+              'An error occurred while setting the tab name. Please contact your administrator.',
             ),
           ),
         ),
@@ -873,7 +871,7 @@ export function saveQuery(query) {
           query,
           result: savedQuery,
         });
-        dispatch(queryEditorSetTitle(query, query.title));
+        dispatch(queryEditorSetTitle(query, query.name));
         return savedQuery;
       })
       .catch(() =>
@@ -908,7 +906,7 @@ export function updateSavedQuery(query) {
     })
       .then(() => {
         dispatch(addSuccessToast(t('Your query was updated')));
-        dispatch(queryEditorSetTitle(query, query.title));
+        dispatch(queryEditorSetTitle(query, query.name));
       })
       .catch(() =>
         dispatch(addDangerToast(t('Your query could not be updated'))),
@@ -965,7 +963,7 @@ export function queryEditorSetQueryLimit(queryEditor, queryLimit) {
         dispatch(
           addDangerToast(
             t(
-              'An error occurred while setting the tab title. Please contact your administrator.',
+              'An error occurred while setting the tab name. Please contact your administrator.',
             ),
           ),
         ),
@@ -1264,7 +1262,7 @@ export function popStoredQuery(urlId) {
       .then(({ json }) =>
         dispatch(
           addQueryEditor({
-            title: json.title ? json.title : t('Shared query'),
+            name: json.name ? json.name : t('Shared query'),
             dbId: json.dbId ? parseInt(json.dbId, 10) : null,
             schema: json.schema ? json.schema : null,
             autorun: json.autorun ? json.autorun : false,
@@ -1302,7 +1300,7 @@ export function popQuery(queryId) {
           dbId: queryData.database.id,
           schema: queryData.schema,
           sql: queryData.sql,
-          title: `Copy of ${queryData.tab_name}`,
+          name: `Copy of ${queryData.tab_name}`,
           autorun: false,
         };
         return dispatch(addQueryEditor(queryEditorProps));
@@ -1318,7 +1316,7 @@ export function popDatasourceQuery(datasourceKey, sql) {
       .then(({ json }) =>
         dispatch(
           addQueryEditor({
-            title: `Query ${json.name}`,
+            name: `Query ${json.name}`,
             dbId: json.database.id,
             schema: json.schema,
             autorun: sql !== undefined,

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.js
@@ -38,8 +38,8 @@ describe('async actions', () => {
     latestQueryId: null,
     selectedText: null,
     sql: 'SELECT *\nFROM\nWHERE',
-    title: 'Untitled Query 1',
-    schemaOptions: [{ value: 'main', label: 'main', title: 'main' }],
+    name: 'Untitled Query 1',
+    schemaOptions: [{ value: 'main', label: 'main', name: 'main' }],
   };
 
   let dispatch;
@@ -290,7 +290,7 @@ describe('async actions', () => {
       const state = {
         sqlLab: {
           tabHistory: [id],
-          queryEditors: [{ id, title: 'Dummy query editor' }],
+          queryEditors: [{ id, name: 'Dummy query editor' }],
         },
       };
       const store = mockStore(state);
@@ -350,7 +350,7 @@ describe('async actions', () => {
       const state = {
         sqlLab: {
           tabHistory: [id],
-          queryEditors: [{ id, title: 'Dummy query editor' }],
+          queryEditors: [{ id, name: 'Dummy query editor' }],
         },
       };
       const store = mockStore(state);
@@ -358,7 +358,7 @@ describe('async actions', () => {
         {
           type: actions.ADD_QUERY_EDITOR,
           queryEditor: {
-            title: 'Copy of Dummy query editor',
+            name: 'Copy of Dummy query editor',
             dbId: 1,
             schema: null,
             autorun: true,
@@ -617,17 +617,17 @@ describe('async actions', () => {
       it('updates the tab state in the backend', () => {
         expect.assertions(2);
 
-        const title = 'title';
+        const name = 'name';
         const store = mockStore({});
         const expectedActions = [
           {
             type: actions.QUERY_EDITOR_SET_TITLE,
             queryEditor,
-            title,
+            name,
           },
         ];
         return store
-          .dispatch(actions.queryEditorSetTitle(queryEditor, title))
+          .dispatch(actions.queryEditorSetTitle(queryEditor, name))
           .then(() => {
             expect(store.getActions()).toEqual(expectedActions);
             expect(fetchMock.calls(updateTabStateEndpoint)).toHaveLength(1);

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -29,19 +29,14 @@ import {
   SaveDatasetModal,
 } from 'src/SqlLab/components/SaveDatasetModal';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
-import { EXPLORE_CHART_DEFAULT } from 'src/SqlLab/types';
-import { mountExploreUrl } from 'src/explore/exploreUtils';
-import { postFormData } from 'src/explore/exploreUtils/formData';
 import ProgressBar from 'src/components/ProgressBar';
 import Loading from 'src/components/Loading';
 import FilterableTable, {
   MAX_COLUMNS_FOR_TABLE,
 } from 'src/components/FilterableTable';
 import CopyToClipboard from 'src/components/CopyToClipboard';
-import { addDangerToast } from 'src/components/MessageToasts/actions';
 import { prepareCopyToClipboardTabularData } from 'src/utils/common';
 import { CtasEnum } from 'src/SqlLab/actions/sqlLab';
-import { URL_PARAMS } from 'src/constants';
 import ExploreCtasResultsButton from '../ExploreCtasResultsButton';
 import ExploreResultsButton from '../ExploreResultsButton';
 import HighlightedSql from '../HighlightedSql';
@@ -188,7 +183,7 @@ export default class ResultSet extends React.PureComponent<
   popSelectStar(tempSchema: string | null, tempTable: string) {
     const qe = {
       id: shortid.generate(),
-      title: tempTable,
+      name: tempTable,
       autorun: false,
       dbId: this.props.query.dbId,
       sql: `SELECT * FROM ${tempSchema ? `${tempSchema}.` : ''}${tempTable}`,
@@ -223,26 +218,6 @@ export default class ResultSet extends React.PureComponent<
       this.props.actions.reRunQuery(query);
     }
   }
-
-  createExploreResultsOnClick = async () => {
-    const { results } = this.props.query;
-
-    if (results?.query_id) {
-      const key = await postFormData(results.query_id, 'query', {
-        ...EXPLORE_CHART_DEFAULT,
-        datasource: `${results.query_id}__query`,
-        ...{
-          all_columns: results.columns.map(column => column.name),
-        },
-      });
-      const url = mountExploreUrl(null, {
-        [URL_PARAMS.formDataKey.name]: key,
-      });
-      window.open(url, '_blank', 'noreferrer');
-    } else {
-      addDangerToast(t('Unable to create chart without a query id.'));
-    }
-  };
 
   renderControls() {
     if (this.props.search || this.props.visualize || this.props.csv) {
@@ -281,11 +256,19 @@ export default class ResultSet extends React.PureComponent<
               this.props.database?.allows_virtual_table_explore && (
                 <ExploreResultsButton
                   database={this.props.database}
-                  onClick={() => this.setState({ showSaveDatasetModal: true })}
+                  onClick={() => {
+                    // There is currently redux / state issue where sometimes a query will have serverId
+                    // and other times it will not.  We need this attribute consistently for this to work
+                    // const qid = this.props?.query?.results?.query_id;
+                    // if (qid) {
+                    //   // This will open explore using the query as datasource
+                    //   window.location.href = `/explore/?dataset_type=query&dataset_id=${qid}`;
+                    // } else {
+                    //   this.setState({ showSaveDatasetModal: true });
+                    // }
+                    this.setState({ showSaveDatasetModal: true });
+                  }}
                 />
-                // In order to use the new workflow for a query powered chart, replace the
-                // above function with:
-                // onClick={this.createExploreResultsOnClick}
               )}
             {this.props.csv && (
               <Button buttonSize="small" href={`/superset/csv/${query.id}`}>

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -29,14 +29,19 @@ import {
   SaveDatasetModal,
 } from 'src/SqlLab/components/SaveDatasetModal';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
+import { EXPLORE_CHART_DEFAULT } from 'src/SqlLab/types';
+import { mountExploreUrl } from 'src/explore/exploreUtils';
+import { postFormData } from 'src/explore/exploreUtils/formData';
 import ProgressBar from 'src/components/ProgressBar';
 import Loading from 'src/components/Loading';
 import FilterableTable, {
   MAX_COLUMNS_FOR_TABLE,
 } from 'src/components/FilterableTable';
 import CopyToClipboard from 'src/components/CopyToClipboard';
+import { addDangerToast } from 'src/components/MessageToasts/actions';
 import { prepareCopyToClipboardTabularData } from 'src/utils/common';
 import { CtasEnum } from 'src/SqlLab/actions/sqlLab';
+import { URL_PARAMS } from 'src/constants';
 import ExploreCtasResultsButton from '../ExploreCtasResultsButton';
 import ExploreResultsButton from '../ExploreResultsButton';
 import HighlightedSql from '../HighlightedSql';
@@ -219,6 +224,26 @@ export default class ResultSet extends React.PureComponent<
     }
   }
 
+  createExploreResultsOnClick = async () => {
+    const { results } = this.props.query;
+
+    if (results?.query_id) {
+      const key = await postFormData(results.query_id, 'query', {
+        ...EXPLORE_CHART_DEFAULT,
+        datasource: `${results.query_id}__query`,
+        ...{
+          all_columns: results.columns.map(column => column.name),
+        },
+      });
+      const url = mountExploreUrl(null, {
+        [URL_PARAMS.formDataKey.name]: key,
+      });
+      window.open(url, '_blank', 'noreferrer');
+    } else {
+      addDangerToast(t('Unable to create chart without a query id.'));
+    }
+  };
+
   renderControls() {
     if (this.props.search || this.props.visualize || this.props.csv) {
       let { data } = this.props.query.results;
@@ -256,18 +281,7 @@ export default class ResultSet extends React.PureComponent<
               this.props.database?.allows_virtual_table_explore && (
                 <ExploreResultsButton
                   database={this.props.database}
-                  onClick={() => {
-                    // There is currently redux / state issue where sometimes a query will have serverId
-                    // and other times it will not.  We need this attribute consistently for this to work
-                    // const qid = this.props?.query?.results?.query_id;
-                    // if (qid) {
-                    //   // This will open explore using the query as datasource
-                    //   window.location.href = `/explore/?dataset_type=query&dataset_id=${qid}`;
-                    // } else {
-                    //   this.setState({ showSaveDatasetModal: true });
-                    // }
-                    this.setState({ showSaveDatasetModal: true });
-                  }}
+                  onClick={() => this.setState({ showSaveDatasetModal: true })}
                 />
               )}
             {this.props.csv && (

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -283,6 +283,9 @@ export default class ResultSet extends React.PureComponent<
                   database={this.props.database}
                   onClick={() => this.setState({ showSaveDatasetModal: true })}
                 />
+                // In order to use the new workflow for a query powered chart, replace the
+                // above function with:
+                // onClick={this.createExploreResultsOnClick}
               )}
             {this.props.csv && (
               <Button buttonSize="small" href={`/superset/csv/${query.id}`}>

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -281,11 +281,8 @@ export default class ResultSet extends React.PureComponent<
               this.props.database?.allows_virtual_table_explore && (
                 <ExploreResultsButton
                   database={this.props.database}
-                  onClick={() => this.setState({ showSaveDatasetModal: true })}
+                  onClick={this.createExploreResultsOnClick}
                 />
-                // In order to use the new workflow for a query powered chart, replace the
-                // above function with:
-                // onClick={this.createExploreResultsOnClick}
               )}
             {this.props.csv && (
               <Button buttonSize="small" href={`/superset/csv/${query.id}`}>

--- a/superset-frontend/src/SqlLab/components/RunQueryActionButton/index.tsx
+++ b/superset-frontend/src/SqlLab/components/RunQueryActionButton/index.tsx
@@ -20,13 +20,11 @@ import React, { useMemo } from 'react';
 import { t, styled, useTheme } from '@superset-ui/core';
 
 import { Menu } from 'src/components/Menu';
-import Button, { ButtonProps } from 'src/components/Button';
+import Button from 'src/components/Button';
 import Icons from 'src/components/Icons';
-import {
-  DropdownButton,
-  DropdownButtonProps,
-} from 'src/components/DropdownButton';
+import { DropdownButton } from 'src/components/DropdownButton';
 import { detectOS } from 'src/utils/common';
+import { QueryButtonProps } from 'src/SqlLab/types';
 
 interface Props {
   allowAsync: boolean;
@@ -37,8 +35,6 @@ interface Props {
   sql: string;
   overlayCreateAsMenu: typeof Menu | null;
 }
-
-type QueryButtonProps = DropdownButtonProps | ButtonProps;
 
 const buildText = (
   shouldShowStopButton: boolean,
@@ -80,7 +76,7 @@ const StyledButton = styled.span`
     }
     span[name='caret-down'] {
       display: flex;
-      margin-right: ${({ theme }) => theme.gridUnit * -2}px;
+      margin-left: ${({ theme }) => theme.gridUnit * 1}px;
     }
   }
 `;

--- a/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/SaveDatasetActionButton.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/SaveDatasetActionButton.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { render, screen } from 'spec/helpers/testing-library';
+import userEvent from '@testing-library/user-event';
+import { Menu } from 'src/components/Menu';
+import SaveDatasetActionButton from 'src/SqlLab/components/SaveDatasetActionButton';
+
+const overlayMenu = (
+  <Menu>
+    <Menu.Item>Save dataset</Menu.Item>
+  </Menu>
+);
+
+describe('SaveDatasetActionButton', () => {
+  it('renders a split save button', () => {
+    render(
+      <SaveDatasetActionButton
+        toggleSave={() => {}}
+        overlayMenu={overlayMenu}
+      />,
+    );
+
+    const saveBtn = screen.getByRole('button', { name: /save/i });
+    const caretBtn = screen.getByRole('button', { name: /caret-down/i });
+
+    expect(saveBtn).toBeVisible();
+    expect(caretBtn).toBeVisible();
+  });
+
+  it('renders a "save dataset" dropdown menu item when user clicks caret button', () => {
+    render(
+      <SaveDatasetActionButton
+        toggleSave={() => {}}
+        overlayMenu={overlayMenu}
+      />,
+    );
+
+    const caretBtn = screen.getByRole('button', { name: /caret-down/i });
+    userEvent.click(caretBtn);
+
+    const saveDatasetMenuItem = screen.getByText(/save dataset/i);
+
+    expect(saveDatasetMenuItem).toBeInTheDocument();
+  });
+});

--- a/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/SaveDatasetActionButton.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/SaveDatasetActionButton.test.tsx
@@ -32,7 +32,7 @@ describe('SaveDatasetActionButton', () => {
   it('renders a split save button', () => {
     render(
       <SaveDatasetActionButton
-        toggleSave={() => {}}
+        setShowSave={() => true}
         overlayMenu={overlayMenu}
       />,
     );
@@ -47,7 +47,7 @@ describe('SaveDatasetActionButton', () => {
   it('renders a "save dataset" dropdown menu item when user clicks caret button', () => {
     render(
       <SaveDatasetActionButton
-        toggleSave={() => {}}
+        setShowSave={() => true}
         overlayMenu={overlayMenu}
       />,
     );

--- a/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/index.tsx
@@ -24,12 +24,12 @@ import Button from 'src/components/Button';
 import { DropdownButtonProps } from 'antd/lib/dropdown';
 
 interface Props {
-  toggleSave: () => void;
+  setShowSave: (arg0: boolean) => void;
   overlayMenu: JSX.Element | null;
 }
 
 export default function SaveDatasetActionButton({
-  toggleSave,
+  setShowSave,
   overlayMenu,
 }: Props) {
   const theme = useTheme();
@@ -58,7 +58,7 @@ export default function SaveDatasetActionButton({
 
   return !overlayMenu ? (
     <Button
-      onClick={toggleSave}
+      onClick={() => setShowSave(true)}
       buttonStyle="primary"
       css={{ width: theme.gridUnit * 25 }}
     >
@@ -66,7 +66,7 @@ export default function SaveDatasetActionButton({
     </Button>
   ) : (
     <StyledDropdownButton
-      onClick={toggleSave}
+      onClick={() => setShowSave(true)}
       overlay={overlayMenu}
       icon={
         <Icons.CaretDown

--- a/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/index.tsx
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { t, useTheme, styled } from '@superset-ui/core';
+import Icons from 'src/components/Icons';
+import { DropdownButton } from 'src/components/DropdownButton';
+import Button from 'src/components/Button';
+import { DropdownButtonProps } from 'antd/lib/dropdown';
+
+interface Props {
+  toggleSave: () => void;
+  overlayMenu: JSX.Element | null;
+}
+
+export default function SaveDatasetActionButton({
+  toggleSave,
+  overlayMenu,
+}: Props) {
+  const theme = useTheme();
+
+  const StyledDropdownButton = styled(
+    DropdownButton as React.FC<DropdownButtonProps>,
+  )`
+    &.ant-dropdown-button button.ant-btn.ant-btn-default {
+      &:first-of-type {
+        width: ${theme.gridUnit * 16}px;
+      }
+      background-color: ${theme.colors.primary.light4};
+      color: ${theme.colors.primary.dark1};
+      &:nth-child(2) {
+        &:before,
+        &:hover:before {
+          border-left: 1px solid ${theme.colors.primary.dark2};
+        }
+      }
+    }
+    span[name='caret-down'] {
+      margin-left: ${theme.gridUnit * 1}px;
+      color: ${theme.colors.primary.dark2};
+    }
+  `;
+
+  return !overlayMenu ? (
+    <Button
+      onClick={toggleSave}
+      buttonStyle="primary"
+      css={{ width: theme.gridUnit * 25 }}
+    >
+      {t('Save')}
+    </Button>
+  ) : (
+    <StyledDropdownButton
+      onClick={toggleSave}
+      overlay={overlayMenu}
+      icon={
+        <Icons.CaretDown
+          iconColor={theme.colors.grayscale.light5}
+          name="caret-down"
+        />
+      }
+      trigger={['click']}
+    >
+      {t('Save')}
+    </StyledDropdownButton>
+  );
+}

--- a/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/index.tsx
@@ -41,12 +41,13 @@ export default function SaveDatasetActionButton({
       &:first-of-type {
         width: ${theme.gridUnit * 16}px;
       }
+      font-weight: ${theme.gridUnit * 150};
       background-color: ${theme.colors.primary.light4};
       color: ${theme.colors.primary.dark1};
       &:nth-child(2) {
         &:before,
         &:hover:before {
-          border-left: 1px solid ${theme.colors.primary.dark2};
+          border-left: 2px solid ${theme.colors.primary.dark2};
         }
       }
     }

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
@@ -21,8 +21,16 @@ import {
   ISaveableDatasource,
   SaveDatasetModal,
 } from 'src/SqlLab/components/SaveDatasetModal';
-import { render, screen } from 'spec/helpers/testing-library';
+import { Select } from 'src/components';
+import {
+  render,
+  screen,
+  act,
+  waitFor,
+  within,
+} from 'spec/helpers/testing-library';
 import { DatasourceType } from '@superset-ui/core';
+import userEvent from '@testing-library/user-event';
 
 const testQuery: ISaveableDatasource = {
   name: 'unimportant',
@@ -55,9 +63,732 @@ const mockedProps = {
   datasource: testQuery,
 };
 
-describe('SaveDatasetModal RTL', () => {
-  it('renders a "Save as new" field', () => {
-    render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
+const testDatasetList = {
+  count: 25,
+  description_columns: {},
+  ids: [
+    48, 42, 36, 47, 46, 45, 44, 43, 41, 40, 39, 38, 37, 35, 34, 33, 32, 31, 30,
+    29,
+  ],
+  label_columns: {
+    'changed_by.first_name': 'Changed By First Name',
+    'changed_by.username': 'Changed By Username',
+    changed_by_name: 'Changed By Name',
+    changed_by_url: 'Changed By Url',
+    changed_on_delta_humanized: 'Changed On Delta Humanized',
+    changed_on_utc: 'Changed On Utc',
+    'database.database_name': 'Database Database Name',
+    'database.id': 'Database Id',
+    datasource_type: 'Datasource Type',
+    default_endpoint: 'Default Endpoint',
+    description: 'Description',
+    explore_url: 'Explore Url',
+    extra: 'Extra',
+    id: 'Id',
+    kind: 'Kind',
+    'owners.first_name': 'Owners First Name',
+    'owners.id': 'Owners Id',
+    'owners.last_name': 'Owners Last Name',
+    'owners.username': 'Owners Username',
+    schema: 'Schema',
+    sql: 'Sql',
+    table_name: 'Table Name',
+  },
+  list_columns: [
+    'id',
+    'database.id',
+    'database.database_name',
+    'changed_by_name',
+    'changed_by_url',
+    'changed_by.first_name',
+    'changed_by.username',
+    'changed_on_utc',
+    'changed_on_delta_humanized',
+    'default_endpoint',
+    'description',
+    'datasource_type',
+    'explore_url',
+    'extra',
+    'kind',
+    'owners.id',
+    'owners.username',
+    'owners.first_name',
+    'owners.last_name',
+    'schema',
+    'sql',
+    'table_name',
+  ],
+  list_title: 'List Sqla Table',
+  order_columns: [
+    'table_name',
+    'schema',
+    'changed_by.first_name',
+    'changed_on_delta_humanized',
+    'database.database_name',
+  ],
+  result: [
+    {
+      changed_by: {
+        first_name: 'Admin I.',
+        username: 'admin',
+      },
+      changed_by_name: 'Admin I. Strator',
+      changed_by_url: '/superset/profile/admin',
+      changed_on_delta_humanized: '20 hours ago',
+      changed_on_utc: '2022-07-12T22:41:31.297778+0000',
+      database: {
+        database_name: 'Google Sheets',
+        id: 2,
+      },
+      datasource_type: 'table',
+      default_endpoint: null,
+      description: null,
+      explore_url: '/explore/?dataset_type=table&dataset_id=48',
+      extra: null,
+      id: 48,
+      kind: 'virtual',
+      owners: [
+        {
+          first_name: 'Admin I.',
+          id: 1,
+          last_name: 'Strator',
+          username: 'admin',
+        },
+      ],
+      schema: null,
+      sql: 'SELECT * FROM Sheet1  ',
+      table_name: 'Garfield query 07/12/2022 14:30:54',
+    },
+    {
+      changed_by: {
+        first_name: 'Admin I.',
+        username: 'admin',
+      },
+      changed_by_name: 'Admin I. Strator',
+      changed_by_url: '/superset/profile/admin',
+      changed_on_delta_humanized: '20 hours ago',
+      changed_on_utc: '2022-07-12T22:24:58.698853+0000',
+      database: {
+        database_name: 'Google Sheets',
+        id: 2,
+      },
+      datasource_type: 'table',
+      default_endpoint: null,
+      description: null,
+      explore_url: '/explore/?dataset_type=table&dataset_id=42',
+      extra: null,
+      id: 42,
+      kind: 'virtual',
+      owners: [
+        {
+          first_name: 'Admin I.',
+          id: 1,
+          last_name: 'Strator',
+          username: 'admin',
+        },
+      ],
+      schema: 'main',
+      sql: 'SELECT * FROM Sheet1  ',
+      table_name: 'undefined 06/27/2022 18:24:39',
+    },
+    {
+      changed_by: {
+        first_name: 'Admin I.',
+        username: 'admin',
+      },
+      changed_by_name: 'Admin I. Strator',
+      changed_by_url: '/superset/profile/admin',
+      changed_on_delta_humanized: 'a day ago',
+      changed_on_utc: '2022-07-12T16:32:36.599554+0000',
+      database: {
+        database_name: 'Google Sheets',
+        id: 2,
+      },
+      datasource_type: 'table',
+      default_endpoint: null,
+      description: null,
+      explore_url: '/explore/?dataset_type=table&dataset_id=36',
+      extra: null,
+      id: 36,
+      kind: 'virtual',
+      owners: [
+        {
+          first_name: 'Admin I.',
+          id: 1,
+          last_name: 'Strator',
+          username: 'admin',
+        },
+      ],
+      schema: 'main',
+      sql: 'SELECT * FROM Sheet1  ',
+      table_name: 'Query 05/19/2022 18:56:50',
+    },
+    {
+      changed_by: {
+        first_name: 'Admin I.',
+        username: 'admin',
+      },
+      changed_by_name: 'Admin I. Strator',
+      changed_by_url: '/superset/profile/admin',
+      changed_on_delta_humanized: '8 days ago',
+      changed_on_utc: '2022-07-05T17:38:12.502830+0000',
+      database: {
+        database_name: 'Google Sheets',
+        id: 2,
+      },
+      datasource_type: 'table',
+      default_endpoint: null,
+      description: null,
+      explore_url: '/explore/?dataset_type=table&dataset_id=47',
+      extra: null,
+      id: 47,
+      kind: 'virtual',
+      owners: [
+        {
+          first_name: 'Admin I.',
+          id: 1,
+          last_name: 'Strator',
+          username: 'admin',
+        },
+      ],
+      schema: 'main',
+      sql: 'SELECT * FROM Sheet1',
+      table_name: 'Untitled Query 1 07/05/2022 12:38:08',
+    },
+    {
+      changed_by: {
+        first_name: 'Admin I.',
+        username: 'admin',
+      },
+      changed_by_name: 'Admin I. Strator',
+      changed_by_url: '/superset/profile/admin',
+      changed_on_delta_humanized: '10 days ago',
+      changed_on_utc: '2022-07-03T02:32:59.161912+0000',
+      database: {
+        database_name: 'Google Sheets',
+        id: 2,
+      },
+      datasource_type: 'table',
+      default_endpoint: null,
+      description: null,
+      explore_url: '/explore/?dataset_type=table&dataset_id=46',
+      extra: null,
+      id: 46,
+      kind: 'virtual',
+      owners: [
+        {
+          first_name: 'Admin I.',
+          id: 1,
+          last_name: 'Strator',
+          username: 'admin',
+        },
+      ],
+      schema: 'main',
+      sql: 'SELECT * FROM Sheet1',
+      table_name: 'Untitled Query 1 07/02/2022 21:28:53',
+    },
+    {
+      changed_by: {
+        first_name: 'Admin I.',
+        username: 'admin',
+      },
+      changed_by_name: 'Admin I. Strator',
+      changed_by_url: '/superset/profile/admin',
+      changed_on_delta_humanized: '13 days ago',
+      changed_on_utc: '2022-06-30T18:43:02.757895+0000',
+      database: {
+        database_name: 'Google Sheets',
+        id: 2,
+      },
+      datasource_type: 'table',
+      default_endpoint: null,
+      description: null,
+      explore_url: '/explore/?dataset_type=table&dataset_id=45',
+      extra: null,
+      id: 45,
+      kind: 'virtual',
+      owners: [
+        {
+          first_name: 'Admin I.',
+          id: 1,
+          last_name: 'Strator',
+          username: 'admin',
+        },
+      ],
+      schema: null,
+      sql: 'SELECT * FROM Sheet1',
+      table_name: 'Untitled 06/30/2022 13:43:00',
+    },
+    {
+      changed_by: {
+        first_name: 'Admin I.',
+        username: 'admin',
+      },
+      changed_by_name: 'Admin I. Strator',
+      changed_by_url: '/superset/profile/admin',
+      changed_on_delta_humanized: '13 days ago',
+      changed_on_utc: '2022-06-30T17:32:38.088415+0000',
+      database: {
+        database_name: 'Google Sheets',
+        id: 2,
+      },
+      datasource_type: 'table',
+      default_endpoint: null,
+      description: null,
+      explore_url: '/explore/?dataset_type=table&dataset_id=44',
+      extra: null,
+      id: 44,
+      kind: 'virtual',
+      owners: [
+        {
+          first_name: 'Admin I.',
+          id: 1,
+          last_name: 'Strator',
+          username: 'admin',
+        },
+      ],
+      schema: 'main',
+      sql: 'SELECT * FROM Sheet1',
+      table_name: 'Untitled Query 1 06/30/2022 12:30:59',
+    },
+    {
+      changed_by: {
+        first_name: 'Admin I.',
+        username: 'admin',
+      },
+      changed_by_name: 'Admin I. Strator',
+      changed_by_url: '/superset/profile/admin',
+      changed_on_delta_humanized: '13 days ago',
+      changed_on_utc: '2022-06-30T17:30:59.136026+0000',
+      database: {
+        database_name: 'Google Sheets',
+        id: 2,
+      },
+      datasource_type: 'table',
+      default_endpoint: null,
+      description: null,
+      explore_url: '/explore/?dataset_type=table&dataset_id=43',
+      extra: null,
+      id: 43,
+      kind: 'virtual',
+      owners: [
+        {
+          first_name: 'Admin I.',
+          id: 1,
+          last_name: 'Strator',
+          username: 'admin',
+        },
+      ],
+      schema: 'main',
+      sql: 'SELECT * FROM Sheet1',
+      table_name: 'Untitled Query 1 06/30/2022 12:30:44',
+    },
+    {
+      changed_by: {
+        first_name: 'Admin I.',
+        username: 'admin',
+      },
+      changed_by_name: 'Admin I. Strator',
+      changed_by_url: '/superset/profile/admin',
+      changed_on_delta_humanized: '20 days ago',
+      changed_on_utc: '2022-06-22T19:53:04.308253+0000',
+      database: {
+        database_name: 'examples',
+        id: 1,
+      },
+      datasource_type: 'table',
+      default_endpoint: null,
+      description: null,
+      explore_url: '/explore/?dataset_type=table&dataset_id=41',
+      extra: null,
+      id: 41,
+      kind: 'virtual',
+      owners: [
+        {
+          first_name: 'Admin I.',
+          id: 1,
+          last_name: 'Strator',
+          username: 'admin',
+        },
+      ],
+      schema: 'main',
+      sql: 'SELECT * FROM "FCC 2018 Survey"',
+      table_name: 'Untitled Query 1 06/22/2022 14:46:56',
+    },
+    {
+      changed_by: {
+        first_name: 'Admin I.',
+        username: 'admin',
+      },
+      changed_by_name: 'Admin I. Strator',
+      changed_by_url: '/superset/profile/admin',
+      changed_on_delta_humanized: '20 days ago',
+      changed_on_utc: '2022-06-22T19:46:56.758263+0000',
+      database: {
+        database_name: 'examples',
+        id: 1,
+      },
+      datasource_type: 'table',
+      default_endpoint: null,
+      description: null,
+      explore_url: '/explore/?dataset_type=table&dataset_id=40',
+      extra: null,
+      id: 40,
+      kind: 'virtual',
+      owners: [
+        {
+          first_name: 'Admin I.',
+          id: 1,
+          last_name: 'Strator',
+          username: 'admin',
+        },
+      ],
+      schema: 'main',
+      sql: 'SELECT * FROM "FCC 2018 Survey"',
+      table_name: 'Untitled Query 1 06/22/2022 14:46:05',
+    },
+    {
+      changed_by: {
+        first_name: 'Admin I.',
+        username: 'admin',
+      },
+      changed_by_name: 'Admin I. Strator',
+      changed_by_url: '/superset/profile/admin',
+      changed_on_delta_humanized: '20 days ago',
+      changed_on_utc: '2022-06-22T19:13:10.106631+0000',
+      database: {
+        database_name: 'examples',
+        id: 1,
+      },
+      datasource_type: 'table',
+      default_endpoint: null,
+      description: null,
+      explore_url: '/explore/?dataset_type=table&dataset_id=39',
+      extra: null,
+      id: 39,
+      kind: 'virtual',
+      owners: [
+        {
+          first_name: 'Admin I.',
+          id: 1,
+          last_name: 'Strator',
+          username: 'admin',
+        },
+      ],
+      schema: null,
+      sql: 'SELECT * FROM "FCC 2018 Survey"',
+      table_name: 'Untitled Dataset 06/22/2022 14:13:00',
+    },
+    {
+      changed_by: {
+        first_name: 'Admin I.',
+        username: 'admin',
+      },
+      changed_by_name: 'Admin I. Strator',
+      changed_by_url: '/superset/profile/admin',
+      changed_on_delta_humanized: '21 days ago',
+      changed_on_utc: '2022-06-21T19:43:58.510913+0000',
+      database: {
+        database_name: 'examples',
+        id: 1,
+      },
+      datasource_type: 'table',
+      default_endpoint: null,
+      description: null,
+      explore_url: '/explore/?dataset_type=table&dataset_id=38',
+      extra: null,
+      id: 38,
+      kind: 'physical',
+      owners: [
+        {
+          first_name: 'Admin I.',
+          id: 1,
+          last_name: 'Strator',
+          username: 'admin',
+        },
+      ],
+      schema: null,
+      sql: '',
+      table_name: 'Untitled Dataset 06/21/2022 14:43:54',
+    },
+    {
+      changed_by: {
+        first_name: 'Admin I.',
+        username: 'admin',
+      },
+      changed_by_name: 'Admin I. Strator',
+      changed_by_url: '/superset/profile/admin',
+      changed_on_delta_humanized: '21 days ago',
+      changed_on_utc: '2022-06-21T19:42:46.112798+0000',
+      database: {
+        database_name: 'examples',
+        id: 1,
+      },
+      datasource_type: 'table',
+      default_endpoint: null,
+      description: null,
+      explore_url: '/explore/?dataset_type=table&dataset_id=37',
+      extra: null,
+      id: 37,
+      kind: 'physical',
+      owners: [
+        {
+          first_name: 'Admin I.',
+          id: 1,
+          last_name: 'Strator',
+          username: 'admin',
+        },
+      ],
+      schema: null,
+      sql: '',
+      table_name: 'Untitled Dataset 06/21/2022 14:42:36',
+    },
+    {
+      changed_by: {
+        first_name: 'Admin I.',
+        username: 'admin',
+      },
+      changed_by_name: 'Admin I. Strator',
+      changed_by_url: '/superset/profile/admin',
+      changed_on_delta_humanized: 'a month ago',
+      changed_on_utc: '2022-05-17T14:25:41.210001+0000',
+      database: {
+        database_name: 'examples',
+        id: 1,
+      },
+      datasource_type: 'table',
+      default_endpoint: null,
+      description: null,
+      explore_url: '/explore/?dataset_type=table&dataset_id=35',
+      extra: null,
+      id: 35,
+      kind: 'virtual',
+      owners: [
+        {
+          first_name: 'Admin I.',
+          id: 1,
+          last_name: 'Strator',
+          username: 'admin',
+        },
+      ],
+      schema: 'main',
+      sql: 'SELECT * FROM "FCC 2018 Survey"',
+      table_name: 'Untitled Query 1 05/16/2022 16:31:04',
+    },
+    {
+      changed_by: {
+        first_name: 'Admin I.',
+        username: 'admin',
+      },
+      changed_by_name: 'Admin I. Strator',
+      changed_by_url: '/superset/profile/admin',
+      changed_on_delta_humanized: 'a month ago',
+      changed_on_utc: '2022-05-16T21:02:33.825514+0000',
+      database: {
+        database_name: 'examples',
+        id: 1,
+      },
+      datasource_type: 'table',
+      default_endpoint: null,
+      description: null,
+      explore_url: '/explore/?dataset_type=table&dataset_id=34',
+      extra: null,
+      id: 34,
+      kind: 'virtual',
+      owners: [
+        {
+          first_name: 'Admin I.',
+          id: 1,
+          last_name: 'Strator',
+          username: 'admin',
+        },
+      ],
+      schema: 'main',
+      sql: 'SELECT * FROM "FCC 2018 Survey"',
+      table_name: 'Untitled Query 1 05/16/2022 16:02:04',
+    },
+    {
+      changed_by: {
+        first_name: 'Admin I.',
+        username: 'admin',
+      },
+      changed_by_name: 'Admin I. Strator',
+      changed_by_url: '/superset/profile/admin',
+      changed_on_delta_humanized: 'a month ago',
+      changed_on_utc: '2022-05-16T21:02:04.789763+0000',
+      database: {
+        database_name: 'examples',
+        id: 1,
+      },
+      datasource_type: 'table',
+      default_endpoint: null,
+      description: null,
+      explore_url: '/explore/?dataset_type=table&dataset_id=33',
+      extra: null,
+      id: 33,
+      kind: 'virtual',
+      owners: [
+        {
+          first_name: 'Admin I.',
+          id: 1,
+          last_name: 'Strator',
+          username: 'admin',
+        },
+      ],
+      schema: 'main',
+      sql: 'SELECT * FROM "FCC 2018 Survey"',
+      table_name: 'Untitled Query 1 05/16/2022 16:02:00',
+    },
+    {
+      changed_by: {
+        first_name: 'Admin I.',
+        username: 'admin',
+      },
+      changed_by_name: 'Admin I. Strator',
+      changed_by_url: '/superset/profile/admin',
+      changed_on_delta_humanized: 'a month ago',
+      changed_on_utc: '2022-05-16T20:14:23.034596+0000',
+      database: {
+        database_name: 'examples',
+        id: 1,
+      },
+      datasource_type: 'table',
+      default_endpoint: null,
+      description: null,
+      explore_url: '/explore/?dataset_type=table&dataset_id=32',
+      extra: null,
+      id: 32,
+      kind: 'virtual',
+      owners: [
+        {
+          first_name: 'Admin I.',
+          id: 1,
+          last_name: 'Strator',
+          username: 'admin',
+        },
+      ],
+      schema: 'main',
+      sql: 'SELECT * FROM "FCC 2018 Survey"',
+      table_name: 'Untitled Query 1 05/16/2022 15:14:18',
+    },
+    {
+      changed_by: {
+        first_name: 'Admin I.',
+        username: 'admin',
+      },
+      changed_by_name: 'Admin I. Strator',
+      changed_by_url: '/superset/profile/admin',
+      changed_on_delta_humanized: 'a month ago',
+      changed_on_utc: '2022-05-16T18:27:26.167253+0000',
+      database: {
+        database_name: 'examples',
+        id: 1,
+      },
+      datasource_type: 'table',
+      default_endpoint: null,
+      description: null,
+      explore_url: '/explore/?dataset_type=table&dataset_id=31',
+      extra: null,
+      id: 31,
+      kind: 'virtual',
+      owners: [
+        {
+          first_name: 'Admin I.',
+          id: 1,
+          last_name: 'Strator',
+          username: 'admin',
+        },
+      ],
+      schema: 'main',
+      sql: 'SELECT * FROM "FCC 2018 Survey"',
+      table_name: 'Untitled Query 1 05/16/2022 13:27:20',
+    },
+    {
+      changed_by: {
+        first_name: 'Admin I.',
+        username: 'admin',
+      },
+      changed_by_name: 'Admin I. Strator',
+      changed_by_url: '/superset/profile/admin',
+      changed_on_delta_humanized: '2 months ago',
+      changed_on_utc: '2022-05-13T17:32:43.420029+0000',
+      database: {
+        database_name: 'examples',
+        id: 1,
+      },
+      datasource_type: 'table',
+      default_endpoint: null,
+      description: null,
+      explore_url: '/explore/?dataset_type=table&dataset_id=30',
+      extra: null,
+      id: 30,
+      kind: 'virtual',
+      owners: [
+        {
+          first_name: 'Admin I.',
+          id: 1,
+          last_name: 'Strator',
+          username: 'admin',
+        },
+      ],
+      schema: 'main',
+      sql: 'SELECT * FROM "FCC 2018 Survey"',
+      table_name: 'Untitled Query 1 05/13/2022 12:27:46',
+    },
+    {
+      changed_by: {
+        first_name: 'Admin I.',
+        username: 'admin',
+      },
+      changed_by_name: 'Admin I. Strator',
+      changed_by_url: '/superset/profile/admin',
+      changed_on_delta_humanized: '2 months ago',
+      changed_on_utc: '2022-05-13T17:27:46.998589+0000',
+      database: {
+        database_name: 'examples',
+        id: 1,
+      },
+      datasource_type: 'table',
+      default_endpoint: null,
+      description: null,
+      explore_url: '/explore/?dataset_type=table&dataset_id=29',
+      extra: null,
+      id: 29,
+      kind: 'virtual',
+      owners: [
+        {
+          first_name: 'Admin I.',
+          id: 1,
+          last_name: 'Strator',
+          username: 'admin',
+        },
+      ],
+      schema: 'main',
+      sql: 'SELECT * FROM "FCC 2018 Survey"',
+      table_name: 'Untitled Query 1 05/13/2022 12:27:43',
+    },
+  ],
+};
+
+const mockDatasetNames = testDatasetList.result.map(
+  dataset => dataset.table_name,
+);
+
+const getElementByClassName = (className: string) =>
+  document.querySelector(className)! as HTMLElement;
+
+const findSelectValue = () =>
+  waitFor(() => getElementByClassName('.ant-select-selection-item'));
+const getElementsByClassName = (className: string) =>
+  document.querySelectorAll(className)! as NodeListOf<HTMLElement>;
+const findAllSelectOptions = () =>
+  waitFor(() => getElementsByClassName('.ant-select-item-option-content'));
+
+describe('SaveDatasetModal', () => {
+  it('renders a "Save as new" field', async () => {
+    await act(async () => {
+      render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
+    });
 
     const saveRadioBtn = screen.getByRole('radio', {
       name: /save as new unimportant/i,
@@ -73,8 +804,10 @@ describe('SaveDatasetModal RTL', () => {
     expect(inputFieldText).toBeVisible();
   });
 
-  it('renders an "Overwrite existing" field', () => {
-    render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
+  it('renders an "Overwrite existing" field', async () => {
+    await act(async () => {
+      render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
+    });
 
     const overwriteRadioBtn = screen.getByRole('radio', {
       name: /overwrite existing/i,
@@ -89,15 +822,116 @@ describe('SaveDatasetModal RTL', () => {
     expect(placeholderText).toBeVisible();
   });
 
-  it('renders a save button', () => {
-    render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
+  it('renders a close button', async () => {
+    await act(async () => {
+      render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
+    });
 
+    expect(screen.getByRole('button', { name: /close/i })).toBeVisible();
+  });
+
+  it('renders a save button when "Save as new" is selected', async () => {
+    await act(async () => {
+      render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
+    });
+
+    // "Save as new" is selected when the modal opens by default
     expect(screen.getByRole('button', { name: /save/i })).toBeVisible();
   });
 
-  it('renders a close button', () => {
-    render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
+  it('renders a back and overwrite button when "Overwrite existing" is selected', async () => {
+    await act(async () => {
+      render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
+    });
 
-    expect(screen.getByRole('button', { name: /close/i })).toBeVisible();
+    const overwriteRadioBtn = screen.getByRole('radio', {
+      name: /overwrite existing/i,
+    });
+
+    // Click the overwrite radio button to reveal the overwrite buttons
+    userEvent.click(overwriteRadioBtn);
+
+    expect(screen.getByRole('button', { name: /back/i })).toBeVisible();
+    expect(screen.getByRole('button', { name: /overwrite/i })).toBeVisible();
+  });
+
+  const OPTIONS = [
+    { label: 'John', value: 1, gender: 'Male' },
+    { label: 'Liam', value: 2, gender: 'Male' },
+    { label: 'Olivia', value: 3, gender: 'Female' },
+    { label: 'Emma', value: 4, gender: 'Female' },
+    { label: 'Noah', value: 5, gender: 'Male' },
+    { label: 'Ava', value: 6, gender: 'Female' },
+    { label: 'Oliver', value: 7, gender: 'Male' },
+    { label: 'ElijahH', value: 8, gender: 'Male' },
+    { label: 'Charlotte', value: 9, gender: 'Female' },
+    { label: 'Giovanni', value: 10, gender: 'Male' },
+    { label: 'Franco', value: 11, gender: 'Male' },
+    { label: 'Sandro', value: 12, gender: 'Male' },
+    { label: 'Alehandro', value: 13, gender: 'Male' },
+    { label: 'Johnny', value: 14, gender: 'Male' },
+    { label: 'Nikole', value: 15, gender: 'Female' },
+    { label: 'Igor', value: 16, gender: 'Male' },
+    { label: 'Guilherme', value: 17, gender: 'Male' },
+    { label: 'Irfan', value: 18, gender: 'Male' },
+    { label: 'George', value: 19, gender: 'Male' },
+    { label: 'Ashfaq', value: 20, gender: 'Male' },
+    { label: 'Herme', value: 21, gender: 'Male' },
+    { label: 'Cher', value: 22, gender: 'Female' },
+    { label: 'Her', value: 23, gender: 'Male' },
+  ].sort((option1, option2) => option1.label.localeCompare(option2.label));
+  const defaultSelectProps = {
+    allowClear: true,
+    ariaLabel: 'Test',
+    labelInValue: true,
+    options: OPTIONS,
+    pageSize: 10,
+    showSearch: true,
+  };
+
+  it('renders the overwrite button as disabled until an existing dataset is selected', async () => {
+    await act(async () => {
+      render(
+        <SaveDatasetModal {...mockedProps}>
+          <Select {...defaultSelectProps} allowNewOptions />
+        </SaveDatasetModal>,
+        { useRedux: true },
+      );
+    });
+
+    // expect.assertions(2);
+    const overwriteRadioBtn = screen.getByRole('radio', {
+      name: /overwrite existing/i,
+    });
+
+    await act(async () => {
+      userEvent.click(overwriteRadioBtn);
+    });
+
+    expect(screen.getByRole('button', { name: /overwrite/i })).toBeDisabled();
+    expect(screen.queryByText(/no data/i)).toBe(null);
+
+    const select = screen.getByRole('combobox', { name: /existing dataset/i });
+
+    await act(async () => {
+      userEvent.clear(select);
+      userEvent.click(select);
+      userEvent.type(select, 'e');
+      const options = await findAllSelectOptions();
+      console.log(options);
+      // userEvent.click(await findAllSelectOptions()[0]);
+    });
+    screen.logTestingPlaygroundURL();
+
+    // expect(screen.queryByText(/no data/i)?.innerHTML).toBe('No Data');
+    // expect(screen.queryByText(/no data/i)).toBeInTheDocument();
+
+    // await act(async () => {
+    //   userEvent.click(screen.getByText(/no data/i));
+    // });
+    // const options = await findSelectValue();
+
+    // screen.debug(options);
+    // console.log(options);
   });
 });

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
@@ -17,20 +17,33 @@
  * under the License.
  */
 import React from 'react';
+import * as reactRedux from 'react-redux';
 import {
   ISaveableDatasource,
   SaveDatasetModal,
 } from 'src/SqlLab/components/SaveDatasetModal';
-import { Select } from 'src/components';
-import {
-  render,
-  screen,
-  act,
-  waitFor,
-  within,
-} from 'spec/helpers/testing-library';
+import { render, screen, waitFor } from 'spec/helpers/testing-library';
 import { DatasourceType } from '@superset-ui/core';
 import userEvent from '@testing-library/user-event';
+import fetchMock from 'fetch-mock';
+
+const user = {
+  createdOn: '2021-04-27T18:12:38.952304',
+  email: 'admin',
+  firstName: 'admin',
+  isActive: true,
+  lastName: 'admin',
+  permissions: {},
+  roles: {
+    Admin: [
+      ['can_sqllab', 'Superset'],
+      ['can_write', 'Dashboard'],
+      ['can_write', 'Chart'],
+    ],
+  },
+  userId: 1,
+  username: 'admin',
+};
 
 const testQuery: ISaveableDatasource = {
   name: 'unimportant',
@@ -55,6 +68,20 @@ const testQuery: ISaveableDatasource = {
   ],
 };
 
+const mockdatasets = [...new Array(3)].map((_, i) => ({
+  changed_by_name: 'user',
+  kind: i === 0 ? 'virtual' : 'physical', // ensure there is 1 virtual
+  changed_by_url: 'changed_by_url',
+  changed_by: 'user',
+  changed_on: new Date().toISOString(),
+  database_name: `db ${i}`,
+  explore_url: `/explore/?dataset_type=table&dataset_id=${i}`,
+  id: i,
+  schema: `schema ${i}`,
+  table_name: `coolest table ${i}`,
+  owners: [{ username: 'admin', userId: 1 }],
+}));
+
 const mockedProps = {
   visible: true,
   onHide: () => {},
@@ -63,732 +90,18 @@ const mockedProps = {
   datasource: testQuery,
 };
 
-const testDatasetList = {
-  count: 25,
-  description_columns: {},
-  ids: [
-    48, 42, 36, 47, 46, 45, 44, 43, 41, 40, 39, 38, 37, 35, 34, 33, 32, 31, 30,
-    29,
-  ],
-  label_columns: {
-    'changed_by.first_name': 'Changed By First Name',
-    'changed_by.username': 'Changed By Username',
-    changed_by_name: 'Changed By Name',
-    changed_by_url: 'Changed By Url',
-    changed_on_delta_humanized: 'Changed On Delta Humanized',
-    changed_on_utc: 'Changed On Utc',
-    'database.database_name': 'Database Database Name',
-    'database.id': 'Database Id',
-    datasource_type: 'Datasource Type',
-    default_endpoint: 'Default Endpoint',
-    description: 'Description',
-    explore_url: 'Explore Url',
-    extra: 'Extra',
-    id: 'Id',
-    kind: 'Kind',
-    'owners.first_name': 'Owners First Name',
-    'owners.id': 'Owners Id',
-    'owners.last_name': 'Owners Last Name',
-    'owners.username': 'Owners Username',
-    schema: 'Schema',
-    sql: 'Sql',
-    table_name: 'Table Name',
-  },
-  list_columns: [
-    'id',
-    'database.id',
-    'database.database_name',
-    'changed_by_name',
-    'changed_by_url',
-    'changed_by.first_name',
-    'changed_by.username',
-    'changed_on_utc',
-    'changed_on_delta_humanized',
-    'default_endpoint',
-    'description',
-    'datasource_type',
-    'explore_url',
-    'extra',
-    'kind',
-    'owners.id',
-    'owners.username',
-    'owners.first_name',
-    'owners.last_name',
-    'schema',
-    'sql',
-    'table_name',
-  ],
-  list_title: 'List Sqla Table',
-  order_columns: [
-    'table_name',
-    'schema',
-    'changed_by.first_name',
-    'changed_on_delta_humanized',
-    'database.database_name',
-  ],
-  result: [
-    {
-      changed_by: {
-        first_name: 'Admin I.',
-        username: 'admin',
-      },
-      changed_by_name: 'Admin I. Strator',
-      changed_by_url: '/superset/profile/admin',
-      changed_on_delta_humanized: '20 hours ago',
-      changed_on_utc: '2022-07-12T22:41:31.297778+0000',
-      database: {
-        database_name: 'Google Sheets',
-        id: 2,
-      },
-      datasource_type: 'table',
-      default_endpoint: null,
-      description: null,
-      explore_url: '/explore/?dataset_type=table&dataset_id=48',
-      extra: null,
-      id: 48,
-      kind: 'virtual',
-      owners: [
-        {
-          first_name: 'Admin I.',
-          id: 1,
-          last_name: 'Strator',
-          username: 'admin',
-        },
-      ],
-      schema: null,
-      sql: 'SELECT * FROM Sheet1  ',
-      table_name: 'Garfield query 07/12/2022 14:30:54',
-    },
-    {
-      changed_by: {
-        first_name: 'Admin I.',
-        username: 'admin',
-      },
-      changed_by_name: 'Admin I. Strator',
-      changed_by_url: '/superset/profile/admin',
-      changed_on_delta_humanized: '20 hours ago',
-      changed_on_utc: '2022-07-12T22:24:58.698853+0000',
-      database: {
-        database_name: 'Google Sheets',
-        id: 2,
-      },
-      datasource_type: 'table',
-      default_endpoint: null,
-      description: null,
-      explore_url: '/explore/?dataset_type=table&dataset_id=42',
-      extra: null,
-      id: 42,
-      kind: 'virtual',
-      owners: [
-        {
-          first_name: 'Admin I.',
-          id: 1,
-          last_name: 'Strator',
-          username: 'admin',
-        },
-      ],
-      schema: 'main',
-      sql: 'SELECT * FROM Sheet1  ',
-      table_name: 'undefined 06/27/2022 18:24:39',
-    },
-    {
-      changed_by: {
-        first_name: 'Admin I.',
-        username: 'admin',
-      },
-      changed_by_name: 'Admin I. Strator',
-      changed_by_url: '/superset/profile/admin',
-      changed_on_delta_humanized: 'a day ago',
-      changed_on_utc: '2022-07-12T16:32:36.599554+0000',
-      database: {
-        database_name: 'Google Sheets',
-        id: 2,
-      },
-      datasource_type: 'table',
-      default_endpoint: null,
-      description: null,
-      explore_url: '/explore/?dataset_type=table&dataset_id=36',
-      extra: null,
-      id: 36,
-      kind: 'virtual',
-      owners: [
-        {
-          first_name: 'Admin I.',
-          id: 1,
-          last_name: 'Strator',
-          username: 'admin',
-        },
-      ],
-      schema: 'main',
-      sql: 'SELECT * FROM Sheet1  ',
-      table_name: 'Query 05/19/2022 18:56:50',
-    },
-    {
-      changed_by: {
-        first_name: 'Admin I.',
-        username: 'admin',
-      },
-      changed_by_name: 'Admin I. Strator',
-      changed_by_url: '/superset/profile/admin',
-      changed_on_delta_humanized: '8 days ago',
-      changed_on_utc: '2022-07-05T17:38:12.502830+0000',
-      database: {
-        database_name: 'Google Sheets',
-        id: 2,
-      },
-      datasource_type: 'table',
-      default_endpoint: null,
-      description: null,
-      explore_url: '/explore/?dataset_type=table&dataset_id=47',
-      extra: null,
-      id: 47,
-      kind: 'virtual',
-      owners: [
-        {
-          first_name: 'Admin I.',
-          id: 1,
-          last_name: 'Strator',
-          username: 'admin',
-        },
-      ],
-      schema: 'main',
-      sql: 'SELECT * FROM Sheet1',
-      table_name: 'Untitled Query 1 07/05/2022 12:38:08',
-    },
-    {
-      changed_by: {
-        first_name: 'Admin I.',
-        username: 'admin',
-      },
-      changed_by_name: 'Admin I. Strator',
-      changed_by_url: '/superset/profile/admin',
-      changed_on_delta_humanized: '10 days ago',
-      changed_on_utc: '2022-07-03T02:32:59.161912+0000',
-      database: {
-        database_name: 'Google Sheets',
-        id: 2,
-      },
-      datasource_type: 'table',
-      default_endpoint: null,
-      description: null,
-      explore_url: '/explore/?dataset_type=table&dataset_id=46',
-      extra: null,
-      id: 46,
-      kind: 'virtual',
-      owners: [
-        {
-          first_name: 'Admin I.',
-          id: 1,
-          last_name: 'Strator',
-          username: 'admin',
-        },
-      ],
-      schema: 'main',
-      sql: 'SELECT * FROM Sheet1',
-      table_name: 'Untitled Query 1 07/02/2022 21:28:53',
-    },
-    {
-      changed_by: {
-        first_name: 'Admin I.',
-        username: 'admin',
-      },
-      changed_by_name: 'Admin I. Strator',
-      changed_by_url: '/superset/profile/admin',
-      changed_on_delta_humanized: '13 days ago',
-      changed_on_utc: '2022-06-30T18:43:02.757895+0000',
-      database: {
-        database_name: 'Google Sheets',
-        id: 2,
-      },
-      datasource_type: 'table',
-      default_endpoint: null,
-      description: null,
-      explore_url: '/explore/?dataset_type=table&dataset_id=45',
-      extra: null,
-      id: 45,
-      kind: 'virtual',
-      owners: [
-        {
-          first_name: 'Admin I.',
-          id: 1,
-          last_name: 'Strator',
-          username: 'admin',
-        },
-      ],
-      schema: null,
-      sql: 'SELECT * FROM Sheet1',
-      table_name: 'Untitled 06/30/2022 13:43:00',
-    },
-    {
-      changed_by: {
-        first_name: 'Admin I.',
-        username: 'admin',
-      },
-      changed_by_name: 'Admin I. Strator',
-      changed_by_url: '/superset/profile/admin',
-      changed_on_delta_humanized: '13 days ago',
-      changed_on_utc: '2022-06-30T17:32:38.088415+0000',
-      database: {
-        database_name: 'Google Sheets',
-        id: 2,
-      },
-      datasource_type: 'table',
-      default_endpoint: null,
-      description: null,
-      explore_url: '/explore/?dataset_type=table&dataset_id=44',
-      extra: null,
-      id: 44,
-      kind: 'virtual',
-      owners: [
-        {
-          first_name: 'Admin I.',
-          id: 1,
-          last_name: 'Strator',
-          username: 'admin',
-        },
-      ],
-      schema: 'main',
-      sql: 'SELECT * FROM Sheet1',
-      table_name: 'Untitled Query 1 06/30/2022 12:30:59',
-    },
-    {
-      changed_by: {
-        first_name: 'Admin I.',
-        username: 'admin',
-      },
-      changed_by_name: 'Admin I. Strator',
-      changed_by_url: '/superset/profile/admin',
-      changed_on_delta_humanized: '13 days ago',
-      changed_on_utc: '2022-06-30T17:30:59.136026+0000',
-      database: {
-        database_name: 'Google Sheets',
-        id: 2,
-      },
-      datasource_type: 'table',
-      default_endpoint: null,
-      description: null,
-      explore_url: '/explore/?dataset_type=table&dataset_id=43',
-      extra: null,
-      id: 43,
-      kind: 'virtual',
-      owners: [
-        {
-          first_name: 'Admin I.',
-          id: 1,
-          last_name: 'Strator',
-          username: 'admin',
-        },
-      ],
-      schema: 'main',
-      sql: 'SELECT * FROM Sheet1',
-      table_name: 'Untitled Query 1 06/30/2022 12:30:44',
-    },
-    {
-      changed_by: {
-        first_name: 'Admin I.',
-        username: 'admin',
-      },
-      changed_by_name: 'Admin I. Strator',
-      changed_by_url: '/superset/profile/admin',
-      changed_on_delta_humanized: '20 days ago',
-      changed_on_utc: '2022-06-22T19:53:04.308253+0000',
-      database: {
-        database_name: 'examples',
-        id: 1,
-      },
-      datasource_type: 'table',
-      default_endpoint: null,
-      description: null,
-      explore_url: '/explore/?dataset_type=table&dataset_id=41',
-      extra: null,
-      id: 41,
-      kind: 'virtual',
-      owners: [
-        {
-          first_name: 'Admin I.',
-          id: 1,
-          last_name: 'Strator',
-          username: 'admin',
-        },
-      ],
-      schema: 'main',
-      sql: 'SELECT * FROM "FCC 2018 Survey"',
-      table_name: 'Untitled Query 1 06/22/2022 14:46:56',
-    },
-    {
-      changed_by: {
-        first_name: 'Admin I.',
-        username: 'admin',
-      },
-      changed_by_name: 'Admin I. Strator',
-      changed_by_url: '/superset/profile/admin',
-      changed_on_delta_humanized: '20 days ago',
-      changed_on_utc: '2022-06-22T19:46:56.758263+0000',
-      database: {
-        database_name: 'examples',
-        id: 1,
-      },
-      datasource_type: 'table',
-      default_endpoint: null,
-      description: null,
-      explore_url: '/explore/?dataset_type=table&dataset_id=40',
-      extra: null,
-      id: 40,
-      kind: 'virtual',
-      owners: [
-        {
-          first_name: 'Admin I.',
-          id: 1,
-          last_name: 'Strator',
-          username: 'admin',
-        },
-      ],
-      schema: 'main',
-      sql: 'SELECT * FROM "FCC 2018 Survey"',
-      table_name: 'Untitled Query 1 06/22/2022 14:46:05',
-    },
-    {
-      changed_by: {
-        first_name: 'Admin I.',
-        username: 'admin',
-      },
-      changed_by_name: 'Admin I. Strator',
-      changed_by_url: '/superset/profile/admin',
-      changed_on_delta_humanized: '20 days ago',
-      changed_on_utc: '2022-06-22T19:13:10.106631+0000',
-      database: {
-        database_name: 'examples',
-        id: 1,
-      },
-      datasource_type: 'table',
-      default_endpoint: null,
-      description: null,
-      explore_url: '/explore/?dataset_type=table&dataset_id=39',
-      extra: null,
-      id: 39,
-      kind: 'virtual',
-      owners: [
-        {
-          first_name: 'Admin I.',
-          id: 1,
-          last_name: 'Strator',
-          username: 'admin',
-        },
-      ],
-      schema: null,
-      sql: 'SELECT * FROM "FCC 2018 Survey"',
-      table_name: 'Untitled Dataset 06/22/2022 14:13:00',
-    },
-    {
-      changed_by: {
-        first_name: 'Admin I.',
-        username: 'admin',
-      },
-      changed_by_name: 'Admin I. Strator',
-      changed_by_url: '/superset/profile/admin',
-      changed_on_delta_humanized: '21 days ago',
-      changed_on_utc: '2022-06-21T19:43:58.510913+0000',
-      database: {
-        database_name: 'examples',
-        id: 1,
-      },
-      datasource_type: 'table',
-      default_endpoint: null,
-      description: null,
-      explore_url: '/explore/?dataset_type=table&dataset_id=38',
-      extra: null,
-      id: 38,
-      kind: 'physical',
-      owners: [
-        {
-          first_name: 'Admin I.',
-          id: 1,
-          last_name: 'Strator',
-          username: 'admin',
-        },
-      ],
-      schema: null,
-      sql: '',
-      table_name: 'Untitled Dataset 06/21/2022 14:43:54',
-    },
-    {
-      changed_by: {
-        first_name: 'Admin I.',
-        username: 'admin',
-      },
-      changed_by_name: 'Admin I. Strator',
-      changed_by_url: '/superset/profile/admin',
-      changed_on_delta_humanized: '21 days ago',
-      changed_on_utc: '2022-06-21T19:42:46.112798+0000',
-      database: {
-        database_name: 'examples',
-        id: 1,
-      },
-      datasource_type: 'table',
-      default_endpoint: null,
-      description: null,
-      explore_url: '/explore/?dataset_type=table&dataset_id=37',
-      extra: null,
-      id: 37,
-      kind: 'physical',
-      owners: [
-        {
-          first_name: 'Admin I.',
-          id: 1,
-          last_name: 'Strator',
-          username: 'admin',
-        },
-      ],
-      schema: null,
-      sql: '',
-      table_name: 'Untitled Dataset 06/21/2022 14:42:36',
-    },
-    {
-      changed_by: {
-        first_name: 'Admin I.',
-        username: 'admin',
-      },
-      changed_by_name: 'Admin I. Strator',
-      changed_by_url: '/superset/profile/admin',
-      changed_on_delta_humanized: 'a month ago',
-      changed_on_utc: '2022-05-17T14:25:41.210001+0000',
-      database: {
-        database_name: 'examples',
-        id: 1,
-      },
-      datasource_type: 'table',
-      default_endpoint: null,
-      description: null,
-      explore_url: '/explore/?dataset_type=table&dataset_id=35',
-      extra: null,
-      id: 35,
-      kind: 'virtual',
-      owners: [
-        {
-          first_name: 'Admin I.',
-          id: 1,
-          last_name: 'Strator',
-          username: 'admin',
-        },
-      ],
-      schema: 'main',
-      sql: 'SELECT * FROM "FCC 2018 Survey"',
-      table_name: 'Untitled Query 1 05/16/2022 16:31:04',
-    },
-    {
-      changed_by: {
-        first_name: 'Admin I.',
-        username: 'admin',
-      },
-      changed_by_name: 'Admin I. Strator',
-      changed_by_url: '/superset/profile/admin',
-      changed_on_delta_humanized: 'a month ago',
-      changed_on_utc: '2022-05-16T21:02:33.825514+0000',
-      database: {
-        database_name: 'examples',
-        id: 1,
-      },
-      datasource_type: 'table',
-      default_endpoint: null,
-      description: null,
-      explore_url: '/explore/?dataset_type=table&dataset_id=34',
-      extra: null,
-      id: 34,
-      kind: 'virtual',
-      owners: [
-        {
-          first_name: 'Admin I.',
-          id: 1,
-          last_name: 'Strator',
-          username: 'admin',
-        },
-      ],
-      schema: 'main',
-      sql: 'SELECT * FROM "FCC 2018 Survey"',
-      table_name: 'Untitled Query 1 05/16/2022 16:02:04',
-    },
-    {
-      changed_by: {
-        first_name: 'Admin I.',
-        username: 'admin',
-      },
-      changed_by_name: 'Admin I. Strator',
-      changed_by_url: '/superset/profile/admin',
-      changed_on_delta_humanized: 'a month ago',
-      changed_on_utc: '2022-05-16T21:02:04.789763+0000',
-      database: {
-        database_name: 'examples',
-        id: 1,
-      },
-      datasource_type: 'table',
-      default_endpoint: null,
-      description: null,
-      explore_url: '/explore/?dataset_type=table&dataset_id=33',
-      extra: null,
-      id: 33,
-      kind: 'virtual',
-      owners: [
-        {
-          first_name: 'Admin I.',
-          id: 1,
-          last_name: 'Strator',
-          username: 'admin',
-        },
-      ],
-      schema: 'main',
-      sql: 'SELECT * FROM "FCC 2018 Survey"',
-      table_name: 'Untitled Query 1 05/16/2022 16:02:00',
-    },
-    {
-      changed_by: {
-        first_name: 'Admin I.',
-        username: 'admin',
-      },
-      changed_by_name: 'Admin I. Strator',
-      changed_by_url: '/superset/profile/admin',
-      changed_on_delta_humanized: 'a month ago',
-      changed_on_utc: '2022-05-16T20:14:23.034596+0000',
-      database: {
-        database_name: 'examples',
-        id: 1,
-      },
-      datasource_type: 'table',
-      default_endpoint: null,
-      description: null,
-      explore_url: '/explore/?dataset_type=table&dataset_id=32',
-      extra: null,
-      id: 32,
-      kind: 'virtual',
-      owners: [
-        {
-          first_name: 'Admin I.',
-          id: 1,
-          last_name: 'Strator',
-          username: 'admin',
-        },
-      ],
-      schema: 'main',
-      sql: 'SELECT * FROM "FCC 2018 Survey"',
-      table_name: 'Untitled Query 1 05/16/2022 15:14:18',
-    },
-    {
-      changed_by: {
-        first_name: 'Admin I.',
-        username: 'admin',
-      },
-      changed_by_name: 'Admin I. Strator',
-      changed_by_url: '/superset/profile/admin',
-      changed_on_delta_humanized: 'a month ago',
-      changed_on_utc: '2022-05-16T18:27:26.167253+0000',
-      database: {
-        database_name: 'examples',
-        id: 1,
-      },
-      datasource_type: 'table',
-      default_endpoint: null,
-      description: null,
-      explore_url: '/explore/?dataset_type=table&dataset_id=31',
-      extra: null,
-      id: 31,
-      kind: 'virtual',
-      owners: [
-        {
-          first_name: 'Admin I.',
-          id: 1,
-          last_name: 'Strator',
-          username: 'admin',
-        },
-      ],
-      schema: 'main',
-      sql: 'SELECT * FROM "FCC 2018 Survey"',
-      table_name: 'Untitled Query 1 05/16/2022 13:27:20',
-    },
-    {
-      changed_by: {
-        first_name: 'Admin I.',
-        username: 'admin',
-      },
-      changed_by_name: 'Admin I. Strator',
-      changed_by_url: '/superset/profile/admin',
-      changed_on_delta_humanized: '2 months ago',
-      changed_on_utc: '2022-05-13T17:32:43.420029+0000',
-      database: {
-        database_name: 'examples',
-        id: 1,
-      },
-      datasource_type: 'table',
-      default_endpoint: null,
-      description: null,
-      explore_url: '/explore/?dataset_type=table&dataset_id=30',
-      extra: null,
-      id: 30,
-      kind: 'virtual',
-      owners: [
-        {
-          first_name: 'Admin I.',
-          id: 1,
-          last_name: 'Strator',
-          username: 'admin',
-        },
-      ],
-      schema: 'main',
-      sql: 'SELECT * FROM "FCC 2018 Survey"',
-      table_name: 'Untitled Query 1 05/13/2022 12:27:46',
-    },
-    {
-      changed_by: {
-        first_name: 'Admin I.',
-        username: 'admin',
-      },
-      changed_by_name: 'Admin I. Strator',
-      changed_by_url: '/superset/profile/admin',
-      changed_on_delta_humanized: '2 months ago',
-      changed_on_utc: '2022-05-13T17:27:46.998589+0000',
-      database: {
-        database_name: 'examples',
-        id: 1,
-      },
-      datasource_type: 'table',
-      default_endpoint: null,
-      description: null,
-      explore_url: '/explore/?dataset_type=table&dataset_id=29',
-      extra: null,
-      id: 29,
-      kind: 'virtual',
-      owners: [
-        {
-          first_name: 'Admin I.',
-          id: 1,
-          last_name: 'Strator',
-          username: 'admin',
-        },
-      ],
-      schema: 'main',
-      sql: 'SELECT * FROM "FCC 2018 Survey"',
-      table_name: 'Untitled Query 1 05/13/2022 12:27:43',
-    },
-  ],
-};
+fetchMock.get('glob:*/api/v1/dataset?*', {
+  result: mockdatasets,
+  dataset_count: 3,
+});
 
-const mockDatasetNames = testDatasetList.result.map(
-  dataset => dataset.table_name,
-);
-
-const getElementByClassName = (className: string) =>
-  document.querySelector(className)! as HTMLElement;
-
-const findSelectValue = () =>
-  waitFor(() => getElementByClassName('.ant-select-selection-item'));
-const getElementsByClassName = (className: string) =>
-  document.querySelectorAll(className)! as NodeListOf<HTMLElement>;
-const findAllSelectOptions = () =>
-  waitFor(() => getElementsByClassName('.ant-select-item-option-content'));
+// Mock the user
+const useSelectorMock = jest.spyOn(reactRedux, 'useSelector');
+beforeEach(() => useSelectorMock.mockClear());
 
 describe('SaveDatasetModal', () => {
   it('renders a "Save as new" field', async () => {
-    await act(async () => {
-      render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
-    });
+    render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
 
     const saveRadioBtn = screen.getByRole('radio', {
       name: /save as new unimportant/i,
@@ -805,9 +118,7 @@ describe('SaveDatasetModal', () => {
   });
 
   it('renders an "Overwrite existing" field', async () => {
-    await act(async () => {
-      render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
-    });
+    render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
 
     const overwriteRadioBtn = screen.getByRole('radio', {
       name: /overwrite existing/i,
@@ -823,115 +134,60 @@ describe('SaveDatasetModal', () => {
   });
 
   it('renders a close button', async () => {
-    await act(async () => {
-      render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
-    });
+    render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
 
     expect(screen.getByRole('button', { name: /close/i })).toBeVisible();
   });
 
   it('renders a save button when "Save as new" is selected', async () => {
-    await act(async () => {
-      render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
-    });
+    render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
 
     // "Save as new" is selected when the modal opens by default
     expect(screen.getByRole('button', { name: /save/i })).toBeVisible();
   });
 
   it('renders a back and overwrite button when "Overwrite existing" is selected', async () => {
-    await act(async () => {
-      render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
-    });
+    render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
 
+    // Click the overwrite radio button to reveal the overwrite confirmation and back buttons
     const overwriteRadioBtn = screen.getByRole('radio', {
       name: /overwrite existing/i,
     });
-
-    // Click the overwrite radio button to reveal the overwrite buttons
     userEvent.click(overwriteRadioBtn);
 
     expect(screen.getByRole('button', { name: /back/i })).toBeVisible();
     expect(screen.getByRole('button', { name: /overwrite/i })).toBeVisible();
   });
 
-  const OPTIONS = [
-    { label: 'John', value: 1, gender: 'Male' },
-    { label: 'Liam', value: 2, gender: 'Male' },
-    { label: 'Olivia', value: 3, gender: 'Female' },
-    { label: 'Emma', value: 4, gender: 'Female' },
-    { label: 'Noah', value: 5, gender: 'Male' },
-    { label: 'Ava', value: 6, gender: 'Female' },
-    { label: 'Oliver', value: 7, gender: 'Male' },
-    { label: 'ElijahH', value: 8, gender: 'Male' },
-    { label: 'Charlotte', value: 9, gender: 'Female' },
-    { label: 'Giovanni', value: 10, gender: 'Male' },
-    { label: 'Franco', value: 11, gender: 'Male' },
-    { label: 'Sandro', value: 12, gender: 'Male' },
-    { label: 'Alehandro', value: 13, gender: 'Male' },
-    { label: 'Johnny', value: 14, gender: 'Male' },
-    { label: 'Nikole', value: 15, gender: 'Female' },
-    { label: 'Igor', value: 16, gender: 'Male' },
-    { label: 'Guilherme', value: 17, gender: 'Male' },
-    { label: 'Irfan', value: 18, gender: 'Male' },
-    { label: 'George', value: 19, gender: 'Male' },
-    { label: 'Ashfaq', value: 20, gender: 'Male' },
-    { label: 'Herme', value: 21, gender: 'Male' },
-    { label: 'Cher', value: 22, gender: 'Female' },
-    { label: 'Her', value: 23, gender: 'Male' },
-  ].sort((option1, option2) => option1.label.localeCompare(option2.label));
-  const defaultSelectProps = {
-    allowClear: true,
-    ariaLabel: 'Test',
-    labelInValue: true,
-    options: OPTIONS,
-    pageSize: 10,
-    showSearch: true,
-  };
-
   it('renders the overwrite button as disabled until an existing dataset is selected', async () => {
-    await act(async () => {
-      render(
-        <SaveDatasetModal {...mockedProps}>
-          <Select {...defaultSelectProps} allowNewOptions />
-        </SaveDatasetModal>,
-        { useRedux: true },
-      );
-    });
+    useSelectorMock.mockReturnValue({ ...user });
+    render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
 
-    // expect.assertions(2);
+    // Click the overwrite radio button
     const overwriteRadioBtn = screen.getByRole('radio', {
       name: /overwrite existing/i,
     });
-
-    await act(async () => {
+    await waitFor(async () => {
       userEvent.click(overwriteRadioBtn);
     });
 
-    expect(screen.getByRole('button', { name: /overwrite/i })).toBeDisabled();
-    expect(screen.queryByText(/no data/i)).toBe(null);
-
-    const select = screen.getByRole('combobox', { name: /existing dataset/i });
-
-    await act(async () => {
-      userEvent.clear(select);
-      userEvent.click(select);
-      userEvent.type(select, 'e');
-      const options = await findAllSelectOptions();
-      console.log(options);
-      // userEvent.click(await findAllSelectOptions()[0]);
+    // Overwrite confirmation button should be disabled at this point
+    const overwriteConfirmationBtn = screen.getByRole('button', {
+      name: /overwrite/i,
     });
-    screen.logTestingPlaygroundURL();
+    expect(overwriteConfirmationBtn).toBeDisabled();
 
-    // expect(screen.queryByText(/no data/i)?.innerHTML).toBe('No Data');
-    // expect(screen.queryByText(/no data/i)).toBeInTheDocument();
+    // Click the select component
+    const select = screen.getByRole('combobox', { name: /existing dataset/i });
+    await waitFor(async () => userEvent.click(select));
 
-    // await act(async () => {
-    //   userEvent.click(screen.getByText(/no data/i));
-    // });
-    // const options = await findSelectValue();
+    // Select the first "existing dataset" from the listbox
+    await waitFor(async () => {
+      const listbox = screen.getByRole('listbox');
+      userEvent.selectOptions(listbox, 'coolest table 0');
+    });
 
-    // screen.debug(options);
-    // console.log(options);
+    // Overwrite button should now be enabled
+    expect(overwriteConfirmationBtn).toBeEnabled();
   });
 });

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
@@ -18,69 +18,11 @@
  */
 import React from 'react';
 import * as reactRedux from 'react-redux';
-import {
-  ISaveableDatasource,
-  SaveDatasetModal,
-} from 'src/SqlLab/components/SaveDatasetModal';
 import { render, screen, waitFor, within } from 'spec/helpers/testing-library';
-import { DatasourceType } from '@superset-ui/core';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
-
-const user = {
-  createdOn: '2021-04-27T18:12:38.952304',
-  email: 'admin',
-  firstName: 'admin',
-  isActive: true,
-  lastName: 'admin',
-  permissions: {},
-  roles: {
-    Admin: [
-      ['can_sqllab', 'Superset'],
-      ['can_write', 'Dashboard'],
-      ['can_write', 'Chart'],
-    ],
-  },
-  userId: 1,
-  username: 'admin',
-};
-
-const testQuery: ISaveableDatasource = {
-  name: 'unimportant',
-  dbId: 1,
-  sql: 'SELECT *',
-  columns: [
-    {
-      name: 'Column 1',
-      type: DatasourceType.Query,
-      is_dttm: false,
-    },
-    {
-      name: 'Column 3',
-      type: DatasourceType.Query,
-      is_dttm: false,
-    },
-    {
-      name: 'Column 2',
-      type: DatasourceType.Query,
-      is_dttm: true,
-    },
-  ],
-};
-
-const mockdatasets = [...new Array(3)].map((_, i) => ({
-  changed_by_name: 'user',
-  kind: i === 0 ? 'virtual' : 'physical', // ensure there is 1 virtual
-  changed_by_url: 'changed_by_url',
-  changed_by: 'user',
-  changed_on: new Date().toISOString(),
-  database_name: `db ${i}`,
-  explore_url: `/explore/?dataset_type=table&dataset_id=${i}`,
-  id: i,
-  schema: `schema ${i}`,
-  table_name: `coolest table ${i}`,
-  owners: [{ username: 'admin', userId: 1 }],
-}));
+import { SaveDatasetModal } from 'src/SqlLab/components/SaveDatasetModal';
+import { user, testQuery, mockdatasets } from 'src/SqlLab/fixtures';
 
 const mockedProps = {
   visible: true,
@@ -178,7 +120,7 @@ describe('SaveDatasetModal', () => {
     expect(overwriteConfirmationBtn).toBeDisabled();
 
     // Click the select component
-    const select = screen.getByRole('combobox', { name: /existing dataset/i });
+    const select = screen.getByRole('combobox', { name: /existing dataset/i })!;
     await waitFor(async () => userEvent.click(select));
 
     // Select the first "existing dataset" from the listbox

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
@@ -22,7 +22,7 @@ import {
   ISaveableDatasource,
   SaveDatasetModal,
 } from 'src/SqlLab/components/SaveDatasetModal';
-import { render, screen, waitFor } from 'spec/helpers/testing-library';
+import { render, screen, waitFor, within } from 'spec/helpers/testing-library';
 import { DatasourceType } from '@superset-ui/core';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
@@ -182,10 +182,10 @@ describe('SaveDatasetModal', () => {
     await waitFor(async () => userEvent.click(select));
 
     // Select the first "existing dataset" from the listbox
-    await waitFor(async () => {
-      const listbox = screen.getByRole('listbox');
-      userEvent.selectOptions(listbox, 'coolest table 0');
-    });
+    const option = within(
+      document.querySelector('.rc-virtual-list')!,
+    ).getByText('coolest table 0')!;
+    userEvent.click(option);
 
     // Overwrite button should now be enabled
     expect(overwriteConfirmationBtn).toBeEnabled();

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -186,6 +186,11 @@ export const SaveDatasetModal: FunctionComponent<SaveDatasetModalProps> = ({
     ...(formData || {}),
   };
   const handleOverwriteDataset = async () => {
+    // if user wants to overwrite a dataset we need to prompt them
+    if (!shouldOverwriteDataset) {
+      setShouldOverwriteDataset(true);
+      return;
+    }
     const [, key] = await Promise.all([
       updateDataset(
         datasource?.dbId,
@@ -257,12 +262,6 @@ export const SaveDatasetModal: FunctionComponent<SaveDatasetModalProps> = ({
   );
 
   const handleSaveInDataset = () => {
-    // if user wants to overwrite a dataset we need to prompt them
-    if (newOrOverwrite === DatasetRadioState.OVERWRITE_DATASET) {
-      setShouldOverwriteDataset(true);
-      return;
-    }
-
     const selectedColumns = datasource?.columns ?? [];
 
     // The filters param is only used to test jinja templates.
@@ -346,7 +345,7 @@ export const SaveDatasetModal: FunctionComponent<SaveDatasetModalProps> = ({
       onHide={onHide}
       footer={
         <>
-          {!shouldOverwriteDataset && (
+          {newOrOverwrite === DatasetRadioState.SAVE_NEW && (
             <Button
               disabled={disableSaveAndExploreBtn}
               buttonStyle="primary"
@@ -355,7 +354,7 @@ export const SaveDatasetModal: FunctionComponent<SaveDatasetModalProps> = ({
               {buttonTextOnSave}
             </Button>
           )}
-          {shouldOverwriteDataset && (
+          {newOrOverwrite === DatasetRadioState.OVERWRITE_DATASET && (
             <>
               <Button onClick={handleOverwriteCancel}>Back</Button>
               <Button

--- a/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.jsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.jsx
@@ -17,60 +17,87 @@
  * under the License.
  */
 import React from 'react';
-import { shallow } from 'enzyme';
-import * as sinon from 'sinon';
+import { render, screen } from 'spec/helpers/testing-library';
+import userEvent from '@testing-library/user-event';
 import SaveQuery from 'src/SqlLab/components/SaveQuery';
-import Modal from 'src/components/Modal';
-import Button from 'src/components/Button';
-import { FormItem } from 'src/components/Form';
+import { databases } from 'src/SqlLab/fixtures';
+
+const mockedProps = {
+  query: {
+    dbId: 1,
+    schema: 'main',
+    sql: 'SELECT * FROM t',
+  },
+  defaultLabel: 'untitled',
+  animation: false,
+  database: databases.result[0],
+  onUpdate: () => {},
+  onSave: () => {},
+};
+
+const splitSaveBtnProps = {
+  ...mockedProps,
+  database: {
+    ...mockedProps.database,
+    allows_virtual_table_explore: true,
+  },
+};
 
 describe('SavedQuery', () => {
-  const mockedProps = {
-    query: {
-      dbId: 1,
-      schema: 'main',
-      sql: 'SELECT * FROM t',
-    },
-    defaultLabel: 'untitled',
-    animation: false,
-  };
-  it('is valid', () => {
-    expect(React.isValidElement(<SaveQuery />)).toBe(true);
-  });
-  it('is valid with props', () => {
-    expect(React.isValidElement(<SaveQuery {...mockedProps} />)).toBe(true);
-  });
-  it('has a Modal', () => {
-    const wrapper = shallow(<SaveQuery {...mockedProps} />);
-    expect(wrapper.find(Modal)).toExist();
-  });
-  // TODO: eschutho convert test to RTL
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('has a cancel button', () => {
-    const wrapper = shallow(<SaveQuery {...mockedProps} />);
-    const modal = wrapper.find(Modal);
+  it('renders a non-split save button when allows_virtual_table_explore is not enabled', () => {
+    render(<SaveQuery {...mockedProps} />, { useRedux: true });
 
-    expect(modal.find('[data-test="cancel-query"]')).toHaveLength(1);
-  });
-  it('has 2 FormItem', () => {
-    const wrapper = shallow(<SaveQuery {...mockedProps} />);
-    const modal = wrapper.find(Modal);
+    const saveBtn = screen.getByRole('button', { name: /save/i });
 
-    expect(modal.find(FormItem)).toHaveLength(2);
+    expect(saveBtn).toBeVisible();
   });
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('has a save button if this is a new query', () => {
-    const saveSpy = sinon.spy();
-    const wrapper = shallow(<SaveQuery {...mockedProps} onSave={saveSpy} />);
-    const modal = wrapper.find(Modal);
 
-    expect(modal.find(Button)).toHaveLength(2);
-    modal.find(Button).at(0).simulate('click');
-    expect(saveSpy.calledOnce).toBe(true);
+  it('renders a save query modal when user clicks save button', () => {
+    render(<SaveQuery {...mockedProps} />, { useRedux: true });
+
+    const saveBtn = screen.getByRole('button', { name: /save/i });
+    userEvent.click(saveBtn);
+
+    const saveQueryModalHeader = screen.getByRole('heading', {
+      name: /save query/i,
+    });
+
+    expect(saveQueryModalHeader).toBeVisible();
   });
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('has an update button if this is an existing query', () => {
-    const updateSpy = sinon.spy();
+
+  it('renders the save query modal UI', () => {
+    render(<SaveQuery {...mockedProps} />, { useRedux: true });
+
+    const saveBtn = screen.getByRole('button', { name: /save/i });
+    userEvent.click(saveBtn);
+
+    const closeBtn = screen.getByRole('button', { name: /close/i });
+    const saveQueryModalHeader = screen.getByRole('heading', {
+      name: /save query/i,
+    });
+    const nameLabel = screen.getByText(/name/i);
+    const descriptionLabel = screen.getByText(/description/i);
+    const textBoxes = screen.getAllByRole('textbox');
+    const nameTextbox = textBoxes[0];
+    const descriptionTextbox = textBoxes[1];
+    // There are now two save buttons, the initial save button and the modal save button
+    const saveBtns = screen.getAllByRole('button', { name: /save/i });
+    const cancelBtn = screen.getByRole('button', { name: /cancel/i });
+
+    expect(closeBtn).toBeVisible();
+    expect(saveQueryModalHeader).toBeVisible();
+    expect(nameLabel).toBeVisible();
+    expect(descriptionLabel).toBeVisible();
+    expect(textBoxes.length).toBe(2);
+    expect(nameTextbox).toBeVisible();
+    expect(descriptionTextbox).toBeVisible();
+    expect(saveBtns.length).toBe(2);
+    expect(saveBtns[0]).toBeVisible();
+    expect(saveBtns[1]).toBeVisible();
+    expect(cancelBtn).toBeVisible();
+  });
+
+  it('renders a "save as new" and "update" button if query already exists', () => {
     const props = {
       ...mockedProps,
       query: {
@@ -78,11 +105,75 @@ describe('SavedQuery', () => {
         remoteId: '42',
       },
     };
-    const wrapper = shallow(<SaveQuery {...props} onUpdate={updateSpy} />);
-    const modal = wrapper.find(Modal);
+    render(<SaveQuery {...props} />, { useRedux: true });
 
-    expect(modal.find(Button)).toHaveLength(3);
-    modal.find(Button).at(0).simulate('click');
-    expect(updateSpy.calledOnce).toBe(true);
+    const saveBtn = screen.getByRole('button', { name: /save/i });
+    userEvent.click(saveBtn);
+
+    const saveAsNewBtn = screen.getByRole('button', { name: /save as new/i });
+    const updateBtn = screen.getByRole('button', { name: /update/i });
+
+    expect(saveAsNewBtn).toBeVisible();
+    expect(updateBtn).toBeVisible();
+  });
+
+  it('renders a split save button when allows_virtual_table_explore is enabled', () => {
+    render(<SaveQuery {...splitSaveBtnProps} />, { useRedux: true });
+
+    const saveBtn = screen.getByRole('button', { name: /save/i });
+    const caretBtn = screen.getByRole('button', { name: /caret-down/i });
+
+    expect(saveBtn).toBeVisible();
+    expect(caretBtn).toBeVisible();
+  });
+
+  it('renders a save dataset modal when user clicks "save dataset" menu item', () => {
+    render(<SaveQuery {...splitSaveBtnProps} />, { useRedux: true });
+
+    const caretBtn = screen.getByRole('button', { name: /caret-down/i });
+    userEvent.click(caretBtn);
+
+    const saveDatasetMenuItem = screen.getByText(/save dataset/i);
+    userEvent.click(saveDatasetMenuItem);
+
+    const saveDatasetHeader = screen.getByText(/save or overwrite dataset/i);
+
+    expect(saveDatasetHeader).toBeVisible();
+  });
+
+  it('renders the save dataset modal UI', () => {
+    render(<SaveQuery {...splitSaveBtnProps} />, { useRedux: true });
+
+    const caretBtn = screen.getByRole('button', { name: /caret-down/i });
+    userEvent.click(caretBtn);
+
+    const saveDatasetMenuItem = screen.getByText(/save dataset/i);
+    userEvent.click(saveDatasetMenuItem);
+
+    const closeBtn = screen.getByRole('button', { name: /close/i });
+    const saveDatasetHeader = screen.getByText(/save or overwrite dataset/i);
+    const saveRadio = screen.getByRole('radio', {
+      name: /save as new untitled dataset/i,
+    });
+    const saveLabel = screen.getByText(/save as new/i);
+    const saveTextbox = screen.getByRole('textbox');
+    const overwriteRadio = screen.getByRole('radio', {
+      name: /overwrite existing/i,
+    });
+    const overwriteLabel = screen.getByText(/overwrite existing/i);
+    const overwriteCombobox = screen.getByRole('combobox');
+    const overwritePlaceholderText = screen.getByText(
+      /select or type dataset name/i,
+    );
+
+    expect(saveDatasetHeader).toBeVisible();
+    expect(closeBtn).toBeVisible();
+    expect(saveRadio).toBeVisible();
+    expect(saveLabel).toBeVisible();
+    expect(saveTextbox).toBeVisible();
+    expect(overwriteRadio).toBeVisible();
+    expect(overwriteLabel).toBeVisible();
+    expect(overwriteCombobox).toBeVisible();
+    expect(overwritePlaceholderText).toBeVisible();
   });
 });

--- a/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.jsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.jsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { render, screen } from 'spec/helpers/testing-library';
+import { render, screen, waitFor } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
 import SaveQuery from 'src/SqlLab/components/SaveQuery';
 import { databases } from 'src/SqlLab/fixtures';
@@ -117,38 +117,44 @@ describe('SavedQuery', () => {
     expect(updateBtn).toBeVisible();
   });
 
-  it('renders a split save button when allows_virtual_table_explore is enabled', () => {
+  it('renders a split save button when allows_virtual_table_explore is enabled', async () => {
     render(<SaveQuery {...splitSaveBtnProps} />, { useRedux: true });
 
-    const saveBtn = screen.getByRole('button', { name: /save/i });
-    const caretBtn = screen.getByRole('button', { name: /caret-down/i });
+    await waitFor(() => {
+      const saveBtn = screen.getByRole('button', { name: /save/i });
+      const caretBtn = screen.getByRole('button', { name: /caret-down/i });
 
-    expect(saveBtn).toBeVisible();
-    expect(caretBtn).toBeVisible();
+      expect(saveBtn).toBeVisible();
+      expect(caretBtn).toBeVisible();
+    });
   });
 
-  it('renders a save dataset modal when user clicks "save dataset" menu item', () => {
+  it('renders a save dataset modal when user clicks "save dataset" menu item', async () => {
     render(<SaveQuery {...splitSaveBtnProps} />, { useRedux: true });
 
-    const caretBtn = screen.getByRole('button', { name: /caret-down/i });
-    userEvent.click(caretBtn);
+    await waitFor(() => {
+      const caretBtn = screen.getByRole('button', { name: /caret-down/i });
+      userEvent.click(caretBtn);
 
-    const saveDatasetMenuItem = screen.getByText(/save dataset/i);
-    userEvent.click(saveDatasetMenuItem);
+      const saveDatasetMenuItem = screen.getByText(/save dataset/i);
+      userEvent.click(saveDatasetMenuItem);
+    });
 
     const saveDatasetHeader = screen.getByText(/save or overwrite dataset/i);
 
     expect(saveDatasetHeader).toBeVisible();
   });
 
-  it('renders the save dataset modal UI', () => {
+  it('renders the save dataset modal UI', async () => {
     render(<SaveQuery {...splitSaveBtnProps} />, { useRedux: true });
 
-    const caretBtn = screen.getByRole('button', { name: /caret-down/i });
-    userEvent.click(caretBtn);
+    await waitFor(() => {
+      const caretBtn = screen.getByRole('button', { name: /caret-down/i });
+      userEvent.click(caretBtn);
 
-    const saveDatasetMenuItem = screen.getByText(/save dataset/i);
-    userEvent.click(saveDatasetMenuItem);
+      const saveDatasetMenuItem = screen.getByText(/save dataset/i);
+      userEvent.click(saveDatasetMenuItem);
+    });
 
     const closeBtn = screen.getByRole('button', { name: /close/i });
     const saveDatasetHeader = screen.getByText(/save or overwrite dataset/i);

--- a/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
@@ -21,21 +21,11 @@ import { Row, Col } from 'src/components';
 import { Input, TextArea } from 'src/components/Input';
 import { t, styled } from '@superset-ui/core';
 import Button from 'src/components/Button';
+import { Menu } from 'src/components/Menu';
 import { Form, FormItem } from 'src/components/Form';
 import Modal from 'src/components/Modal';
-import Icons from 'src/components/Icons';
-
-const Styles = styled.span`
-  span[role='img'] {
-    display: flex;
-    margin: 0;
-    color: ${({ theme }) => theme.colors.grayscale.base};
-    svg {
-      vertical-align: -${({ theme }) => theme.gridUnit * 1.25}px;
-      margin: 0;
-    }
-  }
-`;
+import SaveDatasetActionButton from 'src/SqlLab/components/SaveDatasetActionButton';
+import { SaveDatasetModal } from 'src/SqlLab/components/SaveDatasetModal';
 
 interface SaveQueryProps {
   query: any;
@@ -43,6 +33,7 @@ interface SaveQueryProps {
   onSave: (arg0: QueryPayload) => void;
   onUpdate: (arg0: QueryPayload) => void;
   saveQueryWarning: string | null;
+  database: Record<string, any>;
 }
 
 type QueryPayload = {
@@ -68,8 +59,20 @@ type QueryPayload = {
     type: string;
     value: string;
   }>;
-  title: string;
+  name: string;
 };
+
+const Styles = styled.span`
+  span[role='img'] {
+    display: flex;
+    margin: 0;
+    color: ${({ theme }) => theme.colors.grayscale.base};
+    svg {
+      vertical-align: -${({ theme }) => theme.gridUnit * 1.25}px;
+      margin: 0;
+    }
+  }
+`;
 
 export default function SaveQuery({
   query,
@@ -77,28 +80,36 @@ export default function SaveQuery({
   onSave = () => {},
   onUpdate,
   saveQueryWarning = null,
+  database,
 }: SaveQueryProps) {
   const [description, setDescription] = useState<string>(
     query.description || '',
   );
   const [label, setLabel] = useState<string>(defaultLabel);
   const [showSave, setShowSave] = useState<boolean>(false);
+  const [showSaveDatasetModal, setShowSaveDatasetModal] = useState(false);
   const isSaved = !!query.remoteId;
+  const canExploreDatabase = !!database?.allows_virtual_table_explore;
+
+  const overlayMenu = (
+    <Menu>
+      <Menu.Item onClick={() => setShowSaveDatasetModal(true)}>
+        {t('Save dataset')}
+      </Menu.Item>
+    </Menu>
+  );
 
   const queryPayload = () => ({
     ...query,
-    title: label,
+    name: label,
     description,
   });
 
   useEffect(() => {
-    if (!isSaved) {
-      setLabel(defaultLabel);
-    }
+    if (!isSaved) setLabel(defaultLabel);
   }, [defaultLabel]);
-  const close = () => {
-    setShowSave(false);
-  };
+
+  const close = () => setShowSave(false);
 
   const onSaveWrapper = () => {
     onSave(queryPayload());
@@ -118,9 +129,7 @@ export default function SaveQuery({
     setDescription(e.target.value);
   };
 
-  const toggleSave = () => {
-    setShowSave(!showSave);
-  };
+  const toggleSave = () => setShowSave(!showSave);
 
   const renderModalBody = () => (
     <Form layout="vertical">
@@ -161,10 +170,17 @@ export default function SaveQuery({
 
   return (
     <Styles className="SaveQuery">
-      <Button buttonSize="small" onClick={toggleSave}>
-        <Icons.Save iconSize="xl" />
-        {isSaved ? t('Save') : t('Save as')}
-      </Button>
+      <SaveDatasetActionButton
+        toggleSave={toggleSave}
+        overlayMenu={canExploreDatabase ? overlayMenu : null}
+      />
+      <SaveDatasetModal
+        visible={showSaveDatasetModal}
+        onHide={() => setShowSaveDatasetModal(false)}
+        buttonTextOnSave={t('Save')}
+        buttonTextOnOverwrite={t('Overwrite')}
+        datasource={query}
+      />
       <Modal
         className="save-query-modal"
         onHandledPrimaryAction={onSaveWrapper}

--- a/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
@@ -129,8 +129,6 @@ export default function SaveQuery({
     setDescription(e.target.value);
   };
 
-  const toggleSave = () => setShowSave(!showSave);
-
   const renderModalBody = () => (
     <Form layout="vertical">
       <Row>
@@ -171,7 +169,7 @@ export default function SaveQuery({
   return (
     <Styles className="SaveQuery">
       <SaveDatasetActionButton
-        toggleSave={toggleSave}
+        setShowSave={setShowSave}
         overlayMenu={canExploreDatabase ? overlayMenu : null}
       />
       <SaveDatasetModal

--- a/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
@@ -175,8 +175,8 @@ export default function SaveQuery({
       <SaveDatasetModal
         visible={showSaveDatasetModal}
         onHide={() => setShowSaveDatasetModal(false)}
-        buttonTextOnSave={t('Save')}
-        buttonTextOnOverwrite={t('Overwrite')}
+        buttonTextOnSave={t('Save & Explore')}
+        buttonTextOnOverwrite={t('Overwrite & Explore')}
         datasource={query}
       />
       <Modal

--- a/superset-frontend/src/SqlLab/components/ShareSqlLabQuery/ShareSqlLabQuery.test.jsx
+++ b/superset-frontend/src/SqlLab/components/ShareSqlLabQuery/ShareSqlLabQuery.test.jsx
@@ -42,7 +42,7 @@ const standardProvider = ({ children }) => (
 const defaultProps = {
   queryEditor: {
     dbId: 0,
-    title: 'query title',
+    name: 'query title',
     schema: 'query_schema',
     autorun: false,
     sql: 'SELECT * FROM ...',

--- a/superset-frontend/src/SqlLab/components/ShareSqlLabQuery/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ShareSqlLabQuery/index.tsx
@@ -49,8 +49,8 @@ function ShareSqlLabQuery({
   const theme = useTheme();
 
   const getCopyUrlForKvStore = (callback: Function) => {
-    const { dbId, title, schema, autorun, sql } = queryEditor;
-    const sharedQuery = { dbId, title, schema, autorun, sql };
+    const { dbId, name, schema, autorun, sql } = queryEditor;
+    const sharedQuery = { dbId, name, schema, autorun, sql };
 
     return storeQuery(sharedQuery)
       .then(shortUrl => {

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -345,10 +345,10 @@ class SqlEditor extends React.PureComponent {
         key: userOS === 'Windows' ? 'ctrl+q' : 'ctrl+t',
         descr: t('New tab'),
         func: () => {
-          const title = newQueryTabName(this.props.queryEditors || []);
+          const name = newQueryTabName(this.props.queryEditors || []);
           this.props.addQueryEditor({
             ...this.props.queryEditor,
-            title,
+            name,
           });
         },
       },
@@ -463,7 +463,7 @@ class SqlEditor extends React.PureComponent {
       dbId: qe.dbId,
       sql: qe.selectedText ? qe.selectedText : qe.sql,
       sqlEditorId: qe.id,
-      tab: qe.title,
+      tab: qe.name,
       schema: qe.schema,
       tempTable: ctas ? this.state.ctas : '',
       templateParams: qe.templateParams,
@@ -584,7 +584,7 @@ class SqlEditor extends React.PureComponent {
         {scheduledQueriesConf && (
           <Menu.Item>
             <ScheduleQueryButton
-              defaultLabel={qe.title}
+              defaultLabel={qe.name}
               sql={qe.sql}
               onSchedule={this.props.actions.scheduleQuery}
               schema={qe.schema}
@@ -722,10 +722,11 @@ class SqlEditor extends React.PureComponent {
           <span>
             <SaveQuery
               query={qe}
-              defaultLabel={qe.title || qe.description}
+              defaultLabel={qe.name || qe.description}
               onSave={this.saveQuery}
               onUpdate={this.props.actions.updateSavedQuery}
               saveQueryWarning={this.props.saveQueryWarning}
+              database={this.props.database}
             />
           </span>
           <span>

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors/TabbedSqlEditors.test.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors/TabbedSqlEditors.test.jsx
@@ -55,7 +55,7 @@ describe('TabbedSqlEditors', () => {
       schema: null,
       selectedText: null,
       sql: 'SELECT ds...',
-      title: 'Untitled Query',
+      name: 'Untitled Query',
     },
   ];
   const queries = {
@@ -177,7 +177,7 @@ describe('TabbedSqlEditors', () => {
 
     wrapper.instance().newQueryEditor();
     expect(
-      wrapper.instance().props.actions.addQueryEditor.getCall(0).args[0].title,
+      wrapper.instance().props.actions.addQueryEditor.getCall(0).args[0].name,
     ).toContain('Untitled Query');
   });
   it('should properly increment query tab name', () => {
@@ -186,7 +186,7 @@ describe('TabbedSqlEditors', () => {
 
     wrapper.instance().newQueryEditor();
     expect(
-      wrapper.instance().props.actions.addQueryEditor.getCall(0).args[0].title,
+      wrapper.instance().props.actions.addQueryEditor.getCall(0).args[0].name,
     ).toContain('Untitled Query 2');
   });
   it('should duplicate query editor', () => {

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx
@@ -167,7 +167,7 @@ class TabbedSqlEditors extends React.PureComponent {
           }
         }
         const newQueryEditor = {
-          title: query.title,
+          name: query.name,
           dbId,
           schema: query.schema,
           autorun: query.autorun,
@@ -266,7 +266,7 @@ class TabbedSqlEditors extends React.PureComponent {
     const newTitle = newQueryTabName(this.props.queryEditors || []);
 
     const qe = {
-      title: newTitle,
+      name: newTitle,
       dbId:
         activeQueryEditor && activeQueryEditor.dbId
           ? activeQueryEditor.dbId
@@ -376,7 +376,7 @@ class TabbedSqlEditors extends React.PureComponent {
       const tabHeader = (
         <TabTitleWrapper>
           <Dropdown overlay={menu} trigger={['click']} />
-          <TabTitle>{qe.title}</TabTitle> <TabStatusIcon tabState={state} />{' '}
+          <TabTitle>{qe.name}</TabTitle> <TabStatusIcon tabState={state} />{' '}
         </TabTitleWrapper>
       );
       return (

--- a/superset-frontend/src/SqlLab/fixtures.ts
+++ b/superset-frontend/src/SqlLab/fixtures.ts
@@ -181,12 +181,12 @@ export const defaultQueryEditor = {
   latestQueryId: null,
   selectedText: null,
   sql: 'SELECT *\nFROM\nWHERE',
-  title: 'Untitled Query 1',
+  name: 'Untitled Query 1',
   schemaOptions: [
     {
       value: 'main',
       label: 'main',
-      title: 'main',
+      name: 'main',
     },
   ],
 };

--- a/superset-frontend/src/SqlLab/fixtures.ts
+++ b/superset-frontend/src/SqlLab/fixtures.ts
@@ -20,6 +20,7 @@ import sinon from 'sinon';
 import * as actions from 'src/SqlLab/actions/sqlLab';
 import { ColumnKeyTypeType } from 'src/SqlLab/components/ColumnElement';
 import { DatasourceType, QueryResponse, QueryState } from '@superset-ui/core';
+import { ISaveableDatasource } from 'src/SqlLab/components/SaveDatasetModal';
 
 export const mockedActions = sinon.stub({ ...actions });
 
@@ -670,3 +671,40 @@ export const query = {
   ctas: false,
   cached: false,
 };
+
+export const testQuery: ISaveableDatasource = {
+  name: 'unimportant',
+  dbId: 1,
+  sql: 'SELECT *',
+  columns: [
+    {
+      name: 'Column 1',
+      type: DatasourceType.Query,
+      is_dttm: false,
+    },
+    {
+      name: 'Column 3',
+      type: DatasourceType.Query,
+      is_dttm: false,
+    },
+    {
+      name: 'Column 2',
+      type: DatasourceType.Query,
+      is_dttm: true,
+    },
+  ],
+};
+
+export const mockdatasets = [...new Array(3)].map((_, i) => ({
+  changed_by_name: 'user',
+  kind: i === 0 ? 'virtual' : 'physical', // ensure there is 1 virtual
+  changed_by_url: 'changed_by_url',
+  changed_by: 'user',
+  changed_on: new Date().toISOString(),
+  database_name: `db ${i}`,
+  explore_url: `/explore/?dataset_type=table&dataset_id=${i}`,
+  id: i,
+  schema: `schema ${i}`,
+  table_name: `coolest table ${i}`,
+  owners: [{ username: 'admin', userId: 1 }],
+}));

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.js
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.js
@@ -41,7 +41,7 @@ export default function getInitialState({
   const defaultQueryEditor = {
     id: null,
     loaded: true,
-    title: t('Untitled query'),
+    name: t('Untitled query'),
     sql: 'SELECT *\nFROM\nWHERE',
     selectedText: null,
     latestQueryId: null,
@@ -73,7 +73,7 @@ export default function getInitialState({
       queryEditor = {
         id: id.toString(),
         loaded: true,
-        title: activeTab.label,
+        name: activeTab.label,
         sql: activeTab.sql || undefined,
         selectedText: undefined,
         latestQueryId: activeTab.latest_query
@@ -99,7 +99,7 @@ export default function getInitialState({
         ...defaultQueryEditor,
         id: id.toString(),
         loaded: false,
-        title: label,
+        name: label,
       };
     }
     queryEditors.push(queryEditor);

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -48,7 +48,7 @@ export default function sqlLabReducer(state = {}, action) {
         existing,
         {
           remoteId: result.remoteId,
-          title: query.title,
+          name: query.name,
         },
         'id',
       );
@@ -71,7 +71,7 @@ export default function sqlLabReducer(state = {}, action) {
       );
       const qe = {
         remoteId: progenitor.remoteId,
-        title: t('Copy of %s', progenitor.title),
+        name: t('Copy of %s', progenitor.name),
         dbId: action.query.dbId ? action.query.dbId : null,
         schema: action.query.schema ? action.query.schema : null,
         autorun: true,
@@ -467,7 +467,7 @@ export default function sqlLabReducer(state = {}, action) {
     },
     [actions.QUERY_EDITOR_SET_TITLE]() {
       return alterInArr(state, 'queryEditors', action.queryEditor, {
-        title: action.title,
+        name: action.name,
       });
     },
     [actions.QUERY_EDITOR_SET_SQL]() {

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
@@ -96,14 +96,14 @@ describe('sqlLabReducer', () => {
       expect(newState.queryEditors[1].autorun).toBe(true);
     });
     it('should not fail while setting title', () => {
-      const title = 'a new title';
+      const title = 'Untitled Query 1';
       const action = {
         type: actions.QUERY_EDITOR_SET_TITLE,
         queryEditor: qe,
         title,
       };
       newState = sqlLabReducer(newState, action);
-      expect(newState.queryEditors[1].title).toBe(title);
+      expect(newState.queryEditors[0].name).toBe(title);
     });
     it('should not fail while setting Sql', () => {
       const sql = 'SELECT nothing from dev_null';

--- a/superset-frontend/src/SqlLab/types.ts
+++ b/superset-frontend/src/SqlLab/types.ts
@@ -21,6 +21,10 @@ import { SupersetError } from 'src/components/ErrorMessage/types';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 import { ToastType } from 'src/components/MessageToasts/types';
 import { RootState } from 'src/dashboard/types';
+import { DropdownButtonProps } from 'src/components/DropdownButton';
+import { ButtonProps } from 'src/components/Button';
+
+export type QueryButtonProps = DropdownButtonProps | ButtonProps;
 
 // Object as Dictionary (associative array) with Query id as the key and type Query as the value
 export type QueryDictionary = {
@@ -29,7 +33,7 @@ export type QueryDictionary = {
 
 export interface QueryEditor {
   dbId?: number;
-  title: string;
+  name: string;
   schema: string;
   autorun: boolean;
   sql: string;

--- a/superset-frontend/src/SqlLab/utils/newQueryTabName.test.ts
+++ b/superset-frontend/src/SqlLab/utils/newQueryTabName.test.ts
@@ -36,8 +36,8 @@ describe('newQueryTabName', () => {
   it('should return next available number if there are unsaved editors', () => {
     const untitledQueryText = 'Untitled Query';
     const unsavedEditors = [
-      { ...emptyEditor, title: `${untitledQueryText} 1` },
-      { ...emptyEditor, title: `${untitledQueryText} 2` },
+      { ...emptyEditor, name: `${untitledQueryText} 1` },
+      { ...emptyEditor, name: `${untitledQueryText} 2` },
     ];
 
     const nextTitle = newQueryTabName(unsavedEditors);

--- a/superset-frontend/src/SqlLab/utils/newQueryTabName.ts
+++ b/superset-frontend/src/SqlLab/utils/newQueryTabName.ts
@@ -31,10 +31,10 @@ export const newQueryTabName = (
 
   if (queryEditors.length > 0) {
     const mappedUntitled = queryEditors.filter(qe =>
-      qe.title.match(untitledQueryRegex),
+      qe.name.match(untitledQueryRegex),
     );
     const untitledQueryNumbers = mappedUntitled.map(
-      qe => +qe.title.replace(untitledQuery, ''),
+      qe => +qe.name.replace(untitledQuery, ''),
     );
     if (untitledQueryNumbers.length > 0) {
       // When there are query tabs open, and at least one is called "Untitled Query #"

--- a/superset-frontend/src/components/Chart/Chart.jsx
+++ b/superset-frontend/src/components/Chart/Chart.jsx
@@ -25,6 +25,7 @@ import { PLACEHOLDER_DATASOURCE } from 'src/dashboard/constants';
 import Loading from 'src/components/Loading';
 import { EmptyStateBig } from 'src/components/EmptyState';
 import ErrorBoundary from 'src/components/ErrorBoundary';
+import { SaveDatasetModal } from 'src/SqlLab/components/SaveDatasetModal';
 import { Logger, LOG_ACTIONS_RENDER_CHART } from 'src/logger/LogUtils';
 import { URL_PARAMS } from 'src/constants';
 import { getUrlParam } from 'src/utils/urlUtils';
@@ -122,8 +123,10 @@ const MonospaceDiv = styled.div`
 class Chart extends React.PureComponent {
   constructor(props) {
     super(props);
+    this.state = { showSaveDatasetModal: false };
     this.handleRenderContainerFailure =
       this.handleRenderContainerFailure.bind(this);
+    this.toggleSaveDatasetModal = this.toggleSaveDatasetModal.bind(this);
   }
 
   componentDidMount() {
@@ -135,6 +138,12 @@ class Chart extends React.PureComponent {
       this.runQuery();
     }
   }
+
+  toggleSaveDatasetModal = () => {
+    this.setState(({ showSaveDatasetModal }) => ({
+      showSaveDatasetModal: !showSaveDatasetModal,
+    }));
+  };
 
   componentDidUpdate() {
     // during migration, hold chart queries before user choose review or cancel
@@ -253,6 +262,7 @@ class Chart extends React.PureComponent {
       width,
     } = this.props;
 
+    const { showSaveDatasetModal } = this.state;
     const isLoading = chartStatus === 'loading';
     this.renderContainerStartTime = Logger.getTimestamp();
     if (chartStatus === 'failed') {
@@ -296,27 +306,39 @@ class Chart extends React.PureComponent {
     }
 
     return (
-      <ErrorBoundary
-        onError={this.handleRenderContainerFailure}
-        showMessage={false}
-      >
-        <Styles
-          data-ui-anchor="chart"
-          className="chart-container"
-          data-test="chart-container"
-          height={height}
-          width={width}
+      <>
+        <ErrorBoundary
+          onError={this.handleRenderContainerFailure}
+          showMessage={false}
         >
-          <div className="slice_container" data-test="slice-container">
-            <ChartRenderer
-              {...this.props}
-              source={this.props.dashboardId ? 'dashboard' : 'explore'}
-              data-test={this.props.vizType}
-            />
-          </div>
-          {isLoading && !isDeactivatedViz && <Loading />}
-        </Styles>
-      </ErrorBoundary>
+          <Styles
+            data-ui-anchor="chart"
+            className="chart-container"
+            data-test="chart-container"
+            height={height}
+            width={width}
+          >
+            <div className="slice_container" data-test="slice-container">
+              <ChartRenderer
+                {...this.props}
+                source={this.props.dashboardId ? 'dashboard' : 'explore'}
+                data-test={this.props.vizType}
+              />
+            </div>
+            {isLoading && !isDeactivatedViz && <Loading />}
+          </Styles>
+        </ErrorBoundary>
+        {showSaveDatasetModal && (
+          <SaveDatasetModal
+            key={Math.random()}
+            visible={showSaveDatasetModal}
+            onHide={this.toggleSaveDatasetModal}
+            buttonTextOnSave={t('Save')}
+            buttonTextOnOverwrite={t('Overwrite')}
+            datasource={this.props.datasource}
+          />
+        )}
+      </>
     );
   }
 }

--- a/superset-frontend/src/components/Chart/Chart.jsx
+++ b/superset-frontend/src/components/Chart/Chart.jsx
@@ -25,7 +25,6 @@ import { PLACEHOLDER_DATASOURCE } from 'src/dashboard/constants';
 import Loading from 'src/components/Loading';
 import { EmptyStateBig } from 'src/components/EmptyState';
 import ErrorBoundary from 'src/components/ErrorBoundary';
-import { SaveDatasetModal } from 'src/SqlLab/components/SaveDatasetModal';
 import { Logger, LOG_ACTIONS_RENDER_CHART } from 'src/logger/LogUtils';
 import { URL_PARAMS } from 'src/constants';
 import { getUrlParam } from 'src/utils/urlUtils';
@@ -123,10 +122,8 @@ const MonospaceDiv = styled.div`
 class Chart extends React.PureComponent {
   constructor(props) {
     super(props);
-    this.state = { showSaveDatasetModal: false };
     this.handleRenderContainerFailure =
       this.handleRenderContainerFailure.bind(this);
-    this.toggleSaveDatasetModal = this.toggleSaveDatasetModal.bind(this);
   }
 
   componentDidMount() {
@@ -138,12 +135,6 @@ class Chart extends React.PureComponent {
       this.runQuery();
     }
   }
-
-  toggleSaveDatasetModal = () => {
-    this.setState(({ showSaveDatasetModal }) => ({
-      showSaveDatasetModal: !showSaveDatasetModal,
-    }));
-  };
 
   componentDidUpdate() {
     // during migration, hold chart queries before user choose review or cancel
@@ -245,7 +236,6 @@ class Chart extends React.PureComponent {
         link={queryResponse ? queryResponse.link : null}
         source={dashboardId ? 'dashboard' : 'explore'}
         stackTrace={chartStackTrace}
-        errorMitigationFunction={this.toggleSaveDatasetModal}
       />
     );
   }
@@ -262,7 +252,6 @@ class Chart extends React.PureComponent {
       width,
     } = this.props;
 
-    const { showSaveDatasetModal } = this.state;
     const isLoading = chartStatus === 'loading';
     this.renderContainerStartTime = Logger.getTimestamp();
     if (chartStatus === 'failed') {
@@ -328,16 +317,6 @@ class Chart extends React.PureComponent {
             {isLoading && !isDeactivatedViz && <Loading />}
           </Styles>
         </ErrorBoundary>
-        {showSaveDatasetModal && (
-          <SaveDatasetModal
-            key={Math.random()}
-            visible={showSaveDatasetModal}
-            onHide={this.toggleSaveDatasetModal}
-            buttonTextOnSave={t('Save')}
-            buttonTextOnOverwrite={t('Overwrite')}
-            datasource={this.props.datasource}
-          />
-        )}
       </>
     );
   }

--- a/superset-frontend/src/components/Chart/Chart.jsx
+++ b/superset-frontend/src/components/Chart/Chart.jsx
@@ -295,29 +295,27 @@ class Chart extends React.PureComponent {
     }
 
     return (
-      <>
-        <ErrorBoundary
-          onError={this.handleRenderContainerFailure}
-          showMessage={false}
+      <ErrorBoundary
+        onError={this.handleRenderContainerFailure}
+        showMessage={false}
+      >
+        <Styles
+          data-ui-anchor="chart"
+          className="chart-container"
+          data-test="chart-container"
+          height={height}
+          width={width}
         >
-          <Styles
-            data-ui-anchor="chart"
-            className="chart-container"
-            data-test="chart-container"
-            height={height}
-            width={width}
-          >
-            <div className="slice_container" data-test="slice-container">
-              <ChartRenderer
-                {...this.props}
-                source={this.props.dashboardId ? 'dashboard' : 'explore'}
-                data-test={this.props.vizType}
-              />
-            </div>
-            {isLoading && !isDeactivatedViz && <Loading />}
-          </Styles>
-        </ErrorBoundary>
-      </>
+          <div className="slice_container" data-test="slice-container">
+            <ChartRenderer
+              {...this.props}
+              source={this.props.dashboardId ? 'dashboard' : 'explore'}
+              data-test={this.props.vizType}
+            />
+          </div>
+          {isLoading && !isDeactivatedViz && <Loading />}
+        </Styles>
+      </ErrorBoundary>
     );
   }
 }

--- a/superset-frontend/src/components/Chart/ChartErrorMessage.tsx
+++ b/superset-frontend/src/components/Chart/ChartErrorMessage.tsx
@@ -42,5 +42,6 @@ export const ChartErrorMessage: React.FC<Props> = ({
     ...error,
     extra: { ...error.extra, owners },
   };
+
   return <ErrorMessageWithStackTrace {...props} error={ownedError} />;
 };

--- a/superset-frontend/src/components/Chart/ChartErrorMessage.tsx
+++ b/superset-frontend/src/components/Chart/ChartErrorMessage.tsx
@@ -42,6 +42,5 @@ export const ChartErrorMessage: React.FC<Props> = ({
     ...error,
     extra: { ...error.extra, owners },
   };
-
   return <ErrorMessageWithStackTrace {...props} error={ownedError} />;
 };

--- a/superset-frontend/src/components/DropdownButton/index.tsx
+++ b/superset-frontend/src/components/DropdownButton/index.tsx
@@ -52,10 +52,9 @@ const StyledDropdownButton = styled.div`
           border-left: 1px solid ${({ theme }) => theme.colors.grayscale.light5};
           content: '';
           display: block;
-          height: 23px;
+          height: ${({ theme }) => theme.gridUnit * 8}px;
           margin: 0;
           position: absolute;
-          top: ${({ theme }) => theme.gridUnit * 0.75}px;
           width: ${({ theme }) => theme.gridUnit * 0.25}px;
         }
 

--- a/superset-frontend/src/utils/datasourceUtils.js
+++ b/superset-frontend/src/utils/datasourceUtils.js
@@ -18,7 +18,7 @@
  */
 export const getDatasourceAsSaveableDataset = source => ({
   columns: source.columns,
-  name: source?.datasource_name || 'Untitled',
+  name: source?.datasource_name || source?.name || 'Untitled',
   dbId: source.database.id,
   sql: source?.sql || '',
   schema: source?.schema,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This changes the current save query button into a split save button if the database has "Allow this database to be explored" enabled. When the user clicks the caret section of the button, they can now save the query as a dataset.

`Bonus`: In order to create this button, I conveniently needed to fix the styling on the "Run" query split button. The split line now goes all the way through the button and the caret is centered.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### BEFORE:
![saveButtonBefore](https://user-images.githubusercontent.com/55605634/176063560-492b124a-40ce-4aaf-8745-691ddfa271ef.png)
![runButtonBefore](https://user-images.githubusercontent.com/55605634/176329868-20285ba0-16be-41ad-89fc-eb7dd6aba913.png)

#### AFTER:
![splitSaveButtonAfter](https://user-images.githubusercontent.com/55605634/181859659-2f7101dc-d8c2-459d-9809-888edf3608f2.png)
![saveButtonAfter](https://user-images.githubusercontent.com/55605634/176063591-55dafb31-a843-4052-8372-a10bb9d0526a.png)
![runButtonAfter](https://user-images.githubusercontent.com/55605634/176067479-c5ba02bc-834a-4d0b-8e01-3b1eb0787c65.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- From SqlLab, open a query for a database that has "Allow this database to be explored" enabled.
  - Observe the new split save button
    - Click the "Save" section of the button to see the save query modal
    - Click the caret `v` section of the button, then click "Save dataset" to see the save dataset modal
    - Both of these modals should be fully functional
- From SqlLab, open a query for a database that does NOT have "Allow this database to be explored" enabled.
  - Observe that the save button is a normal button, not split
    - Clicking this button should show the save query modal

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
