### PR TITLE
docs: Removing erroneous FAQ timeout message

### DIFF
--- a/docs/docs/frequently-asked-questions.mdx
+++ b/docs/docs/frequently-asked-questions.mdx
@@ -57,14 +57,6 @@ timeout in configuration. For example:
 SQLLAB_ASYNC_TIME_LIMIT_SEC = 60 * 60 * 6
 ```
 
-Superset is running on gunicorn web server, which may time out web requests. If you want to increase
-the default (50), you can specify the timeout when starting the web server with the -t flag, which
-is expressed in seconds.
-
-```
-superset runserver -t 300
-```
-
 If you are seeing timeouts (504 Gateway Time-out) when loading dashboard or explore slice, you are
 probably behind gateway or proxy server (such as Nginx). If it did not receive a timely response
 from Superset server (which is processing long queries), these web servers will send 504 status code


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR removes an erroneous entry in the FAQ regarding timeouts. Firstly the `superset runserver` command doesn't exist, and secondly the `guicorn` timeout (which isn't explicitly mentioned but possibly inferred) is related to the timeout of idle workers rather than web requests.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
