### PR TITLE
fix: create property for schema_perm for `Query`

### DIFF
--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -272,6 +272,10 @@ class Query(Model, ExtraJSONMixin, ExploreMixin):  # pylint: disable=abstract-me
         return [col.get("column_name") for col in self.columns if col.get("is_dttm")]
 
     @property
+    def schema_perm(self) -> str:
+        return f"{self.database.name}.{self.database.schema}"
+
+    @property
     def default_endpoint(self) -> str:
         return ""
 

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -273,7 +273,7 @@ class Query(Model, ExtraJSONMixin, ExploreMixin):  # pylint: disable=abstract-me
 
     @property
     def schema_perm(self) -> str:
-        return f"{self.database.name}.{self.database.schema}"
+        return f"{self.database.database_name}.{self.schema}"
 
     @property
     def default_endpoint(self) -> str:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To allow users to query data from adhoc queries, we need add the property `schema_perm` to validate if the current user has access to run this query based upon the database and schema.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
