### PR TITLE
feat(helm): add RollingUpdate parameters

### DIFF
--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
   - name: craig-rueda
     email: craig@craigrueda.com
     url: https://github.com/craig-rueda
-version: 0.7.3
+version: 0.7.4
 dependencies:
 - name: postgresql
   version: 11.1.22

--- a/helm/superset/templates/deployment-worker.yaml
+++ b/helm/superset/templates/deployment-worker.yaml
@@ -33,6 +33,11 @@ spec:
     matchLabels:
       app: {{ template "superset.name" . }}-worker
       release: {{ .Release.Name }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: {{ .Values.supersetWorker.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.supersetWorker.rollingUpdate.maxUnavailable }}
   template:
     metadata:
       annotations:

--- a/helm/superset/templates/deployment-worker.yaml
+++ b/helm/superset/templates/deployment-worker.yaml
@@ -33,11 +33,10 @@ spec:
     matchLabels:
       app: {{ template "superset.name" . }}-worker
       release: {{ .Release.Name }}
+  {{- if .Values.supersetWorker.strategy }}
   strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: {{ .Values.supersetWorker.rollingUpdate.maxSurge }}
-      maxUnavailable: {{ .Values.supersetWorker.rollingUpdate.maxUnavailable }}
+    {{- toYaml .Values.supersetWorker.strategy | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/helm/superset/templates/deployment.yaml
+++ b/helm/superset/templates/deployment.yaml
@@ -29,6 +29,11 @@ metadata:
 {{- end }}
 spec:
   replicas: {{ .Values.supersetNode.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: {{ .Values.supersetNode.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.supersetNode.rollingUpdate.maxUnavailable }}
   selector:
     matchLabels:
       app: {{ template "superset.name" . }}

--- a/helm/superset/templates/deployment.yaml
+++ b/helm/superset/templates/deployment.yaml
@@ -29,11 +29,10 @@ metadata:
 {{- end }}
 spec:
   replicas: {{ .Values.supersetNode.replicaCount }}
+  {{- if .Values.supersetNode.strategy }}
   strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: {{ .Values.supersetNode.rollingUpdate.maxSurge }}
-      maxUnavailable: {{ .Values.supersetNode.rollingUpdate.maxUnavailable }}
+    {{- toYaml .Values.supersetNode.strategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "superset.name" . }}

--- a/helm/superset/values.schema.json
+++ b/helm/superset/values.schema.json
@@ -344,8 +344,8 @@
                 "containerSecurityContext": {
                     "type": "object"
                 },
-                "rollingUpdate": {
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.23.0/_definitions.json##/definitions/io.k8s.api.apps.v1.DeploymentStrategy/properties/rollingUpdate"
+                "strategy": {
+                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.23.0/_definitions.json##/definitions/io.k8s.api.apps.v1.DeploymentStrategy"
                 }
             },
             "required": [
@@ -390,8 +390,8 @@
                 "containerSecurityContext": {
                     "type": "object"
                 },
-                "rollingUpdate": {
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.23.0/_definitions.json##/definitions/io.k8s.api.apps.v1.DeploymentStrategy/properties/rollingUpdate"
+                "strategy": {
+                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.23.0/_definitions.json##/definitions/io.k8s.api.apps.v1.DeploymentStrategy"
                 }
             },
             "required": [

--- a/helm/superset/values.schema.json
+++ b/helm/superset/values.schema.json
@@ -343,6 +343,9 @@
                 },
                 "containerSecurityContext": {
                     "type": "object"
+                },
+                "rollingUpdate": {
+                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.23.0/_definitions.json##/definitions/io.k8s.api.apps.v1.DeploymentStrategy/properties/rollingUpdate"
                 }
             },
             "required": [
@@ -386,6 +389,9 @@
                 },
                 "containerSecurityContext": {
                     "type": "object"
+                },
+                "rollingUpdate": {
+                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.23.0/_definitions.json##/definitions/io.k8s.api.apps.v1.DeploymentStrategy/properties/rollingUpdate"
                 }
             },
             "required": [

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -289,9 +289,11 @@ supersetNode:
     #  memory: 128Mi
   podSecurityContext: {}
   containerSecurityContext: {}
-  rollingUpdate:
-    maxSurge: 25%
-    maxUnavailable: 25%
+  strategy: {}
+    # type: RollingUpdate
+    # rollingUpdate:
+    #   maxSurge: 25%
+    #   maxUnavailable: 25%
 
 ##
 ## Superset worker configuration
@@ -326,9 +328,11 @@ supersetWorker:
     #  memory: 128Mi
   podSecurityContext: {}
   containerSecurityContext: {}
-  rollingUpdate:
-    maxSurge: 25%
-    maxUnavailable: 25%
+  strategy: {}
+    # type: RollingUpdate
+    # rollingUpdate:
+    #   maxSurge: 25%
+    #   maxUnavailable: 25%
 
 ##
 ## Superset beat configuration (to trigger scheduled jobs like reports)

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -289,6 +289,10 @@ supersetNode:
     #  memory: 128Mi
   podSecurityContext: {}
   containerSecurityContext: {}
+  rollingUpdate:
+    maxSurge: 25%
+    maxUnavailable: 25%
+
 ##
 ## Superset worker configuration
 supersetWorker:
@@ -322,6 +326,10 @@ supersetWorker:
     #  memory: 128Mi
   podSecurityContext: {}
   containerSecurityContext: {}
+  rollingUpdate:
+    maxSurge: 25%
+    maxUnavailable: 25%
+
 ##
 ## Superset beat configuration (to trigger scheduled jobs like reports)
 supersetCeleryBeat:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
We want to handle the RollingUpdate parameters for the supersetNode and supersetWorker.

### How
- Add the parameters in the `deployment.yaml` and `deployment-worker.yaml` templates
- Get default values from [K8S documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#deploymentstrategy-v1-apps) to ensure no change
- Put default values in `values.yaml`
- Update JSON schema
- Bump chart version

### TESTING INSTRUCTIONS
```sh
helm lint
helm template . superset-release
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
