### PR TITLE
chore: change Sort-by and Sort-Descending controls for Bar Chart v2

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -328,6 +328,35 @@ const config: ControlPanelConfig = {
     row_limit: {
       default: rowLimit,
     },
+    limit: {
+      rerender: ['timeseries_limit_metric', 'order_desc'],
+    },
+    timeseries_limit_metric: {
+      label: t('Series Limit Sort By'),
+      description: t(
+        'Metric used to order the limit if a series limit is present. ' +
+          'If undefined reverts to the first metric (where appropriate).',
+      ),
+      visibility: ({ controls }) => Boolean(controls?.limit.value),
+      mapStateToProps: (state, controlState) => {
+        const timeserieslimitProps =
+          sharedControls.timeseries_limit_metric.mapStateToProps?.(
+            state,
+            controlState,
+          ) || {};
+        timeserieslimitProps.value = state.controls?.limit?.value
+          ? controlState.value
+          : [];
+        return timeserieslimitProps;
+      },
+    },
+    order_desc: {
+      label: t('Series Limit Sort Descending'),
+      default: false,
+      description: t(
+        'Whether to sort descending or ascending if a series limit is present',
+      ),
+    },
   },
   formDataOverrides: formData => ({
     ...formData,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Two changes on time series bar v2:
- Hide the sort by and sort descending check boxes if there's no series limit set
- If there's a series limit set, update the labels to "Series Limit Sort By" and "Series Limit Sort Descending"
This was done for the time series bar chart here: https://github.com/apache/superset/pull/18950 , we make the same changes to v2

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
