### PR TITLE
fix(viz): Header scrolling for Time Table in dashboard

### DIFF
--- a/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
+++ b/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
@@ -98,12 +98,13 @@ const defaultProps = {
   url: '',
 };
 
+// @z-index-above-dashboard-charts + 1 = 11
 const TimeTableStyles = styled.div`
   height: ${props => props.height}px;
   overflow: auto;
 
   th {
-    z-index: 1; // to cover sparkline
+    z-index: 11 !important; // to cover sparkline
   }
 `;
 
@@ -326,7 +327,7 @@ const TimeTable = ({
 
   return (
     <TimeTableStyles
-      data-test="time-table"
+      data-test="time-table-loco"
       className={className}
       height={height}
     >

--- a/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
+++ b/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
@@ -327,7 +327,7 @@ const TimeTable = ({
 
   return (
     <TimeTableStyles
-      data-test="time-table-loco"
+      data-test="time-table"
       className={className}
       height={height}
     >


### PR DESCRIPTION
### SUMMARY
Our dashboard includes `dnd.less` which makes our headers fall under the sparkline when scrolling. So we  Increase the z-index in order to avoid such scenario.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
![error](https://user-images.githubusercontent.com/38889534/181089423-f36c0317-1882-4945-a9bc-96d88cd35c1f.gif)

AFTER:
![test](https://user-images.githubusercontent.com/38889534/181089468-198148d9-f63c-44db-93f6-d787d3cc1374.gif)


### TESTING INSTRUCTIONS
1. Create a time series table
2. Add a time series column and make it a sparkline
3. Add your chart to a dashboard
4. On the dashboard, scroll the chart

Expected Results:
1. The sparklines don't overlap with the header of the table

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
