### PR TITLE
fix: add having_druid back into the chart schema

### DIFF
--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -851,6 +851,12 @@ class ChartDataExtrasSchema(Schema):
         description="HAVING clause to be added to aggregate queries using "
         "AND operator.",
     )
+    having_druid = fields.List(
+        fields.Nested(ChartDataFilterSchema),
+        description="HAVING filters to be added to legacy Druid datasource queries. "
+        "This field is deprecated",
+        deprecated=True,
+    )
     time_grain_sqla = fields.String(
         description="To what level of granularity should the temporal column be "
         "aggregated. Supports "

--- a/tests/common/query_context_generator.py
+++ b/tests/common/query_context_generator.py
@@ -22,7 +22,7 @@ from superset.common.chart_data import ChartDataResultType
 from superset.utils.core import AnnotationType, DTTM_ALIAS
 
 query_birth_names = {
-    "extras": {"where": "", "time_grain_sqla": "P1D"},
+    "extras": {"where": "", "time_grain_sqla": "P1D", "having_druid": []},
     "columns": ["name"],
     "metrics": [{"label": "sum__num"}],
     "orderby": [("sum__num", False)],


### PR DESCRIPTION
### SUMMARY
The `having_druid` key still exists in some query table extras json blobs in the database. We removed the key from the chart schema in the native druid cleanup work https://github.com/apache/superset/pull/20338 but need to run a migration in order to remove the key permanently from query objects in the database. This PR is a temporary fix to add the property back into the schema for an easier cherry prior to the db migration. We need to remove this property again and run the migration together next. 

The error that we're seeing is on some reports that still have the old key`{"message":"Request is incorrect: {'queries': {0: {'extras': {'having_druid': ['Unknown field.']}}}}"}`

### TESTING INSTRUCTIONS
I added `having_druid` to an existing test and validated that it failed and then fixed the code and validated that it passed. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
