### PR TITLE
feat: Use SPA navigation from datasets list to Explore

### DIFF
--- a/superset-frontend/src/components/GenericLink/GenericLink.test.tsx
+++ b/superset-frontend/src/components/GenericLink/GenericLink.test.tsx
@@ -46,3 +46,14 @@ test('navigates to external URL', () => {
   const externalLink = screen.getByTestId('external-link');
   expect(externalLink).toHaveAttribute('href', 'https://superset.apache.org/');
 });
+
+test('navigates to external URL without host', () => {
+  render(
+    <GenericLink to="superset.apache.org/">
+      Link to external website
+    </GenericLink>,
+    { useRouter: true },
+  );
+  const externalLink = screen.getByTestId('external-link');
+  expect(externalLink).toHaveAttribute('href', '//superset.apache.org/');
+});

--- a/superset-frontend/src/components/GenericLink/GenericLink.test.tsx
+++ b/superset-frontend/src/components/GenericLink/GenericLink.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import { render, screen } from 'spec/helpers/testing-library';
+import { GenericLink } from './GenericLink';
+
+test('renders', () => {
+  render(<GenericLink to={'/explore'}>Link to Explore</GenericLink>, {
+    useRouter: true,
+  });
+  expect(screen.getByText('Link to Explore')).toBeVisible();
+});
+
+test('navigates to internal URL', () => {
+  render(<GenericLink to={'/explore'}>Link to Explore</GenericLink>, {
+    useRouter: true,
+  });
+  const internalLink = screen.getByTestId('internal-link');
+  expect(internalLink).toHaveAttribute('href', '/explore');
+});
+
+test('navigates to external URL', () => {
+  render(
+    <GenericLink to={'https://superset.apache.org/'}>
+      Link to external website
+    </GenericLink>,
+    { useRouter: true },
+  );
+  const externalLink = screen.getByTestId('external-link');
+  expect(externalLink).toHaveAttribute('href', 'https://superset.apache.org/');
+});

--- a/superset-frontend/src/components/GenericLink/GenericLink.test.tsx
+++ b/superset-frontend/src/components/GenericLink/GenericLink.test.tsx
@@ -22,14 +22,14 @@ import { render, screen } from 'spec/helpers/testing-library';
 import { GenericLink } from './GenericLink';
 
 test('renders', () => {
-  render(<GenericLink to={'/explore'}>Link to Explore</GenericLink>, {
+  render(<GenericLink to="/explore">Link to Explore</GenericLink>, {
     useRouter: true,
   });
   expect(screen.getByText('Link to Explore')).toBeVisible();
 });
 
 test('navigates to internal URL', () => {
-  render(<GenericLink to={'/explore'}>Link to Explore</GenericLink>, {
+  render(<GenericLink to="/explore">Link to Explore</GenericLink>, {
     useRouter: true,
   });
   const internalLink = screen.getByTestId('internal-link');
@@ -38,7 +38,7 @@ test('navigates to internal URL', () => {
 
 test('navigates to external URL', () => {
   render(
-    <GenericLink to={'https://superset.apache.org/'}>
+    <GenericLink to="https://superset.apache.org/">
       Link to external website
     </GenericLink>,
     { useRouter: true },

--- a/superset-frontend/src/components/GenericLink/GenericLink.tsx
+++ b/superset-frontend/src/components/GenericLink/GenericLink.tsx
@@ -20,15 +20,15 @@
 import React from 'react';
 import { Link, LinkProps } from 'react-router-dom';
 
-export const GenericLink = ({
+export const GenericLink = <S,>({
   to,
   component,
   replace,
   innerRef,
   children,
   ...rest
-}: // css prop type check was failing, override with any
-LinkProps & { css?: any }) => {
+}: React.PropsWithoutRef<LinkProps<S>> &
+  React.RefAttributes<HTMLAnchorElement>) => {
   if (typeof to === 'string' && /^https?:\/\//.test(to)) {
     return (
       <a data-test="external-link" href={to} {...rest}>

--- a/superset-frontend/src/components/GenericLink/GenericLink.tsx
+++ b/superset-frontend/src/components/GenericLink/GenericLink.tsx
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import React from 'react';
 import { Link, LinkProps } from 'react-router-dom';
 

--- a/superset-frontend/src/components/GenericLink/GenericLink.tsx
+++ b/superset-frontend/src/components/GenericLink/GenericLink.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Link, LinkProps } from 'react-router-dom';
+
+export const GenericLink = ({
+  to,
+  component,
+  replace,
+  innerRef,
+  children,
+  ...rest
+}: // css prop type check was failing, override with any
+LinkProps & { css?: any }) => {
+  if (typeof to === 'string' && /^https?:\/\//.test(to)) {
+    return (
+      <a data-test="external-link" href={to} {...rest}>
+        {children}
+      </a>
+    );
+  }
+  return (
+    <Link
+      data-test="internal-link"
+      to={to}
+      component={component}
+      replace={replace}
+      innerRef={innerRef}
+      {...rest}
+    >
+      {children}
+    </Link>
+  );
+};

--- a/superset-frontend/src/components/GenericLink/GenericLink.tsx
+++ b/superset-frontend/src/components/GenericLink/GenericLink.tsx
@@ -19,6 +19,7 @@
 
 import React from 'react';
 import { Link, LinkProps } from 'react-router-dom';
+import { isUrlExternal, parseUrl } from 'src/utils/urlUtils';
 
 export const GenericLink = <S,>({
   to,
@@ -29,9 +30,9 @@ export const GenericLink = <S,>({
   ...rest
 }: React.PropsWithoutRef<LinkProps<S>> &
   React.RefAttributes<HTMLAnchorElement>) => {
-  if (typeof to === 'string' && /^https?:\/\//.test(to)) {
+  if (typeof to === 'string' && isUrlExternal(to)) {
     return (
-      <a data-test="external-link" href={to} {...rest}>
+      <a data-test="external-link" href={parseUrl(to)} {...rest}>
         {children}
       </a>
     );

--- a/superset-frontend/src/utils/urlUtils.test.ts
+++ b/superset-frontend/src/utils/urlUtils.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * 'License'); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { isUrlExternal, parseUrl } from './urlUtils';
+
+test('isUrlExternal', () => {
+  expect(isUrlExternal('http://google.com')).toBeTruthy();
+  expect(isUrlExternal('https://google.com')).toBeTruthy();
+  expect(isUrlExternal('//google.com')).toBeTruthy();
+  expect(isUrlExternal('google.com')).toBeTruthy();
+  expect(isUrlExternal('www.google.com')).toBeTruthy();
+  expect(isUrlExternal('mailto:mail@example.com')).toBeTruthy();
+
+  // treat all urls starting with protocol or hostname as external
+  // such urls are not handled well by react-router Link component
+  expect(isUrlExternal('http://localhost:8888/port')).toBeTruthy();
+  expect(isUrlExternal('https://localhost/secure')).toBeTruthy();
+  expect(isUrlExternal('http://localhost/about')).toBeTruthy();
+  expect(isUrlExternal('HTTP://localhost/about')).toBeTruthy();
+  expect(isUrlExternal('//localhost/about')).toBeTruthy();
+  expect(isUrlExternal('localhost/about')).toBeTruthy();
+
+  expect(isUrlExternal('/about')).toBeFalsy();
+  expect(isUrlExternal('#anchor')).toBeFalsy();
+});
+
+test('parseUrl', () => {
+  expect(parseUrl('http://google.com')).toEqual('http://google.com');
+  expect(parseUrl('//google.com')).toEqual('//google.com');
+  expect(parseUrl('mailto:mail@example.com')).toEqual(
+    'mailto:mail@example.com',
+  );
+  expect(parseUrl('google.com')).toEqual('//google.com');
+  expect(parseUrl('www.google.com')).toEqual('//www.google.com');
+
+  expect(parseUrl('/about')).toEqual('/about');
+  expect(parseUrl('#anchor')).toEqual('#anchor');
+});

--- a/superset-frontend/src/utils/urlUtils.ts
+++ b/superset-frontend/src/utils/urlUtils.ts
@@ -16,7 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { JsonObject, QueryFormData, SupersetClient } from '@superset-ui/core';
+import {
+  isDefined,
+  JsonObject,
+  QueryFormData,
+  SupersetClient,
+} from '@superset-ui/core';
 import rison from 'rison';
 import { isEmpty } from 'lodash';
 import {
@@ -174,4 +179,27 @@ export function getDashboardPermalink({
     activeTabs,
     anchor,
   });
+}
+
+const externalUrlRegex =
+  /^([^:/?#]+:)?(?:(\/\/)?([^/?#]*))?([^?#]+)?(\?[^#]*)?(#.*)?/;
+
+export function isUrlExternal(url: string) {
+  const match = url.match(externalUrlRegex) || [];
+  return (
+    (typeof match[1] === 'string' && match[1].length > 0) ||
+    match[2] === '//' ||
+    (typeof match[3] === 'string' && match[3].length > 0)
+  );
+}
+
+export function parseUrl(url: string) {
+  const match = url.match(externalUrlRegex) || [];
+  // if url is external but start with protocol or '//',
+  // it can't be used correctly with <a> element
+  // in such case, add '//' prefix
+  if (isUrlExternal(url) && !isDefined(match[1]) && !url.startsWith('//')) {
+    return `//${url}`;
+  }
+  return url;
 }

--- a/superset-frontend/src/utils/urlUtils.ts
+++ b/superset-frontend/src/utils/urlUtils.ts
@@ -184,6 +184,9 @@ export function getDashboardPermalink({
 const externalUrlRegex =
   /^([^:/?#]+:)?(?:(\/\/)?([^/?#]*))?([^?#]+)?(\?[^#]*)?(#.*)?/;
 
+// group 1 matches protocol
+// group 2 matches '//'
+// group 3 matches hostname
 export function isUrlExternal(url: string) {
   const match = url.match(externalUrlRegex) || [];
   return (

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
@@ -60,6 +60,7 @@ import ImportModelsModal from 'src/components/ImportModal/index';
 import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 import WarningIconWithTooltip from 'src/components/WarningIconWithTooltip';
 import { isUserAdmin } from 'src/dashboard/util/permissionUtils';
+import { GenericLink } from 'src/components/GenericLink/GenericLink';
 import AddDatasetModal from './AddDatasetModal';
 
 import {
@@ -289,7 +290,11 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
             },
           },
         }: any) => {
-          const titleLink = <a href={exploreURL}>{datasetTitle}</a>;
+          const titleLink = (
+            // exploreUrl can be a link to Explore or an external link
+            // in the first case use SPA routing, else use HTML anchor
+            <GenericLink to={exploreURL}>{datasetTitle}</GenericLink>
+          );
           try {
             const parsedExtra = JSON.parse(extra);
             return (


### PR DESCRIPTION
### SUMMARY
This PR implements SPA navigation in Datasets list. By default, clicking on dataset's name opens Explore, but user can override it with some external URL. Default react-router Link component can't handle external URLs, so I implemented a `GenericLink` component, which check if URL is external - if it does, use HTML anchor element, else use react-router Link.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/15073128/181757636-957f38fb-9640-4c9f-a21e-19dc2763cd8a.mov

### TESTING INSTRUCTIONS
1. Open datasets list
2. Click dataset's name, verify that Explore opens
3. Go back to datasets list, click "Edit" -> tab "Settings" -> set some external URL in "Default URL" field (like "https://google.com" or whatever) -> Save
4. Click dataset's name, verify that external URL opens

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
