### PR TITLE
test: suppress flask_appbuilder logs in CI

### DIFF
--- a/tests/integration_tests/superset_test_config.py
+++ b/tests/integration_tests/superset_test_config.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 # type: ignore
+import logging
 import math
 from copy import copy
 from datetime import timedelta
@@ -23,6 +24,11 @@ from superset.config import *
 from tests.integration_tests.superset_test_custom_template_processors import (
     CustomPrestoTemplateProcessor,
 )
+
+logging.getLogger("flask_appbuilder.baseviews").setLevel(logging.WARNING)
+logging.getLogger("flask_appbuilder.base").setLevel(logging.WARNING)
+logging.getLogger("flask_appbuilder.api").setLevel(logging.WARNING)
+logging.getLogger("flask_appbuilder.security.sqla.manager").setLevel(logging.WARNING)
 
 AUTH_USER_REGISTRATION_ROLE = "alpha"
 SQLALCHEMY_DATABASE_URI = "sqlite:///" + os.path.join(

--- a/tests/integration_tests/superset_test_config.py
+++ b/tests/integration_tests/superset_test_config.py
@@ -29,6 +29,7 @@ logging.getLogger("flask_appbuilder.baseviews").setLevel(logging.WARNING)
 logging.getLogger("flask_appbuilder.base").setLevel(logging.WARNING)
 logging.getLogger("flask_appbuilder.api").setLevel(logging.WARNING)
 logging.getLogger("flask_appbuilder.security.sqla.manager").setLevel(logging.WARNING)
+logging.getLogger("sqlalchemy.engine.Engine").setLevel(logging.WARNING)
 
 AUTH_USER_REGISTRATION_ROLE = "alpha"
 SQLALCHEMY_DATABASE_URI = "sqlite:///" + os.path.join(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

FAB and SQL throws a lot of non-essential logs upon app initialization which makes it harder to see actual error logs from tests.

I think I'd make sense to suppress such logs as if there's anything wrong with them, other parts of the app will throw errors anyway.

<img width="1192" alt="image" src="https://user-images.githubusercontent.com/335541/181058410-4407714f-75e9-4def-b032-8a1408a355de.png">

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Check CI logs

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
