### PR TITLE
fix: invalid metric should raise an exception

### DIFF
--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -383,8 +383,10 @@ class DashboardRestApi(BaseSupersetModelRestApi):
                 self.dashboard_dataset_schema.dump(dataset) for dataset in datasets
             ]
             return self.response(200, result=result)
-        except TypeError:
-            return self.response_400(message=gettext("Dataset schema is invalid."))
+        except (TypeError, ValueError) as err:
+            return self.response_400(
+                message=gettext(f"Dataset schema is invalid, caused by: {str(err)}")
+            )
         except DashboardAccessDeniedError:
             return self.response_403()
         except DashboardNotFoundError:

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -385,7 +385,9 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             return self.response(200, result=result)
         except (TypeError, ValueError) as err:
             return self.response_400(
-                message=gettext(f"Dataset schema is invalid, caused by: {str(err)}")
+                message=gettext(
+                    "Dataset schema is invalid, caused by: %(error)s", error=str(err)
+                )
             )
         except DashboardAccessDeniedError:
             return self.response_403()

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -61,7 +61,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class Query(Model, ExtraJSONMixin, ExploreMixin):  # pylint: disable=abstract-method
+class Query(
+    Model, ExtraJSONMixin, ExploreMixin
+):  # pylint: disable=abstract-method,too-many-public-methods
     """ORM model for SQL query
 
     Now that SQL Lab support multi-statement execution, an entry in this

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1304,8 +1304,11 @@ def get_metric_name(
                 return column_name
         raise ValueError(__("Invalid metric object"))
 
-    verbose_map = verbose_map or {}
-    return verbose_map.get(metric, metric)  # type: ignore
+    if isinstance(metric, str):
+        verbose_map = verbose_map or {}
+        return verbose_map.get(metric, metric)
+
+    raise ValueError(__("Invalid metric object: %(metric)s", metric=str(metric)))
 
 
 def get_column_names(

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1302,7 +1302,6 @@ def get_metric_name(
                 return f"{aggregate}({column_name})"
             if column_name:
                 return column_name
-        raise ValueError(__("Invalid metric object"))
 
     if isinstance(metric, str):
         verbose_map = verbose_map or {}

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1294,7 +1294,7 @@ def get_metric_name(
             sql_expression = metric.get("sqlExpression")
             if sql_expression:
                 return sql_expression
-        elif expression_type == "SIMPLE":
+        if expression_type == "SIMPLE":
             column: AdhocMetricColumn = metric.get("column") or {}
             column_name = column.get("column_name")
             aggregate = metric.get("aggregate")

--- a/tests/integration_tests/fixtures/deck_geojson_form_data.json
+++ b/tests/integration_tests/fixtures/deck_geojson_form_data.json
@@ -43,5 +43,5 @@
   "granularity_sqla": null,
   "autozoom": true,
   "url_params": {},
-  "size": 100
+  "size": "100"
 }

--- a/tests/integration_tests/fixtures/deck_path_form_data.json
+++ b/tests/integration_tests/fixtures/deck_path_form_data.json
@@ -45,5 +45,5 @@
   "granularity_sqla": null,
   "autozoom": true,
   "url_params": {},
-  "size": 100
+  "size": "100"
 }

--- a/tests/integration_tests/viz_tests.py
+++ b/tests/integration_tests/viz_tests.py
@@ -742,6 +742,10 @@ class TestPairedTTest(SupersetTestCase):
         }
         self.assertEqual(data, expected)
 
+        form_data = {"groupby": [], "metrics": [None]}
+        with self.assertRaises(ValueError):
+            viz.viz_types["paired_ttest"](datasource, form_data)
+
 
 class TestPartitionViz(SupersetTestCase):
     @patch("superset.viz.BaseViz.query_obj")

--- a/tests/integration_tests/viz_tests.py
+++ b/tests/integration_tests/viz_tests.py
@@ -716,7 +716,7 @@ class TestPairedTTest(SupersetTestCase):
         self.assertEqual(data, expected)
 
     def test_get_data_empty_null_keys(self):
-        form_data = {"groupby": [], "metrics": ["", None]}
+        form_data = {"groupby": [], "metrics": [""]}
         datasource = self.get_datasource_mock()
         # Test data
         raw = {}
@@ -735,16 +735,6 @@ class TestPairedTTest(SupersetTestCase):
                         {"x": 100, "y": 1},
                         {"x": 200, "y": 2},
                         {"x": 300, "y": 3},
-                    ],
-                    "group": "All",
-                }
-            ],
-            "NULL": [
-                {
-                    "values": [
-                        {"x": 100, "y": 10},
-                        {"x": 200, "y": 20},
-                        {"x": 300, "y": 30},
                     ],
                     "group": "All",
                 }

--- a/tests/unit_tests/core_tests.py
+++ b/tests/unit_tests/core_tests.py
@@ -105,6 +105,18 @@ def test_get_metric_name_invalid_metric():
     with pytest.raises(ValueError):
         get_metric_name(metric)
 
+    metric = deepcopy(SQL_ADHOC_METRIC)
+    del metric["expressionType"]
+    with pytest.raises(ValueError):
+        get_metric_name(metric)
+
+    with pytest.raises(ValueError):
+        get_metric_name(None)
+    with pytest.raises(ValueError):
+        get_metric_name(0)
+    with pytest.raises(ValueError):
+        get_metric_name({})
+
 
 def test_get_metric_names():
     assert get_metric_names(


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In some `unknown cases`(may be database migration?) the ad-hoc metric may be missing `expressionType` field, then an exception should be raised to let the user handle the incorrect metrics.

------------------------
the original issue was reported from shortcut.
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/flask_appbuilder/api/__init__.py", line 85, in wraps
    return f(self, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/superset/views/base_api.py", line 113, in wraps
    raise ex
  File "/usr/local/lib/python3.8/site-packages/superset/views/base_api.py", line 110, in wraps
    duration, response = time_function(f, self, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/superset/utils/core.py", line 1507, in time_function
    response = func(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/superset/utils/log.py", line 245, in wrapper
    value = f(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/superset/dashboards/api.py", line 381, in get_datasets
    datasets = DashboardDAO.get_datasets_for_dashboard(id_or_slug)
  File "/usr/local/lib/python3.8/site-packages/superset/dashboards/dao.py", line 52, in get_datasets_for_dashboard
    return dashboard.datasets_trimmed_for_slices()
  File "/usr/local/lib/python3.8/site-packages/flask_caching/__init__.py", line 905, in decorated_function
    return f(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/superset/models/dashboard.py", line 314, in datasets_trimmed_for_slices
    result.append(datasource.data_for_slices(slices))
  File "/usr/local/lib/python3.8/site-packages/superset/connectors/base/models.py", line 313, in data_for_slices
    metric_names.add(utils.get_metric_name(metric))
  File "/usr/local/lib/python3.8/site-packages/superset/utils/core.py", line 1309, in get_metric_name
    return verbose_map.get(metric, metric)  # type: ignore
TypeError: unhashable type: 'dict'
```

Just judging from this error, the first `metric` is not a `hashable` type. e.g.
```
>>> foo = {'key': 123}
>>> bar = {'a': 1}
>>>
>>> bar.get(foo)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unhashable type: 'dict'
```

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
### before fix
1. open explore page, use `birth_name` as datasource,  `table` as viz
2. Click metrics control, create a adhoc metic as following screenshot.
![image](https://user-images.githubusercontent.com/2016594/181182080-a9127a35-c4cc-483f-bb26-50c2001a5617.png)
3. save chart and save to a new dashboard
4. open a arbitrary SQL client to connect superset metadata
5. open `slices` table and find out the newest record.
6. check out `params` column and remove `"expressionType":"SQL",` in it.
<img width="781" alt="image" src="https://user-images.githubusercontent.com/2016594/181185480-894af21f-2128-4e6b-94f9-6f9b7329e1b7.png">
7. go to `/api/v1/dashboard/{$DashboardID}}/datasets` will look at the error, responded status code is 500

### after fix
7. go to `/api/v1/dashboard/{$DashboardID}}/datasets` will look at the error, the status code is 400, and error message will point out specific errors and failed the metric.



### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
