### PR TITLE
fix(explore): Time controls not showing for Queries

### DIFF
--- a/superset-frontend/src/explore/controlUtils/getSectionsToRender.ts
+++ b/superset-frontend/src/explore/controlUtils/getSectionsToRender.ts
@@ -54,11 +54,11 @@ const getMemoizedSectionsToRender = memoizeOne(
 
     const { datasourceAndVizType } = sections;
 
-    // list of datasource-specific controls that should be removed
-    const invalidControls =
-      datasourceType === 'table'
-        ? ['granularity']
-        : ['granularity_sqla', 'time_grain_sqla'];
+    // list of datasource-specific controls that should be removed if the datasource is a specific type
+    const filterControlsForTypes = [DatasourceType.Query, DatasourceType.Table];
+    const invalidControls = filterControlsForTypes.includes(datasourceType)
+      ? ['granularity']
+      : ['granularity_sqla', 'time_grain_sqla'];
 
     return [datasourceAndVizType]
       .concat(controlPanelSections.filter(isControlPanelSectionConfig))


### PR DESCRIPTION


<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Time column went missing after creating charts from query

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before with bug:
![Clipboard 2022-22-07 at 4 58 49 PM](https://user-images.githubusercontent.com/5614266/181842314-16e37a6a-4e92-4a19-8f7a-9255e58e426f.png)

With Fix:
<img width="324" alt="Screen Shot 2022-07-29 at 1 44 14 PM" src="https://user-images.githubusercontent.com/5614266/181840889-e9bcebd5-8b2e-4e9c-96c4-48ddf5f95134.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Verify the Explore Time panel shows the correct time components - Time Column & Time Grain
2. Enable the "Create Chart" button in SQL Lab to open explore
3. Create and run a query
4. Click the "Create Chart" button
5. Verify the time controls show correctly (same as they do for dataset)
Expected Controls when in Explore when datasource type is table or query:
<img width="324" alt="Screen Shot 2022-07-29 at 1 44 14 PM" src="https://user-images.githubusercontent.com/5614266/181840889-e9bcebd5-8b2e-4e9c-96c4-48ddf5f95134.png">
Time Column & Time Grain
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
