### PR TITLE
feat: add header_data into emails

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -1066,6 +1066,12 @@ def SQL_QUERY_MUTATOR(  # pylint: disable=invalid-name,unused-argument
     return sql
 
 
+def NOTIFICATION_EMAIL_HEADER_MUTATOR(  # pylint: disable=invalid-name,unused-argument
+    msg: Dict[str, Any], **kwargs: Any
+) -> Dict[str, Any]:
+    return msg
+
+
 # This auth provider is used by background (offline) tasks that need to access
 # protected resources. Can be overridden by end users in order to support
 # custom auth mechanisms

--- a/superset/config.py
+++ b/superset/config.py
@@ -30,6 +30,7 @@ import re
 import sys
 from collections import OrderedDict
 from datetime import timedelta
+from email.mime.multipart import MIMEMultipart
 from typing import (
     Any,
     Callable,
@@ -1066,9 +1067,12 @@ def SQL_QUERY_MUTATOR(  # pylint: disable=invalid-name,unused-argument
     return sql
 
 
-def NOTIFICATION_EMAIL_HEADER_MUTATOR(  # pylint: disable=invalid-name,unused-argument
-    msg: Dict[str, Any], **kwargs: Any
-) -> Dict[str, Any]:
+# This allows for a user to add header data to any outgoing emails. For example,
+# if you need to include metadata in the header or you want to change the specifications
+# of the email title, header, or sender.
+def EMAIL_HEADER_MUTATOR(  # pylint: disable=invalid-name,unused-argument
+    msg: MIMEMultipart, **kwargs: Any
+) -> MIMEMultipart:
     return msg
 
 

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -62,6 +62,7 @@ from superset.reports.models import (
     ReportRecipientType,
     ReportSchedule,
     ReportScheduleType,
+    ReportSourceFormat,
     ReportState,
 )
 from superset.reports.notifications import create_notification
@@ -342,16 +343,23 @@ class BaseReportState:
         ):
             embedded_data = self._get_embedded_data()
 
+        notification_source = None
+        notification_source_id = None
         if self._report_schedule.chart:
             name = (
                 f"{self._report_schedule.name}: "
                 f"{self._report_schedule.chart.slice_name}"
             )
+            notification_source = ReportSourceFormat.CHART
+            notification_source_id = self._report_schedule.chart_id
         else:
             name = (
                 f"{self._report_schedule.name}: "
                 f"{self._report_schedule.dashboard.dashboard_title}"
             )
+            notification_source = ReportSourceFormat.DASHBOARDS
+            notification_source_id = self._report_schedule.dashboard_id
+
         return NotificationContent(
             name=name,
             url=url,
@@ -359,6 +367,10 @@ class BaseReportState:
             description=self._report_schedule.description,
             csv=csv_data,
             embedded_data=embedded_data,
+            notification_type=self._report_schedule.type,
+            notification_source=notification_source,
+            notification_source_id=notification_source_id,
+            notification_format=self._report_schedule.report_format,
         )
 
     def _send(

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -17,7 +17,7 @@
 import json
 import logging
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, List, Optional, Union
 from uuid import UUID
 
 import pandas as pd
@@ -73,6 +73,8 @@ from superset.utils.csv import get_chart_csv_data, get_chart_dataframe
 from superset.utils.screenshots import ChartScreenshot, DashboardScreenshot
 from superset.utils.urls import get_url_path
 from superset.utils.webdriver import DashboardStandaloneMode
+
+from ...utils.core import HeaderDataType
 
 logger = logging.getLogger(__name__)
 
@@ -306,7 +308,7 @@ class BaseReportState:
                 "Please try loading the chart and saving it again."
             ) from ex
 
-    def _get_log_data(self) -> Dict[str, Any]:
+    def _get_log_data(self) -> HeaderDataType:
         chart_id = None
         dashboard_id = None
         report_source = None
@@ -316,13 +318,14 @@ class BaseReportState:
         else:
             report_source = ReportSourceFormat.DASHBOARD
             dashboard_id = self._report_schedule.dashboard_id
-        log_data = {
-            "notification_type": self._report_schedule.type or None,
+
+        log_data: HeaderDataType = {
+            "notification_type": self._report_schedule.type,
             "notification_source": report_source,
-            "notification_format": self._report_schedule.report_format or None,
+            "notification_format": self._report_schedule.report_format,
             "chart_id": chart_id,
             "dashboard_id": dashboard_id,
-            "owners": self._report_schedule.owners or None,
+            "owners": self._report_schedule.owners,
         }
         return log_data
 

--- a/superset/reports/models.py
+++ b/superset/reports/models.py
@@ -82,6 +82,11 @@ class ReportCreationMethod(str, enum.Enum):
     ALERTS_REPORTS = "alerts_reports"
 
 
+class ReportSourceFormat(str, enum.Enum):
+    CHART = "chart"
+    DASHBOARDS = "dashboard"
+
+
 report_schedule_user = Table(
     "report_schedule_user",
     metadata,

--- a/superset/reports/models.py
+++ b/superset/reports/models.py
@@ -84,7 +84,7 @@ class ReportCreationMethod(str, enum.Enum):
 
 class ReportSourceFormat(str, enum.Enum):
     CHART = "chart"
-    DASHBOARDS = "dashboard"
+    DASHBOARD = "dashboard"
 
 
 report_schedule_user = Table(

--- a/superset/reports/notifications/base.py
+++ b/superset/reports/notifications/base.py
@@ -32,6 +32,10 @@ class NotificationContent:
     description: Optional[str] = ""
     url: Optional[str] = None  # url to chart/dashboard for this screenshot
     embedded_data: Optional[pd.DataFrame] = None
+    notification_type: Optional[str] = None
+    notification_format: Optional[str] = None
+    notification_source: Optional[str] = None
+    notification_source_id: Optional[int] = None
 
 
 class BaseNotification:  # pylint: disable=too-few-public-methods

--- a/superset/reports/notifications/base.py
+++ b/superset/reports/notifications/base.py
@@ -15,8 +15,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from dataclasses import dataclass
-from typing import Any, List, Optional, Type
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Type
 
 import pandas as pd
 
@@ -32,10 +32,7 @@ class NotificationContent:
     description: Optional[str] = ""
     url: Optional[str] = None  # url to chart/dashboard for this screenshot
     embedded_data: Optional[pd.DataFrame] = None
-    notification_type: Optional[str] = None
-    notification_format: Optional[str] = None
-    notification_source: Optional[str] = None
-    notification_source_id: Optional[int] = None
+    header_data: Optional[Dict[Any, Any]] = field(default_factory=lambda: {})
 
 
 class BaseNotification:  # pylint: disable=too-few-public-methods

--- a/superset/reports/notifications/base.py
+++ b/superset/reports/notifications/base.py
@@ -19,24 +19,17 @@ from dataclasses import dataclass
 from typing import Any, List, Optional, Type
 
 import pandas as pd
-from typing_extensions import TypedDict
 
 from superset.reports.models import ReportRecipients, ReportRecipientType
-
-
-class HeaderDataType(TypedDict):
-    notification_format: str
-    owners: List[int]
-    notification_type: str
-    notification_source: Optional[str]
-    chart_id: Optional[int]
-    dashboard_id: Optional[int]
+from superset.utils.core import HeaderDataType
 
 
 @dataclass
 class NotificationContent:
     name: str
-    header_data: HeaderDataType
+    header_data: Optional[
+        HeaderDataType
+    ] = None  # this is optional to account for error states
     csv: Optional[bytes] = None  # bytes for csv file
     screenshots: Optional[List[bytes]] = None  # bytes for a list of screenshots
     text: Optional[str] = None

--- a/superset/reports/notifications/base.py
+++ b/superset/reports/notifications/base.py
@@ -15,24 +15,34 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Type
+from dataclasses import dataclass
+from typing import Any, List, Optional, Type
 
 import pandas as pd
+from typing_extensions import TypedDict
 
 from superset.reports.models import ReportRecipients, ReportRecipientType
+
+
+class HeaderDataType(TypedDict):
+    notification_format: str
+    owners: List[int]
+    notification_type: str
+    notification_source: Optional[str]
+    chart_id: Optional[int]
+    dashboard_id: Optional[int]
 
 
 @dataclass
 class NotificationContent:
     name: str
+    header_data: HeaderDataType
     csv: Optional[bytes] = None  # bytes for csv file
     screenshots: Optional[List[bytes]] = None  # bytes for a list of screenshots
     text: Optional[str] = None
     description: Optional[str] = ""
     url: Optional[str] = None  # url to chart/dashboard for this screenshot
     embedded_data: Optional[pd.DataFrame] = None
-    header_data: Optional[Dict[Any, Any]] = field(default_factory=lambda: {})
 
 
 class BaseNotification:  # pylint: disable=too-few-public-methods

--- a/superset/reports/notifications/base.py
+++ b/superset/reports/notifications/base.py
@@ -27,9 +27,7 @@ from superset.utils.core import HeaderDataType
 @dataclass
 class NotificationContent:
     name: str
-    header_data: Optional[
-        HeaderDataType
-    ] = None  # this is optional to account for error states
+    header_data: HeaderDataType  # this is optional to account for error states
     csv: Optional[bytes] = None  # bytes for csv file
     screenshots: Optional[List[bytes]] = None  # bytes for a list of screenshots
     text: Optional[str] = None

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -27,9 +27,9 @@ from flask_babel import gettext as __
 
 from superset import app
 from superset.reports.models import ReportRecipientType
-from superset.reports.notifications.base import BaseNotification, HeaderDataType
+from superset.reports.notifications.base import BaseNotification
 from superset.reports.notifications.exceptions import NotificationError
-from superset.utils.core import send_email_smtp
+from superset.utils.core import HeaderDataType, send_email_smtp
 from superset.utils.decorators import statsd_gauge
 from superset.utils.urls import modify_url_query
 

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -26,7 +26,7 @@ import bleach
 from flask_babel import gettext as __
 
 from superset import app
-from superset.reports.models import ReportRecipientType, ReportSourceFormat
+from superset.reports.models import ReportRecipientType
 from superset.reports.notifications.base import BaseNotification
 from superset.reports.notifications.exceptions import NotificationError
 from superset.utils.core import send_email_smtp
@@ -69,16 +69,7 @@ class EmailContent:
     body: str
     data: Optional[Dict[str, Any]] = None
     images: Optional[Dict[str, bytes]] = None
-
-
-@dataclass
-class LogDataContent:
-    owner: str
-    report_type: Optional[str] = None
-    report_source: Optional[str] = None
-    file_type: Optional[str] = None
-    chart_id: Optional[int] = None
-    dashboard_id: Optional[int] = None
+    header_data: Optional[Dict[str, Any]] = None
 
 
 class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-methods
@@ -180,7 +171,12 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
 
         if self._content.csv:
             csv_data = {__("%(name)s.csv", name=self._content.name): self._content.csv}
-        return EmailContent(body=body, images=images, data=csv_data)
+        return EmailContent(
+            body=body,
+            images=images,
+            data=csv_data,
+            header_data=self._content.header_data,
+        )
 
     def _get_subject(self) -> str:
         return __(
@@ -192,31 +188,11 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
     def _get_to(self) -> str:
         return json.loads(self._recipient.recipient_config_json)["target"]
 
-    def _get_log_data(self) -> Dict[str, Any]:
-        chart_id = None
-        dashboard_id = None
-        owner = self._get_to()
-        if self._content.notification_source == ReportSourceFormat.CHART:
-            chart_id = self._content.notification_source_id
-        else:
-            dashboard_id = self._content.notification_source_id
-
-        log_data = LogDataContent(
-            report_type=self._content.notification_type,
-            file_type=self._content.notification_format,
-            report_source=self._content.notification_source,
-            chart_id=chart_id,
-            dashboard_id=dashboard_id,
-            owner=owner,
-        )
-        return log_data.__dict__
-
     @statsd_gauge("reports.email.send")
     def send(self) -> None:
         subject = self._get_subject()
         content = self._get_content()
         to = self._get_to()
-        log_data = self._get_log_data()
         try:
             send_email_smtp(
                 to,
@@ -229,7 +205,7 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
                 bcc="",
                 mime_subtype="related",
                 dryrun=False,
-                log_data=log_data,
+                header_data=content.header_data,
             )
             logger.info("Report sent to email")
         except Exception as ex:

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -27,7 +27,7 @@ from flask_babel import gettext as __
 
 from superset import app
 from superset.reports.models import ReportRecipientType
-from superset.reports.notifications.base import BaseNotification
+from superset.reports.notifications.base import BaseNotification, HeaderDataType
 from superset.reports.notifications.exceptions import NotificationError
 from superset.utils.core import send_email_smtp
 from superset.utils.decorators import statsd_gauge
@@ -67,9 +67,9 @@ ALLOWED_ATTRIBUTES = {
 @dataclass
 class EmailContent:
     body: str
+    header_data: Optional[HeaderDataType] = None
     data: Optional[Dict[str, Any]] = None
     images: Optional[Dict[str, bytes]] = None
-    header_data: Optional[Dict[str, Any]] = None
 
 
 class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-methods

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -99,7 +99,6 @@ from superset.exceptions import (
     SupersetException,
     SupersetTimeoutException,
 )
-from superset.reports.notifications.base import HeaderDataType
 from superset.sql_parse import sanitize_clause
 from superset.superset_typing import (
     AdhocColumn,
@@ -183,6 +182,15 @@ class DatasourceType(str, Enum):
     QUERY = "query"
     SAVEDQUERY = "saved_query"
     VIEW = "view"
+
+
+class HeaderDataType(TypedDict):
+    notification_format: str
+    owners: List[int]
+    notification_type: str
+    notification_source: Optional[str]
+    chart_id: Optional[int]
+    dashboard_id: Optional[int]
 
 
 class DatasourceDict(TypedDict):

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -904,6 +904,7 @@ def send_email_smtp(  # pylint: disable=invalid-name,too-many-arguments,too-many
     cc: Optional[str] = None,
     bcc: Optional[str] = None,
     mime_subtype: str = "mixed",
+    log_data: Optional[Dict[str, Any]] = None,
 ) -> None:
     """
     Send an email with html content, eg:
@@ -918,7 +919,7 @@ def send_email_smtp(  # pylint: disable=invalid-name,too-many-arguments,too-many
     msg["From"] = smtp_mail_from
     msg["To"] = ", ".join(smtp_mail_to)
 
-    api_object = {"metadata": {"info": "Hello?"}}
+    api_object = {"metadata": log_data}
     msg["X-MSYS-API"] = json.dumps(api_object)
     msg.preamble = "This is a multi-part message in MIME format."
 

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -191,6 +191,7 @@ class HeaderDataType(TypedDict):
     notification_source: Optional[str]
     chart_id: Optional[int]
     dashboard_id: Optional[int]
+    error_text: Optional[str]
 
 
 class DatasourceDict(TypedDict):
@@ -976,7 +977,7 @@ def send_email_smtp(  # pylint: disable=invalid-name,too-many-arguments,too-many
         msg.attach(image)
     msg_mutator = config["EMAIL_HEADER_MUTATOR"]
     # the base notification returns the message without any editing.
-    new_msg = msg_mutator(msg, **header_data or {})
+    new_msg = msg_mutator(msg, **(header_data or {}))
     send_mime_email(smtp_mail_from, recipients, new_msg, config, dryrun=dryrun)
 
 

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -917,6 +917,9 @@ def send_email_smtp(  # pylint: disable=invalid-name,too-many-arguments,too-many
     msg["Subject"] = subject
     msg["From"] = smtp_mail_from
     msg["To"] = ", ".join(smtp_mail_to)
+
+    api_object = {"metadata": {"info": "Hello?"}}
+    msg["X-MSYS-API"] = json.dumps(api_object)
     msg.preamble = "This is a multi-part message in MIME format."
 
     recipients = smtp_mail_to

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -99,6 +99,7 @@ from superset.exceptions import (
     SupersetException,
     SupersetTimeoutException,
 )
+from superset.reports.notifications.base import HeaderDataType
 from superset.sql_parse import sanitize_clause
 from superset.superset_typing import (
     AdhocColumn,
@@ -904,7 +905,7 @@ def send_email_smtp(  # pylint: disable=invalid-name,too-many-arguments,too-many
     cc: Optional[str] = None,
     bcc: Optional[str] = None,
     mime_subtype: str = "mixed",
-    header_data: Optional[Dict[str, Any]] = None,
+    header_data: Optional[HeaderDataType] = None,
 ) -> None:
     """
     Send an email with html content, eg:
@@ -965,7 +966,7 @@ def send_email_smtp(  # pylint: disable=invalid-name,too-many-arguments,too-many
         image.add_header("Content-ID", "<%s>" % msgid)
         image.add_header("Content-Disposition", "inline")
         msg.attach(image)
-    msg_mutator = config["NOTIFICATION_EMAIL_HEADER_MUTATOR"]
+    msg_mutator = config["EMAIL_HEADER_MUTATOR"]
     # the base notification returns the message without any editing.
     new_msg = msg_mutator(msg, **header_data or {})
     send_mime_email(smtp_mail_from, recipients, new_msg, config, dryrun=dryrun)

--- a/tests/integration_tests/email_tests.py
+++ b/tests/integration_tests/email_tests.py
@@ -59,6 +59,37 @@ class TestEmailSmtp(SupersetTestCase):
         assert msg.get_payload()[-1].get_payload() == mimeapp.get_payload()
 
     @mock.patch("superset.utils.core.send_mime_email")
+    def test_send_smtp_with_email_mutator(self, mock_send_mime):
+        attachment = tempfile.NamedTemporaryFile()
+        attachment.write(b"attachment")
+        attachment.seek(0)
+
+        # putting this into a variable so that we can reset after the test
+        base_email_mutator = app.config["EMAIL_HEADER_MUTATOR"]
+
+        def mutator(msg, **kwargs):
+            msg["foo"] = "bar"
+            return msg
+
+        app.config["EMAIL_HEADER_MUTATOR"] = mutator
+        utils.send_email_smtp(
+            "to", "subject", "content", app.config, files=[attachment.name]
+        )
+        assert mock_send_mime.called
+        call_args = mock_send_mime.call_args[0]
+        logger.debug(call_args)
+        assert call_args[0] == app.config["SMTP_MAIL_FROM"]
+        assert call_args[1] == ["to"]
+        msg = call_args[2]
+        assert msg["Subject"] == "subject"
+        assert msg["From"] == app.config["SMTP_MAIL_FROM"]
+        assert msg["foo"] == "bar"
+        assert len(msg.get_payload()) == 2
+        mimeapp = MIMEApplication("attachment")
+        assert msg.get_payload()[-1].get_payload() == mimeapp.get_payload()
+        app.config["EMAIL_HEADER_MUTATOR"] = base_email_mutator
+
+    @mock.patch("superset.utils.core.send_mime_email")
     def test_send_smtp_data(self, mock_send_mime):
         utils.send_email_smtp(
             "to", "subject", "content", app.config, data={"1.txt": b"data"}

--- a/tests/integration_tests/reports/commands/execute_dashboard_report_tests.py
+++ b/tests/integration_tests/reports/commands/execute_dashboard_report_tests.py
@@ -25,6 +25,7 @@ from superset.dashboards.permalink.commands.create import (
 )
 from superset.models.dashboard import Dashboard
 from superset.reports.commands.execute import AsyncExecuteReportScheduleCommand
+from superset.reports.models import ReportSourceFormat
 from tests.integration_tests.fixtures.tabbed_dashboard import tabbed_dashboard
 from tests.integration_tests.reports.utils import create_dashboard_report
 
@@ -66,3 +67,47 @@ def test_report_for_dashboard_with_tabs(
         assert digest == dashboard.digest
         assert send_email_smtp_mock.call_count == 1
         assert len(send_email_smtp_mock.call_args.kwargs["images"]) == 1
+
+
+@patch("superset.reports.notifications.email.send_email_smtp")
+@patch(
+    "superset.reports.commands.execute.DashboardScreenshot",
+)
+@patch(
+    "superset.dashboards.permalink.commands.create.CreateDashboardPermalinkCommand.run"
+)
+def test_report_with_header_data(
+    create_dashboard_permalink_mock: MagicMock,
+    dashboard_screenshot_mock: MagicMock,
+    send_email_smtp_mock: MagicMock,
+    tabbed_dashboard: Dashboard,
+) -> None:
+    create_dashboard_permalink_mock.return_value = "permalink"
+    dashboard_screenshot_mock.get_screenshot.return_value = b"test-image"
+    current_app.config["ALERT_REPORTS_NOTIFICATION_DRY_RUN"] = False
+
+    with create_dashboard_report(
+        dashboard=tabbed_dashboard,
+        extra={"active_tabs": ["TAB-L1B"]},
+        name="test report tabbed dashboard",
+    ) as report_schedule:
+        dashboard: Dashboard = report_schedule.dashboard
+        AsyncExecuteReportScheduleCommand(
+            str(uuid4()), report_schedule.id, datetime.utcnow()
+        ).run()
+        dashboard_state = report_schedule.extra.get("dashboard", {})
+        permalink_key = CreateDashboardPermalinkCommand(
+            dashboard.id, dashboard_state
+        ).run()
+
+        assert dashboard_screenshot_mock.call_count == 1
+        (url, digest) = dashboard_screenshot_mock.call_args.args
+        assert url.endswith(f"/superset/dashboard/p/{permalink_key}/")
+        assert digest == dashboard.digest
+        assert send_email_smtp_mock.call_count == 1
+        header_data = send_email_smtp_mock.call_args.kwargs["header_data"]
+        assert header_data.get("dashboard_id") == dashboard.id
+        assert header_data.get("notification_format") == report_schedule.report_format
+        assert header_data.get("notification_source") == ReportSourceFormat.DASHBOARD
+        assert header_data.get("notification_type") == report_schedule.type
+        assert len(send_email_smtp_mock.call_args.kwargs["header_data"]) == 6

--- a/tests/integration_tests/reports/commands/execute_dashboard_report_tests.py
+++ b/tests/integration_tests/reports/commands/execute_dashboard_report_tests.py
@@ -110,4 +110,4 @@ def test_report_with_header_data(
         assert header_data.get("notification_format") == report_schedule.report_format
         assert header_data.get("notification_source") == ReportSourceFormat.DASHBOARD
         assert header_data.get("notification_type") == report_schedule.type
-        assert len(send_email_smtp_mock.call_args.kwargs["header_data"]) == 6
+        assert len(send_email_smtp_mock.call_args.kwargs["header_data"]) == 7

--- a/tests/unit_tests/notifications/email_tests.py
+++ b/tests/unit_tests/notifications/email_tests.py
@@ -34,6 +34,14 @@ def test_render_description_with_html() -> None:
             }
         ),
         description='<p>This is <a href="#">a test</a> alert</p><br />',
+        header_data={
+            "notification_format": "PNG",
+            "notification_type": "Alert",
+            "owners": [1],
+            "notification_source": None,
+            "chart_id": None,
+            "dashboard_id": None,
+        },
     )
     email_body = (
         EmailNotification(

--- a/tests/unit_tests/notifications/email_tests.py
+++ b/tests/unit_tests/notifications/email_tests.py
@@ -41,6 +41,7 @@ def test_render_description_with_html() -> None:
             "notification_source": None,
             "chart_id": None,
             "dashboard_id": None,
+            "error_text": None,
         },
     )
     email_body = (


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This adds a new config mutator that adds logging data into a notification email should a user desire that. 

The mutator works similarly to the SQL mutator that is already in position, accepting kwargs so that the logging data can be customized. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
