### PR TITLE
fix(sqllab): hide tracking url when fetching

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { CSSProperties } from 'react';
+import React from 'react';
 import ButtonGroup from 'src/components/ButtonGroup';
 import Alert from 'src/components/Alert';
 import Button from 'src/components/Button';
@@ -54,8 +54,6 @@ enum LIMITING_FACTOR {
   NOT_LIMITED = 'NOT_LIMITED',
 }
 
-const LOADING_STYLES: CSSProperties = { position: 'relative', minHeight: 100 };
-
 interface ResultSetProps {
   showControls?: boolean;
   actions: Record<string, any>;
@@ -79,6 +77,14 @@ interface ResultSetState {
   showSaveDatasetModal: boolean;
   alertIsOpen: boolean;
 }
+
+const Styles = styled.div`
+  position: relative;
+  minheight: 100px;
+  .sql-result-track-job {
+    margin-top: ${({ theme }) => theme.gridUnit * 2}px;
+  }
+`;
 
 // Making text render line breaks/tabs as is as monospace,
 // but wrapping text too so text doesn't overflow
@@ -109,9 +115,6 @@ const ResultSetButtons = styled.div`
 
 const ResultSetErrorMessage = styled.div`
   padding-top: ${({ theme }) => 4 * theme.gridUnit}px;
-  .sql-result-track-job {
-    margin-top: ${({ theme }) => 2 * theme.gridUnit}px;
-  }
 `;
 
 export default class ResultSet extends React.PureComponent<
@@ -421,7 +424,11 @@ export default class ResultSet extends React.PureComponent<
       exploreDBId = this.props.database.explore_database_id;
     }
     let trackingUrl;
-    if (query.trackingUrl) {
+    if (
+      query.trackingUrl &&
+      query.state !== 'success' &&
+      query.state !== 'fetching'
+    ) {
       trackingUrl = (
         <Button
           className="sql-result-track-job"
@@ -582,7 +589,7 @@ export default class ResultSet extends React.PureComponent<
         : null;
 
     return (
-      <div style={LOADING_STYLES}>
+      <Styles>
         <div>{!progressBar && <Loading position="normal" />}</div>
         {/* show loading bar whenever progress bar is completed but needs time to render */}
         <div>{query.progress === 100 && <Loading position="normal" />}</div>
@@ -591,8 +598,8 @@ export default class ResultSet extends React.PureComponent<
           {progressMsg && <Alert type="success" message={progressMsg} />}
         </div>
         <div>{query.progress !== 100 && progressBar}</div>
-        <div>{trackingUrl}</div>
-      </div>
+        {trackingUrl && <div>{trackingUrl}</div>}
+      </Styles>
     );
   }
 }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Hide tracking url when SQL Lab is fetching query results or when query is successful. Also fix missing margin when progress bar hasn't show up.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

<img width="447" alt="Xnip2022-07-28_12-42-11" src="https://user-images.githubusercontent.com/335541/181624062-7a20a284-c0d7-4a80-a290-a3af282f16eb.png">

#### After

<img width="451" alt="Xnip2022-07-28_12-41-41" src="https://user-images.githubusercontent.com/335541/181624047-f0bfeba0-4427-4768-b038-1901da3afbe0.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
