### PR TITLE
test: autouse app_context in unit tests

### DIFF
--- a/tests/unit_tests/advanced_data_type/types_tests.py
+++ b/tests/unit_tests/advanced_data_type/types_tests.py
@@ -17,11 +17,8 @@
 # isort:skip_file
 """Unit tests for Superset"""
 
-from ipaddress import ip_address
 import sqlalchemy
-from flask.ctx import AppContext
 from sqlalchemy import Column, Integer
-from tests.integration_tests.base_tests import SupersetTestCase
 from superset.advanced_data_type.types import (
     AdvancedDataTypeRequest,
     AdvancedDataTypeResponse,
@@ -36,7 +33,7 @@ from superset.advanced_data_type.plugins.internet_port import internet_port as p
 # tox -e py38 -- tests/unit_tests/advanced_data_type/types_tests.py
 
 
-def test_ip_func_valid_ip(app_context: None):
+def test_ip_func_valid_ip():
     """Test to see if the cidr_func behaves as expected when a valid IP is passed in"""
     cidr_request: AdvancedDataTypeRequest = {
         "advanced_data_type": "cidr",
@@ -59,7 +56,7 @@ def test_ip_func_valid_ip(app_context: None):
     assert internet_address.translate_type(cidr_request) == cidr_response
 
 
-def test_cidr_func_invalid_ip(app_context: None):
+def test_cidr_func_invalid_ip():
     """Test to see if the cidr_func behaves as expected when an invalid IP is passed in"""
     cidr_request: AdvancedDataTypeRequest = {
         "advanced_data_type": "cidr",
@@ -82,7 +79,7 @@ def test_cidr_func_invalid_ip(app_context: None):
     assert internet_address.translate_type(cidr_request) == cidr_response
 
 
-def test_port_translation_func_valid_port_number(app_context: None):
+def test_port_translation_func_valid_port_number():
     """Test to see if the port_translation_func behaves as expected when a valid port number
     is passed in"""
     port_request: AdvancedDataTypeRequest = {
@@ -106,7 +103,7 @@ def test_port_translation_func_valid_port_number(app_context: None):
     assert port.translate_type(port_request) == port_response
 
 
-def test_port_translation_func_valid_port_name(app_context: None):
+def test_port_translation_func_valid_port_name():
     """Test to see if the port_translation_func behaves as expected when a valid port name
     is passed in"""
     port_request: AdvancedDataTypeRequest = {
@@ -130,7 +127,7 @@ def test_port_translation_func_valid_port_name(app_context: None):
     assert port.translate_type(port_request) == port_response
 
 
-def test_port_translation_func_invalid_port_name(app_context: None):
+def test_port_translation_func_invalid_port_name():
     """Test to see if the port_translation_func behaves as expected when an invalid port name
     is passed in"""
     port_request: AdvancedDataTypeRequest = {
@@ -154,7 +151,7 @@ def test_port_translation_func_invalid_port_name(app_context: None):
     assert port.translate_type(port_request) == port_response
 
 
-def test_port_translation_func_invalid_port_number(app_context: None):
+def test_port_translation_func_invalid_port_number():
     """Test to see if the port_translation_func behaves as expected when an invalid port
     number is passed in"""
     port_request: AdvancedDataTypeRequest = {
@@ -178,7 +175,7 @@ def test_port_translation_func_invalid_port_number(app_context: None):
     assert port.translate_type(port_request) == port_response
 
 
-def test_cidr_translate_filter_func_equals(app_context: None):
+def test_cidr_translate_filter_func_equals():
     """Test to see if the cidr_translate_filter_func behaves as expected when the EQUALS
     operator is used"""
 
@@ -193,7 +190,7 @@ def test_cidr_translate_filter_func_equals(app_context: None):
     ).compare(cidr_translate_filter_response)
 
 
-def test_cidr_translate_filter_func_not_equals(app_context: None):
+def test_cidr_translate_filter_func_not_equals():
     """Test to see if the cidr_translate_filter_func behaves as expected when the NOT_EQUALS
     operator is used"""
 
@@ -208,7 +205,7 @@ def test_cidr_translate_filter_func_not_equals(app_context: None):
     ).compare(cidr_translate_filter_response)
 
 
-def test_cidr_translate_filter_func_greater_than_or_equals(app_context: None):
+def test_cidr_translate_filter_func_greater_than_or_equals():
     """Test to see if the cidr_translate_filter_func behaves as expected when the
     GREATER_THAN_OR_EQUALS operator is used"""
 
@@ -225,7 +222,7 @@ def test_cidr_translate_filter_func_greater_than_or_equals(app_context: None):
     ).compare(cidr_translate_filter_response)
 
 
-def test_cidr_translate_filter_func_greater_than(app_context: None):
+def test_cidr_translate_filter_func_greater_than():
     """Test to see if the cidr_translate_filter_func behaves as expected when the
     GREATER_THAN operator is used"""
 
@@ -242,7 +239,7 @@ def test_cidr_translate_filter_func_greater_than(app_context: None):
     ).compare(cidr_translate_filter_response)
 
 
-def test_cidr_translate_filter_func_less_than(app_context: None):
+def test_cidr_translate_filter_func_less_than():
     """Test to see if the cidr_translate_filter_func behaves as expected when the LESS_THAN
     operator is used"""
 
@@ -259,7 +256,7 @@ def test_cidr_translate_filter_func_less_than(app_context: None):
     ).compare(cidr_translate_filter_response)
 
 
-def test_cidr_translate_filter_func_less_than_or_equals(app_context: None):
+def test_cidr_translate_filter_func_less_than_or_equals():
     """Test to see if the cidr_translate_filter_func behaves as expected when the
     LESS_THAN_OR_EQUALS operator is used"""
 
@@ -276,7 +273,7 @@ def test_cidr_translate_filter_func_less_than_or_equals(app_context: None):
     ).compare(cidr_translate_filter_response)
 
 
-def test_cidr_translate_filter_func_in_single(app_context: None):
+def test_cidr_translate_filter_func_in_single():
     """Test to see if the cidr_translate_filter_func behaves as expected when the IN operator
     is used with a single IP"""
 
@@ -293,7 +290,7 @@ def test_cidr_translate_filter_func_in_single(app_context: None):
     ).compare(cidr_translate_filter_response)
 
 
-def test_cidr_translate_filter_func_in_double(app_context: None):
+def test_cidr_translate_filter_func_in_double():
     """Test to see if the cidr_translate_filter_func behaves as expected when the IN operator
     is used with two IP's"""
 
@@ -312,7 +309,7 @@ def test_cidr_translate_filter_func_in_double(app_context: None):
     ).compare(cidr_translate_filter_response)
 
 
-def test_cidr_translate_filter_func_not_in_single(app_context: None):
+def test_cidr_translate_filter_func_not_in_single():
     """Test to see if the cidr_translate_filter_func behaves as expected when the NOT_IN
     operator is used with a single IP"""
 
@@ -329,7 +326,7 @@ def test_cidr_translate_filter_func_not_in_single(app_context: None):
     ).compare(cidr_translate_filter_response)
 
 
-def test_cidr_translate_filter_func_not_in_double(app_context: None):
+def test_cidr_translate_filter_func_not_in_double():
     """Test to see if the cidr_translate_filter_func behaves as expected when the NOT_IN
     operator is used with two IP's"""
 
@@ -348,7 +345,7 @@ def test_cidr_translate_filter_func_not_in_double(app_context: None):
     ).compare(cidr_translate_filter_response)
 
 
-def test_port_translate_filter_func_equals(app_context: None):
+def test_port_translate_filter_func_equals():
     """Test to see if the port_translate_filter_func behaves as expected when the EQUALS
     operator is used"""
 
@@ -365,7 +362,7 @@ def test_port_translate_filter_func_equals(app_context: None):
     )
 
 
-def test_port_translate_filter_func_not_equals(app_context: None):
+def test_port_translate_filter_func_not_equals():
     """Test to see if the port_translate_filter_func behaves as expected when the NOT_EQUALS
     operator is used"""
 
@@ -382,7 +379,7 @@ def test_port_translate_filter_func_not_equals(app_context: None):
     )
 
 
-def test_port_translate_filter_func_greater_than_or_equals(app_context: None):
+def test_port_translate_filter_func_greater_than_or_equals():
     """Test to see if the port_translate_filter_func behaves as expected when the
     GREATER_THAN_OR_EQUALS operator is used"""
 
@@ -399,7 +396,7 @@ def test_port_translate_filter_func_greater_than_or_equals(app_context: None):
     )
 
 
-def test_port_translate_filter_func_greater_than(app_context: None):
+def test_port_translate_filter_func_greater_than():
     """Test to see if the port_translate_filter_func behaves as expected when the
     GREATER_THAN operator is used"""
 
@@ -416,7 +413,7 @@ def test_port_translate_filter_func_greater_than(app_context: None):
     )
 
 
-def test_port_translate_filter_func_less_than_or_equals(app_context: None):
+def test_port_translate_filter_func_less_than_or_equals():
     """Test to see if the port_translate_filter_func behaves as expected when the
     LESS_THAN_OR_EQUALS operator is used"""
 
@@ -433,7 +430,7 @@ def test_port_translate_filter_func_less_than_or_equals(app_context: None):
     )
 
 
-def test_port_translate_filter_func_less_than(app_context: None):
+def test_port_translate_filter_func_less_than():
     """Test to see if the port_translate_filter_func behaves as expected when the LESS_THAN
     operator is used"""
 
@@ -450,7 +447,7 @@ def test_port_translate_filter_func_less_than(app_context: None):
     )
 
 
-def test_port_translate_filter_func_in_single(app_context: None):
+def test_port_translate_filter_func_in_single():
     """Test to see if the port_translate_filter_func behaves as expected when the IN operator
     is used with a single port"""
 
@@ -467,7 +464,7 @@ def test_port_translate_filter_func_in_single(app_context: None):
     )
 
 
-def test_port_translate_filter_func_in_double(app_context: None):
+def test_port_translate_filter_func_in_double():
     """Test to see if the port_translate_filter_func behaves as expected when the IN operator
     is used with two ports"""
 
@@ -484,7 +481,7 @@ def test_port_translate_filter_func_in_double(app_context: None):
     )
 
 
-def test_port_translate_filter_func_not_in_single(app_context: None):
+def test_port_translate_filter_func_not_in_single():
     """Test to see if the port_translate_filter_func behaves as expected when the NOT_IN
     operator is used with a single port"""
 
@@ -501,7 +498,7 @@ def test_port_translate_filter_func_not_in_single(app_context: None):
     )
 
 
-def test_port_translate_filter_func_not_in_double(app_context: None):
+def test_port_translate_filter_func_not_in_double():
     """Test to see if the port_translate_filter_func behaves as expected when the NOT_IN
     operator is used with two ports"""
 

--- a/tests/unit_tests/charts/commands/importers/v1/import_test.py
+++ b/tests/unit_tests/charts/commands/importers/v1/import_test.py
@@ -21,7 +21,7 @@ import copy
 from sqlalchemy.orm.session import Session
 
 
-def test_import_chart(app_context: None, session: Session) -> None:
+def test_import_chart(session: Session) -> None:
     """
     Test importing a chart.
     """
@@ -45,7 +45,7 @@ def test_import_chart(app_context: None, session: Session) -> None:
     assert chart.external_url is None
 
 
-def test_import_chart_managed_externally(app_context: None, session: Session) -> None:
+def test_import_chart_managed_externally(session: Session) -> None:
     """
     Test importing a chart that is managed externally.
     """

--- a/tests/unit_tests/columns/test_models.py
+++ b/tests/unit_tests/columns/test_models.py
@@ -20,7 +20,7 @@
 from sqlalchemy.orm.session import Session
 
 
-def test_column_model(app_context: None, session: Session) -> None:
+def test_column_model(session: Session) -> None:
     """
     Test basic attributes of a ``Column``.
     """

--- a/tests/unit_tests/commands/export_test.py
+++ b/tests/unit_tests/commands/export_test.py
@@ -20,7 +20,7 @@ from freezegun import freeze_time
 from pytest_mock import MockFixture
 
 
-def test_export_assets_command(mocker: MockFixture, app_context: None) -> None:
+def test_export_assets_command(mocker: MockFixture) -> None:
     """
     Test that all assets are exported correctly.
     """

--- a/tests/unit_tests/config_test.py
+++ b/tests/unit_tests/config_test.py
@@ -74,7 +74,7 @@ def apply_dttm_defaults(table: "SqlaTable", dttm_defaults: Dict[str, Any]) -> No
 
 
 @pytest.fixture
-def test_table(app_context: None, session: Session) -> "SqlaTable":
+def test_table(session: Session) -> "SqlaTable":
     """
     Fixture that generates an in-memory table.
     """

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -102,7 +102,7 @@ def client(app: SupersetApp) -> Any:
         yield client
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def app_context(app: SupersetApp) -> Iterator[None]:
     """
     A fixture that yields and application context.

--- a/tests/unit_tests/dao/queries_test.py
+++ b/tests/unit_tests/dao/queries_test.py
@@ -21,7 +21,7 @@ import pytest
 from sqlalchemy.orm.session import Session
 
 
-def test_query_dao_save_metadata(app_context: None, session: Session) -> None:
+def test_query_dao_save_metadata(session: Session) -> None:
     from superset.models.core import Database
     from superset.models.sql_lab import Query
 

--- a/tests/unit_tests/dashboards/commands/importers/v1/import_test.py
+++ b/tests/unit_tests/dashboards/commands/importers/v1/import_test.py
@@ -21,7 +21,7 @@ import copy
 from sqlalchemy.orm.session import Session
 
 
-def test_import_dashboard(app_context: None, session: Session) -> None:
+def test_import_dashboard(session: Session) -> None:
     """
     Test importing a dashboard.
     """
@@ -43,9 +43,7 @@ def test_import_dashboard(app_context: None, session: Session) -> None:
     assert dashboard.external_url is None
 
 
-def test_import_dashboard_managed_externally(
-    app_context: None, session: Session
-) -> None:
+def test_import_dashboard_managed_externally(session: Session) -> None:
     """
     Test importing a dashboard that is managed externally.
     """

--- a/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
@@ -82,7 +82,7 @@ def test_update_id_refs_immune_missing(  # pylint: disable=invalid-name
     }
 
 
-def test_update_native_filter_config_scope_excluded(app_context: None):
+def test_update_native_filter_config_scope_excluded():
     from superset.dashboards.commands.importers.v1.utils import update_id_refs
 
     config = {

--- a/tests/unit_tests/databases/commands/importers/v1/import_test.py
+++ b/tests/unit_tests/databases/commands/importers/v1/import_test.py
@@ -21,7 +21,7 @@ import copy
 from sqlalchemy.orm.session import Session
 
 
-def test_import_database(app_context: None, session: Session) -> None:
+def test_import_database(session: Session) -> None:
     """
     Test importing a database.
     """
@@ -48,9 +48,7 @@ def test_import_database(app_context: None, session: Session) -> None:
     assert database.external_url is None
 
 
-def test_import_database_managed_externally(
-    app_context: None, session: Session
-) -> None:
+def test_import_database_managed_externally(session: Session) -> None:
     """
     Test importing a database that is managed externally.
     """

--- a/tests/unit_tests/databases/utils_test.py
+++ b/tests/unit_tests/databases/utils_test.py
@@ -21,7 +21,7 @@ from sqlalchemy.orm.session import Session
 from superset.databases.utils import make_url_safe
 
 
-def test_make_url_safe_string(app_context: None, session: Session) -> None:
+def test_make_url_safe_string(session: Session) -> None:
     """
     Test converting a string to a safe uri
     """
@@ -31,7 +31,7 @@ def test_make_url_safe_string(app_context: None, session: Session) -> None:
     assert uri_safe == make_url(uri_string)
 
 
-def test_make_url_safe_url(app_context: None, session: Session) -> None:
+def test_make_url_safe_url(session: Session) -> None:
     """
     Test converting a url to a safe uri
     """

--- a/tests/unit_tests/dataframe_test.py
+++ b/tests/unit_tests/dataframe_test.py
@@ -24,7 +24,7 @@ from superset.dataframe import df_to_records
 from superset.superset_typing import DbapiDescription
 
 
-def test_df_to_records(app_context: None) -> None:
+def test_df_to_records() -> None:
     from superset.db_engine_specs import BaseEngineSpec
     from superset.result_set import SupersetResultSet
 
@@ -41,7 +41,7 @@ def test_df_to_records(app_context: None) -> None:
     ]
 
 
-def test_js_max_int(app_context: None) -> None:
+def test_js_max_int() -> None:
     from superset.db_engine_specs import BaseEngineSpec
     from superset.result_set import SupersetResultSet
 

--- a/tests/unit_tests/datasets/commands/export_test.py
+++ b/tests/unit_tests/datasets/commands/export_test.py
@@ -21,7 +21,7 @@ import json
 from sqlalchemy.orm.session import Session
 
 
-def test_export(app_context: None, session: Session) -> None:
+def test_export(session: Session) -> None:
     """
     Test exporting a dataset.
     """

--- a/tests/unit_tests/datasets/commands/importers/v1/import_test.py
+++ b/tests/unit_tests/datasets/commands/importers/v1/import_test.py
@@ -24,7 +24,7 @@ from typing import Any, Dict
 from sqlalchemy.orm.session import Session
 
 
-def test_import_dataset(app_context: None, session: Session) -> None:
+def test_import_dataset(session: Session) -> None:
     """
     Test importing a dataset.
     """
@@ -137,7 +137,7 @@ def test_import_dataset(app_context: None, session: Session) -> None:
     assert sqla_table.database.id == database.id
 
 
-def test_import_dataset_duplicate_column(app_context: None, session: Session) -> None:
+def test_import_dataset_duplicate_column(session: Session) -> None:
     """
     Test importing a dataset with a column that already exists.
     """
@@ -260,7 +260,7 @@ def test_import_dataset_duplicate_column(app_context: None, session: Session) ->
     assert sqla_table.database.id == database.id
 
 
-def test_import_column_extra_is_string(app_context: None, session: Session) -> None:
+def test_import_column_extra_is_string(session: Session) -> None:
     """
     Test importing a dataset when the column extra is a string.
     """
@@ -340,7 +340,7 @@ def test_import_column_extra_is_string(app_context: None, session: Session) -> N
     assert sqla_table.extra == '{"warning_markdown": "*WARNING*"}'
 
 
-def test_import_dataset_managed_externally(app_context: None, session: Session) -> None:
+def test_import_dataset_managed_externally(session: Session) -> None:
     """
     Test importing a dataset that is managed externally.
     """

--- a/tests/unit_tests/datasets/test_models.py
+++ b/tests/unit_tests/datasets/test_models.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from superset.connectors.sqla.models import SqlMetric, TableColumn
 
 
-def test_dataset_model(app_context: None, session: Session) -> None:
+def test_dataset_model(session: Session) -> None:
     """
     Test basic attributes of a ``Dataset``.
     """
@@ -86,7 +86,7 @@ FROM my_catalog.my_schema.my_table
     assert [column.name for column in dataset.columns] == ["position"]
 
 
-def test_cascade_delete_table(app_context: None, session: Session) -> None:
+def test_cascade_delete_table(session: Session) -> None:
     """
     Test that deleting ``Table`` also deletes its columns.
     """
@@ -121,7 +121,7 @@ def test_cascade_delete_table(app_context: None, session: Session) -> None:
     assert len(columns) == 0
 
 
-def test_cascade_delete_dataset(app_context: None, session: Session) -> None:
+def test_cascade_delete_dataset(session: Session) -> None:
     """
     Test that deleting ``Dataset`` also deletes its columns.
     """
@@ -175,7 +175,7 @@ FROM my_catalog.my_schema.my_table
     assert len(columns) == 2
 
 
-def test_dataset_attributes(app_context: None, session: Session) -> None:
+def test_dataset_attributes(session: Session) -> None:
     """
     Test that checks attributes in the dataset.
 
@@ -649,7 +649,7 @@ FROM
     }
 
 
-def test_delete_sqlatable(app_context: None, session: Session) -> None:
+def test_delete_sqlatable(session: Session) -> None:
     """
     Test that deleting a ``SqlaTable`` also deletes the corresponding ``Dataset``.
     """
@@ -689,7 +689,7 @@ def test_delete_sqlatable(app_context: None, session: Session) -> None:
 
 
 def test_update_physical_sqlatable_columns(
-    mocker: MockFixture, app_context: None, session: Session
+    mocker: MockFixture, session: Session
 ) -> None:
     """
     Test that updating a ``SqlaTable`` also updates the corresponding ``Dataset``.
@@ -765,7 +765,7 @@ def test_update_physical_sqlatable_columns(
 
 
 def test_update_physical_sqlatable_schema(
-    mocker: MockFixture, app_context: None, session: Session
+    mocker: MockFixture, session: Session
 ) -> None:
     """
     Test that updating a ``SqlaTable`` schema also updates the corresponding ``Dataset``.
@@ -1046,7 +1046,7 @@ def test_update_physical_sqlatable_database(
 
 
 def test_update_virtual_sqlatable_references(
-    mocker: MockFixture, app_context: None, session: Session
+    mocker: MockFixture, session: Session
 ) -> None:
     """
     Test that changing the SQL of a virtual ``SqlaTable`` updates ``Dataset``.
@@ -1122,7 +1122,7 @@ def test_update_virtual_sqlatable_references(
     assert new_dataset.tables[2].name == "table_c"
 
 
-def test_quote_expressions(app_context: None, session: Session) -> None:
+def test_quote_expressions(session: Session) -> None:
     """
     Test that expressions are quoted appropriately in columns and datasets.
     """

--- a/tests/unit_tests/datasource/dao_tests.py
+++ b/tests/unit_tests/datasource/dao_tests.py
@@ -99,9 +99,7 @@ FROM my_catalog.my_schema.my_table
     yield session
 
 
-def test_get_datasource_sqlatable(
-    app_context: None, session_with_data: Session
-) -> None:
+def test_get_datasource_sqlatable(session_with_data: Session) -> None:
     from superset.connectors.sqla.models import SqlaTable
     from superset.datasource.dao import DatasourceDAO
 
@@ -116,7 +114,7 @@ def test_get_datasource_sqlatable(
     assert isinstance(result, SqlaTable)
 
 
-def test_get_datasource_query(app_context: None, session_with_data: Session) -> None:
+def test_get_datasource_query(session_with_data: Session) -> None:
     from superset.datasource.dao import DatasourceDAO
     from superset.models.sql_lab import Query
 
@@ -128,9 +126,7 @@ def test_get_datasource_query(app_context: None, session_with_data: Session) -> 
     assert isinstance(result, Query)
 
 
-def test_get_datasource_saved_query(
-    app_context: None, session_with_data: Session
-) -> None:
+def test_get_datasource_saved_query(session_with_data: Session) -> None:
     from superset.datasource.dao import DatasourceDAO
     from superset.models.sql_lab import SavedQuery
 
@@ -144,7 +140,7 @@ def test_get_datasource_saved_query(
     assert isinstance(result, SavedQuery)
 
 
-def test_get_datasource_sl_table(app_context: None, session_with_data: Session) -> None:
+def test_get_datasource_sl_table(session_with_data: Session) -> None:
     from superset.datasource.dao import DatasourceDAO
     from superset.tables.models import Table
 
@@ -160,9 +156,7 @@ def test_get_datasource_sl_table(app_context: None, session_with_data: Session) 
     assert isinstance(result, Table)
 
 
-def test_get_datasource_sl_dataset(
-    app_context: None, session_with_data: Session
-) -> None:
+def test_get_datasource_sl_dataset(session_with_data: Session) -> None:
     from superset.datasets.models import Dataset
     from superset.datasource.dao import DatasourceDAO
 
@@ -178,9 +172,7 @@ def test_get_datasource_sl_dataset(
     assert isinstance(result, Dataset)
 
 
-def test_get_datasource_w_str_param(
-    app_context: None, session_with_data: Session
-) -> None:
+def test_get_datasource_w_str_param(session_with_data: Session) -> None:
     from superset.connectors.sqla.models import SqlaTable
     from superset.datasets.models import Dataset
     from superset.datasource.dao import DatasourceDAO
@@ -205,7 +197,7 @@ def test_get_datasource_w_str_param(
     )
 
 
-def test_get_all_datasources(app_context: None, session_with_data: Session) -> None:
+def test_get_all_datasources(session_with_data: Session) -> None:
     from superset.connectors.sqla.models import SqlaTable
 
     result = SqlaTable.get_all_datasources(session=session_with_data)

--- a/tests/unit_tests/db_engine_specs/test_athena.py
+++ b/tests/unit_tests/db_engine_specs/test_athena.py
@@ -18,8 +18,6 @@
 import re
 from datetime import datetime
 
-from flask.ctx import AppContext
-
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from tests.unit_tests.fixtures.common import dttm
 
@@ -28,7 +26,7 @@ SYNTAX_ERROR_REGEX = re.compile(
 )
 
 
-def test_convert_dttm(app_context: AppContext, dttm: datetime) -> None:
+def test_convert_dttm(dttm: datetime) -> None:
     """
     Test that date objects are converted correctly.
     """
@@ -43,7 +41,7 @@ def test_convert_dttm(app_context: AppContext, dttm: datetime) -> None:
     )
 
 
-def test_extract_errors(app_context: AppContext) -> None:
+def test_extract_errors() -> None:
     """
     Test that custom error messages are extracted correctly.
     """
@@ -70,7 +68,7 @@ def test_extract_errors(app_context: AppContext) -> None:
     ]
 
 
-def test_get_text_clause_with_colon(app_context: AppContext) -> None:
+def test_get_text_clause_with_colon() -> None:
     """
     Make sure text clauses don't escape the colon character
     """

--- a/tests/unit_tests/db_engine_specs/test_base.py
+++ b/tests/unit_tests/db_engine_specs/test_base.py
@@ -19,11 +19,10 @@
 from textwrap import dedent
 
 import pytest
-from flask.ctx import AppContext
 from sqlalchemy.types import TypeEngine
 
 
-def test_get_text_clause_with_colon(app_context: AppContext) -> None:
+def test_get_text_clause_with_colon() -> None:
     """
     Make sure text clauses are correctly escaped
     """
@@ -36,7 +35,7 @@ def test_get_text_clause_with_colon(app_context: AppContext) -> None:
     assert text_clause.text == "SELECT foo FROM tbl WHERE foo = '123\\:456')"
 
 
-def test_parse_sql_single_statement(app_context: AppContext) -> None:
+def test_parse_sql_single_statement() -> None:
     """
     `parse_sql` should properly strip leading and trailing spaces and semicolons
     """
@@ -47,7 +46,7 @@ def test_parse_sql_single_statement(app_context: AppContext) -> None:
     assert queries == ["SELECT foo FROM tbl"]
 
 
-def test_parse_sql_multi_statement(app_context: AppContext) -> None:
+def test_parse_sql_multi_statement() -> None:
     """
     For string with multiple SQL-statements `parse_sql` method should return list
     where each element represents the single SQL-statement
@@ -95,9 +94,7 @@ select 'USD' as cur
         ),
     ],
 )
-def test_cte_query_parsing(
-    app_context: AppContext, original: TypeEngine, expected: str
-) -> None:
+def test_cte_query_parsing(original: TypeEngine, expected: str) -> None:
     from superset.db_engine_specs.base import BaseEngineSpec
 
     actual = BaseEngineSpec.get_cte_query(original)

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -16,14 +16,13 @@
 # under the License.
 # pylint: disable=unused-argument, import-outside-toplevel, protected-access
 
-from flask.ctx import AppContext
 from pybigquery.sqlalchemy_bigquery import BigQueryDialect
 from pytest_mock import MockFixture
 from sqlalchemy import select
 from sqlalchemy.sql import sqltypes
 
 
-def test_get_fields(app_context: AppContext) -> None:
+def test_get_fields() -> None:
     """
     Test the custom ``_get_fields`` method.
 
@@ -66,7 +65,7 @@ def test_get_fields(app_context: AppContext) -> None:
     )
 
 
-def test_select_star(mocker: MockFixture, app_context: AppContext) -> None:
+def test_select_star(mocker: MockFixture) -> None:
     """
     Test the ``select_star`` method.
 

--- a/tests/unit_tests/db_engine_specs/test_drill.py
+++ b/tests/unit_tests/db_engine_specs/test_drill.py
@@ -16,11 +16,10 @@
 # under the License.
 # pylint: disable=unused-argument, import-outside-toplevel, protected-access
 
-from flask.ctx import AppContext
 from pytest import raises
 
 
-def test_odbc_impersonation(app_context: AppContext) -> None:
+def test_odbc_impersonation() -> None:
     """
     Test ``get_url_for_impersonation`` method when driver == odbc.
 
@@ -36,7 +35,7 @@ def test_odbc_impersonation(app_context: AppContext) -> None:
     assert url.query["DelegationUID"] == username
 
 
-def test_jdbc_impersonation(app_context: AppContext) -> None:
+def test_jdbc_impersonation() -> None:
     """
     Test ``get_url_for_impersonation`` method when driver == jdbc.
 
@@ -52,7 +51,7 @@ def test_jdbc_impersonation(app_context: AppContext) -> None:
     assert url.query["impersonation_target"] == username
 
 
-def test_sadrill_impersonation(app_context: AppContext) -> None:
+def test_sadrill_impersonation() -> None:
     """
     Test ``get_url_for_impersonation`` method when driver == sadrill.
 
@@ -68,7 +67,7 @@ def test_sadrill_impersonation(app_context: AppContext) -> None:
     assert url.query["impersonation_target"] == username
 
 
-def test_invalid_impersonation(app_context: AppContext) -> None:
+def test_invalid_impersonation() -> None:
     """
     Test ``get_url_for_impersonation`` method when driver == foobar.
 

--- a/tests/unit_tests/db_engine_specs/test_gsheets.py
+++ b/tests/unit_tests/db_engine_specs/test_gsheets.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from flask.ctx import AppContext
 from pytest_mock import MockFixture
 
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
@@ -28,7 +27,6 @@ class ProgrammingError(Exception):
 
 def test_validate_parameters_simple(
     mocker: MockFixture,
-    app_context: AppContext,
 ) -> None:
     from superset.db_engine_specs.gsheets import (
         GSheetsEngineSpec,
@@ -52,7 +50,6 @@ def test_validate_parameters_simple(
 
 def test_validate_parameters_catalog(
     mocker: MockFixture,
-    app_context: AppContext,
 ) -> None:
     from superset.db_engine_specs.gsheets import (
         GSheetsEngineSpec,
@@ -143,7 +140,6 @@ def test_validate_parameters_catalog(
 
 def test_validate_parameters_catalog_and_credentials(
     mocker: MockFixture,
-    app_context: AppContext,
 ) -> None:
     from superset.db_engine_specs.gsheets import (
         GSheetsEngineSpec,

--- a/tests/unit_tests/db_engine_specs/test_kusto.py
+++ b/tests/unit_tests/db_engine_specs/test_kusto.py
@@ -18,7 +18,6 @@
 from datetime import datetime
 
 import pytest
-from flask.ctx import AppContext
 
 from tests.unit_tests.fixtures.common import dttm
 
@@ -32,9 +31,7 @@ from tests.unit_tests.fixtures.common import dttm
         ("INSERT INTO tbl (foo) VALUES (1)", False),
     ],
 )
-def test_sql_is_readonly_query(
-    app_context: AppContext, sql: str, expected: bool
-) -> None:
+def test_sql_is_readonly_query(sql: str, expected: bool) -> None:
     """
     Make sure that SQL dialect consider only SELECT statements as read-only
     """
@@ -56,7 +53,7 @@ def test_sql_is_readonly_query(
         (".show tables", False),
     ],
 )
-def test_kql_is_select_query(app_context: AppContext, kql: str, expected: bool) -> None:
+def test_kql_is_select_query(kql: str, expected: bool) -> None:
     """
     Make sure that KQL dialect consider only statements that do not start with "." (dot)
     as a SELECT statements
@@ -83,9 +80,7 @@ def test_kql_is_select_query(app_context: AppContext, kql: str, expected: bool) 
         (".set-or-append table foo <| bar", False),
     ],
 )
-def test_kql_is_readonly_query(
-    app_context: AppContext, kql: str, expected: bool
-) -> None:
+def test_kql_is_readonly_query(kql: str, expected: bool) -> None:
     """
     Make sure that KQL dialect consider only SELECT statements as read-only
     """
@@ -99,7 +94,7 @@ def test_kql_is_readonly_query(
     assert expected == is_readonly
 
 
-def test_kql_parse_sql(app_context: AppContext) -> None:
+def test_kql_parse_sql() -> None:
     """
     parse_sql method should always return a list with a single element
     which is an original query
@@ -121,7 +116,6 @@ def test_kql_parse_sql(app_context: AppContext) -> None:
     ],
 )
 def test_kql_convert_dttm(
-    app_context: AppContext,
     target_type: str,
     expected_dttm: str,
     dttm: datetime,
@@ -145,7 +139,6 @@ def test_kql_convert_dttm(
     ],
 )
 def test_sql_convert_dttm(
-    app_context: AppContext,
     target_type: str,
     expected_dttm: str,
     dttm: datetime,

--- a/tests/unit_tests/db_engine_specs/test_mssql.py
+++ b/tests/unit_tests/db_engine_specs/test_mssql.py
@@ -19,7 +19,6 @@ from datetime import datetime
 from textwrap import dedent
 
 import pytest
-from flask.ctx import AppContext
 from sqlalchemy import column, table
 from sqlalchemy.dialects import mssql
 from sqlalchemy.dialects.mssql import DATE, NTEXT, NVARCHAR, TEXT, VARCHAR
@@ -44,7 +43,6 @@ from tests.unit_tests.fixtures.common import dttm
     ],
 )
 def test_mssql_column_types(
-    app_context: AppContext,
     type_string: str,
     type_expected: TypeEngine,
     generic_type_expected: GenericDataType,
@@ -61,7 +59,7 @@ def test_mssql_column_types(
             assert column_spec.generic_type == generic_type_expected
 
 
-def test_where_clause_n_prefix(app_context: AppContext) -> None:
+def test_where_clause_n_prefix() -> None:
     from superset.db_engine_specs.mssql import MssqlEngineSpec
 
     dialect = mssql.dialect()
@@ -95,7 +93,7 @@ def test_where_clause_n_prefix(app_context: AppContext) -> None:
     assert query == query_expected
 
 
-def test_time_exp_mixd_case_col_1y(app_context: AppContext) -> None:
+def test_time_exp_mixd_case_col_1y() -> None:
     from superset.db_engine_specs.mssql import MssqlEngineSpec
 
     col = column("MixedCase")
@@ -122,7 +120,6 @@ def test_time_exp_mixd_case_col_1y(app_context: AppContext) -> None:
     ],
 )
 def test_convert_dttm(
-    app_context: AppContext,
     actual: str,
     expected: str,
     dttm: datetime,
@@ -132,7 +129,7 @@ def test_convert_dttm(
     assert MssqlEngineSpec.convert_dttm(actual, dttm) == expected
 
 
-def test_extract_error_message(app_context: AppContext) -> None:
+def test_extract_error_message() -> None:
     from superset.db_engine_specs.mssql import MssqlEngineSpec
 
     test_mssql_exception = Exception(
@@ -158,7 +155,7 @@ def test_extract_error_message(app_context: AppContext) -> None:
     assert expected_message == error_message
 
 
-def test_fetch_data(app_context: AppContext) -> None:
+def test_fetch_data() -> None:
     from superset.db_engine_specs.base import BaseEngineSpec
     from superset.db_engine_specs.mssql import MssqlEngineSpec
 
@@ -185,9 +182,7 @@ def test_fetch_data(app_context: AppContext) -> None:
         (NTEXT(collation="utf8_general_ci"), "NTEXT"),
     ],
 )
-def test_column_datatype_to_string(
-    app_context: AppContext, original: TypeEngine, expected: str
-) -> None:
+def test_column_datatype_to_string(original: TypeEngine, expected: str) -> None:
     from superset.db_engine_specs.mssql import MssqlEngineSpec
 
     actual = MssqlEngineSpec.column_datatype_to_string(original, mssql.dialect())
@@ -239,9 +234,7 @@ select 'USD' as cur
         ),
     ],
 )
-def test_cte_query_parsing(
-    app_context: AppContext, original: TypeEngine, expected: str
-) -> None:
+def test_cte_query_parsing(original: TypeEngine, expected: str) -> None:
     from superset.db_engine_specs.mssql import MssqlEngineSpec
 
     actual = MssqlEngineSpec.get_cte_query(original)
@@ -270,16 +263,14 @@ select TOP 100 * from currency""",
         ),
     ],
 )
-def test_top_query_parsing(
-    app_context: AppContext, original: TypeEngine, expected: str, top: int
-) -> None:
+def test_top_query_parsing(original: TypeEngine, expected: str, top: int) -> None:
     from superset.db_engine_specs.mssql import MssqlEngineSpec
 
     actual = MssqlEngineSpec.apply_top_to_sql(original, top)
     assert actual == expected
 
 
-def test_extract_errors(app_context: AppContext) -> None:
+def test_extract_errors() -> None:
     """
     Test that custom error messages are extracted correctly.
     """

--- a/tests/unit_tests/db_engine_specs/test_presto.py
+++ b/tests/unit_tests/db_engine_specs/test_presto.py
@@ -19,7 +19,6 @@ from typing import Optional
 
 import pytest
 import pytz
-from flask.ctx import AppContext
 
 
 @pytest.mark.parametrize(
@@ -45,7 +44,6 @@ from flask.ctx import AppContext
     ],
 )
 def test_convert_dttm(
-    app_context: AppContext,
     target_type: str,
     dttm: datetime,
     result: Optional[str],

--- a/tests/unit_tests/db_engine_specs/test_snowflake.py
+++ b/tests/unit_tests/db_engine_specs/test_snowflake.py
@@ -19,7 +19,6 @@ from datetime import datetime
 from unittest import mock
 
 import pytest
-from flask.ctx import AppContext
 
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from tests.unit_tests.fixtures.common import dttm
@@ -33,15 +32,13 @@ from tests.unit_tests.fixtures.common import dttm
         ("TIMESTAMP", "TO_TIMESTAMP('2019-01-02T03:04:05.678900')"),
     ],
 )
-def test_convert_dttm(
-    app_context: AppContext, actual: str, expected: str, dttm: datetime
-) -> None:
+def test_convert_dttm(actual: str, expected: str, dttm: datetime) -> None:
     from superset.db_engine_specs.snowflake import SnowflakeEngineSpec
 
     assert SnowflakeEngineSpec.convert_dttm(actual, dttm) == expected
 
 
-def test_database_connection_test_mutator(app_context: AppContext) -> None:
+def test_database_connection_test_mutator() -> None:
     from superset.db_engine_specs.snowflake import SnowflakeEngineSpec
     from superset.models.core import Database
 
@@ -54,7 +51,7 @@ def test_database_connection_test_mutator(app_context: AppContext) -> None:
     } == engine_params
 
 
-def test_extract_errors(app_context: AppContext) -> None:
+def test_extract_errors() -> None:
     from superset.db_engine_specs.snowflake import SnowflakeEngineSpec
 
     msg = "Object dumbBrick does not exist or not authorized."

--- a/tests/unit_tests/db_engine_specs/test_sqlite.py
+++ b/tests/unit_tests/db_engine_specs/test_sqlite.py
@@ -19,31 +19,30 @@ from datetime import datetime
 from unittest import mock
 
 import pytest
-from flask.ctx import AppContext
 from sqlalchemy.engine import create_engine
 
 from tests.unit_tests.fixtures.common import dttm
 
 
-def test_convert_dttm(app_context: AppContext, dttm: datetime) -> None:
+def test_convert_dttm(dttm: datetime) -> None:
     from superset.db_engine_specs.sqlite import SqliteEngineSpec
 
     assert SqliteEngineSpec.convert_dttm("TEXT", dttm) == "'2019-01-02 03:04:05.678900'"
 
 
-def test_convert_dttm_lower(app_context: AppContext, dttm: datetime) -> None:
+def test_convert_dttm_lower(dttm: datetime) -> None:
     from superset.db_engine_specs.sqlite import SqliteEngineSpec
 
     assert SqliteEngineSpec.convert_dttm("text", dttm) == "'2019-01-02 03:04:05.678900'"
 
 
-def test_convert_dttm_invalid_type(app_context: AppContext, dttm: datetime) -> None:
+def test_convert_dttm_invalid_type(dttm: datetime) -> None:
     from superset.db_engine_specs.sqlite import SqliteEngineSpec
 
     assert SqliteEngineSpec.convert_dttm("other", dttm) is None
 
 
-def test_get_all_datasource_names_table(app_context: AppContext) -> None:
+def test_get_all_datasource_names_table() -> None:
     from superset.db_engine_specs.sqlite import SqliteEngineSpec
 
     database = mock.MagicMock()
@@ -62,7 +61,7 @@ def test_get_all_datasource_names_table(app_context: AppContext) -> None:
     )
 
 
-def test_get_all_datasource_names_view(app_context: AppContext) -> None:
+def test_get_all_datasource_names_view() -> None:
     from superset.db_engine_specs.sqlite import SqliteEngineSpec
 
     database = mock.MagicMock()
@@ -81,7 +80,7 @@ def test_get_all_datasource_names_view(app_context: AppContext) -> None:
     )
 
 
-def test_get_all_datasource_names_invalid_type(app_context: AppContext) -> None:
+def test_get_all_datasource_names_invalid_type() -> None:
     from superset.db_engine_specs.sqlite import SqliteEngineSpec
 
     database = mock.MagicMock()
@@ -132,9 +131,7 @@ def test_get_all_datasource_names_invalid_type(app_context: AppContext) -> None:
         ("2022-12-04T05:06:07.89Z", "P3M", "2022-10-01 00:00:00"),
     ],
 )
-def test_time_grain_expressions(
-    dttm: str, grain: str, expected: str, app_context: AppContext
-) -> None:
+def test_time_grain_expressions(dttm: str, grain: str, expected: str) -> None:
     from superset.db_engine_specs.sqlite import SqliteEngineSpec
 
     engine = create_engine("sqlite://")

--- a/tests/unit_tests/db_engine_specs/test_teradata.py
+++ b/tests/unit_tests/db_engine_specs/test_teradata.py
@@ -16,7 +16,6 @@
 # under the License.
 # pylint: disable=unused-argument, import-outside-toplevel, protected-access
 import pytest
-from flask.ctx import AppContext
 
 
 @pytest.mark.parametrize(
@@ -32,7 +31,6 @@ from flask.ctx import AppContext
     ],
 )
 def test_apply_top_to_sql_limit(
-    app_context: AppContext,
     limit: int,
     original: str,
     expected: str,

--- a/tests/unit_tests/explore/utils_test.py
+++ b/tests/unit_tests/explore/utils_test.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from flask.ctx import AppContext
 from flask_appbuilder.security.sqla.models import User
 from pytest import raises
 from pytest_mock import MockFixture
@@ -51,7 +50,7 @@ query_datasources_by_name = (
 )
 
 
-def test_unsaved_chart_no_dataset_id(app_context: AppContext) -> None:
+def test_unsaved_chart_no_dataset_id() -> None:
     from superset.explore.utils import check_access as check_chart_access
 
     with raises(DatasourceNotFoundValidationError):
@@ -63,9 +62,7 @@ def test_unsaved_chart_no_dataset_id(app_context: AppContext) -> None:
             )
 
 
-def test_unsaved_chart_unknown_dataset_id(
-    mocker: MockFixture, app_context: AppContext
-) -> None:
+def test_unsaved_chart_unknown_dataset_id(mocker: MockFixture) -> None:
     from superset.explore.utils import check_access as check_chart_access
 
     with raises(DatasetNotFoundError):
@@ -79,9 +76,7 @@ def test_unsaved_chart_unknown_dataset_id(
             )
 
 
-def test_unsaved_chart_unknown_query_id(
-    mocker: MockFixture, app_context: AppContext
-) -> None:
+def test_unsaved_chart_unknown_query_id(mocker: MockFixture) -> None:
     from superset.explore.utils import check_access as check_chart_access
 
     with raises(QueryNotFoundValidationError):
@@ -95,9 +90,7 @@ def test_unsaved_chart_unknown_query_id(
             )
 
 
-def test_unsaved_chart_unauthorized_dataset(
-    mocker: MockFixture, app_context: AppContext
-) -> None:
+def test_unsaved_chart_unauthorized_dataset(mocker: MockFixture) -> None:
     from superset.connectors.sqla.models import SqlaTable
     from superset.explore.utils import check_access as check_chart_access
 
@@ -113,9 +106,7 @@ def test_unsaved_chart_unauthorized_dataset(
             )
 
 
-def test_unsaved_chart_authorized_dataset(
-    mocker: MockFixture, app_context: AppContext
-) -> None:
+def test_unsaved_chart_authorized_dataset(mocker: MockFixture) -> None:
     from superset.connectors.sqla.models import SqlaTable
     from superset.explore.utils import check_access as check_chart_access
 
@@ -130,9 +121,7 @@ def test_unsaved_chart_authorized_dataset(
         )
 
 
-def test_saved_chart_unknown_chart_id(
-    mocker: MockFixture, app_context: AppContext
-) -> None:
+def test_saved_chart_unknown_chart_id(mocker: MockFixture) -> None:
     from superset.connectors.sqla.models import SqlaTable
     from superset.explore.utils import check_access as check_chart_access
 
@@ -149,9 +138,7 @@ def test_saved_chart_unknown_chart_id(
             )
 
 
-def test_saved_chart_unauthorized_dataset(
-    mocker: MockFixture, app_context: AppContext
-) -> None:
+def test_saved_chart_unauthorized_dataset(mocker: MockFixture) -> None:
     from superset.connectors.sqla.models import SqlaTable
     from superset.explore.utils import check_access as check_chart_access
 
@@ -167,7 +154,7 @@ def test_saved_chart_unauthorized_dataset(
             )
 
 
-def test_saved_chart_is_admin(mocker: MockFixture, app_context: AppContext) -> None:
+def test_saved_chart_is_admin(mocker: MockFixture) -> None:
     from superset.connectors.sqla.models import SqlaTable
     from superset.explore.utils import check_access as check_chart_access
     from superset.models.slice import Slice
@@ -185,7 +172,7 @@ def test_saved_chart_is_admin(mocker: MockFixture, app_context: AppContext) -> N
         )
 
 
-def test_saved_chart_is_owner(mocker: MockFixture, app_context: AppContext) -> None:
+def test_saved_chart_is_owner(mocker: MockFixture) -> None:
     from superset.connectors.sqla.models import SqlaTable
     from superset.explore.utils import check_access as check_chart_access
     from superset.models.slice import Slice
@@ -204,7 +191,7 @@ def test_saved_chart_is_owner(mocker: MockFixture, app_context: AppContext) -> N
         )
 
 
-def test_saved_chart_has_access(mocker: MockFixture, app_context: AppContext) -> None:
+def test_saved_chart_has_access(mocker: MockFixture) -> None:
     from superset.connectors.sqla.models import SqlaTable
     from superset.explore.utils import check_access as check_chart_access
     from superset.models.slice import Slice
@@ -224,7 +211,7 @@ def test_saved_chart_has_access(mocker: MockFixture, app_context: AppContext) ->
         )
 
 
-def test_saved_chart_no_access(mocker: MockFixture, app_context: AppContext) -> None:
+def test_saved_chart_no_access(mocker: MockFixture) -> None:
     from superset.connectors.sqla.models import SqlaTable
     from superset.explore.utils import check_access as check_chart_access
     from superset.models.slice import Slice
@@ -245,7 +232,7 @@ def test_saved_chart_no_access(mocker: MockFixture, app_context: AppContext) -> 
             )
 
 
-def test_dataset_has_access(mocker: MockFixture, app_context: AppContext) -> None:
+def test_dataset_has_access(mocker: MockFixture) -> None:
     from superset.connectors.sqla.models import SqlaTable
     from superset.explore.utils import check_datasource_access
 
@@ -263,7 +250,7 @@ def test_dataset_has_access(mocker: MockFixture, app_context: AppContext) -> Non
     )
 
 
-def test_query_has_access(mocker: MockFixture, app_context: AppContext) -> None:
+def test_query_has_access(mocker: MockFixture) -> None:
     from superset.explore.utils import check_datasource_access
     from superset.models.sql_lab import Query
 
@@ -281,7 +268,7 @@ def test_query_has_access(mocker: MockFixture, app_context: AppContext) -> None:
     )
 
 
-def test_query_no_access(mocker: MockFixture, client, app_context: AppContext) -> None:
+def test_query_no_access(mocker: MockFixture, client) -> None:
     from superset.connectors.sqla.models import SqlaTable
     from superset.explore.utils import check_datasource_access
     from superset.models.core import Database

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -34,7 +34,7 @@ def test_where_in() -> None:
     assert where_in(["O'Malley's"]) == "('O''Malley''s')"
 
 
-def test_dataset_macro(mocker: MockFixture, app_context: None) -> None:
+def test_dataset_macro(mocker: MockFixture) -> None:
     """
     Test the ``dataset_macro`` macro.
     """

--- a/tests/unit_tests/notifications/email_tests.py
+++ b/tests/unit_tests/notifications/email_tests.py
@@ -15,10 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 import pandas as pd
-from flask.ctx import AppContext
 
 
-def test_render_description_with_html(app_context: AppContext) -> None:
+def test_render_description_with_html() -> None:
     # `superset.models.helpers`, a dependency of following imports,
     # requires app context
     from superset.reports.models import ReportRecipients, ReportRecipientType

--- a/tests/unit_tests/result_set_test.py
+++ b/tests/unit_tests/result_set_test.py
@@ -18,7 +18,7 @@
 # pylint: disable=import-outside-toplevel, unused-argument
 
 
-def test_column_names_as_bytes(app_context: None) -> None:
+def test_column_names_as_bytes() -> None:
     """
     Test that we can handle column names as bytes.
     """

--- a/tests/unit_tests/sql_lab_test.py
+++ b/tests/unit_tests/sql_lab_test.py
@@ -63,7 +63,6 @@ def test_execute_sql_statement(mocker: MockerFixture, app: None) -> None:
 
 def test_execute_sql_statement_with_rls(
     mocker: MockerFixture,
-    app_context: None,
 ) -> None:
     """
     Test for `execute_sql_statement` when an RLS rule is in place.
@@ -118,7 +117,6 @@ def test_execute_sql_statement_with_rls(
 def test_sql_lab_insert_rls(
     mocker: MockerFixture,
     session: Session,
-    app_context: None,
 ) -> None:
     """
     Integration test for `insert_rls`.

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -1445,7 +1445,7 @@ def test_add_table_name(rls: str, table: str, expected: str) -> None:
     assert str(condition) == expected
 
 
-def test_get_rls_for_table(mocker: MockerFixture, app_context: None) -> None:
+def test_get_rls_for_table(mocker: MockerFixture) -> None:
     """
     Tests for ``get_rls_for_table``.
     """

--- a/tests/unit_tests/tables/test_models.py
+++ b/tests/unit_tests/tables/test_models.py
@@ -20,7 +20,7 @@
 from sqlalchemy.orm.session import Session
 
 
-def test_table_model(app_context: None, session: Session) -> None:
+def test_table_model(session: Session) -> None:
     """
     Test basic attributes of a ``Table``.
     """

--- a/tests/unit_tests/tasks/test_cron_util.py
+++ b/tests/unit_tests/tasks/test_cron_util.py
@@ -20,7 +20,6 @@ from typing import List
 import pytest
 import pytz
 from dateutil import parser
-from flask.ctx import AppContext
 from freezegun import freeze_time
 from freezegun.api import FakeDatetime  # type: ignore
 
@@ -50,7 +49,7 @@ from superset.tasks.cron_util import cron_schedule_window
     ],
 )
 def test_cron_schedule_window_los_angeles(
-    app_context: AppContext, current_dttm: str, cron: str, expected: List[FakeDatetime]
+    current_dttm: str, cron: str, expected: List[FakeDatetime]
 ) -> None:
     """
     Reports scheduler: Test cron schedule window for "America/Los_Angeles"
@@ -87,7 +86,7 @@ def test_cron_schedule_window_los_angeles(
     ],
 )
 def test_cron_schedule_window_invalid_timezone(
-    app_context: AppContext, current_dttm: str, cron: str, expected: List[FakeDatetime]
+    current_dttm: str, cron: str, expected: List[FakeDatetime]
 ) -> None:
     """
     Reports scheduler: Test cron schedule window for "invalid timezone"
@@ -125,7 +124,7 @@ def test_cron_schedule_window_invalid_timezone(
     ],
 )
 def test_cron_schedule_window_new_york(
-    app_context: AppContext, current_dttm: str, cron: str, expected: List[FakeDatetime]
+    current_dttm: str, cron: str, expected: List[FakeDatetime]
 ) -> None:
     """
     Reports scheduler: Test cron schedule window for "America/New_York"
@@ -162,7 +161,7 @@ def test_cron_schedule_window_new_york(
     ],
 )
 def test_cron_schedule_window_chicago(
-    app_context: AppContext, current_dttm: str, cron: str, expected: List[FakeDatetime]
+    current_dttm: str, cron: str, expected: List[FakeDatetime]
 ) -> None:
     """
     Reports scheduler: Test cron schedule window for "America/Chicago"
@@ -199,7 +198,7 @@ def test_cron_schedule_window_chicago(
     ],
 )
 def test_cron_schedule_window_chicago_daylight(
-    app_context: AppContext, current_dttm: str, cron: str, expected: List[FakeDatetime]
+    current_dttm: str, cron: str, expected: List[FakeDatetime]
 ) -> None:
     """
     Reports scheduler: Test cron schedule window for "America/Chicago"

--- a/tests/unit_tests/test_jinja_context.py
+++ b/tests/unit_tests/test_jinja_context.py
@@ -18,7 +18,6 @@ import json
 from typing import Any
 
 import pytest
-from flask.ctx import AppContext
 from sqlalchemy.dialects.postgresql import dialect
 
 from superset import app
@@ -26,30 +25,30 @@ from superset.exceptions import SupersetTemplateException
 from superset.jinja_context import ExtraCache, safe_proxy
 
 
-def test_filter_values_default(app_context: AppContext) -> None:
+def test_filter_values_default() -> None:
     cache = ExtraCache()
     assert cache.filter_values("name", "foo") == ["foo"]
     assert cache.removed_filters == []
 
 
-def test_filter_values_remove_not_present(app_context: AppContext) -> None:
+def test_filter_values_remove_not_present() -> None:
     cache = ExtraCache()
     assert cache.filter_values("name", remove_filter=True) == []
     assert cache.removed_filters == []
 
 
-def test_get_filters_remove_not_present(app_context: AppContext) -> None:
+def test_get_filters_remove_not_present() -> None:
     cache = ExtraCache()
     assert cache.get_filters("name", remove_filter=True) == []
     assert cache.removed_filters == []
 
 
-def test_filter_values_no_default(app_context: AppContext) -> None:
+def test_filter_values_no_default() -> None:
     cache = ExtraCache()
     assert cache.filter_values("name") == []
 
 
-def test_filter_values_adhoc_filters(app_context: AppContext) -> None:
+def test_filter_values_adhoc_filters() -> None:
     with app.test_request_context(
         data={
             "form_data": json.dumps(
@@ -93,7 +92,7 @@ def test_filter_values_adhoc_filters(app_context: AppContext) -> None:
         assert cache.applied_filters == ["name"]
 
 
-def test_get_filters_adhoc_filters(app_context: AppContext) -> None:
+def test_get_filters_adhoc_filters() -> None:
     with app.test_request_context(
         data={
             "form_data": json.dumps(
@@ -167,7 +166,7 @@ def test_get_filters_adhoc_filters(app_context: AppContext) -> None:
         assert cache.applied_filters == ["name"]
 
 
-def test_filter_values_extra_filters(app_context: AppContext) -> None:
+def test_filter_values_extra_filters() -> None:
     with app.test_request_context(
         data={
             "form_data": json.dumps(
@@ -180,25 +179,25 @@ def test_filter_values_extra_filters(app_context: AppContext) -> None:
         assert cache.applied_filters == ["name"]
 
 
-def test_url_param_default(app_context: AppContext) -> None:
+def test_url_param_default() -> None:
     with app.test_request_context():
         cache = ExtraCache()
         assert cache.url_param("foo", "bar") == "bar"
 
 
-def test_url_param_no_default(app_context: AppContext) -> None:
+def test_url_param_no_default() -> None:
     with app.test_request_context():
         cache = ExtraCache()
         assert cache.url_param("foo") is None
 
 
-def test_url_param_query(app_context: AppContext) -> None:
+def test_url_param_query() -> None:
     with app.test_request_context(query_string={"foo": "bar"}):
         cache = ExtraCache()
         assert cache.url_param("foo") == "bar"
 
 
-def test_url_param_form_data(app_context: AppContext) -> None:
+def test_url_param_form_data() -> None:
     with app.test_request_context(
         query_string={"form_data": json.dumps({"url_params": {"foo": "bar"}})}
     ):
@@ -206,7 +205,7 @@ def test_url_param_form_data(app_context: AppContext) -> None:
         assert cache.url_param("foo") == "bar"
 
 
-def test_url_param_escaped_form_data(app_context: AppContext) -> None:
+def test_url_param_escaped_form_data() -> None:
     with app.test_request_context(
         query_string={"form_data": json.dumps({"url_params": {"foo": "O'Brien"}})}
     ):
@@ -214,7 +213,7 @@ def test_url_param_escaped_form_data(app_context: AppContext) -> None:
         assert cache.url_param("foo") == "O''Brien"
 
 
-def test_url_param_escaped_default_form_data(app_context: AppContext) -> None:
+def test_url_param_escaped_default_form_data() -> None:
     with app.test_request_context(
         query_string={"form_data": json.dumps({"url_params": {"foo": "O'Brien"}})}
     ):
@@ -222,7 +221,7 @@ def test_url_param_escaped_default_form_data(app_context: AppContext) -> None:
         assert cache.url_param("bar", "O'Malley") == "O''Malley"
 
 
-def test_url_param_unescaped_form_data(app_context: AppContext) -> None:
+def test_url_param_unescaped_form_data() -> None:
     with app.test_request_context(
         query_string={"form_data": json.dumps({"url_params": {"foo": "O'Brien"}})}
     ):
@@ -230,7 +229,7 @@ def test_url_param_unescaped_form_data(app_context: AppContext) -> None:
         assert cache.url_param("foo", escape_result=False) == "O'Brien"
 
 
-def test_url_param_unescaped_default_form_data(app_context: AppContext) -> None:
+def test_url_param_unescaped_default_form_data() -> None:
     with app.test_request_context(
         query_string={"form_data": json.dumps({"url_params": {"foo": "O'Brien"}})}
     ):
@@ -238,21 +237,21 @@ def test_url_param_unescaped_default_form_data(app_context: AppContext) -> None:
         assert cache.url_param("bar", "O'Malley", escape_result=False) == "O'Malley"
 
 
-def test_safe_proxy_primitive(app_context: AppContext) -> None:
+def test_safe_proxy_primitive() -> None:
     def func(input_: Any) -> Any:
         return input_
 
     assert safe_proxy(func, "foo") == "foo"
 
 
-def test_safe_proxy_dict(app_context: AppContext) -> None:
+def test_safe_proxy_dict() -> None:
     def func(input_: Any) -> Any:
         return input_
 
     assert safe_proxy(func, {"foo": "bar"}) == {"foo": "bar"}
 
 
-def test_safe_proxy_lambda(app_context: AppContext) -> None:
+def test_safe_proxy_lambda() -> None:
     def func(input_: Any) -> Any:
         return input_
 
@@ -260,7 +259,7 @@ def test_safe_proxy_lambda(app_context: AppContext) -> None:
         safe_proxy(func, lambda: "bar")
 
 
-def test_safe_proxy_nested_lambda(app_context: AppContext) -> None:
+def test_safe_proxy_nested_lambda() -> None:
     def func(input_: Any) -> Any:
         return input_
 

--- a/tests/unit_tests/utils/cache_test.py
+++ b/tests/unit_tests/utils/cache_test.py
@@ -21,7 +21,7 @@
 from pytest_mock import MockerFixture
 
 
-def test_memoized_func(app_context: None, mocker: MockerFixture) -> None:
+def test_memoized_func(mocker: MockerFixture) -> None:
     """
     Test the ``memoized_func`` decorator.
     """


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

I have yet to see a test case where having an app_context is troublesome. Since it's fairly cheap to create a new context, we can just autouse the `app_context` fixture to save some boilerplate code.

Doing this for integration tests may have more complications. Will try it in another PR.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
