### PR TITLE
feat: allow more HTML tags in report description

### DIFF
--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -23,7 +23,6 @@ from email.utils import make_msgid, parseaddr
 from typing import Any, Dict, Optional
 
 import bleach
-
 from flask_babel import gettext as __
 
 from superset import app

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -23,6 +23,7 @@ from email.utils import make_msgid, parseaddr
 from typing import Any, Dict, Optional
 
 import bleach
+
 from flask_babel import gettext as __
 
 from superset import app
@@ -37,6 +38,31 @@ logger = logging.getLogger(__name__)
 
 TABLE_TAGS = ["table", "th", "tr", "td", "thead", "tbody", "tfoot"]
 TABLE_ATTRIBUTES = ["colspan", "rowspan", "halign", "border", "class"]
+
+ALLOWED_TAGS = [
+    "a",
+    "abbr",
+    "acronym",
+    "b",
+    "blockquote",
+    "br",
+    "code",
+    "div",
+    "em",
+    "i",
+    "li",
+    "ol",
+    "p",
+    "strong",
+    "ul",
+] + TABLE_TAGS
+
+ALLOWED_ATTRIBUTES = {
+    "a": ["href", "title"],
+    "abbr": ["title"],
+    "acronym": ["title"],
+    **{tag: TABLE_ATTRIBUTES for tag in TABLE_TAGS},
+}
 
 
 @dataclass
@@ -82,13 +108,19 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
             }
 
         # Strip any malicious HTML from the description
-        description = bleach.clean(self._content.description or "")
+        description = bleach.clean(
+            self._content.description or "",
+            tags=ALLOWED_TAGS,
+            attributes=ALLOWED_ATTRIBUTES,
+        )
 
         # Strip malicious HTML from embedded data, allowing only table elements
         if self._content.embedded_data is not None:
             df = self._content.embedded_data
             html_table = bleach.clean(
-                df.to_html(na_rep="", index=True),
+                df.to_html(na_rep="", index=True, escape=True),
+                # pandas will escape the HTML in cells already, so passing
+                # more allowed tags here will not work
                 tags=TABLE_TAGS,
                 attributes=TABLE_ATTRIBUTES,
             )
@@ -127,7 +159,8 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
                 </style>
               </head>
               <body>
-                <p>{description}</p>
+                <div>{description}</div>
+                <br>
                 <b><a href="{url}">{call_to_action}</a></b><p></p>
                 {html_table}
                 {img_tag}

--- a/tests/unit_tests/notifications/email_tests.py
+++ b/tests/unit_tests/notifications/email_tests.py
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import pandas as pd
+
+
+def test_render_description_with_html(app_context):
+    # `superset.models.helpers`, a dependency of following imports,
+    # requires app context
+    from superset.reports.models import ReportRecipients, ReportRecipientType
+    from superset.reports.notifications.base import NotificationContent
+    from superset.reports.notifications.email import EmailNotification
+
+    content = NotificationContent(
+        name="test alert",
+        embedded_data=pd.DataFrame(
+            {
+                "A": [1, 2, 3],
+                "B": [4, 5, 6],
+                "C": ["111", "222", '<a href="http://www.example.com">333</a>'],
+            }
+        ),
+        description='<p>This is <a href="#">a test</a> alert</p><br />',
+    )
+    email_body = (
+        EmailNotification(
+            recipient=ReportRecipients(type=ReportRecipientType.EMAIL), content=content
+        )
+        ._get_content()
+        .body
+    )
+    assert '<p>This is <a href="#">a test</a> alert</p><br>' in email_body
+    assert '<td>&lt;a href="http://www.example.com"&gt;333&lt;/a&gt;</td>' in email_body

--- a/tests/unit_tests/notifications/email_tests.py
+++ b/tests/unit_tests/notifications/email_tests.py
@@ -15,9 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 import pandas as pd
+from flask.ctx import AppContext
 
 
-def test_render_description_with_html(app_context):
+def test_render_description_with_html(app_context: AppContext) -> None:
     # `superset.models.helpers`, a dependency of following imports,
     # requires app context
     from superset.reports.models import ReportRecipients, ReportRecipientType


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Our users want to write multi-line descriptions for alerts & reports. This PR adds `<br>, <p>, <div>`, as well as HTML table related tags to the list of allowed tags.

Slack messages need to be handled differently. We'll address it in future PRs if necessary.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

Unit test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
