### PR TITLE
chore: add cypress codeowners to e2e tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,3 +17,6 @@
 # Notify Helm Chart maintainers about changes in it
 
 /helm/superset/ @craig-rueda @dpgaspar @villebro
+
+# Notify E2E test maintainers of changes
+/superset-frontend/cypress-base/ @jinghua-qa


### PR DESCRIPTION
### SUMMARY
Addind in @jinghua-qa as a codeowner to cypress tests for visibility

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
