### PR TITLE
other(mypy): Enable warn_unused_ignores

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ disallow_untyped_calls = true
 disallow_untyped_defs = true
 ignore_missing_imports = true
 no_implicit_optional = true
-warn_unused_ignores = false
+warn_unused_ignores = true
 
 [mypy-superset.migrations.versions.*]
 ignore_errors = true

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -750,7 +750,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
     def get_extra_cache_keys(query_obj: Dict[str, Any]) -> List[str]:
         raise NotImplementedError()
 
-    def _process_sql_expression(  # type: ignore # pylint: disable=no-self-use
+    def _process_sql_expression(  # pylint: disable=no-self-use
         self,
         expression: Optional[str],
         database_id: int,
@@ -1061,7 +1061,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
             sqla_column = sa.column(column_name)
             sqla_metric = self.sqla_aggregations[metric["aggregate"]](sqla_column)
         elif expression_type == utils.AdhocMetricExpressionType.SQL:
-            expression = self._process_sql_expression(  # type: ignore
+            expression = self._process_sql_expression(
                 expression=metric["sqlExpression"],
                 database_id=self.database_id,
                 schema=self.schema,
@@ -1170,8 +1170,8 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         :rtype: sqlalchemy.sql.column
         """
         label = utils.get_column_name(col)  # type: ignore
-        expression = self._process_sql_expression(  # type: ignore
-            expression=col["sqlExpression"],  # type: ignore
+        expression = self._process_sql_expression(
+            expression=col["sqlExpression"],
             database_id=self.database_id,
             schema=self.schema,
             template_processor=template_processor,
@@ -1351,7 +1351,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                 metrics_exprs.append(
                     self.adhoc_metric_to_sqla(
                         metric=metric,
-                        columns_by_name=columns_by_name,  # type: ignore
+                        columns_by_name=columns_by_name,
                         template_processor=template_processor,
                     )
                 )
@@ -1379,7 +1379,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
             if isinstance(col, dict):
                 col = cast(AdhocMetric, col)
                 if col.get("sqlExpression"):
-                    col["sqlExpression"] = self._process_sql_expression(  # type: ignore
+                    col["sqlExpression"] = self._process_sql_expression(
                         expression=col["sqlExpression"],
                         database_id=self.database_id,
                         schema=self.schema,
@@ -1387,7 +1387,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                     )
                 if utils.is_adhoc_metric(col):
                     # add adhoc sort by column to columns_by_name if not exists
-                    col = self.adhoc_metric_to_sqla(col, columns_by_name)  # type: ignore
+                    col = self.adhoc_metric_to_sqla(col, columns_by_name)
                     # if the adhoc metric has been defined before
                     # use the existing instance.
                     col = metrics_exprs_by_expr.get(str(col), col)

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1689,7 +1689,7 @@ def extract_dataframe_dtypes(
         column_object = columns_by_name.get(column)
         series = df[column]
         inferred_type = infer_dtype(series)
-        if isinstance(column_object, dict):  # type: ignore
+        if isinstance(column_object, dict):
             generic_type = (
                 GenericDataType.TEMPORAL
                 if column_object and column_object.get("is_dttm")


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

I'm not sure exactly why `warn_unused_ignores` was set to `false`, but this PR switches the flag to `true` to ensure the code remains clean as of any unnecessary `# type: ignore` comments. Given that Mypy is continually evolving and stubs added it's not uncommon for type resolution to change over time.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
