### PR TITLE
fix(import): error with disable_data_preview field

### DIFF
--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -626,6 +626,7 @@ class ImportV1DatabaseExtraSchema(Schema):
     cost_estimate_enabled = fields.Boolean()
     allows_virtual_table_explore = fields.Boolean(required=False)
     cancel_query_on_windows_unload = fields.Boolean(required=False)
+    disable_data_preview = fields.Boolean(required=False)
 
 
 class ImportV1DatabaseSchema(Schema):

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -144,7 +144,7 @@ class ImportV1ColumnSchema(Schema):
     @pre_load
     def fix_extra(self, data: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:
         """
-        Fix for extra initially beeing exported as a string.
+        Fix for extra initially being exported as a string.
         """
         if isinstance(data.get("extra"), str):
             data["extra"] = json.loads(data["extra"])
@@ -170,7 +170,7 @@ class ImportV1MetricSchema(Schema):
     @pre_load
     def fix_extra(self, data: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:
         """
-        Fix for extra initially beeing exported as a string.
+        Fix for extra initially being exported as a string.
         """
         if isinstance(data.get("extra"), str):
             data["extra"] = json.loads(data["extra"])
@@ -192,7 +192,7 @@ class ImportV1DatasetSchema(Schema):
     @pre_load
     def fix_extra(self, data: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:
         """
-        Fix for extra initially beeing exported as a string.
+        Fix for extra initially being exported as a string.
         """
         if isinstance(data.get("extra"), str):
             data["extra"] = json.loads(data["extra"])


### PR DESCRIPTION
### SUMMARY

Updated V1 database extra schema to make import works with `disable_data_preview` field.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://user-images.githubusercontent.com/17252075/182145119-a6d875a9-6e86-4161-bb1a-e85a59ac555e.mov

After:

https://user-images.githubusercontent.com/17252075/182145073-eba786d2-6323-46b2-a1ae-7ed117729d7b.mov

### TESTING INSTRUCTIONS

1. Create a DB connection (alternatively, you can modify an existing one). 
2. On the DB configuration pop up, navigate to the **ADVANCED** tab.
3. Expand **SQL Lab**.
4. Check `Disable SQL Lab data preview queries`. 
5. Save your changes. 
6. Hover the mouse over the modified DB, and click on the export icon under the **Actions** column.
7. Try to import this ZIP file.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
