### PR TITLE
fix: make a new entrypoint for deprecated postgres dialect

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,8 @@ setup(
     zip_safe=False,
     entry_points={
         "console_scripts": ["superset=superset.cli.main:superset"],
+        # the `postgres+psycopg2://` scheme was removed in SQLAlchemy 1.4, add an alias here
+        # to prevent breaking existing databases
         "sqlalchemy.dialects": [
             "postgres.psycopg2=sqlalchemy.dialects.postgresql:dialect"
         ],

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,9 @@ setup(
     zip_safe=False,
     entry_points={
         "console_scripts": ["superset=superset.cli.main:superset"],
+        "sqlalchemy.dialects": [
+            "postgres.psycopg2=sqlalchemy.dialects.postgresql:dialect"
+        ],
     },
     install_requires=[
         "backoff>=1.8.0",


### PR DESCRIPTION
### SUMMARY
Sqlalchemy 1.4 deprecated the `postgres` dialect and any existing Sqlalchemy URI strings that use `postgres` as opposed to the current `postgresql` will not work. This PR creates a new entry point that will map the old postgres dialect to the current postgresql one. 


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
