### PR TITLE
fix: adjust timeseries grid right offset to match the rest

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
@@ -31,7 +31,7 @@ import {
 export const NULL_STRING = '<NULL>';
 
 export const TIMESERIES_CONSTANTS = {
-  gridOffsetRight: 40,
+  gridOffsetRight: 20,
   gridOffsetLeft: 20,
   gridOffsetTop: 20,
   gridOffsetBottom: 20,


### PR DESCRIPTION
### SUMMARY

Adjust the grid right offset default margin to 20px, the same as the other sides.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

<img width="695" alt="Screen Shot 2022-08-01 at 10 01 07" src="https://user-images.githubusercontent.com/17252075/182153807-fcc35a16-191b-47b8-b729-e252869ff5c7.png">

After:

<img width="696" alt="new" src="https://user-images.githubusercontent.com/17252075/182153843-6f06d224-73d2-482b-9828-c3880a82b23a.png">

### TESTING INSTRUCTIONS

Create any timeseries chart and ensure the padding adjusted to the new base configuration

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
